### PR TITLE
Replace modulo with bitwise operator when possible

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/UnsafeByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/UnsafeByteBufUtil.java
@@ -431,7 +431,7 @@ final class UnsafeByteBufUtil {
             PlatformDependent.putLong(data, index, ZERO);
             index += 8;
         }
-        final int remaining = length % 8;
+        final int remaining = length & 0x07;
         for (int i = 0; i < remaining; i++) {
             PlatformDependent.putByte(data, index + i, ZERO);
         }
@@ -642,7 +642,7 @@ final class UnsafeByteBufUtil {
             PlatformDependent.putLong(addr, ZERO);
             addr += 8;
         }
-        final int remaining = length % 8;
+        final int remaining = length & 0x07;
         for (int i = 0; i < remaining; i++) {
             PlatformDependent.putByte(addr + i, ZERO);
         }

--- a/buffer/src/main/java/io/netty/buffer/UnsafeByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/UnsafeByteBufUtil.java
@@ -426,7 +426,7 @@ final class UnsafeByteBufUtil {
     }
 
     private static void batchSetZero(byte[] data, int index, int length) {
-        int longBatches = length / 8;
+        int longBatches = length >>> 3;
         for (int i = 0; i < longBatches; i++) {
             PlatformDependent.putLong(data, index, ZERO);
             index += 8;
@@ -637,7 +637,7 @@ final class UnsafeByteBufUtil {
     }
 
     private static void batchSetZero(long addr, int length) {
-        int longBatches = length / 8;
+        int longBatches = length >>> 3;
         for (int i = 0; i < longBatches; i++) {
             PlatformDependent.putLong(addr, ZERO);
             addr += 8;

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttEncoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttEncoder.java
@@ -685,8 +685,8 @@ public final class MqttEncoder extends MessageToMessageEncoder<MqttMessage> {
 
     private static void writeVariableLengthInt(ByteBuf buf, int num) {
         do {
-            int digit = num % 128;
-            num /= 128;
+            int digit = num & 0x7F;
+            num >>>= 7;
             if (num > 0) {
                 digit |= 0x80;
             }


### PR DESCRIPTION
Motivation:

In some cases modulo operator can be replaced with a cheaper bitwise version:

`% 128` -> `& 0x7F`
`% 8` -> `& 0x07`
`/ 128` -> `>>> 7`

Modification:

Replaced modulo operator with bitwise + division with shifting.

Result:

Cheaper CPU instructions used instead of modulo operator.
