### PR TITLE
Remove dependency on hamcrest (#15264)

### DIFF
--- a/buffer/pom.xml
+++ b/buffer/pom.xml
@@ -58,11 +58,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
@@ -59,12 +59,9 @@ import static io.netty.buffer.Unpooled.directBuffer;
 import static io.netty.buffer.Unpooled.unreleasableBuffer;
 import static io.netty.buffer.Unpooled.wrappedBuffer;
 import static io.netty.util.internal.EmptyArrays.EMPTY_BYTES;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -106,8 +103,8 @@ public abstract class AbstractByteBufTest {
     @AfterEach
     public void dispose() {
         if (buffer != null) {
-            assertThat(buffer.release(), is(true));
-            assertThat(buffer.refCnt(), is(0));
+            assertTrue(buffer.release());
+            assertEquals(0, buffer.refCnt());
 
             try {
                 buffer.release();
@@ -2612,19 +2609,19 @@ public abstract class AbstractByteBufTest {
 
         final AtomicInteger lastIndex = new AtomicInteger();
         buffer.setIndex(CAPACITY / 4, CAPACITY * 3 / 4);
-        assertThat(buffer.forEachByte(new ByteProcessor() {
+        assertEquals(-1, buffer.forEachByte(new ByteProcessor() {
             int i = CAPACITY / 4;
 
             @Override
             public boolean process(byte value) throws Exception {
-                assertThat(value, is((byte) (i + 1)));
+                assertEquals((byte) (i + 1), value);
                 lastIndex.set(i);
                 i ++;
                 return true;
             }
-        }), is(-1));
+        }));
 
-        assertThat(lastIndex.get(), is(CAPACITY * 3 / 4 - 1));
+        assertEquals(CAPACITY * 3 / 4 - 1, lastIndex.get());
     }
 
     @Test
@@ -2635,12 +2632,12 @@ public abstract class AbstractByteBufTest {
         }
 
         final int stop = CAPACITY / 2;
-        assertThat(buffer.forEachByte(CAPACITY / 3, CAPACITY / 3, new ByteProcessor() {
+        assertEquals(stop, buffer.forEachByte(CAPACITY / 3, CAPACITY / 3, new ByteProcessor() {
             int i = CAPACITY / 3;
 
             @Override
             public boolean process(byte value) throws Exception {
-                assertThat(value, is((byte) (i + 1)));
+                assertEquals((byte) (i + 1), value);
                 if (i == stop) {
                     return false;
                 }
@@ -2648,7 +2645,7 @@ public abstract class AbstractByteBufTest {
                 i++;
                 return true;
             }
-        }), is(stop));
+        }));
     }
 
     @Test
@@ -2659,19 +2656,19 @@ public abstract class AbstractByteBufTest {
         }
 
         final AtomicInteger lastIndex = new AtomicInteger();
-        assertThat(buffer.forEachByteDesc(CAPACITY / 4, CAPACITY * 2 / 4, new ByteProcessor() {
+        assertEquals(-1, buffer.forEachByteDesc(CAPACITY / 4, CAPACITY * 2 / 4, new ByteProcessor() {
             int i = CAPACITY * 3 / 4 - 1;
 
             @Override
             public boolean process(byte value) throws Exception {
-                assertThat(value, is((byte) (i + 1)));
+                assertEquals((byte) (i + 1), value);
                 lastIndex.set(i);
                 i --;
                 return true;
             }
-        }), is(-1));
+        }));
 
-        assertThat(lastIndex.get(), is(CAPACITY / 4));
+        assertEquals(CAPACITY / 4, lastIndex.get());
     }
 
     @Test

--- a/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
@@ -38,12 +38,10 @@ import static io.netty.buffer.Unpooled.compositeBuffer;
 import static io.netty.buffer.Unpooled.directBuffer;
 import static io.netty.buffer.Unpooled.wrappedBuffer;
 import static io.netty.util.internal.EmptyArrays.EMPTY_BYTES;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -651,10 +649,10 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
     public void testComponentMustBeDuplicate() {
         CompositeByteBuf buf = compositeBuffer();
         buf.addComponent(buffer(4, 6).setIndex(1, 3));
-        assertThat(buf.component(0), is(instanceOf(AbstractDerivedByteBuf.class)));
-        assertThat(buf.component(0).capacity(), is(4));
-        assertThat(buf.component(0).maxCapacity(), is(6));
-        assertThat(buf.component(0).readableBytes(), is(2));
+        assertInstanceOf(AbstractDerivedByteBuf.class, buf.component(0));
+        assertEquals(4, buf.component(0).capacity());
+        assertEquals(6, buf.component(0).maxCapacity());
+        assertEquals(2, buf.component(0).readableBytes());
         buf.release();
     }
 
@@ -665,19 +663,19 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
         ByteBuf c3 = buffer().writeByte(3).retain(2);
 
         CompositeByteBuf buf = compositeBuffer();
-        assertThat(buf.refCnt(), is(1));
+        assertEquals(1, buf.refCnt());
         buf.addComponents(c1, c2, c3);
 
-        assertThat(buf.refCnt(), is(1));
+        assertEquals(1, buf.refCnt());
 
         // Ensure that c[123]'s refCount did not change.
-        assertThat(c1.refCnt(), is(1));
-        assertThat(c2.refCnt(), is(2));
-        assertThat(c3.refCnt(), is(3));
+        assertEquals(1, c1.refCnt());
+        assertEquals(2, c2.refCnt());
+        assertEquals(3, c3.refCnt());
 
-        assertThat(buf.component(0).refCnt(), is(1));
-        assertThat(buf.component(1).refCnt(), is(2));
-        assertThat(buf.component(2).refCnt(), is(3));
+        assertEquals(1, buf.component(0).refCnt());
+        assertEquals(2, buf.component(1).refCnt());
+        assertEquals(3, buf.component(2).refCnt());
 
         c3.release(2);
         c2.release();
@@ -697,24 +695,24 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
         bufB.addComponents(bufA);
 
         // Ensure that bufA.refCnt() did not change.
-        assertThat(bufA.refCnt(), is(1));
+        assertEquals(1, bufA.refCnt());
 
         // Ensure that c[123]'s refCnt did not change.
-        assertThat(c1.refCnt(), is(1));
-        assertThat(c2.refCnt(), is(2));
-        assertThat(c3.refCnt(), is(3));
+        assertEquals(1, c1.refCnt());
+        assertEquals(2, c2.refCnt());
+        assertEquals(3, c3.refCnt());
 
         // This should decrease bufA.refCnt().
         bufB.release();
-        assertThat(bufB.refCnt(), is(0));
+        assertEquals(0, bufB.refCnt());
 
         // Ensure bufA.refCnt() changed.
-        assertThat(bufA.refCnt(), is(0));
+        assertEquals(0, bufA.refCnt());
 
         // Ensure that c[123]'s refCnt also changed due to the deallocation of bufA.
-        assertThat(c1.refCnt(), is(0));
-        assertThat(c2.refCnt(), is(1));
-        assertThat(c3.refCnt(), is(2));
+        assertEquals(0, c1.refCnt());
+        assertEquals(1, c2.refCnt());
+        assertEquals(2, c3.refCnt());
 
         c3.release(2);
         c2.release();
@@ -727,20 +725,20 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
         ByteBuf c3 = buffer().writeByte(3).retain(2);
 
         CompositeByteBuf buf = compositeBuffer();
-        assertThat(buf.refCnt(), is(1));
+        assertEquals(1, buf.refCnt());
 
         List<ByteBuf> components = new ArrayList<ByteBuf>();
         Collections.addAll(components, c1, c2, c3);
         buf.addComponents(components);
 
         // Ensure that c[123]'s refCount did not change.
-        assertThat(c1.refCnt(), is(1));
-        assertThat(c2.refCnt(), is(2));
-        assertThat(c3.refCnt(), is(3));
+        assertEquals(1, c1.refCnt());
+        assertEquals(2, c2.refCnt());
+        assertEquals(3, c3.refCnt());
 
-        assertThat(buf.component(0).refCnt(), is(1));
-        assertThat(buf.component(1).refCnt(), is(2));
-        assertThat(buf.component(2).refCnt(), is(3));
+        assertEquals(1, buf.component(0).refCnt());
+        assertEquals(2, buf.component(1).refCnt());
+        assertEquals(3, buf.component(2).refCnt());
 
         c3.release(2);
         c2.release();
@@ -756,11 +754,11 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
                         .addComponent(wrappedBuffer(new byte[]{3, 4})).slice(1, 2));
 
         ByteBuffer[] nioBuffers = buf.nioBuffers(0, 2);
-        assertThat(nioBuffers.length, is(2));
-        assertThat(nioBuffers[0].remaining(), is(1));
-        assertThat(nioBuffers[0].get(), is((byte) 2));
-        assertThat(nioBuffers[1].remaining(), is(1));
-        assertThat(nioBuffers[1].get(), is((byte) 3));
+        assertEquals(2, nioBuffers.length);
+        assertEquals(1, nioBuffers[0].remaining());
+        assertEquals(2, nioBuffers[0].get());
+        assertEquals(1, nioBuffers[1].remaining());
+        assertEquals(3, nioBuffers[1].get());
 
         buf.release();
     }

--- a/buffer/src/test/java/io/netty/buffer/AbstractPooledByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractPooledByteBufTest.java
@@ -18,9 +18,7 @@ package io.netty.buffer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -48,7 +46,7 @@ public abstract class AbstractPooledByteBufTest extends AbstractByteBufTest {
     public void ensureWritableWithEnoughSpaceShouldNotThrow() {
         ByteBuf buf = newBuffer(1, 10);
         buf.ensureWritable(3);
-        assertThat(buf.writableBytes(), is(greaterThanOrEqualTo(3)));
+        assertThat(buf.writableBytes()).isGreaterThanOrEqualTo(3);
         buf.release();
     }
 

--- a/buffer/src/test/java/io/netty/buffer/ByteBufDerivationTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufDerivationTest.java
@@ -21,8 +21,11 @@ import org.junit.jupiter.api.Test;
 import java.nio.ByteOrder;
 import java.util.Random;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Tests wrapping a wrapped buffer does not go way too deep chaining.
@@ -34,16 +37,16 @@ public class ByteBufDerivationTest {
         ByteBuf buf = Unpooled.buffer(8).setIndex(1, 7);
         ByteBuf slice = buf.slice(1, 7);
 
-        assertThat(slice, instanceOf(AbstractUnpooledSlicedByteBuf.class));
-        assertThat(slice.unwrap(), sameInstance(buf));
-        assertThat(slice.readerIndex(), is(0));
-        assertThat(slice.writerIndex(), is(7));
-        assertThat(slice.capacity(), is(7));
-        assertThat(slice.maxCapacity(), is(7));
+        assertInstanceOf(AbstractUnpooledSlicedByteBuf.class, slice);
+        assertSame(buf, slice.unwrap());
+        assertEquals(0, slice.readerIndex());
+        assertEquals(7, slice.writerIndex());
+        assertEquals(7, slice.capacity());
+        assertEquals(7, slice.maxCapacity());
 
         slice.setIndex(1, 6);
-        assertThat(buf.readerIndex(), is(1));
-        assertThat(buf.writerIndex(), is(7));
+        assertEquals(1, buf.readerIndex());
+        assertEquals(7, buf.writerIndex());
     }
 
     @Test
@@ -52,11 +55,11 @@ public class ByteBufDerivationTest {
         ByteBuf slice = buf.slice(1, 7);
         ByteBuf slice2 = slice.slice(0, 6);
 
-        assertThat(slice2, not(sameInstance(slice)));
-        assertThat(slice2, instanceOf(AbstractUnpooledSlicedByteBuf.class));
-        assertThat(slice2.unwrap(), sameInstance(buf));
-        assertThat(slice2.writerIndex(), is(6));
-        assertThat(slice2.capacity(), is(6));
+        assertNotSame(slice, slice2);
+        assertInstanceOf(AbstractUnpooledSlicedByteBuf.class, slice2);
+        assertSame(buf, slice2.unwrap());
+        assertEquals(6, slice2.writerIndex());
+        assertEquals(6, slice2.capacity());
     }
 
     @Test
@@ -64,16 +67,16 @@ public class ByteBufDerivationTest {
         ByteBuf buf = Unpooled.buffer(8).setIndex(1, 7);
         ByteBuf dup = buf.duplicate();
 
-        assertThat(dup, instanceOf(DuplicatedByteBuf.class));
-        assertThat(dup.unwrap(), sameInstance(buf));
-        assertThat(dup.readerIndex(), is(buf.readerIndex()));
-        assertThat(dup.writerIndex(), is(buf.writerIndex()));
-        assertThat(dup.capacity(), is(buf.capacity()));
-        assertThat(dup.maxCapacity(), is(buf.maxCapacity()));
+        assertInstanceOf(DuplicatedByteBuf.class, dup);
+        assertSame(buf, dup.unwrap());
+        assertEquals(buf.readerIndex(), dup.readerIndex());
+        assertEquals(buf.writerIndex(), dup.writerIndex());
+        assertEquals(buf.capacity(), dup.capacity());
+        assertEquals(buf.maxCapacity(), dup.maxCapacity());
 
         dup.setIndex(2, 6);
-        assertThat(buf.readerIndex(), is(1));
-        assertThat(buf.writerIndex(), is(7));
+        assertEquals(1, buf.readerIndex());
+        assertEquals(7, buf.writerIndex());
     }
 
     @Test
@@ -82,13 +85,13 @@ public class ByteBufDerivationTest {
         ByteBuf dup = buf.duplicate().setIndex(2, 6);
         ByteBuf dup2 = dup.duplicate();
 
-        assertThat(dup2, not(sameInstance(dup)));
-        assertThat(dup2, instanceOf(DuplicatedByteBuf.class));
-        assertThat(dup2.unwrap(), sameInstance(buf));
-        assertThat(dup2.readerIndex(), is(dup.readerIndex()));
-        assertThat(dup2.writerIndex(), is(dup.writerIndex()));
-        assertThat(dup2.capacity(), is(dup.capacity()));
-        assertThat(dup2.maxCapacity(), is(dup.maxCapacity()));
+        assertNotSame(dup, dup2);
+        assertInstanceOf(DuplicatedByteBuf.class, dup2);
+        assertSame(buf, dup2.unwrap());
+        assertEquals(dup.readerIndex(), dup2.readerIndex());
+        assertEquals(dup.writerIndex(), dup2.writerIndex());
+        assertEquals(dup.capacity(), dup2.capacity());
+        assertEquals(dup.maxCapacity(), dup2.maxCapacity());
     }
 
     @Test
@@ -96,15 +99,15 @@ public class ByteBufDerivationTest {
         ByteBuf buf = Unpooled.buffer(8).setIndex(1, 7);
         ByteBuf ro = Unpooled.unmodifiableBuffer(buf);
 
-        assertThat(ro, instanceOf(ReadOnlyByteBuf.class));
-        assertThat(ro.unwrap(), sameInstance(buf));
-        assertThat(ro.readerIndex(), is(buf.readerIndex()));
-        assertThat(ro.writerIndex(), is(buf.writerIndex()));
-        assertThat(ro.capacity(), is(buf.capacity()));
-        assertThat(ro.maxCapacity(), is(buf.maxCapacity()));
+        assertInstanceOf(ReadOnlyByteBuf.class, ro);
+        assertSame(buf, ro.unwrap());
+        assertEquals(buf.readerIndex(), ro.readerIndex());
+        assertEquals(buf.writerIndex(), ro.writerIndex());
+        assertEquals(buf.capacity(), ro.capacity());
+        assertEquals(buf.maxCapacity(), ro.maxCapacity());
 
         ro.setIndex(2, 6);
-        assertThat(buf.readerIndex(), is(1));
+        assertEquals(1, buf.readerIndex());
     }
 
     @Test
@@ -113,13 +116,13 @@ public class ByteBufDerivationTest {
         ByteBuf ro = Unpooled.unmodifiableBuffer(buf).setIndex(2, 6);
         ByteBuf ro2 = Unpooled.unmodifiableBuffer(ro);
 
-        assertThat(ro2, not(sameInstance(ro)));
-        assertThat(ro2, instanceOf(ReadOnlyByteBuf.class));
-        assertThat(ro2.unwrap(), sameInstance(buf));
-        assertThat(ro2.readerIndex(), is(ro.readerIndex()));
-        assertThat(ro2.writerIndex(), is(ro.writerIndex()));
-        assertThat(ro2.capacity(), is(ro.capacity()));
-        assertThat(ro2.maxCapacity(), is(ro.maxCapacity()));
+        assertNotSame(ro, ro2);
+        assertInstanceOf(ReadOnlyByteBuf.class, ro2);
+        assertSame(buf, ro2.unwrap());
+        assertEquals(ro.readerIndex(), ro2.readerIndex());
+        assertEquals(ro.writerIndex(), ro2.writerIndex());
+        assertEquals(ro.capacity(), ro2.capacity());
+        assertEquals(ro.maxCapacity(), ro2.maxCapacity());
     }
 
     @Test
@@ -128,12 +131,12 @@ public class ByteBufDerivationTest {
         ByteBuf dup = buf.duplicate().setIndex(2, 6);
         ByteBuf ro = Unpooled.unmodifiableBuffer(dup);
 
-        assertThat(ro, instanceOf(ReadOnlyByteBuf.class));
-        assertThat(ro.unwrap(), sameInstance(buf));
-        assertThat(ro.readerIndex(), is(dup.readerIndex()));
-        assertThat(ro.writerIndex(), is(dup.writerIndex()));
-        assertThat(ro.capacity(), is(dup.capacity()));
-        assertThat(ro.maxCapacity(), is(dup.maxCapacity()));
+        assertInstanceOf(ReadOnlyByteBuf.class, ro);
+        assertSame(buf, ro.unwrap());
+        assertEquals(dup.readerIndex(), ro.readerIndex());
+        assertEquals(dup.writerIndex(), ro.writerIndex());
+        assertEquals(dup.capacity(), ro.capacity());
+        assertEquals(dup.maxCapacity(), ro.maxCapacity());
     }
 
     @Test
@@ -142,12 +145,12 @@ public class ByteBufDerivationTest {
         ByteBuf ro = Unpooled.unmodifiableBuffer(buf).setIndex(2, 6);
         ByteBuf dup = ro.duplicate();
 
-        assertThat(dup, instanceOf(ReadOnlyByteBuf.class));
-        assertThat(dup.unwrap(), sameInstance(buf));
-        assertThat(dup.readerIndex(), is(ro.readerIndex()));
-        assertThat(dup.writerIndex(), is(ro.writerIndex()));
-        assertThat(dup.capacity(), is(ro.capacity()));
-        assertThat(dup.maxCapacity(), is(ro.maxCapacity()));
+        assertInstanceOf(ReadOnlyByteBuf.class, ro);
+        assertSame(buf, ro.unwrap());
+        assertEquals(dup.readerIndex(), ro.readerIndex());
+        assertEquals(dup.writerIndex(), ro.writerIndex());
+        assertEquals(dup.capacity(), ro.capacity());
+        assertEquals(dup.maxCapacity(), ro.maxCapacity());
     }
 
     @Test
@@ -155,14 +158,14 @@ public class ByteBufDerivationTest {
         ByteBuf buf = Unpooled.buffer(8).setIndex(1, 7);
         ByteBuf swapped = buf.order(ByteOrder.LITTLE_ENDIAN);
 
-        assertThat(swapped, instanceOf(SwappedByteBuf.class));
-        assertThat(swapped.unwrap(), sameInstance(buf));
-        assertThat(swapped.order(ByteOrder.LITTLE_ENDIAN), sameInstance(swapped));
-        assertThat(swapped.order(ByteOrder.BIG_ENDIAN), sameInstance(buf));
+        assertInstanceOf(SwappedByteBuf.class, swapped);
+        assertSame(buf, swapped.unwrap());
+        assertSame(swapped, swapped.order(ByteOrder.LITTLE_ENDIAN));
+        assertSame(buf, swapped.order(ByteOrder.BIG_ENDIAN));
 
         buf.setIndex(2, 6);
-        assertThat(swapped.readerIndex(), is(2));
-        assertThat(swapped.writerIndex(), is(6));
+        assertEquals(2, swapped.readerIndex());
+        assertEquals(6, swapped.writerIndex());
     }
 
     @Test
@@ -190,10 +193,8 @@ public class ByteBufDerivationTest {
                 throw new Error();
             }
 
-            assertThat("nest level of " + newDerived, nestLevel(newDerived), is(lessThanOrEqualTo(3)));
-            assertThat(
-                    "nest level of " + newDerived.order(ByteOrder.BIG_ENDIAN),
-                    nestLevel(newDerived.order(ByteOrder.BIG_ENDIAN)), is(lessThanOrEqualTo(2)));
+            assertThat(nestLevel(newDerived)).isLessThanOrEqualTo(3);
+            assertThat(nestLevel(newDerived.order(ByteOrder.BIG_ENDIAN))).isLessThanOrEqualTo(2);
 
             derived = newDerived;
         }

--- a/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
@@ -33,13 +33,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static io.netty.buffer.Unpooled.unreleasableBuffer;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -684,7 +682,7 @@ public class ByteBufUtilTest {
     }
 
     private static void assertWrapped(ByteBuf buf) {
-        assertThat(buf, instanceOf(WrappedByteBuf.class));
+        assertInstanceOf(WrappedByteBuf.class, buf);
     }
 
     @ParameterizedTest(name = PARAMETERIZED_NAME)
@@ -1034,8 +1032,8 @@ public class ByteBufUtilTest {
             slice.writerIndex(0);
 
             assertTrue(slice.hasArray());
-            assertThat(slice.arrayOffset(), is(1));
-            assertThat(slice.array().length, is(buf.capacity()));
+            assertEquals(1, slice.arrayOffset());
+            assertEquals(buf.capacity(), slice.array().length);
 
             checkGetBytes(slice);
         } finally {
@@ -1055,8 +1053,8 @@ public class ByteBufUtilTest {
             slice.writerIndex(0);
 
             assertTrue(slice.hasArray());
-            assertThat(slice.arrayOffset(), is(0));
-            assertThat(slice.array().length, greaterThan(slice.capacity()));
+            assertEquals(0, slice.arrayOffset());
+            assertThat(slice.array().length).isGreaterThan(slice.capacity());
 
             checkGetBytes(slice);
         } finally {

--- a/buffer/src/test/java/io/netty/buffer/EmptyByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/EmptyByteBufTest.java
@@ -18,10 +18,10 @@ package io.netty.buffer;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -65,26 +65,25 @@ public class EmptyByteBufTest {
     @Test
     public void testArray() {
         EmptyByteBuf empty = new EmptyByteBuf(UnpooledByteBufAllocator.DEFAULT);
-        assertThat(empty.hasArray(), is(true));
-        assertThat(empty.array().length, is(0));
-        assertThat(empty.arrayOffset(), is(0));
+        assertTrue(empty.hasArray());
+        assertEquals(0, empty.array().length);
+        assertEquals(0, empty.arrayOffset());
     }
 
     @Test
     public void testNioBuffer() {
         EmptyByteBuf empty = new EmptyByteBuf(UnpooledByteBufAllocator.DEFAULT);
-        assertThat(empty.nioBufferCount(), is(1));
-        assertThat(empty.nioBuffer().position(), is(0));
-        assertThat(empty.nioBuffer().limit(), is(0));
-        assertThat(empty.nioBuffer(), is(sameInstance(empty.nioBuffer())));
-        assertThat(empty.nioBuffer(), is(sameInstance(empty.internalNioBuffer(empty.readerIndex(), 0))));
+        assertEquals(1, empty.nioBufferCount());
+        assertEquals(0, empty.nioBuffer().position());
+        assertEquals(0, empty.nioBuffer().limit());
+        assertSame(empty.nioBuffer(), empty.internalNioBuffer(empty.readerIndex(), 0));
     }
 
     @Test
     public void testMemoryAddress() {
         EmptyByteBuf empty = new EmptyByteBuf(UnpooledByteBufAllocator.DEFAULT);
         if (empty.hasMemoryAddress()) {
-            assertThat(empty.memoryAddress(), is(not(0L)));
+            assertNotEquals(0L, empty.memoryAddress());
         } else {
             try {
                 empty.memoryAddress();

--- a/buffer/src/test/java/io/netty/buffer/SimpleLeakAwareCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SimpleLeakAwareCompositeByteBufTest.java
@@ -17,7 +17,7 @@ package io.netty.buffer;
 
 import io.netty.util.ByteProcessor;
 import io.netty.util.ResourceLeakTracker;
-import org.hamcrest.CoreMatchers;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,8 +25,8 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayDeque;
 import java.util.Queue;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -138,9 +138,9 @@ public class SimpleLeakAwareCompositeByteBufTest extends WrappedCompositeByteBuf
     @Test
     public void forEachByteUnderLeakDetectionShouldNotThrowException() {
         CompositeByteBuf buf = (CompositeByteBuf) newBuffer(8);
-        assertThat(buf, CoreMatchers.instanceOf(SimpleLeakAwareCompositeByteBuf.class));
+        assertInstanceOf(SimpleLeakAwareCompositeByteBuf.class, buf);
         CompositeByteBuf comp = (CompositeByteBuf) newBuffer(8);
-        assertThat(comp, CoreMatchers.instanceOf(SimpleLeakAwareCompositeByteBuf.class));
+        assertInstanceOf(SimpleLeakAwareCompositeByteBuf.class, comp);
 
         ByteBuf inner = comp.alloc().directBuffer(1).writeByte(0);
         comp.addComponent(true, inner);

--- a/codec-dns/pom.xml
+++ b/codec-dns/pom.xml
@@ -92,11 +92,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsQueryTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsQueryTest.java
@@ -25,8 +25,6 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -58,10 +56,10 @@ public class DnsQueryTest {
                 new DefaultDnsQuestion("example.com", DnsRecordType.CNAME)));
 
         for (DnsQuery query: queries) {
-            assertThat(query.count(DnsSection.QUESTION), is(1));
-            assertThat(query.count(DnsSection.ANSWER), is(0));
-            assertThat(query.count(DnsSection.AUTHORITY), is(0));
-            assertThat(query.count(DnsSection.ADDITIONAL), is(0));
+            assertEquals(1, query.count(DnsSection.QUESTION));
+            assertEquals(0, query.count(DnsSection.ANSWER));
+            assertEquals(0, query.count(DnsSection.AUTHORITY));
+            assertEquals(0, query.count(DnsSection.ADDITIONAL));
 
             assertTrue(writeChannel.writeOutbound(query));
 

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsResponseTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsResponseTest.java
@@ -26,9 +26,10 @@ import org.junit.jupiter.api.function.Executable;
 
 import java.net.InetSocketAddress;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DnsResponseTest {
@@ -78,16 +79,16 @@ public class DnsResponseTest {
             ByteBuf packet = embedder.alloc().buffer(512).writeBytes(p);
             embedder.writeInbound(new DatagramPacket(packet, null, new InetSocketAddress(0)));
             AddressedEnvelope<DnsResponse, InetSocketAddress> envelope = embedder.readInbound();
-            assertThat(envelope, is(instanceOf(DatagramDnsResponse.class)));
+            assertInstanceOf(DatagramDnsResponse.class, envelope);
             DnsResponse response = envelope.content();
-            assertThat(response, is(sameInstance((Object) envelope)));
+            assertSame(envelope, response);
 
             ByteBuf raw = Unpooled.wrappedBuffer(p);
-            assertThat(response.id(), is(raw.getUnsignedShort(0)));
-            assertThat(response.count(DnsSection.QUESTION), is(raw.getUnsignedShort(4)));
-            assertThat(response.count(DnsSection.ANSWER), is(raw.getUnsignedShort(6)));
-            assertThat(response.count(DnsSection.AUTHORITY), is(raw.getUnsignedShort(8)));
-            assertThat(response.count(DnsSection.ADDITIONAL), is(raw.getUnsignedShort(10)));
+            assertEquals(raw.getUnsignedShort(0), response.id());
+            assertEquals(raw.getUnsignedShort(4), response.count(DnsSection.QUESTION));
+            assertEquals(raw.getUnsignedShort(6), response.count(DnsSection.ANSWER));
+            assertEquals(raw.getUnsignedShort(8), response.count(DnsSection.AUTHORITY));
+            assertEquals(raw.getUnsignedShort(10), response.count(DnsSection.ADDITIONAL));
 
             envelope.release();
         }

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/TcpDnsTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/TcpDnsTest.java
@@ -23,8 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Random;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -43,8 +42,8 @@ public class TcpDnsTest {
         assertTrue(channel.writeInbound(query));
 
         DnsQuery readQuery = channel.readInbound();
-        assertThat(readQuery, is(query));
-        assertThat(readQuery.recordAt(DnsSection.QUESTION).name(), is(query.recordAt(DnsSection.QUESTION).name()));
+        assertEquals(query, readQuery);
+        assertEquals(query.recordAt(DnsSection.QUESTION).name(), readQuery.recordAt(DnsSection.QUESTION).name());
         readQuery.release();
         assertFalse(channel.finish());
     }
@@ -60,7 +59,7 @@ public class TcpDnsTest {
         final ByteBuf encoded = encoder.readOutbound();
         assertTrue(decoder.writeInbound(encoded));
         final DnsQuery decoded = decoder.readInbound();
-        assertThat(decoded, is(query));
+        assertEquals(query, decoded);
 
         ReferenceCountUtil.release(decoded);
 
@@ -83,11 +82,11 @@ public class TcpDnsTest {
         channel.writeInbound(newResponse(query, question, QUERY_RESULT));
 
         DnsResponse readResponse = channel.readInbound();
-        assertThat(readResponse.recordAt(DnsSection.QUESTION), is((DnsRecord) question));
+        assertEquals(question, readResponse.recordAt(DnsSection.QUESTION));
         DnsRawRecord record = new DefaultDnsRawRecord(question.name(),
                 DnsRecordType.A, TTL, Unpooled.wrappedBuffer(QUERY_RESULT));
-        assertThat(readResponse.recordAt(DnsSection.ANSWER), is((DnsRecord) record));
-        assertThat(readResponse.<DnsRawRecord>recordAt(DnsSection.ANSWER).content(), is(record.content()));
+        assertEquals(record, readResponse.recordAt(DnsSection.ANSWER));
+        assertEquals(record.content(), readResponse.<DnsRawRecord>recordAt(DnsSection.ANSWER).content());
         ReferenceCountUtil.release(readResponse);
         ReferenceCountUtil.release(record);
         query.release();

--- a/codec-haproxy/pom.xml
+++ b/codec-haproxy/pom.xml
@@ -81,11 +81,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/codec-http/pom.xml
+++ b/codec-http/pom.xml
@@ -144,11 +144,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/codec-http/src/test/java/io/netty/handler/codec/http/CombinedHttpHeadersTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/CombinedHttpHeadersTest.java
@@ -25,8 +25,6 @@ import java.util.Iterator;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.SET_COOKIE;
 import static io.netty.util.AsciiString.contentEquals;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -79,7 +77,7 @@ public class CombinedHttpHeadersTest {
         otherHeaders.add(SET_COOKIE, "b");
         otherHeaders.add(SET_COOKIE, "c");
         headers.add(otherHeaders);
-        assertThat(headers.getAll(SET_COOKIE), hasSize(3));
+        assertEquals(3, headers.getAll(SET_COOKIE).size());
     }
 
     @Test
@@ -90,7 +88,7 @@ public class CombinedHttpHeadersTest {
         otherHeaders.add("set-cookie", "b");
         otherHeaders.add("SET-COOKIE", "c");
         headers.add(otherHeaders);
-        assertThat(headers.getAll(SET_COOKIE), hasSize(3));
+        assertEquals(3, headers.getAll(SET_COOKIE).size());
     }
 
     @Test
@@ -311,7 +309,7 @@ public class CombinedHttpHeadersTest {
         final CombinedHttpHeaders headers = newCombinedHttpHeaders();
         headers.add(SET_COOKIE, "a");
         headers.add(SET_COOKIE, "b");
-        assertThat(headers.getAll(SET_COOKIE), hasSize(2));
+        assertEquals(2, headers.getAll(SET_COOKIE).size());
         assertEquals(Arrays.asList("a", "b"), headers.getAll(SET_COOKIE));
     }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/DefaultHttpHeadersTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/DefaultHttpHeadersTest.java
@@ -36,8 +36,6 @@ import static io.netty.handler.codec.http.HttpHeaderValues.ZERO;
 import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
 import static io.netty.util.AsciiString.contentEquals;
 import static java.util.Arrays.asList;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -164,10 +162,10 @@ public class DefaultHttpHeadersTest {
 
     @Test
     public void testEqualsIgnoreCase() {
-        assertThat(AsciiString.contentEqualsIgnoreCase(null, null), is(true));
-        assertThat(AsciiString.contentEqualsIgnoreCase(null, "foo"), is(false));
-        assertThat(AsciiString.contentEqualsIgnoreCase("bar", null), is(false));
-        assertThat(AsciiString.contentEqualsIgnoreCase("FoO", "fOo"), is(true));
+        assertTrue(AsciiString.contentEqualsIgnoreCase(null, null));
+        assertFalse(AsciiString.contentEqualsIgnoreCase(null, "foo"));
+        assertFalse(AsciiString.contentEqualsIgnoreCase("bar", null));
+        assertTrue(AsciiString.contentEqualsIgnoreCase("FoO", "fOo"));
     }
 
     @Test

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorOptionsTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorOptionsTest.java
@@ -22,12 +22,10 @@ import io.netty.handler.codec.compression.StandardCompressionOptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnabledIf("isBrotiAvailable")
@@ -137,16 +135,16 @@ class HttpContentCompressorOptionsTest {
 
     private static void assertEncodedResponse(EmbeddedChannel ch) {
         Object o = ch.readOutbound();
-        assertThat(o, is(instanceOf(HttpResponse.class)));
+        assertInstanceOf(HttpResponse.class, o);
 
         assertEncodedResponse((HttpResponse) o);
     }
 
     private static void assertEncodedResponse(HttpResponse res) {
-        assertThat(res, is(not(instanceOf(HttpContent.class))));
-        assertThat(res.headers().get(HttpHeaderNames.TRANSFER_ENCODING), is("chunked"));
-        assertThat(res.headers().get(HttpHeaderNames.CONTENT_LENGTH), is(nullValue()));
-        assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING), is("br"));
+        assertThat(res).isNotInstanceOf(HttpContent.class);
+        assertEquals("chunked", res.headers().get(HttpHeaderNames.TRANSFER_ENCODING));
+        assertNull(res.headers().get(HttpHeaderNames.CONTENT_LENGTH));
+        assertEquals("br", res.headers().get(HttpHeaderNames.CONTENT_ENCODING));
     }
 
     private static FullHttpRequest newRequest() {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorTest.java
@@ -54,13 +54,10 @@ import org.junit.jupiter.api.condition.EnabledIf;
 import java.nio.charset.StandardCharsets;
 
 import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -148,28 +145,28 @@ public class HttpContentCompressorTest {
 
         HttpContent chunk;
         chunk = ch.readOutbound();
-        assertThat(ByteBufUtil.hexDump(chunk.content()), is("1f8b0800000000000000f248cdc901000000ffff"));
+        assertEquals("1f8b0800000000000000f248cdc901000000ffff", ByteBufUtil.hexDump(chunk.content()));
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(ByteBufUtil.hexDump(chunk.content()), is("cad7512807000000ffff"));
+        assertEquals("cad7512807000000ffff", ByteBufUtil.hexDump(chunk.content()));
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(ByteBufUtil.hexDump(chunk.content()), is("ca2fca4901000000ffff"));
+        assertEquals("ca2fca4901000000ffff", ByteBufUtil.hexDump(chunk.content()));
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(ByteBufUtil.hexDump(chunk.content()), is("0300c2a99ae70c000000"));
-        assertThat(chunk, is(instanceOf(HttpContent.class)));
+        assertEquals("0300c2a99ae70c000000", ByteBufUtil.hexDump(chunk.content()));
+        assertInstanceOf(HttpContent.class, chunk);
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(chunk.content().isReadable(), is(false));
-        assertThat(chunk, is(instanceOf(LastHttpContent.class)));
+        assertFalse(chunk.content().isReadable());
+        assertInstanceOf(LastHttpContent.class, chunk);
         chunk.release();
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
     }
 
     @Test
@@ -189,28 +186,28 @@ public class HttpContentCompressorTest {
 
         HttpContent chunk;
         chunk = ch.readOutbound();
-        assertThat(ByteBufUtil.hexDump(chunk.content()), is("1f8b0800000000000000f248cdc901000000ffff"));
+        assertEquals("1f8b0800000000000000f248cdc901000000ffff", ByteBufUtil.hexDump(chunk.content()));
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(ByteBufUtil.hexDump(chunk.content()), is("cad7512807000000ffff"));
+        assertEquals("cad7512807000000ffff", ByteBufUtil.hexDump(chunk.content()));
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(ByteBufUtil.hexDump(chunk.content()), is("ca2fca4901000000ffff"));
+        assertEquals("ca2fca4901000000ffff", ByteBufUtil.hexDump(chunk.content()));
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(ByteBufUtil.hexDump(chunk.content()), is("0300c2a99ae70c000000"));
-        assertThat(chunk, is(instanceOf(HttpContent.class)));
+        assertEquals("0300c2a99ae70c000000", ByteBufUtil.hexDump(chunk.content()));
+        assertInstanceOf(HttpContent.class, chunk);
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(chunk.content().isReadable(), is(false));
-        assertThat(chunk, is(instanceOf(LastHttpContent.class)));
+        assertFalse(chunk.content().isReadable());
+        assertInstanceOf(LastHttpContent.class, chunk);
         chunk.release();
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
     }
 
     @Test
@@ -230,28 +227,28 @@ public class HttpContentCompressorTest {
 
         HttpContent chunk;
         chunk = ch.readOutbound();
-        assertThat(ByteBufUtil.hexDump(chunk.content()), is("1f8b0800000000000000f248cdc901000000ffff"));
+        assertEquals("1f8b0800000000000000f248cdc901000000ffff", ByteBufUtil.hexDump(chunk.content()));
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(ByteBufUtil.hexDump(chunk.content()), is("cad7512807000000ffff"));
+        assertEquals("cad7512807000000ffff", ByteBufUtil.hexDump(chunk.content()));
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(ByteBufUtil.hexDump(chunk.content()), is("ca2fca4901000000ffff"));
+        assertEquals("ca2fca4901000000ffff", ByteBufUtil.hexDump(chunk.content()));
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(ByteBufUtil.hexDump(chunk.content()), is("0300c2a99ae70c000000"));
-        assertThat(chunk, is(instanceOf(HttpContent.class)));
+        assertEquals("0300c2a99ae70c000000", ByteBufUtil.hexDump(chunk.content()));
+        assertInstanceOf(HttpContent.class, chunk);
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(chunk.content().isReadable(), is(false));
-        assertThat(chunk, is(instanceOf(LastHttpContent.class)));
+        assertFalse(chunk.content().isReadable());
+        assertInstanceOf(LastHttpContent.class, chunk);
         chunk.release();
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
     }
 
     @Test
@@ -269,19 +266,19 @@ public class HttpContentCompressorTest {
 
         HttpContent chunk;
         chunk = ch.readOutbound();
-        assertThat(chunk.content().toString(StandardCharsets.UTF_8), is("Hell"));
+        assertEquals("Hell", chunk.content().toString(StandardCharsets.UTF_8));
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(chunk.content().toString(StandardCharsets.UTF_8), is("o, w"));
+        assertEquals("o, w", chunk.content().toString(StandardCharsets.UTF_8));
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(chunk.content().toString(StandardCharsets.UTF_8), is("orld"));
-        assertThat(chunk, is(instanceOf(LastHttpContent.class)));
+        assertEquals("orld", chunk.content().toString(StandardCharsets.UTF_8));
+        assertInstanceOf(LastHttpContent.class, chunk);
         chunk.release();
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
     }
 
     @Test
@@ -298,19 +295,19 @@ public class HttpContentCompressorTest {
 
         HttpContent chunk;
         chunk = ch.readOutbound();
-        assertThat(chunk.content().toString(StandardCharsets.UTF_8), is("Hell"));
+        assertEquals("Hell", chunk.content().toString(StandardCharsets.UTF_8));
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(chunk.content().toString(StandardCharsets.UTF_8), is("o, w"));
+        assertEquals("o, w", chunk.content().toString(StandardCharsets.UTF_8));
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(chunk.content().toString(StandardCharsets.UTF_8), is("orld"));
-        assertThat(chunk, is(instanceOf(LastHttpContent.class)));
+        assertEquals("orld", chunk.content().toString(StandardCharsets.UTF_8));
+        assertInstanceOf(LastHttpContent.class, chunk);
         chunk.release();
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
     }
 
     @Test
@@ -332,30 +329,30 @@ public class HttpContentCompressorTest {
 
         HttpContent chunk;
         chunk = ch.readOutbound();
-        assertThat(ByteBufUtil.hexDump(chunk.content()), is("1f8b0800000000000000f248cdc901000000ffff"));
+        assertEquals("1f8b0800000000000000f248cdc901000000ffff", ByteBufUtil.hexDump(chunk.content()));
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(ByteBufUtil.hexDump(chunk.content()), is("cad7512807000000ffff"));
+        assertEquals("cad7512807000000ffff", ByteBufUtil.hexDump(chunk.content()));
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(ByteBufUtil.hexDump(chunk.content()), is("ca2fca4901000000ffff"));
+        assertEquals("ca2fca4901000000ffff", ByteBufUtil.hexDump(chunk.content()));
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(ByteBufUtil.hexDump(chunk.content()), is("0300c2a99ae70c000000"));
-        assertThat(chunk, is(instanceOf(HttpContent.class)));
+        assertEquals("0300c2a99ae70c000000", ByteBufUtil.hexDump(chunk.content()));
+        assertInstanceOf(HttpContent.class, chunk);
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(chunk.content().isReadable(), is(false));
-        assertThat(chunk, is(instanceOf(LastHttpContent.class)));
+        assertFalse(chunk.content().isReadable());
+        assertInstanceOf(LastHttpContent.class, chunk);
         assertEquals("Netty", ((LastHttpContent) chunk).trailingHeaders().get(of("X-Test")));
         assertEquals(DecoderResult.SUCCESS, chunk.decoderResult());
         chunk.release();
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
     }
 
     @Test
@@ -370,29 +367,29 @@ public class HttpContentCompressorTest {
         ch.writeOutbound(fullRes);
 
         HttpResponse res = ch.readOutbound();
-        assertThat(res, is(not(instanceOf(HttpContent.class))));
+        assertInstanceOf(HttpResponse.class, res);
 
-        assertThat(res.headers().get(HttpHeaderNames.TRANSFER_ENCODING), is(nullValue()));
-        assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING), is("gzip"));
+        assertNull(res.headers().get(HttpHeaderNames.TRANSFER_ENCODING));
+        assertEquals("gzip", res.headers().get(HttpHeaderNames.CONTENT_ENCODING));
 
         long contentLengthHeaderValue = HttpUtil.getContentLength(res);
         long observedLength = 0;
 
         HttpContent c = ch.readOutbound();
         observedLength += c.content().readableBytes();
-        assertThat(ByteBufUtil.hexDump(c.content()), is("1f8b0800000000000000f248cdc9c9d75108cf2fca4901000000ffff"));
+        assertEquals("1f8b0800000000000000f248cdc9c9d75108cf2fca4901000000ffff", ByteBufUtil.hexDump(c.content()));
         c.release();
 
         c = ch.readOutbound();
         observedLength += c.content().readableBytes();
-        assertThat(ByteBufUtil.hexDump(c.content()), is("0300c6865b260c000000"));
+        assertEquals("0300c6865b260c000000", ByteBufUtil.hexDump(c.content()));
         c.release();
 
         LastHttpContent last = ch.readOutbound();
-        assertThat(last.content().readableBytes(), is(0));
+        assertEquals(0, last.content().readableBytes());
         last.release();
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
         assertEquals(contentLengthHeaderValue, observedLength);
     }
 
@@ -408,18 +405,18 @@ public class HttpContentCompressorTest {
 
         assertEncodedResponse(ch);
         HttpContent c = ch.readOutbound();
-        assertThat(ByteBufUtil.hexDump(c.content()), is("1f8b0800000000000000f248cdc9c9d75108cf2fca4901000000ffff"));
+        assertEquals("1f8b0800000000000000f248cdc9c9d75108cf2fca4901000000ffff", ByteBufUtil.hexDump(c.content()));
         c.release();
 
         c = ch.readOutbound();
-        assertThat(ByteBufUtil.hexDump(c.content()), is("0300c6865b260c000000"));
+        assertEquals("0300c6865b260c000000", ByteBufUtil.hexDump(c.content()));
         c.release();
 
         LastHttpContent last = ch.readOutbound();
-        assertThat(last.content().readableBytes(), is(0));
+        assertEquals(0, last.content().readableBytes());
         last.release();
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
     }
 
     @Test
@@ -493,18 +490,18 @@ public class HttpContentCompressorTest {
             assertEncodedResponse((HttpResponse) responses.poll(1, TimeUnit.SECONDS));
             HttpContent c = (HttpContent) responses.poll(1, TimeUnit.SECONDS);
             assertNotNull(c);
-            assertThat(ByteBufUtil.hexDump(c.content()),
-                is("1f8b0800000000000000f248cdc9c9d75108cf2fca4901000000ffff"));
+            assertEquals("1f8b0800000000000000f248cdc9c9d75108cf2fca4901000000ffff",
+                    ByteBufUtil.hexDump(c.content()));
             c.release();
 
             c = (HttpContent) responses.poll(1, TimeUnit.SECONDS);
             assertNotNull(c);
-            assertThat(ByteBufUtil.hexDump(c.content()), is("0300c6865b260c000000"));
+            assertEquals("0300c6865b260c000000", ByteBufUtil.hexDump(c.content()));
             c.release();
 
             LastHttpContent last = (LastHttpContent) responses.poll(1, TimeUnit.SECONDS);
             assertNotNull(last);
-            assertThat(last.content().readableBytes(), is(0));
+            assertEquals(0, last.content().readableBytes());
             last.release();
 
             assertNull(responses.poll(1, TimeUnit.SECONDS));
@@ -534,16 +531,16 @@ public class HttpContentCompressorTest {
 
         ch.writeOutbound(LastHttpContent.EMPTY_LAST_CONTENT);
         HttpContent chunk = ch.readOutbound();
-        assertThat(ByteBufUtil.hexDump(chunk.content()), is("1f8b080000000000000003000000000000000000"));
-        assertThat(chunk, is(instanceOf(HttpContent.class)));
+        assertEquals("1f8b080000000000000003000000000000000000", ByteBufUtil.hexDump(chunk.content()));
+        assertInstanceOf(HttpContent.class, chunk);
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(chunk.content().isReadable(), is(false));
-        assertThat(chunk, is(instanceOf(LastHttpContent.class)));
+        assertFalse(chunk.content().isReadable());
+        assertInstanceOf(LastHttpContent.class, chunk);
         chunk.release();
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
     }
 
     /**
@@ -559,18 +556,18 @@ public class HttpContentCompressorTest {
         ch.writeOutbound(res);
 
         Object o = ch.readOutbound();
-        assertThat(o, is(instanceOf(FullHttpResponse.class)));
+        assertInstanceOf(FullHttpResponse.class, o);
 
         res = (FullHttpResponse) o;
-        assertThat(res.headers().get(HttpHeaderNames.TRANSFER_ENCODING), is(nullValue()));
+        assertNull(res.headers().get(HttpHeaderNames.TRANSFER_ENCODING));
 
         // Content encoding shouldn't be modified.
-        assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING), is(nullValue()));
-        assertThat(res.content().readableBytes(), is(0));
-        assertThat(res.content().toString(CharsetUtil.US_ASCII), is(""));
+        assertNull(res.headers().get(HttpHeaderNames.CONTENT_ENCODING));
+        assertEquals(0, res.content().readableBytes());
+        assertEquals("", res.content().toString(CharsetUtil.US_ASCII));
         res.release();
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
     }
 
     @Test
@@ -584,18 +581,18 @@ public class HttpContentCompressorTest {
         ch.writeOutbound(res);
 
         Object o = ch.readOutbound();
-        assertThat(o, is(instanceOf(FullHttpResponse.class)));
+        assertInstanceOf(FullHttpResponse.class, o);
 
         res = (FullHttpResponse) o;
-        assertThat(res.headers().get(HttpHeaderNames.TRANSFER_ENCODING), is(nullValue()));
+        assertNull(res.headers().get(HttpHeaderNames.TRANSFER_ENCODING));
 
         // Content encoding shouldn't be modified.
-        assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING), is(nullValue()));
-        assertThat(res.content().readableBytes(), is(0));
-        assertThat(res.content().toString(CharsetUtil.US_ASCII), is(""));
+        assertNull(res.headers().get(HttpHeaderNames.CONTENT_ENCODING));
+        assertEquals(0, res.content().readableBytes());
+        assertEquals("", res.content().toString(CharsetUtil.US_ASCII));
         assertEquals("Netty", res.trailingHeaders().get(of("X-Test")));
         assertEquals(DecoderResult.SUCCESS, res.decoderResult());
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
     }
 
     @Test
@@ -617,25 +614,25 @@ public class HttpContentCompressorTest {
         ch.writeOutbound(res);
 
         Object o = ch.readOutbound();
-        assertThat(o, is(instanceOf(FullHttpResponse.class)));
+        assertInstanceOf(FullHttpResponse.class, o);
 
         res = (FullHttpResponse) o;
         assertSame(continueResponse, res);
         res.release();
 
         o = ch.readOutbound();
-        assertThat(o, is(instanceOf(FullHttpResponse.class)));
+        assertInstanceOf(FullHttpResponse.class, o);
 
         res = (FullHttpResponse) o;
-        assertThat(res.headers().get(HttpHeaderNames.TRANSFER_ENCODING), is(nullValue()));
+        assertNull(res.headers().get(HttpHeaderNames.TRANSFER_ENCODING));
 
         // Content encoding shouldn't be modified.
-        assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING), is(nullValue()));
-        assertThat(res.content().readableBytes(), is(0));
-        assertThat(res.content().toString(CharsetUtil.US_ASCII), is(""));
+        assertNull(res.headers().get(HttpHeaderNames.CONTENT_ENCODING));
+        assertEquals(0, res.content().readableBytes());
+        assertEquals("", res.content().toString(CharsetUtil.US_ASCII));
         assertEquals("Netty", res.trailingHeaders().get(of("X-Test")));
         assertEquals(DecoderResult.SUCCESS, res.decoderResult());
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
     }
 
     @Test
@@ -661,32 +658,32 @@ public class HttpContentCompressorTest {
         ch.writeOutbound(res);
 
         Object o = ch.readOutbound();
-        assertThat(o, is(instanceOf(FullHttpResponse.class)));
+        assertInstanceOf(FullHttpResponse.class, o);
 
         res = (FullHttpResponse) o;
         assertSame(continueResponse, res);
         res.release();
 
         o = ch.readOutbound();
-        assertThat(o, is(instanceOf(FullHttpResponse.class)));
+        assertInstanceOf(FullHttpResponse.class, o);
 
         res = (FullHttpResponse) o;
         assertSame(earlyHintsResponse, res);
         res.release();
 
         o = ch.readOutbound();
-        assertThat(o, is(instanceOf(FullHttpResponse.class)));
+        assertInstanceOf(FullHttpResponse.class, o);
 
         res = (FullHttpResponse) o;
-        assertThat(res.headers().get(HttpHeaderNames.TRANSFER_ENCODING), is(nullValue()));
+        assertNull(res.headers().get(HttpHeaderNames.TRANSFER_ENCODING));
 
         // Content encoding shouldn't be modified.
-        assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING), is(nullValue()));
-        assertThat(res.content().readableBytes(), is(0));
-        assertThat(res.content().toString(CharsetUtil.US_ASCII), is(""));
+        assertNull(res.headers().get(HttpHeaderNames.CONTENT_ENCODING));
+        assertEquals(0, res.content().readableBytes());
+        assertEquals("", res.content().toString(CharsetUtil.US_ASCII));
         assertEquals("Netty", res.trailingHeaders().get(of("X-Test")));
         assertEquals(DecoderResult.SUCCESS, res.decoderResult());
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
 
         assertTrue(ch.finishAndReleaseAll());
     }
@@ -709,25 +706,25 @@ public class HttpContentCompressorTest {
         ch.writeOutbound(res);
 
         Object o = ch.readOutbound();
-        assertThat(o, is(instanceOf(FullHttpResponse.class)));
+        assertInstanceOf(FullHttpResponse.class, o);
 
         res = (FullHttpResponse) o;
         assertSame(earlyHintsResponse, res);
         res.release();
 
         o = ch.readOutbound();
-        assertThat(o, is(instanceOf(FullHttpResponse.class)));
+        assertInstanceOf(FullHttpResponse.class, o);
 
         res = (FullHttpResponse) o;
-        assertThat(res.headers().get(HttpHeaderNames.TRANSFER_ENCODING), is(nullValue()));
+        assertNull(res.headers().get(HttpHeaderNames.TRANSFER_ENCODING));
 
         // Content encoding shouldn't be modified.
-        assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING), is(nullValue()));
-        assertThat(res.content().readableBytes(), is(0));
-        assertThat(res.content().toString(CharsetUtil.US_ASCII), is(""));
+        assertNull(res.headers().get(HttpHeaderNames.CONTENT_ENCODING));
+        assertEquals(0, res.content().readableBytes());
+        assertEquals("", res.content().toString(CharsetUtil.US_ASCII));
         assertEquals("Netty", res.trailingHeaders().get(of("X-Test")));
         assertEquals(DecoderResult.SUCCESS, res.decoderResult());
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
 
         assertTrue(ch.finishAndReleaseAll());
     }
@@ -865,11 +862,11 @@ public class HttpContentCompressorTest {
         ch.writeOutbound(res);
 
         HttpResponse outboundRes = ch.readOutbound();
-        assertThat(outboundRes, is(not(instanceOf(HttpContent.class))));
-        assertThat(outboundRes.headers().get(HttpHeaderNames.TRANSFER_ENCODING), is("chunked"));
-        assertThat(outboundRes.headers().get(HttpHeaderNames.CONTENT_LENGTH), is(nullValue()));
-        assertThat(outboundRes.headers().get(HttpHeaderNames.CONTENT_ENCODING), is("br"));
-        assertThat(outboundRes.headers().get(HttpHeaderNames.CONTENT_TYPE), is("text/plain"));
+        assertThat(outboundRes).isNotInstanceOf(HttpContent.class);
+        assertEquals("chunked", outboundRes.headers().get(HttpHeaderNames.TRANSFER_ENCODING));
+        assertNull(outboundRes.headers().get(HttpHeaderNames.CONTENT_LENGTH));
+        assertEquals("br", outboundRes.headers().get(HttpHeaderNames.CONTENT_ENCODING));
+        assertEquals("text/plain", outboundRes.headers().get(HttpHeaderNames.CONTENT_TYPE));
 
         ch.writeOutbound(new DefaultHttpContent(Unpooled.copiedBuffer("Hell", CharsetUtil.US_ASCII)));
         ch.writeOutbound(new DefaultHttpContent(Unpooled.copiedBuffer("o world. Hello w", CharsetUtil.US_ASCII)));
@@ -904,7 +901,7 @@ public class HttpContentCompressorTest {
                 Unpooled.wrappedBuffer(new byte[1023]));
         assertTrue(ch.writeOutbound(res1023));
         DefaultHttpResponse response1023 = ch.readOutbound();
-        assertThat(response1023.headers().get(HttpHeaderNames.CONTENT_ENCODING), is("gzip"));
+        assertEquals("gzip", response1023.headers().get(HttpHeaderNames.CONTENT_ENCODING));
         ch.releaseOutbound();
 
         assertTrue(ch.writeInbound(newRequest()));
@@ -913,7 +910,7 @@ public class HttpContentCompressorTest {
                 Unpooled.wrappedBuffer(new byte[1024]));
         assertTrue(ch.writeOutbound(res1024));
         DefaultHttpResponse response1024 = ch.readOutbound();
-        assertThat(response1024.headers().get(HttpHeaderNames.CONTENT_ENCODING), is("gzip"));
+        assertEquals("gzip", response1024.headers().get(HttpHeaderNames.CONTENT_ENCODING));
         assertTrue(ch.finishAndReleaseAll());
     }
 
@@ -936,7 +933,7 @@ public class HttpContentCompressorTest {
                 Unpooled.wrappedBuffer(new byte[1024]));
         assertTrue(ch.writeOutbound(res1024));
         DefaultHttpResponse response1024 = ch.readOutbound();
-        assertThat(response1024.headers().get(HttpHeaderNames.CONTENT_ENCODING), is("gzip"));
+        assertEquals("gzip", response1024.headers().get(HttpHeaderNames.CONTENT_ENCODING));
         assertTrue(ch.finishAndReleaseAll());
     }
 
@@ -958,18 +955,18 @@ public class HttpContentCompressorTest {
 
         assertEncodedResponse(ch);
         HttpContent c = ch.readOutbound();
-        assertThat(ByteBufUtil.hexDump(c.content()), is("1f8b080000000000000072afca2c5008cfcc03000000ffff"));
+        assertEquals("1f8b080000000000000072afca2c5008cfcc03000000ffff", ByteBufUtil.hexDump(c.content()));
         c.release();
 
         c = ch.readOutbound();
-        assertThat(ByteBufUtil.hexDump(c.content()), is("03001f2ebf0f08000000"));
+        assertEquals("03001f2ebf0f08000000", ByteBufUtil.hexDump(c.content()));
         c.release();
 
         LastHttpContent last = ch.readOutbound();
-        assertThat(last.content().readableBytes(), is(0));
+        assertEquals(0, last.content().readableBytes());
         last.release();
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
         assertTrue(ch.finishAndReleaseAll());
     }
 
@@ -1002,28 +999,28 @@ public class HttpContentCompressorTest {
 
     private static void assertEncodedResponse(EmbeddedChannel ch) {
         Object o = ch.readOutbound();
-        assertThat(o, is(instanceOf(HttpResponse.class)));
+        assertInstanceOf(HttpResponse.class, o);
 
         assertEncodedResponse((HttpResponse) o);
     }
 
     private static void assertEncodedResponse(HttpResponse res) {
-        assertThat(res, is(not(instanceOf(HttpContent.class))));
-        assertThat(res.headers().get(HttpHeaderNames.TRANSFER_ENCODING), is("chunked"));
-        assertThat(res.headers().get(HttpHeaderNames.CONTENT_LENGTH), is(nullValue()));
-        assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING), is("gzip"));
+        assertThat(res).isNotInstanceOf(HttpContent.class);
+        assertEquals("chunked", res.headers().get(HttpHeaderNames.TRANSFER_ENCODING));
+        assertNull(res.headers().get(HttpHeaderNames.CONTENT_LENGTH));
+        assertEquals("gzip", res.headers().get(HttpHeaderNames.CONTENT_ENCODING));
     }
 
     private static void assertAssembledEncodedResponse(EmbeddedChannel ch) {
         Object o = ch.readOutbound();
-        assertThat(o, is(instanceOf(AssembledHttpResponse.class)));
+        assertInstanceOf(AssembledHttpResponse.class, o);
 
         AssembledHttpResponse res = (AssembledHttpResponse) o;
         try {
-            assertThat(res, is(instanceOf(HttpContent.class)));
-            assertThat(res.headers().get(HttpHeaderNames.TRANSFER_ENCODING), is("chunked"));
-            assertThat(res.headers().get(HttpHeaderNames.CONTENT_LENGTH), is(nullValue()));
-            assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING), is("gzip"));
+            assertInstanceOf(HttpContent.class, res);
+            assertEquals("chunked", res.headers().get(HttpHeaderNames.TRANSFER_ENCODING));
+            assertNull(res.headers().get(HttpHeaderNames.CONTENT_LENGTH));
+            assertEquals("gzip", res.headers().get(HttpHeaderNames.CONTENT_ENCODING));
         } finally {
             res.release();
         }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentDecoderTest.java
@@ -40,11 +40,9 @@ import java.util.Queue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -102,7 +100,7 @@ public class HttpContentDecoderTest {
         assertTrue(channel.writeInbound(buf));
 
         Object o = channel.readInbound();
-        assertThat(o, is(instanceOf(FullHttpRequest.class)));
+        assertInstanceOf(FullHttpRequest.class, o);
         FullHttpRequest req = (FullHttpRequest) o;
         assertEquals(HELLO_WORLD.length(), req.headers().getInt(HttpHeaderNames.CONTENT_LENGTH).intValue());
         assertEquals(HELLO_WORLD, req.content().toString(CharsetUtil.US_ASCII));
@@ -135,16 +133,16 @@ public class HttpContentDecoderTest {
         assertTrue(channel.writeInbound(Unpooled.copiedBuffer("My-Trailer: 42\r\n\r\n\r\n", CharsetUtil.US_ASCII)));
 
         Object ob1 = channel.readInbound();
-        assertThat(ob1, is(instanceOf(DefaultHttpResponse.class)));
+        assertInstanceOf(DefaultHttpResponse.class, ob1);
 
         Object ob2 = channel.readInbound();
-        assertThat(ob2, is(instanceOf(HttpContent.class)));
+        assertInstanceOf(HttpContent.class, ob2);
         HttpContent content = (HttpContent) ob2;
         assertEquals(HELLO_WORLD, content.content().toString(CharsetUtil.US_ASCII));
         content.release();
 
         Object ob3 = channel.readInbound();
-        assertThat(ob3, is(instanceOf(LastHttpContent.class)));
+        assertInstanceOf(LastHttpContent.class, ob3);
         LastHttpContent lastContent = (LastHttpContent) ob3;
         assertNotNull(lastContent.decoderResult());
         assertTrue(lastContent.decoderResult().isSuccess());
@@ -171,7 +169,7 @@ public class HttpContentDecoderTest {
         assertTrue(channel.writeInbound(buf));
 
         Object o = channel.readInbound();
-        assertThat(o, is(instanceOf(FullHttpResponse.class)));
+        assertInstanceOf(FullHttpResponse.class, o);
         FullHttpResponse resp = (FullHttpResponse) o;
         assertEquals(HELLO_WORLD.length(), resp.headers().getInt(HttpHeaderNames.CONTENT_LENGTH).intValue());
         assertEquals(HELLO_WORLD, resp.content().toString(CharsetUtil.UTF_8));
@@ -199,7 +197,7 @@ public class HttpContentDecoderTest {
         assertTrue(channel.writeInbound(buf));
 
         Object o = channel.readInbound();
-        assertThat(o, is(instanceOf(FullHttpResponse.class)));
+        assertInstanceOf(FullHttpResponse.class, o);
         FullHttpResponse resp = (FullHttpResponse) o;
         assertEquals(HELLO_WORLD.length(), resp.headers().getInt(HttpHeaderNames.CONTENT_LENGTH).intValue());
         assertEquals(HELLO_WORLD, resp.content().toString(CharsetUtil.US_ASCII));
@@ -228,7 +226,7 @@ public class HttpContentDecoderTest {
         assertTrue(channel.writeInbound(buf));
 
         Object o = channel.readInbound();
-        assertThat(o, is(instanceOf(FullHttpResponse.class)));
+        assertInstanceOf(FullHttpResponse.class, o);
         FullHttpResponse resp = (FullHttpResponse) o;
         assertNull(resp.headers().get(HttpHeaderNames.CONTENT_ENCODING), "Content-Encoding header should be removed");
         assertEquals(SAMPLE_STRING, resp.content().toString(CharsetUtil.UTF_8),
@@ -270,7 +268,7 @@ public class HttpContentDecoderTest {
         }
 
         Object o = channel.readInbound();
-        assertThat(o, is(instanceOf(FullHttpResponse.class)));
+        assertInstanceOf(FullHttpResponse.class, o);
         FullHttpResponse resp = (FullHttpResponse) o;
         assertEquals(SAMPLE_STRING, resp.content().toString(CharsetUtil.UTF_8),
                 "Response body should match uncompressed string");
@@ -296,7 +294,7 @@ public class HttpContentDecoderTest {
         assertTrue(channel.writeInbound(buf));
 
         Object o = channel.readInbound();
-        assertThat(o, is(instanceOf(FullHttpResponse.class)));
+        assertInstanceOf(FullHttpResponse.class, o);
         FullHttpResponse resp = (FullHttpResponse) o;
         assertNull(resp.headers().get(HttpHeaderNames.CONTENT_ENCODING), "Content-Encoding header should be removed");
         assertEquals(SAMPLE_STRING, resp.content().toString(CharsetUtil.UTF_8),
@@ -335,7 +333,7 @@ public class HttpContentDecoderTest {
         }
 
         Object o = channel.readInbound();
-        assertThat(o, is(instanceOf(FullHttpResponse.class)));
+        assertInstanceOf(FullHttpResponse.class, o);
         FullHttpResponse resp = (FullHttpResponse) o;
         assertEquals(SAMPLE_STRING, resp.content().toString(CharsetUtil.UTF_8),
           "Response body should match uncompressed string");
@@ -363,7 +361,7 @@ public class HttpContentDecoderTest {
         assertFalse(channel.writeInbound(Unpooled.wrappedBuffer(req.getBytes())));
 
         Object o = channel.readOutbound();
-        assertThat(o, is(instanceOf(FullHttpResponse.class)));
+        assertInstanceOf(FullHttpResponse.class, o);
         FullHttpResponse r = (FullHttpResponse) o;
         assertEquals(100, r.status().code());
         assertTrue(channel.writeInbound(Unpooled.copiedBuffer(GZ_HELLO_WORLD)));
@@ -389,7 +387,7 @@ public class HttpContentDecoderTest {
         assertFalse(channel.writeInbound(Unpooled.wrappedBuffer(req.getBytes())));
 
         Object o = channel.readOutbound();
-        assertThat(o, is(instanceOf(FullHttpResponse.class)));
+        assertInstanceOf(FullHttpResponse.class, o);
         FullHttpResponse r = (FullHttpResponse) o;
         assertEquals(100, r.status().code());
         r.release();
@@ -416,7 +414,7 @@ public class HttpContentDecoderTest {
         assertFalse(channel.writeInbound(Unpooled.wrappedBuffer(req.getBytes())));
 
         Object o = channel.readOutbound();
-        assertThat(o, is(instanceOf(FullHttpResponse.class)));
+        assertInstanceOf(FullHttpResponse.class, o);
         FullHttpResponse r = (FullHttpResponse) o;
         assertEquals(100, r.status().code());
         r.release();
@@ -443,7 +441,7 @@ public class HttpContentDecoderTest {
         assertFalse(channel.writeInbound(Unpooled.wrappedBuffer(req.getBytes())));
 
         Object o = channel.readOutbound();
-        assertThat(o, is(instanceOf(FullHttpResponse.class)));
+        assertInstanceOf(FullHttpResponse.class, o);
         FullHttpResponse r = (FullHttpResponse) o;
         assertEquals(100, r.status().code());
         r.release();
@@ -527,7 +525,7 @@ public class HttpContentDecoderTest {
         Queue<Object> req = channel.inboundMessages();
         assertTrue(req.size() >= 1);
         Object o = req.peek();
-        assertThat(o, is(instanceOf(HttpRequest.class)));
+        assertInstanceOf(HttpRequest.class, o);
         HttpRequest r = (HttpRequest) o;
         String v = r.headers().get(HttpHeaderNames.CONTENT_LENGTH);
         Long value = v == null ? null : Long.parseLong(v);
@@ -555,7 +553,7 @@ public class HttpContentDecoderTest {
         assertTrue(channel.writeInbound(buf));
 
         Object o = channel.readInbound();
-        assertThat(o, is(instanceOf(FullHttpRequest.class)));
+        assertInstanceOf(FullHttpRequest.class, o);
         FullHttpRequest r = (FullHttpRequest) o;
         String v = r.headers().get(HttpHeaderNames.CONTENT_LENGTH);
         Long value = v == null ? null : Long.parseLong(v);
@@ -588,7 +586,7 @@ public class HttpContentDecoderTest {
         Queue<Object> resp = channel.inboundMessages();
         assertTrue(resp.size() >= 1);
         Object o = resp.peek();
-        assertThat(o, is(instanceOf(HttpResponse.class)));
+        assertInstanceOf(HttpResponse.class, o);
         HttpResponse r = (HttpResponse) o;
 
         assertFalse(r.headers().contains(HttpHeaderNames.CONTENT_LENGTH), "Content-Length header not removed.");
@@ -619,7 +617,7 @@ public class HttpContentDecoderTest {
         assertTrue(channel.writeInbound(buf));
 
         Object o = channel.readInbound();
-        assertThat(o, is(instanceOf(FullHttpResponse.class)));
+        assertInstanceOf(FullHttpResponse.class, o);
         FullHttpResponse r = (FullHttpResponse) o;
         String v = r.headers().get(HttpHeaderNames.CONTENT_LENGTH);
         Long value = v == null ? null : Long.parseLong(v);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentEncoderTest.java
@@ -32,12 +32,10 @@ import org.junit.jupiter.api.function.Executable;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -72,23 +70,23 @@ public class HttpContentEncoderTest {
 
         HttpContent chunk;
         chunk = ch.readOutbound();
-        assertThat(chunk.content().toString(CharsetUtil.US_ASCII), is("3"));
+        assertEquals("3", chunk.content().toString(CharsetUtil.US_ASCII));
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(chunk.content().toString(CharsetUtil.US_ASCII), is("2"));
+        assertEquals("2", chunk.content().toString(CharsetUtil.US_ASCII));
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(chunk.content().toString(CharsetUtil.US_ASCII), is("1"));
+        assertEquals("1", chunk.content().toString(CharsetUtil.US_ASCII));
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(chunk.content().isReadable(), is(false));
-        assertThat(chunk, is(instanceOf(LastHttpContent.class)));
+        assertFalse(chunk.content().isReadable());
+        assertInstanceOf(LastHttpContent.class, chunk);
         chunk.release();
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
     }
 
     @Test
@@ -108,24 +106,24 @@ public class HttpContentEncoderTest {
 
         HttpContent chunk;
         chunk = ch.readOutbound();
-        assertThat(chunk.content().toString(CharsetUtil.US_ASCII), is("3"));
+        assertEquals("3", chunk.content().toString(CharsetUtil.US_ASCII));
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(chunk.content().toString(CharsetUtil.US_ASCII), is("2"));
+        assertEquals("2", chunk.content().toString(CharsetUtil.US_ASCII));
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(chunk.content().toString(CharsetUtil.US_ASCII), is("1"));
-        assertThat(chunk, is(instanceOf(HttpContent.class)));
+        assertEquals("1", chunk.content().toString(CharsetUtil.US_ASCII));
+        assertInstanceOf(HttpContent.class, chunk);
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(chunk.content().isReadable(), is(false));
-        assertThat(chunk, is(instanceOf(LastHttpContent.class)));
+        assertFalse(chunk.content().isReadable());
+        assertInstanceOf(LastHttpContent.class, chunk);
         chunk.release();
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
     }
 
     @Test
@@ -147,26 +145,26 @@ public class HttpContentEncoderTest {
 
         HttpContent chunk;
         chunk = ch.readOutbound();
-        assertThat(chunk.content().toString(CharsetUtil.US_ASCII), is("3"));
+        assertEquals("3", chunk.content().toString(CharsetUtil.US_ASCII));
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(chunk.content().toString(CharsetUtil.US_ASCII), is("2"));
+        assertEquals("2", chunk.content().toString(CharsetUtil.US_ASCII));
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(chunk.content().toString(CharsetUtil.US_ASCII), is("1"));
-        assertThat(chunk, is(instanceOf(HttpContent.class)));
+        assertEquals("1", chunk.content().toString(CharsetUtil.US_ASCII));
+        assertInstanceOf(HttpContent.class, chunk);
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(chunk.content().isReadable(), is(false));
-        assertThat(chunk, is(instanceOf(LastHttpContent.class)));
+        assertFalse(chunk.content().isReadable());
+        assertInstanceOf(LastHttpContent.class, chunk);
         assertEquals("Netty", ((LastHttpContent) chunk).trailingHeaders().get(of("X-Test")));
         assertEquals(DecoderResult.SUCCESS, res.decoderResult());
         chunk.release();
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
     }
 
     @Test
@@ -180,21 +178,21 @@ public class HttpContentEncoderTest {
         ch.writeOutbound(fullRes);
 
         HttpResponse res = ch.readOutbound();
-        assertThat(res, is(not(instanceOf(HttpContent.class))));
-        assertThat(res.headers().get(HttpHeaderNames.TRANSFER_ENCODING), is(nullValue()));
-        assertThat(res.headers().get(HttpHeaderNames.CONTENT_LENGTH), is("2"));
-        assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING), is("test"));
+        assertThat(res).isNotInstanceOf(HttpContent.class);
+        assertNull(res.headers().get(HttpHeaderNames.TRANSFER_ENCODING));
+        assertEquals("2", res.headers().get(HttpHeaderNames.CONTENT_LENGTH));
+        assertEquals("test", res.headers().get(HttpHeaderNames.CONTENT_ENCODING));
 
         HttpContent c = ch.readOutbound();
-        assertThat(c.content().readableBytes(), is(2));
-        assertThat(c.content().toString(CharsetUtil.US_ASCII), is("42"));
+        assertEquals(2, c.content().readableBytes());
+        assertEquals("42", c.content().toString(CharsetUtil.US_ASCII));
         c.release();
 
         LastHttpContent last = ch.readOutbound();
-        assertThat(last.content().readableBytes(), is(0));
+        assertEquals(0, last.content().readableBytes());
         last.release();
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
     }
 
     @Test
@@ -208,15 +206,15 @@ public class HttpContentEncoderTest {
 
         assertEncodedResponse(ch);
         HttpContent c = ch.readOutbound();
-        assertThat(c.content().readableBytes(), is(2));
-        assertThat(c.content().toString(CharsetUtil.US_ASCII), is("42"));
+        assertEquals(2, c.content().readableBytes());
+        assertEquals("42", c.content().toString(CharsetUtil.US_ASCII));
         c.release();
 
         LastHttpContent last = ch.readOutbound();
-        assertThat(last.content().readableBytes(), is(0));
+        assertEquals(0, last.content().readableBytes());
         last.release();
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
     }
 
     /**
@@ -233,16 +231,16 @@ public class HttpContentEncoderTest {
 
         ch.writeOutbound(LastHttpContent.EMPTY_LAST_CONTENT);
         HttpContent chunk = ch.readOutbound();
-        assertThat(chunk.content().toString(CharsetUtil.US_ASCII), is("0"));
-        assertThat(chunk, is(instanceOf(HttpContent.class)));
+        assertEquals("0", chunk.content().toString(CharsetUtil.US_ASCII));
+        assertInstanceOf(HttpContent.class, chunk);
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(chunk.content().isReadable(), is(false));
-        assertThat(chunk, is(instanceOf(LastHttpContent.class)));
+        assertFalse(chunk.content().isReadable());
+        assertInstanceOf(LastHttpContent.class, chunk);
         chunk.release();
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
     }
 
     /**
@@ -258,18 +256,18 @@ public class HttpContentEncoderTest {
         ch.writeOutbound(res);
 
         Object o = ch.readOutbound();
-        assertThat(o, is(instanceOf(FullHttpResponse.class)));
+        assertInstanceOf(FullHttpResponse.class, o);
 
         res = (FullHttpResponse) o;
-        assertThat(res.headers().get(HttpHeaderNames.TRANSFER_ENCODING), is(nullValue()));
+        assertNull(res.headers().get(HttpHeaderNames.TRANSFER_ENCODING));
 
         // Content encoding shouldn't be modified.
-        assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING), is(nullValue()));
-        assertThat(res.content().readableBytes(), is(0));
-        assertThat(res.content().toString(CharsetUtil.US_ASCII), is(""));
+        assertNull(res.headers().get(HttpHeaderNames.CONTENT_ENCODING));
+        assertEquals(0, res.content().readableBytes());
+        assertEquals("", res.content().toString(CharsetUtil.US_ASCII));
         res.release();
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
     }
 
     @Test
@@ -283,18 +281,18 @@ public class HttpContentEncoderTest {
         ch.writeOutbound(res);
 
         Object o = ch.readOutbound();
-        assertThat(o, is(instanceOf(FullHttpResponse.class)));
+        assertInstanceOf(FullHttpResponse.class, o);
 
         res = (FullHttpResponse) o;
-        assertThat(res.headers().get(HttpHeaderNames.TRANSFER_ENCODING), is(nullValue()));
+        assertNull(res.headers().get(HttpHeaderNames.TRANSFER_ENCODING));
 
         // Content encoding shouldn't be modified.
-        assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING), is(nullValue()));
-        assertThat(res.content().readableBytes(), is(0));
-        assertThat(res.content().toString(CharsetUtil.US_ASCII), is(""));
+        assertNull(res.headers().get(HttpHeaderNames.CONTENT_ENCODING));
+        assertEquals(0, res.content().readableBytes());
+        assertEquals("", res.content().toString(CharsetUtil.US_ASCII));
         assertEquals("Netty", res.trailingHeaders().get(of("X-Test")));
         assertEquals(DecoderResult.SUCCESS, res.decoderResult());
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
     }
 
     @Test
@@ -356,20 +354,20 @@ public class HttpContentEncoderTest {
 
         assertEncodedResponse(ch);
         Object o = ch.readOutbound();
-        assertThat(o, is(instanceOf(HttpContent.class)));
+        assertInstanceOf(HttpContent.class, o);
         HttpContent chunk = (HttpContent) o;
-        assertThat(chunk.content().toString(CharsetUtil.US_ASCII), is("28"));
+        assertEquals("28", chunk.content().toString(CharsetUtil.US_ASCII));
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(chunk.content().isReadable(), is(true));
-        assertThat(chunk.content().toString(CharsetUtil.US_ASCII), is("0"));
+        assertTrue(chunk.content().isReadable());
+        assertEquals("0", chunk.content().toString(CharsetUtil.US_ASCII));
         chunk.release();
 
         chunk = ch.readOutbound();
-        assertThat(chunk, is(instanceOf(LastHttpContent.class)));
+        assertInstanceOf(LastHttpContent.class, chunk);
         chunk.release();
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
     }
 
     @Test
@@ -439,27 +437,27 @@ public class HttpContentEncoderTest {
 
     private static void assertEmptyResponse(EmbeddedChannel ch) {
         Object o = ch.readOutbound();
-        assertThat(o, is(instanceOf(HttpResponse.class)));
+        assertInstanceOf(HttpResponse.class, o);
 
         HttpResponse res = (HttpResponse) o;
-        assertThat(res, is(not(instanceOf(HttpContent.class))));
-        assertThat(res.headers().get(HttpHeaderNames.TRANSFER_ENCODING), is("chunked"));
-        assertThat(res.headers().get(HttpHeaderNames.CONTENT_LENGTH), is(nullValue()));
+        assertThat(res).isNotInstanceOf(HttpContent.class);
+        assertEquals("chunked", res.headers().get(HttpHeaderNames.TRANSFER_ENCODING));
+        assertNull(res.headers().get(HttpHeaderNames.CONTENT_LENGTH));
 
         HttpContent chunk = ch.readOutbound();
-        assertThat(chunk, is(instanceOf(LastHttpContent.class)));
+        assertInstanceOf(LastHttpContent.class, chunk);
         chunk.release();
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
     }
 
     private static void assertEncodedResponse(EmbeddedChannel ch) {
         Object o = ch.readOutbound();
-        assertThat(o, is(instanceOf(HttpResponse.class)));
+        assertInstanceOf(HttpResponse.class, o);
 
         HttpResponse res = (HttpResponse) o;
-        assertThat(res, is(not(instanceOf(HttpContent.class))));
-        assertThat(res.headers().get(HttpHeaderNames.TRANSFER_ENCODING), is("chunked"));
-        assertThat(res.headers().get(HttpHeaderNames.CONTENT_LENGTH), is(nullValue()));
-        assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING), is("test"));
+        assertThat(res).isNotInstanceOf(HttpContent.class);
+        assertEquals("chunked", res.headers().get(HttpHeaderNames.TRANSFER_ENCODING));
+        assertNull(res.headers().get(HttpHeaderNames.CONTENT_LENGTH));
+        assertEquals("test", res.headers().get(HttpHeaderNames.CONTENT_ENCODING));
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpHeadersTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpHeadersTest.java
@@ -22,8 +22,6 @@ import org.junit.jupiter.api.function.Executable;
 import java.util.List;
 
 import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -57,10 +55,10 @@ public class HttpHeadersTest {
 
     @Test
     public void testEqualsIgnoreCase() {
-        assertThat(AsciiString.contentEqualsIgnoreCase(null, null), is(true));
-        assertThat(AsciiString.contentEqualsIgnoreCase(null, "foo"), is(false));
-        assertThat(AsciiString.contentEqualsIgnoreCase("bar", null), is(false));
-        assertThat(AsciiString.contentEqualsIgnoreCase("FoO", "fOo"), is(true));
+        assertTrue(AsciiString.contentEqualsIgnoreCase(null, null));
+        assertFalse(AsciiString.contentEqualsIgnoreCase(null, "foo"));
+        assertFalse(AsciiString.contentEqualsIgnoreCase("bar", null));
+        assertTrue(AsciiString.contentEqualsIgnoreCase("FoO", "fOo"));
     }
 
     @Test

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpObjectAggregatorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpObjectAggregatorTest.java
@@ -35,12 +35,10 @@ import java.nio.channels.ClosedChannelException;
 import java.util.List;
 
 import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -172,7 +170,7 @@ public class HttpObjectAggregatorTest {
         assertEquals(HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE, response.status());
         assertEquals("0", response.headers().get(HttpHeaderNames.CONTENT_LENGTH));
 
-        assertThat(response, instanceOf(LastHttpContent.class));
+        assertInstanceOf(LastHttpContent.class, response);
         ReferenceCountUtil.release(response);
 
         assertTrue(embedder.isOpen());
@@ -219,7 +217,7 @@ public class HttpObjectAggregatorTest {
         assertEquals(HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE, response.status());
         assertEquals("0", response.headers().get(HttpHeaderNames.CONTENT_LENGTH));
 
-        assertThat(response, instanceOf(LastHttpContent.class));
+        assertInstanceOf(LastHttpContent.class, response);
         ReferenceCountUtil.release(response);
 
         if (serverShouldCloseConnection(message, response)) {
@@ -369,7 +367,7 @@ public class HttpObjectAggregatorTest {
         EmbeddedChannel ch = new EmbeddedChannel(new HttpRequestDecoder(), new HttpObjectAggregator(1024 * 1024));
         ch.writeInbound(Unpooled.copiedBuffer("GET / HTTP/1.0 with extra\r\n", CharsetUtil.UTF_8));
         Object inbound = ch.readInbound();
-        assertThat(inbound, is(instanceOf(FullHttpRequest.class)));
+        assertInstanceOf(FullHttpRequest.class, inbound);
         assertTrue(((DecoderResultProvider) inbound).decoderResult().isFailure());
         assertNull(ch.readInbound());
         ch.finish();
@@ -380,7 +378,7 @@ public class HttpObjectAggregatorTest {
         EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder(), new HttpObjectAggregator(1024 * 1024));
         ch.writeInbound(Unpooled.copiedBuffer("HTTP/1.0 BAD_CODE Bad Server\r\n", CharsetUtil.UTF_8));
         Object inbound = ch.readInbound();
-        assertThat(inbound, is(instanceOf(FullHttpResponse.class)));
+        assertInstanceOf(FullHttpResponse.class, inbound);
         assertTrue(((DecoderResultProvider) inbound).decoderResult().isFailure());
         assertNull(ch.readInbound());
         ch.finish();
@@ -470,9 +468,9 @@ public class HttpObjectAggregatorTest {
             assertTrue(embedder.writeInbound(Unpooled.copiedBuffer("GET / HTTP/1.1\r\n\r\n", CharsetUtil.US_ASCII)));
 
             final FullHttpRequest request = embedder.readInbound();
-            assertThat(request.method(), is(HttpMethod.GET));
-            assertThat(request.uri(), is("/"));
-            assertThat(request.content().readableBytes(), is(0));
+            assertEquals(HttpMethod.GET, request.method());
+            assertEquals("/", request.uri());
+            assertEquals(0, request.content().readableBytes());
             request.release();
         }
 
@@ -517,9 +515,9 @@ public class HttpObjectAggregatorTest {
         embedder.writeInbound(Unpooled.copiedBuffer("GET /max-upload-size HTTP/1.1\r\n\r\n", CharsetUtil.US_ASCII));
 
         FullHttpRequest request = embedder.readInbound();
-        assertThat(request.method(), is(HttpMethod.GET));
-        assertThat(request.uri(), is("/max-upload-size"));
-        assertThat(request.content().readableBytes(), is(0));
+        assertEquals(HttpMethod.GET, request.method());
+        assertEquals("/max-upload-size", request.uri());
+        assertEquals(0, request.content().readableBytes());
         request.release();
 
         assertFalse(embedder.finish());

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -34,10 +34,6 @@ import java.util.Map;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.*;
 import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -244,7 +240,7 @@ public class HttpRequestDecoderTest {
                 "Content-Length: 1048576000\r\n\r\n";
 
         channel.writeInbound(Unpooled.copiedBuffer(oversized, CharsetUtil.US_ASCII));
-        assertThat(channel.readInbound(), is(instanceOf(HttpRequest.class)));
+        assertInstanceOf(HttpRequest.class, channel.readInbound());
 
         // At this point, we assume that we sent '413 Entity Too Large' to the peer without closing the connection
         // so that the client can try again.
@@ -252,10 +248,10 @@ public class HttpRequestDecoderTest {
 
         String query = "GET /max-file-size HTTP/1.1\r\n\r\n";
         channel.writeInbound(Unpooled.copiedBuffer(query, CharsetUtil.US_ASCII));
-        assertThat(channel.readInbound(), is(instanceOf(HttpRequest.class)));
-        assertThat(channel.readInbound(), is(instanceOf(LastHttpContent.class)));
+        assertInstanceOf(HttpRequest.class, channel.readInbound());
+        assertInstanceOf(LastHttpContent.class, channel.readInbound());
 
-        assertThat(channel.finish(), is(false));
+        assertFalse(channel.finish());
     }
 
     @Test
@@ -269,12 +265,12 @@ public class HttpRequestDecoderTest {
                 "WAY_TOO_LARGE_DATA_BEGINS";
 
         channel.writeInbound(Unpooled.copiedBuffer(oversized, CharsetUtil.US_ASCII));
-        assertThat(channel.readInbound(), is(instanceOf(HttpRequest.class)));
+        assertInstanceOf(HttpRequest.class, channel.readInbound());
 
         HttpContent prematureData = channel.readInbound();
         prematureData.release();
 
-        assertThat(channel.readInbound(), is(nullValue()));
+        assertNull(channel.readInbound());
 
         // At this point, we assume that we sent '413 Entity Too Large' to the peer without closing the connection
         // so that the client can try again.
@@ -282,10 +278,10 @@ public class HttpRequestDecoderTest {
 
         String query = "GET /max-file-size HTTP/1.1\r\n\r\n";
         channel.writeInbound(Unpooled.copiedBuffer(query, CharsetUtil.US_ASCII));
-        assertThat(channel.readInbound(), is(instanceOf(HttpRequest.class)));
-        assertThat(channel.readInbound(), is(instanceOf(LastHttpContent.class)));
+        assertInstanceOf(HttpRequest.class, channel.readInbound());
+        assertInstanceOf(LastHttpContent.class, channel.readInbound());
 
-        assertThat(channel.finish(), is(false));
+        assertFalse(channel.finish());
     }
 
     @Test
@@ -328,7 +324,7 @@ public class HttpRequestDecoderTest {
         assertTrue(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
         HttpRequest request = channel.readInbound();
         assertTrue(request.decoderResult().isFailure());
-        assertThat(request.decoderResult().cause(), instanceOf(TooLongHttpLineException.class));
+        assertInstanceOf(TooLongHttpLineException.class, request.decoderResult().cause());
         assertFalse(channel.finish());
     }
 
@@ -627,11 +623,11 @@ public class HttpRequestDecoderTest {
         assertTrue(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
         HttpRequest request = channel.readInbound();
         assertTrue(request.decoderResult().isSuccess());
-        assertThat(request.decoderResult(), instanceOf(HttpMessageDecoderResult.class));
+        assertInstanceOf(HttpMessageDecoderResult.class, request.decoderResult());
         HttpMessageDecoderResult decoderResult = (HttpMessageDecoderResult) request.decoderResult();
-        assertThat(decoderResult.initialLineLength(), is(23));
-        assertThat(decoderResult.headerSize(), is(35));
-        assertThat(decoderResult.totalSize(), is(58));
+        assertEquals(23, decoderResult.initialLineLength());
+        assertEquals(35, decoderResult.headerSize());
+        assertEquals(58, decoderResult.totalSize());
         HttpContent c = channel.readInbound();
         c.release();
         assertFalse(channel.finish());
@@ -775,7 +771,7 @@ public class HttpRequestDecoderTest {
         EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
         assertTrue(channel.writeInbound(requestBuffer));
         HttpRequest request = channel.readInbound();
-        assertThat(request.decoderResult().cause(), instanceOf(IllegalArgumentException.class));
+        assertInstanceOf(IllegalArgumentException.class, request.decoderResult().cause());
         assertTrue(request.decoderResult().isFailure());
         assertFalse(channel.finish());
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestEncoderTest.java
@@ -30,11 +30,9 @@ import java.nio.charset.Charset;
 import java.util.concurrent.ExecutionException;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -149,7 +147,7 @@ public class HttpRequestEncoderTest {
                 channel.writeAndFlush(buf).get();
             }
         });
-        assertThat(e.getCause().getCause(), is(instanceOf(IllegalReferenceCountException.class)));
+        assertInstanceOf(IllegalReferenceCountException.class, e.getCause().getCause());
 
         channel.finishAndReleaseAll();
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseEncoderTest.java
@@ -25,8 +25,6 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.channels.WritableByteChannel;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -138,7 +136,7 @@ public class HttpResponseEncoderTest {
         // Test writing an empty buffer works when the encoder is at ST_INIT.
         channel.writeOutbound(Unpooled.EMPTY_BUFFER);
         ByteBuf buffer = channel.readOutbound();
-        assertThat(buffer, is(sameInstance(Unpooled.EMPTY_BUFFER)));
+        assertSame(Unpooled.EMPTY_BUFFER, buffer);
 
         // Leave the ST_INIT state.
         HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
@@ -150,7 +148,7 @@ public class HttpResponseEncoderTest {
         // Test writing an empty buffer works when the encoder is not at ST_INIT.
         channel.writeOutbound(Unpooled.EMPTY_BUFFER);
         buffer = channel.readOutbound();
-        assertThat(buffer, is(sameInstance(Unpooled.EMPTY_BUFFER)));
+        assertSame(Unpooled.EMPTY_BUFFER, buffer);
 
         assertFalse(channel.finish());
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerCodecTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerCodecTest.java
@@ -21,11 +21,10 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HttpServerCodecTest {
@@ -80,28 +79,28 @@ public class HttpServerCodecTest {
                 "Content-Length: 1\r\n\r\n", CharsetUtil.UTF_8));
 
         // Ensure the aggregator generates nothing.
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
 
         // Ensure the aggregator writes a 100 Continue response.
         ByteBuf continueResponse = ch.readOutbound();
-        assertThat(continueResponse.toString(CharsetUtil.UTF_8), is("HTTP/1.1 100 Continue\r\n\r\n"));
+        assertEquals("HTTP/1.1 100 Continue\r\n\r\n", continueResponse.toString(CharsetUtil.UTF_8));
         continueResponse.release();
 
         // But nothing more.
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
 
         // Send the content of the request.
         ch.writeInbound(Unpooled.wrappedBuffer(new byte[] { 42 }));
 
         // Ensure the aggregator generates a full request.
         FullHttpRequest req = ch.readInbound();
-        assertThat(req.headers().get(HttpHeaderNames.CONTENT_LENGTH), is("1"));
-        assertThat(req.content().readableBytes(), is(1));
-        assertThat(req.content().readByte(), is((byte) 42));
+        assertEquals("1", req.headers().get(HttpHeaderNames.CONTENT_LENGTH));
+        assertEquals(1, req.content().readableBytes());
+        assertEquals((byte) 42, req.content().readByte());
         req.release();
 
         // But nothing more.
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
 
         // Send the actual response.
         FullHttpResponse res = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.CREATED);
@@ -111,8 +110,8 @@ public class HttpServerCodecTest {
 
         // Ensure the encoder handles the response after handling 100 Continue.
         ByteBuf encodedRes = ch.readOutbound();
-        assertThat(encodedRes.toString(CharsetUtil.UTF_8),
-                   is("HTTP/1.1 201 Created\r\n" + HttpHeaderNames.CONTENT_LENGTH + ": 2\r\n\r\nOK"));
+        assertEquals("HTTP/1.1 201 Created\r\n" + HttpHeaderNames.CONTENT_LENGTH + ": 2\r\n\r\nOK",
+                encodedRes.toString(CharsetUtil.UTF_8));
         encodedRes.release();
 
         ch.finish();

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerExpectContinueHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerExpectContinueHandlerTest.java
@@ -19,8 +19,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.ReferenceCountUtil;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -42,8 +41,8 @@ public class HttpServerExpectContinueHandlerTest {
         channel.writeInbound(request);
         HttpResponse response = channel.readOutbound();
 
-        assertThat(response.status(), is(HttpResponseStatus.CONTINUE));
-        assertThat(response.headers().get("foo"), is("bar"));
+        assertEquals(HttpResponseStatus.CONTINUE, response.status());
+        assertEquals("bar", response.headers().get("foo"));
         ReferenceCountUtil.release(response);
 
         HttpRequest processedRequest = channel.readInbound();
@@ -75,7 +74,7 @@ public class HttpServerExpectContinueHandlerTest {
         channel.writeInbound(request);
         HttpResponse response = channel.readOutbound();
 
-        assertThat(response.status(), is(HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE));
+        assertEquals(HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE, response.status());
         ReferenceCountUtil.release(response);
 
         // request was swallowed

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cookie/ClientCookieDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cookie/ClientCookieDecoderTest.java
@@ -26,11 +26,9 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.TimeZone;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -54,7 +52,7 @@ public class ClientCookieDecoderTest {
         assertEquals("/apathsomewhere", cookie.path());
         assertTrue(cookie.isSecure());
 
-        assertThat(cookie, is(instanceOf(DefaultCookie.class)));
+        assertInstanceOf(DefaultCookie.class, cookie);
         DefaultCookie c = (DefaultCookie) cookie;
         assertEquals(SameSite.None, c.sameSite());
         assertTrue(c.isPartitioned());

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cookie/ServerCookieEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cookie/ServerCookieEncoderTest.java
@@ -15,8 +15,7 @@
  */
 package io.netty.handler.codec.http.cookie;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -142,7 +141,7 @@ public class ServerCookieEncoderTest {
         try {
             ServerCookieEncoder.STRICT.encode(new DefaultCookie("name", "\"value,\""));
         } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage().toLowerCase(), containsString("cookie value contains an invalid char: ,"));
+            assertThat(e.getMessage().toLowerCase()).contains("cookie value contains an invalid char: ,");
         }
     }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cors/CorsConfigTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cors/CorsConfigTest.java
@@ -17,7 +17,6 @@ package io.netty.handler.codec.http.cors;
 
 import io.netty.handler.codec.http.EmptyHttpHeaders;
 import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -26,105 +25,105 @@ import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
 import static io.netty.handler.codec.http.cors.CorsConfigBuilder.forAnyOrigin;
 import static io.netty.handler.codec.http.cors.CorsConfigBuilder.forOrigin;
 import static io.netty.handler.codec.http.cors.CorsConfigBuilder.forOrigins;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CorsConfigTest {
 
     @Test
     public void disabled() {
         final CorsConfig cors = forAnyOrigin().disable().build();
-        assertThat(cors.isCorsSupportEnabled(), is(false));
+        assertFalse(cors.isCorsSupportEnabled());
     }
 
     @Test
     public void anyOrigin() {
         final CorsConfig cors = forAnyOrigin().build();
-        assertThat(cors.isAnyOriginSupported(), is(true));
-        assertThat(cors.origin(), is("*"));
-        assertThat(cors.origins().isEmpty(), is(true));
+        assertTrue(cors.isAnyOriginSupported());
+        assertEquals("*", cors.origin());
+        assertTrue(cors.origins().isEmpty());
     }
 
     @Test
     public void wildcardOrigin() {
         final CorsConfig cors = forOrigin("*").build();
-        assertThat(cors.isAnyOriginSupported(), is(true));
-        assertThat(cors.origin(), equalTo("*"));
-        assertThat(cors.origins().isEmpty(), is(true));
+        assertTrue(cors.isAnyOriginSupported());
+        assertEquals("*", cors.origin());
+        assertTrue(cors.origins().isEmpty());
     }
 
     @Test
     public void origin() {
         final CorsConfig cors = forOrigin("http://localhost:7888").build();
-        assertThat(cors.origin(), is(equalTo("http://localhost:7888")));
-        assertThat(cors.isAnyOriginSupported(), is(false));
+        assertEquals("http://localhost:7888", cors.origin());
+        assertFalse(cors.isAnyOriginSupported());
     }
 
     @Test
     public void origins() {
         final String[] origins = {"http://localhost:7888", "https://localhost:7888"};
         final CorsConfig cors = forOrigins(origins).build();
-        assertThat(cors.origins(), hasItems(origins));
-        assertThat(cors.isAnyOriginSupported(), is(false));
+        assertThat(cors.origins()).contains(origins);
+        assertFalse(cors.isAnyOriginSupported());
     }
 
     @Test
     public void exposeHeaders() {
         final CorsConfig cors = forAnyOrigin().exposeHeaders("custom-header1", "custom-header2").build();
-        assertThat(cors.exposedHeaders(), hasItems("custom-header1", "custom-header2"));
+        assertThat(cors.exposedHeaders()).contains("custom-header1", "custom-header2");
     }
 
     @Test
     public void allowCredentials() {
         final CorsConfig cors = forAnyOrigin().allowCredentials().build();
-        assertThat(cors.isCredentialsAllowed(), is(true));
+        assertTrue(cors.isCredentialsAllowed());
     }
 
     @Test
     public void maxAge() {
         final CorsConfig cors = forAnyOrigin().maxAge(3000).build();
-        assertThat(cors.maxAge(), is(3000L));
+        assertEquals(3000L, cors.maxAge());
     }
 
     @Test
     public void requestMethods() {
         final CorsConfig cors = forAnyOrigin().allowedRequestMethods(HttpMethod.POST, HttpMethod.GET).build();
-        assertThat(cors.allowedRequestMethods(), hasItems(HttpMethod.POST, HttpMethod.GET));
+        assertThat(cors.allowedRequestMethods()).contains(HttpMethod.POST, HttpMethod.GET);
     }
 
     @Test
     public void requestHeaders() {
         final CorsConfig cors = forAnyOrigin().allowedRequestHeaders("preflight-header1", "preflight-header2").build();
-        assertThat(cors.allowedRequestHeaders(), hasItems("preflight-header1", "preflight-header2"));
+        assertThat(cors.allowedRequestHeaders()).contains("preflight-header1", "preflight-header2");
     }
 
     @Test
     public void preflightResponseHeadersSingleValue() {
         final CorsConfig cors = forAnyOrigin().preflightResponseHeader("SingleValue", "value").build();
-        assertThat(cors.preflightResponseHeaders().get(of("SingleValue")), equalTo("value"));
+        assertEquals("value", cors.preflightResponseHeaders().get(of("SingleValue")));
     }
 
     @Test
     public void preflightResponseHeadersMultipleValues() {
         final CorsConfig cors = forAnyOrigin().preflightResponseHeader("MultipleValues", "value1", "value2").build();
-        assertThat(cors.preflightResponseHeaders().getAll(of("MultipleValues")), hasItems("value1", "value2"));
+        assertThat(cors.preflightResponseHeaders().getAll(of("MultipleValues"))).contains("value1", "value2");
     }
 
     @Test
     public void defaultPreflightResponseHeaders() {
         final CorsConfig cors = forAnyOrigin().build();
-        assertThat(cors.preflightResponseHeaders().get(HttpHeaderNames.DATE), is(notNullValue()));
-        assertThat(cors.preflightResponseHeaders().get(HttpHeaderNames.CONTENT_LENGTH), is("0"));
+        assertNotNull(cors.preflightResponseHeaders().get(HttpHeaderNames.DATE));
+        assertEquals("0", cors.preflightResponseHeaders().get(HttpHeaderNames.CONTENT_LENGTH));
     }
 
     @Test
     public void emptyPreflightResponseHeaders() {
         final CorsConfig cors = forAnyOrigin().noPreflightResponseHeaders().build();
-        assertThat(cors.preflightResponseHeaders(), equalTo((HttpHeaders) EmptyHttpHeaders.INSTANCE));
+        assertEquals(EmptyHttpHeaders.INSTANCE, cors.preflightResponseHeaders());
     }
 
     @Test
@@ -140,7 +139,6 @@ public class CorsConfigTest {
     @Test
     public void shortCircuit() {
         final CorsConfig cors = forOrigin("http://localhost:8080").shortCircuit().build();
-        assertThat(cors.isShortCircuit(), is(true));
+        assertTrue(cors.isShortCircuit());
     }
-
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cors/CorsHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cors/CorsHandlerTest.java
@@ -28,7 +28,6 @@ import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.util.AsciiString;
 import io.netty.util.ReferenceCountUtil;
-import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -45,25 +44,28 @@ import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 import static io.netty.handler.codec.http.cors.CorsConfigBuilder.*;
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsEqual.equalTo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CorsHandlerTest {
 
     @Test
     public void nonCorsRequest() {
         final HttpResponse response = simpleRequest(forAnyOrigin().build(), null);
-        assertThat(response.headers().contains(ACCESS_CONTROL_ALLOW_ORIGIN), is(false));
-        assertThat(ReferenceCountUtil.release(response), is(true));
+        assertFalse(response.headers().contains(ACCESS_CONTROL_ALLOW_ORIGIN));
+        assertTrue(ReferenceCountUtil.release(response));
     }
 
     @Test
     public void simpleRequestWithAnyOrigin() {
         final HttpResponse response = simpleRequest(forAnyOrigin().build(), "http://localhost:7777");
-        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN), is("*"));
-        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS), is(nullValue()));
-        assertThat(ReferenceCountUtil.release(response), is(true));
+        assertEquals("*", response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN));
+        assertNull(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS));
+        assertTrue(ReferenceCountUtil.release(response));
     }
 
     @Test
@@ -71,19 +73,19 @@ public class CorsHandlerTest {
         final HttpResponse response = simpleRequest(forOrigin("http://test.com").allowNullOrigin()
                 .allowCredentials()
                 .build(), "null");
-        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN), is("null"));
-        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_CREDENTIALS), is(equalTo("true")));
-        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS), is(nullValue()));
-        assertThat(ReferenceCountUtil.release(response), is(true));
+        assertEquals("null", response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN));
+        assertEquals("true", response.headers().get(ACCESS_CONTROL_ALLOW_CREDENTIALS));
+        assertNull(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS));
+        assertTrue(ReferenceCountUtil.release(response));
     }
 
     @Test
     public void simpleRequestWithOrigin() {
         final String origin = "http://localhost:8888";
         final HttpResponse response = simpleRequest(forOrigin(origin).build(), origin);
-        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN), is(origin));
-        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS), is(nullValue()));
-        assertThat(ReferenceCountUtil.release(response), is(true));
+        assertEquals(origin, response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN));
+        assertNull(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS));
+        assertTrue(ReferenceCountUtil.release(response));
     }
 
     @Test
@@ -92,14 +94,14 @@ public class CorsHandlerTest {
         final String origin2 = "https://localhost:8888";
         final String[] origins = {origin1, origin2};
         final HttpResponse response1 = simpleRequest(forOrigins(origins).build(), origin1);
-        assertThat(response1.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN), is(origin1));
-        assertThat(response1.headers().get(ACCESS_CONTROL_ALLOW_HEADERS), is(nullValue()));
-        assertThat(ReferenceCountUtil.release(response1), is(true));
+        assertEquals(origin1, response1.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN));
+        assertNull(response1.headers().get(ACCESS_CONTROL_ALLOW_HEADERS));
+        assertTrue(ReferenceCountUtil.release(response1));
 
         final HttpResponse response2 = simpleRequest(forOrigins(origins).build(), origin2);
-        assertThat(response2.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN), is(origin2));
-        assertThat(response2.headers().get(ACCESS_CONTROL_ALLOW_HEADERS), is(nullValue()));
-        assertThat(ReferenceCountUtil.release(response2), is(true));
+        assertEquals(origin2, response2.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN));
+        assertNull(response2.headers().get(ACCESS_CONTROL_ALLOW_HEADERS));
+        assertTrue(ReferenceCountUtil.release(response2));
     }
 
     @Test
@@ -107,9 +109,9 @@ public class CorsHandlerTest {
         final String origin = "http://localhost:8888";
         final HttpResponse response = simpleRequest(
                 forOrigins("https://localhost:8888").build(), origin);
-        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN), is(nullValue()));
-        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS), is(nullValue()));
-        assertThat(ReferenceCountUtil.release(response), is(true));
+        assertNull(response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN));
+        assertNull(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS));
+        assertTrue(ReferenceCountUtil.release(response));
     }
 
     @Test
@@ -118,11 +120,11 @@ public class CorsHandlerTest {
                 .allowedRequestMethods(GET, DELETE)
                 .build();
         final HttpResponse response = preflightRequest(config, "http://localhost:8888", "content-type, xheader1");
-        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN), is("http://localhost:8888"));
-        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_METHODS), containsString("GET"));
-        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_METHODS), containsString("DELETE"));
-        assertThat(response.headers().get(VARY), equalTo(ORIGIN.toString()));
-        assertThat(ReferenceCountUtil.release(response), is(true));
+        assertEquals("http://localhost:8888", response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN));
+        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_METHODS)).contains("GET");
+        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_METHODS)).contains("DELETE");
+        assertEquals(ORIGIN.toString(), response.headers().get(VARY));
+        assertTrue(ReferenceCountUtil.release(response));
     }
 
     @Test
@@ -132,23 +134,23 @@ public class CorsHandlerTest {
                 .allowedRequestHeaders("content-type", "xheader1")
                 .build();
         final HttpResponse response = preflightRequest(config, "http://localhost:8888", "content-type, xheader1");
-        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN), is("http://localhost:8888"));
-        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_METHODS), containsString("OPTIONS"));
-        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_METHODS), containsString("GET"));
-        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS), containsString("content-type"));
-        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS), containsString("xheader1"));
-        assertThat(response.headers().get(VARY), equalTo(ORIGIN.toString()));
-        assertThat(ReferenceCountUtil.release(response), is(true));
+        assertEquals("http://localhost:8888", response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN));
+        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_METHODS)).contains("OPTIONS");
+        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_METHODS)).contains("GET");
+        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS)).contains("content-type");
+        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS)).contains("xheader1");
+        assertEquals(ORIGIN.toString(), response.headers().get(VARY));
+        assertTrue(ReferenceCountUtil.release(response));
     }
 
     @Test
     public void preflightRequestWithDefaultHeaders() {
         final CorsConfig config = forOrigin("http://localhost:8888").build();
         final HttpResponse response = preflightRequest(config, "http://localhost:8888", "content-type, xheader1");
-        assertThat(response.headers().get(CONTENT_LENGTH), is("0"));
-        assertThat(response.headers().get(DATE), is(notNullValue()));
-        assertThat(response.headers().get(VARY), equalTo(ORIGIN.toString()));
-        assertThat(ReferenceCountUtil.release(response), is(true));
+        assertEquals("0", response.headers().get(CONTENT_LENGTH));
+        assertNotNull(response.headers().get(DATE));
+        assertEquals(ORIGIN.toString(), response.headers().get(VARY));
+        assertTrue(ReferenceCountUtil.release(response));
     }
 
     @Test
@@ -157,10 +159,10 @@ public class CorsHandlerTest {
                 .preflightResponseHeader("CustomHeader", "somevalue")
                 .build();
         final HttpResponse response = preflightRequest(config, "http://localhost:8888", "content-type, xheader1");
-        assertThat(response.headers().get(of("CustomHeader")), equalTo("somevalue"));
-        assertThat(response.headers().get(VARY), equalTo(ORIGIN.toString()));
-        assertThat(response.headers().get(CONTENT_LENGTH), is("0"));
-        assertThat(ReferenceCountUtil.release(response), is(true));
+        assertEquals("somevalue", response.headers().get(of("CustomHeader")));
+        assertEquals(ORIGIN.toString(), response.headers().get(VARY));
+        assertEquals("0", response.headers().get(CONTENT_LENGTH));
+        assertTrue(ReferenceCountUtil.release(response));
     }
 
     @Test
@@ -168,8 +170,8 @@ public class CorsHandlerTest {
         final String origin = "http://host";
         final CorsConfig config = forOrigin("http://localhost").build();
         final HttpResponse response = preflightRequest(config, origin, "xheader1");
-        assertThat(response.headers().contains(ACCESS_CONTROL_ALLOW_ORIGIN), is(false));
-        assertThat(ReferenceCountUtil.release(response), is(true));
+        assertFalse(response.headers().contains(ACCESS_CONTROL_ALLOW_ORIGIN));
+        assertTrue(ReferenceCountUtil.release(response));
     }
 
     @Test
@@ -182,8 +184,8 @@ public class CorsHandlerTest {
                 .build();
         final HttpResponse response = preflightRequest(config, "http://localhost:8888", "content-type, xheader1");
         assertValues(response, headerName, value1, value2);
-        assertThat(response.headers().get(VARY), equalTo(ORIGIN.toString()));
-        assertThat(ReferenceCountUtil.release(response), is(true));
+        assertEquals(ORIGIN.toString(), response.headers().get(VARY));
+        assertTrue(ReferenceCountUtil.release(response));
     }
 
     @Test
@@ -196,8 +198,8 @@ public class CorsHandlerTest {
                 .build();
         final HttpResponse response = preflightRequest(config, "http://localhost:8888", "content-type, xheader1");
         assertValues(response, headerName, value1, value2);
-        assertThat(response.headers().get(VARY), equalTo(ORIGIN.toString()));
-        assertThat(ReferenceCountUtil.release(response), is(true));
+        assertEquals(ORIGIN.toString(), response.headers().get(VARY));
+        assertTrue(ReferenceCountUtil.release(response));
     }
 
     @Test
@@ -210,9 +212,9 @@ public class CorsHandlerTest {
                     }
                 }).build();
         final HttpResponse response = preflightRequest(config, "http://localhost:8888", "content-type, xheader1");
-        assertThat(response.headers().get(of("GenHeader")), equalTo("generatedValue"));
-        assertThat(response.headers().get(VARY), equalTo(ORIGIN.toString()));
-        assertThat(ReferenceCountUtil.release(response), is(true));
+        assertEquals("generatedValue", response.headers().get(of("GenHeader")));
+        assertEquals(ORIGIN.toString(), response.headers().get(VARY));
+        assertTrue(ReferenceCountUtil.release(response));
     }
 
     @Test
@@ -223,9 +225,9 @@ public class CorsHandlerTest {
                 .allowCredentials()
                 .build();
         final HttpResponse response = preflightRequest(config, origin, "content-type, xheader1");
-        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN), is(equalTo("null")));
-        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_CREDENTIALS), is(equalTo("true")));
-        assertThat(ReferenceCountUtil.release(response), is(true));
+        assertEquals("null", response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN));
+        assertEquals("true", response.headers().get(ACCESS_CONTROL_ALLOW_CREDENTIALS));
+        assertTrue(ReferenceCountUtil.release(response));
     }
 
     @Test
@@ -233,8 +235,8 @@ public class CorsHandlerTest {
         final String origin = "null";
         final CorsConfig config = forOrigin(origin).allowCredentials().build();
         final HttpResponse response = preflightRequest(config, origin, "content-type, xheader1");
-        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_CREDENTIALS), is(equalTo("true")));
-        assertThat(ReferenceCountUtil.release(response), is(true));
+        assertEquals("true", response.headers().get(ACCESS_CONTROL_ALLOW_CREDENTIALS));
+        assertTrue(ReferenceCountUtil.release(response));
     }
 
     @Test
@@ -242,80 +244,80 @@ public class CorsHandlerTest {
         final CorsConfig config = forOrigin("http://localhost:8888").build();
         final HttpResponse response = preflightRequest(config, "http://localhost:8888", "");
         // the only valid value for Access-Control-Allow-Credentials is true.
-        assertThat(response.headers().contains(ACCESS_CONTROL_ALLOW_CREDENTIALS), is(false));
-        assertThat(ReferenceCountUtil.release(response), is(true));
+        assertFalse(response.headers().contains(ACCESS_CONTROL_ALLOW_CREDENTIALS));
+        assertTrue(ReferenceCountUtil.release(response));
     }
 
     @Test
     public void simpleRequestCustomHeaders() {
         final CorsConfig config = forAnyOrigin().exposeHeaders("custom1", "custom2").build();
         final HttpResponse response = simpleRequest(config, "http://localhost:7777");
-        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN), equalTo("*"));
-        assertThat(response.headers().get(ACCESS_CONTROL_EXPOSE_HEADERS), containsString("custom1"));
-        assertThat(response.headers().get(ACCESS_CONTROL_EXPOSE_HEADERS), containsString("custom2"));
-        assertThat(ReferenceCountUtil.release(response), is(true));
+        assertEquals("*", response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN));
+        assertThat(response.headers().get(ACCESS_CONTROL_EXPOSE_HEADERS)).contains("custom1");
+        assertThat(response.headers().get(ACCESS_CONTROL_EXPOSE_HEADERS)).contains("custom2");
+        assertTrue(ReferenceCountUtil.release(response));
     }
 
     @Test
     public void simpleRequestAllowCredentials() {
         final CorsConfig config = forAnyOrigin().allowCredentials().build();
         final HttpResponse response = simpleRequest(config, "http://localhost:7777");
-        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_CREDENTIALS), equalTo("true"));
-        assertThat(ReferenceCountUtil.release(response), is(true));
+        assertEquals("true", response.headers().get(ACCESS_CONTROL_ALLOW_CREDENTIALS));
+        assertTrue(ReferenceCountUtil.release(response));
     }
 
     @Test
     public void simpleRequestDoNotAllowCredentials() {
         final CorsConfig config = forAnyOrigin().build();
         final HttpResponse response = simpleRequest(config, "http://localhost:7777");
-        assertThat(response.headers().contains(ACCESS_CONTROL_ALLOW_CREDENTIALS), is(false));
-        assertThat(ReferenceCountUtil.release(response), is(true));
+        assertFalse(response.headers().contains(ACCESS_CONTROL_ALLOW_CREDENTIALS));
+        assertTrue(ReferenceCountUtil.release(response));
     }
 
     @Test
     public void anyOriginAndAllowCredentialsShouldEchoRequestOrigin() {
         final CorsConfig config = forAnyOrigin().allowCredentials().build();
         final HttpResponse response = simpleRequest(config, "http://localhost:7777");
-        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_CREDENTIALS), equalTo("true"));
-        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN), equalTo("http://localhost:7777"));
-        assertThat(response.headers().get(VARY), equalTo(ORIGIN.toString()));
-        assertThat(ReferenceCountUtil.release(response), is(true));
+        assertEquals("true", response.headers().get(ACCESS_CONTROL_ALLOW_CREDENTIALS));
+        assertEquals("http://localhost:7777", response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN));
+        assertEquals(ORIGIN.toString(), response.headers().get(VARY));
+        assertTrue(ReferenceCountUtil.release(response));
     }
 
     @Test
     public void simpleRequestExposeHeaders() {
         final CorsConfig config = forAnyOrigin().exposeHeaders("one", "two").build();
         final HttpResponse response = simpleRequest(config, "http://localhost:7777");
-        assertThat(response.headers().get(ACCESS_CONTROL_EXPOSE_HEADERS), containsString("one"));
-        assertThat(response.headers().get(ACCESS_CONTROL_EXPOSE_HEADERS), containsString("two"));
-        assertThat(ReferenceCountUtil.release(response), is(true));
+        assertThat(response.headers().get(ACCESS_CONTROL_EXPOSE_HEADERS)).contains("one");
+        assertThat(response.headers().get(ACCESS_CONTROL_EXPOSE_HEADERS)).contains("two");
+        assertTrue(ReferenceCountUtil.release(response));
     }
 
     @Test
     public void simpleRequestShortCircuit() {
         final CorsConfig config = forOrigin("http://localhost:8080").shortCircuit().build();
         final HttpResponse response = simpleRequest(config, "http://localhost:7777");
-        assertThat(response.status(), is(FORBIDDEN));
-        assertThat(response.headers().get(CONTENT_LENGTH), is("0"));
-        assertThat(ReferenceCountUtil.release(response), is(true));
+        assertEquals(FORBIDDEN, response.status());
+        assertEquals("0", response.headers().get(CONTENT_LENGTH));
+        assertTrue(ReferenceCountUtil.release(response));
     }
 
     @Test
     public void simpleRequestNoShortCircuit() {
         final CorsConfig config = forOrigin("http://localhost:8080").build();
         final HttpResponse response = simpleRequest(config, "http://localhost:7777");
-        assertThat(response.status(), is(OK));
-        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN), is(nullValue()));
-        assertThat(ReferenceCountUtil.release(response), is(true));
+        assertEquals(OK, response.status());
+        assertNull(response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN));
+        assertTrue(ReferenceCountUtil.release(response));
     }
 
     @Test
     public void shortCircuitNonCorsRequest() {
         final CorsConfig config = forOrigin("https://localhost").shortCircuit().build();
         final HttpResponse response = simpleRequest(config, null);
-        assertThat(response.status(), is(OK));
-        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN), is(nullValue()));
-        assertThat(ReferenceCountUtil.release(response), is(true));
+        assertEquals(OK, response.status());
+        assertNull(response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN));
+        assertTrue(ReferenceCountUtil.release(response));
     }
 
     @Test
@@ -326,14 +328,14 @@ public class CorsHandlerTest {
         request.headers().set(ORIGIN, "http://localhost:8888");
         request.headers().set(CONNECTION, KEEP_ALIVE);
 
-        assertThat(channel.writeInbound(request), is(false));
+        assertFalse(channel.writeInbound(request));
         final HttpResponse response = channel.readOutbound();
-        assertThat(HttpUtil.isKeepAlive(response), is(true));
+        assertTrue(HttpUtil.isKeepAlive(response));
 
-        assertThat(channel.isOpen(), is(true));
-        assertThat(response.status(), is(FORBIDDEN));
-        assertThat(ReferenceCountUtil.release(response), is(true));
-        assertThat(channel.finish(), is(false));
+        assertTrue(channel.isOpen());
+        assertEquals(FORBIDDEN, response.status());
+        assertTrue(ReferenceCountUtil.release(response));
+        assertFalse(channel.finish());
     }
 
     @Test
@@ -343,14 +345,14 @@ public class CorsHandlerTest {
         final FullHttpRequest request = createHttpRequest(GET);
         request.headers().set(ORIGIN, "http://localhost:8888");
 
-        assertThat(channel.writeInbound(request), is(false));
+        assertFalse(channel.writeInbound(request));
         final HttpResponse response = channel.readOutbound();
-        assertThat(HttpUtil.isKeepAlive(response), is(true));
+        assertTrue(HttpUtil.isKeepAlive(response));
 
-        assertThat(channel.isOpen(), is(true));
-        assertThat(response.status(), is(FORBIDDEN));
-        assertThat(ReferenceCountUtil.release(response), is(true));
-        assertThat(channel.finish(), is(false));
+        assertTrue(channel.isOpen());
+        assertEquals(FORBIDDEN, response.status());
+        assertTrue(ReferenceCountUtil.release(response));
+        assertFalse(channel.finish());
     }
 
     @Test
@@ -361,14 +363,14 @@ public class CorsHandlerTest {
         request.headers().set(ORIGIN, "http://localhost:8888");
         request.headers().set(CONNECTION, CLOSE);
 
-        assertThat(channel.writeInbound(request), is(false));
+        assertFalse(channel.writeInbound(request));
         final HttpResponse response = channel.readOutbound();
-        assertThat(HttpUtil.isKeepAlive(response), is(false));
+        assertFalse(HttpUtil.isKeepAlive(response));
 
-        assertThat(channel.isOpen(), is(false));
-        assertThat(response.status(), is(FORBIDDEN));
-        assertThat(ReferenceCountUtil.release(response), is(true));
-        assertThat(channel.finish(), is(false));
+        assertFalse(channel.isOpen());
+        assertEquals(FORBIDDEN, response.status());
+        assertTrue(ReferenceCountUtil.release(response));
+        assertFalse(channel.finish());
     }
 
     @Test
@@ -378,10 +380,10 @@ public class CorsHandlerTest {
                 .build();
         final EmbeddedChannel channel = new EmbeddedChannel(new CorsHandler(config));
         final FullHttpRequest request = optionsRequest("http://localhost:8888", "content-type, xheader1", null);
-        assertThat(channel.writeInbound(request), is(false));
-        assertThat(request.refCnt(), is(0));
-        assertThat(ReferenceCountUtil.release(channel.readOutbound()), is(true));
-        assertThat(channel.finish(), is(false));
+        assertFalse(channel.writeInbound(request));
+        assertEquals(0, request.refCnt());
+        assertTrue(ReferenceCountUtil.release(channel.readOutbound()));
+        assertFalse(channel.finish());
     }
 
     @Test
@@ -390,14 +392,14 @@ public class CorsHandlerTest {
         final CorsConfig config = forOrigin("http://localhost:8888").build();
         final EmbeddedChannel channel = new EmbeddedChannel(new CorsHandler(config));
         final FullHttpRequest request = optionsRequest("http://localhost:8888", "", KEEP_ALIVE);
-        assertThat(channel.writeInbound(request), is(false));
+        assertFalse(channel.writeInbound(request));
         final HttpResponse response = channel.readOutbound();
-        assertThat(HttpUtil.isKeepAlive(response), is(true));
+        assertTrue(HttpUtil.isKeepAlive(response));
 
-        assertThat(channel.isOpen(), is(true));
-        assertThat(response.status(), is(OK));
-        assertThat(ReferenceCountUtil.release(response), is(true));
-        assertThat(channel.finish(), is(false));
+        assertTrue(channel.isOpen());
+        assertEquals(OK, response.status());
+        assertTrue(ReferenceCountUtil.release(response));
+        assertFalse(channel.finish());
     }
 
     @Test
@@ -406,14 +408,14 @@ public class CorsHandlerTest {
         final CorsConfig config = forOrigin("http://localhost:8888").build();
         final EmbeddedChannel channel = new EmbeddedChannel(new CorsHandler(config));
         final FullHttpRequest request = optionsRequest("http://localhost:8888", "", null);
-        assertThat(channel.writeInbound(request), is(false));
+        assertFalse(channel.writeInbound(request));
         final HttpResponse response = channel.readOutbound();
-        assertThat(HttpUtil.isKeepAlive(response), is(true));
+        assertTrue(HttpUtil.isKeepAlive(response));
 
-        assertThat(channel.isOpen(), is(true));
-        assertThat(response.status(), is(OK));
-        assertThat(ReferenceCountUtil.release(response), is(true));
-        assertThat(channel.finish(), is(false));
+        assertTrue(channel.isOpen());
+        assertEquals(OK, response.status());
+        assertTrue(ReferenceCountUtil.release(response));
+        assertFalse(channel.finish());
     }
 
     @Test
@@ -422,14 +424,14 @@ public class CorsHandlerTest {
         final CorsConfig config = forOrigin("http://localhost:8888").build();
         final EmbeddedChannel channel = new EmbeddedChannel(new CorsHandler(config));
         final FullHttpRequest request = optionsRequest("http://localhost:8888", "", CLOSE);
-        assertThat(channel.writeInbound(request), is(false));
+        assertFalse(channel.writeInbound(request));
         final HttpResponse response = channel.readOutbound();
-        assertThat(HttpUtil.isKeepAlive(response), is(false));
+        assertFalse(HttpUtil.isKeepAlive(response));
 
-        assertThat(channel.isOpen(), is(false));
-        assertThat(response.status(), is(OK));
-        assertThat(ReferenceCountUtil.release(response), is(true));
-        assertThat(channel.finish(), is(false));
+        assertFalse(channel.isOpen());
+        assertEquals(OK, response.status());
+        assertTrue(ReferenceCountUtil.release(response));
+        assertFalse(channel.finish());
     }
 
     @Test
@@ -438,10 +440,10 @@ public class CorsHandlerTest {
         final EmbeddedChannel channel = new EmbeddedChannel(new CorsHandler(config), new EchoHandler());
         final FullHttpRequest request = createHttpRequest(GET);
         request.headers().set(ORIGIN, "http://localhost:8888");
-        assertThat(channel.writeInbound(request), is(false));
-        assertThat(request.refCnt(), is(0));
-        assertThat(ReferenceCountUtil.release(channel.readOutbound()), is(true));
-        assertThat(channel.finish(), is(false));
+        assertFalse(channel.writeInbound(request));
+        assertEquals(0, request.refCnt());
+        assertTrue(ReferenceCountUtil.release(channel.readOutbound()));
+        assertFalse(channel.finish());
     }
 
     @Test
@@ -455,12 +457,12 @@ public class CorsHandlerTest {
         List<CorsConfig> corsConfigs = Arrays.asList(rule1, rule2);
 
         final HttpResponse preFlightHost1 = preflightRequest(corsConfigs, host1, "", false);
-        assertThat(preFlightHost1.headers().get(ACCESS_CONTROL_ALLOW_METHODS), is("GET"));
-        assertThat(preFlightHost1.headers().getAsString(ACCESS_CONTROL_ALLOW_CREDENTIALS), is(nullValue()));
+        assertEquals("GET", preFlightHost1.headers().get(ACCESS_CONTROL_ALLOW_METHODS));
+        assertNull(preFlightHost1.headers().getAsString(ACCESS_CONTROL_ALLOW_CREDENTIALS));
 
         final HttpResponse preFlightHost2 = preflightRequest(corsConfigs, host2, "", false);
         assertValues(preFlightHost2, ACCESS_CONTROL_ALLOW_METHODS.toString(), "GET", "POST");
-        assertThat(preFlightHost2.headers().getAsString(ACCESS_CONTROL_ALLOW_CREDENTIALS), IsEqual.equalTo("true"));
+        assertEquals("true", preFlightHost2.headers().getAsString(ACCESS_CONTROL_ALLOW_CREDENTIALS));
     }
 
     @Test
@@ -475,13 +477,13 @@ public class CorsHandlerTest {
         List<CorsConfig> rules = Arrays.asList(forHost1, allowAll);
 
         final HttpResponse host1Response = preflightRequest(rules, host1, "", false);
-        assertThat(host1Response.headers().get(ACCESS_CONTROL_ALLOW_METHODS), is("GET"));
-        assertThat(host1Response.headers().getAsString(ACCESS_CONTROL_MAX_AGE), equalTo("3600"));
+        assertEquals("GET", host1Response.headers().get(ACCESS_CONTROL_ALLOW_METHODS));
+        assertEquals("3600", host1Response.headers().getAsString(ACCESS_CONTROL_MAX_AGE));
 
         final HttpResponse host2Response = preflightRequest(rules, host2, "", false);
         assertValues(host2Response, ACCESS_CONTROL_ALLOW_METHODS.toString(), "POST", "GET", "OPTIONS");
-        assertThat(host2Response.headers().getAsString(ACCESS_CONTROL_ALLOW_ORIGIN), equalTo("*"));
-        assertThat(host2Response.headers().getAsString(ACCESS_CONTROL_MAX_AGE), equalTo("1800"));
+        assertEquals("*", host2Response.headers().getAsString(ACCESS_CONTROL_ALLOW_ORIGIN));
+        assertEquals("1800", host2Response.headers().getAsString(ACCESS_CONTROL_MAX_AGE));
     }
 
     @Test
@@ -490,11 +492,11 @@ public class CorsHandlerTest {
         final EmbeddedChannel channel = new EmbeddedChannel(new CorsHandler(config));
         final FullHttpRequest request = optionsRequest("http://localhost:8888", "", null);
         request.headers().set(ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK, "true");
-        assertThat(channel.writeInbound(request), is(false));
+        assertFalse(channel.writeInbound(request));
         final HttpResponse response = channel.readOutbound();
 
-        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK), equalTo("true"));
-        assertThat(ReferenceCountUtil.release(response), is(true));
+        assertEquals("true", response.headers().get(ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK));
+        assertTrue(ReferenceCountUtil.release(response));
     }
 
     @Test
@@ -503,11 +505,11 @@ public class CorsHandlerTest {
         final EmbeddedChannel channel = new EmbeddedChannel(new CorsHandler(config));
         final FullHttpRequest request = optionsRequest("http://localhost:8888", "", null);
         request.headers().set(ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK, "true");
-        assertThat(channel.writeInbound(request), is(false));
+        assertFalse(channel.writeInbound(request));
         final HttpResponse response = channel.readOutbound();
 
-        assertThat(response.headers().get(ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK), equalTo("false"));
-        assertThat(ReferenceCountUtil.release(response), is(true));
+        assertEquals("false", response.headers().get(ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK));
+        assertTrue(ReferenceCountUtil.release(response));
     }
 
     private static HttpResponse simpleRequest(final CorsConfig config, final String origin) {
@@ -532,9 +534,9 @@ public class CorsHandlerTest {
         if (requestHeaders != null) {
             httpRequest.headers().set(ACCESS_CONTROL_REQUEST_HEADERS, requestHeaders);
         }
-        assertThat(channel.writeInbound(httpRequest), is(false));
+        assertFalse(channel.writeInbound(httpRequest));
         HttpResponse response =  channel.readOutbound();
-        assertThat(channel.finish(), is(false));
+        assertFalse(channel.finish());
         return response;
     }
 
@@ -549,9 +551,9 @@ public class CorsHandlerTest {
                                                  final String requestHeaders,
                                                  final boolean isSHortCircuit) {
         final EmbeddedChannel channel = new EmbeddedChannel(new CorsHandler(configs, isSHortCircuit));
-        assertThat(channel.writeInbound(optionsRequest(origin, requestHeaders, null)), is(false));
+        assertFalse(channel.writeInbound(optionsRequest(origin, requestHeaders, null)));
         HttpResponse response = channel.readOutbound();
-        assertThat(channel.finish(), is(false));
+        assertFalse(channel.finish());
         return response;
     }
 
@@ -585,7 +587,7 @@ public class CorsHandlerTest {
     private static void assertValues(final HttpResponse response, final String headerName, final String... values) {
         final String header = response.headers().get(of(headerName));
         for (String value : values) {
-            assertThat(header, containsString(value));
+            assertThat(header).contains(value);
         }
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketCloseStatusTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketCloseStatusTest.java
@@ -19,11 +19,10 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 
 import org.assertj.core.api.ThrowableAssert;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -73,12 +72,11 @@ public class WebSocketCloseStatusTest {
 
     @Test
     public void testNaturalOrder() {
-        assertThat(PROTOCOL_ERROR, Matchers.greaterThan(NORMAL_CLOSURE));
-        assertThat(PROTOCOL_ERROR, Matchers.greaterThan(valueOf(1001)));
-        assertThat(PROTOCOL_ERROR, Matchers.comparesEqualTo(PROTOCOL_ERROR));
-        assertThat(PROTOCOL_ERROR, Matchers.comparesEqualTo(valueOf(1002)));
-        assertThat(PROTOCOL_ERROR, Matchers.lessThan(INVALID_MESSAGE_TYPE));
-        assertThat(PROTOCOL_ERROR, Matchers.lessThan(valueOf(1007)));
+        assertThat(PROTOCOL_ERROR).isGreaterThan(NORMAL_CLOSURE);
+        assertThat(PROTOCOL_ERROR).isGreaterThan(valueOf(1001));
+        assertEquals(PROTOCOL_ERROR, valueOf(1002));
+        assertThat(PROTOCOL_ERROR).isLessThan(INVALID_MESSAGE_TYPE);
+        assertThat(PROTOCOL_ERROR).isLessThan(valueOf(1007));
     }
 
     @Test

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketProtocolHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketProtocolHandlerTest.java
@@ -25,15 +25,14 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.flow.FlowControlHandler;
 import io.netty.util.ReferenceCountUtil;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicReference;
 
 import static io.netty.util.CharsetUtil.UTF_8;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -173,7 +172,7 @@ public class WebSocketProtocolHandlerTest {
             channel.runPendingTasks();
         } while (!future.isDone());
 
-        assertThat(future.cause(), Matchers.instanceOf(WebSocketHandshakeException.class));
+        assertInstanceOf(WebSocketHandshakeException.class, future.cause());
         assertFalse(ref.get().isDone());
         assertFalse(channel.finish());
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13Test.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13Test.java
@@ -39,10 +39,9 @@ import org.junit.jupiter.api.function.Executable;
 import java.util.Iterator;
 
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -188,7 +187,7 @@ public class WebSocketServerHandshaker13Test extends WebSocketServerHandshakerTe
             // expected
         }
         ReferenceCounted closeMessage = ch.readOutbound();
-        assertThat(closeMessage, instanceOf(ByteBuf.class));
+        assertInstanceOf(ByteBuf.class, closeMessage);
         closeMessage.release();
         assertFalse(ch.finish());
     }

--- a/codec-http2/pom.xml
+++ b/codec-http2/pom.xml
@@ -164,11 +164,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/AbstractDecoratingHttp2ConnectionDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/AbstractDecoratingHttp2ConnectionDecoderTest.java
@@ -14,14 +14,13 @@
  */
 package io.netty.handler.codec.http2;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -48,8 +47,7 @@ public abstract class AbstractDecoratingHttp2ConnectionDecoderTest {
         decoder.frameListener(listener);
         verify(delegate).frameListener(listenerArgumentCaptor.capture());
 
-        assertThat(decoder.frameListener(),
-                CoreMatchers.not(CoreMatchers.instanceOf(delegatingFrameListenerType())));
+        assertThat(decoder.frameListener()).isNotInstanceOf(delegatingFrameListenerType());
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
@@ -50,11 +50,7 @@ import static io.netty.handler.codec.http2.Http2Stream.State.OPEN;
 import static io.netty.handler.codec.http2.Http2Stream.State.RESERVED_REMOTE;
 import static io.netty.util.CharsetUtil.UTF_8;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.not;
-
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -329,7 +325,7 @@ public class DefaultHttp2ConnectionDecoderTest {
                 try {
                     decode().onDataRead(ctx, STREAM_ID, data, padding, true);
                 } catch (Http2Exception ex) {
-                    assertThat(ex, not(instanceOf(Http2Exception.StreamException.class)));
+                    assertThat(ex).isNotInstanceOf(Http2Exception.StreamException.class);
                     throw ex;
                 }
             }
@@ -602,7 +598,7 @@ public class DefaultHttp2ConnectionDecoderTest {
             }
         });
         assertEquals(PROTOCOL_ERROR, ex.error());
-        assertThat(ex.getMessage(), containsString(pseudoHeader));
+        assertThat(ex.getMessage()).contains(pseudoHeader);
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
@@ -50,10 +50,9 @@ import static io.netty.handler.codec.http2.Http2Stream.State.HALF_CLOSED_REMOTE;
 import static io.netty.handler.codec.http2.Http2Stream.State.RESERVED_LOCAL;
 import static io.netty.handler.codec.http2.Http2TestUtil.newVoidPromise;
 import static io.netty.util.CharsetUtil.UTF_8;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -834,7 +833,7 @@ public class DefaultHttp2ConnectionEncoderTest {
         encoder.writeData(ctx, STREAM_ID, data, 0, false, promise);
         assertTrue(promise.isDone());
         assertFalse(promise.isSuccess());
-        assertThat(promise.cause(), instanceOf(IllegalArgumentException.class));
+        assertInstanceOf(IllegalArgumentException.class, promise.cause());
         verify(data).release();
     }
 
@@ -846,7 +845,7 @@ public class DefaultHttp2ConnectionEncoderTest {
         encoder.writeData(ctx, STREAM_ID, data, 0, false, promise);
         assertTrue(promise.isDone());
         assertFalse(promise.isSuccess());
-        assertThat(promise.cause(), instanceOf(IllegalStateException.class));
+        assertInstanceOf(IllegalStateException.class, promise.cause());
         verify(data).release();
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackDecoderTest.java
@@ -51,9 +51,7 @@ import static io.netty.handler.codec.http2.Http2HeadersEncoder.NEVER_SENSITIVE;
 import static io.netty.util.AsciiString.EMPTY_STRING;
 import static io.netty.util.AsciiString.of;
 import static java.lang.Integer.MAX_VALUE;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -647,7 +645,7 @@ public class HpackDecoderTest {
             final Http2Headers decoded = new DefaultHttp2Headers();
 
             // SETTINGS_MAX_HEADER_LIST_SIZE is big enough for the header to fit...
-            assertThat(hpackDecoder.getMaxHeaderListSize(), is(greaterThanOrEqualTo(headerSize)));
+            assertThat(hpackDecoder.getMaxHeaderListSize()).isGreaterThanOrEqualTo(headerSize);
 
             // ... but decode should fail because we add some overhead for each header entry
             assertThrows(Http2Exception.HeaderListSizeException.class, new Executable() {
@@ -717,9 +715,9 @@ public class HpackDecoderTest {
 
             hpackDecoder.decode(1, in, decoded, false);
 
-            assertThat(decoded.valueIterator(":test").next().toString(), is("1"));
-            assertThat(decoded.status().toString(), is("200"));
-            assertThat(decoded.method().toString(), is("GET"));
+            assertEquals("1", decoded.valueIterator(":test").next().toString());
+            assertEquals("200", decoded.status().toString());
+            assertEquals("GET", decoded.method().toString());
         } finally {
             in.release();
         }
@@ -792,8 +790,8 @@ public class HpackDecoderTest {
                     hpackDecoder.decode(3, in, decoded, true);
                 }
             });
-            assertThat(e.streamId(), is(3));
-            assertThat(e.error(), is(PROTOCOL_ERROR));
+            assertEquals(3, e.streamId());
+            assertEquals(PROTOCOL_ERROR, e.error());
         } finally {
             in.release();
         }
@@ -820,8 +818,8 @@ public class HpackDecoderTest {
                     hpackDecoder.decode(3, in, decoded, true);
                 }
             });
-            assertThat(e.streamId(), is(3));
-            assertThat(e.error(), is(PROTOCOL_ERROR));
+            assertEquals(3, e.streamId());
+            assertEquals(PROTOCOL_ERROR, e.error());
         } finally {
             in.release();
         }
@@ -885,8 +883,8 @@ public class HpackDecoderTest {
                     hpackDecoder.decode(3, in, decoded, true);
                 }
             });
-            assertThat(e.streamId(), is(3));
-            assertThat(e.error(), is(PROTOCOL_ERROR));
+            assertEquals(3, e.streamId());
+            assertEquals(PROTOCOL_ERROR, e.error());
         } finally {
             in.release();
         }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -65,13 +65,11 @@ import static io.netty.handler.codec.http2.Http2TestUtil.randomString;
 import static io.netty.handler.codec.http2.Http2TestUtil.runInChannel;
 import static java.lang.Integer.MAX_VALUE;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -572,7 +570,7 @@ public class Http2ConnectionRoundtripTest {
         assertTrue(serverWriteHeadersLatch.await(DEFAULT_AWAIT_TIMEOUT_SECONDS, SECONDS));
         Throwable serverWriteHeadersCause = serverWriteHeadersCauseRef.get();
         assertNotNull(serverWriteHeadersCause);
-        assertThat(serverWriteHeadersCauseRef.get(), not(instanceOf(Http2Exception.class)));
+        assertThat(serverWriteHeadersCauseRef.get()).isNotInstanceOf(Http2Exception.class);
 
         // Server should receive a RST_STREAM for stream 3.
         verify(serverListener, never()).onGoAwayRead(any(ChannelHandlerContext.class), anyInt(), anyLong(),
@@ -731,7 +729,7 @@ public class Http2ConnectionRoundtripTest {
                 emptyDataPromise.get();
             }
         });
-        assertThat(e.getCause(), is(instanceOf(IllegalReferenceCountException.class)));
+        assertInstanceOf(IllegalReferenceCountException.class, e.getCause());
     }
 
     @Test
@@ -783,7 +781,7 @@ public class Http2ConnectionRoundtripTest {
                 dataPromise.get();
             }
         });
-        assertThat(e.getCause(), is(instanceOf(IllegalStateException.class)));
+        assertInstanceOf(IllegalStateException.class, e.getCause());
         assertPromise.sync();
     }
 
@@ -935,7 +933,7 @@ public class Http2ConnectionRoundtripTest {
         ChannelFuture clientWriteAfterGoAwayFuture = clientWriteAfterGoAwayFutureRef.get();
         assertNotNull(clientWriteAfterGoAwayFuture);
         Throwable clientCause = clientWriteAfterGoAwayFuture.cause();
-        assertThat(clientCause, is(instanceOf(Http2Exception.StreamException.class)));
+        assertInstanceOf(Http2Exception.StreamException.class, clientCause);
         assertEquals(Http2Error.REFUSED_STREAM.code(), ((Http2Exception.StreamException) clientCause).error().code());
 
         // Wait for the server to receive a GO_AWAY, but this is expected to timeout!

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
@@ -63,10 +63,9 @@ import static io.netty.handler.codec.http2.Http2TestUtil.anyChannelPromise;
 import static io.netty.handler.codec.http2.Http2TestUtil.anyHttp2Settings;
 import static io.netty.handler.codec.http2.Http2TestUtil.assertEqualsAndRelease;
 import static io.netty.handler.codec.http2.Http2TestUtil.bb;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -390,7 +389,7 @@ public class Http2FrameCodecTest {
         f.await();
         assertTrue(f.isDone());
         assertFalse(f.isSuccess());
-        assertThat(f.cause(), instanceOf(UnsupportedMessageTypeException.class));
+        assertInstanceOf(UnsupportedMessageTypeException.class, f.cause());
         assertEquals(0, frame.refCnt());
     }
 
@@ -517,7 +516,7 @@ public class Http2FrameCodecTest {
         ChannelFuture f = channel.write(new DefaultHttp2WindowUpdateFrame(100).stream(stream2));
         assertTrue(f.isDone());
         assertFalse(f.isSuccess());
-        assertThat(f.cause(), instanceOf(Http2Exception.class));
+        assertInstanceOf(Http2Exception.class, f.cause());
     }
 
     @Test
@@ -740,7 +739,7 @@ public class Http2FrameCodecTest {
         assertEquals(NO_ERROR.code(), goAwayFrame.errorCode());
         assertEquals(Integer.MAX_VALUE, goAwayFrame.lastStreamId());
         goAwayFrame.release();
-        assertThat(writePromise.cause(), instanceOf(Http2NoMoreStreamIdsException.class));
+        assertInstanceOf(Http2NoMoreStreamIdsException.class, writePromise.cause());
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrapTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrapTest.java
@@ -31,7 +31,6 @@ import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import org.hamcrest.core.IsInstanceOf;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
@@ -42,9 +41,8 @@ import java.util.concurrent.ExecutionException;
 import static io.netty.handler.codec.http2.Http2FrameCodecBuilder.forClient;
 import static io.netty.handler.codec.http2.Http2FrameCodecBuilder.forServer;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -108,7 +106,7 @@ public class Http2StreamChannelBootstrapTest {
             Http2StreamChannelBootstrap bootstrap = new Http2StreamChannelBootstrap(clientChannel);
             final Promise<Http2StreamChannel> promise = clientChannel.eventLoop().newPromise();
             bootstrap.open(promise);
-            assertThat(promise.isDone(), is(false));
+            assertFalse(promise.isDone());
             closeLatch.countDown();
 
             ExecutionException exception = assertThrows(ExecutionException.class, new Executable() {
@@ -117,7 +115,7 @@ public class Http2StreamChannelBootstrapTest {
                     promise.get(3, SECONDS);
                 }
             });
-            assertThat(exception.getCause(), IsInstanceOf.<Throwable>instanceOf(ClosedChannelException.class));
+            assertInstanceOf(ClosedChannelException.class, exception.getCause());
         } finally {
             safeClose(clientChannel);
             safeClose(serverConnectedChannel);
@@ -160,7 +158,7 @@ public class Http2StreamChannelBootstrapTest {
 
         Promise<Http2StreamChannel> promise = new DefaultPromise<Http2StreamChannel>(mock(EventExecutor.class));
         bootstrap.open0(ctx, promise);
-        assertThat(promise.isDone(), is(true));
-        assertThat(promise.cause(), is(instanceOf(IllegalStateException.class)));
+        assertTrue(promise.isDone());
+        assertInstanceOf(IllegalStateException.class, promise.cause());
     }
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodecTest.java
@@ -55,11 +55,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -74,10 +70,10 @@ public class Http2StreamFrameToHttpObjectCodecTest {
         assertTrue(ch.writeOutbound(new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK)));
 
         Http2HeadersFrame headersFrame = ch.readOutbound();
-        assertThat(headersFrame.headers().status().toString(), is("200"));
+        assertEquals("200", headersFrame.headers().status().toString());
         assertTrue(headersFrame.isEndStream());
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
         assertFalse(ch.finish());
     }
 
@@ -88,10 +84,10 @@ public class Http2StreamFrameToHttpObjectCodecTest {
                 HttpVersion.HTTP_1_1, HttpResponseStatus.CONTINUE)));
 
         Http2HeadersFrame headersFrame = ch.readOutbound();
-        assertThat(headersFrame.headers().status().toString(), is("100"));
+        assertEquals("100", headersFrame.headers().status().toString());
         assertFalse(headersFrame.isEndStream());
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
         assertFalse(ch.finish());
     }
 
@@ -115,18 +111,18 @@ public class Http2StreamFrameToHttpObjectCodecTest {
         assertTrue(ch.writeOutbound(new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, hello)));
 
         Http2HeadersFrame headersFrame = ch.readOutbound();
-        assertThat(headersFrame.headers().status().toString(), is("200"));
+        assertEquals("200", headersFrame.headers().status().toString());
         assertFalse(headersFrame.isEndStream());
 
         Http2DataFrame dataFrame = ch.readOutbound();
         try {
-            assertThat(dataFrame.content().toString(CharsetUtil.UTF_8), is("hello world"));
+            assertEquals("hello world", dataFrame.content().toString(CharsetUtil.UTF_8));
             assertTrue(dataFrame.isEndStream());
         } finally {
             dataFrame.release();
         }
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
         assertFalse(ch.finish());
     }
 
@@ -139,14 +135,14 @@ public class Http2StreamFrameToHttpObjectCodecTest {
         assertTrue(ch.writeOutbound(response));
 
         Http2HeadersFrame headersFrame = ch.readOutbound();
-        assertThat(headersFrame.headers().status().toString(), is("200"));
+        assertEquals("200", headersFrame.headers().status().toString());
         assertFalse(headersFrame.isEndStream());
 
         Http2HeadersFrame trailersFrame = ch.readOutbound();
-        assertThat(trailersFrame.headers().get("key").toString(), is("value"));
+        assertEquals("value", trailersFrame.headers().get("key").toString());
         assertTrue(trailersFrame.isEndStream());
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
         assertFalse(ch.finish());
     }
 
@@ -160,22 +156,22 @@ public class Http2StreamFrameToHttpObjectCodecTest {
         assertTrue(ch.writeOutbound(response));
 
         Http2HeadersFrame headersFrame = ch.readOutbound();
-        assertThat(headersFrame.headers().status().toString(), is("200"));
+        assertEquals("200", headersFrame.headers().status().toString());
         assertFalse(headersFrame.isEndStream());
 
         Http2DataFrame dataFrame = ch.readOutbound();
         try {
-            assertThat(dataFrame.content().toString(CharsetUtil.UTF_8), is("hello world"));
+            assertEquals("hello world", dataFrame.content().toString(CharsetUtil.UTF_8));
             assertFalse(dataFrame.isEndStream());
         } finally {
             dataFrame.release();
         }
 
         Http2HeadersFrame trailersFrame = ch.readOutbound();
-        assertThat(trailersFrame.headers().get("key").toString(), is("value"));
+        assertEquals("value", trailersFrame.headers().get("key").toString());
         assertTrue(trailersFrame.isEndStream());
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
         assertFalse(ch.finish());
     }
 
@@ -186,10 +182,10 @@ public class Http2StreamFrameToHttpObjectCodecTest {
         assertTrue(ch.writeOutbound(response));
 
         Http2HeadersFrame headersFrame = ch.readOutbound();
-        assertThat(headersFrame.headers().status().toString(), is("200"));
+        assertEquals("200", headersFrame.headers().status().toString());
         assertFalse(headersFrame.isEndStream());
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
         assertFalse(ch.finish());
     }
 
@@ -202,13 +198,13 @@ public class Http2StreamFrameToHttpObjectCodecTest {
 
         Http2DataFrame dataFrame = ch.readOutbound();
         try {
-            assertThat(dataFrame.content().toString(CharsetUtil.UTF_8), is("hello world"));
+            assertEquals("hello world", dataFrame.content().toString(CharsetUtil.UTF_8));
             assertFalse(dataFrame.isEndStream());
         } finally {
             dataFrame.release();
         }
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
         assertFalse(ch.finish());
     }
 
@@ -220,13 +216,13 @@ public class Http2StreamFrameToHttpObjectCodecTest {
 
         Http2DataFrame emptyFrame = ch.readOutbound();
         try {
-            assertThat(emptyFrame.content().readableBytes(), is(0));
+            assertEquals(0, emptyFrame.content().readableBytes());
             assertTrue(emptyFrame.isEndStream());
         } finally {
             emptyFrame.release();
         }
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
         assertFalse(ch.finish());
     }
 
@@ -239,13 +235,13 @@ public class Http2StreamFrameToHttpObjectCodecTest {
 
         Http2DataFrame dataFrame = ch.readOutbound();
         try {
-            assertThat(dataFrame.content().toString(CharsetUtil.UTF_8), is("hello world"));
+            assertEquals("hello world", dataFrame.content().toString(CharsetUtil.UTF_8));
             assertTrue(dataFrame.isEndStream());
         } finally {
             dataFrame.release();
         }
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
         assertFalse(ch.finish());
     }
 
@@ -258,10 +254,10 @@ public class Http2StreamFrameToHttpObjectCodecTest {
         assertTrue(ch.writeOutbound(trailers));
 
         Http2HeadersFrame headerFrame = ch.readOutbound();
-        assertThat(headerFrame.headers().get("key").toString(), is("value"));
+        assertEquals("value", headerFrame.headers().get("key").toString());
         assertTrue(headerFrame.isEndStream());
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
         assertFalse(ch.finish());
     }
 
@@ -276,17 +272,17 @@ public class Http2StreamFrameToHttpObjectCodecTest {
 
         Http2DataFrame dataFrame = ch.readOutbound();
         try {
-            assertThat(dataFrame.content().toString(CharsetUtil.UTF_8), is("hello world"));
+            assertEquals("hello world", dataFrame.content().toString(CharsetUtil.UTF_8));
             assertFalse(dataFrame.isEndStream());
         } finally {
             dataFrame.release();
         }
 
         Http2HeadersFrame headerFrame = ch.readOutbound();
-        assertThat(headerFrame.headers().get("key").toString(), is("value"));
+        assertEquals("value", headerFrame.headers().get("key").toString());
         assertTrue(headerFrame.isEndStream());
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
         assertFalse(ch.finish());
     }
 
@@ -300,13 +296,13 @@ public class Http2StreamFrameToHttpObjectCodecTest {
         assertTrue(ch.writeInbound(new DefaultHttp2HeadersFrame(headers)));
 
         HttpRequest request = ch.readInbound();
-        assertThat(request.uri(), is("/"));
-        assertThat(request.method(), is(HttpMethod.GET));
-        assertThat(request.protocolVersion(), is(HttpVersion.HTTP_1_1));
-        assertFalse(request instanceof FullHttpRequest);
+        assertEquals("/", request.uri());
+        assertEquals(HttpMethod.GET, request.method());
+        assertEquals(HttpVersion.HTTP_1_1, request.protocolVersion());
+        assertThat(request).isNotInstanceOf(FullHttpRequest.class);
         assertTrue(HttpUtil.isTransferEncodingChunked(request));
 
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
         assertFalse(ch.finish());
     }
 
@@ -321,13 +317,13 @@ public class Http2StreamFrameToHttpObjectCodecTest {
         assertTrue(ch.writeInbound(new DefaultHttp2HeadersFrame(headers)));
 
         HttpRequest request = ch.readInbound();
-        assertThat(request.uri(), is("/"));
-        assertThat(request.method(), is(HttpMethod.GET));
-        assertThat(request.protocolVersion(), is(HttpVersion.HTTP_1_1));
-        assertFalse(request instanceof FullHttpRequest);
+        assertEquals("/", request.uri());
+        assertEquals(HttpMethod.GET, request.method());
+        assertEquals(HttpVersion.HTTP_1_1, request.protocolVersion());
+        assertThat(request).isNotInstanceOf(FullHttpRequest.class);
         assertFalse(HttpUtil.isTransferEncodingChunked(request));
 
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
         assertFalse(ch.finish());
     }
 
@@ -342,17 +338,17 @@ public class Http2StreamFrameToHttpObjectCodecTest {
 
         FullHttpRequest request = ch.readInbound();
         try {
-            assertThat(request.uri(), is("/"));
-            assertThat(request.method(), is(HttpMethod.GET));
-            assertThat(request.protocolVersion(), is(HttpVersion.HTTP_1_1));
-            assertThat(request.content().readableBytes(), is(0));
+            assertEquals("/", request.uri());
+            assertEquals(HttpMethod.GET, request.method());
+            assertEquals(HttpVersion.HTTP_1_1, request.protocolVersion());
+            assertEquals(0, request.content().readableBytes());
             assertTrue(request.trailingHeaders().isEmpty());
             assertFalse(HttpUtil.isTransferEncodingChunked(request));
         } finally {
             request.release();
         }
 
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
         assertFalse(ch.finish());
     }
 
@@ -365,14 +361,14 @@ public class Http2StreamFrameToHttpObjectCodecTest {
 
         LastHttpContent trailers = ch.readInbound();
         try {
-            assertThat(trailers.content().readableBytes(), is(0));
-            assertThat(trailers.trailingHeaders().get("key"), is("value"));
-            assertFalse(trailers instanceof FullHttpRequest);
+            assertEquals(0, trailers.content().readableBytes());
+            assertEquals("value", trailers.trailingHeaders().get("key"));
+            assertThat(trailers).isNotInstanceOf(FullHttpRequest.class);
         } finally {
             trailers.release();
         }
 
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
         assertFalse(ch.finish());
     }
 
@@ -384,13 +380,13 @@ public class Http2StreamFrameToHttpObjectCodecTest {
 
         HttpContent content = ch.readInbound();
         try {
-            assertThat(content.content().toString(CharsetUtil.UTF_8), is("hello world"));
+            assertEquals("hello world", content.content().toString(CharsetUtil.UTF_8));
             assertFalse(content instanceof LastHttpContent);
         } finally {
             content.release();
         }
 
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
         assertFalse(ch.finish());
     }
 
@@ -402,13 +398,13 @@ public class Http2StreamFrameToHttpObjectCodecTest {
 
         LastHttpContent content = ch.readInbound();
         try {
-            assertThat(content.content().toString(CharsetUtil.UTF_8), is("hello world"));
+            assertEquals("hello world", content.content().toString(CharsetUtil.UTF_8));
             assertTrue(content.trailingHeaders().isEmpty());
         } finally {
             content.release();
         }
 
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
         assertFalse(ch.finish());
     }
 
@@ -425,7 +421,7 @@ public class Http2StreamFrameToHttpObjectCodecTest {
         Http2GoAwayFrame frame = ch.readInbound();
         try {
             assertEquals(goaway, frame);
-            assertThat(ch.readInbound(), is(nullValue()));
+            assertNull(ch.readInbound());
             assertFalse(ch.finish());
         } finally {
             goaway.release();
@@ -442,12 +438,12 @@ public class Http2StreamFrameToHttpObjectCodecTest {
         Http2HeadersFrame headersFrame = ch.readOutbound();
         Http2Headers headers = headersFrame.headers();
 
-        assertThat(headers.scheme().toString(), is("http"));
-        assertThat(headers.method().toString(), is("GET"));
-        assertThat(headers.path().toString(), is("/hello/world"));
+        assertEquals("http", headers.scheme().toString());
+        assertEquals("GET", headers.method().toString());
+        assertEquals("/hello/world", headers.path().toString());
         assertTrue(headersFrame.isEndStream());
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
         assertFalse(ch.finish());
     }
 
@@ -478,9 +474,9 @@ public class Http2StreamFrameToHttpObjectCodecTest {
             Http2HeadersFrame headersFrame = (Http2HeadersFrame) frames.poll();
             Http2Headers headers = headersFrame.headers();
 
-            assertThat(headers.scheme().toString(), is("https"));
-            assertThat(headers.method().toString(), is("GET"));
-            assertThat(headers.path().toString(), is("/hello/world"));
+            assertEquals("https", headers.scheme().toString());
+            assertEquals("GET", headers.method().toString());
+            assertEquals("/hello/world", headers.path().toString());
             assertTrue(headersFrame.isEndStream());
             assertNull(frames.poll());
         } finally {
@@ -498,20 +494,20 @@ public class Http2StreamFrameToHttpObjectCodecTest {
         Http2HeadersFrame headersFrame = ch.readOutbound();
         Http2Headers headers = headersFrame.headers();
 
-        assertThat(headers.scheme().toString(), is("http"));
-        assertThat(headers.method().toString(), is("PUT"));
-        assertThat(headers.path().toString(), is("/hello/world"));
+        assertEquals("http", headers.scheme().toString());
+        assertEquals("PUT", headers.method().toString());
+        assertEquals("/hello/world", headers.path().toString());
         assertFalse(headersFrame.isEndStream());
 
         Http2DataFrame dataFrame = ch.readOutbound();
         try {
-            assertThat(dataFrame.content().toString(CharsetUtil.UTF_8), is("hello world"));
+            assertEquals("hello world", dataFrame.content().toString(CharsetUtil.UTF_8));
             assertTrue(dataFrame.isEndStream());
         } finally {
             dataFrame.release();
         }
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
         assertFalse(ch.finish());
     }
 
@@ -528,16 +524,16 @@ public class Http2StreamFrameToHttpObjectCodecTest {
         Http2HeadersFrame headersFrame = ch.readOutbound();
         Http2Headers headers = headersFrame.headers();
 
-        assertThat(headers.scheme().toString(), is("http"));
-        assertThat(headers.method().toString(), is("PUT"));
-        assertThat(headers.path().toString(), is("/hello/world"));
+        assertEquals("http", headers.scheme().toString());
+        assertEquals("PUT", headers.method().toString());
+        assertEquals("/hello/world", headers.path().toString());
         assertFalse(headersFrame.isEndStream());
 
         Http2HeadersFrame trailersFrame = ch.readOutbound();
-        assertThat(trailersFrame.headers().get("key").toString(), is("value"));
+        assertEquals("value", trailersFrame.headers().get("key").toString());
         assertTrue(trailersFrame.isEndStream());
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
         assertFalse(ch.finish());
     }
 
@@ -555,24 +551,24 @@ public class Http2StreamFrameToHttpObjectCodecTest {
         Http2HeadersFrame headersFrame = ch.readOutbound();
         Http2Headers headers = headersFrame.headers();
 
-        assertThat(headers.scheme().toString(), is("http"));
-        assertThat(headers.method().toString(), is("PUT"));
-        assertThat(headers.path().toString(), is("/hello/world"));
+        assertEquals("http", headers.scheme().toString());
+        assertEquals("PUT", headers.method().toString());
+        assertEquals("/hello/world", headers.path().toString());
         assertFalse(headersFrame.isEndStream());
 
         Http2DataFrame dataFrame = ch.readOutbound();
         try {
-            assertThat(dataFrame.content().toString(CharsetUtil.UTF_8), is("hello world"));
+            assertEquals("hello world", dataFrame.content().toString(CharsetUtil.UTF_8));
             assertFalse(dataFrame.isEndStream());
         } finally {
             dataFrame.release();
         }
 
         Http2HeadersFrame trailersFrame = ch.readOutbound();
-        assertThat(trailersFrame.headers().get("key").toString(), is("value"));
+        assertEquals("value", trailersFrame.headers().get("key").toString());
         assertTrue(trailersFrame.isEndStream());
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
         assertFalse(ch.finish());
     }
 
@@ -585,12 +581,12 @@ public class Http2StreamFrameToHttpObjectCodecTest {
         Http2HeadersFrame headersFrame = ch.readOutbound();
         Http2Headers headers = headersFrame.headers();
 
-        assertThat(headers.scheme().toString(), is("http"));
-        assertThat(headers.method().toString(), is("GET"));
-        assertThat(headers.path().toString(), is("/hello/world"));
+        assertEquals("http", headers.scheme().toString());
+        assertEquals("GET", headers.method().toString());
+        assertEquals("/hello/world", headers.path().toString());
         assertFalse(headersFrame.isEndStream());
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
         assertFalse(ch.finish());
     }
 
@@ -603,13 +599,13 @@ public class Http2StreamFrameToHttpObjectCodecTest {
 
         Http2DataFrame dataFrame = ch.readOutbound();
         try {
-            assertThat(dataFrame.content().toString(CharsetUtil.UTF_8), is("hello world"));
+            assertEquals("hello world", dataFrame.content().toString(CharsetUtil.UTF_8));
             assertFalse(dataFrame.isEndStream());
         } finally {
             dataFrame.release();
         }
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
         assertFalse(ch.finish());
     }
 
@@ -621,13 +617,13 @@ public class Http2StreamFrameToHttpObjectCodecTest {
 
         Http2DataFrame emptyFrame = ch.readOutbound();
         try {
-            assertThat(emptyFrame.content().readableBytes(), is(0));
+            assertEquals(0, emptyFrame.content().readableBytes());
             assertTrue(emptyFrame.isEndStream());
         } finally {
             emptyFrame.release();
         }
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
         assertFalse(ch.finish());
     }
 
@@ -640,13 +636,13 @@ public class Http2StreamFrameToHttpObjectCodecTest {
 
         Http2DataFrame dataFrame = ch.readOutbound();
         try {
-            assertThat(dataFrame.content().toString(CharsetUtil.UTF_8), is("hello world"));
+            assertEquals("hello world", dataFrame.content().toString(CharsetUtil.UTF_8));
             assertTrue(dataFrame.isEndStream());
         } finally {
             dataFrame.release();
         }
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
         assertFalse(ch.finish());
     }
 
@@ -659,10 +655,10 @@ public class Http2StreamFrameToHttpObjectCodecTest {
         assertTrue(ch.writeOutbound(trailers));
 
         Http2HeadersFrame headerFrame = ch.readOutbound();
-        assertThat(headerFrame.headers().get("key").toString(), is("value"));
+        assertEquals("value", headerFrame.headers().get("key").toString());
         assertTrue(headerFrame.isEndStream());
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
         assertFalse(ch.finish());
     }
 
@@ -677,17 +673,17 @@ public class Http2StreamFrameToHttpObjectCodecTest {
 
         Http2DataFrame dataFrame = ch.readOutbound();
         try {
-            assertThat(dataFrame.content().toString(CharsetUtil.UTF_8), is("hello world"));
+            assertEquals("hello world", dataFrame.content().toString(CharsetUtil.UTF_8));
             assertFalse(dataFrame.isEndStream());
         } finally {
             dataFrame.release();
         }
 
         Http2HeadersFrame headerFrame = ch.readOutbound();
-        assertThat(headerFrame.headers().get("key").toString(), is("value"));
+        assertEquals("value", headerFrame.headers().get("key").toString());
         assertTrue(headerFrame.isEndStream());
 
-        assertThat(ch.readOutbound(), is(nullValue()));
+        assertNull(ch.readOutbound());
         assertFalse(ch.finish());
     }
 
@@ -702,13 +698,13 @@ public class Http2StreamFrameToHttpObjectCodecTest {
 
         final FullHttpResponse response = ch.readInbound();
         try {
-            assertThat(response.status(), is(HttpResponseStatus.CONTINUE));
-            assertThat(response.protocolVersion(), is(HttpVersion.HTTP_1_1));
+            assertEquals(HttpResponseStatus.CONTINUE, response.status());
+            assertEquals(HttpVersion.HTTP_1_1, response.protocolVersion());
         } finally {
             response.release();
         }
 
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
         assertFalse(ch.finish());
     }
 
@@ -733,14 +729,14 @@ public class Http2StreamFrameToHttpObjectCodecTest {
 
         final FullHttpResponse response = ch.readInbound();
         try {
-            assertThat(response.status(), is(HttpResponseStatus.EARLY_HINTS));
-            assertThat(response.protocolVersion(), is(HttpVersion.HTTP_1_1));
-            assertThat(response.headers().get("key"), is("value"));
+            assertEquals(HttpResponseStatus.EARLY_HINTS, response.status());
+            assertEquals(HttpVersion.HTTP_1_1, response.protocolVersion());
+            assertEquals("value", response.headers().get("key"));
         } finally {
             response.release();
         }
 
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
         assertFalse(ch.finish());
     }
 
@@ -754,12 +750,12 @@ public class Http2StreamFrameToHttpObjectCodecTest {
         assertTrue(ch.writeInbound(new DefaultHttp2HeadersFrame(headers)));
 
         HttpResponse response = ch.readInbound();
-        assertThat(response.status(), is(HttpResponseStatus.OK));
-        assertThat(response.protocolVersion(), is(HttpVersion.HTTP_1_1));
+        assertEquals(HttpResponseStatus.OK, response.status());
+        assertEquals(HttpVersion.HTTP_1_1, response.protocolVersion());
         assertFalse(response instanceof FullHttpResponse);
         assertTrue(HttpUtil.isTransferEncodingChunked(response));
 
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
         assertFalse(ch.finish());
     }
 
@@ -774,12 +770,12 @@ public class Http2StreamFrameToHttpObjectCodecTest {
         assertTrue(ch.writeInbound(new DefaultHttp2HeadersFrame(headers)));
 
         HttpResponse response = ch.readInbound();
-        assertThat(response.status(), is(HttpResponseStatus.OK));
-        assertThat(response.protocolVersion(), is(HttpVersion.HTTP_1_1));
-        assertFalse(response instanceof FullHttpResponse);
+        assertEquals(HttpResponseStatus.OK, response.status());
+        assertEquals(HttpVersion.HTTP_1_1, response.protocolVersion());
+        assertThat(response).isNotInstanceOf(FullHttpResponse.class);
         assertFalse(HttpUtil.isTransferEncodingChunked(response));
 
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
         assertFalse(ch.finish());
     }
 
@@ -794,12 +790,12 @@ public class Http2StreamFrameToHttpObjectCodecTest {
         assertTrue(ch.writeInbound(new DefaultHttp2HeadersFrame(headers)));
 
         HttpResponse request = ch.readInbound();
-        assertThat(request.status().codeAsText().toString(), is(statusCode));
-        assertThat(request.protocolVersion(), is(HttpVersion.HTTP_1_1));
-        assertThat(request, is(not(instanceOf(FullHttpResponse.class))));
+        assertEquals(statusCode, request.status().codeAsText().toString());
+        assertEquals(HttpVersion.HTTP_1_1, request.protocolVersion());
+        assertThat(request).isNotInstanceOf(FullHttpResponse.class);
         assertFalse(HttpUtil.isTransferEncodingChunked(request));
 
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
         assertFalse(ch.finish());
     }
 
@@ -838,9 +834,9 @@ public class Http2StreamFrameToHttpObjectCodecTest {
 
         FullHttpResponse response = ch.readInbound();
         try {
-            assertThat(response.status(), is(HttpResponseStatus.OK));
-            assertThat(response.protocolVersion(), is(HttpVersion.HTTP_1_1));
-            assertThat(response.content().readableBytes(), is(0));
+            assertEquals(HttpResponseStatus.OK, response.status());
+            assertEquals(HttpVersion.HTTP_1_1, response.protocolVersion());
+            assertEquals(0, response.content().readableBytes());
             assertTrue(response.trailingHeaders().isEmpty());
             assertFalse(HttpUtil.isTransferEncodingChunked(response));
             if (withStreamId) {
@@ -851,7 +847,7 @@ public class Http2StreamFrameToHttpObjectCodecTest {
             response.release();
         }
 
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
         assertFalse(ch.finish());
     }
 
@@ -864,14 +860,14 @@ public class Http2StreamFrameToHttpObjectCodecTest {
 
         LastHttpContent trailers = ch.readInbound();
         try {
-            assertThat(trailers.content().readableBytes(), is(0));
-            assertThat(trailers.trailingHeaders().get("key"), is("value"));
-            assertFalse(trailers instanceof FullHttpRequest);
+            assertEquals(0, trailers.content().readableBytes());
+            assertEquals("value", trailers.trailingHeaders().get("key"));
+            assertThat(trailers).isNotInstanceOf(FullHttpRequest.class);
         } finally {
             trailers.release();
         }
 
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
         assertFalse(ch.finish());
     }
 
@@ -883,13 +879,13 @@ public class Http2StreamFrameToHttpObjectCodecTest {
 
         HttpContent content = ch.readInbound();
         try {
-            assertThat(content.content().toString(CharsetUtil.UTF_8), is("hello world"));
-            assertFalse(content instanceof LastHttpContent);
+            assertEquals("hello world", content.content().toString(CharsetUtil.UTF_8));
+            assertThat(content).isNotInstanceOf(LastHttpContent.class);
         } finally {
             content.release();
         }
 
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
         assertFalse(ch.finish());
     }
 
@@ -901,13 +897,13 @@ public class Http2StreamFrameToHttpObjectCodecTest {
 
         LastHttpContent content = ch.readInbound();
         try {
-            assertThat(content.content().toString(CharsetUtil.UTF_8), is("hello world"));
+            assertEquals("hello world", content.content().toString(CharsetUtil.UTF_8));
             assertTrue(content.trailingHeaders().isEmpty());
         } finally {
             content.release();
         }
 
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
         assertFalse(ch.finish());
     }
 
@@ -924,7 +920,7 @@ public class Http2StreamFrameToHttpObjectCodecTest {
         Http2GoAwayFrame frame = ch.readInbound();
         try {
             assertEquals(goaway, frame);
-            assertThat(ch.readInbound(), is(nullValue()));
+            assertNull(ch.readInbound());
             assertFalse(ch.finish());
         } finally {
             goaway.release();
@@ -972,9 +968,9 @@ public class Http2StreamFrameToHttpObjectCodecTest {
         Http2HeadersFrame headersFrame = (Http2HeadersFrame) frames.poll();
         Http2Headers headers = headersFrame.headers();
 
-        assertThat(headers.scheme().toString(), is("https"));
-        assertThat(headers.method().toString(), is("GET"));
-        assertThat(headers.path().toString(), is("/hello/world"));
+        assertEquals("https", headers.scheme().toString());
+        assertEquals("GET", headers.method().toString());
+        assertEquals("/hello/world", headers.path().toString());
         assertTrue(headersFrame.isEndStream());
         assertNull(frames.poll());
 
@@ -986,9 +982,9 @@ public class Http2StreamFrameToHttpObjectCodecTest {
         headersFrame = (Http2HeadersFrame) frames.poll();
         headers = headersFrame.headers();
 
-        assertThat(headers.scheme().toString(), is("http"));
-        assertThat(headers.method().toString(), is("GET"));
-        assertThat(headers.path().toString(), is("/hello/world"));
+        assertEquals("http", headers.scheme().toString());
+        assertEquals("GET", headers.method().toString());
+        assertEquals("/hello/world", headers.path().toString());
         assertTrue(headersFrame.isEndStream());
         assertNull(frames.poll());
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
@@ -63,10 +63,9 @@ import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 import static io.netty.handler.codec.http2.Http2TestUtil.of;
 import static io.netty.util.CharsetUtil.UTF_8;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
@@ -374,12 +373,12 @@ public class HttpToHttp2ConnectionHandlerTest {
         assertTrue(writePromise.isDone());
         assertFalse(writePromise.isSuccess());
         Throwable cause = writePromise.cause();
-        assertThat(cause, instanceOf(Http2NoMoreStreamIdsException.class));
+        assertInstanceOf(Http2NoMoreStreamIdsException.class, cause);
 
         assertTrue(writeFuture.isDone());
         assertFalse(writeFuture.isSuccess());
         cause = writeFuture.cause();
-        assertThat(cause, instanceOf(Http2NoMoreStreamIdsException.class));
+        assertInstanceOf(Http2NoMoreStreamIdsException.class, cause);
     }
 
     @Test

--- a/codec-memcache/pom.xml
+++ b/codec-memcache/pom.xml
@@ -86,11 +86,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheDecoderTest.java
+++ b/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheDecoderTest.java
@@ -26,10 +26,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.*;
-import static org.hamcrest.core.IsNull.notNullValue;
-import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -90,16 +90,16 @@ public class BinaryMemcacheDecoderTest {
 
         BinaryMemcacheRequest request = channel.readInbound();
 
-        assertThat(request, notNullValue());
-        assertThat(request.key(), notNullValue());
-        assertThat(request.extras(), nullValue());
+        assertNotNull(request);
+        assertNotNull(request.key());
+        assertNull(request.extras());
 
-        assertThat(request.keyLength(), is((short) 3));
-        assertThat(request.extrasLength(), is((byte) 0));
-        assertThat(request.totalBodyLength(), is(3));
+        assertEquals((short) 3, request.keyLength());
+        assertEquals((byte) 0, request.extrasLength());
+        assertEquals(3, request.totalBodyLength());
 
         request.release();
-        assertThat(channel.readInbound(), instanceOf(LastMemcacheContent.class));
+        assertInstanceOf(LastMemcacheContent.class, channel.readInbound());
     }
 
     /**
@@ -116,13 +116,13 @@ public class BinaryMemcacheDecoderTest {
 
         BinaryMemcacheRequest request = channel.readInbound();
 
-        assertThat(request, notNullValue());
-        assertThat(request.key(), notNullValue());
-        assertThat(request.extras(), nullValue());
+        assertNotNull(request);
+        assertNotNull(request.key());
+        assertNull(request.extras());
 
-        assertThat(request.keyLength(), is((short) 3));
-        assertThat(request.extrasLength(), is((byte) 0));
-        assertThat(request.totalBodyLength(), is(11));
+        assertEquals((short) 3, request.keyLength());
+        assertEquals((byte) 0, request.extrasLength());
+        assertEquals(11, request.totalBodyLength());
 
         request.release();
 
@@ -130,14 +130,14 @@ public class BinaryMemcacheDecoderTest {
         for (int i = 1; i <= expectedContentChunks; i++) {
             MemcacheContent content = channel.readInbound();
             if (i < expectedContentChunks) {
-                assertThat(content, instanceOf(MemcacheContent.class));
+                assertInstanceOf(MemcacheContent.class, content);
             } else {
-                assertThat(content, instanceOf(LastMemcacheContent.class));
+                assertInstanceOf(LastMemcacheContent.class, content);
             }
-            assertThat(content.content().readableBytes(), is(2));
+            assertEquals(2, content.content().readableBytes());
             content.release();
         }
-        assertThat(channel.readInbound(), nullValue());
+        assertNull(channel.readInbound());
     }
 
     /**
@@ -154,20 +154,20 @@ public class BinaryMemcacheDecoderTest {
 
         BinaryMemcacheRequest request = channel.readInbound();
 
-        assertThat(request, notNullValue());
-        assertThat(request.key(), notNullValue());
-        assertThat(request.extras(), nullValue());
+        assertNotNull(request);
+        assertNotNull(request.key());
+        assertNull(request.extras());
 
         request.release();
 
         MemcacheContent content1 = channel.readInbound();
         MemcacheContent content2 = channel.readInbound();
 
-        assertThat(content1, instanceOf(MemcacheContent.class));
-        assertThat(content2, instanceOf(LastMemcacheContent.class));
+        assertInstanceOf(MemcacheContent.class, content1);
+        assertInstanceOf(LastMemcacheContent.class, content2);
 
-        assertThat(content1.content().readableBytes(), is(3));
-        assertThat(content2.content().readableBytes(), is(5));
+        assertEquals(3, content1.content().readableBytes());
+        assertEquals(5, content2.content().readableBytes());
 
         content1.release();
         content2.release();
@@ -182,21 +182,21 @@ public class BinaryMemcacheDecoderTest {
         channel.writeInbound(Unpooled.buffer().writeBytes(GET_REQUEST).writeBytes(GET_REQUEST));
 
         BinaryMemcacheRequest request = channel.readInbound();
-        assertThat(request, instanceOf(BinaryMemcacheRequest.class));
-        assertThat(request, notNullValue());
+        assertInstanceOf(BinaryMemcacheRequest.class, request);
+        assertNotNull(request);
         request.release();
 
         Object lastContent = channel.readInbound();
-        assertThat(lastContent, instanceOf(LastMemcacheContent.class));
+        assertInstanceOf(LastMemcacheContent.class, lastContent);
         ((ReferenceCounted) lastContent).release();
 
         request = channel.readInbound();
-        assertThat(request, instanceOf(BinaryMemcacheRequest.class));
-        assertThat(request, notNullValue());
+        assertInstanceOf(BinaryMemcacheRequest.class, request);
+        assertNotNull(request);
         request.release();
 
         lastContent = channel.readInbound();
-        assertThat(lastContent, instanceOf(LastMemcacheContent.class));
+        assertInstanceOf(LastMemcacheContent.class, lastContent);
         ((ReferenceCounted) lastContent).release();
     }
 
@@ -210,44 +210,44 @@ public class BinaryMemcacheDecoderTest {
 
         // First message
         BinaryMemcacheResponse response = channel.readInbound();
-        assertThat(response.status(), is(BinaryMemcacheResponseStatus.KEY_ENOENT));
-        assertThat(response.totalBodyLength(), is(msgBody.length()));
+        assertEquals(BinaryMemcacheResponseStatus.KEY_ENOENT, response.status());
+        assertEquals(msgBody.length(), response.totalBodyLength());
         response.release();
 
         // First message first content chunk
         MemcacheContent content = channel.readInbound();
-        assertThat(content, instanceOf(LastMemcacheContent.class));
-        assertThat(content.content().toString(CharsetUtil.UTF_8), is(msgBody));
+        assertInstanceOf(LastMemcacheContent.class, content);
+        assertEquals(msgBody, content.content().toString(CharsetUtil.UTF_8));
         content.release();
 
         // Second message
         response = channel.readInbound();
-        assertThat(response.status(), is(BinaryMemcacheResponseStatus.KEY_ENOENT));
-        assertThat(response.totalBodyLength(), is(msgBody.length()));
+        assertEquals(BinaryMemcacheResponseStatus.KEY_ENOENT, response.status());
+        assertEquals(msgBody.length(), response.totalBodyLength());
         response.release();
 
         // Second message first content chunk
         content = channel.readInbound();
-        assertThat(content, instanceOf(MemcacheContent.class));
-        assertThat(content.content().toString(CharsetUtil.UTF_8), is(msgBody.substring(0, 7)));
+        assertInstanceOf(MemcacheContent.class, content);
+        assertEquals(msgBody.substring(0, 7), content.content().toString(CharsetUtil.UTF_8));
         content.release();
 
         // Second message second content chunk
         content = channel.readInbound();
-        assertThat(content, instanceOf(LastMemcacheContent.class));
-        assertThat(content.content().toString(CharsetUtil.UTF_8), is(msgBody.substring(7, 9)));
+        assertInstanceOf(LastMemcacheContent.class, content);
+        assertEquals(msgBody.substring(7, 9), content.content().toString(CharsetUtil.UTF_8));
         content.release();
 
         // Third message
         response = channel.readInbound();
-        assertThat(response.status(), is(BinaryMemcacheResponseStatus.KEY_ENOENT));
-        assertThat(response.totalBodyLength(), is(msgBody.length()));
+        assertEquals(BinaryMemcacheResponseStatus.KEY_ENOENT, response.status());
+        assertEquals(msgBody.length(), response.totalBodyLength());
         response.release();
 
         // Third message first content chunk
         content = channel.readInbound();
-        assertThat(content, instanceOf(LastMemcacheContent.class));
-        assertThat(content.content().toString(CharsetUtil.UTF_8), is(msgBody));
+        assertInstanceOf(LastMemcacheContent.class, content);
+        assertEquals(msgBody, content.content().toString(CharsetUtil.UTF_8));
         content.release();
     }
 

--- a/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheEncoderTest.java
+++ b/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheEncoderTest.java
@@ -27,10 +27,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Verifies the correct functionality of the {@link AbstractBinaryMemcacheEncoder}.
@@ -56,12 +55,12 @@ public class BinaryMemcacheEncoderTest {
         BinaryMemcacheRequest request = new DefaultBinaryMemcacheRequest();
 
         boolean result = channel.writeOutbound(request);
-        assertThat(result, is(true));
+        assertTrue(result);
 
         ByteBuf written = channel.readOutbound();
-        assertThat(written.readableBytes(), is(DEFAULT_HEADER_SIZE));
-        assertThat(written.readByte(), is((byte) 0x80));
-        assertThat(written.readByte(), is((byte) 0x00));
+        assertEquals(DEFAULT_HEADER_SIZE, written.readableBytes());
+        assertEquals((byte) 0x80, written.readByte());
+        assertEquals((byte) 0x00, written.readByte());
         written.release();
     }
 
@@ -72,12 +71,12 @@ public class BinaryMemcacheEncoderTest {
         request.setOpcode(BinaryMemcacheOpcodes.GET);
 
         boolean result = channel.writeOutbound(request);
-        assertThat(result, is(true));
+        assertTrue(result);
 
         ByteBuf written = channel.readOutbound();
-        assertThat(written.readableBytes(), is(DEFAULT_HEADER_SIZE));
-        assertThat(written.readByte(), is((byte) 0xAA));
-        assertThat(written.readByte(), is(BinaryMemcacheOpcodes.GET));
+        assertEquals(DEFAULT_HEADER_SIZE, written.readableBytes());
+        assertEquals((byte) 0xAA, written.readByte());
+        assertEquals(BinaryMemcacheOpcodes.GET, written.readByte());
         written.release();
     }
 
@@ -90,12 +89,12 @@ public class BinaryMemcacheEncoderTest {
         BinaryMemcacheRequest request = new DefaultBinaryMemcacheRequest(Unpooled.EMPTY_BUFFER, extras);
 
         boolean result = channel.writeOutbound(request);
-        assertThat(result, is(true));
+        assertTrue(result);
 
         ByteBuf written = channel.readOutbound();
-        assertThat(written.readableBytes(), is(DEFAULT_HEADER_SIZE + extrasLength));
+        assertEquals(DEFAULT_HEADER_SIZE + extrasLength, written.readableBytes());
         written.skipBytes(DEFAULT_HEADER_SIZE);
-        assertThat(written.readSlice(extrasLength).toString(CharsetUtil.UTF_8), equalTo(extrasContent));
+        assertEquals(extrasContent, written.readSlice(extrasLength).toString(CharsetUtil.UTF_8));
         written.release();
     }
 
@@ -107,12 +106,12 @@ public class BinaryMemcacheEncoderTest {
         BinaryMemcacheRequest request = new DefaultBinaryMemcacheRequest(key);
 
         boolean result = channel.writeOutbound(request);
-        assertThat(result, is(true));
+        assertTrue(result);
 
         ByteBuf written = channel.readOutbound();
-        assertThat(written.readableBytes(), is(DEFAULT_HEADER_SIZE + keyLength));
+        assertEquals(DEFAULT_HEADER_SIZE + keyLength, written.readableBytes());
         written.skipBytes(DEFAULT_HEADER_SIZE);
-        assertThat(written.readSlice(keyLength).toString(CharsetUtil.UTF_8), equalTo("netty"));
+        assertEquals("netty", written.readSlice(keyLength).toString(CharsetUtil.UTF_8));
         written.release();
     }
 
@@ -128,29 +127,27 @@ public class BinaryMemcacheEncoderTest {
         request.setTotalBodyLength(totalBodyLength);
 
         boolean result = channel.writeOutbound(request);
-        assertThat(result, is(true));
+        assertTrue(result);
         result = channel.writeOutbound(content1);
-        assertThat(result, is(true));
+        assertTrue(result);
         result = channel.writeOutbound(content2);
-        assertThat(result, is(true));
+        assertTrue(result);
 
         ByteBuf written = channel.readOutbound();
-        assertThat(written.readableBytes(), is(DEFAULT_HEADER_SIZE));
+        assertEquals(DEFAULT_HEADER_SIZE, written.readableBytes());
         written.release();
 
         written = channel.readOutbound();
-        assertThat(written.readableBytes(), is(content1.content().readableBytes()));
-        assertThat(
-                written.readSlice(content1.content().readableBytes()).toString(CharsetUtil.UTF_8),
-                is("Netty")
+        assertEquals(content1.content().readableBytes(), written.readableBytes());
+        assertEquals("Netty",
+                written.readSlice(content1.content().readableBytes()).toString(CharsetUtil.UTF_8)
         );
         written.release();
 
         written = channel.readOutbound();
-        assertThat(written.readableBytes(), is(content2.content().readableBytes()));
-        assertThat(
-                written.readSlice(content2.content().readableBytes()).toString(CharsetUtil.UTF_8),
-                is(" Rocks!")
+        assertEquals(content2.content().readableBytes(), written.readableBytes());
+        assertEquals(" Rocks!",
+                written.readSlice(content2.content().readableBytes()).toString(CharsetUtil.UTF_8)
         );
         written.release();
     }

--- a/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheObjectAggregatorTest.java
+++ b/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheObjectAggregatorTest.java
@@ -23,11 +23,11 @@ import io.netty.handler.codec.memcache.DefaultMemcacheContent;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.*;
-import static org.hamcrest.core.IsNull.notNullValue;
-import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -64,17 +64,17 @@ public class BinaryMemcacheObjectAggregatorTest {
 
         FullBinaryMemcacheRequest request = channel.readInbound();
 
-        assertThat(request, instanceOf(FullBinaryMemcacheRequest.class));
-        assertThat(request, notNullValue());
-        assertThat(request.key(), notNullValue());
-        assertThat(request.extras(), nullValue());
+        assertInstanceOf(FullBinaryMemcacheRequest.class, request);
+        assertNotNull(request);
+        assertNotNull(request.key());
+        assertNull(request.extras());
 
-        assertThat(request.content().readableBytes(), is(8));
-        assertThat(request.content().readByte(), is((byte) 0x01));
-        assertThat(request.content().readByte(), is((byte) 0x02));
+        assertEquals(8, request.content().readableBytes());
+        assertEquals((byte) 0x01, request.content().readByte());
+        assertEquals((byte) 0x02, request.content().readByte());
         request.release();
 
-        assertThat(channel.readInbound(), nullValue());
+        assertNull(channel.readInbound());
 
         assertFalse(channel.finish());
     }
@@ -100,14 +100,14 @@ public class BinaryMemcacheObjectAggregatorTest {
 
         assertTrue(channel.writeOutbound(request, content1, content2));
 
-        assertThat(channel.outboundMessages().size(), is(3));
+        assertEquals(3, channel.outboundMessages().size());
         assertTrue(channel.writeInbound(channel.readOutbound(), channel.readOutbound(), channel.readOutbound()));
 
         FullBinaryMemcacheRequest read = channel.readInbound();
-        assertThat(read, notNullValue());
-        assertThat(read.key().toString(CharsetUtil.UTF_8), is("Netty"));
-        assertThat(read.extras().toString(CharsetUtil.UTF_8), is("extras"));
-        assertThat(read.content().toString(CharsetUtil.UTF_8), is("Netty Rocks!"));
+        assertNotNull(read);
+        assertEquals("Netty", read.key().toString(CharsetUtil.UTF_8));
+        assertEquals("extras", read.extras().toString(CharsetUtil.UTF_8));
+        assertEquals("Netty Rocks!", read.content().toString(CharsetUtil.UTF_8));
 
         read.release();
         assertFalse(channel.finish());

--- a/codec-mqtt/pom.xml
+++ b/codec-mqtt/pom.xml
@@ -90,11 +90,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
@@ -55,11 +55,11 @@ import static io.netty.handler.codec.mqtt.MqttSubscriptionOption.RetainedHandlin
 import static io.netty.handler.codec.mqtt.MqttTestUtils.validateProperties;
 import static io.netty.handler.codec.mqtt.MqttTestUtils.validateSubscribePayload;
 import static io.netty.handler.codec.mqtt.MqttTestUtils.validateUnsubscribePayload;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -175,7 +175,7 @@ public class MqttCodecTest {
         final MqttMessage decodedMessage = (MqttMessage) out.get(0);
         assertTrue(decodedMessage.decoderResult().isFailure());
         Throwable cause = decodedMessage.decoderResult().cause();
-        assertThat(cause, instanceOf(DecoderException.class));
+        assertInstanceOf(DecoderException.class, cause);
         assertEquals("non-zero reserved flag", cause.getMessage());
     }
 
@@ -247,9 +247,9 @@ public class MqttCodecTest {
 
     private void checkForSingleDecoderException(final List<Object> out) {
         assertEquals(1, out.size());
-        assertThat(out.get(0), not(instanceOf(MqttConnectMessage.class)));
+        assertThat(out.get(0)).isNotInstanceOf(MqttConnectMessage.class);
         MqttMessage result = (MqttMessage) out.get(0);
-        assertThat(result.decoderResult().cause(), instanceOf(DecoderException.class));
+        assertInstanceOf(DecoderException.class, result.decoderResult().cause());
     }
 
     @Test
@@ -422,7 +422,7 @@ public class MqttCodecTest {
         final MqttMessage decodedMessage = (MqttMessage) out.get(0);
         assertTrue(decodedMessage.decoderResult().isFailure());
         Throwable cause = decodedMessage.decoderResult().cause();
-        assertThat(cause, instanceOf(DecoderException.class));
+        assertInstanceOf(DecoderException.class, cause);
         assertEquals("AUTH message requires at least MQTT 5", cause.getMessage());
     }
 
@@ -1101,7 +1101,7 @@ public class MqttCodecTest {
         assertNull(message.payload());
         assertTrue(message.decoderResult().isFailure());
         Throwable cause = message.decoderResult().cause();
-        assertThat(cause, instanceOf(TooLongFrameException.class));
+        assertInstanceOf(TooLongFrameException.class, cause);
     }
 
     private static void validatePubReplyVariableHeader(

--- a/codec-redis/pom.xml
+++ b/codec-redis/pom.xml
@@ -86,11 +86,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisDecoderTest.java
+++ b/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisDecoderTest.java
@@ -30,10 +30,12 @@ import org.junit.jupiter.api.function.Executable;
 import java.util.List;
 
 import static io.netty.handler.codec.redis.RedisCodecTestUtil.*;
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -99,7 +101,7 @@ public class RedisDecoderTest {
 
         InlineCommandRedisMessage msg = channel.readInbound();
 
-        assertThat(msg.content(), is("PING"));
+        assertEquals("PING", msg.content());
 
         ReferenceCountUtil.release(msg);
     }
@@ -113,7 +115,7 @@ public class RedisDecoderTest {
 
         SimpleStringRedisMessage msg = channel.readInbound();
 
-        assertThat(msg.content(), is("OK"));
+        assertEquals("OK", msg.content());
 
         ReferenceCountUtil.release(msg);
     }
@@ -127,11 +129,11 @@ public class RedisDecoderTest {
         assertTrue(channel.writeInbound(byteBufOf("OND\r\n")));
 
         SimpleStringRedisMessage msg1 = channel.readInbound();
-        assertThat(msg1.content(), is("OK"));
+        assertEquals("OK", msg1.content());
         ReferenceCountUtil.release(msg1);
 
         SimpleStringRedisMessage msg2 = channel.readInbound();
-        assertThat(msg2.content(), is("SECOND"));
+        assertEquals("SECOND", msg2.content());
         ReferenceCountUtil.release(msg2);
     }
 
@@ -145,7 +147,7 @@ public class RedisDecoderTest {
 
         ErrorRedisMessage msg = channel.readInbound();
 
-        assertThat(msg.content(), is(content));
+        assertEquals(content, msg.content());
 
         ReferenceCountUtil.release(msg);
     }
@@ -160,7 +162,7 @@ public class RedisDecoderTest {
 
         IntegerRedisMessage msg = channel.readInbound();
 
-        assertThat(msg.value(), is(value));
+        assertEquals(value, msg.value());
 
         ReferenceCountUtil.release(msg);
     }
@@ -179,7 +181,7 @@ public class RedisDecoderTest {
 
         FullBulkStringRedisMessage msg = channel.readInbound();
 
-        assertThat(bytesOf(msg.content()), is(content));
+        assertArrayEquals(content, bytesOf(msg.content()));
 
         ReferenceCountUtil.release(msg);
     }
@@ -195,7 +197,7 @@ public class RedisDecoderTest {
 
         FullBulkStringRedisMessage msg = channel.readInbound();
 
-        assertThat(bytesOf(msg.content()), is(content));
+        assertArrayEquals(content, bytesOf(msg.content()));
 
         ReferenceCountUtil.release(msg);
     }
@@ -211,15 +213,15 @@ public class RedisDecoderTest {
         assertTrue(channel.writeInbound(byteBufOf("\r\n")));
 
         FullBulkStringRedisMessage msg1 = channel.readInbound();
-        assertThat(msg1.isNull(), is(true));
+        assertTrue(msg1.isNull());
         ReferenceCountUtil.release(msg1);
 
         FullBulkStringRedisMessage msg2 = channel.readInbound();
-        assertThat(msg2.isNull(), is(true));
+        assertTrue(msg2.isNull());
         ReferenceCountUtil.release(msg2);
 
         FullBulkStringRedisMessage msg3 = channel.readInbound();
-        assertThat(msg3, is(nullValue()));
+        assertNull(msg3);
     }
 
     @Test
@@ -233,14 +235,14 @@ public class RedisDecoderTest {
         ArrayRedisMessage msg = channel.readInbound();
         List<RedisMessage> children = msg.children();
 
-        assertThat(msg.children().size(), is(equalTo(3)));
+        assertEquals(3, msg.children().size());
 
-        assertThat(children.get(0), instanceOf(IntegerRedisMessage.class));
-        assertThat(((IntegerRedisMessage) children.get(0)).value(), is(1234L));
-        assertThat(children.get(1), instanceOf(SimpleStringRedisMessage.class));
-        assertThat(((SimpleStringRedisMessage) children.get(1)).content(), is("simple"));
-        assertThat(children.get(2), instanceOf(ErrorRedisMessage.class));
-        assertThat(((ErrorRedisMessage) children.get(2)).content(), is("error"));
+        assertInstanceOf(IntegerRedisMessage.class, children.get(0));
+        assertEquals(1234L, ((IntegerRedisMessage) children.get(0)).value());
+        assertInstanceOf(SimpleStringRedisMessage.class, children.get(1));
+        assertEquals("simple", ((SimpleStringRedisMessage) children.get(1)).content());
+        assertInstanceOf(ErrorRedisMessage.class, children.get(2));
+        assertEquals("error", ((ErrorRedisMessage) children.get(2)).content());
 
         ReferenceCountUtil.release(msg);
     }
@@ -256,19 +258,19 @@ public class RedisDecoderTest {
         ArrayRedisMessage msg = channel.readInbound();
         List<RedisMessage> children = msg.children();
 
-        assertThat(msg.children().size(), is(2));
+        assertEquals(2, msg.children().size());
 
         ArrayRedisMessage intArray = (ArrayRedisMessage) children.get(0);
         ArrayRedisMessage strArray = (ArrayRedisMessage) children.get(1);
 
-        assertThat(intArray.children().size(), is(3));
-        assertThat(((IntegerRedisMessage) intArray.children().get(0)).value(), is(1L));
-        assertThat(((IntegerRedisMessage) intArray.children().get(1)).value(), is(2L));
-        assertThat(((IntegerRedisMessage) intArray.children().get(2)).value(), is(3L));
+        assertEquals(3, intArray.children().size());
+        assertEquals(1L, ((IntegerRedisMessage) intArray.children().get(0)).value());
+        assertEquals(2L, ((IntegerRedisMessage) intArray.children().get(1)).value());
+        assertEquals(3L, ((IntegerRedisMessage) intArray.children().get(2)).value());
 
-        assertThat(strArray.children().size(), is(2));
-        assertThat(((SimpleStringRedisMessage) strArray.children().get(0)).content(), is("Foo"));
-        assertThat(((ErrorRedisMessage) strArray.children().get(1)).content(), is("Bar"));
+        assertEquals(2, strArray.children().size());
+        assertEquals("Foo", ((SimpleStringRedisMessage) strArray.children().get(0)).content());
+        assertEquals("Bar", ((ErrorRedisMessage) strArray.children().get(1)).content());
 
         ReferenceCountUtil.release(msg);
     }

--- a/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisEncoderTest.java
+++ b/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisEncoderTest.java
@@ -27,10 +27,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static io.netty.handler.codec.redis.RedisCodecTestUtil.*;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Verifies the correct functionality of the {@link RedisEncoder}.
@@ -54,10 +53,10 @@ public class RedisEncoderTest {
         RedisMessage msg = new InlineCommandRedisMessage("ping");
 
         boolean result = channel.writeOutbound(msg);
-        assertThat(result, is(true));
+        assertTrue(result);
 
         ByteBuf written = readAll(channel);
-        assertThat(bytesOf(written), is(bytesOf("ping\r\n")));
+        assertArrayEquals(bytesOf("ping\r\n"), bytesOf(written));
         written.release();
     }
 
@@ -66,10 +65,10 @@ public class RedisEncoderTest {
         RedisMessage msg = new SimpleStringRedisMessage("simple");
 
         boolean result = channel.writeOutbound(msg);
-        assertThat(result, is(true));
+        assertTrue(result);
 
         ByteBuf written = readAll(channel);
-        assertThat(bytesOf(written), is(bytesOf("+simple\r\n")));
+        assertArrayEquals(bytesOf("+simple\r\n"), bytesOf(written));
         written.release();
     }
 
@@ -78,10 +77,10 @@ public class RedisEncoderTest {
         RedisMessage msg = new ErrorRedisMessage("error1");
 
         boolean result = channel.writeOutbound(msg);
-        assertThat(result, is(true));
+        assertTrue(result);
 
         ByteBuf written = readAll(channel);
-        assertThat(bytesOf(written), is(equalTo(bytesOf("-error1\r\n"))));
+        assertArrayEquals(bytesOf("-error1\r\n"), bytesOf(written));
         written.release();
     }
 
@@ -90,10 +89,10 @@ public class RedisEncoderTest {
         RedisMessage msg = new IntegerRedisMessage(1234L);
 
         boolean result = channel.writeOutbound(msg);
-        assertThat(result, is(true));
+        assertTrue(result);
 
         ByteBuf written = readAll(channel);
-        assertThat(bytesOf(written), is(equalTo(bytesOf(":1234\r\n"))));
+        assertArrayEquals(bytesOf(":1234\r\n"), bytesOf(written));
         written.release();
     }
 
@@ -103,12 +102,12 @@ public class RedisEncoderTest {
         RedisMessage body1 = new DefaultBulkStringRedisContent(byteBufOf("bulk\nstr").retain());
         RedisMessage body2 = new DefaultLastBulkStringRedisContent(byteBufOf("ing\ntest").retain());
 
-        assertThat(channel.writeOutbound(header), is(true));
-        assertThat(channel.writeOutbound(body1), is(true));
-        assertThat(channel.writeOutbound(body2), is(true));
+        assertTrue(channel.writeOutbound(header));
+        assertTrue(channel.writeOutbound(body1));
+        assertTrue(channel.writeOutbound(body2));
 
         ByteBuf written = readAll(channel);
-        assertThat(bytesOf(written), is(equalTo(bytesOf("$16\r\nbulk\nstring\ntest\r\n"))));
+        assertArrayEquals(bytesOf("$16\r\nbulk\nstring\ntest\r\n"), bytesOf(written));
         written.release();
     }
 
@@ -119,10 +118,10 @@ public class RedisEncoderTest {
         RedisMessage msg = new FullBulkStringRedisMessage(bulkString);
 
         boolean result = channel.writeOutbound(msg);
-        assertThat(result, is(true));
+        assertTrue(result);
 
         ByteBuf written = readAll(channel);
-        assertThat(bytesOf(written), is(equalTo(bytesOf("$" + length + "\r\nbulk\nstring\ntest\r\n"))));
+        assertArrayEquals(bytesOf("$" + length + "\r\nbulk\nstring\ntest\r\n"), bytesOf(written));
         written.release();
     }
 
@@ -134,10 +133,10 @@ public class RedisEncoderTest {
         RedisMessage msg = new ArrayRedisMessage(children);
 
         boolean result = channel.writeOutbound(msg);
-        assertThat(result, is(true));
+        assertTrue(result);
 
         ByteBuf written = readAll(channel);
-        assertThat(bytesOf(written), is(equalTo(bytesOf("*2\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"))));
+        assertArrayEquals(bytesOf("*2\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"), bytesOf(written));
         written.release();
     }
 
@@ -146,10 +145,10 @@ public class RedisEncoderTest {
         RedisMessage msg = ArrayRedisMessage.NULL_INSTANCE;
 
         boolean result = channel.writeOutbound(msg);
-        assertThat(result, is(true));
+        assertTrue(result);
 
         ByteBuf written = readAll(channel);
-        assertThat(bytesOf(written), is(equalTo(bytesOf("*-1\r\n"))));
+        assertArrayEquals(bytesOf("*-1\r\n"), bytesOf(written));
         written.release();
     }
 
@@ -158,10 +157,10 @@ public class RedisEncoderTest {
         RedisMessage msg = ArrayRedisMessage.EMPTY_INSTANCE;
 
         boolean result = channel.writeOutbound(msg);
-        assertThat(result, is(true));
+        assertTrue(result);
 
         ByteBuf written = readAll(channel);
-        assertThat(bytesOf(written), is(equalTo(bytesOf("*0\r\n"))));
+        assertArrayEquals(bytesOf("*0\r\n"), bytesOf(written));
         written.release();
     }
 
@@ -176,10 +175,10 @@ public class RedisEncoderTest {
         RedisMessage msg = new ArrayRedisMessage(children);
 
         boolean result = channel.writeOutbound(msg);
-        assertThat(result, is(true));
+        assertTrue(result);
 
         ByteBuf written = readAll(channel);
-        assertThat(bytesOf(written), is(equalTo(bytesOf("*2\r\n+foo\r\n*2\r\n$3\r\nbar\r\n:-1234\r\n"))));
+        assertArrayEquals(bytesOf("*2\r\n+foo\r\n*2\r\n$3\r\nbar\r\n:-1234\r\n"), bytesOf(written));
         written.release();
     }
 

--- a/codec-smtp/pom.xml
+++ b/codec-smtp/pom.xml
@@ -86,11 +86,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/codec-socks/pom.xml
+++ b/codec-socks/pom.xml
@@ -86,11 +86,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/codec-stomp/pom.xml
+++ b/codec-stomp/pom.xml
@@ -86,11 +86,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/codec-xml/pom.xml
+++ b/codec-xml/pom.xml
@@ -85,11 +85,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/codec-xml/src/test/java/io/netty/handler/codec/xml/XmlDecoderTest.java
+++ b/codec-xml/src/test/java/io/netty/handler/codec/xml/XmlDecoderTest.java
@@ -22,9 +22,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.*;
-import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Verifies the basic functionality of the {@link XmlDecoder}.
@@ -72,155 +74,155 @@ public class XmlDecoderTest {
         write(XML1);
 
         temp = channel.readInbound();
-        assertThat(temp, instanceOf(XmlDocumentStart.class));
-        assertThat(((XmlDocumentStart) temp).version(), is("1.0"));
-        assertThat(((XmlDocumentStart) temp).encoding(), is("UTF-8"));
-        assertThat(((XmlDocumentStart) temp).standalone(), is(false));
-        assertThat(((XmlDocumentStart) temp).encodingScheme(), is(nullValue()));
+        assertInstanceOf(XmlDocumentStart.class, temp);
+        assertEquals("1.0", ((XmlDocumentStart) temp).version());
+        assertEquals("UTF-8", ((XmlDocumentStart) temp).encoding());
+        assertFalse(((XmlDocumentStart) temp).standalone());
+        assertNull(((XmlDocumentStart) temp).encodingScheme());
 
         temp = channel.readInbound();
-        assertThat(temp, instanceOf(XmlDTD.class));
-        assertThat(((XmlDTD) temp).text(), is("employee.dtd"));
+        assertInstanceOf(XmlDTD.class, temp);
+        assertEquals("employee.dtd", ((XmlDTD) temp).text());
 
         temp = channel.readInbound();
-        assertThat(temp, instanceOf(XmlProcessingInstruction.class));
-        assertThat(((XmlProcessingInstruction) temp).target(), is("xml-stylesheet"));
-        assertThat(((XmlProcessingInstruction) temp).data(), is("type=\"text/css\" href=\"netty.css\""));
+        assertInstanceOf(XmlProcessingInstruction.class, temp);
+        assertEquals("xml-stylesheet", ((XmlProcessingInstruction) temp).target());
+        assertEquals("type=\"text/css\" href=\"netty.css\"", ((XmlProcessingInstruction) temp).data());
 
         temp = channel.readInbound();
-        assertThat(temp, instanceOf(XmlProcessingInstruction.class));
-        assertThat(((XmlProcessingInstruction) temp).target(), is("xml-test"));
-        assertThat(((XmlProcessingInstruction) temp).data(), is(""));
+        assertInstanceOf(XmlProcessingInstruction.class, temp);
+        assertEquals("xml-test", ((XmlProcessingInstruction) temp).target());
+        assertEquals("", ((XmlProcessingInstruction) temp).data());
 
         temp = channel.readInbound();
-        assertThat(temp, instanceOf(XmlElementStart.class));
-        assertThat(((XmlElementStart) temp).name(), is("employee"));
-        assertThat(((XmlElementStart) temp).prefix(), is(""));
-        assertThat(((XmlElementStart) temp).namespace(), is(""));
-        assertThat(((XmlElementStart) temp).attributes().size(), is(0));
-        assertThat(((XmlElementStart) temp).namespaces().size(), is(1));
-        assertThat(((XmlElementStart) temp).namespaces().get(0).prefix(), is("nettya"));
-        assertThat(((XmlElementStart) temp).namespaces().get(0).uri(), is("https://netty.io/netty/a"));
+        assertInstanceOf(XmlElementStart.class, temp);
+        assertEquals("employee", ((XmlElementStart) temp).name());
+        assertEquals("", ((XmlElementStart) temp).prefix());
+        assertEquals("", ((XmlElementStart) temp).namespace());
+        assertEquals(0, ((XmlElementStart) temp).attributes().size());
+        assertEquals(1, ((XmlElementStart) temp).namespaces().size());
+        assertEquals("nettya", ((XmlElementStart) temp).namespaces().get(0).prefix());
+        assertEquals("https://netty.io/netty/a", ((XmlElementStart) temp).namespaces().get(0).uri());
 
         temp = channel.readInbound();
-        assertThat(temp, instanceOf(XmlElementStart.class));
-        assertThat(((XmlElementStart) temp).name(), is("id"));
-        assertThat(((XmlElementStart) temp).prefix(), is("nettya"));
-        assertThat(((XmlElementStart) temp).namespace(), is("https://netty.io/netty/a"));
-        assertThat(((XmlElementStart) temp).attributes().size(), is(0));
-        assertThat(((XmlElementStart) temp).namespaces().size(), is(0));
+        assertInstanceOf(XmlElementStart.class, temp);
+        assertEquals("id", ((XmlElementStart) temp).name());
+        assertEquals("nettya", ((XmlElementStart) temp).prefix());
+        assertEquals("https://netty.io/netty/a", ((XmlElementStart) temp).namespace());
+        assertEquals(0, ((XmlElementStart) temp).attributes().size());
+        assertEquals(0, ((XmlElementStart) temp).namespaces().size());
 
         temp = channel.readInbound();
-        assertThat(temp, instanceOf(XmlEntityReference.class));
-        assertThat(((XmlEntityReference) temp).name(), is("plusmn"));
-        assertThat(((XmlEntityReference) temp).text(), is(""));
+        assertInstanceOf(XmlEntityReference.class, temp);
+        assertEquals("plusmn", ((XmlEntityReference) temp).name());
+        assertEquals("", ((XmlEntityReference) temp).text());
 
         temp = channel.readInbound();
-        assertThat(temp, instanceOf(XmlCharacters.class));
-        assertThat(((XmlCharacters) temp).data(), is("1"));
+        assertInstanceOf(XmlCharacters.class, temp);
+        assertEquals("1", ((XmlCharacters) temp).data());
 
         temp = channel.readInbound();
-        assertThat(temp, instanceOf(XmlElementEnd.class));
-        assertThat(((XmlElementEnd) temp).name(), is("id"));
-        assertThat(((XmlElementEnd) temp).prefix(), is("nettya"));
-        assertThat(((XmlElementEnd) temp).namespace(), is("https://netty.io/netty/a"));
+        assertInstanceOf(XmlElementEnd.class, temp);
+        assertEquals("id", ((XmlElementEnd) temp).name());
+        assertEquals("nettya", ((XmlElementEnd) temp).prefix());
+        assertEquals("https://netty.io/netty/a", ((XmlElementEnd) temp).namespace());
 
         temp = channel.readInbound();
-        assertThat(temp, instanceOf(XmlCharacters.class));
-        assertThat(((XmlCharacters) temp).data(), is("\n"));
+        assertInstanceOf(XmlCharacters.class, temp);
+        assertEquals("\n", ((XmlCharacters) temp).data());
 
         temp = channel.readInbound();
-        assertThat(temp, nullValue());
+        assertNull(temp);
 
         write(XML2);
 
         temp = channel.readInbound();
-        assertThat(temp, instanceOf(XmlElementStart.class));
-        assertThat(((XmlElementStart) temp).name(), is("name"));
-        assertThat(((XmlElementStart) temp).prefix(), is(""));
-        assertThat(((XmlElementStart) temp).namespace(), is(""));
-        assertThat(((XmlElementStart) temp).attributes().size(), is(1));
-        assertThat(((XmlElementStart) temp).attributes().get(0).name(), is("type"));
-        assertThat(((XmlElementStart) temp).attributes().get(0).value(), is("given"));
-        assertThat(((XmlElementStart) temp).attributes().get(0).prefix(), is(""));
-        assertThat(((XmlElementStart) temp).attributes().get(0).namespace(), is(""));
-        assertThat(((XmlElementStart) temp).namespaces().size(), is(0));
+        assertInstanceOf(XmlElementStart.class, temp);
+        assertEquals("name", ((XmlElementStart) temp).name());
+        assertEquals("", ((XmlElementStart) temp).prefix());
+        assertEquals("", ((XmlElementStart) temp).namespace());
+        assertEquals(1, ((XmlElementStart) temp).attributes().size());
+        assertEquals("type", ((XmlElementStart) temp).attributes().get(0).name());
+        assertEquals("given", ((XmlElementStart) temp).attributes().get(0).value());
+        assertEquals("", ((XmlElementStart) temp).attributes().get(0).prefix());
+        assertEquals("", ((XmlElementStart) temp).attributes().get(0).namespace());
+        assertEquals(0, ((XmlElementStart) temp).namespaces().size());
 
         temp = channel.readInbound();
-        assertThat(temp, instanceOf(XmlCharacters.class));
-        assertThat(((XmlCharacters) temp).data(), is("Alba"));
+        assertInstanceOf(XmlCharacters.class, temp);
+        assertEquals("Alba", ((XmlCharacters) temp).data());
 
         temp = channel.readInbound();
-        assertThat(temp, instanceOf(XmlElementEnd.class));
-        assertThat(((XmlElementEnd) temp).name(), is("name"));
-        assertThat(((XmlElementEnd) temp).prefix(), is(""));
-        assertThat(((XmlElementEnd) temp).namespace(), is(""));
+        assertInstanceOf(XmlElementEnd.class, temp);
+        assertEquals("name", ((XmlElementEnd) temp).name());
+        assertEquals("", ((XmlElementEnd) temp).prefix());
+        assertEquals("", ((XmlElementEnd) temp).namespace());
 
         temp = channel.readInbound();
-        assertThat(temp, instanceOf(XmlCdata.class));
-        assertThat(((XmlCdata) temp).data(), is(" <some data &gt;/> "));
+        assertInstanceOf(XmlCdata.class, temp);
+        assertEquals(" <some data &gt;/> ", ((XmlCdata) temp).data());
 
         temp = channel.readInbound();
-        assertThat(temp, instanceOf(XmlCharacters.class));
-        assertThat(((XmlCharacters) temp).data(), is("   "));
+        assertInstanceOf(XmlCharacters.class, temp);
+        assertEquals("   ", ((XmlCharacters) temp).data());
 
         temp = channel.readInbound();
-        assertThat(temp, instanceOf(XmlComment.class));
-        assertThat(((XmlComment) temp).data(), is(" namespaced "));
+        assertInstanceOf(XmlComment.class, temp);
+        assertEquals(" namespaced ", ((XmlComment) temp).data());
 
         temp = channel.readInbound();
-        assertThat(temp, instanceOf(XmlElementStart.class));
-        assertThat(((XmlElementStart) temp).name(), is("salary"));
-        assertThat(((XmlElementStart) temp).prefix(), is("nettyb"));
-        assertThat(((XmlElementStart) temp).namespace(), is("https://netty.io/netty/b"));
-        assertThat(((XmlElementStart) temp).attributes().size(), is(1));
-        assertThat(((XmlElementStart) temp).attributes().get(0).name(), is("period"));
-        assertThat(((XmlElementStart) temp).attributes().get(0).value(), is("weekly"));
-        assertThat(((XmlElementStart) temp).attributes().get(0).prefix(), is("nettyb"));
-        assertThat(((XmlElementStart) temp).attributes().get(0).namespace(), is("https://netty.io/netty/b"));
-        assertThat(((XmlElementStart) temp).namespaces().size(), is(1));
-        assertThat(((XmlElementStart) temp).namespaces().get(0).prefix(), is("nettyb"));
-        assertThat(((XmlElementStart) temp).namespaces().get(0).uri(), is("https://netty.io/netty/b"));
+        assertInstanceOf(XmlElementStart.class, temp);
+        assertEquals("salary", ((XmlElementStart) temp).name());
+        assertEquals("nettyb", ((XmlElementStart) temp).prefix());
+        assertEquals("https://netty.io/netty/b", ((XmlElementStart) temp).namespace());
+        assertEquals(1, ((XmlElementStart) temp).attributes().size());
+        assertEquals("period", ((XmlElementStart) temp).attributes().get(0).name());
+        assertEquals("weekly", ((XmlElementStart) temp).attributes().get(0).value());
+        assertEquals("nettyb", ((XmlElementStart) temp).attributes().get(0).prefix());
+        assertEquals("https://netty.io/netty/b", ((XmlElementStart) temp).attributes().get(0).namespace());
+        assertEquals(1, ((XmlElementStart) temp).namespaces().size());
+        assertEquals("nettyb", ((XmlElementStart) temp).namespaces().get(0).prefix());
+        assertEquals("https://netty.io/netty/b", ((XmlElementStart) temp).namespaces().get(0).uri());
 
         temp = channel.readInbound();
-        assertThat(temp, instanceOf(XmlCharacters.class));
-        assertThat(((XmlCharacters) temp).data(), is("100"));
+        assertInstanceOf(XmlCharacters.class, temp);
+        assertEquals("100", ((XmlCharacters) temp).data());
 
         temp = channel.readInbound();
-        assertThat(temp, instanceOf(XmlElementEnd.class));
-        assertThat(((XmlElementEnd) temp).name(), is("salary"));
-        assertThat(((XmlElementEnd) temp).prefix(), is("nettyb"));
-        assertThat(((XmlElementEnd) temp).namespace(), is("https://netty.io/netty/b"));
-        assertThat(((XmlElementEnd) temp).namespaces().size(), is(1));
-        assertThat(((XmlElementEnd) temp).namespaces().get(0).prefix(), is("nettyb"));
-        assertThat(((XmlElementEnd) temp).namespaces().get(0).uri(), is("https://netty.io/netty/b"));
+        assertInstanceOf(XmlElementEnd.class, temp);
+        assertEquals("salary", ((XmlElementEnd) temp).name());
+        assertEquals("nettyb", ((XmlElementEnd) temp).prefix());
+        assertEquals("https://netty.io/netty/b", ((XmlElementEnd) temp).namespace());
+        assertEquals(1, ((XmlElementEnd) temp).namespaces().size());
+        assertEquals("nettyb", ((XmlElementEnd) temp).namespaces().get(0).prefix());
+        assertEquals("https://netty.io/netty/b", ((XmlElementEnd) temp).namespaces().get(0).uri());
 
         temp = channel.readInbound();
-        assertThat(temp, instanceOf(XmlElementStart.class));
-        assertThat(((XmlElementStart) temp).name(), is("last"));
-        assertThat(((XmlElementStart) temp).prefix(), is(""));
-        assertThat(((XmlElementStart) temp).namespace(), is(""));
-        assertThat(((XmlElementStart) temp).attributes().size(), is(0));
-        assertThat(((XmlElementStart) temp).namespaces().size(), is(0));
+        assertInstanceOf(XmlElementStart.class, temp);
+        assertEquals("last", ((XmlElementStart) temp).name());
+        assertEquals("", ((XmlElementStart) temp).prefix());
+        assertEquals("", ((XmlElementStart) temp).namespace());
+        assertEquals(0, ((XmlElementStart) temp).attributes().size());
+        assertEquals(0, ((XmlElementStart) temp).namespaces().size());
 
         temp = channel.readInbound();
-        assertThat(temp, instanceOf(XmlElementEnd.class));
-        assertThat(((XmlElementEnd) temp).name(), is("last"));
-        assertThat(((XmlElementEnd) temp).prefix(), is(""));
-        assertThat(((XmlElementEnd) temp).namespace(), is(""));
-        assertThat(((XmlElementEnd) temp).namespaces().size(), is(0));
+        assertInstanceOf(XmlElementEnd.class, temp);
+        assertEquals("last", ((XmlElementEnd) temp).name());
+        assertEquals("", ((XmlElementEnd) temp).prefix());
+        assertEquals("", ((XmlElementEnd) temp).namespace());
+        assertEquals(0, ((XmlElementEnd) temp).namespaces().size());
 
         temp = channel.readInbound();
-        assertThat(temp, instanceOf(XmlElementEnd.class));
-        assertThat(((XmlElementEnd) temp).name(), is("employee"));
-        assertThat(((XmlElementEnd) temp).prefix(), is(""));
-        assertThat(((XmlElementEnd) temp).namespace(), is(""));
-        assertThat(((XmlElementEnd) temp).namespaces().size(), is(1));
-        assertThat(((XmlElementEnd) temp).namespaces().get(0).prefix(), is("nettya"));
-        assertThat(((XmlElementEnd) temp).namespaces().get(0).uri(), is("https://netty.io/netty/a"));
+        assertInstanceOf(XmlElementEnd.class, temp);
+        assertEquals("employee", ((XmlElementEnd) temp).name());
+        assertEquals("", ((XmlElementEnd) temp).prefix());
+        assertEquals("", ((XmlElementEnd) temp).namespace());
+        assertEquals(1, ((XmlElementEnd) temp).namespaces().size());
+        assertEquals("nettya", ((XmlElementEnd) temp).namespaces().get(0).prefix());
+        assertEquals("https://netty.io/netty/a", ((XmlElementEnd) temp).namespaces().get(0).uri());
 
         temp = channel.readInbound();
-        assertThat(temp, nullValue());
+        assertNull(temp);
     }
 
     /**
@@ -233,29 +235,29 @@ public class XmlDecoderTest {
         write(XML3);
 
         temp = channel.readInbound();
-        assertThat(temp, instanceOf(XmlDocumentStart.class));
-        assertThat(((XmlDocumentStart) temp).version(), is("1.1"));
-        assertThat(((XmlDocumentStart) temp).encoding(), is("UTF-8"));
-        assertThat(((XmlDocumentStart) temp).standalone(), is(true));
-        assertThat(((XmlDocumentStart) temp).encodingScheme(), is("UTF-8"));
+        assertInstanceOf(XmlDocumentStart.class, temp);
+        assertEquals("1.1", ((XmlDocumentStart) temp).version());
+        assertEquals("UTF-8", ((XmlDocumentStart) temp).encoding());
+        assertTrue(((XmlDocumentStart) temp).standalone());
+        assertEquals("UTF-8", ((XmlDocumentStart) temp).encodingScheme());
 
         temp = channel.readInbound();
-        assertThat(temp, instanceOf(XmlElementStart.class));
-        assertThat(((XmlElementStart) temp).name(), is("netty"));
-        assertThat(((XmlElementStart) temp).prefix(), is(""));
-        assertThat(((XmlElementStart) temp).namespace(), is(""));
-        assertThat(((XmlElementStart) temp).attributes().size(), is(0));
-        assertThat(((XmlElementStart) temp).namespaces().size(), is(0));
+        assertInstanceOf(XmlElementStart.class, temp);
+        assertEquals("netty", ((XmlElementStart) temp).name());
+        assertEquals("", ((XmlElementStart) temp).prefix());
+        assertEquals("", ((XmlElementStart) temp).namespace());
+        assertEquals(0, ((XmlElementStart) temp).attributes().size());
+        assertEquals(0, ((XmlElementStart) temp).namespaces().size());
 
         temp = channel.readInbound();
-        assertThat(temp, instanceOf(XmlElementEnd.class));
-        assertThat(((XmlElementEnd) temp).name(), is("netty"));
-        assertThat(((XmlElementEnd) temp).prefix(), is(""));
-        assertThat(((XmlElementEnd) temp).namespace(), is(""));
-        assertThat(((XmlElementEnd) temp).namespaces().size(), is(0));
+        assertInstanceOf(XmlElementEnd.class, temp);
+        assertEquals("netty", ((XmlElementEnd) temp).name());
+        assertEquals("", ((XmlElementEnd) temp).prefix());
+        assertEquals("", ((XmlElementEnd) temp).namespace());
+        assertEquals(0, ((XmlElementEnd) temp).namespaces().size());
 
         temp = channel.readInbound();
-        assertThat(temp, nullValue());
+        assertNull(temp);
     }
 
     /**
@@ -268,33 +270,32 @@ public class XmlDecoderTest {
         write(XML4);
 
         temp = channel.readInbound();
-        assertThat(temp, instanceOf(XmlDocumentStart.class));
-        assertThat(((XmlDocumentStart) temp).version(), is(nullValue()));
-        assertThat(((XmlDocumentStart) temp).encoding(), is("UTF-8"));
-        assertThat(((XmlDocumentStart) temp).standalone(), is(false));
-        assertThat(((XmlDocumentStart) temp).encodingScheme(), is(nullValue()));
+        assertInstanceOf(XmlDocumentStart.class, temp);
+        assertNull(((XmlDocumentStart) temp).version());
+        assertEquals("UTF-8", ((XmlDocumentStart) temp).encoding());
+        assertFalse(((XmlDocumentStart) temp).standalone());
+        assertNull(((XmlDocumentStart) temp).encodingScheme());
 
         temp = channel.readInbound();
-        assertThat(temp, instanceOf(XmlElementStart.class));
-        assertThat(((XmlElementStart) temp).name(), is("netty"));
-        assertThat(((XmlElementStart) temp).prefix(), is(""));
-        assertThat(((XmlElementStart) temp).namespace(), is(""));
-        assertThat(((XmlElementStart) temp).attributes().size(), is(0));
-        assertThat(((XmlElementStart) temp).namespaces().size(), is(0));
+        assertInstanceOf(XmlElementStart.class, temp);
+        assertEquals("netty", ((XmlElementStart) temp).name());
+        assertEquals("", ((XmlElementStart) temp).prefix());
+        assertEquals("", ((XmlElementStart) temp).namespace());
+        assertEquals(0, ((XmlElementStart) temp).attributes().size());
+        assertEquals(0, ((XmlElementStart) temp).namespaces().size());
 
         temp = channel.readInbound();
-        assertThat(temp, instanceOf(XmlElementEnd.class));
-        assertThat(((XmlElementEnd) temp).name(), is("netty"));
-        assertThat(((XmlElementEnd) temp).prefix(), is(""));
-        assertThat(((XmlElementEnd) temp).namespace(), is(""));
-        assertThat(((XmlElementEnd) temp).namespaces().size(), is(0));
+        assertInstanceOf(XmlElementEnd.class, temp);
+        assertEquals("netty", ((XmlElementEnd) temp).name());
+        assertEquals("", ((XmlElementEnd) temp).prefix());
+        assertEquals("", ((XmlElementEnd) temp).namespace());
+        assertEquals(0, ((XmlElementEnd) temp).namespaces().size());
 
         temp = channel.readInbound();
-        assertThat(temp, nullValue());
+        assertNull(temp);
     }
 
     private void write(String content) {
-        assertThat(channel.writeInbound(Unpooled.copiedBuffer(content, CharsetUtil.UTF_8)), is(true));
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(content, CharsetUtil.UTF_8)));
     }
-
 }

--- a/codec/pom.xml
+++ b/codec/pom.xml
@@ -180,11 +180,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/codec/src/test/java/io/netty/handler/codec/DefaultHeadersTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/DefaultHeadersTest.java
@@ -28,9 +28,7 @@ import java.util.NoSuchElementException;
 
 import static io.netty.util.AsciiString.of;
 import static java.util.Arrays.asList;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.hasSize;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -805,8 +803,8 @@ public class DefaultHeadersTest {
         simulateCookieSplitting(headers);
         List<CharSequence> cookies = headers.getAll("Cookie");
 
-        assertThat(cookies, hasSize(3));
-        assertThat(cookies, containsInAnyOrder((CharSequence) "a=b", "c=d", "e=f"));
+        assertEquals(3, cookies.size());
+        assertThat(cookies).contains((CharSequence) "a=b", "c=d", "e=f");
     }
 
     /**

--- a/codec/src/test/java/io/netty/handler/codec/LineBasedFrameDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/LineBasedFrameDecoderTest.java
@@ -22,10 +22,9 @@ import io.netty.util.ReferenceCountUtil;
 import org.junit.jupiter.api.Test;
 
 import static io.netty.buffer.Unpooled.*;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.CoreMatchers.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -78,13 +77,13 @@ public class LineBasedFrameDecoderTest {
             ch.writeInbound(copiedBuffer("12345678901234567890\r\nfirst\nsecond", CharsetUtil.US_ASCII));
             fail();
         } catch (Exception e) {
-            assertThat(e, is(instanceOf(TooLongFrameException.class)));
+            assertInstanceOf(TooLongFrameException.class, e);
         }
 
         ByteBuf buf = ch.readInbound();
         ByteBuf buf2 = copiedBuffer("first\n", CharsetUtil.US_ASCII);
-        assertThat(buf, is(buf2));
-        assertThat(ch.finish(), is(false));
+        assertEquals(buf2, buf);
+        assertFalse(ch.finish());
 
         buf.release();
         buf2.release();
@@ -99,13 +98,13 @@ public class LineBasedFrameDecoderTest {
             ch.writeInbound(copiedBuffer("890\r\nfirst\r\n", CharsetUtil.US_ASCII));
             fail();
         } catch (Exception e) {
-            assertThat(e, is(instanceOf(TooLongFrameException.class)));
+            assertInstanceOf(TooLongFrameException.class, e);
         }
 
         ByteBuf buf = ch.readInbound();
         ByteBuf buf2 = copiedBuffer("first\r\n", CharsetUtil.US_ASCII);
-        assertThat(buf, is(buf2));
-        assertThat(ch.finish(), is(false));
+        assertEquals(buf2, buf);
+        assertFalse(ch.finish());
 
         buf.release();
         buf2.release();
@@ -119,16 +118,16 @@ public class LineBasedFrameDecoderTest {
             ch.writeInbound(copiedBuffer("12345678901234567", CharsetUtil.US_ASCII));
             fail();
         } catch (Exception e) {
-            assertThat(e, is(instanceOf(TooLongFrameException.class)));
+            assertInstanceOf(TooLongFrameException.class, e);
         }
 
-        assertThat(ch.writeInbound(copiedBuffer("890", CharsetUtil.US_ASCII)), is(false));
-        assertThat(ch.writeInbound(copiedBuffer("123\r\nfirst\r\n", CharsetUtil.US_ASCII)), is(true));
+        assertFalse(ch.writeInbound(copiedBuffer("890", CharsetUtil.US_ASCII)));
+        assertTrue(ch.writeInbound(copiedBuffer("123\r\nfirst\r\n", CharsetUtil.US_ASCII)));
 
         ByteBuf buf = ch.readInbound();
         ByteBuf buf2 = copiedBuffer("first\r\n", CharsetUtil.US_ASCII);
-        assertThat(buf, is(buf2));
-        assertThat(ch.finish(), is(false));
+        assertEquals(buf2, buf);
+        assertFalse(ch.finish());
 
         buf.release();
         buf2.release();

--- a/codec/src/test/java/io/netty/handler/codec/bytes/ByteArrayDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/bytes/ByteArrayDecoderTest.java
@@ -23,8 +23,8 @@ import org.junit.jupiter.api.Test;
 import java.util.Random;
 
 import static io.netty.buffer.Unpooled.*;
-import static org.hamcrest.core.Is.*;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class ByteArrayDecoderTest {
 
@@ -40,19 +40,19 @@ public class ByteArrayDecoderTest {
         byte[] b = new byte[2048];
         new Random().nextBytes(b);
         ch.writeInbound(wrappedBuffer(b));
-        assertThat((byte[]) ch.readInbound(), is(b));
+        assertArrayEquals(b, ch.<byte[]>readInbound());
     }
 
     @Test
     public void testDecodeEmpty() {
         ch.writeInbound(EMPTY_BUFFER);
-        assertThat((byte[]) ch.readInbound(), is(EmptyArrays.EMPTY_BYTES));
+        assertArrayEquals(EmptyArrays.EMPTY_BYTES, ch.<byte[]>readInbound());
     }
 
     @Test
     public void testDecodeOtherType() {
         String str = "Meep!";
         ch.writeInbound(str);
-        assertThat(ch.readInbound(), is((Object) str));
+        assertSame(str, ch.readInbound());
     }
 }

--- a/codec/src/test/java/io/netty/handler/codec/bytes/ByteArrayEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/bytes/ByteArrayEncoderTest.java
@@ -25,8 +25,9 @@ import org.junit.jupiter.api.Test;
 import java.util.Random;
 
 import static io.netty.buffer.Unpooled.*;
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class ByteArrayEncoderTest {
 
@@ -39,7 +40,7 @@ public class ByteArrayEncoderTest {
 
     @AfterEach
     public void tearDown() {
-        assertThat(ch.finish(), is(false));
+        assertFalse(ch.finish());
     }
 
     @Test
@@ -48,20 +49,20 @@ public class ByteArrayEncoderTest {
         new Random().nextBytes(b);
         ch.writeOutbound(b);
         ByteBuf encoded = ch.readOutbound();
-        assertThat(encoded, is(wrappedBuffer(b)));
+        assertEquals(wrappedBuffer(b), encoded);
         encoded.release();
     }
 
     @Test
     public void testEncodeEmpty() {
         ch.writeOutbound(EmptyArrays.EMPTY_BYTES);
-        assertThat((ByteBuf) ch.readOutbound(), is(sameInstance(EMPTY_BUFFER)));
+        assertSame(EMPTY_BUFFER, ch.readOutbound());
     }
 
     @Test
     public void testEncodeOtherType() {
         String str = "Meep!";
         ch.writeOutbound(str);
-        assertThat(ch.readOutbound(), is((Object) str));
+        assertSame(str, ch.readOutbound());
     }
 }

--- a/codec/src/test/java/io/netty/handler/codec/compression/AbstractIntegrationTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/AbstractIntegrationTest.java
@@ -27,8 +27,6 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Random;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -166,7 +164,6 @@ public abstract class AbstractIntegrationTest {
             while ((msg = encoder.readOutbound()) != null) {
                 compressed.addComponent(true, msg);
             }
-            assertThat(compressed, is(notNullValue()));
 
             decoder.writeInbound(compressed.retain());
             assertFalse(compressed.isReadable());

--- a/codec/src/test/java/io/netty/handler/codec/compression/FastLzIntegrationTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/FastLzIntegrationTest.java
@@ -20,8 +20,6 @@ import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
@@ -87,7 +85,6 @@ public class FastLzIntegrationTest extends AbstractIntegrationTest {
             while ((msg = encoder.readOutbound()) != null) {
                 compressed.addComponent(true, msg);
             }
-            assertThat(compressed, is(notNullValue()));
 
             final byte[] compressedArray = new byte[compressed.readableBytes()];
             compressed.readBytes(compressedArray);

--- a/codec/src/test/java/io/netty/handler/codec/compression/Lz4FrameEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/Lz4FrameEncoderTest.java
@@ -50,10 +50,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.zip.Checksum;
 
 import static io.netty.handler.codec.compression.Lz4Constants.DEFAULT_SEED;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.core.Is.is;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -308,7 +306,7 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
             assertNotNull(writeFailCause);
             Throwable writeFailCauseCause = writeFailCause.getCause();
             if (writeFailCauseCause != null) {
-                assertThat(writeFailCauseCause, is(not(instanceOf(NullPointerException.class))));
+                assertThat(writeFailCauseCause).isNotInstanceOf(NullPointerException.class);
             }
         } finally {
             if (serverChannel != null) {

--- a/codec/src/test/java/io/netty/handler/codec/protobuf/ProtobufVarint32FrameDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/protobuf/ProtobufVarint32FrameDecoderTest.java
@@ -21,10 +21,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static io.netty.buffer.Unpooled.*;
-import static org.hamcrest.core.Is.*;
-import static org.hamcrest.core.IsNull.*;
-import static org.hamcrest.MatcherAssert.assertThat;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ProtobufVarint32FrameDecoderTest {
@@ -40,15 +40,15 @@ public class ProtobufVarint32FrameDecoderTest {
     public void testTinyDecode() {
         byte[] b = { 4, 1, 1, 1, 1 };
         assertFalse(ch.writeInbound(wrappedBuffer(b, 0, 1)));
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
         assertFalse(ch.writeInbound(wrappedBuffer(b, 1, 2)));
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
         assertTrue(ch.writeInbound(wrappedBuffer(b, 3, b.length - 3)));
 
         ByteBuf expected = wrappedBuffer(new byte[] { 1, 1, 1, 1 });
         ByteBuf actual = ch.readInbound();
 
-        assertThat(expected, is(actual));
+        assertEquals(expected, actual);
         assertFalse(ch.finish());
 
         expected.release();
@@ -64,16 +64,16 @@ public class ProtobufVarint32FrameDecoderTest {
         b[0] = -2;
         b[1] = 15;
         assertFalse(ch.writeInbound(wrappedBuffer(b, 0, 1)));
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
         assertFalse(ch.writeInbound(wrappedBuffer(b, 1, 127)));
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
         assertFalse(ch.writeInbound(wrappedBuffer(b, 127, 600)));
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
         assertTrue(ch.writeInbound(wrappedBuffer(b, 727, b.length - 727)));
 
         ByteBuf expected = wrappedBuffer(b, 2, b.length - 2);
         ByteBuf actual = ch.readInbound();
-        assertThat(expected, is(actual));
+        assertEquals(expected, actual);
         assertFalse(ch.finish());
 
         expected.release();

--- a/codec/src/test/java/io/netty/handler/codec/protobuf/ProtobufVarint32LengthFieldPrependerTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/protobuf/ProtobufVarint32LengthFieldPrependerTest.java
@@ -21,8 +21,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static io.netty.buffer.Unpooled.*;
-import static org.hamcrest.core.Is.*;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -39,7 +38,7 @@ public class ProtobufVarint32LengthFieldPrependerTest {
     public void testSize1Varint() {
         final int size = 1;
         final int num = 10;
-        assertThat(ProtobufVarint32LengthFieldPrepender.computeRawVarint32Size(num), is(size));
+        assertEquals(size, ProtobufVarint32LengthFieldPrepender.computeRawVarint32Size(num));
         final byte[] buf = new byte[size + num];
         //0000 1010
         buf[0] = 0x0A;
@@ -51,7 +50,7 @@ public class ProtobufVarint32LengthFieldPrependerTest {
         ByteBuf expected = wrappedBuffer(buf);
         ByteBuf actual = ch.readOutbound();
 
-        assertThat(expected, is(actual));
+        assertEquals(expected, actual);
         assertFalse(ch.finish());
 
         expected.release();
@@ -62,7 +61,7 @@ public class ProtobufVarint32LengthFieldPrependerTest {
     public void testSize2Varint() {
         final int size = 2;
         final int num = 266;
-        assertThat(ProtobufVarint32LengthFieldPrepender.computeRawVarint32Size(num), is(size));
+        assertEquals(size, ProtobufVarint32LengthFieldPrepender.computeRawVarint32Size(num));
         final byte[] buf = new byte[size + num];
         /**
          * 8    A    0    2
@@ -86,7 +85,7 @@ public class ProtobufVarint32LengthFieldPrependerTest {
         ByteBuf expected = wrappedBuffer(buf);
         ByteBuf actual = ch.readOutbound();
 
-        assertThat(actual, is(expected));
+        assertEquals(actual, expected);
         assertFalse(ch.finish());
 
         expected.release();
@@ -97,7 +96,7 @@ public class ProtobufVarint32LengthFieldPrependerTest {
     public void testSize3Varint() {
         final int size = 3;
         final int num = 0x4000;
-        assertThat(ProtobufVarint32LengthFieldPrepender.computeRawVarint32Size(num), is(size));
+        assertEquals(size, ProtobufVarint32LengthFieldPrepender.computeRawVarint32Size(num));
         final byte[] buf = new byte[size + num];
         /**
          * 8    0    8    0    0    1
@@ -122,7 +121,7 @@ public class ProtobufVarint32LengthFieldPrependerTest {
         ByteBuf expected = wrappedBuffer(buf);
         ByteBuf actual = ch.readOutbound();
 
-        assertThat(expected, is(actual));
+        assertEquals(expected, actual);
         assertFalse(ch.finish());
 
         expected.release();
@@ -133,7 +132,7 @@ public class ProtobufVarint32LengthFieldPrependerTest {
     public void testSize4Varint() {
         final int size = 4;
         final int num = 0x200000;
-        assertThat(ProtobufVarint32LengthFieldPrepender.computeRawVarint32Size(num), is(size));
+        assertEquals(size, ProtobufVarint32LengthFieldPrepender.computeRawVarint32Size(num));
         final byte[] buf = new byte[size + num];
         /**
          * 8    0    8    0    8    0    0    1
@@ -159,7 +158,7 @@ public class ProtobufVarint32LengthFieldPrependerTest {
         ByteBuf expected = wrappedBuffer(buf);
         ByteBuf actual = ch.readOutbound();
 
-        assertThat(actual, is(expected));
+        assertEquals(expected, actual);
         assertFalse(ch.finish());
 
         expected.release();
@@ -174,7 +173,7 @@ public class ProtobufVarint32LengthFieldPrependerTest {
         ByteBuf expected = wrappedBuffer(b);
         ByteBuf actual = ch.readOutbound();
 
-        assertThat(actual, is(expected));
+        assertEquals(expected, actual);
         assertFalse(ch.finish());
 
         expected.release();
@@ -194,7 +193,7 @@ public class ProtobufVarint32LengthFieldPrependerTest {
         ByteBuf expected = wrappedBuffer(b);
         ByteBuf actual = ch.readOutbound();
 
-        assertThat(actual, is(expected));
+        assertEquals(expected, actual);
         assertFalse(ch.finish());
 
         expected.release();

--- a/codec/src/test/java/io/netty/handler/codec/xml/XmlFrameDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/xml/XmlFrameDecoderTest.java
@@ -37,8 +37,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class XmlFrameDecoderTest {
@@ -208,7 +207,7 @@ public class XmlFrameDecoderTest {
         try {
             List<Object> expectedList = new ArrayList<Object>();
             Collections.addAll(expectedList, expected);
-            assertThat(actual, is(expectedList));
+            assertEquals(expectedList, actual);
         } finally {
             ch.finish();
         }

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -115,11 +115,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
+++ b/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
@@ -23,8 +23,6 @@ import java.util.Random;
 
 import static io.netty.util.AsciiString.contains;
 import static io.netty.util.AsciiString.containsIgnoreCase;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -245,23 +243,23 @@ public class AsciiStringCharacterTest {
 
     @Test
     public void testEqualsIgnoreCase() {
-        assertThat(AsciiString.contentEqualsIgnoreCase(null, null), is(true));
-        assertThat(AsciiString.contentEqualsIgnoreCase(null, "foo"), is(false));
-        assertThat(AsciiString.contentEqualsIgnoreCase("bar", null), is(false));
-        assertThat(AsciiString.contentEqualsIgnoreCase("FoO", "fOo"), is(true));
-        assertThat(AsciiString.contentEqualsIgnoreCase("FoO", "bar"), is(false));
-        assertThat(AsciiString.contentEqualsIgnoreCase("Foo", "foobar"), is(false));
-        assertThat(AsciiString.contentEqualsIgnoreCase("foobar", "Foo"), is(false));
+        assertTrue(AsciiString.contentEqualsIgnoreCase(null, null));
+        assertFalse(AsciiString.contentEqualsIgnoreCase(null, "foo"));
+        assertFalse(AsciiString.contentEqualsIgnoreCase("bar", null));
+        assertTrue(AsciiString.contentEqualsIgnoreCase("FoO", "fOo"));
+        assertFalse(AsciiString.contentEqualsIgnoreCase("FoO", "bar"));
+        assertFalse(AsciiString.contentEqualsIgnoreCase("Foo", "foobar"));
+        assertFalse(AsciiString.contentEqualsIgnoreCase("foobar", "Foo"));
 
         // Test variations (Ascii + String, Ascii + Ascii, String + Ascii)
-        assertThat(AsciiString.contentEqualsIgnoreCase(new AsciiString("FoO"), "fOo"), is(true));
-        assertThat(AsciiString.contentEqualsIgnoreCase(new AsciiString("FoO"), new AsciiString("fOo")), is(true));
-        assertThat(AsciiString.contentEqualsIgnoreCase("FoO", new AsciiString("fOo")), is(true));
+        assertTrue(AsciiString.contentEqualsIgnoreCase(new AsciiString("FoO"), "fOo"));
+        assertTrue(AsciiString.contentEqualsIgnoreCase(new AsciiString("FoO"), new AsciiString("fOo")));
+        assertTrue(AsciiString.contentEqualsIgnoreCase("FoO", new AsciiString("fOo")));
 
         // Test variations (Ascii + String, Ascii + Ascii, String + Ascii)
-        assertThat(AsciiString.contentEqualsIgnoreCase(new AsciiString("FoO"), "bAr"), is(false));
-        assertThat(AsciiString.contentEqualsIgnoreCase(new AsciiString("FoO"), new AsciiString("bAr")), is(false));
-        assertThat(AsciiString.contentEqualsIgnoreCase("FoO", new AsciiString("bAr")), is(false));
+        assertFalse(AsciiString.contentEqualsIgnoreCase(new AsciiString("FoO"), "bAr"));
+        assertFalse(AsciiString.contentEqualsIgnoreCase(new AsciiString("FoO"), new AsciiString("bAr")));
+        assertFalse(AsciiString.contentEqualsIgnoreCase("FoO", new AsciiString("bAr")));
     }
 
     @Test

--- a/common/src/test/java/io/netty/util/ConstantPoolTest.java
+++ b/common/src/test/java/io/netty/util/ConstantPoolTest.java
@@ -23,8 +23,9 @@ import java.util.Comparator;
 import java.util.Set;
 import java.util.TreeSet;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ConstantPoolTest {
@@ -57,14 +58,14 @@ public class ConstantPoolTest {
     public void testUniqueness() {
         TestConstant a = pool.valueOf(new String("Leroy"));
         TestConstant b = pool.valueOf(new String("Leroy"));
-        assertThat(a, is(sameInstance(b)));
+        assertSame(a, b);
     }
 
     @Test
     public void testIdUniqueness() {
         TestConstant one = pool.valueOf("one");
         TestConstant two = pool.valueOf("two");
-        assertThat(one.id(), is(not(two.id())));
+        assertNotEquals(one.id(), two.id());
     }
 
     @Test
@@ -83,7 +84,7 @@ public class ConstantPoolTest {
         set.add(a);
 
         TestConstant[] array = set.toArray(new TestConstant[0]);
-        assertThat(array.length, is(5));
+        assertEquals(5, array.length);
 
         // Sort by name
         Arrays.sort(array, new Comparator<TestConstant>() {
@@ -93,16 +94,16 @@ public class ConstantPoolTest {
             }
         });
 
-        assertThat(array[0], is(sameInstance(a)));
-        assertThat(array[1], is(sameInstance(b)));
-        assertThat(array[2], is(sameInstance(c)));
-        assertThat(array[3], is(sameInstance(d)));
-        assertThat(array[4], is(sameInstance(e)));
+        assertSame(a, array[0]);
+        assertSame(b, array[1]);
+        assertSame(c, array[2]);
+        assertSame(d, array[3]);
+        assertSame(e, array[4]);
     }
 
     @Test
     public void testComposedName() {
         TestConstant a = pool.valueOf(Object.class, "A");
-        assertThat(a.name(), is("java.lang.Object#A"));
+        assertEquals("java.lang.Object#A", a.name());
     }
 }

--- a/common/src/test/java/io/netty/util/NettyRuntimeTests.java
+++ b/common/src/test/java/io/netty/util/NettyRuntimeTests.java
@@ -23,10 +23,8 @@ import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasToString;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -41,7 +39,7 @@ public class NettyRuntimeTests {
                 holder.setAvailableProcessors(i);
                 fail();
             } catch (final IllegalArgumentException e) {
-                assertThat(e, hasToString(containsString("(expected: > 0)")));
+                assertThat(e.getMessage()).contains("(expected: > 0)");
             }
         }
     }
@@ -54,7 +52,7 @@ public class NettyRuntimeTests {
             holder.setAvailableProcessors(2);
             fail();
         } catch (final IllegalStateException e) {
-            assertThat(e, hasToString(containsString("availableProcessors is already set to [1], rejecting [2]")));
+            assertThat(e.getMessage()).contains("availableProcessors is already set to [1], rejecting [2]");
         }
     }
 
@@ -66,7 +64,7 @@ public class NettyRuntimeTests {
             holder.setAvailableProcessors(1);
             fail();
         } catch (final IllegalStateException e) {
-            assertThat(e, hasToString(containsString("availableProcessors is already set")));
+            assertThat(e.getMessage()).contains("availableProcessors is already set");
         }
     }
 
@@ -155,7 +153,7 @@ public class NettyRuntimeTests {
         set.join();
 
         if (setException.get() == null) {
-            assertThat(holder.availableProcessors(), equalTo(2048));
+            assertEquals(2048, holder.availableProcessors());
         } else {
             assertNotNull(setException.get());
         }
@@ -167,7 +165,7 @@ public class NettyRuntimeTests {
         try {
             System.setProperty("io.netty.availableProcessors", "2048");
             final NettyRuntime.AvailableProcessorsHolder holder = new NettyRuntime.AvailableProcessorsHolder();
-            assertThat(holder.availableProcessors(), equalTo(2048));
+            assertEquals(2048, holder.availableProcessors());
         } finally {
             if (availableProcessorsSystemProperty != null) {
                 System.setProperty("io.netty.availableProcessors", availableProcessorsSystemProperty);
@@ -184,7 +182,7 @@ public class NettyRuntimeTests {
         try {
             System.clearProperty("io.netty.availableProcessors");
             final NettyRuntime.AvailableProcessorsHolder holder = new NettyRuntime.AvailableProcessorsHolder();
-            assertThat(holder.availableProcessors(), equalTo(Runtime.getRuntime().availableProcessors()));
+            assertEquals(Runtime.getRuntime().availableProcessors(), holder.availableProcessors());
         } finally {
             if (availableProcessorsSystemProperty != null) {
                 System.setProperty("io.netty.availableProcessors", availableProcessorsSystemProperty);

--- a/common/src/test/java/io/netty/util/ThreadDeathWatcherTest.java
+++ b/common/src/test/java/io/netty/util/ThreadDeathWatcherTest.java
@@ -24,9 +24,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class ThreadDeathWatcherTest {
@@ -68,7 +68,7 @@ public class ThreadDeathWatcherTest {
         ThreadDeathWatcher.watch(t, task);
 
         // As long as the thread is alive, the task should not run.
-        assertThat(latch.await(750, TimeUnit.MILLISECONDS), is(false));
+        assertFalse(latch.await(750, TimeUnit.MILLISECONDS));
 
         // Interrupt the thread to terminate it.
         t.interrupt();
@@ -114,10 +114,10 @@ public class ThreadDeathWatcherTest {
         t.join();
 
         // Wait until the watcher thread terminates itself.
-        assertThat(ThreadDeathWatcher.awaitInactivity(Long.MAX_VALUE, TimeUnit.SECONDS), is(true));
+        assertTrue(ThreadDeathWatcher.awaitInactivity(Long.MAX_VALUE, TimeUnit.SECONDS));
 
         // And the task should not run.
-        assertThat(run.get(), is(false));
+        assertFalse(run.get());
     }
 
     @Test

--- a/common/src/test/java/io/netty/util/concurrent/FastThreadLocalTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/FastThreadLocalTest.java
@@ -30,12 +30,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.nullValue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -43,7 +40,7 @@ public class FastThreadLocalTest {
     @BeforeEach
     public void setUp() {
         FastThreadLocal.removeAll();
-        assertThat(FastThreadLocal.size(), is(0));
+        assertEquals(0, FastThreadLocal.size());
     }
 
     @Test
@@ -91,13 +88,13 @@ public class FastThreadLocalTest {
         };
 
         // Initialize a thread-local variable.
-        assertThat(var.get(), is(nullValue()));
-        assertThat(FastThreadLocal.size(), is(1));
+        assertNull(var.get());
+        assertEquals(1, FastThreadLocal.size());
 
         // And then remove it.
         FastThreadLocal.removeAll();
-        assertThat(removed.get(), is(true));
-        assertThat(FastThreadLocal.size(), is(0));
+        assertTrue(removed.get());
+        assertEquals(0, FastThreadLocal.size());
     }
 
     @Test
@@ -281,7 +278,7 @@ public class FastThreadLocalTest {
                 throwable.set(t);
             } finally {
                 // Assert the max index cannot greater than (ARRAY_LIST_CAPACITY_MAX_SIZE - 1).
-                assertThat(throwable.get(), is(instanceOf(IllegalStateException.class)));
+                assertInstanceOf(IllegalStateException.class, throwable.get());
                 // Assert the index was reset to ARRAY_LIST_CAPACITY_MAX_SIZE
                 // after it reaches ARRAY_LIST_CAPACITY_MAX_SIZE.
                 assertEquals(ARRAY_LIST_CAPACITY_MAX_SIZE - 1, InternalThreadLocalMap.lastVariableIndex());
@@ -316,7 +313,7 @@ public class FastThreadLocalTest {
         fastThreadLocalThread.start();
         fastThreadLocalThread.join();
         // assert the expanded size is not overflowed to negative value
-        assertThat(throwable.get(), is(not(instanceOf(NegativeArraySizeException.class))));
+        assertThat(throwable.get()).isNotInstanceOf(NegativeArraySizeException.class);
     }
 
     @Test
@@ -374,6 +371,6 @@ public class FastThreadLocalTest {
         FastThreadLocalThread fastThreadLocalThread = new FastThreadLocalThread(runnable);
         fastThreadLocalThread.start();
         fastThreadLocalThread.join();
-        assertThat(throwable.get(), is(instanceOf(IllegalArgumentException.class)));
+        assertInstanceOf(IllegalArgumentException.class, throwable.get());
     }
 }

--- a/common/src/test/java/io/netty/util/concurrent/GlobalEventExecutorTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/GlobalEventExecutorTest.java
@@ -24,12 +24,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GlobalEventExecutorTest {
 
@@ -55,21 +53,21 @@ public class GlobalEventExecutorTest {
 
         // Ensure the new thread has started.
         Thread thread = e.thread;
-        assertThat(thread, is(not(nullValue())));
-        assertThat(thread.isAlive(), is(true));
+        assertNotNull(thread);
+        assertTrue(thread.isAlive());
 
         thread.join();
-        assertThat(task.ran.get(), is(true));
+        assertTrue(task.ran.get());
 
         // Ensure another new thread starts again.
         task.ran.set(false);
         e.execute(task);
-        assertThat(e.thread, not(sameInstance(thread)));
+        assertNotSame(e.thread, thread);
         thread = e.thread;
 
         thread.join();
 
-        assertThat(task.ran.get(), is(true));
+        assertTrue(task.ran.get());
     }
 
     @Test
@@ -78,12 +76,12 @@ public class GlobalEventExecutorTest {
         TestRunnable task = new TestRunnable(0);
         ScheduledFuture<?> f = e.schedule(task, 1500, TimeUnit.MILLISECONDS);
         f.sync();
-        assertThat(task.ran.get(), is(true));
+        assertTrue(task.ran.get());
 
         // Ensure the thread is still running.
         Thread thread = e.thread;
-        assertThat(thread, is(not(nullValue())));
-        assertThat(thread.isAlive(), is(true));
+        assertNotNull(thread);
+        assertTrue(thread.isAlive());
 
         thread.join();
     }
@@ -129,9 +127,9 @@ public class GlobalEventExecutorTest {
 
         f.sync();
 
-        assertThat(beforeTask.ran.get(), is(true));
-        assertThat(scheduledTask.ran.get(), is(true));
-        assertThat(afterTask.ran.get(), is(true));
+        assertTrue(beforeTask.ran.get());
+        assertTrue(scheduledTask.ran.get());
+        assertTrue(afterTask.ran.get());
     }
 
     @Test
@@ -155,7 +153,7 @@ public class GlobalEventExecutorTest {
 
         f.sync();
 
-        assertThat(t.ran.get(), is(true));
+        assertTrue(t.ran.get());
     }
 
     private static final class TestRunnable implements Runnable {

--- a/common/src/test/java/io/netty/util/concurrent/PromiseAggregatorTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/PromiseAggregatorTest.java
@@ -19,8 +19,7 @@ package io.netty.util.concurrent;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
@@ -84,7 +83,7 @@ public class PromiseAggregatorTest {
         when(p2.isSuccess()).thenReturn(true);
         when(p.setSuccess(null)).thenReturn(p);
 
-        assertThat(a.add(p1, null, p2), is(a));
+        assertEquals(a, a.add(p1, null, p2));
         a.operationComplete(p1);
         a.operationComplete(p2);
 

--- a/common/src/test/java/io/netty/util/concurrent/SingleThreadEventExecutorTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/SingleThreadEventExecutorTest.java
@@ -34,8 +34,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -374,9 +372,10 @@ public class SingleThreadEventExecutorTest {
 
         f.sync();
 
-        assertThat(beforeTask.ran.get(), is(true));
-        assertThat(scheduledTask.ran.get(), is(true));
-        assertThat(afterTask.ran.get(), is(true));
+        assertTrue(beforeTask.ran.get());
+        assertTrue(scheduledTask.ran.get());
+        assertTrue(afterTask.ran.get());
+        executor.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS).syncUninterruptibly();
     }
 
     @Test
@@ -414,7 +413,8 @@ public class SingleThreadEventExecutorTest {
 
         f.sync();
 
-        assertThat(t.ran.get(), is(true));
+        assertTrue(t.ran.get());
+        executor.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS).syncUninterruptibly();
     }
 
     private static final class TestRunnable implements Runnable {

--- a/common/src/test/java/io/netty/util/internal/StringUtilTest.java
+++ b/common/src/test/java/io/netty/util/internal/StringUtilTest.java
@@ -32,8 +32,6 @@ import static io.netty.util.internal.StringUtil.toHexString;
 import static io.netty.util.internal.StringUtil.toHexStringPadded;
 import static io.netty.util.internal.StringUtil.unescapeCsv;
 import static io.netty.util.internal.StringUtil.unescapeCsvFields;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -51,20 +49,20 @@ public class StringUtilTest {
 
     @Test
     public void testToHexString() {
-        assertThat(toHexString(new byte[] { 0 }), is("0"));
-        assertThat(toHexString(new byte[] { 1 }), is("1"));
-        assertThat(toHexString(new byte[] { 0, 0 }), is("0"));
-        assertThat(toHexString(new byte[] { 1, 0 }), is("100"));
-        assertThat(toHexString(EmptyArrays.EMPTY_BYTES), is(""));
+        assertEquals("0", toHexString(new byte[] { 0 }));
+        assertEquals("1", toHexString(new byte[] { 1 }));
+        assertEquals("0", toHexString(new byte[] { 0, 0 }));
+        assertEquals("100", toHexString(new byte[] { 1, 0 }));
+        assertEquals("", toHexString(EmptyArrays.EMPTY_BYTES));
     }
 
     @Test
     public void testToHexStringPadded() {
-        assertThat(toHexStringPadded(new byte[]{0}), is("00"));
-        assertThat(toHexStringPadded(new byte[]{1}), is("01"));
-        assertThat(toHexStringPadded(new byte[]{0, 0}), is("0000"));
-        assertThat(toHexStringPadded(new byte[]{1, 0}), is("0100"));
-        assertThat(toHexStringPadded(EmptyArrays.EMPTY_BYTES), is(""));
+        assertEquals("00", toHexStringPadded(new byte[]{0}));
+        assertEquals("01", toHexStringPadded(new byte[]{1}));
+        assertEquals("0000", toHexStringPadded(new byte[]{0, 0}));
+        assertEquals("0100", toHexStringPadded(new byte[]{1, 0}));
+        assertEquals("", toHexStringPadded(EmptyArrays.EMPTY_BYTES));
     }
 
     @Test

--- a/handler-proxy/pom.xml
+++ b/handler-proxy/pom.xml
@@ -115,11 +115,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/handler-proxy/src/test/java/io/netty/handler/proxy/HttpProxyServer.java
+++ b/handler-proxy/src/test/java/io/netty/handler/proxy/HttpProxyServer.java
@@ -38,9 +38,8 @@ import io.netty.util.internal.SocketUtils;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 final class HttpProxyServer extends ProxyServer {
 
@@ -74,7 +73,7 @@ final class HttpProxyServer extends ProxyServer {
     }
 
     private boolean authenticate(ChannelHandlerContext ctx, FullHttpRequest req) {
-        assertThat(req.method(), is(HttpMethod.CONNECT));
+        assertEquals(HttpMethod.CONNECT, req.method());
 
         if (testMode != TestMode.INTERMEDIARY) {
             ctx.pipeline().addBefore(ctx.name(), "lineDecoder", new LineBasedFrameDecoder(64, false, true));
@@ -120,7 +119,7 @@ final class HttpProxyServer extends ProxyServer {
                 res = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
                 String uri = req.uri();
                 int lastColonPos = uri.lastIndexOf(':');
-                assertThat(lastColonPos, is(greaterThan(0)));
+                assertThat(lastColonPos).isGreaterThan(0);
                 intermediaryDestination = SocketUtils.socketAddress(
                         uri.substring(0, lastColonPos), Integer.parseInt(uri.substring(lastColonPos + 1)));
             }

--- a/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyHandlerTest.java
+++ b/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyHandlerTest.java
@@ -65,8 +65,11 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.Random;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class ProxyHandlerTest {
@@ -593,8 +596,8 @@ public class ProxyHandlerTest {
             for (ChannelHandler h: clientHandlers) {
                 if (h instanceof ProxyHandler) {
                     ProxyHandler ph = (ProxyHandler) h;
-                    assertThat(ph.connectFuture().isDone(), is(true));
-                    assertThat(ph.connectFuture().isSuccess(), is(success));
+                    assertTrue(ph.connectFuture().isDone());
+                    assertEquals(ph.connectFuture().isSuccess(), success);
                 }
             }
         }
@@ -662,10 +665,10 @@ public class ProxyHandlerTest {
 
             assertProxyHandlers(true);
 
-            assertThat(testHandler.received.toArray(), is(new Object[] { "0", "1", "2", "3" }));
-            assertThat(testHandler.exceptions.toArray(), is(EmptyArrays.EMPTY_OBJECTS));
-            assertThat(testHandler.eventCount, is(expectedEventCount));
-            assertThat(finished, is(true));
+            assertArrayEquals(new Object[] { "0", "1", "2", "3" }, testHandler.received.toArray());
+            assertArrayEquals(EmptyArrays.EMPTY_OBJECTS, testHandler.exceptions.toArray());
+            assertEquals(expectedEventCount, testHandler.eventCount);
+            assertTrue(finished);
         }
     }
 
@@ -703,11 +706,11 @@ public class ProxyHandlerTest {
 
             assertProxyHandlers(false);
 
-            assertThat(testHandler.exceptions.size(), is(1));
+            assertEquals(1, testHandler.exceptions.size());
             Throwable e = testHandler.exceptions.poll();
-            assertThat(e, is(instanceOf(ProxyConnectException.class)));
-            assertThat(String.valueOf(e), containsString(expectedMessage));
-            assertThat(finished, is(true));
+            assertInstanceOf(ProxyConnectException.class, e);
+            assertThat(String.valueOf(e)).contains(expectedMessage);
+            assertTrue(finished);
         }
     }
 
@@ -749,11 +752,11 @@ public class ProxyHandlerTest {
 
             assertProxyHandlers(false);
 
-            assertThat(testHandler.exceptions.size(), is(1));
+            assertEquals(1, testHandler.exceptions.size());
             Throwable e = testHandler.exceptions.poll();
-            assertThat(e, is(instanceOf(ProxyConnectException.class)));
-            assertThat(String.valueOf(e), containsString("timeout"));
-            assertThat(finished, is(true));
+            assertInstanceOf(ProxyConnectException.class, e);
+            assertThat(String.valueOf(e)).contains("timeout");
+            assertTrue(finished);
         }
     }
 }

--- a/handler-proxy/src/test/java/io/netty/handler/proxy/Socks4ProxyServer.java
+++ b/handler-proxy/src/test/java/io/netty/handler/proxy/Socks4ProxyServer.java
@@ -34,8 +34,7 @@ import io.netty.util.internal.SocketUtils;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 final class Socks4ProxyServer extends ProxyServer {
 
@@ -68,7 +67,7 @@ final class Socks4ProxyServer extends ProxyServer {
     }
 
     private boolean authenticate(ChannelHandlerContext ctx, Socks4CommandRequest req) {
-        assertThat(req.type(), is(Socks4CommandType.CONNECT));
+        assertEquals(Socks4CommandType.CONNECT, req.type());
 
         if (testMode != TestMode.INTERMEDIARY) {
             ctx.pipeline().addBefore(ctx.name(), "lineDecoder", new LineBasedFrameDecoder(64, false, true));

--- a/handler-proxy/src/test/java/io/netty/handler/proxy/Socks5ProxyServer.java
+++ b/handler-proxy/src/test/java/io/netty/handler/proxy/Socks5ProxyServer.java
@@ -43,8 +43,7 @@ import io.netty.util.internal.SocketUtils;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 final class Socks5ProxyServer extends ProxyServer {
 
@@ -118,7 +117,7 @@ final class Socks5ProxyServer extends ProxyServer {
             }
 
             Socks5CommandRequest req = (Socks5CommandRequest) msg;
-            assertThat(req.type(), is(Socks5CommandType.CONNECT));
+            assertEquals(Socks5CommandType.CONNECT, req.type());
 
             Socks5CommandResponse res =
                     new DefaultSocks5CommandResponse(Socks5CommandStatus.SUCCESS, Socks5AddressType.IPv4);
@@ -150,7 +149,7 @@ final class Socks5ProxyServer extends ProxyServer {
             }
 
             Socks5CommandRequest req = (Socks5CommandRequest) msg;
-            assertThat(req.type(), is(Socks5CommandType.CONNECT));
+            assertEquals(Socks5CommandType.CONNECT, req.type());
 
             ctx.pipeline().addBefore(ctx.name(), "lineDecoder", new LineBasedFrameDecoder(64, false, true));
 

--- a/handler-ssl-ocsp/pom.xml
+++ b/handler-ssl-ocsp/pom.xml
@@ -69,11 +69,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -147,11 +147,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/handler/src/test/java/io/netty/handler/logging/LoggingHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/logging/LoggingHandlerTest.java
@@ -42,11 +42,9 @@ import java.util.Iterator;
 import java.util.List;
 
 import static io.netty.util.internal.StringUtil.NEWLINE;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
@@ -219,8 +217,8 @@ public class LoggingHandlerTest {
         verify(appender).doAppend(argThat(new RegexLogMatcher(".+READ: " + msg + '$')));
 
         String handledMsg = channel.readInbound();
-        assertThat(msg, is(sameInstance(handledMsg)));
-        assertThat(channel.readInbound(), is(nullValue()));
+        assertSame(msg, handledMsg);
+        assertNull(channel.readInbound());
     }
 
     @Test
@@ -231,9 +229,9 @@ public class LoggingHandlerTest {
         verify(appender).doAppend(argThat(new RegexLogMatcher(".+READ: " + msg.readableBytes() + "B$", true)));
 
         ByteBuf handledMsg = channel.readInbound();
-        assertThat(msg, is(sameInstance(handledMsg)));
+        assertSame(msg, handledMsg);
         handledMsg.release();
-        assertThat(channel.readInbound(), is(nullValue()));
+        assertNull(channel.readInbound());
     }
 
     @Test
@@ -244,9 +242,9 @@ public class LoggingHandlerTest {
         verify(appender).doAppend(argThat(new RegexLogMatcher(".+READ: " + msg.readableBytes() + "B$", false)));
 
         ByteBuf handledMsg = channel.readInbound();
-        assertThat(msg, is(sameInstance(handledMsg)));
+        assertSame(msg, handledMsg);
         handledMsg.release();
-        assertThat(channel.readInbound(), is(nullValue()));
+        assertNull(channel.readInbound());
     }
 
     @Test
@@ -257,8 +255,8 @@ public class LoggingHandlerTest {
         verify(appender).doAppend(argThat(new RegexLogMatcher(".+READ: 0B$", false)));
 
         ByteBuf handledMsg = channel.readInbound();
-        assertThat(msg, is(sameInstance(handledMsg)));
-        assertThat(channel.readInbound(), is(nullValue()));
+        assertSame(msg, handledMsg);
+        assertNull(channel.readInbound());
     }
 
     @Test
@@ -275,9 +273,9 @@ public class LoggingHandlerTest {
         verify(appender).doAppend(argThat(new RegexLogMatcher(".+READ: foobar, 5B$", true)));
 
         ByteBufHolder handledMsg = channel.readInbound();
-        assertThat(msg, is(sameInstance(handledMsg)));
+        assertSame(msg, handledMsg);
         handledMsg.release();
-        assertThat(channel.readInbound(), is(nullValue()));
+        assertNull(channel.readInbound());
     }
 
     @Test

--- a/handler/src/test/java/io/netty/handler/ssl/CipherSuiteConverterTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/CipherSuiteConverterTest.java
@@ -21,11 +21,10 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Isolated;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Isolated
 public class CipherSuiteConverterTest {
@@ -135,7 +134,7 @@ public class CipherSuiteConverterTest {
     private static void testJ2OMapping(String javaCipherSuite, String openSslCipherSuite) {
         final String actual = CipherSuiteConverter.toOpenSslUncached(javaCipherSuite, false);
         logger.info("{} => {}", javaCipherSuite, actual);
-        assertThat(actual, is(openSslCipherSuite));
+        assertEquals(openSslCipherSuite, actual);
     }
 
     @Test
@@ -292,7 +291,7 @@ public class CipherSuiteConverterTest {
     private static void testO2JMapping(String javaCipherSuite, String openSslCipherSuite) {
         final String actual = CipherSuiteConverter.toJavaUncached(openSslCipherSuite);
         logger.info("{} => {}", openSslCipherSuite, actual);
-        assertThat(actual, is(javaCipherSuite));
+        assertEquals(javaCipherSuite, actual);
     }
 
     @Test
@@ -333,22 +332,22 @@ public class CipherSuiteConverterTest {
 
         // For TLSv1.3 this should make no diffierence if boringSSL is true or false
         final String actual1 = CipherSuiteConverter.toOpenSsl(javaCipherSuite, false);
-        assertThat(actual1, is(openSslCipherSuite));
+        assertEquals(openSslCipherSuite, actual1);
         final String actual2 = CipherSuiteConverter.toOpenSsl(javaCipherSuite, true);
         assertEquals(actual1, actual2);
 
         // Ensure that the cache entries have been created.
-        assertThat(CipherSuiteConverter.isJ2OCached(javaCipherSuite, actual1), is(true));
-        assertThat(CipherSuiteConverter.isO2JCached(actual1, "", javaCipherSuite.substring(4)), is(true));
-        assertThat(CipherSuiteConverter.isO2JCached(actual1, "SSL", "SSL_" + javaCipherSuite.substring(4)), is(true));
-        assertThat(CipherSuiteConverter.isO2JCached(actual1, "TLS", "TLS_" + javaCipherSuite.substring(4)), is(true));
+        assertTrue(CipherSuiteConverter.isJ2OCached(javaCipherSuite, actual1));
+        assertTrue(CipherSuiteConverter.isO2JCached(actual1, "", javaCipherSuite.substring(4)));
+        assertTrue(CipherSuiteConverter.isO2JCached(actual1, "SSL", "SSL_" + javaCipherSuite.substring(4)));
+        assertTrue(CipherSuiteConverter.isO2JCached(actual1, "TLS", "TLS_" + javaCipherSuite.substring(4)));
 
         final String actual3 = CipherSuiteConverter.toOpenSsl(javaCipherSuite, false);
-        assertThat(actual3, is(openSslCipherSuite));
+        assertEquals(openSslCipherSuite, actual3);
 
         // Test if the returned cipher strings are identical,
         // so that the TLS sessions with the same cipher suite do not create many strings.
-        assertThat(actual1, is(sameInstance(actual3)));
+        assertSame(actual1, actual3);
     }
 
     @Test
@@ -364,25 +363,25 @@ public class CipherSuiteConverterTest {
 
         final String tlsActual1 = CipherSuiteConverter.toJava(openSslCipherSuite, "TLS");
         final String sslActual1 = CipherSuiteConverter.toJava(openSslCipherSuite, "SSL");
-        assertThat(tlsActual1, is(tlsExpected));
-        assertThat(sslActual1, is(sslExpected));
+        assertEquals(tlsExpected, tlsActual1);
+        assertEquals(sslExpected, sslActual1);
 
         // Ensure that the cache entries have been created.
-        assertThat(CipherSuiteConverter.isO2JCached(openSslCipherSuite, "", javaCipherSuite), is(true));
-        assertThat(CipherSuiteConverter.isO2JCached(openSslCipherSuite, "SSL", sslExpected), is(true));
-        assertThat(CipherSuiteConverter.isO2JCached(openSslCipherSuite, "TLS", tlsExpected), is(true));
-        assertThat(CipherSuiteConverter.isJ2OCached(tlsExpected, openSslCipherSuite), is(true));
-        assertThat(CipherSuiteConverter.isJ2OCached(sslExpected, openSslCipherSuite), is(true));
+        assertTrue(CipherSuiteConverter.isO2JCached(openSslCipherSuite, "", javaCipherSuite));
+        assertTrue(CipherSuiteConverter.isO2JCached(openSslCipherSuite, "SSL", sslExpected));
+        assertTrue(CipherSuiteConverter.isO2JCached(openSslCipherSuite, "TLS", tlsExpected));
+        assertTrue(CipherSuiteConverter.isJ2OCached(tlsExpected, openSslCipherSuite));
+        assertTrue(CipherSuiteConverter.isJ2OCached(sslExpected, openSslCipherSuite));
 
         final String tlsActual2 = CipherSuiteConverter.toJava(openSslCipherSuite, "TLS");
         final String sslActual2 = CipherSuiteConverter.toJava(openSslCipherSuite, "SSL");
-        assertThat(tlsActual2, is(tlsExpected));
-        assertThat(sslActual2, is(sslExpected));
+        assertEquals(tlsExpected, tlsActual2);
+        assertEquals(sslExpected, sslActual2);
 
         // Test if the returned cipher strings are identical,
         // so that the TLS sessions with the same cipher suite do not create many strings.
-        assertThat(tlsActual1, is(sameInstance(tlsActual2)));
-        assertThat(sslActual1, is(sameInstance(sslActual2)));
+        assertSame(tlsActual1, tlsActual2);
+        assertSame(sslActual1, sslActual2);
     }
 
     @Test

--- a/handler/src/test/java/io/netty/handler/ssl/EnhancedX509ExtendedTrustManagerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/EnhancedX509ExtendedTrustManagerTest.java
@@ -17,7 +17,6 @@
 package io.netty.handler.ssl;
 
 import io.netty.util.internal.EmptyArrays;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -37,7 +36,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -312,7 +311,7 @@ public class EnhancedX509ExtendedTrustManagerTest {
         CertificateException exception = assertThrows(CertificateException.class, executable);
         // We should wrap the original cause with our own.
         assertInstanceOf(CertificateException.class, exception.getCause());
-        assertThat(exception.getMessage(), Matchers.containsString("some.netty.io"));
+        assertThat(exception.getMessage()).contains("some.netty.io");
     }
 
     @ParameterizedTest
@@ -321,6 +320,6 @@ public class EnhancedX509ExtendedTrustManagerTest {
         CertificateException exception = assertThrows(CertificateException.class, executable);
         // We should not wrap the original cause with our own.
         assertNull(exception.getCause());
-        assertThat(exception.getMessage(), Matchers.not(Matchers.containsString("some.netty.io")));
+        assertNull(exception.getMessage());
     }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslCachingKeyMaterialProviderTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslCachingKeyMaterialProviderTest.java
@@ -16,14 +16,14 @@
 package io.netty.handler.ssl;
 
 import io.netty.buffer.UnpooledByteBufAllocator;
-import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.KeyManagerFactory;
 
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -77,8 +77,7 @@ public class OpenSslCachingKeyMaterialProviderTest extends OpenSslKeyMaterialPro
         OpenSslCachingX509KeyManagerFactory factory = new OpenSslCachingX509KeyManagerFactory(
                 super.newKeyManagerFactory("SunX509"));
         OpenSslKeyMaterialProvider provider = factory.newProvider(PASSWORD);
-        assertThat(provider,
-                CoreMatchers.<OpenSslKeyMaterialProvider>instanceOf(OpenSslCachingKeyMaterialProvider.class));
+        assertInstanceOf(OpenSslCachingKeyMaterialProvider.class, provider);
     }
 
     @Test
@@ -86,7 +85,6 @@ public class OpenSslCachingKeyMaterialProviderTest extends OpenSslKeyMaterialPro
         OpenSslCachingX509KeyManagerFactory factory = new OpenSslCachingX509KeyManagerFactory(
                 super.newKeyManagerFactory("PKIX"));
         OpenSslKeyMaterialProvider provider = factory.newProvider(PASSWORD);
-        assertThat(provider, CoreMatchers.not(
-                CoreMatchers.<OpenSslKeyMaterialProvider>instanceOf(OpenSslCachingKeyMaterialProvider.class)));
+        assertThat(provider).isNotInstanceOf(OpenSslCachingKeyMaterialProvider.class);
     }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslPrivateKeyMethodTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslPrivateKeyMethodTest.java
@@ -38,7 +38,6 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.ThreadLocalRandom;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -66,8 +65,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.netty.handler.ssl.OpenSslTestUtils.checkShouldUseKeyManagerFactory;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -372,7 +371,7 @@ public class OpenSslPrivateKeyMethodTest {
                         Throwable clientCause = clientSslHandler.handshakeFuture().await().cause();
                         Throwable serverCause = serverSslHandler.handshakeFuture().await().cause();
                         assertNotNull(clientCause);
-                        assertThat(serverCause, Matchers.instanceOf(SSLHandshakeException.class));
+                        assertInstanceOf(SSLHandshakeException.class, serverCause);
                     } finally {
                         client.close().sync();
                     }

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslRenegotiateTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslRenegotiateTest.java
@@ -21,9 +21,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import javax.net.ssl.SSLException;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 public class OpenSslRenegotiateTest extends RenegotiateTest {
 
@@ -40,6 +38,6 @@ public class OpenSslRenegotiateTest extends RenegotiateTest {
     protected void verifyResult(AtomicReference<Throwable> error) throws Throwable {
         Throwable cause = error.get();
         // Renegotiation is not supported by the OpenSslEngine.
-        assertThat(cause, is(instanceOf(SSLException.class)));
+        assertInstanceOf(SSLException.class, cause);
     }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -54,7 +54,6 @@ import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.conscrypt.OpenSSLProvider;
-import org.hamcrest.Matcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -130,10 +129,7 @@ import javax.net.ssl.X509TrustManager;
 import javax.security.cert.X509Certificate;
 
 import static io.netty.handler.ssl.SslUtils.*;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -3324,15 +3320,14 @@ public abstract class SSLEngineTest {
                         assertEquals(Boolean.TRUE, clientEngine.getSession().getValue(key));
                     }
 
-                    Matcher<Long> creationTimeMatcher;
                     if (clientSessionReused == SessionReusedState.REUSED) {
                         // If we know for sure it was reused so the accessedTime needs to be larger.
-                        creationTimeMatcher = greaterThan(clientEngine.getSession().getCreationTime());
+                        assertThat(clientEngine.getSession().getLastAccessedTime())
+                                .isGreaterThan(clientEngine.getSession().getCreationTime());
                     } else {
-                        creationTimeMatcher = greaterThanOrEqualTo(clientEngine.getSession().getCreationTime());
+                        assertThat(clientEngine.getSession().getLastAccessedTime())
+                                .isGreaterThanOrEqualTo(clientEngine.getSession().getCreationTime());
                     }
-                    assertThat(clientEngine.getSession().getLastAccessedTime(),
-                            is(creationTimeMatcher));
                 }
             } else {
                 // Ensure we sleep 1ms in between as getLastAccessedTime() abd getCreationTime() are in milliseconds.

--- a/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
@@ -64,17 +64,13 @@ import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.ResourcesUtil;
 import io.netty.util.internal.StringUtil;
-import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -177,12 +173,12 @@ public class SniHandlerTest {
                         ch.writeInbound(Unpooled.wrappedBuffer(bytes));
                     }
                 });
-                assertThat(e.getCause(), CoreMatchers.instanceOf(NotSslRecordException.class));
+                assertInstanceOf(NotSslRecordException.class, e.getCause());
                 assertFalse(ch.finish());
             } finally {
                 ch.finishAndReleaseAll();
             }
-            assertThat(evtRef.get().cause(), CoreMatchers.instanceOf(NotSslRecordException.class));
+            assertInstanceOf(NotSslRecordException.class, evtRef.get().cause());
         } finally {
             releaseAll(nettyContext);
         }
@@ -236,8 +232,8 @@ public class SniHandlerTest {
                 // This should produce an alert
                 assertTrue(ch.finish());
 
-                assertThat(handler.hostname(), is("chat4.leancloud.cn"));
-                assertThat(handler.sslContext(), is(leanContext));
+                assertEquals("chat4.leancloud.cn", handler.hostname());
+                assertEquals(leanContext, handler.sslContext());
 
                 SniCompletionEvent evt = evtRef.get();
                 assertNotNull(evt);
@@ -345,9 +341,9 @@ public class SniHandlerTest {
                 buf.release();
             }
 
-            assertThat(ch.finish(), is(false));
-            assertThat(handler.hostname(), nullValue());
-            assertThat(handler.sslContext(), is(nettyContext));
+            assertFalse(ch.finish());
+            assertNull(handler.hostname());
+            assertEquals(nettyContext, handler.sslContext());
         } finally {
             releaseAll(leanContext, leanContext2, nettyContext);
         }
@@ -388,9 +384,9 @@ public class SniHandlerTest {
                 buf.release();
             }
 
-            assertThat(ch.finish(), is(false));
-            assertThat(handler.hostname(), nullValue());
-            assertThat(handler.sslContext(), is(nettyContext));
+            assertFalse(ch.finish());
+            assertNull(handler.hostname());
+            assertEquals(nettyContext, handler.sslContext());
         } finally {
             releaseAll(nettyContext);
         }
@@ -467,8 +463,8 @@ public class SniHandlerTest {
                 assertTrue(clientApnDoneLatch.await(5, TimeUnit.SECONDS));
                 assertTrue(serverApnCtx.get());
                 assertTrue(clientApnCtx.get());
-                assertThat(handler.hostname(), is("sni.fake.site"));
-                assertThat(handler.sslContext(), is(sniContext));
+                assertEquals("sni.fake.site", handler.hostname());
+                assertEquals(sniContext, handler.sslContext());
             } finally {
                 if (serverChannel != null) {
                     serverChannel.close().sync();

--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -61,8 +61,7 @@ import io.netty.util.concurrent.ImmediateExecutor;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.PlatformDependent;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.Matchers;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.function.Executable;
@@ -92,14 +91,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static io.netty.buffer.Unpooled.wrappedBuffer;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -165,10 +161,10 @@ public class SslHandlerTest {
             writeCauseLatch.await();
             Throwable writeCause = failureRef.get();
             assertNotNull(writeCause);
-            assertThat(writeCause, is(CoreMatchers.<Throwable>instanceOf(SSLException.class)));
+            assertInstanceOf(SSLException.class, writeCause);
             Throwable cause = handler.handshakeFuture().cause();
             assertNotNull(cause);
-            assertThat(cause, is(CoreMatchers.<Throwable>instanceOf(SSLException.class)));
+            assertInstanceOf(SSLException.class, cause);
         } finally {
             assertFalse(ch.finishAndReleaseAll());
         }
@@ -322,7 +318,7 @@ public class SslHandlerTest {
         ch.writeInbound(wrappedBuffer(new byte[]{22, 3, 1, 0, 5}));
 
         // Should decode nothing yet.
-        assertThat(ch.readInbound(), is(nullValue()));
+        assertNull(ch.readInbound());
 
         DecoderException e = assertThrows(DecoderException.class, new Executable() {
             @Override
@@ -337,7 +333,7 @@ public class SslHandlerTest {
         ch.finishAndReleaseAll();
 
         // The pushed message is invalid, so it should raise an exception if it decoded the message correctly.
-        assertThat(e.getCause(), is(instanceOf(SSLProtocolException.class)));
+        assertInstanceOf(SSLProtocolException.class, e.getCause());
     }
 
     @Test
@@ -362,7 +358,7 @@ public class SslHandlerTest {
                 ch.write(referenceCounted).get();
             }
         });
-        assertThat(e.getCause(), is(instanceOf(UnsupportedMessageTypeException.class)));
+        assertInstanceOf(UnsupportedMessageTypeException.class, e.getCause());
         assertEquals(0, referenceCounted.refCnt());
         assertTrue(ch.finishAndReleaseAll());
     }
@@ -392,7 +388,7 @@ public class SslHandlerTest {
         assertFalse(promise.isDone());
         assertTrue(ch.finishAndReleaseAll());
         assertTrue(promise.isDone());
-        assertThat(promise.cause(), is(instanceOf(SSLException.class)));
+        assertInstanceOf(SSLException.class, promise.cause());
     }
 
     @Test
@@ -566,8 +562,8 @@ public class SslHandlerTest {
 
         assertFalse(ch.finishAndReleaseAll());
 
-        assertThat(handler.handshakeFuture().cause(), instanceOf(ClosedChannelException.class));
-        assertThat(handler.sslCloseFuture().cause(), instanceOf(ClosedChannelException.class));
+        assertInstanceOf(ClosedChannelException.class, handler.handshakeFuture().cause());
+        assertInstanceOf(ClosedChannelException.class, handler.sslCloseFuture().cause());
     }
 
     @Test
@@ -588,11 +584,11 @@ public class SslHandlerTest {
 
         SslCompletionEvent evt = events.take();
         assertTrue(evt instanceof SslHandshakeCompletionEvent);
-        assertThat(evt.cause(), instanceOf(ClosedChannelException.class));
+        assertInstanceOf(ClosedChannelException.class, evt.cause());
 
         evt = events.take();
         assertTrue(evt instanceof SslCloseCompletionEvent);
-        assertThat(evt.cause(), instanceOf(ClosedChannelException.class));
+        assertInstanceOf(ClosedChannelException.class, evt.cause());
         assertTrue(events.isEmpty());
     }
 
@@ -664,10 +660,10 @@ public class SslHandlerTest {
 
             SslCompletionEvent evt = (SslCompletionEvent) events.take();
             assertTrue(evt instanceof SslHandshakeCompletionEvent);
-            assertThat(evt.cause(), is(instanceOf(SSLException.class)));
+            assertInstanceOf(SSLException.class, evt.cause());
 
             ChannelFuture future = (ChannelFuture) events.take();
-            assertThat(future.cause(), is(instanceOf(SSLException.class)));
+            assertInstanceOf(SSLException.class, future.cause());
 
             serverChannel.close().sync();
             serverChannel = null;
@@ -677,7 +673,7 @@ public class SslHandlerTest {
             latch2.await();
             evt = (SslCompletionEvent) events.take();
             assertTrue(evt instanceof SslCloseCompletionEvent);
-            assertThat(evt.cause(), is(instanceOf(ClosedChannelException.class)));
+            assertInstanceOf(ClosedChannelException.class, evt.cause());
             assertTrue(events.isEmpty());
         } finally {
             if (serverChannel != null) {
@@ -895,8 +891,7 @@ public class SslHandlerTest {
             if (error != null) {
                 throw error;
             }
-            assertThat(sslHandler.handshakeFuture().await().cause(),
-                       CoreMatchers.<Throwable>instanceOf(SSLException.class));
+            assertInstanceOf(SSLException.class, sslHandler.handshakeFuture().await().cause());
         } finally {
             if (cc != null) {
                 cc.close().syncUninterruptibly();
@@ -970,8 +965,8 @@ public class SslHandlerTest {
             cc = future.syncUninterruptibly().channel();
 
             Throwable cause = sslHandler.handshakeFuture().await().cause();
-            assertThat(cause, CoreMatchers.<Throwable>instanceOf(SSLException.class));
-            assertThat(cause.getMessage(), containsString("timed out"));
+            assertInstanceOf(SSLException.class, cause);
+            assertThat(cause.getMessage()).contains("timed out");
         } finally {
             if (cc != null) {
                 cc.close().syncUninterruptibly();
@@ -1242,11 +1237,11 @@ public class SslHandlerTest {
 
             if (client) {
                 Throwable cause = clientSslHandler.handshakeFuture().await().cause();
-                assertThat(cause, CoreMatchers.<Throwable>instanceOf(SslHandshakeTimeoutException.class));
+                assertInstanceOf(SslHandshakeTimeoutException.class, cause);
                 assertFalse(serverSslHandler.handshakeFuture().await().isSuccess());
             } else {
                 Throwable cause = serverSslHandler.handshakeFuture().await().cause();
-                assertThat(cause, CoreMatchers.<Throwable>instanceOf(SslHandshakeTimeoutException.class));
+                assertInstanceOf(SslHandshakeTimeoutException.class, cause);
                 assertFalse(clientSslHandler.handshakeFuture().await().isSuccess());
             }
         } finally {
@@ -1544,8 +1539,8 @@ public class SslHandlerTest {
             assertFalse(serverSslHandler.handshakeFuture().await().isSuccess());
 
             Object error = errorQueue.take();
-            assertThat(error, Matchers.instanceOf(DecoderException.class));
-            assertThat(((Throwable) error).getCause(), Matchers.<Throwable>instanceOf(SSLException.class));
+            assertInstanceOf(DecoderException.class, error);
+            assertInstanceOf(SSLException.class, ((Throwable) error).getCause());
             Object terminal = errorQueue.take();
             assertSame(terminalEvent, terminal);
 
@@ -1660,23 +1655,21 @@ public class SslHandlerTest {
             cc = future.syncUninterruptibly().channel();
 
             Throwable clientCause = clientSslHandler.handshakeFuture().await().cause();
-            assertThat(clientCause, CoreMatchers.<Throwable>instanceOf(SSLException.class));
-            assertThat(clientCause.getCause(), not(CoreMatchers.<Throwable>instanceOf(ClosedChannelException.class)));
+            assertInstanceOf(SSLException.class, clientCause);
+            assertNull(clientCause.getCause());
             Throwable serverCause = serverSslHandler.handshakeFuture().await().cause();
-            assertThat(serverCause, CoreMatchers.<Throwable>instanceOf(SSLException.class));
-            assertThat(serverCause.getCause(), not(CoreMatchers.<Throwable>instanceOf(ClosedChannelException.class)));
+            assertInstanceOf(SSLException.class, serverCause);
+            assertNull(serverCause.getCause());
             cc.close().syncUninterruptibly();
             sc.close().syncUninterruptibly();
 
             Throwable eventClientCause = clientEvent.get().cause();
-            assertThat(eventClientCause, CoreMatchers.<Throwable>instanceOf(SSLException.class));
-            assertThat(eventClientCause.getCause(),
-                    not(CoreMatchers.<Throwable>instanceOf(ClosedChannelException.class)));
+            assertInstanceOf(SSLException.class, eventClientCause);
+            assertNull(eventClientCause.getCause());
             Throwable serverEventCause = serverEvent.get().cause();
 
-            assertThat(serverEventCause, CoreMatchers.<Throwable>instanceOf(SSLException.class));
-            assertThat(serverEventCause.getCause(),
-                    not(CoreMatchers.<Throwable>instanceOf(ClosedChannelException.class)));
+            assertInstanceOf(SSLException.class, serverEventCause);
+            assertNull(serverEventCause.getCause());
         } finally {
             group.shutdownGracefully();
             ReferenceCountUtil.release(sslClientCtx);
@@ -1704,7 +1697,7 @@ public class SslHandlerTest {
                 channel.writeInbound(buf);
             }
         });
-        assertThat(e.getCause(), instanceOf(NotSslRecordException.class));
+        assertInstanceOf(NotSslRecordException.class, e.getCause());
         assertTrue(channel.finishAndReleaseAll());
     }
 

--- a/handler/src/test/java/io/netty/handler/ssl/ocsp/OcspTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ocsp/OcspTest.java
@@ -42,7 +42,6 @@ import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
-import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -56,8 +55,8 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import javax.net.ssl.SSLHandshakeException;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -255,7 +254,7 @@ public class OcspTest {
         assertArrayEquals(response, actual);
 
         Throwable cause = causeRef.get();
-        assertThat(cause, CoreMatchers.instanceOf(SSLHandshakeException.class));
+        assertInstanceOf(SSLHandshakeException.class, cause);
     }
 
     @Test

--- a/handler/src/test/java/io/netty/handler/timeout/IdleStateEventTest.java
+++ b/handler/src/test/java/io/netty/handler/timeout/IdleStateEventTest.java
@@ -19,17 +19,16 @@ package io.netty.handler.timeout;
 import org.junit.jupiter.api.Test;
 
 import static io.netty.handler.timeout.IdleStateEvent.*;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasToString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class IdleStateEventTest {
     @Test
     public void testHumanReadableToString() {
-        assertThat(FIRST_READER_IDLE_STATE_EVENT, hasToString("IdleStateEvent(READER_IDLE, first)"));
-        assertThat(READER_IDLE_STATE_EVENT, hasToString("IdleStateEvent(READER_IDLE)"));
-        assertThat(FIRST_WRITER_IDLE_STATE_EVENT, hasToString("IdleStateEvent(WRITER_IDLE, first)"));
-        assertThat(WRITER_IDLE_STATE_EVENT, hasToString("IdleStateEvent(WRITER_IDLE)"));
-        assertThat(FIRST_ALL_IDLE_STATE_EVENT, hasToString("IdleStateEvent(ALL_IDLE, first)"));
-        assertThat(ALL_IDLE_STATE_EVENT, hasToString("IdleStateEvent(ALL_IDLE)"));
+        assertEquals("IdleStateEvent(READER_IDLE, first)", FIRST_READER_IDLE_STATE_EVENT.toString());
+        assertEquals("IdleStateEvent(READER_IDLE)", READER_IDLE_STATE_EVENT.toString());
+        assertEquals("IdleStateEvent(WRITER_IDLE, first)", FIRST_WRITER_IDLE_STATE_EVENT.toString());
+        assertEquals("IdleStateEvent(WRITER_IDLE)", WRITER_IDLE_STATE_EVENT.toString());
+        assertEquals("IdleStateEvent(ALL_IDLE, first)", FIRST_ALL_IDLE_STATE_EVENT.toString());
+        assertEquals("IdleStateEvent(ALL_IDLE)", ALL_IDLE_STATE_EVENT.toString());
     }
 }

--- a/handler/src/test/java/io/netty/handler/timeout/IdleStateHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/timeout/IdleStateHandlerTest.java
@@ -29,8 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -68,7 +67,7 @@ public class IdleStateHandlerTest {
     }
 
     private static void anyIdle(TestableIdleStateHandler idleStateHandler, Object... expected) throws Exception {
-        assertThat(expected.length,  greaterThanOrEqualTo(1));
+        assertThat(expected.length).isGreaterThanOrEqualTo(1);
 
         final List<Object> events = new ArrayList<Object>();
         ChannelInboundHandlerAdapter handler = new ChannelInboundHandlerAdapter() {

--- a/pom.xml
+++ b/pom.xml
@@ -1163,12 +1163,6 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-library</artifactId>
-        <version>1.3</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>3.18.0</version>

--- a/resolver-dns-classes-macos/pom.xml
+++ b/resolver-dns-classes-macos/pom.xml
@@ -62,11 +62,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/resolver-dns-native-macos/pom.xml
+++ b/resolver-dns-native-macos/pom.xml
@@ -454,11 +454,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/resolver-dns-native-macos/src/test/java/io/netty/resolver/dns/macos/MacOSDnsServerAddressStreamProviderTest.java
+++ b/resolver-dns-native-macos/src/test/java/io/netty/resolver/dns/macos/MacOSDnsServerAddressStreamProviderTest.java
@@ -22,8 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
@@ -47,7 +46,6 @@ class MacOSDnsServerAddressStreamProviderTest {
     @EnabledOnOs(OS.MAC)
     void testDefaultUseCorrectInstance() {
         MacOSDnsServerAddressStreamProvider.ensureAvailability();
-        assertThat(DnsServerAddressStreamProviders.platformDefault(),
-                instanceOf(MacOSDnsServerAddressStreamProvider.class));
+        assertInstanceOf(MacOSDnsServerAddressStreamProvider.class, DnsServerAddressStreamProviders.platformDefault());
     }
 }

--- a/resolver-dns/pom.xml
+++ b/resolver-dns/pom.xml
@@ -122,11 +122,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsAddressResolverGroupTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsAddressResolverGroupTest.java
@@ -32,8 +32,7 @@ import java.net.SocketAddress;
 import java.nio.channels.UnsupportedAddressTypeException;
 import java.util.concurrent.ExecutionException;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -55,8 +54,7 @@ public class DnsAddressResolverGroupTest {
                 @Override
                 public void operationComplete(Future<Object> future) {
                     try {
-                        assertThat(future.cause(),
-                                instanceOf(UnsupportedAddressTypeException.class));
+                        assertInstanceOf(UnsupportedAddressTypeException.class, future.cause());
                         assertTrue(loop.inEventLoop());
                         promise.setSuccess(null);
                     } catch (Throwable cause) {

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -67,7 +67,6 @@ import org.apache.directory.server.dns.messages.ResponseCode;
 import org.apache.directory.server.dns.store.DnsAttribute;
 import org.apache.directory.server.dns.store.RecordStore;
 import org.apache.mina.core.buffer.IoBuffer;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -126,18 +125,12 @@ import static io.netty.resolver.dns.TestDnsServer.newARecord;
 import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-
-import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -549,12 +542,12 @@ public class DnsNameResolverTest {
             final Map<String, InetAddress> resultB = testResolve0(resolver, EXCLUSIONS_RESOLVE_A, null);
 
             // Ensure the result from the cache is identical from the uncached one.
-            assertThat(resultB.size(), is(resultA.size()));
+            assertEquals(resultB.size(), resultA.size());
             for (Entry<String, InetAddress> e : resultA.entrySet()) {
                 InetAddress expected = e.getValue();
                 InetAddress actual = resultB.get(e.getKey());
-                assertThat("Cache for " + e.getKey() + ": " + resolver.resolveAll(e.getKey()).getNow(),
-                        actual, is(expected));
+                assertEquals(expected, actual,
+                        "Cache for " + e.getKey() + ": " + resolver.resolveAll(e.getKey()).getNow());
             }
         } finally {
             resolver.close();
@@ -638,7 +631,7 @@ public class DnsNameResolverTest {
                                                          DnsRecordType cancelledType)
             throws InterruptedException {
 
-        assertThat(resolver.isRecursionDesired(), is(true));
+        assertTrue(resolver.isRecursionDesired());
 
         final Map<String, InetAddress> results = new HashMap<String, InetAddress>();
         final Map<String, Future<InetAddress>> futures =
@@ -658,7 +651,7 @@ public class DnsNameResolverTest {
 
             logger.info("{}: {}", unresolved, resolved.getHostAddress());
 
-            assertThat(resolved.getHostName(), is(unresolved));
+            assertEquals(unresolved, resolved.getHostName());
 
             boolean typeMatches = false;
             for (InternetProtocolFamily f : resolver.resolvedInternetProtocolFamiliesUnsafe()) {
@@ -668,7 +661,7 @@ public class DnsNameResolverTest {
                 }
             }
 
-            assertThat(typeMatches, is(true));
+            assertTrue(typeMatches);
 
             results.put(resolved.getHostName(), resolved);
         }
@@ -683,7 +676,7 @@ public class DnsNameResolverTest {
     public void testQueryMx(DnsNameResolverChannelStrategy strategy) {
         DnsNameResolver resolver = newResolver(strategy).build();
         try {
-            assertThat(resolver.isRecursionDesired(), is(true));
+            assertTrue(resolver.isRecursionDesired());
 
             Map<String, Future<AddressedEnvelope<DnsResponse, InetSocketAddress>>> futures =
                     new LinkedHashMap<String, Future<AddressedEnvelope<DnsResponse, InetSocketAddress>>>();
@@ -700,7 +693,7 @@ public class DnsNameResolverTest {
                 Future<AddressedEnvelope<DnsResponse, InetSocketAddress>> f = e.getValue().awaitUninterruptibly();
 
                 DnsResponse response = f.getNow().content();
-                assertThat(response.code(), is(DnsResponseCode.NOERROR));
+                assertEquals(DnsResponseCode.NOERROR, response.code());
 
                 final int answerCount = response.count(DnsSection.ANSWER);
                 final List<DnsRecord> mxList = new ArrayList<DnsRecord>(answerCount);
@@ -711,7 +704,7 @@ public class DnsNameResolverTest {
                     }
                 }
 
-                assertThat(mxList.size(), is(greaterThan(0)));
+                assertThat(mxList.size()).isGreaterThan(0);
                 StringBuilder buf = new StringBuilder();
                 for (DnsRecord r : mxList) {
                     ByteBuf recordContent = ((ByteBufHolder) r).content();
@@ -770,7 +763,7 @@ public class DnsNameResolverTest {
                 fail("Cached negative lookups did not finish quickly.");
             }
 
-            assertThat(exceptions, hasSize(size));
+            assertEquals(size, exceptions.size());
         } finally {
             resolver.close();
         }
@@ -782,7 +775,7 @@ public class DnsNameResolverTest {
             fail();
             return null;
         } catch (Exception e) {
-            assertThat(e, is(instanceOf(UnknownHostException.class)));
+            assertInstanceOf(UnknownHostException.class, e);
 
             TestRecursiveCacheDnsQueryLifecycleObserverFactory lifecycleObserverFactory =
                     (TestRecursiveCacheDnsQueryLifecycleObserverFactory) resolver.dnsQueryLifecycleObserverFactory();
@@ -1163,7 +1156,7 @@ public class DnsNameResolverTest {
     public void testResolveAllMx(DnsNameResolverChannelStrategy strategy) {
         final DnsNameResolver resolver = newResolver(strategy).build();
         try {
-            assertThat(resolver.isRecursionDesired(), is(true));
+            assertTrue(resolver.isRecursionDesired());
 
             final Map<String, Future<List<DnsRecord>>> futures = new LinkedHashMap<String, Future<List<DnsRecord>>>();
             for (String name : DOMAINS) {
@@ -1179,7 +1172,7 @@ public class DnsNameResolverTest {
                 Future<List<DnsRecord>> f = e.getValue().awaitUninterruptibly();
 
                 final List<DnsRecord> mxList = f.getNow();
-                assertThat(mxList.size(), is(greaterThan(0)));
+                assertThat(mxList.size()).isGreaterThan(0);
                 StringBuilder buf = new StringBuilder();
                 for (DnsRecord r : mxList) {
                     ByteBuf recordContent = ((ByteBufHolder) r).content();
@@ -1227,16 +1220,16 @@ public class DnsNameResolverTest {
 
         final List<DnsRecord> records = resolver.resolveAll(new DefaultDnsQuestion("foo.com.", A))
                 .syncUninterruptibly().getNow();
-        assertThat(records, Matchers.<DnsRecord>hasSize(1));
-        assertThat(records.get(0), Matchers.<DnsRecord>instanceOf(DnsRawRecord.class));
+        assertEquals(1, records.size());
+        assertInstanceOf(DnsRawRecord.class, records.get(0));
 
         final DnsRawRecord record = (DnsRawRecord) records.get(0);
         final ByteBuf content = record.content();
-        assertThat(record.name(), is("foo.com."));
-        assertThat(record.dnsClass(), is(DnsRecord.CLASS_IN));
-        assertThat(record.type(), is(A));
-        assertThat(content.readableBytes(), is(4));
-        assertThat(content.readInt(), is(0x01020304));
+        assertEquals("foo.com.", record.name());
+        assertEquals(DnsRecord.CLASS_IN, record.dnsClass());
+        assertEquals(A, record.type());
+        assertEquals(4, content.readableBytes());
+        assertEquals(0x01020304, content.readInt());
         record.release();
     }
 
@@ -2087,10 +2080,10 @@ public class DnsNameResolverTest {
 
         try {
             final List<InetAddress> addresses = resolver.resolveAll(unresolved).sync().get();
-            assertThat(addresses, Matchers.<InetAddress>hasSize(greaterThan(0)));
+            assertThat(addresses.size()).isGreaterThan(0);
             for (InetAddress address : addresses) {
-                assertThat(address.getHostName(), startsWith(unresolved));
-                assertThat(address.getHostAddress(), startsWith(ipAddrPrefix));
+                assertThat(address.getHostName()).startsWith(unresolved);
+                assertThat(address.getHostAddress()).startsWith(ipAddrPrefix);
             }
         } finally {
             resolver.close();
@@ -2131,10 +2124,8 @@ public class DnsNameResolverTest {
                 .nameServerProvider(new SingletonDnsServerAddressStreamProvider(testDnsServer.localAddress())).build();
 
         try {
-            assertThat(resolver.resolve(domain).await().cause(),
-                    Matchers.<Throwable>instanceOf(UnknownHostException.class));
-            assertThat(resolver.resolveAll(domain).await().cause(),
-                    Matchers.<Throwable>instanceOf(UnknownHostException.class));
+            assertInstanceOf(UnknownHostException.class, resolver.resolve(domain).await().cause());
+            assertInstanceOf(UnknownHostException.class, resolver.resolveAll(domain).await().cause());
         } finally {
             resolver.close();
             testDnsServer.stop();
@@ -2439,9 +2430,8 @@ public class DnsNameResolverTest {
         DnsNameResolver resolver = builder.build();
         Future<InetAddress> result = resolver.resolve("doesnotexist.netty.io").awaitUninterruptibly();
         Throwable cause = result.cause();
-        assertThat(cause, Matchers.instanceOf(UnknownHostException.class));
-        cause.getCause().printStackTrace();
-        assertThat(cause.getCause(), Matchers.instanceOf(DnsNameResolverTimeoutException.class));
+        assertInstanceOf(UnknownHostException.class, cause);
+        assertInstanceOf(DnsNameResolverTimeoutException.class, cause.getCause());
         assertTrue(DnsNameResolver.isTimeoutError(cause));
         assertTrue(DnsNameResolver.isTransportOrTimeoutError(cause));
         resolver.close();
@@ -3287,7 +3277,7 @@ public class DnsNameResolverTest {
             List<InetAddress> addresses = resolver.resolveAll(host).syncUninterruptibly().getNow();
             assertEquals(2, addresses.size());
             for (InetAddress address: addresses) {
-                assertThat(address, instanceOf(Inet4Address.class));
+                assertInstanceOf(Inet4Address.class, address);
                 assertEquals(host, address.getHostName());
             }
         } finally {
@@ -3593,8 +3583,8 @@ public class DnsNameResolverTest {
                 // Just close the socket. This should cause the original exception to be used.
                 socket.close();
                 Throwable error = envelopeFuture.awaitUninterruptibly().cause();
-                assertThat(error, instanceOf(DnsNameResolverTimeoutException.class));
-                assertThat(error.getSuppressed().length, greaterThanOrEqualTo(1));
+                assertInstanceOf(DnsNameResolverTimeoutException.class, error);
+                assertThat(error.getSuppressed().length).isGreaterThanOrEqualTo(1);
             }
         } finally {
             dnsServer2.stop();
@@ -3644,9 +3634,9 @@ public class DnsNameResolverTest {
             resolver.resolve("non-existent.netty.io", promise).sync();
             fail();
         } catch (Exception e) {
-            assertThat(e, is(instanceOf(CancellationException.class)));
+            assertInstanceOf(CancellationException.class, e);
         }
-        assertThat(isQuerySentToSecondServer.get(), is(false));
+        assertFalse(isQuerySentToSecondServer.get());
     }
 
     @ParameterizedTest
@@ -3928,28 +3918,28 @@ public class DnsNameResolverTest {
 
             // We expect these resolves to fail with UnknownHostException,
             // and then check that no unexpected CNAME queries were performed.
-            assertThat(resolver.resolveAll(new DefaultDnsQuestion("lookup-srv.netty.io", SRV)).await().cause(),
-                    instanceOf(UnknownHostException.class));
+            assertInstanceOf(UnknownHostException.class,
+                    resolver.resolveAll(new DefaultDnsQuestion("lookup-srv.netty.io", SRV)).await().cause());
             assertEquals(0, cnameQueries.get());
 
-            assertThat(resolver.resolveAll(new DefaultDnsQuestion("lookup-naptr.netty.io", NAPTR)).await().cause(),
-                    instanceOf(UnknownHostException.class));
+            assertInstanceOf(UnknownHostException.class,
+                    resolver.resolveAll(new DefaultDnsQuestion("lookup-naptr.netty.io", NAPTR)).await().cause());
             assertEquals(0, cnameQueries.get());
 
-            assertThat(resolver.resolveAll(new DefaultDnsQuestion("lookup-cname.netty.io", CNAME)).await().cause(),
-                    instanceOf(UnknownHostException.class));
+            assertInstanceOf(UnknownHostException.class,
+                    resolver.resolveAll(new DefaultDnsQuestion("lookup-cname.netty.io", CNAME)).await().cause());
             assertEquals(1, cnameQueries.getAndSet(0));
 
-            assertThat(resolver.resolveAll(new DefaultDnsQuestion("lookup-a.netty.io", A)).await().cause(),
-                    instanceOf(UnknownHostException.class));
+            assertInstanceOf(UnknownHostException.class,
+                    resolver.resolveAll(new DefaultDnsQuestion("lookup-a.netty.io", A)).await().cause());
             assertEquals(enabled ? 1 : 0, cnameQueries.getAndSet(0));
 
-            assertThat(resolver.resolveAll(new DefaultDnsQuestion("lookup-aaaa.netty.io", AAAA)).await().cause(),
-                    instanceOf(UnknownHostException.class));
+            assertInstanceOf(UnknownHostException.class,
+                    resolver.resolveAll(new DefaultDnsQuestion("lookup-aaaa.netty.io", AAAA)).await().cause());
             assertEquals(enabled ? 1 : 0, cnameQueries.getAndSet(0));
 
-            assertThat(resolver.resolveAll("lookup-address.netty.io").await().cause(),
-                    instanceOf(UnknownHostException.class));
+            assertInstanceOf(UnknownHostException.class,
+                    resolver.resolveAll("lookup-address.netty.io").await().cause());
             assertEquals(enabled ? 1 : 0, cnameQueries.getAndSet(0));
         } finally {
             dnsServer2.stop();
@@ -4242,13 +4232,13 @@ public class DnsNameResolverTest {
                             resolver.resolve("netty.io").sync();
                         }
                     });
-                    assertThat(cause.getCause(), Matchers.<Throwable>instanceOf(BindException.class));
+                    assertInstanceOf(BindException.class, cause.getCause());
                 } finally {
                     resolver.close();
                 }
             } catch (IllegalStateException cause) {
                 // We might also throw directly here... in this case let's verify that we use the correct exception.
-                assertThat(cause.getCause(), Matchers.<Throwable>instanceOf(BindException.class));
+                assertInstanceOf(BindException.class, cause.getCause());
             }
         } finally {
             datagramSocket.close();
@@ -4267,7 +4257,7 @@ public class DnsNameResolverTest {
                 return new DnsServerResponseFeedbackAddressStream() {
                     @Override
                     public void feedbackSuccess(InetSocketAddress address, long queryResponseTimeNanos) {
-                        assertThat(queryResponseTimeNanos, greaterThanOrEqualTo(0L));
+                        assertThat(queryResponseTimeNanos).isGreaterThanOrEqualTo(0L);
                         successCalled.set(true);
                     }
 
@@ -4275,7 +4265,7 @@ public class DnsNameResolverTest {
                     public void feedbackFailure(InetSocketAddress address,
                                                 Throwable failureCause,
                                                 long queryResponseTimeNanos) {
-                        assertThat(queryResponseTimeNanos, greaterThanOrEqualTo(0L));
+                        assertThat(queryResponseTimeNanos).isGreaterThanOrEqualTo(0L);
                         assertNotNull(failureCause);
                         failureCalled.set(true);
                     }
@@ -4323,7 +4313,7 @@ public class DnsNameResolverTest {
                 fail();
             } catch (Exception e) {
                 // expected
-                assertThat(e, is(instanceOf(UnknownHostException.class)));
+                assertInstanceOf(UnknownHostException.class, e);
             } finally {
                 assertFalse(successCalled.get());
                 assertTrue(failureCalled.get());

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsServerAddressesTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsServerAddressesTest.java
@@ -25,8 +25,10 @@ import java.util.IdentityHashMap;
 import java.util.Set;
 
 import static io.netty.resolver.dns.DefaultDnsServerAddressStreamProvider.defaultAddressList;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class DnsServerAddressesTest {
 
@@ -36,13 +38,13 @@ public class DnsServerAddressesTest {
 
     @Test
     public void testDefaultAddresses() {
-        assertThat(defaultAddressList().size(), is(greaterThan(0)));
+        assertThat(defaultAddressList().size()).isGreaterThan(0);
     }
 
     @Test
     public void testSequential() {
         DnsServerAddresses seq = DnsServerAddresses.sequential(ADDR1, ADDR2, ADDR3);
-        assertThat(seq.stream(), is(not(sameInstance(seq.stream()))));
+        assertNotSame(seq.stream(), seq.stream());
 
         for (int j = 0; j < 2; j ++) {
             DnsServerAddressStream i = seq.stream();
@@ -104,8 +106,8 @@ public class DnsServerAddressesTest {
             set.add(i.next());
         }
 
-        assertThat(set.size(), is(3));
-        assertThat(seq.stream(), is(not(sameInstance(seq.stream()))));
+        assertEquals(3, set.size());
+        assertNotSame(seq.stream(), seq.stream());
     }
 
     @Test
@@ -113,7 +115,7 @@ public class DnsServerAddressesTest {
         DnsServerAddresses seq = DnsServerAddresses.singleton(ADDR1);
 
         // Should return the same iterator instance for least possible footprint.
-        assertThat(seq.stream(), is(sameInstance(seq.stream())));
+        assertSame(seq.stream(), seq.stream());
 
         DnsServerAddressStream i = seq.stream();
         assertNext(i, ADDR1);
@@ -122,6 +124,6 @@ public class DnsServerAddressesTest {
     }
 
     private static void assertNext(DnsServerAddressStream i, InetSocketAddress addr) {
-        assertThat(i.next(), is(sameInstance(addr)));
+        assertSame(i.next(), addr);
     }
 }

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/ResolvConfTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/ResolvConfTest.java
@@ -31,9 +31,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
@@ -41,7 +39,7 @@ public class ResolvConfTest {
     @Test
     @DisabledOnOs({OS.WINDOWS})
     public void readSystem() {
-        assertThat(ResolvConf.system().getNameservers().size(), is(greaterThan(0)));
+        assertThat(ResolvConf.system().getNameservers().size()).isGreaterThan(0);
     }
 
     @ParameterizedTest

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/SearchDomainTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/SearchDomainTest.java
@@ -33,12 +33,10 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.core.StringContains.containsString;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SearchDomainTest {
@@ -291,9 +289,8 @@ public class SearchDomainTest {
         assertTrue(fut.await(10, TimeUnit.SECONDS));
         assertFalse(fut.isSuccess());
         final Throwable cause = fut.cause();
-        assertThat(cause, instanceOf(UnknownHostException.class));
-        assertThat("search domain is included in UnknownHostException", cause.getMessage(),
-            containsString("foo.com"));
+        assertInstanceOf(UnknownHostException.class, cause);
+        assertThat(cause.getMessage()).contains("foo.com");
     }
 
     @Test
@@ -308,8 +305,7 @@ public class SearchDomainTest {
         assertTrue(fut.await(10, TimeUnit.SECONDS));
         assertFalse(fut.isSuccess());
         final Throwable cause = fut.cause();
-        assertThat(cause, instanceOf(UnknownHostException.class));
-        assertThat("search domain is included in UnknownHostException", cause.getMessage(),
-                not(containsString("foo.com")));
+        assertInstanceOf(UnknownHostException.class, cause);
+        assertThat(cause.getMessage()).doesNotContain("foo.com");
     }
 }

--- a/resolver/pom.xml
+++ b/resolver/pom.xml
@@ -58,11 +58,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/resolver/src/test/java/io/netty/resolver/DefaultHostsFileEntriesResolverTest.java
+++ b/resolver/src/test/java/io/netty/resolver/DefaultHostsFileEntriesResolverTest.java
@@ -31,9 +31,8 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
@@ -81,7 +80,7 @@ public class DefaultHostsFileEntriesResolverTest {
         DefaultHostsFileEntriesResolver resolver = new DefaultHostsFileEntriesResolver(parser, ENTRIES_TTL);
 
         InetAddress address = resolver.address("localhost", ResolvedAddressTypes.IPV4_PREFERRED);
-        assertThat("Should pick an IPv4 address", address, instanceOf(Inet4Address.class));
+        assertInstanceOf(Inet4Address.class, address, "Should pick an IPv4 address");
     }
 
     @Test
@@ -94,7 +93,7 @@ public class DefaultHostsFileEntriesResolverTest {
         DefaultHostsFileEntriesResolver resolver = new DefaultHostsFileEntriesResolver(parser, ENTRIES_TTL);
 
         InetAddress address = resolver.address("localhost", ResolvedAddressTypes.IPV6_PREFERRED);
-        assertThat("Should pick an IPv6 address", address, instanceOf(Inet6Address.class));
+        assertInstanceOf(Inet6Address.class, address, "Should pick an IPv6 address");
     }
 
     @Test
@@ -122,8 +121,8 @@ public class DefaultHostsFileEntriesResolverTest {
         List<InetAddress> addresses = resolver.addresses("localhost", ResolvedAddressTypes.IPV4_PREFERRED);
         assertNotNull(addresses);
         assertEquals(2, addresses.size());
-        assertThat("Should pick an IPv4 address", addresses.get(0), instanceOf(Inet4Address.class));
-        assertThat("Should pick an IPv6 address", addresses.get(1), instanceOf(Inet6Address.class));
+        assertInstanceOf(Inet4Address.class, addresses.get(0), "Should pick an IPv4 address");
+        assertInstanceOf(Inet6Address.class, addresses.get(1), "Should pick an IPv6 address");
     }
 
     @Test
@@ -138,8 +137,8 @@ public class DefaultHostsFileEntriesResolverTest {
         List<InetAddress> addresses = resolver.addresses("localhost", ResolvedAddressTypes.IPV6_PREFERRED);
         assertNotNull(addresses);
         assertEquals(2, addresses.size());
-        assertThat("Should pick an IPv6 address", addresses.get(0), instanceOf(Inet6Address.class));
-        assertThat("Should pick an IPv4 address", addresses.get(1), instanceOf(Inet4Address.class));
+        assertInstanceOf(Inet6Address.class, addresses.get(0), "Should pick an IPv6 address");
+        assertInstanceOf(Inet4Address.class, addresses.get(1), "Should pick an IPv4 address");
     }
 
     @Test

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -95,11 +95,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>compile</scope>

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketConnectionAttemptTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketConnectionAttemptTest.java
@@ -40,9 +40,10 @@ import java.util.concurrent.TimeUnit;
 import static io.netty.testsuite.transport.socket.SocketTestPermutation.BAD_HOST;
 import static io.netty.testsuite.transport.socket.SocketTestPermutation.BAD_PORT;
 import static io.netty.testsuite.transport.socket.SocketTestPermutation.UNASSIGNED_PORT;
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -63,7 +64,7 @@ public class SocketConnectionAttemptTest extends AbstractClientSocketTest {
         cb.handler(new TestHandler()).option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 2000);
         ChannelFuture future = cb.connect(BAD_HOST, BAD_PORT);
         try {
-            assertThat(future.await(3000), is(true));
+            assertTrue(future.await(3000));
         } finally {
             future.channel().close();
         }
@@ -111,8 +112,8 @@ public class SocketConnectionAttemptTest extends AbstractClientSocketTest {
         cb.handler(handler);
         cb.option(ChannelOption.ALLOW_HALF_CLOSURE, halfClosure);
         ChannelFuture future = cb.connect(NetUtil.LOCALHOST, UNASSIGNED_PORT).awaitUninterruptibly();
-        assertThat(future.cause(), is(instanceOf(ConnectException.class)));
-        assertThat(errorPromise.cause(), is(nullValue()));
+        assertInstanceOf(ConnectException.class, future.cause());
+        assertNull(errorPromise.cause());
     }
 
     @Test
@@ -159,8 +160,8 @@ public class SocketConnectionAttemptTest extends AbstractClientSocketTest {
             }
 
             if (future.cancel(true)) {
-                assertThat(future.channel().closeFuture().await(500), is(true));
-                assertThat(future.isCancelled(), is(true));
+                assertTrue(future.channel().closeFuture().await(500));
+                assertTrue(future.isCancelled());
             } else {
                 // Check if cancellation is supported or not.
                 assertFalse(isConnectCancellationSupported(future.channel()), future.channel().getClass() +

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFileRegionTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFileRegionTest.java
@@ -28,7 +28,6 @@ import io.netty.channel.DefaultFileRegion;
 import io.netty.channel.FileRegion;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.util.internal.PlatformDependent;
-import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
@@ -40,9 +39,8 @@ import java.nio.channels.WritableByteChannel;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class SocketFileRegionTest extends AbstractSocketTest {
@@ -156,7 +154,7 @@ public class SocketFileRegionTest extends AbstractSocketTest {
         FileRegion region = new DefaultFileRegion(
                 new RandomAccessFile(file, "r").getChannel(), 0, data.length + 1024);
 
-        assertThat(cc.writeAndFlush(region).await().cause(), CoreMatchers.<Throwable>instanceOf(IOException.class));
+        assertInstanceOf(IOException.class, cc.writeAndFlush(region).await().cause());
         cc.close().sync();
         sc.close().sync();
     }
@@ -259,7 +257,7 @@ public class SocketFileRegionTest extends AbstractSocketTest {
         }
 
         // Make sure we did not receive more than we expected.
-        assertThat(sh.counter, is(data.length));
+        assertEquals(data.length, sh.counter);
     }
 
     private static class TestHandler extends SimpleChannelInboundHandler<ByteBuf> {

--- a/transport-blockhound-tests/pom.xml
+++ b/transport-blockhound-tests/pom.xml
@@ -193,11 +193,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/transport-blockhound-tests/src/test/java/io/netty/util/internal/NettyBlockHoundIntegrationTest.java
+++ b/transport-blockhound-tests/src/test/java/io/netty/util/internal/NettyBlockHoundIntegrationTest.java
@@ -51,7 +51,6 @@ import io.netty.util.concurrent.ImmediateExecutor;
 import io.netty.util.concurrent.ScheduledFuture;
 import io.netty.util.concurrent.SingleThreadEventExecutor;
 import io.netty.util.internal.Hidden.NettyBlockHoundIntegration;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -79,8 +78,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static io.netty.buffer.Unpooled.wrappedBuffer;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -116,7 +115,7 @@ public class NettyBlockHoundIntegrationTest {
             future.get(5, TimeUnit.SECONDS);
             fail("Expected an exception due to a blocking call but none was thrown");
         } catch (ExecutionException e) {
-            assertThat(e.getCause(), Matchers.instanceOf(BlockingOperationError.class));
+            assertInstanceOf(BlockingOperationError.class, e.getCause());
         }
     }
 

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -668,11 +668,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/transport-native-kqueue/pom.xml
+++ b/transport-native-kqueue/pom.xml
@@ -777,11 +777,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/transport-native-unix-common/pom.xml
+++ b/transport-native-unix-common/pom.xml
@@ -710,11 +710,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/transport-sctp/pom.xml
+++ b/transport-sctp/pom.xml
@@ -86,11 +86,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/transport-udt/pom.xml
+++ b/transport-udt/pom.xml
@@ -88,11 +88,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/transport-udt/src/test/java/io/netty/test/udt/nio/NioUdtProviderTest.java
+++ b/transport-udt/src/test/java/io/netty/test/udt/nio/NioUdtProviderTest.java
@@ -26,9 +26,8 @@ import io.netty.channel.udt.nio.NioUdtMessageConnectorChannel;
 import io.netty.channel.udt.nio.NioUdtMessageRendezvousChannel;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 public class NioUdtProviderTest extends AbstractUdtTest {
 
@@ -69,7 +68,7 @@ public class NioUdtProviderTest extends AbstractUdtTest {
         assertNotNull(NioUdtProvider.channelUDT(nioUdtMessageRendezvousChannel));
 
         // acceptor types
-        assertThat(NioUdtProvider.BYTE_ACCEPTOR.newChannel(), instanceOf(UdtServerChannel.class));
-        assertThat(NioUdtProvider.MESSAGE_ACCEPTOR.newChannel(), instanceOf(UdtServerChannel.class));
+        assertInstanceOf(UdtServerChannel.class, NioUdtProvider.BYTE_ACCEPTOR.newChannel());
+        assertInstanceOf(UdtServerChannel.class, NioUdtProvider.MESSAGE_ACCEPTOR.newChannel());
     }
 }

--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -77,11 +77,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
@@ -62,14 +62,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -334,7 +329,7 @@ public class BootstrapTest {
         bootstrapB.childHandler(dummyHandler);
 
         assertTrue(bootstrapA.config().toString().contains("resolver:"));
-        assertThat(bootstrapA.resolver(), is(instanceOf(TestAddressResolverGroup.class)));
+        assertInstanceOf(TestAddressResolverGroup.class, bootstrapA.resolver());
 
         SocketAddress localAddress = bootstrapB.bind(LocalAddress.ANY).sync().channel().localAddress();
 
@@ -360,10 +355,10 @@ public class BootstrapTest {
         ChannelFuture connectFuture = bootstrapA.connect(localAddress);
 
         // Should fail with the UnknownHostException.
-        assertThat(connectFuture.await(10000), is(true));
-        assertThat(connectFuture.cause(), is(instanceOf(UnknownHostException.class)));
+        assertTrue(connectFuture.await(10000));
+        assertInstanceOf(UnknownHostException.class, connectFuture.cause());
         connectFuture.channel().closeFuture().await(10000);
-        assertThat(connectFuture.channel().isOpen(), is(false));
+        assertFalse(connectFuture.channel().isOpen());
     }
 
     @Test
@@ -392,11 +387,11 @@ public class BootstrapTest {
         ChannelFuture connectFuture = bootstrapA.connect(localAddress);
 
         // Should fail with the IllegalStateException.
-        assertThat(connectFuture.await(10000), is(true));
-        assertThat(connectFuture.cause(), instanceOf(IllegalStateException.class));
-        assertThat(connectFuture.cause().getCause(), instanceOf(TestException.class));
+        assertTrue(connectFuture.await(10000));
+        assertInstanceOf(IllegalStateException.class, connectFuture.cause());
+        assertInstanceOf(TestException.class, connectFuture.cause().getCause());
         connectFuture.channel().closeFuture().await(10000);
-        assertThat(connectFuture.channel().isOpen(), is(false));
+        assertFalse(connectFuture.channel().isOpen());
     }
 
     @Test
@@ -416,9 +411,9 @@ public class BootstrapTest {
         ChannelFuture connectFuture = bootstrap.connect(LocalAddress.ANY);
 
         // Should fail with the RuntimeException.
-        assertThat(connectFuture.await(10000), is(true));
-        assertThat(connectFuture.cause(), sameInstance((Throwable) exception));
-        assertThat(connectFuture.channel(), is(not(nullValue())));
+        assertTrue(connectFuture.await(10000));
+        assertSame(exception, connectFuture.cause());
+        assertNotNull(connectFuture.channel());
     }
 
     @Test

--- a/transport/src/test/java/io/netty/channel/ChannelOutboundBufferTest.java
+++ b/transport/src/test/java/io/netty/channel/ChannelOutboundBufferTest.java
@@ -33,8 +33,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static io.netty.buffer.Unpooled.*;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -297,20 +296,20 @@ public class ChannelOutboundBufferTest {
         ch.write(buffer().writeZero(128));
         // Ensure exceeding the low watermark does not make channel unwritable.
         ch.write(buffer().writeZero(2));
-        assertThat(buf.toString(), is(""));
+        assertEquals("", buf.toString());
 
         ch.unsafe().outboundBuffer().addFlush();
 
         // Ensure exceeding the high watermark makes channel unwritable.
         ch.write(buffer().writeZero(127));
-        assertThat(buf.toString(), is("false "));
+        assertEquals("false ", buf.toString());
 
         // Ensure going down to the low watermark makes channel writable again by flushing the first write.
-        assertThat(ch.unsafe().outboundBuffer().remove(), is(true));
-        assertThat(ch.unsafe().outboundBuffer().remove(), is(true));
-        assertThat(ch.unsafe().outboundBuffer().totalPendingWriteBytes(),
-                is(127L + ChannelOutboundBuffer.CHANNEL_OUTBOUND_BUFFER_ENTRY_OVERHEAD));
-        assertThat(buf.toString(), is("false true "));
+        assertTrue(ch.unsafe().outboundBuffer().remove());
+        assertTrue(ch.unsafe().outboundBuffer().remove());
+        assertEquals(127L + ChannelOutboundBuffer.CHANNEL_OUTBOUND_BUFFER_ENTRY_OVERHEAD,
+                ch.unsafe().outboundBuffer().totalPendingWriteBytes());
+        assertEquals("false true ", buf.toString());
 
         safeClose(ch);
     }
@@ -333,18 +332,18 @@ public class ChannelOutboundBufferTest {
 
         // Ensure that the default value of a user-defined writability flag is true.
         for (int i = 1; i <= 30; i ++) {
-            assertThat(cob.getUserDefinedWritability(i), is(true));
+            assertTrue(cob.getUserDefinedWritability(i));
         }
 
         // Ensure that setting a user-defined writability flag to false affects channel.isWritable();
         cob.setUserDefinedWritability(1, false);
         ch.runPendingTasks();
-        assertThat(buf.toString(), is("false "));
+        assertEquals("false ", buf.toString());
 
         // Ensure that setting a user-defined writability flag to true affects channel.isWritable();
         cob.setUserDefinedWritability(1, true);
         ch.runPendingTasks();
-        assertThat(buf.toString(), is("false true "));
+        assertEquals("false true ", buf.toString());
 
         safeClose(ch);
     }
@@ -368,23 +367,23 @@ public class ChannelOutboundBufferTest {
         // Ensure that setting a user-defined writability flag to false affects channel.isWritable()
         cob.setUserDefinedWritability(1, false);
         ch.runPendingTasks();
-        assertThat(buf.toString(), is("false "));
+        assertEquals("false ", buf.toString());
 
         // Ensure that setting another user-defined writability flag to false does not trigger
         // channelWritabilityChanged.
         cob.setUserDefinedWritability(2, false);
         ch.runPendingTasks();
-        assertThat(buf.toString(), is("false "));
+        assertEquals("false ", buf.toString());
 
         // Ensure that setting only one user-defined writability flag to true does not affect channel.isWritable()
         cob.setUserDefinedWritability(1, true);
         ch.runPendingTasks();
-        assertThat(buf.toString(), is("false "));
+        assertEquals("false ", buf.toString());
 
         // Ensure that setting all user-defined writability flags to true affects channel.isWritable()
         cob.setUserDefinedWritability(2, true);
         ch.runPendingTasks();
-        assertThat(buf.toString(), is("false true "));
+        assertEquals("false true ", buf.toString());
 
         safeClose(ch);
     }
@@ -407,23 +406,23 @@ public class ChannelOutboundBufferTest {
 
         // Trigger channelWritabilityChanged() by writing a lot.
         ch.write(buffer().writeZero(257));
-        assertThat(buf.toString(), is("false "));
+        assertEquals("false ", buf.toString());
 
         // Ensure that setting a user-defined writability flag to false does not trigger channelWritabilityChanged()
         cob.setUserDefinedWritability(1, false);
         ch.runPendingTasks();
-        assertThat(buf.toString(), is("false "));
+        assertEquals("false ", buf.toString());
 
         // Ensure reducing the totalPendingWriteBytes down to zero does not trigger channelWritabilityChanged()
         // because of the user-defined writability flag.
         ch.flush();
-        assertThat(cob.totalPendingWriteBytes(), is(0L));
-        assertThat(buf.toString(), is("false "));
+        assertEquals(0L, cob.totalPendingWriteBytes());
+        assertEquals("false ", buf.toString());
 
         // Ensure that setting the user-defined writability flag to true triggers channelWritabilityChanged()
         cob.setUserDefinedWritability(1, true);
         ch.runPendingTasks();
-        assertThat(buf.toString(), is("false true "));
+        assertEquals("false true ", buf.toString());
 
         safeClose(ch);
     }

--- a/transport/src/test/java/io/netty/channel/DefaultChannelIdTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelIdTest.java
@@ -20,18 +20,13 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.ByteBufOutputStream;
 import io.netty.buffer.Unpooled;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.util.Arrays;
-import java.util.Comparator;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("DynamicRegexReplaceableByCompiledPattern")
@@ -53,14 +48,14 @@ public class DefaultChannelIdTest {
     public void testIdempotentMachineId() {
         String a = DefaultChannelId.newInstance().asLongText().substring(0, 16);
         String b = DefaultChannelId.newInstance().asLongText().substring(0, 16);
-        assertThat(a, is(b));
+        assertEquals(a, b);
     }
 
     @Test
     public void testIdempotentProcessId() {
         String a = DefaultChannelId.newInstance().asLongText().substring(17, 21);
         String b = DefaultChannelId.newInstance().asLongText().substring(17, 21);
-        assertThat(a, is(b));
+        assertEquals(a, b);
     }
 
     @Test
@@ -84,9 +79,9 @@ public class DefaultChannelIdTest {
             in.close();
         }
 
-        assertThat(a, is(b));
-        assertThat(a, is(not(sameInstance(b))));
-        assertThat(a.asLongText(), is(b.asLongText()));
+        assertEquals(a, b);
+        assertNotSame(a, b);
+        assertEquals(a.asLongText(), b.asLongText());
     }
 
     @Test
@@ -114,7 +109,7 @@ public class DefaultChannelIdTest {
                         0x069e6dce9eb4516fL,
                         0x721757b7);
 
-        assertThat(c8.asLongText(), is("0123456789abcdef-000052af-00000000-06504f638eb4c386-d964df5e"));
-        assertThat(c6.asLongText(), is("0123456789ab-ce005283-00000001-069e6dce9eb4516f-721757b7"));
+        assertEquals("0123456789abcdef-000052af-00000000-06504f638eb4c386-d964df5e", c8.asLongText());
+        assertEquals("0123456789ab-ce005283-00000001-069e6dce9eb4516f-721757b7", c6.asLongText());
     }
 }

--- a/transport/src/test/java/io/netty/channel/PendingWriteQueueTest.java
+++ b/transport/src/test/java/io/netty/channel/PendingWriteQueueTest.java
@@ -28,8 +28,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -123,7 +121,7 @@ public class PendingWriteQueueTest {
                     return;
                 }
 
-                assertThat(msg.refCnt(), is(1));
+                assertEquals(1, msg.refCnt());
 
                 // This call will trigger another channelWritabilityChanged() event because the number of
                 // pending bytes will go below the low watermark.
@@ -133,7 +131,7 @@ public class PendingWriteQueueTest {
                 // element twice, resulting in the double release.
                 queue.remove();
 
-                assertThat(msg.refCnt(), is(0));
+                assertEquals(0, msg.refCnt());
             }
         });
 
@@ -147,7 +145,7 @@ public class PendingWriteQueueTest {
 
         channel.finish();
 
-        assertThat(msg.refCnt(), is(0));
+        assertEquals(0, msg.refCnt());
     }
 
     private static void assertWrite(ChannelHandler handler, int count) {

--- a/transport/src/test/java/io/netty/channel/ReentrantChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/ReentrantChannelTest.java
@@ -21,12 +21,11 @@ import io.netty.channel.LoggingHandler.Event;
 import io.netty.channel.local.LocalAddress;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 import java.nio.channels.ClosedChannelException;
 
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -278,7 +277,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
             fail();
         } catch (Throwable cce) {
             // FIXME:  shouldn't this contain the "intentional failure" exception?
-            assertThat(cce, Matchers.instanceOf(ClosedChannelException.class));
+            assertInstanceOf(ClosedChannelException.class, cce);
         }
 
         clientChannel.closeFuture().sync();

--- a/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
@@ -53,11 +53,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -177,14 +175,12 @@ public class LocalChannelTest {
                 cc.writeAndFlush(new Object()).sync();
                 fail("must raise a ClosedChannelException");
             } catch (Exception e) {
-                assertThat(e, is(instanceOf(ClosedChannelException.class)));
+                assertInstanceOf(ClosedChannelException.class, e);
                 // Ensure that the actual write attempt on a closed channel was never made by asserting that
                 // the ClosedChannelException has been created by AbstractUnsafe rather than transport implementations.
                 if (e.getStackTrace().length > 0) {
-                    assertThat(
-                            e.getStackTrace()[0].getClassName(), is(AbstractChannel.class.getName() +
-                                    "$AbstractUnsafe"));
-                    e.printStackTrace();
+                   assertEquals(AbstractChannel.class.getName() +
+                           "$AbstractUnsafe", e.getStackTrace()[0].getClassName());
                 }
             }
         } finally {

--- a/transport/src/test/java/io/netty/channel/nio/NioEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/nio/NioEventLoopTest.java
@@ -50,10 +50,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -229,7 +228,7 @@ public class NioEventLoopTest extends AbstractEventLoopTest {
             group.shutdownNow();
             t.join();
             group.terminationFuture().syncUninterruptibly();
-            assertThat(error.get(), instanceOf(RejectedExecutionException.class));
+            assertInstanceOf(RejectedExecutionException.class, error.get());
             error.set(null);
         }
     }

--- a/transport/src/test/java/io/netty/channel/oio/OioEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/oio/OioEventLoopTest.java
@@ -32,10 +32,9 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.util.concurrent.CountDownLatch;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 public class OioEventLoopTest {
     @Test
@@ -51,8 +50,8 @@ public class OioEventLoopTest {
         ChannelFuture f2 = b.bind(0);
         f2.await();
 
-        assertThat(f2.cause(), is(instanceOf(ChannelException.class)));
-        assertThat(f2.cause().getMessage().toLowerCase(), containsString("too many channels"));
+        assertInstanceOf(ChannelException.class, f2.cause());
+        assertThat(f2.cause().getMessage().toLowerCase()).contains("too many channels");
 
         final CountDownLatch notified = new CountDownLatch(1);
         f2.addListener(new ChannelFutureListener() {
@@ -83,8 +82,8 @@ public class OioEventLoopTest {
         ChannelFuture f2 = cb.connect(NetUtil.LOCALHOST, ((InetSocketAddress) f1.channel().localAddress()).getPort());
         f2.await();
 
-        assertThat(f2.cause(), is(instanceOf(ChannelException.class)));
-        assertThat(f2.cause().getMessage().toLowerCase(), containsString("too many channels"));
+        assertInstanceOf(ChannelException.class, f2.cause());
+        assertThat(f2.cause().getMessage().toLowerCase()).contains("too many channels");
 
         final CountDownLatch notified = new CountDownLatch(1);
         f2.addListener(new ChannelFutureListener() {
@@ -109,7 +108,7 @@ public class OioEventLoopTest {
         f1.sync();
 
         Socket s = new Socket(NetUtil.LOCALHOST, ((InetSocketAddress) f1.channel().localAddress()).getPort());
-        assertThat(s.getInputStream().read(), is(-1));
+        assertEquals(-1, s.getInputStream().read());
         s.close();
 
         g.shutdownGracefully();

--- a/transport/src/test/java/io/netty/channel/pool/SimpleChannelPoolTest.java
+++ b/transport/src/test/java/io/netty/channel/pool/SimpleChannelPoolTest.java
@@ -26,7 +26,6 @@ import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalChannel;
 import io.netty.channel.local.LocalServerChannel;
 import io.netty.util.concurrent.Future;
-import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
@@ -35,7 +34,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import static io.netty.channel.pool.ChannelPoolTestUtils.getLocalAddrId;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -234,7 +232,7 @@ public class SimpleChannelPoolTest {
         channel1.close().syncUninterruptibly();
         Future<Void> releaseFuture =
                 pool.release(channel1, channel1.eventLoop().<Void>newPromise()).syncUninterruptibly();
-        assertThat(releaseFuture.isSuccess(), CoreMatchers.is(true));
+        assertTrue(releaseFuture.isSuccess());
 
         Channel channel2 = pool.acquire().syncUninterruptibly().getNow();
         //verifying that in fact the channel2 is different that means is not pulled from the pool

--- a/transport/src/test/java/io/netty/channel/socket/InternetProtocolFamilyTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/InternetProtocolFamilyTest.java
@@ -18,19 +18,16 @@ package io.netty.channel.socket;
 import io.netty.util.NetUtil;
 import org.junit.jupiter.api.Test;
 
-import java.net.InetAddress;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class InternetProtocolFamilyTest {
     @Test
     public void ipv4ShouldHaveLocalhostOfIpV4() {
-        assertThat(InternetProtocolFamily.IPv4.localhost(), is((InetAddress) NetUtil.LOCALHOST4));
+        assertEquals(NetUtil.LOCALHOST4, InternetProtocolFamily.IPv4.localhost());
     }
 
     @Test
     public void ipv6ShouldHaveLocalhostOfIpV6() {
-        assertThat(InternetProtocolFamily.IPv6.localhost(), is((InetAddress) NetUtil.LOCALHOST6));
+        assertEquals(NetUtil.LOCALHOST6, InternetProtocolFamily.IPv6.localhost());
     }
 }

--- a/transport/src/test/java/io/netty/channel/socket/nio/NioSocketChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/nio/NioSocketChannelTest.java
@@ -55,10 +55,11 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
-
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChannel> {
@@ -104,17 +105,17 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
             }
             s.close();
 
-            assertThat(futures.size(), is(3));
+            assertEquals(3, futures.size());
             ChannelFuture f1 = futures.poll();
             ChannelFuture f2 = futures.poll();
             ChannelFuture f3 = futures.poll();
-            assertThat(f1.isSuccess(), is(true));
-            assertThat(f2.isDone(), is(true));
-            assertThat(f2.isSuccess(), is(false));
-            assertThat(f2.cause(), is(instanceOf(ClosedChannelException.class)));
-            assertThat(f3.isDone(), is(true));
-            assertThat(f3.isSuccess(), is(false));
-            assertThat(f3.cause(), is(instanceOf(ClosedChannelException.class)));
+            assertTrue(f1.isSuccess());
+            assertTrue(f2.isDone());
+            assertFalse(f2.isSuccess());
+            assertInstanceOf(ClosedChannelException.class, f2.cause());
+            assertTrue(f3.isDone());
+            assertFalse(f3.isSuccess());
+            assertInstanceOf(ClosedChannelException.class, f3.cause());
         } finally {
             group.shutdownGracefully().sync();
         }
@@ -154,7 +155,7 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
             byte[] buf = new byte[3];
             in.readFully(buf);
 
-            assertThat(new String(buf, CharsetUtil.US_ASCII), is("abc"));
+            assertEquals("abc", new String(buf, CharsetUtil.US_ASCII));
 
             s.close();
         } finally {


### PR DESCRIPTION
Motivation:

We already use junit and assert4j for testing. There is really no need to also use hamcrest.

Modifications:

- Rewrite tests to replace hamcrest usage with junit / assert4j
- Remove dependency from pom.xml

Result:

Cleanup and more consistent tests