### PR TITLE
Testsuite: Don't assume readerIndex is 0 in SocketFixedLengthEchoTest

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFixedLengthEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFixedLengthEchoTest.java
@@ -164,7 +164,7 @@ public class SocketFixedLengthEchoTest extends AbstractSocketTest {
             assertEquals(1024, msg.readableBytes());
 
             byte[] actual = new byte[msg.readableBytes()];
-            msg.getBytes(0, actual);
+            msg.getBytes(msg.readerIndex(), actual);
 
             int lastIdx = counter;
             for (int i = 0; i < actual.length; i ++) {


### PR DESCRIPTION
Motivation:

We sometimes did see the SocketFixedLengthEchoTest fail on the CI. While inspecting the testcode I noticed that it assumes that the readerIndex of the buffer is always 0 which might not be true.

Modifications:

- Replace getBytes(0, ....) with getBytes(msg.readerIndex(), ...)

Result:

Hopefully fixes the test failures we sometimes see