### PR TITLE
Fix javadoc jar generate for artifact

### DIFF
--- a/testsuite-native-image/pom.xml
+++ b/testsuite-native-image/pom.xml
@@ -80,6 +80,28 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>empty-javadoc-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>javadoc</classifier>
+              <classesDirectory>${basedir}/javadoc</classesDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>skipTests</id>


### PR DESCRIPTION
Motivation:

We did miss to generate a javadoc jar for an artifact and so the central validation failed

Modifications:

Add pom.xml config to generate javadoc jar

Result:

Validate of published bundle works
