### PR TITLE
Explicit module support for HTTP/3 and QUIC codecs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Netty is an asynchronous event-driven network application framework for rapid de
 * [Documentation](https://netty.io/wiki/)
 * [@netty_project](https://twitter.com/netty_project)
 * [Official Discord server](https://discord.gg/q4aQ2XjaCa)
+* [Modular Netty guide](testsuite-jpms/README.md)
 
 ## How to build
 

--- a/codec-http3/pom.xml
+++ b/codec-http3/pom.xml
@@ -70,7 +70,7 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-codec</artifactId>
+      <artifactId>netty-codec-base</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/codec-http3/src/main/java/module-info.yml
+++ b/codec-http3/src/main/java/module-info.yml
@@ -18,6 +18,6 @@ requires:
   - module: io.netty.buffer
   - module: io.netty.transport
   - module: io.netty.codec
+  - module: io.netty.codec.http
   - module: io.netty.handler
-  - module: io.netty.classes.epoll
-    static: true
+  - module: io.netty.codec.classes.quic

--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -30,10 +30,12 @@
   <properties>
     <javaModuleNameClassifier>${os.detected.name}.${os.detected.arch}</javaModuleNameClassifier>
     <javaModuleNameWithClassifier>${javaModuleName}.${javaModuleNameClassifier}</javaModuleNameWithClassifier>
-    <javaModuleName>io.netty.handler.codec.quic</javaModuleName>
+    <fallbackModuleName>io.netty.codec.quic</fallbackModuleName>
+    <javaModuleName>${fallbackModuleName}.${javaModuleNameClassifier}</javaModuleName>
     <fragmentHost>io.netty.netty-codec-classes-quic</fragmentHost>
     <logging.config>${project.basedir}/../codec-native-quic/src/test/resources/logback-test.xml</logging.config>
     <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
+    <fallbackOutputDirectory>${project.build.directory}/fallback-classes</fallbackOutputDirectory>
     <nativeLibOnlyDir>${project.build.directory}/native-lib-only</nativeLibOnlyDir>
     <skipTests>false</skipTests>
     <packaging.type>jar</packaging.type>
@@ -388,6 +390,26 @@
                 <goals>
                   <goal>generate</goal>
                   <goal>build</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>io.github.dmlloyd.module-info</groupId>
+            <artifactId>module-info</artifactId>
+            <executions>
+              <execution>
+                <id>module-info</id>
+              </execution>
+              <execution>
+                <id>fallback-module-info</id>
+                <phase>process-classes</phase>
+                <configuration>
+                  <moduleName>${fallbackModuleName}</moduleName>
+                  <outputDirectory>${fallbackOutputDirectory}/META-INF/versions/11/</outputDirectory>
+                </configuration>
+                <goals>
+                  <goal>generate</goal>
                 </goals>
               </execution>
             </executions>
@@ -992,6 +1014,25 @@
               </target>
             </configuration>
           </execution>
+          <!-- Copy files for the fallback JAR that does not contain the native library
+               and a different module declaration -->
+          <execution>
+            <id>copy-to-native-output</id>
+            <phase>process-test-resources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+
+                <copy todir="${fallbackOutputDirectory}" includeEmptyDirs="false">
+                  <!-- Exclude native lib and attribution for the jar without classifier-->
+                  <zipfileset dir="${project.build.outputDirectory}" excludes="META-INF/versions/**,META-INF/native/**,META-INF/license/**,META-INF/NOTICE.txt,META-INF/LICENSE.txt" />
+                </copy>
+              </target>
+            </configuration>
+          </execution>
           <!-- Copy the manifest file that we populated so far so we can use it as a starting point when generating the jars and adding more things to it. -->
           <execution>
             <id>copy-manifest</id>
@@ -1102,25 +1143,40 @@
       </plugin>
 
       <plugin>
+        <groupId>io.github.dmlloyd.module-info</groupId>
+        <artifactId>module-info</artifactId>
+        <executions>
+          <execution>
+            <id>module-info</id>
+          </execution>
+          <execution>
+            <id>fallback-module-info</id>
+            <phase>process-classes</phase>
+            <configuration>
+              <moduleName>${fallbackModuleName}</moduleName>
+              <outputDirectory>${fallbackOutputDirectory}/META-INF/versions/11/</outputDirectory>
+            </configuration>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <executions>
           <execution>
             <id>default-jar</id>
             <configuration>
-              <!-- Exclude native lib and attribution for the jar without classifier-->
-              <excludes>
-                <exclude>META-INF/native/**</exclude>
-                <exclude>META-INF/license/**</exclude>
-                <exclude>META-INF/NOTICE.txt</exclude>
-                <exclude>META-INF/LICENSE.txt</exclude>
-              </excludes>
+              <classesDirectory>${fallbackOutputDirectory}</classesDirectory>
               <archive>
                 <manifest>
                   <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                   <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                 </manifest>
                 <manifestEntries>
-                  <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>
+                  <Multi-Release>true</Multi-Release>
                 </manifestEntries>
                 <index>true</index>
                 <manifestFile>${project.build.directory}/manifests/MANIFEST.MF</manifestFile>
@@ -1140,7 +1196,7 @@
                   <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                 </manifest>
                 <manifestEntries>
-                  <Automatic-Module-Name>${javaModuleNameWithClassifier}</Automatic-Module-Name>
+                  <Multi-Release>true</Multi-Release>
                   <Fragment-Host>${fragmentHost}</Fragment-Host>
                   <Bundle-NativeCode>${bundleNativeCode}</Bundle-NativeCode>
                 </manifestEntries>

--- a/pkitesting/src/main/java/module-info.yml
+++ b/pkitesting/src/main/java/module-info.yml
@@ -17,3 +17,4 @@ requires:
   - module: io.netty.common
   - module: io.netty.buffer
   - module: org.bouncycastle.provider
+  - module: jdk.crypto.ec

--- a/testsuite-jpms/README.md
+++ b/testsuite-jpms/README.md
@@ -20,6 +20,7 @@ historical reasons. They are listed below:
 * `io.netty.codec.haproxy`
 * `io.netty.codec.http`
 * `io.netty.codec.http2`
+* `io.netty.codec.http3`
 * `io.netty.codec.memcache`
 * `io.netty.codec.mqtt`
 * `io.netty.codec.redis`
@@ -30,6 +31,8 @@ historical reasons. They are listed below:
 * `io.netty.codec.compression`
 * `io.netty.codec.marshalling`
 * `io.netty.codec.protobuf`
+* `io.netty.codec.quic.${os.name}.${os.arch}`
+* `io.netty.codec.classes.quic`
 * `io.netty.common`
 * `io.netty.handler`
 * `io.netty.handler.proxy`
@@ -120,6 +123,15 @@ is only required at runtime. It can be added as module required declaration or a
 It is convenient to only depend on the transport classes and add the required transport native at runtime since the
 `os` and `arch` will vary.
 
+### HTTP/3
+
+HTTP/3 is supported.
+
+The module `io.netty.codec.quic.${os.name}.${os.arch}` contains the native library and its presence
+is only required at runtime. It can be added as module required declaration or at runtime on the module path.
+It is convenient to only depend on the classes and add the required transport native at runtime since the
+`os` and `arch` will vary.
+
 ### OpenSSL
 
 OpenSSL is supported.
@@ -182,12 +194,14 @@ usage: [options]
 --ssl-provider [ JDK | OPENSSL ]
 --port <port>
 --transport [ nio | kqueue | epoll | io_uring ]
+--http3
 ```
 
 - changing port `-m io.netty.testsuite_jpms.main/io.netty.testsuite_jpms.main.HttpHelloWorldServer --port 80`
 - using SSL `-m io.netty.testsuite_jpms.main/io.netty.testsuite_jpms.main.HttpHelloWorldServer --ssl`
 - using Open SSL `--add-modules io.netty.internal.tcnative.openssl.osx.aarch_64 -m io.netty.testsuite_jpms.main/io.netty.testsuite_jpms.main.HttpHelloWorldServer --ssl --ssl-provider OPENSSL`
 - using native transport `--add-modules io.netty.transport.kqueue.osx.aarch_64 -m io.netty.testsuite_jpms.main/io.netty.testsuite_jpms.main.HttpHelloWorldServer --transport kqueue`
+- using HTTP/3 `--add-modules io.netty.handler.codec.quic.osx.aarch_64 -m io.netty.testsuite_jpms.main/io.netty.testsuite_jpms.main.HttpHelloWorldServer --http3`
 
 ## Developer guide
 
@@ -247,5 +261,8 @@ due to the lack of module-info.java descriptors for Netty modules.
 You can however load the [pom.xml](pom.xml) file as a standalone project, the IDE will usually find the modules
 since they will be loaded from the local snapshot repository. 
 
+### Native library loading
 
-
+Netty native library resources are located outside their package structure, e.g. `META-INF/native/libnetty_quiche42_osx_aarch_64.jnilib`.
+As consequence native library modules do not need exports and can be loaded by any other module. These modules do not need
+to be present at compilation time and need only need to be present at runtime.

--- a/testsuite-jpms/README.md
+++ b/testsuite-jpms/README.md
@@ -201,7 +201,7 @@ usage: [options]
 - using SSL `-m io.netty.testsuite_jpms.main/io.netty.testsuite_jpms.main.HttpHelloWorldServer --ssl`
 - using Open SSL `--add-modules io.netty.internal.tcnative.openssl.osx.aarch_64 -m io.netty.testsuite_jpms.main/io.netty.testsuite_jpms.main.HttpHelloWorldServer --ssl --ssl-provider OPENSSL`
 - using native transport `--add-modules io.netty.transport.kqueue.osx.aarch_64 -m io.netty.testsuite_jpms.main/io.netty.testsuite_jpms.main.HttpHelloWorldServer --transport kqueue`
-- using HTTP/3 `--add-modules io.netty.handler.codec.quic.osx.aarch_64 -m io.netty.testsuite_jpms.main/io.netty.testsuite_jpms.main.HttpHelloWorldServer --http3`
+- using HTTP/3 `--add-modules io.netty.codec.quic.osx.aarch_64 -m io.netty.testsuite_jpms.main/io.netty.testsuite_jpms.main.HttpHelloWorldServer --http3`
 
 ## Developer guide
 

--- a/testsuite-jpms/pom.xml
+++ b/testsuite-jpms/pom.xml
@@ -100,6 +100,11 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>netty-codec-http3</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-xml</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
@@ -329,6 +334,7 @@
                 <addModules>
                   <addModule>jdk.jdwp.agent</addModule>
                   <addModule>io.netty.internal.tcnative.openssl.${os.detected.name}.${os.detected.arch}</addModule>
+                  <addModule>io.netty.codec.quic.${os.detected.name}.${os.detected.arch}</addModule>
                 </addModules>
                 <ignoreSigningInformation>true</ignoreSigningInformation>
                 <launcher>http=io.netty.testsuite_jpms.main/io.netty.testsuite_jpms.main.HttpHelloWorldServer</launcher>

--- a/testsuite-jpms/src/main/java/io/netty/testsuite_jpms/main/Http3HelloWorldServerHandler.java
+++ b/testsuite-jpms/src/main/java/io/netty/testsuite_jpms/main/Http3HelloWorldServerHandler.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.testsuite_jpms.main;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http3.DefaultHttp3DataFrame;
+import io.netty.handler.codec.http3.DefaultHttp3HeadersFrame;
+import io.netty.handler.codec.http3.Http3DataFrame;
+import io.netty.handler.codec.http3.Http3HeadersFrame;
+import io.netty.handler.codec.http3.Http3RequestStreamInboundHandler;
+import io.netty.handler.codec.quic.QuicStreamChannel;
+import io.netty.util.ReferenceCountUtil;
+
+import java.nio.charset.StandardCharsets;
+
+public class Http3HelloWorldServerHandler extends Http3RequestStreamInboundHandler {
+
+    @Override
+    protected void channelRead(ChannelHandlerContext ctx, Http3HeadersFrame frame) {
+        ReferenceCountUtil.release(frame);
+    }
+
+    @Override
+    protected void channelRead(ChannelHandlerContext ctx, Http3DataFrame frame) {
+        ReferenceCountUtil.release(frame);
+    }
+
+    @Override
+    protected void channelInputClosed(ChannelHandlerContext ctx) {
+
+        String hello = HttpHelloWorldServer.content(ctx);
+        ByteBuf data = Unpooled.copiedBuffer(hello, StandardCharsets.UTF_8);
+
+        Http3HeadersFrame headersFrame = new DefaultHttp3HeadersFrame();
+        headersFrame.headers().status("200");
+        headersFrame.headers().add("server", "netty");
+        headersFrame.headers().addInt("content-length", data.readableBytes());
+        ctx.write(headersFrame);
+        ctx.writeAndFlush(new DefaultHttp3DataFrame(data))
+                .addListener(QuicStreamChannel.SHUTDOWN_OUTPUT);
+    }
+}

--- a/testsuite-jpms/src/main/java/io/netty/testsuite_jpms/main/Http3HelloWorldServerInitializer.java
+++ b/testsuite-jpms/src/main/java/io/netty/testsuite_jpms/main/Http3HelloWorldServerInitializer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.testsuite_jpms.main;
+
+import io.netty.channel.ChannelInitializer;
+import io.netty.handler.codec.http3.Http3ServerConnectionHandler;
+import io.netty.handler.codec.quic.QuicChannel;
+import io.netty.handler.codec.quic.QuicStreamChannel;
+
+public class Http3HelloWorldServerInitializer extends ChannelInitializer<QuicChannel> {
+
+    @Override
+    protected void initChannel(QuicChannel ch) {
+        // Called for each connection
+        ch.pipeline().addLast(new Http3ServerConnectionHandler(
+                new ChannelInitializer<QuicStreamChannel>() {
+                    // Called for each request-stream,
+                    @Override
+                    protected void initChannel(QuicStreamChannel ch) {
+                        ch.pipeline().addLast(new Http3HelloWorldServerHandler());
+                    }
+                }));
+    }
+}

--- a/testsuite-jpms/src/main/java/io/netty/testsuite_jpms/main/HttpHelloWorldServer.java
+++ b/testsuite-jpms/src/main/java/io/netty/testsuite_jpms/main/HttpHelloWorldServer.java
@@ -48,10 +48,8 @@ import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.pkitesting.CertificateBuilder;
 import io.netty.pkitesting.X509Bundle;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 import java.net.InetSocketAddress;
-import java.security.Security;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -83,8 +81,6 @@ public final class HttpHelloWorldServer {
     }
 
     public static void main(String[] args) throws Exception {
-
-        Security.addProvider(new BouncyCastleProvider());
 
         String transport = "nio";
         boolean ssl = false;

--- a/testsuite-jpms/src/main/java/io/netty/testsuite_jpms/main/HttpHelloWorldServerHandler.java
+++ b/testsuite-jpms/src/main/java/io/netty/testsuite_jpms/main/HttpHelloWorldServerHandler.java
@@ -26,10 +26,8 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
-import io.netty.handler.ssl.SslHandler;
 
 import java.nio.charset.StandardCharsets;
-import java.util.stream.Collectors;
 
 import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
@@ -51,23 +49,7 @@ public class HttpHelloWorldServerHandler extends SimpleChannelInboundHandler<Htt
         if (msg instanceof HttpRequest) {
             HttpRequest req = (HttpRequest) msg;
 
-            String modulesInfo = ModuleLayer.boot().modules().stream()
-                    .map(module -> "- " + module.getName() + " " +
-                            (module.getDescriptor().isAutomatic() ? "(automatic)" : ""))
-                    .collect(Collectors.joining("\r\n", "Boot layer:\r\n", "\r\n"));
-
-            String channelType = ctx.channel().getClass().getName();
-
-            String sslEngineInfo = "";
-            SslHandler sslHandler = ctx.pipeline().get(SslHandler.class);
-            if (sslHandler != null) {
-                sslEngineInfo = "SSL Engine: " + sslHandler.engine().getClass().getName() + "\r\n";
-            }
-
-            String hello = "Hello World\r\n" +
-                    "Transport: " + channelType + "\r\n" +
-                    sslEngineInfo +
-                    modulesInfo;
+            String hello = HttpHelloWorldServer.content(ctx);
 
             boolean keepAlive = HttpUtil.isKeepAlive(req);
             FullHttpResponse response = new DefaultFullHttpResponse(

--- a/testsuite-jpms/src/main/java/module-info.java
+++ b/testsuite-jpms/src/main/java/module-info.java
@@ -14,6 +14,7 @@
  * under the License.
  */
 module io.netty.testsuite_jpms.main {
+    requires io.netty.common;
     requires io.netty.buffer;
     requires io.netty.codec;
     requires io.netty.codec.http;
@@ -24,4 +25,7 @@ module io.netty.testsuite_jpms.main {
     requires io.netty.transport.classes.epoll;
     requires io.netty.transport.classes.io_uring;
     requires io.netty.tcnative.classes.openssl;
+    requires io.netty.codec.http3;
+    requires io.netty.codec.classes.quic;
+    requires org.bouncycastle.provider;
 }

--- a/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/CodecHttp3Test.java
+++ b/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/CodecHttp3Test.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.testsuite_jpms.test;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
+import io.netty.channel.socket.nio.NioDatagramChannel;
+import io.netty.handler.codec.http3.Http3;
+import io.netty.handler.codec.http3.Http3HeadersFrame;
+import io.netty.handler.codec.http3.Http3DataFrame;
+import io.netty.handler.codec.http3.DefaultHttp3DataFrame;
+import io.netty.handler.codec.http3.DefaultHttp3HeadersFrame;
+import io.netty.handler.codec.http3.Http3ClientConnectionHandler;
+import io.netty.handler.codec.http3.Http3ServerConnectionHandler;
+import io.netty.handler.codec.http3.Http3RequestStreamInboundHandler;
+import io.netty.handler.codec.quic.InsecureQuicTokenHandler;
+import io.netty.handler.codec.quic.QuicChannel;
+import io.netty.handler.codec.quic.QuicSslContext;
+import io.netty.handler.codec.quic.QuicSslContextBuilder;
+import io.netty.handler.codec.quic.QuicStreamChannel;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty.util.CharsetUtil;
+import io.netty.util.NetUtil;
+import io.netty.util.ReferenceCountUtil;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.security.cert.CertificateException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CodecHttp3Test {
+
+    private static final byte[] CONTENT = "Hello World!\r\n".getBytes(CharsetUtil.US_ASCII);
+    static final int PORT = 9999;
+
+    @Test
+    public void smokeTest() throws Exception {
+
+        int port = PORT;
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        try {
+            Channel serverChannel = startServer(group, port);
+            runClient(group, port);
+            serverChannel.close().sync();
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+    private void runClient(EventLoopGroup group, int port) throws InterruptedException, ExecutionException {
+        QuicSslContext context = QuicSslContextBuilder.forClient()
+                .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                .applicationProtocols(Http3.supportedApplicationProtocols()).build();
+        ChannelHandler codec = Http3.newQuicClientCodecBuilder()
+                .sslContext(context)
+                .maxIdleTimeout(5000, TimeUnit.MILLISECONDS)
+                .initialMaxData(10000000)
+                .initialMaxStreamDataBidirectionalLocal(1000000)
+                .build();
+
+        Bootstrap bs = new Bootstrap();
+        Channel channel = bs.group(group)
+                .channel(NioDatagramChannel.class)
+                .handler(codec)
+                .bind(0).sync().channel();
+
+        QuicChannel quicChannel = QuicChannel.newBootstrap(channel)
+                .handler(new Http3ClientConnectionHandler())
+                .remoteAddress(new InetSocketAddress(NetUtil.LOCALHOST4, port))
+                .connect()
+                .get();
+
+        CompletableFuture<String> response = new CompletableFuture<>();
+
+        QuicStreamChannel streamChannel = Http3.newRequestStream(quicChannel,
+                new Http3RequestStreamInboundHandler() {
+
+                    @Override
+                    protected void channelRead(ChannelHandlerContext ctx, Http3HeadersFrame frame) {
+                        ReferenceCountUtil.release(frame);
+                    }
+
+                    @Override
+                    protected void channelRead(ChannelHandlerContext ctx, Http3DataFrame frame) {
+                        response.complete(frame.content().toString(CharsetUtil.US_ASCII));
+                        ReferenceCountUtil.release(frame);
+                    }
+
+                    @Override
+                    protected void channelInputClosed(ChannelHandlerContext ctx) {
+                        ctx.close();
+                    }
+                }).sync().getNow();
+
+        // Write the Header frame and send the FIN to mark the end of the request.
+        // After this its not possible anymore to write any more data.
+        Http3HeadersFrame frame = new DefaultHttp3HeadersFrame();
+        frame.headers().method("GET").path("/")
+                .authority(NetUtil.LOCALHOST4.getHostAddress() + ":" + port)
+                .scheme("https");
+        streamChannel.writeAndFlush(frame)
+                .addListener(QuicStreamChannel.SHUTDOWN_OUTPUT).sync();
+
+        // Wait for the stream channel and quic channel to be closed (this will happen after we received the FIN).
+        // After this is done we will close the underlying datagram channel.
+        streamChannel.closeFuture().sync();
+
+        assertEquals("Hello World!\r\n", response.get());
+
+        // After we received the response lets also close the underlying QUIC channel and datagram channel.
+        quicChannel.close().sync();
+        channel.close().sync();
+    }
+
+    private Channel startServer(EventLoopGroup group, int port) throws InterruptedException, CertificateException {
+        SelfSignedCertificate cert = new SelfSignedCertificate();
+        QuicSslContext sslContext = QuicSslContextBuilder.forServer(cert.key(), null, cert.cert())
+                .applicationProtocols(Http3.supportedApplicationProtocols()).build();
+        ChannelHandler codec = Http3.newQuicServerCodecBuilder()
+                .sslContext(sslContext)
+                .maxIdleTimeout(5000, TimeUnit.MILLISECONDS)
+                .initialMaxData(10000000)
+                .initialMaxStreamDataBidirectionalLocal(1000000)
+                .initialMaxStreamDataBidirectionalRemote(1000000)
+                .initialMaxStreamsBidirectional(100)
+                .tokenHandler(InsecureQuicTokenHandler.INSTANCE)
+                .handler(new ChannelInitializer<QuicChannel>() {
+                    @Override
+                    protected void initChannel(QuicChannel ch) {
+                        // Called for each connection
+                        ch.pipeline().addLast(new Http3ServerConnectionHandler(
+                                new ChannelInitializer<QuicStreamChannel>() {
+                                    // Called for each request-stream,
+                                    @Override
+                                    protected void initChannel(QuicStreamChannel ch) {
+                                        ch.pipeline().addLast(new Http3RequestStreamInboundHandler() {
+
+                                            @Override
+                                            protected void channelRead(
+                                                    ChannelHandlerContext ctx, Http3HeadersFrame frame) {
+                                                ReferenceCountUtil.release(frame);
+                                            }
+
+                                            @Override
+                                            protected void channelRead(
+                                                    ChannelHandlerContext ctx, Http3DataFrame frame) {
+                                                ReferenceCountUtil.release(frame);
+                                            }
+
+                                            @Override
+                                            protected void channelInputClosed(ChannelHandlerContext ctx) {
+                                                Http3HeadersFrame headersFrame = new DefaultHttp3HeadersFrame();
+                                                headersFrame.headers().status("404");
+                                                headersFrame.headers().add("server", "netty");
+                                                headersFrame.headers().addInt("content-length", CONTENT.length);
+                                                ctx.write(headersFrame);
+                                                ctx.writeAndFlush(new DefaultHttp3DataFrame(
+                                                                Unpooled.wrappedBuffer(CONTENT)))
+                                                        .addListener(QuicStreamChannel.SHUTDOWN_OUTPUT);
+                                            }
+                                        });
+                                    }
+                                }));
+                    }
+                }).build();
+
+        Bootstrap bs = new Bootstrap();
+        return bs.group(group)
+                .channel(NioDatagramChannel.class)
+                .handler(codec)
+                .bind(new InetSocketAddress(port)).sync().channel();
+    }
+}

--- a/testsuite-jpms/src/test/java/module-info.java
+++ b/testsuite-jpms/src/test/java/module-info.java
@@ -40,6 +40,8 @@ open module io.netty.testsuite_jpms.test {
     requires io.netty.resolver.dns;
     requires io.netty.codec.http;
     requires io.netty.codec.http2;
+    requires io.netty.codec.http3;
+    requires io.netty.codec.classes.quic;
     requires jboss.marshalling;
     requires org.bouncycastle.pkix;
 


### PR DESCRIPTION
Motivation:

HTTP/3 and QUIC codecs have been added and are missing proper modular support as testing.

Changes:

- Update `netty-codec-http3`, `netty-codec-native-quic` and `netty-codec-classes-quic` jar to support explicitly modularity.
- Add testing to the JPMS testsuite.
- Update Modular Netty guide.

Result:

Fixes #15332 
