### PR TITLE
Remove regexp usage from HttpPostRequestEncoder

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
@@ -45,13 +45,10 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
-import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.regex.Pattern;
 
 import static io.netty.buffer.Unpooled.wrappedBuffer;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
-import static java.util.AbstractMap.SimpleImmutableEntry;
 
 /**
  * This encoder will help to encode Request for a FORM as POST.
@@ -94,16 +91,12 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
         HTML5
     }
 
-    @SuppressWarnings("rawtypes")
-    private static final Map.Entry[] percentEncodings;
-
-    static {
-        percentEncodings = new Map.Entry[] {
-                new SimpleImmutableEntry<Pattern, String>(Pattern.compile("\\*"), "%2A"),
-                new SimpleImmutableEntry<Pattern, String>(Pattern.compile("\\+"), "%20"),
-                new SimpleImmutableEntry<Pattern, String>(Pattern.compile("~"), "%7E")
-        };
-    }
+    private static final String ASTERISK = "*";
+    private static final String PLUS = "+";
+    private static final String TILDE = "~";
+    private static final String ASTERISK_REPLACEMENT = "%2A";
+    private static final String PLUS_REPLACEMENT = "%20";
+    private static final String TILDE_REPLACEMENT = "%7E";
 
     /**
      * Factory used to create InterfaceHttpData
@@ -832,7 +825,6 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
      * @throws ErrorDataEncoderException
      *             if the encoding is in error
      */
-    @SuppressWarnings("unchecked")
     private String encodeAttribute(String s, Charset charset) throws ErrorDataEncoderException {
         if (s == null) {
             return "";
@@ -840,10 +832,9 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
         try {
             String encoded = URLEncoder.encode(s, charset.name());
             if (encoderMode == EncoderMode.RFC3986) {
-                for (Map.Entry<Pattern, String> entry : percentEncodings) {
-                    String replacement = entry.getValue();
-                    encoded = entry.getKey().matcher(encoded).replaceAll(replacement);
-                }
+                encoded = encoded.replace(ASTERISK, ASTERISK_REPLACEMENT)
+                                 .replace(PLUS, PLUS_REPLACEMENT)
+                                 .replace(TILDE, TILDE_REPLACEMENT);
             }
             return encoded;
         } catch (UnsupportedEncodingException e) {


### PR DESCRIPTION
Motivation:

Regexp can be easily replaced with custom code. Makes code easier to read and simpler.

Modification:

Regexp replaced with simple `replace` methods chain.

Result:

No more regexp usage in `HttpPostRequestEncoder`
