### PR TITLE
Testsuite: Make testing with wrapped / direct buffers more random

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/TestsuitePermutation.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/TestsuitePermutation.java
@@ -17,12 +17,15 @@ package io.netty.testsuite.transport;
 
 import io.netty.bootstrap.AbstractBootstrap;
 import io.netty.buffer.AdaptiveByteBufAllocator;
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledByteBufAllocator;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 
 public final class TestsuitePermutation {
     private static final AdaptiveByteBufAllocator DEFAULT_ADAPTIVE_ALLOCATOR = new AdaptiveByteBufAllocator();
@@ -44,5 +47,12 @@ public final class TestsuitePermutation {
     public interface BootstrapComboFactory<SB extends AbstractBootstrap<?, ?>, CB extends AbstractBootstrap<?, ?>> {
         SB newServerInstance();
         CB newClientInstance();
+    }
+
+    public static ByteBuf randomBufferType(ByteBufAllocator allocator, byte[] data, int offset, int length) {
+        if (ThreadLocalRandom.current().nextBoolean()) {
+            return allocator.directBuffer().writeBytes(data, offset, length);
+        }
+        return Unpooled.wrappedBuffer(data, offset, length);
     }
 }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/sctp/SctpEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/sctp/SctpEchoTest.java
@@ -35,6 +35,7 @@ import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.TestInfo;
 
+import static io.netty.testsuite.transport.TestsuitePermutation.randomBufferType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -172,7 +173,7 @@ public class SctpEchoTest extends AbstractSctpTest {
             }
 
             if (channel.parent() != null) {
-                channel.writeAndFlush(Unpooled.wrappedBuffer(actual));
+                channel.writeAndFlush(randomBufferType(channel.alloc(), actual, 0, actual.length));
             }
 
             counter += actual.length;

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketAutoReadTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketAutoReadTest.java
@@ -19,7 +19,6 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelHandlerContext;
@@ -36,6 +35,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static io.netty.testsuite.transport.TestsuitePermutation.randomBufferType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -81,11 +81,12 @@ public class SocketAutoReadTest extends AbstractSocketTest {
             clientChannel = cb.connect(serverChannel.localAddress()).syncUninterruptibly().channel();
 
             // 3 bytes means 3 independent reads for TestRecvByteBufAllocator
-            clientChannel.writeAndFlush(Unpooled.wrappedBuffer(new byte[3]));
+            clientChannel.writeAndFlush(randomBufferType(clientChannel.alloc(), new byte[3], 0, 3));
             serverInitializer.autoReadHandler.assertSingleRead();
 
             // 3 bytes means 3 independent reads for TestRecvByteBufAllocator
-            serverInitializer.channel.writeAndFlush(Unpooled.wrappedBuffer(new byte[3]));
+            serverInitializer.channel.writeAndFlush(
+                    randomBufferType(serverInitializer.channel.alloc(), new byte[3], 0, 3));
             clientInitializer.autoReadHandler.assertSingleRead();
 
             if (readOutsideEventLoopThread) {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketEchoTest.java
@@ -18,7 +18,6 @@ package io.netty.testsuite.transport.socket;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -39,6 +38,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
 
+import static io.netty.testsuite.transport.TestsuitePermutation.randomBufferType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
@@ -202,7 +202,7 @@ public class SocketEchoTest extends AbstractSocketTest {
 
         for (int i = 0; i < data.length;) {
             int length = Math.min(random.nextInt(1024 * 64), data.length - i);
-            ByteBuf buf = Unpooled.wrappedBuffer(data, i, length);
+            ByteBuf buf = randomBufferType(cc.alloc(), data, i, length);
             if (voidPromise) {
                 assertEquals(cc.voidPromise(), cc.writeAndFlush(buf, cc.voidPromise()));
             } else {
@@ -281,7 +281,8 @@ public class SocketEchoTest extends AbstractSocketTest {
             }
 
             if (channel.parent() != null) {
-                channel.write(Unpooled.wrappedBuffer(actual));
+
+                channel.write(randomBufferType(channel.alloc(), actual, 0, actual.length));
             }
 
             counter += actual.length;

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketExceptionHandlingTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketExceptionHandlingTest.java
@@ -17,7 +17,6 @@ package io.netty.testsuite.transport.socket;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -32,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.TestInfo;
 
+import static io.netty.testsuite.transport.TestsuitePermutation.randomBufferType;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -59,7 +59,7 @@ public class SocketExceptionHandlingTest extends AbstractSocketTest {
             cb.handler(new MyInitializer());
             clientChannel = cb.connect(serverChannel.localAddress()).syncUninterruptibly().channel();
 
-            clientChannel.writeAndFlush(Unpooled.wrappedBuffer(new byte[1024]));
+            clientChannel.writeAndFlush(randomBufferType(clientChannel.alloc(), new byte[1024], 0, 1024));
 
             // We expect to get 2 exceptions (1 from BuggyChannelHandler and 1 from ExceptionHandler).
             assertTrue(serverInitializer.exceptionHandler.latch1.await(5, TimeUnit.SECONDS));

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFileRegionTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFileRegionTest.java
@@ -18,7 +18,6 @@ package io.netty.testsuite.transport.socket;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandler;
@@ -41,6 +40,7 @@ import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static io.netty.testsuite.transport.TestsuitePermutation.randomBufferType;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -236,11 +236,13 @@ public class SocketFileRegionTest extends AbstractSocketTest {
         // See https://github.com/netty/netty/issues/2769
         //     https://github.com/netty/netty/issues/2964
         if (voidPromise) {
-            assertEquals(cc.voidPromise(), cc.write(Unpooled.wrappedBuffer(data, 0, bufferSize), cc.voidPromise()));
+            assertEquals(cc.voidPromise(), cc.write(
+                    randomBufferType(cc.alloc(), data, 0, bufferSize), cc.voidPromise()));
             assertEquals(cc.voidPromise(), cc.write(emptyRegion, cc.voidPromise()));
             assertEquals(cc.voidPromise(), cc.writeAndFlush(region, cc.voidPromise()));
         } else {
-            assertNotEquals(cc.voidPromise(), cc.write(Unpooled.wrappedBuffer(data, 0, bufferSize)));
+            assertNotEquals(cc.voidPromise(), cc.write(
+                    randomBufferType(cc.alloc(), data, 0, bufferSize)));
             assertNotEquals(cc.voidPromise(), cc.write(emptyRegion));
             assertNotEquals(cc.voidPromise(), cc.writeAndFlush(region));
         }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFixedLengthEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFixedLengthEchoTest.java
@@ -18,7 +18,6 @@ package io.netty.testsuite.transport.socket;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
@@ -32,6 +31,7 @@ import java.io.IOException;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static io.netty.testsuite.transport.TestsuitePermutation.randomBufferType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SocketFixedLengthEchoTest extends AbstractSocketTest {
@@ -97,7 +97,7 @@ public class SocketFixedLengthEchoTest extends AbstractSocketTest {
         Channel cc = cb.connect(sc.localAddress()).sync().channel();
         for (int i = 0; i < data.length;) {
             int length = Math.min(random.nextInt(1024 * 3), data.length - i);
-            cc.writeAndFlush(Unpooled.wrappedBuffer(data, i, length));
+            cc.writeAndFlush(randomBufferType(cc.alloc(), data, i, length));
             i += length;
         }
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketGatheringWriteTest.java
@@ -41,6 +41,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static io.netty.buffer.Unpooled.compositeBuffer;
 import static io.netty.buffer.Unpooled.wrappedBuffer;
+import static io.netty.testsuite.transport.TestsuitePermutation.randomBufferType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -158,11 +159,13 @@ public class SocketGatheringWriteTest extends AbstractSocketTest {
             if (composite && i % 2 == 0) {
                 int firstBufLength = length / 2;
                 CompositeByteBuf comp = compositeBuffer();
-                comp.addComponent(true, wrappedBuffer(data, i, firstBufLength))
-                    .addComponent(true, wrappedBuffer(data, i + firstBufLength, length - firstBufLength));
+                comp.addComponent(true,
+                                randomBufferType(cc.alloc(), data, i, firstBufLength))
+                    .addComponent(true,
+                            randomBufferType(cc.alloc(), data, i + firstBufLength, length - firstBufLength));
                 cc.write(comp);
             } else {
-                cc.write(wrappedBuffer(data, i, length));
+                cc.write(randomBufferType(cc.alloc(), data, i, length));
             }
             i += length;
         }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketReadPendingTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketReadPendingTest.java
@@ -19,7 +19,6 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelHandlerContext;
@@ -37,6 +36,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static io.netty.testsuite.transport.TestsuitePermutation.randomBufferType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -75,11 +75,12 @@ public class SocketReadPendingTest extends AbstractSocketTest {
             clientChannel = cb.connect(serverChannel.localAddress()).syncUninterruptibly().channel();
 
             // 4 bytes means 2 read loops for TestNumReadsRecvByteBufAllocator
-            clientChannel.writeAndFlush(Unpooled.wrappedBuffer(new byte[4]));
+            clientChannel.writeAndFlush(randomBufferType(clientChannel.alloc(), new byte[4], 0, 4));
 
             // 4 bytes means 2 read loops for TestNumReadsRecvByteBufAllocator
             assertTrue(serverInitializer.channelInitLatch.await(5, TimeUnit.SECONDS));
-            serverInitializer.channel.writeAndFlush(Unpooled.wrappedBuffer(new byte[4]));
+            serverInitializer.channel.writeAndFlush(
+                    randomBufferType(serverInitializer.channel.alloc(), new byte[4], 0 , 4));
 
             serverInitializer.channel.read();
             serverInitializer.readPendingHandler.assertAllRead();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketShutdownOutputBySelfTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketShutdownOutputBySelfTest.java
@@ -41,6 +41,7 @@ import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
+import static io.netty.testsuite.transport.TestsuitePermutation.randomBufferType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -73,7 +74,7 @@ public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
             assertFalse(ch.isOutputShutdown());
 
             s = ss.accept();
-            ch.writeAndFlush(Unpooled.wrappedBuffer(new byte[] { 1 })).sync();
+            ch.writeAndFlush(randomBufferType(ch.alloc(), new byte[] { 1 }, 0, 1)).sync();
             assertEquals(1, s.getInputStream().read());
 
             assertTrue(h.ch.isOpen());
@@ -199,7 +200,7 @@ public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
 
             try {
                 // If half-closed, the local endpoint shouldn't be able to write
-                ch.writeAndFlush(Unpooled.wrappedBuffer(new byte[]{ 2 })).sync();
+                ch.writeAndFlush(randomBufferType(ch.alloc(), new byte[]{ 2 }, 0 , 2)).sync();
                 fail();
             } catch (Throwable cause) {
                 checkThrowable(cause);

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
@@ -62,6 +62,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static io.netty.testsuite.transport.TestsuitePermutation.randomBufferType;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.is;
@@ -325,7 +326,7 @@ public class SocketSslEchoTest extends AbstractSocketTest {
         clientHandshakeFuture.sync();
         clientHandshakeEventLatch.await();
 
-        clientChannel.writeAndFlush(Unpooled.wrappedBuffer(data, 0, FIRST_MESSAGE_SIZE));
+        clientChannel.writeAndFlush(randomBufferType(clientChannel.alloc(), data, 0, FIRST_MESSAGE_SIZE));
         clientSendCounter.set(FIRST_MESSAGE_SIZE);
 
         boolean needsRenegotiation = renegotiation.type == RenegotiationType.CLIENT_INITIATED;
@@ -333,7 +334,7 @@ public class SocketSslEchoTest extends AbstractSocketTest {
         while (clientSendCounter.get() < data.length) {
             int clientSendCounterVal = clientSendCounter.get();
             int length = Math.min(random.nextInt(1024 * 64), data.length - clientSendCounterVal);
-            ByteBuf buf = Unpooled.wrappedBuffer(data, clientSendCounterVal, length);
+            ByteBuf buf = randomBufferType(clientChannel.alloc(), data, clientSendCounterVal, length);
             if (useCompositeByteBuf) {
                 buf = Unpooled.compositeBuffer().addComponent(true, buf);
             }
@@ -572,7 +573,7 @@ public class SocketSslEchoTest extends AbstractSocketTest {
                 assertEquals(data[i + lastIdx], actual[i]);
             }
 
-            ByteBuf buf = Unpooled.wrappedBuffer(actual);
+            ByteBuf buf = randomBufferType(ctx.alloc(), actual, 0, actual.length);
             if (useCompositeByteBuf) {
                 buf = Unpooled.compositeBuffer().addComponent(true, buf);
             }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslSessionReuseTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslSessionReuseTest.java
@@ -67,6 +67,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static io.netty.testsuite.transport.TestsuitePermutation.randomBufferType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -158,15 +159,16 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
 
         try {
             SSLSessionContext clientSessionCtx = clientCtx.sessionContext();
-            ByteBuf msg = Unpooled.wrappedBuffer(new byte[] { 0xa, 0xb, 0xc, 0xd }, 0, 4);
             Channel cc = cb.connect(sc.localAddress()).sync().channel();
+            ByteBuf msg = randomBufferType(cc.alloc(), new byte[] { 0xa, 0xb, 0xc, 0xd }, 0, 4);
+
             cc.writeAndFlush(msg).addListener(ChannelFutureListener.CLOSE).sync();
             cc.closeFuture().sync();
             rethrowHandlerExceptions(sh, ch);
             Set<String> sessions = sessionIdSet(clientSessionCtx.getIds());
 
-            msg = Unpooled.wrappedBuffer(new byte[] { 0xa, 0xb, 0xc, 0xd }, 0, 4);
             cc = cb.connect(sc.localAddress()).sync().channel();
+            msg = randomBufferType(cc.alloc(), new byte[] { 0xa, 0xb, 0xc, 0xd }, 0, 4);
             cc.writeAndFlush(msg).addListener(ChannelFutureListener.CLOSE).sync();
             cc.closeFuture().sync();
             assertEquals(sessions, sessionIdSet(clientSessionCtx.getIds()), "Expected no new sessions");
@@ -240,15 +242,15 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
         });
 
         try {
-            ByteBuf msg = Unpooled.wrappedBuffer(new byte[] { 0xa, 0xb, 0xc, 0xd }, 0, 4);
             Channel cc = cb.connect(sc.localAddress()).sync().channel();
+            ByteBuf msg = randomBufferType(cc.alloc(), new byte[] { 0xa, 0xb, 0xc, 0xd }, 0, 4);
             cc.writeAndFlush(msg).addListener(ChannelFutureListener.CLOSE).sync();
             cc.closeFuture().sync();
             rethrowHandlerExceptions(sh, ch);
             assertEquals("value", sessionValue.poll(10, TimeUnit.SECONDS));
 
-            msg = Unpooled.wrappedBuffer(new byte[] { 0xa, 0xb, 0xc, 0xd }, 0, 4);
             cc = cb.connect(sc.localAddress()).sync().channel();
+            msg = randomBufferType(cc.alloc(), new byte[] { 0xa, 0xb, 0xc, 0xd }, 0, 4);
             cc.writeAndFlush(msg).addListener(ChannelFutureListener.CLOSE).sync();
             cc.closeFuture().sync();
             rethrowHandlerExceptions(sh, ch);

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/WriteBeforeRegisteredTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/WriteBeforeRegisteredTest.java
@@ -16,7 +16,6 @@
 package io.netty.testsuite.transport.socket;
 
 import io.netty.bootstrap.Bootstrap;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.socket.SocketChannel;
@@ -25,6 +24,8 @@ import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
 
 import java.util.concurrent.TimeUnit;
+
+import static io.netty.testsuite.transport.TestsuitePermutation.randomBufferType;
 
 public class WriteBeforeRegisteredTest extends AbstractClientSocketTest {
 
@@ -44,7 +45,7 @@ public class WriteBeforeRegisteredTest extends AbstractClientSocketTest {
         SocketChannel ch = null;
         try {
             ch = (SocketChannel) cb.handler(h).connect(newSocketAddress()).channel();
-            ch.writeAndFlush(Unpooled.wrappedBuffer(new byte[] { 1 }));
+            ch.writeAndFlush(randomBufferType(ch.alloc(), new byte[] { 1 }, 0, 1));
         } finally {
             if (ch != null) {
                 ch.close();


### PR DESCRIPTION
Motivation:

In our testsuite we often just wrapped a byte[] and passed it to the write method. While this works it also might end up not testing often with direct buffers. We should make this a bit more random and so cover direct and heap buffers. The idea popped up when reviewing https://github.com/netty/netty/pull/15231

Modifications:

- Add new static helper method that will either return a wrapped buffer or a direct buffers in a random fashion
- Use this method to allocate buffers

Result:

More random testing of heap / direct buffers
