### PR TITLE
Fix netty-buffer OSGi metadata

### DIFF
--- a/buffer/pom.xml
+++ b/buffer/pom.xml
@@ -39,6 +39,8 @@
       <version>${graalvm.version}</version>
       <!-- Provided scope as it is only needed for compiling the SVM substitution classes -->
       <scope>provided</scope>
+      <!-- Optional so maven-bundle-plugin does not make com.oracle.svm.core.annotate a required import -->
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Motivation:

native-image substitution classes delivered in #14928 results in failure
to install in OSGi:

```
Caused by: org.apache.felix.resolver.reason.ReasonException: Unable to resolve io.netty.buffer/4.2.1.Final: missing requirement [io.netty.buffer/4.2.1.Final] osgi.wiring.package; filter:="(osgi.wiring.package=com.oracle.svm.core.annotate)"
```

Modifications:

Mark org.graalvm.nativeimage/svm as optional=true.

Result:

Fixes fixing #15136.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
