### PR TITLE
Adaptive allocator should use the requested allocation size

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -621,7 +621,7 @@ final class AdaptivePoolingAllocator {
         }
 
         private boolean allocate(int size, int maxCapacity, AdaptiveByteBuf buf) {
-            recordAllocationSize(buf.length);
+            recordAllocationSize(size);
             int startingCapacity = getStartingCapacity(size, maxCapacity);
             Chunk curr = current;
             if (curr != null) {


### PR DESCRIPTION
Motivation:

Due to some recent changes the adaptive allocator was using buf.length to record the allocation stats, messing up with its ability to correctly predict/adapt the chunk capacity based on the load

Modifications:

Correctly revert back using the required capacity

Result:

adaptive allocation stats are now working as expected