### PR TITLE
`StreamBufferingEncoder` doesn't work when settings auto-ack is disabled

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/StreamBufferingEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/StreamBufferingEncoder.java
@@ -230,14 +230,26 @@ public class StreamBufferingEncoder extends DecoratingHttp2ConnectionEncoder {
     }
 
     @Override
+    public ChannelFuture writeSettingsAck(ChannelHandlerContext ctx, ChannelPromise promise) {
+        final ChannelFuture future = super.writeSettingsAck(ctx, promise);
+        // In case autoAckSettings was set to false, decorated DefaultHttp2ConnectionEncoder will dequeue pending
+        // settings and call remoteSettings on its own instance. Therefore, we need to consume potentially updated value
+        // after this method returns.
+        updateMaxConcurrentStreams();
+        return future;
+    }
+
+    @Override
     public void remoteSettings(Http2Settings settings) throws Http2Exception {
         // Need to let the delegate decoder handle the settings first, so that it sees the
         // new setting before we attempt to create any new streams.
         super.remoteSettings(settings);
+        updateMaxConcurrentStreams();
+    }
 
+    private void updateMaxConcurrentStreams() {
         // Get the updated value for SETTINGS_MAX_CONCURRENT_STREAMS.
         maxConcurrentStreams = connection().local().maxActiveStreams();
-
         // Try to create new streams up to the new threshold.
         tryCreatePendingStreams();
     }


### PR DESCRIPTION
Motivation:

When users do
```
Http2FrameCodecBuilder.forClient()
    .autoAckSettingsFrame(false)
    .encoderEnforceMaxConcurrentStreams(true)
```
`StreamBufferingEncoder` will be out of sync with wrapped `DefaultHttp2ConnectionEncoder` on `maxConcurrentStreams` value because `StreamBufferingEncoder` updates its internal state only when auto-ack settings is enabled (via `remoteSettings`). When it's disabled, `DefaultHttp2ConnectionEncoder` will call `remoteSettings` internally on
 `writeSettingsAck` and none of `DecoratingHttp2ConnectionEncoder`
 wrappers will see that.

Modifications:

- Implement `StreamBufferingEncoder.writeSettingsAck` and update `maxConcurrentStreams` value after the super class returns control flow.
- Parametrize some of `StreamBufferingEncoderTest` tests to verify both flows: with and without auto-ack settings.

Result:

`StreamBufferingEncoder` keeps its internal `maxConcurrentStreams` state in sync with underlying `DefaultHttp2ConnectionEncoder` regardless of `autoAckSettings` configuration.