### PR TITLE
Fix netty Http3Codec user-controlled data in numeric cast

### DIFF
--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3CodecUtils.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3CodecUtils.java
@@ -149,6 +149,9 @@ final class Http3CodecUtils {
                 encodeLengthIntoBuffer(out, writerIndex, (byte) 0x40);
                 break;
             case 4:
+                if (value < Integer.MIN_VALUE || value > Integer.MAX_VALUE) {
+                    throw new IllegalArgumentException("Value out of range for int: " + value);
+                }
                 out.writeInt((int) value);
                 encodeLengthIntoBuffer(out, writerIndex, (byte) 0x80);
                 break;


### PR DESCRIPTION

Fix the issue need to validate the `value` parameter before casting it to `int`. Specifically:
1. Add a guard to ensure that `value` is within the range of `int` (`Integer.MIN_VALUE` to `Integer.MAX_VALUE`) before performing the cast.
2. If the value is out of range, throw an `IllegalArgumentException` to prevent unintended truncation.
3. Ensure that the fix does not alter the existing functionality of the method.

The changes will be made in the `writeVariableLengthInteger` method in `Http3CodecUtils.java`.

--- 

Casting a user-controlled numeric value to a narrower type can result in truncated values unless the input is validated. narrowing conversions may cause potentially unintended results. For example, casting the positive integer value `128` to type `byte` yields the negative value `-128`.

[NUM12-J. Ensure conversions of numeric types to narrower types do not result in lost or misinterpreted data](https://wiki.sei.cmu.edu/confluence/display/java/NUM12-J.+Ensure+conversions+of+numeric+types+to+narrower+types+do+not+result+in+lost+or+misinterpreted+data)


