### PR TITLE
Depend on QUIC artifacts individually

### DIFF
--- a/codec-http3/pom.xml
+++ b/codec-http3/pom.xml
@@ -92,7 +92,36 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-native-quic</artifactId>
       <version>${project.version}</version>
-      <classifier>${netty.quic.classifier}</classifier>
+      <classifier>linux-aarch_64</classifier>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-codec-native-quic</artifactId>
+      <version>${project.version}</version>
+      <classifier>linux-x86_64</classifier>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-codec-native-quic</artifactId>
+      <version>${project.version}</version>
+      <classifier>osx-aarch_64</classifier>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-codec-native-quic</artifactId>
+      <version>${project.version}</version>
+      <classifier>osx-x86_64</classifier>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-codec-native-quic</artifactId>
+      <version>${project.version}</version>
+      <classifier>windows-x86_64</classifier>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Motivation:

Gradle cannot deal with the `${netty.quic.classifier}` expression in the classifier, and produces the following error: `Could not find netty-codec-native-quic-4.2.2.Final-${os.detected.name}-${os.detected.arch}.jar (io.netty:netty-codec-native-quic:4.2.2.Final).`

Modification:

Depend on all native artifacts individually, with runtime scope. This is the same approach the incubator repo used as of https://github.com/netty/netty-incubator-codec-http3/commit/d31823ceec83ad94ff0b614f3d915e5d997fde49

Result:

Gradle is not confused anymore.

This is still broken because only one platform of quic can be built locally. The other platforms are not available and fail to resolve. With the incubator repos this was not a problem because all quic artifacts would be released before the version would be bumped in the http3 repo, but now that it's a monorepo, it breaks.
