### PR TITLE
Add API to wrap virtual thread task for FastThreadLocal support

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -159,7 +159,7 @@ final class AdaptivePoolingAllocator {
                 @Override
                 protected Object initialValue() {
                     if (cachedMagazinesNonEventLoopThreads || ThreadExecutorMap.currentExecutor() != null) {
-                        if (!FastThreadLocalThread.willCleanupFastThreadLocals(Thread.currentThread())) {
+                        if (!FastThreadLocalThread.currentThreadWillCleanupFastThreadLocals()) {
                             // To prevent a potential leak, we will not use thread-local magazine.
                             return NO_MAGAZINE;
                         }
@@ -220,7 +220,7 @@ final class AdaptivePoolingAllocator {
     private AdaptiveByteBuf allocate(int size, int maxCapacity, Thread currentThread, AdaptiveByteBuf buf) {
         if (size <= MAX_POOLED_BUF_SIZE) {
             FastThreadLocal<Object> threadLocalMagazine = this.threadLocalMagazine;
-            if (threadLocalMagazine != null && currentThread instanceof FastThreadLocalThread) {
+            if (threadLocalMagazine != null && FastThreadLocalThread.currentThreadHasFastThreadLocal()) {
                 Object mag = threadLocalMagazine.get();
                 if (mag != NO_MAGAZINE) {
                     Magazine magazine = (Magazine) mag;
@@ -287,7 +287,7 @@ final class AdaptivePoolingAllocator {
         Object tlMag;
         FastThreadLocal<Object> threadLocalMagazine = this.threadLocalMagazine;
         if (threadLocalMagazine != null &&
-                currentThread instanceof FastThreadLocalThread &&
+                FastThreadLocalThread.currentThreadHasFastThreadLocal() &&
                 (tlMag = threadLocalMagazine.get()) != NO_MAGAZINE) {
             return (Magazine) tlMag;
         }

--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -113,7 +113,7 @@ public final class ByteBufUtil {
         // Only make use of ThreadLocal if we use a FastThreadLocalThread to make the implementation
         // Virtual Thread friendly.
         // See https://github.com/netty/netty/issues/14609
-        if (minLength <= MAX_TL_ARRAY_LEN && Thread.currentThread() instanceof FastThreadLocalThread) {
+        if (minLength <= MAX_TL_ARRAY_LEN && FastThreadLocalThread.currentThreadHasFastThreadLocal()) {
             return BYTE_ARRAYS.get();
         }
         return PlatformDependent.allocateUninitializedArray(minLength);

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -532,13 +532,13 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
 
             if (useCacheForAllThreads ||
                     // If the current thread is a FastThreadLocalThread we will always use the cache
-                    current instanceof FastThreadLocalThread ||
+                    FastThreadLocalThread.currentThreadHasFastThreadLocal() ||
                     // The Thread is used by an EventExecutor, let's use the cache as the chances are good that we
                     // will allocate a lot!
                     executor != null) {
                 final PoolThreadCache cache = new PoolThreadCache(
                         heapArena, directArena, smallCacheSize, normalCacheSize,
-                        DEFAULT_MAX_CACHED_BUFFER_CAPACITY, DEFAULT_CACHE_TRIM_INTERVAL, useCacheFinalizers(current));
+                        DEFAULT_MAX_CACHED_BUFFER_CAPACITY, DEFAULT_CACHE_TRIM_INTERVAL, useCacheFinalizers());
 
                 if (DEFAULT_CACHE_TRIM_INTERVAL_MILLIS > 0) {
                     if (executor != null) {
@@ -579,12 +579,11 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
         }
     }
 
-    private static boolean useCacheFinalizers(Thread current) {
+    private static boolean useCacheFinalizers() {
         if (!defaultDisableCacheFinalizersForFastThreadLocalThreads()) {
             return true;
         }
-        return current instanceof FastThreadLocalThread &&
-               ((FastThreadLocalThread) current).willCleanupFastThreadLocals();
+        return FastThreadLocalThread.currentThreadWillCleanupFastThreadLocals();
     }
 
     @Override

--- a/common/src/main/java/io/netty/util/Recycler.java
+++ b/common/src/main/java/io/netty/util/Recycler.java
@@ -174,7 +174,9 @@ public abstract class Recycler<T> {
 
     @SuppressWarnings("unchecked")
     public final T get() {
-        if (maxCapacityPerThread == 0 || PlatformDependent.isVirtualThread(Thread.currentThread())) {
+        if (maxCapacityPerThread == 0 ||
+                (PlatformDependent.isVirtualThread(Thread.currentThread()) &&
+                        !FastThreadLocalThread.currentThreadHasFastThreadLocal())) {
             return newObject((Handle<T>) NOOP_HANDLE);
         }
         LocalPool<T> localPool = threadLocal.get();
@@ -210,7 +212,8 @@ public abstract class Recycler<T> {
 
     @VisibleForTesting
     final int threadLocalSize() {
-        if (PlatformDependent.isVirtualThread(Thread.currentThread())) {
+        if (PlatformDependent.isVirtualThread(Thread.currentThread()) &&
+                !FastThreadLocalThread.currentThreadHasFastThreadLocal()) {
             return 0;
         }
         LocalPool<T> localPool = threadLocal.getIfExists();
@@ -311,7 +314,8 @@ public abstract class Recycler<T> {
             this.chunkSize = chunkSize;
             batch = new ArrayDeque<DefaultHandle<T>>(chunkSize);
             Thread currentThread = Thread.currentThread();
-            owner = !BATCH_FAST_TL_ONLY || currentThread instanceof FastThreadLocalThread ? currentThread : null;
+            owner = !BATCH_FAST_TL_ONLY || FastThreadLocalThread.currentThreadHasFastThreadLocal()
+                    ? currentThread : null;
             if (BLOCKING_POOL) {
                 pooledHandles = new BlockingMessageQueue<DefaultHandle<T>>(maxCapacity);
             } else {

--- a/common/src/main/java/io/netty/util/concurrent/FastThreadLocalThread.java
+++ b/common/src/main/java/io/netty/util/concurrent/FastThreadLocalThread.java
@@ -18,11 +18,9 @@ package io.netty.util.concurrent;
 import io.netty.util.internal.InternalThreadLocalMap;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import org.jctools.maps.NonBlockingHashMapLong;
 
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 /**
  * A special {@link Thread} that provides fast access to {@link FastThreadLocal} variables.

--- a/common/src/main/java/io/netty/util/concurrent/FastThreadLocalThread.java
+++ b/common/src/main/java/io/netty/util/concurrent/FastThreadLocalThread.java
@@ -179,7 +179,7 @@ public class FastThreadLocalThread extends Thread {
             if (index >= 0) {
                 throw new IllegalStateException("Reentrant call to run()");
             }
-            index = ~index;
+            index = ~index; // same as -(index + 1)
             long[] next = new long[arr.length + 1];
             System.arraycopy(arr, 0, next, 0, index);
             next[index] = id;

--- a/common/src/main/java/io/netty/util/concurrent/FastThreadLocalThread.java
+++ b/common/src/main/java/io/netty/util/concurrent/FastThreadLocalThread.java
@@ -166,10 +166,11 @@ public class FastThreadLocalThread extends Thread {
      * @param runnable The task to run
      */
     public static void runWithFastThreadLocal(Runnable runnable) {
-        long id = currentThread().getId();
-        if (currentThread() instanceof FastThreadLocalThread) {
+        Thread current = currentThread();
+        if (current instanceof FastThreadLocalThread) {
             throw new IllegalStateException("Caller is a real FastThreadLocalThread");
         }
+        long id = current.getId();
         fallbackThreads.updateAndGet(arr -> {
             if (arr == null) {
                 return new long[] { id };
@@ -189,10 +190,7 @@ public class FastThreadLocalThread extends Thread {
             runnable.run();
         } finally {
             fallbackThreads.getAndUpdate(arr -> {
-                if (arr == null) {
-                    return null;
-                }
-                if (arr.length == 1 && arr[0] == id) {
+                if (arr == null || (arr.length == 1 && arr[0] == id)) {
                     return null;
                 }
                 int index = Arrays.binarySearch(arr, id);

--- a/common/src/main/java/io/netty/util/concurrent/FastThreadLocalThread.java
+++ b/common/src/main/java/io/netty/util/concurrent/FastThreadLocalThread.java
@@ -29,6 +29,8 @@ public class FastThreadLocalThread extends Thread {
 
     private static final NonBlockingHashMapLong<Object> fallbackThreads = new NonBlockingHashMapLong<>();
 
+    private static final Object MARKER = new Object();
+
     // This will be set to true if we have a chance to wrap the Runnable.
     private final boolean cleanupFastThreadLocals;
 
@@ -126,9 +128,8 @@ public class FastThreadLocalThread extends Thread {
         Thread currentThread = currentThread();
         if (currentThread instanceof FastThreadLocalThread) {
             return ((FastThreadLocalThread) currentThread).willCleanupFastThreadLocals();
-        } else {
-            return isFastThreadLocalVirtualThread();
         }
+        return isFastThreadLocalVirtualThread();
     }
 
     /**
@@ -157,7 +158,7 @@ public class FastThreadLocalThread extends Thread {
      */
     public static void runWithFastThreadLocal(Runnable runnable) {
         long id = currentThread().getId();
-        if (fallbackThreads.put(id, "") != null || currentThread() instanceof FastThreadLocalThread) {
+        if (currentThread() instanceof FastThreadLocalThread || fallbackThreads.put(id, MARKER) != null) {
             throw new IllegalStateException("Reentrant call to run()");
         }
         try {


### PR DESCRIPTION
Motivation:

Recent changes to avoid ThreadLocals in virtual threads made many optimizations unworkable for those threads. In some scenarios, however, virtual threads live long enough that those optimizations make sense, even if implemented through normal ThreadLocal instead of FastThreadLocalThread.

Modification:

- Add a method FastThreadLocalThread.runWithFastThreadLocal that runs a task as if it was a FastThreadLocalThread. The method also cleans up any FastThreadLocals at the end. The method is designed to make future migration to ScopedValue possible.
- Add utility methods to query current thread FastThreadLocal support, and `willCleanupFastThreadLocals` support independent of FastThreadLocalThread.
- Replace various uses of `instanceof FastThreadLocalThread` with the new methods.
- Amend use of `isVirtualThread` with the new methods.

Result:

Long-running virtual threads can be adapted to support the normal set of ThreadLocal-based optimizations.