### PR TITLE
bom should use netty-parent (#15235)

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -17,15 +17,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>7</version>
-    <relativePath />
+    <groupId>io.netty</groupId>
+    <artifactId>netty-parent</artifactId>
+    <version>4.1.122.Final-SNAPSHOT</version>
   </parent>
 
-  <groupId>io.netty</groupId>
   <artifactId>netty-bom</artifactId>
-  <version>4.1.122.Final-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Netty/BOM</name>


### PR DESCRIPTION
Motivation:

All our modules should use the same parent to ensure everything is setup correct for publishing snapshots and releases

Modifications:

- Use netty-parent as parent
- Remove duplicated config

Result:

Cleanup and ensure snapshots / releases use the same config for all modules