### PR TITLE
replace regexp in SslHandler with custom code

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1306,10 +1306,10 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
     }
 
     private static boolean isIgnorableClassInStack(String classname) {
-        return (classname.contains("SocketChannel") ||
-                classname.contains("DatagramChannel") ||
-                classname.contains("SctpChannel") ||
-                classname.contains("UdtChannel"));
+        return classname.contains("SocketChannel") ||
+               classname.contains("DatagramChannel") ||
+               classname.contains("SctpChannel") ||
+               classname.contains("UdtChannel");
     }
 
     /**


### PR DESCRIPTION
Motivation:

Improves cold start, no need to keep static vatriable

Modification:

Regexp replaced with custom code.

Result:

One regexp less