### PR TITLE
Introduce `ByteBuf.readString` method

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -521,6 +521,13 @@ public abstract class AbstractByteBuf extends ByteBuf {
     }
 
     @Override
+    public String readString(int length, Charset charset) {
+        String string = toString(readerIndex, length, charset);
+        readerIndex += length;
+        return string;
+    }
+
+    @Override
     public ByteBuf setByte(int index, int value) {
         checkIndex(index);
         _setByte(index, value);

--- a/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareByteBuf.java
@@ -529,6 +529,12 @@ final class AdvancedLeakAwareByteBuf extends SimpleLeakAwareByteBuf {
     }
 
     @Override
+    public String readString(int length, Charset charset) {
+        recordLeakNonRefCountingOperation(leak);
+        return super.readString(length, charset);
+    }
+
+    @Override
     public ByteBuf skipBytes(int length) {
         recordLeakNonRefCountingOperation(leak);
         return super.skipBytes(length);

--- a/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareCompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareCompositeByteBuf.java
@@ -508,6 +508,12 @@ final class AdvancedLeakAwareCompositeByteBuf extends SimpleLeakAwareCompositeBy
     }
 
     @Override
+    public String readString(int length, Charset charset) {
+        recordLeakNonRefCountingOperation(leak);
+        return super.readString(length, charset);
+    }
+
+    @Override
     public CompositeByteBuf skipBytes(int length) {
         recordLeakNonRefCountingOperation(leak);
         return super.skipBytes(length);

--- a/buffer/src/main/java/io/netty/buffer/ByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBuf.java
@@ -1746,7 +1746,12 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf>, 
      * @throws IndexOutOfBoundsException
      *         if {@code length} is greater than {@code this.readableBytes}
      */
-    public abstract String readString(int length, Charset charset);
+    public String readString(int length, Charset charset) {
+        int readerIndex = readerIndex();
+        String string = toString(readerIndex, length, charset);
+        readerIndex(readerIndex + length);
+        return string;
+    }
 
     /**
      * Transfers this buffer's data starting at the current {@code readerIndex}

--- a/buffer/src/main/java/io/netty/buffer/ByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBuf.java
@@ -1737,6 +1737,18 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf>, 
     public abstract CharSequence readCharSequence(int length, Charset charset);
 
     /**
+     * Gets a {@link String} with the given length at the current {@code readerIndex}
+     * and increases the {@code readerIndex} by the given length.
+     *
+     * @param length the length to read
+     * @param charset that should be used
+     * @return the string
+     * @throws IndexOutOfBoundsException
+     *         if {@code length} is greater than {@code this.readableBytes}
+     */
+    public abstract String readString(int length, Charset charset);
+
+    /**
      * Transfers this buffer's data starting at the current {@code readerIndex}
      * to the specified channel starting at the given file position.
      * This method does not modify the channel's position.

--- a/buffer/src/main/java/io/netty/buffer/EmptyByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/EmptyByteBuf.java
@@ -682,6 +682,12 @@ public final class EmptyByteBuf extends ByteBuf {
     }
 
     @Override
+    public String readString(int length, Charset charset) {
+        checkLength(length);
+        return StringUtil.EMPTY_STRING;
+    }
+
+    @Override
     public ByteBuf skipBytes(int length) {
         return checkLength(length);
     }

--- a/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
@@ -694,6 +694,11 @@ public class SwappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public String readString(int length, Charset charset) {
+        return buf.readString(length, charset);
+    }
+
+    @Override
     public ByteBuf skipBytes(int length) {
         buf.skipBytes(length);
         return this;

--- a/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
@@ -692,6 +692,11 @@ public class WrappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public String readString(int length, Charset charset) {
+        return buf.readString(length, charset);
+    }
+
+    @Override
     public ByteBuf skipBytes(int length) {
         buf.skipBytes(length);
         return this;

--- a/buffer/src/main/java/io/netty/buffer/WrappedCompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/WrappedCompositeByteBuf.java
@@ -1116,6 +1116,11 @@ class WrappedCompositeByteBuf extends CompositeByteBuf {
     }
 
     @Override
+    public String readString(int length, Charset charset) {
+        return wrapped.readString(length, charset);
+    }
+
+    @Override
     public int setCharSequence(int index, CharSequence sequence, Charset charset) {
         return wrapped.setCharSequence(index, sequence, charset);
     }

--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
@@ -4836,6 +4836,37 @@ public abstract class AbstractByteBufTest {
     }
 
     @Test
+    public void testWriteReadUsAsciiString() {
+        testWriteReadString(CharsetUtil.US_ASCII);
+    }
+
+    @Test
+    public void testWriteReadUtf8String() {
+        testWriteReadString(CharsetUtil.UTF_8);
+    }
+
+    @Test
+    public void testWriteReadIso88591String() {
+        testWriteReadString(CharsetUtil.ISO_8859_1);
+    }
+
+    @Test
+    public void testWriteReadUtf16String() {
+        testWriteReadString(CharsetUtil.UTF_16);
+    }
+
+    private void testWriteReadString(Charset charset) {
+        ByteBuf buf = newBuffer(1024);
+        CharBuffer sequence = CharsetUtil.US_ASCII.equals(charset)
+                ? ASCII_CHARS : EXTENDED_ASCII_CHARS;
+        buf.writerIndex(1);
+        int bytes = buf.writeCharSequence(sequence, charset);
+        buf.readerIndex(1);
+        assertEquals(sequence, CharBuffer.wrap(buf.readString(bytes, charset)));
+        buf.release();
+    }
+
+    @Test
     public void testRetainedSliceIndexOutOfBounds() {
         assertThrows(IndexOutOfBoundsException.class, new Executable() {
             @Override

--- a/buffer/src/test/java/io/netty/buffer/EmptyByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/EmptyByteBufTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -110,6 +111,18 @@ public class EmptyByteBufTest {
     public void testGetCharSequence() {
         EmptyByteBuf empty = new EmptyByteBuf(UnpooledByteBufAllocator.DEFAULT);
         assertEquals("", empty.readCharSequence(0, CharsetUtil.US_ASCII));
+    }
+
+    @Test
+    public void testReadString() {
+        EmptyByteBuf empty = new EmptyByteBuf(UnpooledByteBufAllocator.DEFAULT);
+        assertEquals("", empty.readString(0, CharsetUtil.US_ASCII));
+    }
+
+    @Test
+    public void testReadStringThrowsIndexOutOfBoundsException() {
+        EmptyByteBuf empty = new EmptyByteBuf(UnpooledByteBufAllocator.DEFAULT);
+        assertThrows(IndexOutOfBoundsException.class, () -> empty.readString(1, CharsetUtil.US_ASCII));
     }
 
 }

--- a/codec-base/src/main/java/io/netty/handler/codec/ReplayingDecoderByteBuf.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/ReplayingDecoderByteBuf.java
@@ -713,6 +713,12 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
     }
 
     @Override
+    public String readString(int length, Charset charset) {
+        checkReadableBytes(length);
+        return buffer.readString(length, charset);
+    }
+
+    @Override
     public ByteBuf resetReaderIndex() {
         buffer.resetReaderIndex();
         return this;


### PR DESCRIPTION
Motivation:

Seems like a useful method. `readCharSequence` is also nice, but clients are usually using String, so that `AsciString` optimisation wouldn't work for them.

Modification:

Added `ByteBuf.readString` method.
Also, refactored `MqttDecoder` with a new method.