### PR TITLE
Deprecate WebSocketServerHandshaker.uri method

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
@@ -124,6 +124,7 @@ public abstract class WebSocketServerHandshaker {
     /**
      * Returns the URL of the web socket
      */
+    @Deprecated
     public String uri() {
         return uri;
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
@@ -132,13 +132,6 @@ class WebSocketServerProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
         return true;
     }
 
-    private static void sendHttpResponse(ChannelHandlerContext ctx, HttpRequest req, HttpResponse res) {
-        ChannelFuture f = ctx.writeAndFlush(res);
-        if (!isKeepAlive(req) || res.status().code() != 200) {
-            f.addListener(ChannelFutureListener.CLOSE);
-        }
-    }
-
     private static String getWebSocketLocation(ChannelPipeline cp, HttpRequest req, String path) {
         String protocol = "ws";
         if (cp.get(SslHandler.class) != null) {


### PR DESCRIPTION
Motivation:

Currently, `WebSocketServerProtocolHandshakeHandler` constructs `websocketUrl` on every handshake, by calling `WebSocketServerProtocolHandshakeHandler.getWebSocketLocation`. The problem here is that the constructed URI `WebSocketServerHandshaker.uri` is used only by `WebSocketServerHandshaker00`, which is a fallback in case WebSocket protocol version wasn't detected. By deprecating this method for the removal in future Netty versions, we would be able to fully remove the field `WebSocketServerHandshaker.uri` and avoid unnecessary allocation on handshake.

Modification:

Deprecated `WebSocketServerHandshaker.uri()` and removed unused method from `WebSocketServerProtocolHandshakeHandler`.

Result:

Deprecated `WebSocketServerHandshaker.uri()` is now deprecated.
