### PR TITLE
Migrate using maven central (#15218)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2017,6 +2017,26 @@
         <artifactId>forbiddenapis</artifactId>
         <version>2.2</version>
       </plugin>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.7.0</version>
+        <configuration>
+          <publishingServerId>central</publishingServerId>
+          <skipPublishing>true</skipPublishing>
+          <autoPublish>false</autoPublish>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.7.0</version>
+        <configuration>
+          <serverId>central-portal-snapshots</serverId>
+          <nexusUrl>https://central.sonatype.com/repository/maven-snapshots</nexusUrl>
+          <skipRemoteStaging>true</skipRemoteStaging>
+        </configuration>
+      </plugin>
     </plugins>
 
     <pluginManagement>


### PR DESCRIPTION
Motivation:

OSSRH is deprecated and will be shut down soon. Let's switch to using maven central

Modifications:

- Replace old plugin with central-publishing-maven-plugin for release

Result:

Snapshot deployments and release works again