### PR TITLE
Disable CleanerJava25 at build time for GraalVM <25

### DIFF
--- a/common/src/main/java/io/netty/util/internal/CleanerJava25.java
+++ b/common/src/main/java/io/netty/util/internal/CleanerJava25.java
@@ -37,7 +37,7 @@ final class CleanerJava25 implements Cleaner {
         boolean suitableJavaVersion;
         if (System.getProperty("org.graalvm.nativeimage.imagecode") != null) {
             // native image supports this since 25, but we don't use PlatformDependent0 here, since
-            // we need to initialize CleanerJava24 at build time.
+            // we need to initialize CleanerJava25 at build time.
             String v = System.getProperty("java.specification.version");
             try {
                 suitableJavaVersion = Integer.parseInt(v) >= 25;

--- a/common/src/main/java/io/netty/util/internal/CleanerJava25.java
+++ b/common/src/main/java/io/netty/util/internal/CleanerJava25.java
@@ -51,7 +51,7 @@ final class CleanerJava25 implements Cleaner {
             // - https://bugs.openjdk.org/browse/JDK-8357145
             // - https://bugs.openjdk.org/browse/JDK-8357268
             suitableJavaVersion = PlatformDependent0.javaVersion() >= 25;
-            logger = InternalLoggerFactory.getInstance(CleanerJava24.class);
+            logger = InternalLoggerFactory.getInstance(CleanerJava25.class);
         }
 
         MethodHandle method;

--- a/common/src/main/resources/META-INF/native-image/io.netty/netty-common/native-image.properties
+++ b/common/src/main/resources/META-INF/native-image/io.netty/netty-common/native-image.properties
@@ -19,4 +19,4 @@ Args = --initialize-at-run-time=io.netty.util.AbstractReferenceCounted,io.netty.
        --initialize-at-run-time=io.netty.util.NetUtilSubstitutions$NetUtilLocalhost6LazyHolder \
        --initialize-at-run-time=io.netty.util.NetUtilSubstitutions$NetUtilLocalhostLazyHolder \
        --initialize-at-run-time=io.netty.util.NetUtilSubstitutions$NetUtilNetworkInterfacesLazyHolder \
-       --initialize-at-build-time=io.netty.util.internal.CleanerJava24
+       --initialize-at-build-time=io.netty.util.internal.CleanerJava25

--- a/common/src/main/resources/META-INF/native-image/io.netty/netty-common/native-image.properties
+++ b/common/src/main/resources/META-INF/native-image/io.netty/netty-common/native-image.properties
@@ -12,8 +12,11 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+# Note: This file is overridden by graalvm-reachability-metadata
+
 Args = --initialize-at-run-time=io.netty.util.AbstractReferenceCounted,io.netty.util.concurrent.GlobalEventExecutor,io.netty.util.concurrent.ImmediateEventExecutor,io.netty.util.concurrent.ScheduledFutureTask,io.netty.util.internal.ThreadLocalRandom \
        --initialize-at-run-time=io.netty.util.NetUtilSubstitutions$NetUtilLocalhost4LazyHolder \
        --initialize-at-run-time=io.netty.util.NetUtilSubstitutions$NetUtilLocalhost6LazyHolder \
        --initialize-at-run-time=io.netty.util.NetUtilSubstitutions$NetUtilLocalhostLazyHolder \
-       --initialize-at-run-time=io.netty.util.NetUtilSubstitutions$NetUtilNetworkInterfacesLazyHolder
+       --initialize-at-run-time=io.netty.util.NetUtilSubstitutions$NetUtilNetworkInterfacesLazyHolder \
+       --initialize-at-build-time=io.netty.util.internal.CleanerJava24


### PR DESCRIPTION
Motivation:

On GraalVM 19 to 24, `java.lang.foreign.Arena` becoming reachable is enough to break linking the native image with `/usr/bin/ld: test-suite-http-server-tck-netty-tests.o:(.data+0xf60): undefined reference to 'Java_jdk_internal_misc_ScopedMemoryAccess_closeScope0'`. While `CleanerJava25` does guard any access to the class with a version check and a try catch, these checks cannot be constant folded, so Arena remains reachable.

Modification:

Alter CleanerJava24 so that it can be build-time initialized in native image:

- Remove dependency on PlatformDependent0 when in native image
- Do not initialize logger when in native image

Then, in the native image code path, parse `java.specification.version` manually to ensure we're in 25+ before enabling Arena access.

Update `native-image.properties` to initialize `CleanerJava25` at build time.

Result:

`CleanerJava25` is initialized at build time. Native image sees that Arena is not reachable and the resulting native image links successfully.

Note that native image 25 is broken even with this change for what appears to be an unrelated reason related to Unsafe. I've forwarded this to the native image team.

Note that the `initialize-at-build-time` flag added in this PR actually *does not apply* when using the native image build plugins for maven and gradle, because the shared graalvm-reachability-metadata overrides any configuration in netty-common. To resolve this problem, graalvm-reachability-metadata also needs a patch. I cannot make that patch before this PR however, because making CleanerJava25 build-time initialized *without* this PR actually breaks native image on pre-19 versions too, since the logger cannot be initialized at build time.