### PR TITLE
Fix typo in javadoc

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -120,7 +120,7 @@ public final class DnsNameResolverBuilder {
      * Sets the {@link ChannelFactory} that will create a {@link DatagramChannel}.
      * <p>
      * If <a href="https://tools.ietf.org/html/rfc7766">TCP fallback</a> should be supported as well it is required
-     * to call the {@link #socketChannelFactory(ChannelFactory) or {@link #socketChannelType(Class)}} method.
+     * to call the {@link #socketChannelFactory(ChannelFactory)} or {@link #socketChannelType(Class)} method.
      *
      * @param datagramChannelFactory the {@link ChannelFactory}
      * @return {@code this}
@@ -136,7 +136,7 @@ public final class DnsNameResolverBuilder {
      * Sets the {@link ChannelFactory} that will create a {@link DatagramChannel}.
      * <p>
      * If <a href="https://tools.ietf.org/html/rfc7766">TCP fallback</a> should be supported as well it is required
-     * to call the {@link #socketChannelFactory(ChannelFactory) or {@link #socketChannelType(Class)}} method.
+     * to call the {@link #socketChannelFactory(ChannelFactory)} or {@link #socketChannelType(Class)} method.
      *
      * @param datagramChannelFactory the {@link ChannelFactory}
      * @return {@code this}
@@ -152,7 +152,7 @@ public final class DnsNameResolverBuilder {
      * Use as an alternative to {@link #channelFactory(ChannelFactory)}.
      * <p>
      * If <a href="https://tools.ietf.org/html/rfc7766">TCP fallback</a> should be supported as well it is required
-     * to call the {@link #socketChannelFactory(ChannelFactory) or {@link #socketChannelType(Class)}} method.
+     * to call the {@link #socketChannelFactory(ChannelFactory)} or {@link #socketChannelType(Class)} method.
      *
      * @param channelType the type
      * @return {@code this}
@@ -168,7 +168,7 @@ public final class DnsNameResolverBuilder {
      * Use as an alternative to {@link #datagramChannelFactory(ChannelFactory)}.
      * <p>
      * If <a href="https://tools.ietf.org/html/rfc7766">TCP fallback</a> should be supported as well it is required
-     * to call the {@link #socketChannelFactory(ChannelFactory) or {@link #socketChannelType(Class)}} method.
+     * to call the {@link #socketChannelFactory(ChannelFactory)} or {@link #socketChannelType(Class)} method.
      *
      * @param channelType the type
      * @return {@code this}


### PR DESCRIPTION
Motivation:

Some javadoc rendering is broken due to misplaced brackets.
(e.g. `DnsNameResolverBuilder` - https://netty.io/4.2/api/io/netty/resolver/dns/DnsNameResolverBuilder.html#datagramChannelFactory(io.netty.channel.ChannelFactory))

Modification:

Fix typo.

Result:

Javadoc renders correctly.