### PR TITLE
Update to netty-tcnative 2.0.72.Final

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -62,7 +62,7 @@
 
   <properties>
     <!-- Keep in sync with ../pom.xml -->
-    <tcnative.version>2.0.71.Final</tcnative.version>
+    <tcnative.version>2.0.72.Final</tcnative.version>
   </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -588,7 +588,7 @@
       <id>boringssl-snapshot</id>
       <properties>
         <tcnative.artifactId>netty-tcnative-boringssl-static</tcnative.artifactId>
-        <tcnative.version>2.0.72.Final-SNAPSHOT</tcnative.version>
+        <tcnative.version>2.0.73.Final-SNAPSHOT</tcnative.version>
         <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
       </properties>
     </profile>
@@ -702,7 +702,7 @@
     <os.detection.classifierWithLikes>fedora,suse,arch</os.detection.classifierWithLikes>
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
     <!-- Keep in sync with bom/pom.xml -->
-    <tcnative.version>2.0.71.Final</tcnative.version>
+    <tcnative.version>2.0.72.Final</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <conscrypt.groupId>org.conscrypt</conscrypt.groupId>
     <conscrypt.artifactId>conscrypt-openjdk-uber</conscrypt.artifactId>


### PR DESCRIPTION
Motivation:

We released a new netty-tcnative version

Modifications:

Update to latest release

Result:

Use latest netty-tcnative release
