### PR TITLE
Avoid `WebSocketServerHandshakerFactory` instance allocation

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshakerFactory.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshakerFactory.java
@@ -127,7 +127,11 @@ public class WebSocketServerHandshakerFactory {
      *         socket version is not supported.
      */
     public WebSocketServerHandshaker newHandshaker(HttpRequest req) {
+        return resolveHandshaker(req, webSocketURL, subprotocols, decoderConfig);
+    }
 
+    public static WebSocketServerHandshaker resolveHandshaker(HttpRequest req, String webSocketURL, String subprotocols,
+                                                              WebSocketDecoderConfig decoderConfig) {
         CharSequence version = req.headers().get(HttpHeaderNames.SEC_WEBSOCKET_VERSION);
         if (version != null) {
             if (version.equals(WebSocketVersion.V13.toHttpHeaderValue())) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
@@ -69,10 +69,10 @@ class WebSocketServerProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
             }
 
             try {
-                final WebSocketServerHandshakerFactory wsFactory = new WebSocketServerHandshakerFactory(
+                final WebSocketServerHandshaker handshaker = WebSocketServerHandshakerFactory.resolveHandshaker(
+                        req,
                         getWebSocketLocation(ctx.pipeline(), req, serverConfig.websocketPath()),
                         serverConfig.subprotocols(), serverConfig.decoderConfig());
-                final WebSocketServerHandshaker handshaker = wsFactory.newHandshaker(req);
                 final ChannelPromise localHandshakePromise = handshakePromise;
                 if (handshaker == null) {
                     WebSocketServerHandshakerFactory.sendUnsupportedVersionResponse(ctx.channel());


### PR DESCRIPTION
Motivation:

Each websocket handshake process allocates a `WebSocketServerProtocolHandshakeHandler` class instance, just to call a single method for handshake creation. This allocation could be simply avoided.

Modification:

Extracted `WebSocketServerHandskaerFactory.newHandshaker()` method to a new static `resolveHandshaker` method and invoke it from `WebSocketServerProtocolHandshakeHandler`.

Result:

Fewer allocations and GC work.