### PR TITLE
Always prefer direct buffers for pooled allocators if not explicit di…

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/adapt/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/adapt/AdaptivePoolingAllocator.java
@@ -117,7 +117,7 @@ public class AdaptivePoolingAllocator implements BufferAllocator {
     private final Set<Magazine> liveCachedMagazines;
 
     public AdaptivePoolingAllocator() {
-        this(PlatformDependent.isExplicitNoPreferDirect());
+        this(!PlatformDependent.isExplicitNoPreferDirect());
     }
 
     public AdaptivePoolingAllocator(boolean direct) {

--- a/buffer/src/main/java/io/netty5/buffer/adapt/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/adapt/AdaptivePoolingAllocator.java
@@ -117,7 +117,7 @@ public class AdaptivePoolingAllocator implements BufferAllocator {
     private final Set<Magazine> liveCachedMagazines;
 
     public AdaptivePoolingAllocator() {
-        this(PlatformDependent.directBufferPreferred());
+        this(PlatformDependent.isExplicitNoPreferDirect());
     }
 
     public AdaptivePoolingAllocator(boolean direct) {

--- a/buffer/src/main/java/io/netty5/buffer/pool/PooledBufferAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/pool/PooledBufferAllocator.java
@@ -390,7 +390,7 @@ public class PooledBufferAllocator implements BufferAllocator, BufferAllocatorMe
      * Default prefer direct - System Property: io.netty5.noPreferDirect - default false
      */
     public static boolean defaultPreferDirect() {
-        return PlatformDependent.directBufferPreferred();
+        return !PlatformDependent.isExplicitNoPreferDirect();
     }
 
     /**

--- a/common/src/main/java/io/netty5/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty5/util/internal/PlatformDependent.java
@@ -84,6 +84,7 @@ public final class PlatformDependent {
 
     private static final Throwable UNSAFE_UNAVAILABILITY_CAUSE = unsafeUnavailabilityCause0();
     private static final boolean DIRECT_BUFFER_PREFERRED;
+    private static final boolean EXPLICIT_NO_PREFER_DIRECT;
     private static final long MAX_DIRECT_MEMORY = estimateMaxDirectMemory();
 
     private static final int MPSC_CHUNK_SIZE =  1024;
@@ -168,11 +169,12 @@ public final class PlatformDependent {
             CLEANER = NOOP;
         }
 
+        EXPLICIT_NO_PREFER_DIRECT = SystemPropertyUtil.getBoolean("io.nett5y.noPreferDirect", false);
         // We should always prefer direct buffers by default if we can use a Cleaner to release direct buffers.
         DIRECT_BUFFER_PREFERRED = CLEANER != NOOP
-                                  && !SystemPropertyUtil.getBoolean("io.netty5.noPreferDirect", false);
+                                  && !EXPLICIT_NO_PREFER_DIRECT;
         if (logger.isDebugEnabled()) {
-            logger.debug("-Dio.netty5.noPreferDirect: {}", !DIRECT_BUFFER_PREFERRED);
+            logger.debug("-Dio.netty5.noPreferDirect: {}", EXPLICIT_NO_PREFER_DIRECT);
         }
 
         /*
@@ -347,6 +349,14 @@ public final class PlatformDependent {
      */
     public static boolean directBufferPreferred() {
         return DIRECT_BUFFER_PREFERRED;
+    }
+
+    /**
+     * Returns {@code true} if user has specified
+     * {@code -Dio.netty.noPreferDirect=true} option.
+     */
+    public static boolean isExplicitNoPreferDirect() {
+        return EXPLICIT_NO_PREFER_DIRECT;
     }
 
     /**


### PR DESCRIPTION
…sabled

Motivation:

We should always prefer direct buffers if the ByteBufAllocator implementations are pooled as deallocating these buffers should be rare.

Modifications:

- Add new method to PlatformDependent that can be used to check if default direct buffer usage was explicit disabled
- Use this method in our pooled ByteBufAllocator implementations to check if we should use direct buffers or not by default

Result:

Less memory copies and better performance when using the pooled allocators even if Unsafe can not be used.
