### PR TITLE
Add android-maven-plugin to pluginManagement section

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2006,6 +2006,11 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>com.simpligility.maven.plugins</groupId>
+          <artifactId>android-maven-plugin</artifactId>
+          <version>4.6.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
Motivation:

When building the project a warning was printed:

```
2025-05-23T06:11:05.3315134Z [WARNING]
2025-05-23T06:11:05.3316466Z [WARNING] Some problems were encountered while building the effective model for io.netty:netty-codec-native-quic:jar:4.2.2.Final-SNAPSHOT
2025-05-23T06:11:05.3319415Z [WARNING] 'build.plugins.plugin.version' for com.simpligility.maven.plugins:android-maven-plugin is missing. @ line 1155, column 15
2025-05-23T06:11:05.3320884Z [WARNING]
2025-05-23T06:11:05.3323519Z [WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
2025-05-23T06:11:05.3324556Z [WARNING]
2025-05-23T06:11:05.3325314Z [WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
2025-05-23T06:11:05.3326258Z [WARNING]
```

Modifications:

Add the missing config to pluginManagement section