### PR TITLE
Kqueue: Only test for TCP_FASTOPEN if its supported

### DIFF
--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTestPermutation.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTestPermutation.java
@@ -39,9 +39,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static io.netty.channel.epoll.Native.IS_SUPPORTING_TCP_FASTOPEN_CLIENT;
-import static io.netty.channel.epoll.Native.IS_SUPPORTING_TCP_FASTOPEN_SERVER;
-
 class EpollSocketTestPermutation extends SocketTestPermutation {
 
     static final EpollSocketTestPermutation INSTANCE = new EpollSocketTestPermutation();
@@ -80,7 +77,7 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
                                             .channel(EpollServerSocketChannel.class);
             }
         });
-        if (IS_SUPPORTING_TCP_FASTOPEN_SERVER) {
+        if (Epoll.isTcpFastOpenServerSideAvailable()) {
             toReturn.add(new BootstrapFactory<ServerBootstrap>() {
                 @Override
                 public ServerBootstrap newInstance() {
@@ -127,7 +124,7 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
     public List<BootstrapFactory<Bootstrap>> clientSocketWithFastOpen() {
         List<BootstrapFactory<Bootstrap>> factories = clientSocket();
 
-        if (IS_SUPPORTING_TCP_FASTOPEN_CLIENT) {
+        if (Epoll.isTcpFastOpenClientSideAvailable()) {
             int insertIndex = factories.size() - 1; // Keep NIO fixture last.
             factories.add(insertIndex, new BootstrapFactory<Bootstrap>() {
                 @Override

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTestPermutation.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTestPermutation.java
@@ -68,15 +68,18 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
                                             .channel(KQueueServerSocketChannel.class);
             }
         });
-        toReturn.add(new BootstrapFactory<ServerBootstrap>() {
-            @Override
-            public ServerBootstrap newInstance() {
-                ServerBootstrap serverBootstrap = new ServerBootstrap().group(KQUEUE_BOSS_GROUP, KQUEUE_WORKER_GROUP)
-                                                                       .channel(KQueueServerSocketChannel.class);
-                serverBootstrap.option(ChannelOption.TCP_FASTOPEN, 1);
-                return serverBootstrap;
-            }
-        });
+        if (KQueue.isTcpFastOpenServerSideAvailable()) {
+            toReturn.add(new BootstrapFactory<ServerBootstrap>() {
+                @Override
+                public ServerBootstrap newInstance() {
+                    ServerBootstrap serverBootstrap = new ServerBootstrap()
+                            .group(KQUEUE_BOSS_GROUP, KQUEUE_WORKER_GROUP)
+                            .channel(KQueueServerSocketChannel.class);
+                    serverBootstrap.option(ChannelOption.TCP_FASTOPEN, 1);
+                    return serverBootstrap;
+                }
+            });
+        }
 
         toReturn.add(new BootstrapFactory<ServerBootstrap>() {
             @Override
@@ -114,14 +117,16 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
     public List<BootstrapFactory<Bootstrap>> clientSocketWithFastOpen() {
         List<BootstrapFactory<Bootstrap>> factories = clientSocket();
 
-        int insertIndex = factories.size() - 1; // Keep NIO fixture last.
-        factories.add(insertIndex, new BootstrapFactory<Bootstrap>() {
-            @Override
-            public Bootstrap newInstance() {
-                return new Bootstrap().group(KQUEUE_WORKER_GROUP).channel(KQueueSocketChannel.class)
-                        .option(ChannelOption.TCP_FASTOPEN_CONNECT, true);
-            }
-        });
+        if (KQueue.isTcpFastOpenClientSideAvailable()) {
+            int insertIndex = factories.size() - 1; // Keep NIO fixture last.
+            factories.add(insertIndex, new BootstrapFactory<Bootstrap>() {
+                @Override
+                public Bootstrap newInstance() {
+                    return new Bootstrap().group(KQUEUE_WORKER_GROUP).channel(KQueueSocketChannel.class)
+                            .option(ChannelOption.TCP_FASTOPEN_CONNECT, true);
+                }
+            });
+        }
 
         return factories;
     }


### PR DESCRIPTION
Motivation:

We should only add TCP_FASTOPEN variants to the SocketTestPermutations when its really supported.

Modifications:

- Add Kqueue.is* checks before adding variants
- Replace package-private static fields with public Epoll.is* methods in EpollSocketTestPermutation to make things consistent

Result:

Only try to test for TCP_FASTOPEN on macOS if really supported
