### PR TITLE
dev-tools should use the netty-parent as parent

### DIFF
--- a/dev-tools/pom.xml
+++ b/dev-tools/pom.xml
@@ -17,16 +17,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>7</version>
-    <relativePath />
+    <groupId>io.netty</groupId>
+    <artifactId>netty-parent</artifactId>
+    <version>4.2.2.Final-SNAPSHOT</version>
   </parent>
 
-  <groupId>io.netty</groupId>
   <artifactId>netty-dev-tools</artifactId>
-  <version>4.2.2.Final-SNAPSHOT</version>
-
   <name>Netty/Dev-Tools</name>
 
   <properties>


### PR DESCRIPTION
Motivation:

There is really no reason why we should not use the netty-parent as parent

Modifications:

Change parent and remove config duplication

Result:

Cleanup