### PR TITLE
Remove regexp from AbstractHttpData

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractHttpData.java
@@ -15,8 +15,6 @@
  */
 package io.netty.handler.codec.http.multipart;
 
-import static io.netty.util.internal.ObjectUtil.checkNonEmpty;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelException;
 import io.netty.handler.codec.http.HttpConstants;
@@ -25,15 +23,13 @@ import io.netty.util.internal.ObjectUtil;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.regex.Pattern;
+
+import static io.netty.util.internal.ObjectUtil.checkNonEmpty;
 
 /**
  * Abstract HttpData implementation
  */
 public abstract class AbstractHttpData extends AbstractReferenceCounted implements HttpData {
-
-    private static final Pattern STRIP_PATTERN = Pattern.compile("(?:^\\s+|\\s+$|\\n)");
-    private static final Pattern REPLACE_PATTERN = Pattern.compile("[\\r\\t]");
 
     private final String name;
     protected long definedSize;
@@ -45,14 +41,57 @@ public abstract class AbstractHttpData extends AbstractReferenceCounted implemen
     protected AbstractHttpData(String name, Charset charset, long size) {
         ObjectUtil.checkNotNull(name, "name");
 
-        name = REPLACE_PATTERN.matcher(name).replaceAll(" ");
-        name = STRIP_PATTERN.matcher(name).replaceAll("");
-
-        this.name = checkNonEmpty(name, "name");
+        this.name = checkNonEmpty(cleanName(name), "name");
         if (charset != null) {
             setCharset(charset);
         }
         definedSize = size;
+    }
+
+    //Replaces \r and \t with a space
+    //Removes leading and trailing whitespace and newlines
+    private static String cleanName(String name) {
+        int len = name.length();
+        StringBuilder sb = null;
+
+        int start = 0;
+        int end = len;
+
+        // Trim leading whitespace
+        while (start < end && Character.isWhitespace(name.charAt(start))) {
+            start++;
+        }
+
+        // Trim trailing whitespace
+        while (end > start && Character.isWhitespace(name.charAt(end - 1))) {
+            end--;
+        }
+
+        for (int i = start; i < end; i++) {
+            char c = name.charAt(i);
+
+            if (c == '\n') {
+                // Skip newline entirely
+                if (sb == null) {
+                    sb = new StringBuilder(len);
+                    sb.append(name, start, i);
+                }
+                continue;
+            }
+
+            if (c == '\r' || c == '\t') {
+                if (sb == null) {
+                    sb = new StringBuilder(len);
+                    sb.append(name, start, i);
+                }
+                sb.append(' ');
+            } else if (sb != null) {
+                sb.append(c);
+            }
+        }
+
+        // If no replacements were needed, return the trimmed slice
+        return sb == null ? name.substring(start, end) : sb.toString();
     }
 
     @Override


### PR DESCRIPTION
Motivation:

The used regexp are pretty simple, so we can easily replace them with the custom loop to improve speed and reduce memory usage.

Modification:

Regexp removed and replaced with specialized custom loop.

Result:

No more pattern usages. Speed improved.
