### PR TITLE
Fix graal test

### DIFF
--- a/testsuite-native-image/pom.xml
+++ b/testsuite-native-image/pom.xml
@@ -35,6 +35,7 @@
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <packaging.type>jar</packaging.type>
     <native.maven.plugin.version>0.10.6</native.maven.plugin.version>
+    <native.classifier>${os.detected.name}-${os.detected.arch}</native.classifier>
   </properties>
 
   <dependencies>
@@ -128,21 +129,21 @@
           <groupId>io.netty</groupId>
           <artifactId>netty-transport-native-epoll</artifactId>
           <version>${project.version}</version>
-          <classifier>${os.detected.classifier}</classifier>
+          <classifier>${native.classifier}</classifier>
           <scope>runtime</scope>
         </dependency>
         <dependency>
           <groupId>io.netty</groupId>
           <artifactId>netty-transport-native-io_uring</artifactId>
           <version>${project.version}</version>
-          <classifier>${os.detected.classifier}</classifier>
+          <classifier>${native.classifier}</classifier>
           <scope>runtime</scope>
         </dependency>
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-codec-native-quic</artifactId>
           <version>${project.version}</version>
-          <classifier>${os.detected.classifier}</classifier>
+          <classifier>${native.classifier}</classifier>
         </dependency>
       </dependencies>
       <build>


### PR DESCRIPTION
Motivation:

We need to ensure we use a classifier without -fedora as otherwise we will fail to find the dependency

Modifications:

Use the correct classifier for native dependencies in testsuite-native-image

Result:

Graal CI jobs pass again