### PR TITLE
Add netty-build-common as dependency for maven-surefire-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1527,6 +1527,14 @@
            <!-- Ensure the whole stacktrace is preserved when an exception is thrown. See https://issues.apache.org/jira/browse/SUREFIRE-1457 -->
           <trimStackTrace>false</trimStackTrace>
         </configuration>
+        <dependencies>
+          <!-- Needed for TimedOutTestsListener -->
+          <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>netty-build-common</artifactId>
+            <version>${netty.build.version}</version>
+          </dependency>
+        </dependencies>
       </plugin>
       <!-- always produce osgi bundles -->
       <plugin>


### PR DESCRIPTION
Motivation:

We need to add the dependency as otherwise we might not be able to load the class

Modifications:

Add dependency

Result:

Be able to load listener