### PR TITLE
feat: Add MultithreadEventExecutorGroup#chooser method 

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java
@@ -151,6 +151,13 @@ public abstract class MultithreadEventExecutorGroup extends AbstractEventExecuto
     }
 
     /**
+     * Return the current chooser which is used to select the next {@link EventExecutor}.
+     */
+    protected final EventExecutorChooserFactory.EventExecutorChooser chooser() {
+        return chooser;
+    }
+
+    /**
      * Create a new EventExecutor which will later then accessible via the {@link #next()}  method. This method will be
      * called for each thread that will serve this {@link MultithreadEventExecutorGroup}.
      *


### PR DESCRIPTION
Motivation:

Support to get the current `chooser` of `MultithreadEventExecutorGroup`

refs: 

Modification:

Do choose the next event loop with a hash.

Result:

Fixes https://github.com/netty/netty/issues/15334

