### PR TITLE
IoUring:properly handle ERRNO_ECANCELED_NEGATIVE in splice

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -560,6 +560,9 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
             if (current instanceof IoUringFileRegion) {
                 IoUringFileRegion fileRegion = (IoUringFileRegion) current;
                 try {
+                    if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
+                        return true;
+                    }
                     int result = res >= 0 ? res : ioResult("io_uring splice", res);
                     if (result == 0 && fileRegion.count() > 0) {
                         validateFileRegion(fileRegion.fileRegion, fileRegion.transfered());


### PR DESCRIPTION

Motivation:

Need to properly handle ERRNO_ECANCELED_NEGATIVE in splice instead of throwing an exception

Modification:

Add processing for ERRNO_ECANCELED_NEGATIVE to the splice branch in writeComplete0

Result:

If there is no issue then describe the changes introduced by this PR.
