### PR TITLE
Fix Forbidden method invocation: java.lang.Runtime#availableProcessors() [use NettyRuntime#availableProcessors()]

### DIFF
--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/example/QuicServerSoReusePortExample.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/example/QuicServerSoReusePortExample.java
@@ -36,6 +36,7 @@ import io.netty.handler.codec.quic.QuicSslContext;
 import io.netty.handler.codec.quic.QuicSslContextBuilder;
 import io.netty.handler.codec.quic.QuicStreamChannel;
 import io.netty.util.CharsetUtil;
+import io.netty.util.NettyRuntime;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -56,7 +57,7 @@ public final class QuicServerSoReusePortExample {
                 selfSignedCertificate.privateKey(), null, selfSignedCertificate.certificate())
                 .applicationProtocols("http/0.9").build();
         // We will bind one socket to each EventLoopGroup.
-        int numCores = Runtime.getRuntime().availableProcessors();
+        int numCores = NettyRuntime.availableProcessors();
         EpollEventLoopGroup group = new EpollEventLoopGroup(numCores);
         try {
             Bootstrap bs = new Bootstrap().group(group)


### PR DESCRIPTION
Fix Forbidden method invocation: `java.lang.Runtime#availableProcessors() [use NettyRuntime#availableProcessors()]`

**Motivation:**

During the build

```
Apache Maven 3.9.9 (8e8579a9e76f7d015ee5ec7bfcdc97d260186937)
Maven home: /home/dlovison/.sdkman/candidates/maven/current
Java version: 1.8.0_452, vendor: Temurin, runtime: /home/dlovison/.sdkman/candidates/java/8.0.452-tem/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.13.12-200.fc41.x86_64", arch: "amd64", family: "unix"
```

I executed
```
 mvn clean install -DskipTests
```

I found the following
```
[ERROR] Forbidden method invocation: java.lang.Runtime#availableProcessors() [use NettyRuntime#availableProcessors()]
[ERROR]   in io.netty.handler.codec.quic.example.QuicServerSoReusePortExample (QuicServerSoReusePortExample.java:59)
[ERROR] Scanned 152 (and 294 related) class file(s) for forbidden API invocations (in 0.24s), 1 error(s).


[ERROR] Failed to execute goal de.thetaphi:forbiddenapis:2.2:testCheck (check-forbidden-test-apis) on project netty-codec-native-quic: Check for forbidden API calls failed, see log. -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:

```

Modification:

Changed to `NettyRuntime#availableProcessors()`

Result:

Build success

If there is no issue then describe the changes introduced by this PR.
