### PR TITLE
Avoid regexp usage in HttpVersion

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpVersion.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpVersion.java
@@ -15,15 +15,12 @@
  */
 package io.netty.handler.codec.http;
 
-import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
-import static io.netty.util.internal.ObjectUtil.checkNonEmptyAfterTrim;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.ObjectUtil;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import static io.netty.util.internal.ObjectUtil.checkNonEmptyAfterTrim;
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
 /**
  * The version of HTTP or its derived protocols, such as
@@ -32,8 +29,6 @@ import java.util.regex.Pattern;
  */
 public class HttpVersion implements Comparable<HttpVersion> {
 
-    private static final Pattern VERSION_PATTERN =
-        Pattern.compile("(\\S+)/(\\d+)\\.(\\d+)");
     static final String HTTP_1_0_STRING = "HTTP/1.0";
     static final String HTTP_1_1_STRING = "HTTP/1.1";
 
@@ -138,19 +133,30 @@ public class HttpVersion implements Comparable<HttpVersion> {
             majorVersion = toDecimal(text.charAt(5));
             minorVersion = toDecimal(text.charAt(7));
         } else {
-            Matcher m = VERSION_PATTERN.matcher(text);
-            if (!m.matches()) {
+            int slashIndex = text.indexOf('/');
+            int dotIndex = text.indexOf('.', slashIndex + 1);
+
+            if (slashIndex <= 0 || dotIndex <= slashIndex + 1 || dotIndex >= text.length() - 1) {
                 throw new IllegalArgumentException("invalid version format: " + text);
             }
 
-            protocolName = m.group(1);
-            majorVersion = Integer.parseInt(m.group(2));
-            minorVersion = Integer.parseInt(m.group(3));
+            protocolName = text.substring(0, slashIndex);
+            majorVersion = parseInt(text, slashIndex + 1, dotIndex);
+            minorVersion = parseInt(text, dotIndex + 1, text.length());
         }
 
         this.text = protocolName + '/' + majorVersion + '.' + minorVersion;
         this.keepAliveDefault = keepAliveDefault;
         bytes = null;
+    }
+
+    private static int parseInt(String text, int start, int end) {
+        int result = 0;
+        for (int i = start; i < end; i++) {
+            char ch = text.charAt(i);
+            result = result * 10 + toDecimal(ch);
+        }
+        return result;
     }
 
     private static int toDecimal(final int value) {


### PR DESCRIPTION
Motivation:

`HttpVersion` class initialization causes regexp pattern to compile and it keeps present in static field forever, while it is used in very rare code branch.

Modification:

Replace regexp with custom parsing for very rare code branch.

Result:

No more `Pattern.compile` on `HttpVersion` class initialization. Should improve netty cold start a bit.