### PR TITLE
Fix resolving of netty-tcnative-boringssl-static SNAPSHOTS (#15267)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -617,6 +617,21 @@
         <tcnative.version>2.0.73.Final-SNAPSHOT</tcnative.version>
         <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
       </properties>
+
+      <!-- tcnative uses maven central for snapshots already -->
+      <repositories>
+        <repository>
+          <name>Central Portal Snapshots</name>
+          <id>central-portal-snapshots</id>
+          <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+        </repository>
+      </repositories>
     </profile>
     <profile>
       <id>leak</id>


### PR DESCRIPTION
Motivation:

We need to specify that netty-tcnative SNAPSHOTS are already deployed to maven central as otherwise it will try to pull them from the old repository. This was the reason why the CI builds failed with:

```
[INFO]
[INFO] -----------------------< io.netty:netty-handler >-----------------------
[INFO] Building Netty/Handler 4.2.2.Final-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
Warning:  The POM for io.netty:netty-tcnative-classes:jar:2.0.73.Final-SNAPSHOT is missing, no dependency information available
Warning:  The POM for io.netty:netty-tcnative-boringssl-static:jar:linux-x86_64:2.0.73.Final-SNAPSHOT is missing, no dependency information available
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.397 s
[INFO] Finished at: 2025-05-26T10:12:44Z
[INFO] ------------------------------------------------------------------------
Error:  Failed to execute goal on project netty-handler: Could not resolve dependencies for project io.netty:netty-handler:jar:4.2.2.Final-SNAPSHOT
Error:  dependency: io.netty:netty-tcnative-classes:jar:2.0.73.Final-SNAPSHOT (compile?)
Error:  	Could not find artifact io.netty:netty-tcnative-classes:jar:2.0.73.Final-SNAPSHOT in sonatype-nexus-snapshots (https://oss.sonatype.org/content/repositories/snapshots)
Error:  dependency: io.netty:netty-tcnative-boringssl-static:jar:linux-x86_64:2.0.73.Final-SNAPSHOT (runtime?)
Error:  	Could not find artifact io.netty:netty-tcnative-boringssl-static:jar:linux-x86_64:2.0.73.Final-SNAPSHOT in sonatype-nexus-snapshots (https://oss.sonatype.org/content/repositories/snapshots)
Error:  -> [Help 1]
Error:
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
```

Modifications:

Add repositories section to profile

Result:

Build works again when enabling the boringssl-snapshot profile