### PR TITLE
New tests for channel pool: release with health check and processing order during to acquire

### DIFF
--- a/transport/src/test/java/io/netty/channel/pool/FixedChannelPoolTest.java
+++ b/transport/src/test/java/io/netty/channel/pool/FixedChannelPoolTest.java
@@ -35,6 +35,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -314,6 +316,98 @@ public class FixedChannelPoolTest {
         pool.close();
     }
 
+    @Test
+    public void testChannelReleaseHealthCheck() {
+        Tuple t = bootstrap();
+
+        // Start server
+        Channel sc = t.sb.bind(t.address).syncUninterruptibly().channel();
+        ChannelPoolHandler handler = new TestChannelPoolHandler();
+        InnerFixedChannelPool pool = new InnerFixedChannelPool(t.cb, handler, ChannelHealthChecker.ACTIVE,
+                AcquireTimeoutAction.NEW, 500, 1, Integer.MAX_VALUE, true);
+
+        // releaseHealthCheck=true,channel=open,doHealthCheckOnRelease
+        Channel channel = pool.acquire().syncUninterruptibly().getNow();
+        pool.release(channel).syncUninterruptibly().getNow();
+        Channel sameChannel = pool.acquire().syncUninterruptibly().getNow();
+        assert sameChannel == channel;
+
+        // releaseHealthCheck=true,channel=close,doHealthCheckOnRelease
+        sameChannel.close().syncUninterruptibly();
+        pool.release(channel).syncUninterruptibly().getNow();
+        sameChannel = pool.acquire().syncUninterruptibly().getNow();
+        assert sameChannel != channel;
+
+        // close all and create a new poll
+        sameChannel.close().syncUninterruptibly();
+        channel.close().syncUninterruptibly();
+        pool.close();
+        pool = new InnerFixedChannelPool(t.cb, handler, ChannelHealthChecker.ACTIVE,
+                AcquireTimeoutAction.NEW, 500, 1, Integer.MAX_VALUE, false);
+
+        // releaseHealthCheck=false,channel=open,releaseAndOffer
+        channel = pool.acquire().syncUninterruptibly().getNow();
+        pool.release(channel).syncUninterruptibly().getNow();
+        sameChannel = pool.acquire().syncUninterruptibly().getNow();
+        assert sameChannel == channel;
+
+        // releaseHealthCheck=false,channel=close,releaseAndOffer
+        sameChannel.close().syncUninterruptibly();
+        pool.release(channel).syncUninterruptibly().getNow();
+        // the acquire will do a heath check.. this is why we call the special method
+        sameChannel = pool.pollChannel();
+        assert sameChannel == channel;
+
+        sc.close().syncUninterruptibly();
+        sameChannel.close().syncUninterruptibly();
+        channel.close().syncUninterruptibly();
+        pool.close();
+    }
+
+    @Test
+    public void testChannelProcessingOrder() {
+        boolean[] orderingTypes = {true, false};
+        for (boolean orderingType : orderingTypes) {
+            Tuple t = bootstrap();
+
+            // Start server
+            Channel sc = t.sb.bind(t.address).syncUninterruptibly().channel();
+
+            FixedChannelPool pool = new FixedChannelPool(t.cb, new TestChannelPoolHandler(),
+                    ChannelHealthChecker.ACTIVE, AcquireTimeoutAction.NEW, 500, 1,
+                    Integer.MAX_VALUE, false, orderingType);
+
+            // create
+            int totalChannels = 5;
+            List<Channel> channels = new ArrayList<>();
+            for (int i = 0; i < totalChannels; i++) {
+                Channel channel = pool.acquire().syncUninterruptibly().getNow();
+                channels.add(channel);
+            }
+            for (int i = 0; i < totalChannels; i++) {
+                pool.release(channels.get(i)).syncUninterruptibly().getNow();
+            }
+
+            // test logic
+            for (int i = 0; i < totalChannels; i++) {
+                Channel channel = pool.acquire().syncUninterruptibly().getNow();
+                if (orderingType) {
+                    assert channel == channels.get(channels.size() - 1 - i);
+                } else {
+                    assert channel == channels.get(i);
+                }
+            }
+
+            // close all
+            for (int i = 0; i < totalChannels; i++) {
+                channels.get(i).close().syncUninterruptibly();
+                pool.release(channels.get(i)).syncUninterruptibly();
+            }
+            sc.close().syncUninterruptibly();
+            pool.close();
+        }
+    }
+
     private Tuple bootstrap() {
         LocalAddress addr = new LocalAddress(getLocalAddrId());
         Bootstrap cb = new Bootstrap();
@@ -350,6 +444,26 @@ public class FixedChannelPoolTest {
             this.address = address;
             this.cb = cb;
             this.sb = sb;
+        }
+    }
+
+    private static final class InnerFixedChannelPool extends FixedChannelPool {
+
+        InnerFixedChannelPool(Bootstrap bootstrap, ChannelPoolHandler handler, ChannelHealthChecker healthCheck,
+                                     AcquireTimeoutAction action, long acquireTimeoutMillis, int maxConnections,
+                                     int maxPendingAcquires, boolean releaseHealthCheck) {
+            super(bootstrap, handler, healthCheck, action, acquireTimeoutMillis, maxConnections, maxPendingAcquires,
+                    releaseHealthCheck);
+        }
+
+        /**
+         * The acquire always do a health check.
+         * Only for testing purpose.
+         *
+         * @return channel
+         */
+        public Channel pollChannel() {
+            return super.pollChannel();
         }
     }
 }


### PR DESCRIPTION
New tests for channel pool: release with health check and processing order during to acquire

Motivation:

While working on https://github.com/netty/netty/pull/14723 it was requested to create some tests. Because https://github.com/netty/netty/pull/14723 will introduce deprecation in some constructors and change the way to retrieve the channel it is better have the tests before that change is introduced. This ensure that the current behavior ( now tested ) will continue working.

Modification:

Introcue two new tests

Result:

All tests passed
