### PR TITLE
Avoid generic class resolving when possible

### DIFF
--- a/codec-base/src/main/java/io/netty/handler/codec/ByteToMessageCodec.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/ByteToMessageCodec.java
@@ -86,7 +86,7 @@ public abstract class ByteToMessageCodec<I> extends ChannelDuplexHandler {
     protected ByteToMessageCodec(Class<? extends I> outboundMessageType, boolean preferDirect) {
         ensureNotSharable();
         outboundMsgMatcher = TypeParameterMatcher.get(outboundMessageType);
-        encoder = new Encoder(preferDirect);
+        encoder = new Encoder(preferDirect, outboundMessageType);
     }
 
     /**
@@ -160,6 +160,10 @@ public abstract class ByteToMessageCodec<I> extends ChannelDuplexHandler {
     private final class Encoder extends MessageToByteEncoder<I> {
         Encoder(boolean preferDirect) {
             super(preferDirect);
+        }
+
+        Encoder(boolean preferDirect, Class<? extends I> outboundMessageType) {
+            super(outboundMessageType, preferDirect);
         }
 
         @Override

--- a/codec-base/src/main/java/io/netty/handler/codec/DatagramPacketDecoder.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/DatagramPacketDecoder.java
@@ -42,6 +42,7 @@ public class DatagramPacketDecoder extends MessageToMessageDecoder<DatagramPacke
      * @param decoder the specified {@link ByteBuf} decoder
      */
     public DatagramPacketDecoder(MessageToMessageDecoder<ByteBuf> decoder) {
+        super(DatagramPacket.class);
         this.decoder = checkNotNull(decoder, "decoder");
     }
 

--- a/codec-base/src/main/java/io/netty/handler/codec/LengthFieldPrepender.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/LengthFieldPrepender.java
@@ -143,6 +143,7 @@ public class LengthFieldPrepender extends MessageToMessageEncoder<ByteBuf> {
     public LengthFieldPrepender(
             ByteOrder byteOrder, int lengthFieldLength,
             int lengthAdjustment, boolean lengthIncludesLengthFieldLength) {
+        super(ByteBuf.class);
         if (lengthFieldLength != 1 && lengthFieldLength != 2 &&
             lengthFieldLength != 3 && lengthFieldLength != 4 &&
             lengthFieldLength != 8) {

--- a/codec-base/src/main/java/io/netty/handler/codec/MessageToMessageCodec.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/MessageToMessageCodec.java
@@ -54,7 +54,7 @@ import java.util.List;
  */
 public abstract class MessageToMessageCodec<INBOUND_IN, OUTBOUND_IN> extends ChannelDuplexHandler {
 
-    private final MessageToMessageDecoder<Object> decoder = new MessageToMessageDecoder<Object>() {
+    private final MessageToMessageDecoder<Object> decoder = new MessageToMessageDecoder<Object>(Object.class) {
 
         @Override
         public boolean acceptInboundMessage(Object msg) throws Exception {
@@ -72,7 +72,7 @@ public abstract class MessageToMessageCodec<INBOUND_IN, OUTBOUND_IN> extends Cha
             return MessageToMessageCodec.this.isSharable();
         }
     };
-    private final MessageToMessageEncoder<Object> encoder = new MessageToMessageEncoder<Object>() {
+    private final MessageToMessageEncoder<Object> encoder = new MessageToMessageEncoder<Object>(Object.class) {
 
         @Override
         public boolean acceptOutboundMessage(Object msg) throws Exception {

--- a/codec-base/src/main/java/io/netty/handler/codec/base64/Base64Decoder.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/base64/Base64Decoder.java
@@ -54,6 +54,7 @@ public class Base64Decoder extends MessageToMessageDecoder<ByteBuf> {
     }
 
     public Base64Decoder(Base64Dialect dialect) {
+        super(ByteBuf.class);
         this.dialect = ObjectUtil.checkNotNull(dialect, "dialect");
     }
 

--- a/codec-base/src/main/java/io/netty/handler/codec/base64/Base64Encoder.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/base64/Base64Encoder.java
@@ -55,6 +55,7 @@ public class Base64Encoder extends MessageToMessageEncoder<ByteBuf> {
     }
 
     public Base64Encoder(boolean breakLines, Base64Dialect dialect) {
+        super(ByteBuf.class);
         this.dialect = ObjectUtil.checkNotNull(dialect, "dialect");
         this.breakLines = breakLines;
     }

--- a/codec-base/src/main/java/io/netty/handler/codec/bytes/ByteArrayDecoder.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/bytes/ByteArrayDecoder.java
@@ -50,6 +50,10 @@ import java.util.List;
  * </pre>
  */
 public class ByteArrayDecoder extends MessageToMessageDecoder<ByteBuf> {
+    public ByteArrayDecoder() {
+        super(ByteBuf.class);
+    }
+
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf msg, List<Object> out) throws Exception {
          // copy the ByteBuf content to a byte array

--- a/codec-base/src/main/java/io/netty/handler/codec/bytes/ByteArrayEncoder.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/bytes/ByteArrayEncoder.java
@@ -52,6 +52,10 @@ import java.util.List;
  */
 @Sharable
 public class ByteArrayEncoder extends MessageToMessageEncoder<byte[]> {
+    public ByteArrayEncoder() {
+        super(byte[].class);
+    }
+
     @Override
     protected void encode(ChannelHandlerContext ctx, byte[] msg, List<Object> out) throws Exception {
         out.add(Unpooled.wrappedBuffer(msg));

--- a/codec-base/src/main/java/io/netty/handler/codec/serialization/CompatibleObjectEncoder.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/serialization/CompatibleObjectEncoder.java
@@ -66,6 +66,7 @@ public class CompatibleObjectEncoder extends MessageToByteEncoder<Serializable> 
      *        the long term.
      */
     public CompatibleObjectEncoder(int resetInterval) {
+        super(Serializable.class);
         this.resetInterval = checkPositiveOrZero(resetInterval, "resetInterval");
     }
 

--- a/codec-base/src/main/java/io/netty/handler/codec/serialization/ObjectEncoder.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/serialization/ObjectEncoder.java
@@ -48,6 +48,10 @@ import java.io.Serializable;
 public class ObjectEncoder extends MessageToByteEncoder<Serializable> {
     private static final byte[] LENGTH_PLACEHOLDER = new byte[4];
 
+    public ObjectEncoder() {
+        super(Serializable.class);
+    }
+
     @Override
     protected void encode(ChannelHandlerContext ctx, Serializable msg, ByteBuf out) throws Exception {
         int startIdx = out.writerIndex();

--- a/codec-base/src/main/java/io/netty/handler/codec/string/LineEncoder.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/string/LineEncoder.java
@@ -81,6 +81,7 @@ public class LineEncoder extends MessageToMessageEncoder<CharSequence> {
      * Creates a new instance with the specified line separator and character set.
      */
     public LineEncoder(LineSeparator lineSeparator, Charset charset) {
+        super(CharSequence.class);
         this.charset = ObjectUtil.checkNotNull(charset, "charset");
         this.lineSeparator = ObjectUtil.checkNotNull(lineSeparator, "lineSeparator").value().getBytes(charset);
     }

--- a/codec-base/src/main/java/io/netty/handler/codec/string/StringDecoder.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/string/StringDecoder.java
@@ -69,6 +69,7 @@ public class StringDecoder extends MessageToMessageDecoder<ByteBuf> {
      * Creates a new instance with the specified character set.
      */
     public StringDecoder(Charset charset) {
+        super(ByteBuf.class);
         this.charset = ObjectUtil.checkNotNull(charset, "charset");
     }
 

--- a/codec-base/src/main/java/io/netty/handler/codec/string/StringEncoder.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/string/StringEncoder.java
@@ -65,6 +65,7 @@ public class StringEncoder extends MessageToMessageEncoder<CharSequence> {
      * Creates a new instance with the specified character set.
      */
     public StringEncoder(Charset charset) {
+        super(CharSequence.class);
         this.charset = ObjectUtil.checkNotNull(charset, "charset");
     }
 

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/BrotliEncoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/BrotliEncoder.java
@@ -93,6 +93,7 @@ public final class BrotliEncoder extends MessageToByteEncoder<ByteBuf> {
      * @param isSharable Set to {@code true} if this instance is shared else set to {@code false}
      */
     public BrotliEncoder(Encoder.Parameters parameters, boolean isSharable) {
+        super(ByteBuf.class);
         this.parameters = ObjectUtil.checkNotNull(parameters, "Parameters");
         this.isSharable = isSharable;
     }

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/Bzip2Encoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/Bzip2Encoder.java
@@ -94,6 +94,7 @@ public class Bzip2Encoder extends MessageToByteEncoder<ByteBuf> {
      *        but give better compression ratios. {@code 9} will usually be the best value to use.
      */
     public Bzip2Encoder(final int blockSizeMultiplier) {
+        super(ByteBuf.class);
         if (blockSizeMultiplier < MIN_BLOCK_SIZE || blockSizeMultiplier > MAX_BLOCK_SIZE) {
             throw new IllegalArgumentException(
                     "blockSizeMultiplier: " + blockSizeMultiplier + " (expected: 1-9)");

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/FastLzFrameEncoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/FastLzFrameEncoder.java
@@ -98,6 +98,7 @@ public class FastLzFrameEncoder extends MessageToByteEncoder<ByteBuf> {
      *        You may set {@code null} if you don't want to validate checksum of each block.
      */
     public FastLzFrameEncoder(int level, Checksum checksum) {
+        super(ByteBuf.class);
         if (level != LEVEL_AUTO && level != LEVEL_1 && level != LEVEL_2) {
             throw new IllegalArgumentException(String.format(
                     "level: %d (expected: %d or %d or %d)", level, LEVEL_AUTO, LEVEL_1, LEVEL_2));

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/Lz4FrameEncoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/Lz4FrameEncoder.java
@@ -156,6 +156,7 @@ public class Lz4FrameEncoder extends MessageToByteEncoder<ByteBuf> {
          */
     public Lz4FrameEncoder(LZ4Factory factory, boolean highCompressor, int blockSize,
                            Checksum checksum, int maxEncodeSize) {
+        super(ByteBuf.class);
         ObjectUtil.checkNotNull(factory, "factory");
         ObjectUtil.checkNotNull(checksum, "checksum");
 

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/LzfEncoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/LzfEncoder.java
@@ -145,7 +145,7 @@ public class LzfEncoder extends MessageToByteEncoder<ByteBuf> {
      */
     @Deprecated
     public LzfEncoder(boolean safeInstance, int totalLength, int compressThreshold) {
-        super(false);
+        super(ByteBuf.class, false);
         if (totalLength < MIN_BLOCK_TO_COMPRESS || totalLength > MAX_CHUNK_LEN) {
             throw new IllegalArgumentException("totalLength: " + totalLength +
                     " (expected: " + MIN_BLOCK_TO_COMPRESS + '-' + MAX_CHUNK_LEN + ')');

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/LzmaFrameEncoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/LzmaFrameEncoder.java
@@ -135,6 +135,7 @@ public class LzmaFrameEncoder extends MessageToByteEncoder<ByteBuf> {
      *        available values [{@value #MIN_FAST_BYTES}, {@value #MAX_FAST_BYTES}].
      */
     public LzmaFrameEncoder(int lc, int lp, int pb, int dictionarySize, boolean endMarkerMode, int numFastBytes) {
+        super(ByteBuf.class);
         if (lc < 0 || lc > 8) {
             throw new IllegalArgumentException("lc: " + lc + " (expected: 0-8)");
         }

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/SnappyFrameEncoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/SnappyFrameEncoder.java
@@ -67,6 +67,7 @@ public class SnappyFrameEncoder extends MessageToByteEncoder<ByteBuf> {
     }
 
     private SnappyFrameEncoder(int sliceSize) {
+        super(ByteBuf.class);
         this.sliceSize = sliceSize;
     }
 

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/ZlibEncoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/ZlibEncoder.java
@@ -26,7 +26,7 @@ import io.netty.handler.codec.MessageToByteEncoder;
 public abstract class ZlibEncoder extends MessageToByteEncoder<ByteBuf> {
 
     protected ZlibEncoder() {
-        super(false);
+        super(ByteBuf.class, false);
     }
 
     /**

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/ZstdEncoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/ZstdEncoder.java
@@ -88,7 +88,7 @@ public final class ZstdEncoder extends MessageToByteEncoder<ByteBuf> {
      *           specifies the level of the compression
      */
     public ZstdEncoder(int compressionLevel, int blockSize, int maxEncodeSize) {
-        super(true);
+        super(ByteBuf.class, true);
         this.compressionLevel = ObjectUtil.checkInRange(compressionLevel,
                 MIN_COMPRESSION_LEVEL, MAX_COMPRESSION_LEVEL, "compressionLevel");
         this.blockSize = ObjectUtil.checkPositive(blockSize, "blockSize");

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsQueryDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsQueryDecoder.java
@@ -43,6 +43,7 @@ public class DatagramDnsQueryDecoder extends MessageToMessageDecoder<DatagramPac
      * Creates a new decoder with the specified {@code recordDecoder}.
      */
     public DatagramDnsQueryDecoder(DnsRecordDecoder recordDecoder) {
+        super(DatagramPacket.class);
         this.recordDecoder = checkNotNull(recordDecoder, "recordDecoder");
     }
 

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsResponseDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsResponseDecoder.java
@@ -43,6 +43,7 @@ public class DatagramDnsResponseDecoder extends MessageToMessageDecoder<Datagram
      * Creates a new decoder with the specified {@code recordDecoder}.
      */
     public DatagramDnsResponseDecoder(DnsRecordDecoder recordDecoder) {
+        super(DatagramPacket.class);
         this.responseDecoder = new DnsResponseDecoder<InetSocketAddress>(recordDecoder) {
             @Override
             protected DnsResponse newResponse(InetSocketAddress sender, InetSocketAddress recipient,

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsQueryEncoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsQueryEncoder.java
@@ -36,6 +36,7 @@ public final class TcpDnsQueryEncoder extends MessageToByteEncoder<DnsQuery> {
      * Creates a new encoder with the specified {@code recordEncoder}.
      */
     public TcpDnsQueryEncoder(DnsRecordEncoder recordEncoder) {
+        super(DnsQuery.class);
         this.encoder = new DnsQueryEncoder(recordEncoder);
     }
 

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsResponseEncoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/TcpDnsResponseEncoder.java
@@ -38,6 +38,7 @@ public final class TcpDnsResponseEncoder extends MessageToMessageEncoder<DnsResp
      * Creates a new encoder with the specified {@code encoder}.
      */
     public TcpDnsResponseEncoder(DnsRecordEncoder encoder) {
+        super(DnsResponse.class);
         this.encoder = ObjectUtil.checkNotNull(encoder, "encoder");
     }
 

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessageEncoder.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessageEncoder.java
@@ -43,6 +43,7 @@ public final class HAProxyMessageEncoder extends MessageToByteEncoder<HAProxyMes
     public static final HAProxyMessageEncoder INSTANCE = new HAProxyMessageEncoder();
 
     private HAProxyMessageEncoder() {
+        super(HAProxyMessage.class);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentDecoder.java
@@ -53,6 +53,10 @@ public abstract class HttpContentDecoder extends MessageToMessageDecoder<HttpObj
     private boolean continueResponse;
     private boolean needRead = true;
 
+    public HttpContentDecoder() {
+        super(HttpObject.class);
+    }
+
     @Override
     protected void decode(ChannelHandlerContext ctx, HttpObject msg, List<Object> out) throws Exception {
         try {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentEncoder.java
@@ -69,6 +69,10 @@ public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpReque
     private EmbeddedChannel encoder;
     private State state = State.AWAIT_HEADERS;
 
+    public HttpContentEncoder() {
+        super(HttpRequest.class, HttpObject.class);
+    }
+
     @Override
     public boolean acceptOutboundMessage(Object msg) throws Exception {
         return msg instanceof HttpContent || msg instanceof HttpResponse;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
@@ -125,7 +125,7 @@ public class HttpObjectAggregator
      * consumed and discarded until the next request is received.
      */
     public HttpObjectAggregator(int maxContentLength, boolean closeOnExpectationFailed) {
-        super(maxContentLength);
+        super(maxContentLength, HttpObject.class);
         this.closeOnExpectationFailed = closeOnExpectationFailed;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectEncoder.java
@@ -93,6 +93,10 @@ public abstract class HttpObjectEncoder<H extends HttpMessage> extends MessageTo
         return state == ST_CONTENT_CHUNK || state == ST_CONTENT_NON_CHUNK || state == ST_CONTENT_ALWAYS_EMPTY;
     }
 
+    public HttpObjectEncoder() {
+        super(Object.class);
+    }
+
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
         try {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket00FrameEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket00FrameEncoder.java
@@ -38,6 +38,10 @@ public class WebSocket00FrameEncoder extends MessageToMessageEncoder<WebSocketFr
     private static final ByteBuf _0XFF_0X00 = Unpooled.unreleasableBuffer(
             Unpooled.directBuffer(2, 2).writeByte((byte) 0xFF).writeByte(0x00)).asReadOnly();
 
+    public WebSocket00FrameEncoder() {
+        super(WebSocketFrame.class);
+    }
+
     @Override
     protected void encode(ChannelHandlerContext ctx, WebSocketFrame msg, List<Object> out) throws Exception {
         if (msg instanceof TextWebSocketFrame) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameEncoder.java
@@ -109,6 +109,7 @@ public class WebSocket08FrameEncoder extends MessageToMessageEncoder<WebSocketFr
      *            Server implementations must set this to {@code null}.
      */
     public WebSocket08FrameEncoder(WebSocketFrameMaskGenerator maskGenerator) {
+        super(WebSocketFrame.class);
         this.maskGenerator = maskGenerator;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketFrameAggregator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketFrameAggregator.java
@@ -36,7 +36,7 @@ public class WebSocketFrameAggregator
      *                         a {@link TooLongFrameException} is thrown.
      */
     public WebSocketFrameAggregator(int maxContentLength) {
-        super(maxContentLength);
+        super(maxContentLength, WebSocketFrame.class);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketProtocolHandler.java
@@ -60,6 +60,7 @@ abstract class WebSocketProtocolHandler extends MessageToMessageDecoder<WebSocke
     WebSocketProtocolHandler(boolean dropPongFrames,
                              WebSocketCloseStatus closeStatus,
                              long forceCloseTimeoutMillis) {
+        super(WebSocketFrame.class);
         this.dropPongFrames = dropPongFrames;
         this.closeStatus = closeStatus;
         this.forceCloseTimeoutMillis = forceCloseTimeoutMillis;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketExtensionDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketExtensionDecoder.java
@@ -23,4 +23,8 @@ import io.netty.handler.codec.http.websocketx.WebSocketFrame;
  */
 public abstract class WebSocketExtensionDecoder extends MessageToMessageDecoder<WebSocketFrame> {
 
+    public WebSocketExtensionDecoder() {
+        super(WebSocketFrame.class);
+    }
+
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketExtensionEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketExtensionEncoder.java
@@ -22,5 +22,7 @@ import io.netty.handler.codec.http.websocketx.WebSocketFrame;
  * Convenient class for <tt>io.netty.handler.codec.http.websocketx.extensions.WebSocketExtension</tt> encoder.
  */
 public abstract class WebSocketExtensionEncoder extends MessageToMessageEncoder<WebSocketFrame> {
-
+    public WebSocketExtensionEncoder() {
+        super(WebSocketFrame.class);
+    }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpDecoder.java
@@ -131,6 +131,7 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
      */
     protected SpdyHttpDecoder(SpdyVersion version, int maxContentLength, Map<Integer,
             FullHttpMessage> messageMap, HttpHeadersFactory headersFactory, HttpHeadersFactory trailersFactory) {
+        super(SpdyFrame.class);
         spdyVersion = ObjectUtil.checkNotNull(version, "version").version();
         this.maxContentLength = checkPositive(maxContentLength, "maxContentLength");
         this.messageMap = messageMap;

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpEncoder.java
@@ -145,6 +145,7 @@ public class SpdyHttpEncoder extends MessageToMessageEncoder<HttpObject> {
      * @param validateHeaders    validate the header names and values when adding them to the {@link SpdyHeaders}
      */
     public SpdyHttpEncoder(SpdyVersion version, boolean headersToLowerCase, boolean validateHeaders) {
+        super(HttpObject.class);
         ObjectUtil.checkNotNull(version, "version");
         this.headersToLowerCase = headersToLowerCase;
         this.validateHeaders = validateHeaders;

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpResponseStreamIdHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpResponseStreamIdHandler.java
@@ -35,6 +35,10 @@ public class SpdyHttpResponseStreamIdHandler extends
     private static final Integer NO_ID = -1;
     private final Queue<Integer> ids = new ArrayDeque<Integer>();
 
+    public SpdyHttpResponseStreamIdHandler() {
+        super(Object.class, HttpMessage.class);
+    }
+
     @Override
     public boolean acceptInboundMessage(Object msg) throws Exception {
         return msg instanceof HttpMessage || msg instanceof SpdyRstStreamFrame;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodec.java
@@ -67,6 +67,7 @@ public class Http2StreamFrameToHttpObjectCodec extends MessageToMessageCodec<Htt
 
     public Http2StreamFrameToHttpObjectCodec(final boolean isServer,
                                              final boolean validateHeaders) {
+        super(Http2StreamFrame.class, HttpObject.class);
         this.isServer = isServer;
         this.validateHeaders = validateHeaders;
     }

--- a/codec-marshalling/src/main/java/io/netty/handler/codec/marshalling/CompatibleMarshallingEncoder.java
+++ b/codec-marshalling/src/main/java/io/netty/handler/codec/marshalling/CompatibleMarshallingEncoder.java
@@ -44,6 +44,7 @@ public class CompatibleMarshallingEncoder extends MessageToByteEncoder<Object> {
      * @param provider  the {@link MarshallerProvider} to use to get the {@link Marshaller} for a {@link Channel}
      */
     public CompatibleMarshallingEncoder(MarshallerProvider provider) {
+        super(Object.class);
         this.provider = provider;
     }
 

--- a/codec-marshalling/src/main/java/io/netty/handler/codec/marshalling/MarshallingEncoder.java
+++ b/codec-marshalling/src/main/java/io/netty/handler/codec/marshalling/MarshallingEncoder.java
@@ -46,6 +46,7 @@ public class MarshallingEncoder extends MessageToByteEncoder<Object> {
      * @param provider the {@link MarshallerProvider} to use
      */
     public MarshallingEncoder(MarshallerProvider provider) {
+        super(Object.class);
         this.provider = provider;
     }
 

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/AbstractMemcacheObjectAggregator.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/AbstractMemcacheObjectAggregator.java
@@ -47,7 +47,7 @@ public abstract class AbstractMemcacheObjectAggregator<H extends MemcacheMessage
         MessageAggregator<MemcacheObject, H, MemcacheContent, FullMemcacheMessage> {
 
     protected AbstractMemcacheObjectAggregator(int maxContentLength) {
-        super(maxContentLength);
+        super(maxContentLength, MemcacheObject.class);
     }
 
     @Override

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/AbstractMemcacheObjectEncoder.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/AbstractMemcacheObjectEncoder.java
@@ -37,6 +37,10 @@ public abstract class AbstractMemcacheObjectEncoder<M extends MemcacheMessage> e
 
     private boolean expectingMoreContent;
 
+    public AbstractMemcacheObjectEncoder() {
+        super(Object.class);
+    }
+
     @Override
     protected void encode(ChannelHandlerContext ctx, Object msg, List<Object> out) throws Exception {
         if (msg instanceof MemcacheMessage) {

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttEncoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttEncoder.java
@@ -71,7 +71,9 @@ public final class MqttEncoder extends MessageToMessageEncoder<MqttMessage> {
 
     public static final MqttEncoder INSTANCE = new MqttEncoder();
 
-    private MqttEncoder() { }
+    private MqttEncoder() {
+        super(MqttMessage.class);
+    }
 
     @Override
     protected void encode(ChannelHandlerContext ctx, MqttMessage msg, List<Object> out) throws Exception {

--- a/codec-protobuf/src/main/java/io/netty/handler/codec/protobuf/ProtobufDecoder.java
+++ b/codec-protobuf/src/main/java/io/netty/handler/codec/protobuf/ProtobufDecoder.java
@@ -96,6 +96,7 @@ public class ProtobufDecoder extends MessageToMessageDecoder<ByteBuf> {
     }
 
     public ProtobufDecoder(MessageLite prototype, ExtensionRegistryLite extensionRegistry) {
+        super(ByteBuf.class);
         this.prototype = ObjectUtil.checkNotNull(prototype, "prototype").getDefaultInstanceForType();
         this.extensionRegistry = extensionRegistry;
     }

--- a/codec-protobuf/src/main/java/io/netty/handler/codec/protobuf/ProtobufDecoderNano.java
+++ b/codec-protobuf/src/main/java/io/netty/handler/codec/protobuf/ProtobufDecoderNano.java
@@ -66,6 +66,7 @@ public class ProtobufDecoderNano extends MessageToMessageDecoder<ByteBuf> {
      * Creates a new instance.
      */
     public ProtobufDecoderNano(Class<? extends MessageNano> clazz) {
+        super(ByteBuf.class);
         this.clazz = ObjectUtil.checkNotNull(clazz, "You must provide a Class");
     }
 

--- a/codec-protobuf/src/main/java/io/netty/handler/codec/protobuf/ProtobufEncoder.java
+++ b/codec-protobuf/src/main/java/io/netty/handler/codec/protobuf/ProtobufEncoder.java
@@ -60,6 +60,10 @@ import static io.netty.buffer.Unpooled.*;
  */
 @Sharable
 public class ProtobufEncoder extends MessageToMessageEncoder<MessageLiteOrBuilder> {
+    public ProtobufEncoder() {
+        super(MessageLiteOrBuilder.class);
+    }
+
     @Override
     protected void encode(ChannelHandlerContext ctx, MessageLiteOrBuilder msg, List<Object> out)
             throws Exception {

--- a/codec-protobuf/src/main/java/io/netty/handler/codec/protobuf/ProtobufEncoderNano.java
+++ b/codec-protobuf/src/main/java/io/netty/handler/codec/protobuf/ProtobufEncoderNano.java
@@ -58,6 +58,10 @@ import io.netty.handler.codec.MessageToMessageEncoder;
  */
 @ChannelHandler.Sharable
 public class ProtobufEncoderNano extends MessageToMessageEncoder<MessageNano> {
+    public ProtobufEncoderNano() {
+        super(MessageNano.class);
+    }
+
     @Override
     protected void encode(
             ChannelHandlerContext ctx, MessageNano msg, List<Object> out) throws Exception {

--- a/codec-protobuf/src/main/java/io/netty/handler/codec/protobuf/ProtobufVarint32LengthFieldPrepender.java
+++ b/codec-protobuf/src/main/java/io/netty/handler/codec/protobuf/ProtobufVarint32LengthFieldPrepender.java
@@ -40,6 +40,10 @@ import io.netty.handler.codec.MessageToByteEncoder;
 @Sharable
 public class ProtobufVarint32LengthFieldPrepender extends MessageToByteEncoder<ByteBuf> {
 
+    public ProtobufVarint32LengthFieldPrepender() {
+        super(ByteBuf.class);
+    }
+
     @Override
     protected void encode(
             ChannelHandlerContext ctx, ByteBuf msg, ByteBuf out) throws Exception {

--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisArrayAggregator.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisArrayAggregator.java
@@ -35,6 +35,10 @@ public final class RedisArrayAggregator extends MessageToMessageDecoder<RedisMes
 
     private final Deque<AggregateState> depths = new ArrayDeque<AggregateState>(4);
 
+    public RedisArrayAggregator() {
+        super(RedisMessage.class);
+    }
+
     @Override
     protected void decode(ChannelHandlerContext ctx, RedisMessage msg, List<Object> out) throws Exception {
         if (msg instanceof ArrayHeaderRedisMessage) {

--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisBulkStringAggregator.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisBulkStringAggregator.java
@@ -47,7 +47,7 @@ public final class RedisBulkStringAggregator extends MessageAggregator<RedisMess
      * Creates a new instance.
      */
     public RedisBulkStringAggregator() {
-        super(RedisConstants.REDIS_MESSAGE_MAX_LENGTH);
+        super(RedisConstants.REDIS_MESSAGE_MAX_LENGTH, RedisMessage.class);
     }
 
     @Override

--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisEncoder.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisEncoder.java
@@ -47,6 +47,7 @@ public class RedisEncoder extends MessageToMessageEncoder<RedisMessage> {
      * @param messagePool the predefined message pool.
      */
     public RedisEncoder(RedisMessagePool messagePool) {
+        super(RedisMessage.class);
         this.messagePool = ObjectUtil.checkNotNull(messagePool, "messagePool");
     }
 

--- a/codec-smtp/src/main/java/io/netty/handler/codec/smtp/SmtpRequestEncoder.java
+++ b/codec-smtp/src/main/java/io/netty/handler/codec/smtp/SmtpRequestEncoder.java
@@ -38,6 +38,10 @@ public final class SmtpRequestEncoder extends MessageToMessageEncoder<Object> {
 
     private boolean contentExpected;
 
+    public SmtpRequestEncoder() {
+        super(Object.class);
+    }
+
     @Override
     public boolean acceptOutboundMessage(Object msg) throws Exception {
         return msg instanceof SmtpRequest || msg instanceof SmtpContent;

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksMessageEncoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksMessageEncoder.java
@@ -28,6 +28,10 @@ import io.netty.handler.codec.MessageToByteEncoder;
  */
 @ChannelHandler.Sharable
 public class SocksMessageEncoder extends MessageToByteEncoder<SocksMessage> {
+    public SocksMessageEncoder() {
+        super(SocksMessage.class);
+    }
+
     @Override
     @SuppressWarnings("deprecation")
     protected void encode(ChannelHandlerContext ctx, SocksMessage msg, ByteBuf out) throws Exception {

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/Socks4ClientEncoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/Socks4ClientEncoder.java
@@ -36,7 +36,9 @@ public final class Socks4ClientEncoder extends MessageToByteEncoder<Socks4Comman
 
     private static final byte[] IPv4_DOMAIN_MARKER = {0x00, 0x00, 0x00, 0x01};
 
-    private Socks4ClientEncoder() { }
+    private Socks4ClientEncoder() {
+        super(Socks4CommandRequest.class);
+    }
 
     @Override
     protected void encode(ChannelHandlerContext ctx, Socks4CommandRequest msg, ByteBuf out) throws Exception {

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/Socks4ServerEncoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/Socks4ServerEncoder.java
@@ -33,7 +33,9 @@ public final class Socks4ServerEncoder extends MessageToByteEncoder<Socks4Comman
 
     private static final byte[] IPv4_HOSTNAME_ZEROED = { 0x00, 0x00, 0x00, 0x00 };
 
-    private Socks4ServerEncoder() { }
+    private Socks4ServerEncoder() {
+        super(Socks4CommandResponse.class);
+    }
 
     @Override
     protected void encode(ChannelHandlerContext ctx, Socks4CommandResponse msg, ByteBuf out) throws Exception {

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5ClientEncoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5ClientEncoder.java
@@ -49,6 +49,7 @@ public class Socks5ClientEncoder extends MessageToByteEncoder<Socks5Message> {
      * Creates a new instance with the specified {@link Socks5AddressEncoder}.
      */
     public Socks5ClientEncoder(Socks5AddressEncoder addressEncoder) {
+        super(Socks5Message.class);
         this.addressEncoder = ObjectUtil.checkNotNull(addressEncoder, "addressEncoder");
     }
 

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5ServerEncoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5ServerEncoder.java
@@ -46,6 +46,7 @@ public class Socks5ServerEncoder extends MessageToByteEncoder<Socks5Message> {
      * Creates a new instance with the specified {@link Socks5AddressEncoder}.
      */
     public Socks5ServerEncoder(Socks5AddressEncoder addressEncoder) {
+        super(Socks5Message.class);
         this.addressEncoder = ObjectUtil.checkNotNull(addressEncoder, "addressEncoder");
     }
 

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeAggregator.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeAggregator.java
@@ -39,7 +39,7 @@ public class StompSubframeAggregator
      *        a {@link TooLongFrameException} will be raised.
      */
     public StompSubframeAggregator(int maxContentLength) {
-        super(maxContentLength);
+        super(maxContentLength, StompSubframe.class);
     }
 
     @Override

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeEncoder.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeEncoder.java
@@ -91,6 +91,10 @@ public class StompSubframeEncoder extends MessageToMessageEncoder<StompSubframe>
                 }
             };
 
+    public StompSubframeEncoder() {
+        super(StompSubframe.class);
+    }
+
     @Override
     protected void encode(ChannelHandlerContext ctx, StompSubframe msg, List<Object> out) throws Exception {
         if (msg instanceof StompFrame) {

--- a/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspHttpHandler.java
+++ b/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspHttpHandler.java
@@ -43,6 +43,7 @@ final class OcspHttpHandler extends SimpleChannelInboundHandler<FullHttpResponse
      * @param responsePromise {@link Promise} of {@link OCSPResp}
      */
     OcspHttpHandler(Promise<OCSPResp> responsePromise) {
+        super(FullHttpResponse.class);
         this.responseFuture = checkNotNull(responsePromise, "ResponsePromise");
     }
 

--- a/resolver/src/main/java/io/netty/resolver/NoopAddressResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/NoopAddressResolver.java
@@ -30,7 +30,7 @@ import java.util.List;
 public class NoopAddressResolver extends AbstractAddressResolver<SocketAddress> {
 
     public NoopAddressResolver(EventExecutor executor) {
-        super(executor);
+        super(executor, SocketAddress.class);
     }
 
     @Override

--- a/transport-sctp/src/main/java/io/netty/handler/codec/sctp/SctpInboundByteStreamHandler.java
+++ b/transport-sctp/src/main/java/io/netty/handler/codec/sctp/SctpInboundByteStreamHandler.java
@@ -37,6 +37,7 @@ public class SctpInboundByteStreamHandler extends MessageToMessageDecoder<SctpMe
      * @param protocolIdentifier supported application protocol.
      */
     public SctpInboundByteStreamHandler(int protocolIdentifier, int streamIdentifier) {
+        super(SctpMessage.class);
         this.protocolIdentifier = protocolIdentifier;
         this.streamIdentifier = streamIdentifier;
     }

--- a/transport-sctp/src/main/java/io/netty/handler/codec/sctp/SctpMessageCompletionHandler.java
+++ b/transport-sctp/src/main/java/io/netty/handler/codec/sctp/SctpMessageCompletionHandler.java
@@ -35,6 +35,10 @@ import java.util.List;
 public class SctpMessageCompletionHandler extends MessageToMessageDecoder<SctpMessage> {
     private final IntObjectMap<ByteBuf> fragments = new IntObjectHashMap<ByteBuf>();
 
+    public SctpMessageCompletionHandler() {
+        super(SctpMessage.class);
+    }
+
     @Override
     protected void decode(ChannelHandlerContext ctx, SctpMessage msg, List<Object> out) throws Exception {
         final ByteBuf byteBuf = msg.content();

--- a/transport-sctp/src/main/java/io/netty/handler/codec/sctp/SctpMessageToMessageDecoder.java
+++ b/transport-sctp/src/main/java/io/netty/handler/codec/sctp/SctpMessageToMessageDecoder.java
@@ -22,6 +22,10 @@ import io.netty.handler.codec.MessageToMessageDecoder;
 
 public abstract class SctpMessageToMessageDecoder extends MessageToMessageDecoder<SctpMessage> {
 
+    public SctpMessageToMessageDecoder() {
+        super(SctpMessage.class);
+    }
+
     @Override
     public boolean acceptInboundMessage(Object msg) throws Exception {
         if (msg instanceof SctpMessage) {

--- a/transport-sctp/src/main/java/io/netty/handler/codec/sctp/SctpOutboundByteStreamHandler.java
+++ b/transport-sctp/src/main/java/io/netty/handler/codec/sctp/SctpOutboundByteStreamHandler.java
@@ -46,6 +46,7 @@ public class SctpOutboundByteStreamHandler extends MessageToMessageEncoder<ByteB
      * @param unordered             if {@literal true}, SCTP Data Chunks will be sent with the U (unordered) flag set.
      */
     public SctpOutboundByteStreamHandler(int streamIdentifier, int protocolIdentifier, boolean unordered) {
+        super(ByteBuf.class);
         this.streamIdentifier = streamIdentifier;
         this.protocolIdentifier = protocolIdentifier;
         this.unordered = unordered;


### PR DESCRIPTION
Pass generic type class to a constructor, so that we can avoid reflection calls.