### PR TITLE
Correct what artifacts included in netty-bom

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -202,11 +202,6 @@
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
-        <artifactId>netty-example</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -339,13 +334,13 @@
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative</artifactId>
         <version>${tcnative.version}</version>
-        <classifier>linux-aarch_64-fedora</classifier>
+        <classifier>osx-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative</artifactId>
         <version>${tcnative.version}</version>
-        <classifier>osx-x86_64</classifier>
+        <classifier>osx-aarch_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>


### PR DESCRIPTION
Motivation and modifications:

See discussions in #15265:

1. `netty-tcnative` misses a variant with `osx-aarch_64` classifier.
2. `netty-tcnative` variant with `linux-aarch_64-fedora` classifier was removed starting from version 2.0.72.
3. `netty-example` should not be included in the `netty-bom`.

Result:

`netty-bom` has correct set of managed artifacts.