### PR TITLE
Fix build: Could not resolve dependencies for project

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -97,6 +97,31 @@
     </plugins>
   </build>
 
+  <profiles>
+    <profile>
+      <id>macos-build</id>
+      <activation>
+        <os>
+          <family>mac</family>
+        </os>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-resolver-dns-native-macos</artifactId>
+          <version>${project.version}</version>
+          <scope>runtime</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-kqueue</artifactId>
+          <version>${project.version}</version>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
   <dependencies>
     <!-- All release modules -->
     <dependency>
@@ -251,66 +276,9 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
-      <artifactId>netty-resolver-dns-classes-macos</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-resolver-dns-native-macos</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-resolver-dns-native-macos</artifactId>
-      <version>${project.version}</version>
-      <classifier>osx-x86_64</classifier>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-resolver-dns-native-macos</artifactId>
-      <version>${project.version}</version>
-      <classifier>osx-aarch_64</classifier>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-unix-common</artifactId>
       <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport-native-unix-common</artifactId>
-      <version>${project.version}</version>
-      <classifier>linux-aarch_64</classifier>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport-native-unix-common</artifactId>
-      <version>${project.version}</version>
-      <classifier>linux-riscv64</classifier>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport-native-unix-common</artifactId>
-      <version>${project.version}</version>
-      <classifier>linux-x86_64</classifier>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport-native-unix-common</artifactId>
-      <version>${project.version}</version>
-      <classifier>osx-x86_64</classifier>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport-native-unix-common</artifactId>
-      <version>${project.version}</version>
-      <classifier>osx-aarch_64</classifier>
+      <classifier>${jni.classifier}</classifier>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -322,81 +290,12 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
       <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport-native-epoll</artifactId>
-      <version>${project.version}</version>
-      <classifier>linux-aarch_64</classifier>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport-native-epoll</artifactId>
-      <version>${project.version}</version>
-      <classifier>linux-riscv64</classifier>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport-native-epoll</artifactId>
-      <version>${project.version}</version>
-      <classifier>linux-x86_64</classifier>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport-classes-io_uring</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport-native-io_uring</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport-native-io_uring</artifactId>
-      <version>${project.version}</version>
-      <classifier>linux-aarch_64</classifier>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-io_uring</artifactId>
       <version>${project.version}</version>
-      <classifier>linux-riscv64</classifier>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport-native-io_uring</artifactId>
-      <version>${project.version}</version>
-      <classifier>linux-x86_64</classifier>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport-classes-kqueue</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport-native-kqueue</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport-native-kqueue</artifactId>
-      <version>${project.version}</version>
-      <classifier>osx-x86_64</classifier>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport-native-kqueue</artifactId>
-      <version>${project.version}</version>
-      <classifier>osx-aarch_64</classifier>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -408,40 +307,6 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-native-quic</artifactId>
       <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-codec-native-quic</artifactId>
-      <version>${project.version}</version>
-      <classifier>linux-x86_64</classifier>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-codec-native-quic</artifactId>
-      <version>${project.version}</version>
-      <classifier>linux-aarch_64</classifier>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-codec-native-quic</artifactId>
-      <version>${project.version}</version>
-      <classifier>osx-x86_64</classifier>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-codec-native-quic</artifactId>
-      <version>${project.version}</version>
-      <classifier>osx-aarch_64</classifier>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-codec-native-quic</artifactId>
-      <version>${project.version}</version>
-      <classifier>windows-x86_64</classifier>
       <scope>runtime</scope>
     </dependency>
 
@@ -455,68 +320,12 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative</artifactId>
       <version>${tcnative.version}</version>
