### PR TITLE
Always prefer direct buffers for pooled allocators if not explicit di…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptiveByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptiveByteBufAllocator.java
@@ -45,7 +45,7 @@ public final class AdaptiveByteBufAllocator extends AbstractByteBufAllocator
     private final AdaptivePoolingAllocator heap;
 
     public AdaptiveByteBufAllocator() {
-        this(PlatformDependent.directBufferPreferred());
+        this(!PlatformDependent.isExplicitNoPreferDirect());
     }
 
     public AdaptiveByteBufAllocator(boolean preferDirect) {

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -185,7 +185,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
     }
 
     public static final PooledByteBufAllocator DEFAULT =
-            new PooledByteBufAllocator(PlatformDependent.directBufferPreferred());
+            new PooledByteBufAllocator(!PlatformDependent.isExplicitNoPreferDirect());
 
     private final PoolArena<byte[]>[] heapArenas;
     private final PoolArena<ByteBuffer>[] directArenas;

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -94,6 +94,7 @@ public final class PlatformDependent {
 
     private static final Throwable UNSAFE_UNAVAILABILITY_CAUSE = unsafeUnavailabilityCause0();
     private static final boolean DIRECT_BUFFER_PREFERRED;
+    private static final boolean EXPLICIT_NO_PREFER_DIRECT;
     private static final long MAX_DIRECT_MEMORY = estimateMaxDirectMemory();
 
     private static final int MPSC_CHUNK_SIZE =  1024;
@@ -178,11 +179,12 @@ public final class PlatformDependent {
             CLEANER = NOOP;
         }
 
+        EXPLICIT_NO_PREFER_DIRECT = SystemPropertyUtil.getBoolean("io.netty.noPreferDirect", false);
         // We should always prefer direct buffers by default if we can use a Cleaner to release direct buffers.
         DIRECT_BUFFER_PREFERRED = CLEANER != NOOP
-                                  && !SystemPropertyUtil.getBoolean("io.netty.noPreferDirect", false);
+                                  && !EXPLICIT_NO_PREFER_DIRECT;
         if (logger.isDebugEnabled()) {
-            logger.debug("-Dio.netty.noPreferDirect: {}", !DIRECT_BUFFER_PREFERRED);
+            logger.debug("-Dio.netty.noPreferDirect: {}", EXPLICIT_NO_PREFER_DIRECT);
         }
 
         /*
@@ -372,6 +374,14 @@ public final class PlatformDependent {
      */
     public static boolean directBufferPreferred() {
         return DIRECT_BUFFER_PREFERRED;
+    }
+
+    /**
+     * Returns {@code true} if user has specified
+     * {@code -Dio.netty.noPreferDirect=true} option.
+     */
+    public static boolean isExplicitNoPreferDirect() {
+        return EXPLICIT_NO_PREFER_DIRECT;
     }
 
     /**


### PR DESCRIPTION
…sabled

Motivation:

We should always prefer direct buffers if the ByteBufAllocator implementations are pooled as deallocating these buffers should be rare.

Modifications:

- Add new method to PlatformDependent that can be used to check if default direct buffer usage was explicit disabled
- Use this method in our pooled ByteBufAllocator implementations to check if we should use direct buffers or not by default

Result:

Less memory copies and better performance when using the pooled allocators even if Unsafe can not be used.