### PR TITLE
Re-enable sun.misc.Unsafe by default on Java 24+

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -616,7 +616,6 @@ final class PlatformDependent0 {
     }
 
     private static Throwable explicitNoUnsafeCause0() {
-        boolean explicitProperty = SystemPropertyUtil.contains("io.netty.noUnsafe");
         boolean noUnsafe = SystemPropertyUtil.getBoolean("io.netty.noUnsafe", false);
         logger.debug("-Dio.netty.noUnsafe: {}", noUnsafe);
 
@@ -625,10 +624,7 @@ final class PlatformDependent0 {
         String reason = "io.netty.noUnsafe";
         String unspecified = "<unspecified>";
         String unsafeMemoryAccess = SystemPropertyUtil.get("sun.misc.unsafe.memory.access", unspecified);
-        if (!explicitProperty && unspecified.equals(unsafeMemoryAccess) && javaVersion() >= 24) {
-            reason = "io.netty.noUnsafe=true by default on Java 24+";
-            noUnsafe = true;
-        } else if (!("allow".equals(unsafeMemoryAccess) || unspecified.equals(unsafeMemoryAccess))) {
+        if (!("allow".equals(unsafeMemoryAccess) || unspecified.equals(unsafeMemoryAccess))) {
             reason = "--sun-misc-unsafe-memory-access=" + unsafeMemoryAccess;
             noUnsafe = true;
         }


### PR DESCRIPTION
Motivation:
In https://github.com/netty/netty/pull/14943 we disabled Unsafe by default on Java 24+, to avoid producing warnings from the JVM. However, disabling the use of Unsafe also disables the hacks we use to access `ByteBuffer` cleaners to eagerly deallocate them. This can have dire performance consequences, particularly for busy applications.

Disabling the warnings from Unsafe also did nothing to stem the warnings produced by our JNI code, so many systems still see warnings anyway.

We should instead revert the changed default, and just tolerate the warning in Netty 4.1.

In Netty 4.2 we have https://github.com/netty/netty/pull/15231 as a long-term fix, where we avoid using Unsafe but will have a way to eagerly release the memory of our native ByteBuffer instances.

Modification:
Change the default for our Unsafe usage to no longer be disabled on Java 24+.

Result:
More consistent performance across Java versions.