-      <classifier>linux-x86_64</classifier>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-tcnative</artifactId>
-      <version>${tcnative.version}</version>
-      <classifier>linux-x86_64-fedora</classifier>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-tcnative</artifactId>
-      <version>${tcnative.version}</version>
-      <classifier>osx-x86_64</classifier>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-tcnative</artifactId>
-      <version>${tcnative.version}</version>
-      <classifier>osx-aarch_64</classifier>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
       <version>${tcnative.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>${tcnative.version}</version>
-      <classifier>linux-x86_64</classifier>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>${tcnative.version}</version>
-      <classifier>linux-aarch_64</classifier>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>${tcnative.version}</version>
-      <classifier>osx-x86_64</classifier>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>${tcnative.version}</version>
-      <classifier>osx-aarch_64</classifier>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>${tcnative.version}</version>
-      <classifier>windows-x86_64</classifier>
       <scope>runtime</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Motivation:

During the build, I executed the following on Fedora 41

```
mvn clean install -DskipTests
```

```
Apache Maven 3.9.9 (8e8579a9e76f7d015ee5ec7bfcdc97d260186937)
Maven home: /home/dlovison/.sdkman/candidates/maven/current
Java version: 17.0.15, vendor: Eclipse Adoptium, runtime: /home/dlovison/.sdkman/candidates/java/17.0.15-tem
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.13.12-200.fc41.x86_64", arch: "amd64", family: "unix"

```
I have the following error
```
[INFO] Netty/BOM .......................................... FAILURE [  0.021 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  04:14 min
[INFO] Finished at: 2025-05-29T11:59:37-03:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project netty-bom: Could not resolve dependencies for project io.netty:netty-bom:pom:4.2.2.Final-SNAPSHOT
[ERROR] dependency: io.netty:netty-resolver-dns-native-macos:jar:osx-x86_64:4.2.2.Final-SNAPSHOT (runtime)
[ERROR]         io.netty:netty-resolver-dns-native-macos:jar:osx-x86_64:4.2.2.Final-SNAPSHOT was not found in https://oss.sonatype.org/content/repositories/snapshots during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of sonatype-nexus-snapshots has elapsed or updates are forced
[ERROR] dependency: io.netty:netty-resolver-dns-native-macos:jar:osx-aarch_64:4.2.2.Final-SNAPSHOT (runtime)
[ERROR]         io.netty:netty-resolver-dns-native-macos:jar:osx-aarch_64:4.2.2.Final-SNAPSHOT was not found in https://oss.sonatype.org/content/repositories/snapshots during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of sonatype-nexus-snapshots has elapsed or updates are forced
[ERROR] dependency: io.netty:netty-transport-native-unix-common:jar:linux-aarch_64:4.2.2.Final-SNAPSHOT (runtime)
[ERROR]         io.netty:netty-transport-native-unix-common:jar:linux-aarch_64:4.2.2.Final-SNAPSHOT was not found in https://oss.sonatype.org/content/repositories/snapshots during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of sonatype-nexus-snapshots has elapsed or updates are forced
[ERROR] dependency: io.netty:netty-transport-native-unix-common:jar:linux-riscv64:4.2.2.Final-SNAPSHOT (runtime)
[ERROR]         io.netty:netty-transport-native-unix-common:jar:linux-riscv64:4.2.2.Final-SNAPSHOT was not found in https://oss.sonatype.org/content/repositories/snapshots during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of sonatype-nexus-snapshots has elapsed or updates are forced
[ERROR] dependency: io.netty:netty-transport-native-unix-common:jar:osx-x86_64:4.2.2.Final-SNAPSHOT (runtime)
[ERROR]         io.netty:netty-transport-native-unix-common:jar:osx-x86_64:4.2.2.Final-SNAPSHOT was not found in https://oss.sonatype.org/content/repositories/snapshots during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of sonatype-nexus-snapshots has elapsed or updates are forced
[ERROR] dependency: io.netty:netty-transport-native-unix-common:jar:osx-aarch_64:4.2.2.Final-SNAPSHOT (runtime)
[ERROR]         io.netty:netty-transport-native-unix-common:jar:osx-aarch_64:4.2.2.Final-SNAPSHOT was not found in https://oss.sonatype.org/content/repositories/snapshots during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of sonatype-nexus-snapshots has elapsed or updates are forced
[ERROR] dependency: io.netty:netty-transport-native-epoll:jar:linux-aarch_64:4.2.2.Final-SNAPSHOT (runtime)
[ERROR]         io.netty:netty-transport-native-epoll:jar:linux-aarch_64:4.2.2.Final-SNAPSHOT was not found in https://oss.sonatype.org/content/repositories/snapshots during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of sonatype-nexus-snapshots has elapsed or updates are forced
[ERROR] dependency: io.netty:netty-transport-native-epoll:jar:linux-riscv64:4.2.2.Final-SNAPSHOT (runtime)
[ERROR]         io.netty:netty-transport-native-epoll:jar:linux-riscv64:4.2.2.Final-SNAPSHOT was not found in https://oss.sonatype.org/content/repositories/snapshots during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of sonatype-nexus-snapshots has elapsed or updates are forced
[ERROR] dependency: io.netty:netty-transport-native-io_uring:jar:linux-aarch_64:4.2.2.Final-SNAPSHOT (runtime)
[ERROR]         io.netty:netty-transport-native-io_uring:jar:linux-aarch_64:4.2.2.Final-SNAPSHOT was not found in https://oss.sonatype.org/content/repositories/snapshots during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of sonatype-nexus-snapshots has elapsed or updates are forced
[ERROR] dependency: io.netty:netty-transport-native-io_uring:jar:linux-riscv64:4.2.2.Final-SNAPSHOT (runtime)
[ERROR]         io.netty:netty-transport-native-io_uring:jar:linux-riscv64:4.2.2.Final-SNAPSHOT was not found in https://oss.sonatype.org/content/repositories/snapshots during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of sonatype-nexus-snapshots has elapsed or updates are forced
[ERROR] dependency: io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.2.2.Final-SNAPSHOT (runtime)
[ERROR]         io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.2.2.Final-SNAPSHOT was not found in https://oss.sonatype.org/content/repositories/snapshots during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of sonatype-nexus-snapshots has elapsed or updates are forced
[ERROR] dependency: io.netty:netty-transport-native-kqueue:jar:osx-aarch_64:4.2.2.Final-SNAPSHOT (runtime)
[ERROR]         io.netty:netty-transport-native-kqueue:jar:osx-aarch_64:4.2.2.Final-SNAPSHOT was not found in https://oss.sonatype.org/content/repositories/snapshots during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of sonatype-nexus-snapshots has elapsed or updates are forced
[ERROR] dependency: io.netty:netty-codec-native-quic:jar:linux-aarch_64:4.2.2.Final-SNAPSHOT (runtime)
[ERROR]         io.netty:netty-codec-native-quic:jar:linux-aarch_64:4.2.2.Final-SNAPSHOT was not found in https://oss.sonatype.org/content/repositories/snapshots during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of sonatype-nexus-snapshots has elapsed or updates are forced
[ERROR] dependency: io.netty:netty-codec-native-quic:jar:osx-x86_64:4.2.2.Final-SNAPSHOT (runtime)
[ERROR]         io.netty:netty-codec-native-quic:jar:osx-x86_64:4.2.2.Final-SNAPSHOT was not found in https://oss.sonatype.org/content/repositories/snapshots during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of sonatype-nexus-snapshots has elapsed or updates are forced
[ERROR] dependency: io.netty:netty-codec-native-quic:jar:osx-aarch_64:4.2.2.Final-SNAPSHOT (runtime)
[ERROR]         io.netty:netty-codec-native-quic:jar:osx-aarch_64:4.2.2.Final-SNAPSHOT was not found in https://oss.sonatype.org/content/repositories/snapshots during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of sonatype-nexus-snapshots has elapsed or updates are forced
[ERROR] dependency: io.netty:netty-codec-native-quic:jar:windows-x86_64:4.2.2.Final-SNAPSHOT (runtime)
[ERROR]         io.netty:netty-codec-native-quic:jar:windows-x86_64:4.2.2.Final-SNAPSHOT was not found in https://oss.sonatype.org/content/repositories/snapshots during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of sonatype-nexus-snapshots has elapsed or updates are forced
[ERROR] 
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :netty-bom

```

Modification:

Change `bom/pom.xml`:
* Add `${jni.classifier}` to reduce the number of dependencies of duplicated artificates with a different classifier
* Created a `macos-build` profile specific for builds on MacOS

Result:

The build is working on Fedora but must be tested on MacOS
