### PR TITLE
Kqueue: Delay removal from registration map to fix noisy warnings (#1…

### DIFF
--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
@@ -68,7 +68,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
     final BsdSocket socket;
     private boolean readFilterEnabled;
     private boolean writeFilterEnabled;
-    long registerId;
+    KQueueEventLoop.KQueueRegistration registration;
     boolean readReadyRunnablePending;
     boolean inputClosedSeenErrorOnRead;
     protected volatile boolean active;
@@ -151,7 +151,9 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
 
     @Override
     protected void doDeregister() throws Exception {
-        ((KQueueEventLoop) eventLoop()).remove(this);
+        if (registration != null) {
+            registration.remove();
+        }
 
         // As unregisteredFilters() may have not been called because isOpen() returned false we just set both filters
         // to false to ensure a consistent state in all cases.
@@ -195,7 +197,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
         // new EventLoop.
         readReadyRunnablePending = false;
 
-        registerId = ((KQueueEventLoop) eventLoop()).add(this);
+        registration = ((KQueueEventLoop) eventLoop()).add(this);
 
         // Add the write event first so we get notified of connection refused on the client side!
         if (writeFilterEnabled) {
@@ -364,8 +366,8 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
 
     private void evSet0(short filter, short flags, int fflags) {
         // Only try to add to changeList if the FD is still open, if not we already closed it in the meantime.
-        if (isOpen()) {
-            ((KQueueEventLoop) eventLoop()).evSet(this, filter, flags, fflags, 0, registerId);
+        if (isOpen() && registration != null) {
+            registration.evSet(filter, flags, fflags, 0);
         }
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventArray.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventArray.java
@@ -80,9 +80,9 @@ final class KQueueEventArray {
         size = 0;
     }
 
-    void evSet(AbstractKQueueChannel ch, short filter, short flags, int fflags, long data, long udata) {
+    void evSet(int ident, short filter, short flags, int fflags, long data, long udata) {
         reallocIfNeeded();
-        evSet(getKEventOffset(size++) + memoryAddress, ch.socket.intValue(), filter, flags,
+        evSet(getKEventOffset(size++) + memoryAddress, ident, filter, flags,
                 fflags, data, udata);
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannel.java
@@ -116,7 +116,9 @@ public final class KQueueSocketChannel extends AbstractKQueueStreamChannel imple
                     // because we try to read or write until the actual close happens which may be later due
                     // SO_LINGER handling.
                     // See https://github.com/netty/netty/issues/4449
-                    ((KQueueEventLoop) eventLoop()).remove(KQueueSocketChannel.this);
+                    if (registration != null) {
+                        registration.remove();
+                    }
                     return GlobalEventExecutor.INSTANCE;
                 }
             } catch (Throwable ignore) {


### PR DESCRIPTION
…5279)

Motivation:

In Kqueue it sometimes happened that we did see a WARN that the registration for a given id could not be found. The reason for this was that it is possible that the registration was already be cancelled by the user and so not present anymore. In this case the logs are harmless but still confusing. We should better ensure we handle it better.

Modifications:

When the user cancels a registration just mark it as cancelled and remove it from the map one all events are processed.

Result:

Less confusing logging and more correct handling of cancelled registrations