### PR TITLE
Upgrade Windows GHA images to Windows Server 2022

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -67,7 +67,7 @@ jobs:
         if: ${{ cancelled() }}
 
   build-pr-windows:
-    runs-on: windows-2019
+    runs-on: windows-2022
     name: windows-x86_64-java11-boringssl
     needs: verify-pr
     steps:

--- a/.github/workflows/ci-release-4.2.yml
+++ b/.github/workflows/ci-release-4.2.yml
@@ -273,7 +273,7 @@ jobs:
 
   stage-release-windows:
     needs: prepare-release
-    runs-on: windows-2019
+    runs-on: windows-2022
     name: stage-release-windows-x86_64
     env:
       # Let's limit the amount of ram that is used to unpack rustup as we saw


### PR DESCRIPTION
Motivation:
We are currently using the Windows 2019 images, which will reach end-of-life on June 30, 2025.

Modification:
Change the windows images in our GHA workflows from `windows-2019` to `windows-2022`.

Result:
More up to date windows build agents.