### PR TITLE
KQueueSocketTestPermutation should not ignore SocketProtocolFamily wh…

### DIFF
--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTestPermutation.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTestPermutation.java
@@ -150,7 +150,17 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
                 new BootstrapFactory<Bootstrap>() {
                     @Override
                     public Bootstrap newInstance() {
-                        return new Bootstrap().group(KQUEUE_WORKER_GROUP).channel(KQueueDatagramChannel.class);
+                        return new Bootstrap().group(KQUEUE_WORKER_GROUP).channelFactory(new ChannelFactory<Channel>() {
+                            @Override
+                            public Channel newChannel() {
+                                return new KQueueDatagramChannel(family);
+                            }
+
+                            @Override
+                            public String toString() {
+                                return KQueueDatagramChannel.class.getSimpleName() + ".class";
+                            }
+                        });
                     }
                 }
         );


### PR DESCRIPTION
…en creating KQueueDatagramChannel

Motivation:

Due a bug we missed to construct the KQueueDatagramChannel with the correct constructor and so ignored the SocketProtocolFamily. This can lead to test-failures depending on how the system is configured

Modifications:

Construct KQueueDatagramChannel the correct way

Result:

No more testfailures related to datagram channels when running the testsuite with kqueue