### PR TITLE
Make ByteBuf.memoryAddress work for MemorySegment buffers

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledDirectByteBuf.java
@@ -303,11 +303,16 @@ final class PooledDirectByteBuf extends PooledByteBuf<ByteBuffer> {
 
     @Override
     public boolean hasMemoryAddress() {
-        return false;
+        PoolChunk<ByteBuffer> chunk = this.chunk;
+        return chunk != null && chunk.cleanable.hasMemoryAddress();
     }
 
     @Override
     public long memoryAddress() {
-        throw new UnsupportedOperationException();
+        ensureAccessible();
+        if (!hasMemoryAddress()) {
+            throw new UnsupportedOperationException();
+        }
+        return chunk.cleanable.memoryAddress() + offset;
     }
 }

--- a/buffer/src/main/java/io/netty/buffer/PooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledHeapByteBuf.java
@@ -97,7 +97,7 @@ class PooledHeapByteBuf extends PooledByteBuf<byte[]> {
     @Override
     public final ByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length) {
         checkDstIndex(index, length, dstIndex, dst.capacity());
-        if (dst.hasMemoryAddress()) {
+        if (dst.hasMemoryAddress() && PlatformDependent.hasUnsafe()) {
             PlatformDependent.copyMemory(memory, idx(index), dst.memoryAddress() + dstIndex, length);
         } else if (dst.hasArray()) {
             getBytes(index, dst.array(), dst.arrayOffset() + dstIndex, length);
@@ -177,7 +177,7 @@ class PooledHeapByteBuf extends PooledByteBuf<byte[]> {
     @Override
     public final ByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length) {
         checkSrcIndex(index, length, srcIndex, src.capacity());
-        if (src.hasMemoryAddress()) {
+        if (src.hasMemoryAddress() && PlatformDependent.hasUnsafe()) {
             PlatformDependent.copyMemory(src.memoryAddress() + srcIndex, memory, idx(index), length);
         } else if (src.hasArray()) {
             setBytes(index, src.array(), src.arrayOffset() + srcIndex, length);

--- a/buffer/src/main/java/io/netty/buffer/UnpooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledByteBufAllocator.java
@@ -269,6 +269,16 @@ public final class UnpooledByteBufAllocator extends AbstractByteBufAllocator imp
             delegate.clean();
             alloc.decrementDirect(capacity);
         }
+
+        @Override
+        public boolean hasMemoryAddress() {
+            return delegate.hasMemoryAddress();
+        }
+
+        @Override
+        public long memoryAddress() {
+            return delegate.memoryAddress();
+        }
     }
 
     private static final class UnpooledByteBufAllocatorMetric implements ByteBufAllocatorMetric {

--- a/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
@@ -221,12 +221,17 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     public boolean hasMemoryAddress() {
-        return false;
+        CleanableDirectBuffer cleanable = this.cleanable;
+        return cleanable != null && cleanable.hasMemoryAddress();
     }
 
     @Override
     public long memoryAddress() {
-        throw new UnsupportedOperationException();
+        ensureAccessible();
+        if (!hasMemoryAddress()) {
+            throw new UnsupportedOperationException();
+        }
+        return cleanable.memoryAddress();
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
@@ -166,7 +166,7 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     public ByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length) {
         checkDstIndex(index, length, dstIndex, dst.capacity());
-        if (dst.hasMemoryAddress()) {
+        if (dst.hasMemoryAddress() && PlatformDependent.hasUnsafe()) {
             PlatformDependent.copyMemory(array, index, dst.memoryAddress() + dstIndex, length);
         } else if (dst.hasArray()) {
             getBytes(index, dst.array(), dst.arrayOffset() + dstIndex, length);
@@ -245,7 +245,7 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     public ByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length) {
         checkSrcIndex(index, length, srcIndex, src.capacity());
-        if (src.hasMemoryAddress()) {
+        if (src.hasMemoryAddress() && PlatformDependent.hasUnsafe()) {
             PlatformDependent.copyMemory(src.memoryAddress() + srcIndex, array, index, length);
         } else  if (src.hasArray()) {
             setBytes(index, src.array(), src.arrayOffset() + srcIndex, length);

--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -726,21 +726,6 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
         assertTrue(beforeFreeBytes < afterFreeBytes);
     }
 
-    @Test
-    void directBuffersMustHaveMemoryAddress() throws Exception {
-        // The memory address must always be available when we either have Unsafe available,
-        // or when we have memory segments available (though CleanerJava24 only enables for Java 24+).
-        assumeTrue(PlatformDependent.hasUnsafe() || PlatformDependent.javaVersion() >= 24);
-        PooledByteBufAllocator allocator = newAllocator(true);
-        ByteBuf buf = allocator.directBuffer();
-        try {
-            assertTrue(buf.hasMemoryAddress());
-            assertNotEquals(0L, buf.memoryAddress());
-        } finally {
-            buf.release();
-        }
-    }
-
     @Override
     @Test
     public void testUsedDirectMemory() {

--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -42,6 +42,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -723,6 +724,21 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
         int afterFreeBytes = chunk.freeBytes();
 
         assertTrue(beforeFreeBytes < afterFreeBytes);
+    }
+
+    @Test
+    void directBuffersMustHaveMemoryAddress() throws Exception {
+        // The memory address must always be available when we either have Unsafe available,
+        // or when we have memory segments available (though CleanerJava24 only enables for Java 24+).
+        assumeTrue(PlatformDependent.hasUnsafe() || PlatformDependent.javaVersion() >= 24);
+        PooledByteBufAllocator allocator = newAllocator(true);
+        ByteBuf buf = allocator.directBuffer();
+        try {
+            assertTrue(buf.hasMemoryAddress());
+            assertNotEquals(0L, buf.memoryAddress());
+        } finally {
+            buf.release();
+        }
     }
 
     @Override

--- a/common/src/main/java/io/netty/util/internal/CleanableDirectBuffer.java
+++ b/common/src/main/java/io/netty/util/internal/CleanableDirectBuffer.java
@@ -36,4 +36,21 @@ public interface CleanableDirectBuffer {
      * and the buffer must not be accessed again after this method has been called.
      */
     void clean();
+
+    /**
+     * @return {@code true} if the {@linkplain #memoryAddress() native memory address} is available,
+     * otherwise {@code false}.
+     */
+    default boolean hasMemoryAddress() {
+        return false;
+    }
+
+    /**
+     * Get the native memory address, but only if {@link #hasMemoryAddress()} returns true,
+     * otherwise this may return an unspecified value or throw an exception.
+     * @return The native memory address of this buffer, if available.
+     */
+    default long memoryAddress() {
+        return 0;
+    }
 }

--- a/common/src/main/java/io/netty/util/internal/CleanerJava24.java
+++ b/common/src/main/java/io/netty/util/internal/CleanerJava24.java
@@ -41,21 +41,25 @@ final class CleanerJava24 implements Cleaner {
                 // Here we compose and construct a MethodHandle that takes an 'int' capacity argument,
                 // and produces a 'CleanableDirectBufferImpl' instance.
                 // The method handle will create a new shared Arena instance, allocate a MemorySegment from it,
-                // convert the MemorySegment to a ByteBuffer, and then pass both the Arena and the ByteBuffer to
-                // the CleanableDirectBufferImpl constructor, returning the resulting object.
+                // convert the MemorySegment to a ByteBuffer and a memory address, and then pass both the Arena,
+                // the ByteBuffer, and the memory address to the CleanableDirectBufferImpl constructor,
+                // returning the resulting object.
                 //
                 // Effectively, we are recreating the following the Java code through MethodHandles alone:
                 //
                 //    Arena arena = Arena.ofShared();
+                //    MemorySegment segment = arena.allocate(size);
                 //    return new CleanableDirectBufferImpl(
                 //              (AutoCloseable) arena,
-                //              arena.allocate(size).asByteBuffer());
+                //              segment.asByteBuffer(),
+                //              segment.address());
                 //
                 // First, we need the types we'll use to set this all up.
                 Class<?> arenaCls = Class.forName("java.lang.foreign.Arena");
                 Class<?> memsegCls = Class.forName("java.lang.foreign.MemorySegment");
                 Class<CleanableDirectBufferImpl> bufCls = CleanableDirectBufferImpl.class;
-                // Acquire the private look up, so we can access the private 'CleanableDirectBufferImpl' constructor.
+                // Acquire the private look up, so we can access the package-private 'CleanableDirectBufferImpl'
+                // constructor.
                 MethodHandles.Lookup lookup = MethodHandles.lookup();
 
                 // ofShared.type() = ()Arena
@@ -64,20 +68,34 @@ final class CleanerJava24 implements Cleaner {
                 MethodHandle allocate = lookup.findVirtual(arenaCls, "allocate", methodType(memsegCls, long.class));
                 // asByteBuffer.type() = (MemorySegment)ByteBuffer
                 MethodHandle asByteBuffer = lookup.findVirtual(memsegCls, "asByteBuffer", methodType(ByteBuffer.class));
-                // bufClsCtor.type() = (AutoCloseable,ByteBuffer)CleanableDirectBufferImpl
+                // address.type() = (MemorySegment)long
+                MethodHandle address = lookup.findVirtual(memsegCls, "address", methodType(long.class));
+                // bufClsCtor.type() = (AutoCloseable,ByteBuffer,long)CleanableDirectBufferImpl
                 MethodHandle bufClsCtor = lookup.findConstructor(bufCls,
-                        methodType(void.class, AutoCloseable.class, ByteBuffer.class));
-                // The 'allocate' method takes a 'long' capacity but we'll be providing an 'int'.
+                        methodType(void.class, AutoCloseable.class, ByteBuffer.class, long.class));
+                // The 'allocate' method takes a 'long' capacity, but we'll be providing an 'int'.
                 // Explicitly cast the 'long' to 'int' so we can use 'invokeExact'.
                 // allocateInt.type() = (Arena,int)MemorySegment
                 MethodHandle allocateInt = MethodHandles.explicitCastArguments(allocate,
                         methodType(memsegCls, arenaCls, int.class));
-                // Use the 'asByteBuffer' method as a filter, to transform the constructor into a method that takes a
-                // MemorySegment argument instead of a ByteBuffer argument.
-                // ctorArenaMemseg.type() = (Arena,MemorySegment)CleanableDirectBufferImpl
-                MethodHandle ctorArenaMemseg = MethodHandles.explicitCastArguments(
-                        MethodHandles.filterArguments(bufClsCtor, 1, asByteBuffer),
-                        methodType(bufCls, arenaCls, memsegCls));
+                // Use the 'asByteBuffer' and 'address' methods as a filter, to transform the constructor into a method
+                // that takes two MemorySegment arguments instead of a ByteBuffer and a long argument.
+                // ctorArenaMemsegMemseg.type() = (Arena,MemorySegment,MemorySegment)CleanableDirectBufferImpl
+                MethodHandle ctorArenaMemsegMemseg = MethodHandles.explicitCastArguments(
+                        MethodHandles.filterArguments(bufClsCtor, 1, asByteBuffer, address),
+                        methodType(bufCls, arenaCls, memsegCls, memsegCls));
+                // Our method now takes two MemorySegment arguments, but we actually only want to pass one.
+                // Specifically, we want to get both the ByteBuffer and the memory address from the same MemorySegment
+                // instance.
+                // We permute the argument array such that the first MemorySegment argument gest passed to both
+                // parameters, and then the second parameter value gets ignored.
+                // ctorArenaMemsegNull.type() = (Arena,MemorySegment,MemorySegment)CleanableDirectBufferImpl
+                MethodHandle ctorArenaMemsegNull = MethodHandles.permuteArguments(ctorArenaMemsegMemseg,
+                        methodType(bufCls, arenaCls, memsegCls, memsegCls), 0, 1, 1);
+                // With the second MemorySegment argument ignored, we can statically bind it to 'null' to effectively
+                // drop it from our parameter list.
+                MethodHandle ctorArenaMemseg = MethodHandles.insertArguments(
+                        ctorArenaMemsegNull, 2, new Object[]{null});
                 // Use the 'allocateInt' method to transform the last MemorySegment argument of the constructor,
                 // into an (Arena,int) argument pair.
                 // ctorArenaArenaInt.type() = (Arena,Arena,int)CleanableDirectBufferImpl
@@ -140,11 +158,13 @@ final class CleanerJava24 implements Cleaner {
     private static final class CleanableDirectBufferImpl implements CleanableDirectBuffer {
         private final AutoCloseable closeable;
         private final ByteBuffer buffer;
+        private final long memoryAddress;
 
         // NOTE: must be at least package-protected to allow calls from the method handles!
-        CleanableDirectBufferImpl(AutoCloseable closeable, ByteBuffer buffer) {
+        CleanableDirectBufferImpl(AutoCloseable closeable, ByteBuffer buffer, long memoryAddress) {
             this.closeable = closeable;
             this.buffer = buffer;
+            this.memoryAddress = memoryAddress;
         }
 
         @Override
@@ -161,6 +181,16 @@ final class CleanerJava24 implements Cleaner {
             } catch (Exception e) {
                 throw new IllegalStateException("Unexpected close exception", e);
             }
+        }
+
+        @Override
+        public boolean hasMemoryAddress() {
+            return true;
+        }
+
+        @Override
+        public long memoryAddress() {
+            return memoryAddress;
         }
     }
 }


### PR DESCRIPTION
Motivation:
To take full advantage of direct buffers, we need to be able to get the address of their native memory. We have been relying on Unsafe for this, but now that we are starting to allocate native memory using MemorySegments, we have other and more portable options available.

Modification:
Make the CleanerJava24 extract the native memory address from the MemorySegment instances it allocates, and pass it to its CleanableDirectBuffer instances.

Add methods to the CleanableDirectBuffer interface for querying the native memory address.

Make PooledDirectByteBuf, PooledHeapByteBuf, and UnpooledDirectByteBuf take advantage of these new methods on the CleanableDirectBuffer. Note: the Unsafe variants of these types will continue to use Unsafe as before.

Fix numerous cases where we assume that ByteBuf.hasMemoryAddress returning 'true' means Unsafe is available. This is no longer the case, and we have to query for Unsafe separately.

Result:
We can now get the memory address of direct ByteBuf instances when using memory segments on Java 24+.

Fixes https://github.com/netty/netty/issues/15309