### PR TITLE
AbstractDnsRecord: equals() and hashCode() to ignore name field's case

### DIFF
--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsRecord.java
@@ -129,7 +129,7 @@ public abstract class AbstractDnsRecord implements DnsRecord {
 
         return type().intValue() == that.type().intValue() &&
                dnsClass() == that.dnsClass() &&
-               name().equals(that.name());
+               name().equalsIgnoreCase(that.name());
     }
 
     @Override
@@ -139,7 +139,7 @@ public abstract class AbstractDnsRecord implements DnsRecord {
             return hashCode;
         }
 
-        return this.hashCode = name.hashCode() * 31 + type().intValue() * 31 + dnsClass();
+        return this.hashCode = name.toLowerCase().hashCode() * 31 + type().intValue() * 31 + dnsClass();
     }
 
     @Override

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/AbstractDnsRecordTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/AbstractDnsRecordTest.java
@@ -72,4 +72,16 @@ public class AbstractDnsRecordTest {
             }
         });
     }
+
+    /*
+     * RFC-1034 Section 3.1 (page 7 & 8)
+     * RFC-1035 Section 2.3.3 (page 9 & 10)
+     */
+    @Test
+    public void testEqualsAndHashCodeIgnoreCase() {
+        AbstractDnsRecord lowerCase = new AbstractDnsRecord("example.com.", DnsRecordType.A, 0) { };
+        AbstractDnsRecord upperCase = new AbstractDnsRecord("EXAMPLE.COM.", DnsRecordType.A, 0) { };
+        assertEquals(lowerCase.hashCode(), upperCase.hashCode());
+        assertEquals(lowerCase, upperCase);
+    }
 }


### PR DESCRIPTION
Motivation:

In certain situations, it was found that DNS server implementations may return a response to a DNS question with a case other than that in the original request. In these cases, netty was found to continue waiting for additional responses, eventually timing out as if it had not received an answer to the DNS question.

This PR intends to make DNS answers match DNS questions when they vary only by case.

Modification:

AbstractDnsRecord's equals() and hashCode() methods now behave the same regardless of the name field's case

Result:

Fixes #15327 on the `4.2` branch. 
