### PR TITLE
Use checkAvailable(); in #readByte(); method (#15305)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufInputStream.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufInputStream.java
@@ -207,10 +207,7 @@ public class ByteBufInputStream extends InputStream implements DataInput {
 
     @Override
     public byte readByte() throws IOException {
-        int available = available();
-        if (available == 0) {
-            throw new EOFException();
-        }
+        checkAvailable(1);
         return buffer.readByte();
     }
 


### PR DESCRIPTION
Motivation:

Use checkAvailable(); in #readByte(); method for a better error message and a better consistency between all #read\[...](); methods

Modifications:

#readByte(); method now uses checkAvailable(); method to check if there is at least 1 byte in the buffer. If there is no bytes to read, there will always be an EOFException error but with the message :  "fieldSize is too long! Length is 1, but maximum is 0" (similar to other methods).

Result:
In case of error, an EOF exception with a message.

Fixes #15305.
