### PR TITLE
Only use MemorySegments on Java 25+

### DIFF
--- a/.github/workflows/check-jdk.ea-version.yml
+++ b/.github/workflows/check-jdk.ea-version.yml
@@ -1,0 +1,20 @@
+name: check-jdk.ea-version.yml
+on:
+  schedule:
+    - cron: "15 8 * * *"
+
+jobs:
+  check-jdk-early-access-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Install SDK Man"
+        run: |
+          curl -s "https://get.sdkman.io" | bash
+          source "/root/.sdkman/bin/sdkman-init.sh"
+          # Make sure sdkman works
+          sdk help > /dev/null
+      - name: "Check latest JDK 25 EA version"
+        run: |
+          export JAVA_VERSION=$(sdk list java | grep 25.*-open|head -n 1|cut -f 3 -d '|')
+          # Keep this version in sync with docker-compose.centos-7.25.yaml
+          echo "'$JAVA_VERSION'" | fgrep 25.ea.26

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -208,6 +208,9 @@ jobs:
           - setup: linux-x86_64-java24
             docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-7.24.yaml build"
             docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-7.24.yaml run build"
+          - setup: linux-x86_64-java25
+            docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-7.25.yaml build"
+            docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-7.25.yaml run build"
           - setup: linux-x86_64-java11-boringssl
             docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-7.111.yaml build"
             docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-7.111.yaml run build-leak-boringssl-static"

--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufAllocatorTest.java
@@ -116,8 +116,8 @@ public abstract class AbstractByteBufAllocatorTest<T extends AbstractByteBufAllo
     @Test
     void directBuffersMustHaveMemoryAddress() throws Exception {
         // The memory address must always be available when we either have Unsafe available,
-        // or when we have memory segments available (though CleanerJava24 only enables for Java 24+).
-        assumeTrue(PlatformDependent.hasUnsafe() || PlatformDependent.javaVersion() >= 24);
+        // or when we have memory segments available (though CleanerJava25 only enables for Java 25+).
+        assumeTrue(PlatformDependent.hasUnsafe() || PlatformDependent.javaVersion() >= 25);
         T allocator = newAllocator(true);
         ByteBuf buf = allocator.directBuffer();
         try {

--- a/codec-marshalling/src/main/java/module-info.yml
+++ b/codec-marshalling/src/main/java/module-info.yml
@@ -18,4 +18,4 @@ requires:
   - module: io.netty.buffer
   - module: io.netty.transport
   - module: io.netty.codec
-  - module: jboss.marshalling
+  - module: org.jboss.marshalling

--- a/common/src/main/java/io/netty/util/internal/CleanerJava25.java
+++ b/common/src/main/java/io/netty/util/internal/CleanerJava25.java
@@ -28,15 +28,18 @@ import static java.lang.invoke.MethodType.methodType;
  * Provide a way to clean direct {@link ByteBuffer} instances on Java 24+,
  * where we don't have {@code Unsafe} available, but we have memory segments.
  */
-final class CleanerJava24 implements Cleaner {
-    private static final InternalLogger logger = InternalLoggerFactory.getInstance(CleanerJava24.class);
+final class CleanerJava25 implements Cleaner {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(CleanerJava25.class);
 
     private static final MethodHandle INVOKE_ALLOCATOR;
 
     static {
         MethodHandle method;
         Throwable error;
-        if (PlatformDependent0.javaVersion() >= 24) {
+        // Only attempt to use MemorySegments on Java 25 or greater, because of the following JDK bugs:
+        // - https://bugs.openjdk.org/browse/JDK-8357145
+        // - https://bugs.openjdk.org/browse/JDK-8357268
+        if (PlatformDependent0.javaVersion() >= 25) {
             try {
                 // Here we compose and construct a MethodHandle that takes an 'int' capacity argument,
                 // and produces a 'CleanableDirectBufferImpl' instance.

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -192,9 +192,9 @@ public final class PlatformDependent {
                 // Try Java 9 cleaner first, because it's based on Unsafe and can skip a few steps.
                 if (CleanerJava9.isSupported()) {
                     LEGACY_CLEANER = new CleanerJava9();
-                } else if (CleanerJava24.isSupported()) {
-                    // On Java 24+ we can't use Unsafe, but we have MemorySegment.
-                    LEGACY_CLEANER = new CleanerJava24();
+                } else if (CleanerJava25.isSupported()) {
+                    // On Java 25+ we can't use Unsafe, but we have MemorySegment.
+                    LEGACY_CLEANER = new CleanerJava25();
                 } else {
                     LEGACY_CLEANER = NOOP;
                 }

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -534,11 +534,13 @@ final class PlatformDependent0 {
 
         // See JDK 23 JEP 471 https://openjdk.org/jeps/471 and sun.misc.Unsafe.beforeMemoryAccess() on JDK 23+.
         // And JDK 24 JEP 498 https://openjdk.org/jeps/498, that enable warnings by default.
+        // Due to JDK bugs, we only actually disable Unsafe by default on Java 25+, where we have memory segment APIs
+        // available, and working.
         String reason = "io.netty.noUnsafe";
         String unspecified = "<unspecified>";
         String unsafeMemoryAccess = SystemPropertyUtil.get("sun.misc.unsafe.memory.access", unspecified);
-        if (!explicitProperty && unspecified.equals(unsafeMemoryAccess) && javaVersion() >= 24) {
-            reason = "io.netty.noUnsafe=true by default on Java 24+";
+        if (!explicitProperty && unspecified.equals(unsafeMemoryAccess) && javaVersion() >= 25) {
+            reason = "io.netty.noUnsafe=true by default on Java 25+";
             noUnsafe = true;
         } else if (!("allow".equals(unsafeMemoryAccess) || unspecified.equals(unsafeMemoryAccess))) {
             reason = "--sun-misc-unsafe-memory-access=" + unsafeMemoryAccess;

--- a/common/src/test/java/io/netty/util/internal/PlatformDependentTest.java
+++ b/common/src/test/java/io/netty/util/internal/PlatformDependentTest.java
@@ -161,11 +161,11 @@ public class PlatformDependentTest {
         PlatformDependent.freeDirectNoCleaner(buffer);
     }
 
-    @EnabledForJreRange(min = JRE.JAVA_24)
+    @EnabledForJreRange(min = JRE.JAVA_25)
     @Test
     void java24MustHaveCleanerImplAvailable() throws Exception {
-        assertTrue(CleanerJava24.isSupported(),
-                "The CleanerJava24 implementation must be supported on Java 24+");
+        assertTrue(CleanerJava25.isSupported(),
+                "The CleanerJava25 implementation must be supported on Java 25+");
         // Note: we're not testing on `PlatformDependent.directBufferPreferred()` because some builds
         // might intentionally disable it, in order to exercise those code paths.
     }

--- a/docker/docker-compose.centos-7.25.yaml
+++ b/docker/docker-compose.centos-7.25.yaml
@@ -1,0 +1,30 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: netty:centos-7-25
+    build:
+      args:
+        java_version : "25.ea.26-open"
+
+  build:
+    image: netty:centos-7-25
+
+  build-leak:
+    image: netty:centos-7-25
+
+  build-with-oio-testsuite:
+    image: netty:centos-7-25
+
+  build-boringssl-static:
+    image: netty:centos-7-25
+
+  build-leak-boringssl-static:
+    image: netty:centos-7-25
+
+  build-boringssl-snapshot:
+    image: netty:centos-7-25
+
+  shell:
+    image: netty:centos-7-25

--- a/pom.xml
+++ b/pom.xml
@@ -1379,6 +1379,18 @@
                   <newValue>7</newValue>
                   <justification>SETTINGS_ENABLE_CONNECT_PROTOCOL was added to the standard HTTP/2 settings.</justification>
                 </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.externalClassExposedInAPI</code>
+                  <new>interface org.jboss.marshalling.ClassNameTransformer</new>
+                  <justification>We need to build with upgraded JBoss Marshalling version. Otherwise, testsuite-jpms won't compile.</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.externalClassExposedInAPI</code>
+                  <new>interface org.jboss.marshalling.UnmarshallingObjectInputFilter</new>
+                  <justification>We need to build with upgraded JBoss Marshalling version. Otherwise, testsuite-jpms won't compile.</justification>
+                </item>
               </differences>
             </revapi.differences>
           </analysisConfiguration>

--- a/pom.xml
+++ b/pom.xml
@@ -224,6 +224,29 @@
       </properties>
     </profile>
     <profile>
+      <id>java25</id>
+      <activation>
+        <jdk>25</jdk>
+      </activation>
+      <properties>
+        <argLine.java9.extras />
+        <argLine.java9>${argLine.java9.extras}</argLine.java9>
+        <forbiddenapis.skip>true</forbiddenapis.skip>
+        <!-- 1.4.x does not work in Java10+ -->
+        <!-- 2.0.x does not work in Java25+ -->
+        <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
+        <!-- We need to use 1.8 as otherwise default methods are not picked up and so result in compile errors for
+             our EventExecutorGroup implementations
+        -->
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
+        <!-- pax-exam does not work on latest Java12 EA 22 build -->
+        <skipOsgiTestsuite>true</skipOsgiTestsuite>
+        <revapi.skip>true</revapi.skip>
+      </properties>
+    </profile>
+    <profile>
       <id>java23</id>
       <activation>
         <jdk>23</jdk>

--- a/pom.xml
+++ b/pom.xml
@@ -201,17 +201,14 @@
       </properties>
     </profile>
     <profile>
-      <id>java24</id>
+      <id>java25</id>
       <activation>
-        <jdk>24</jdk>
+        <jdk>25</jdk>
       </activation>
       <properties>
         <argLine.java9.extras />
         <argLine.java9>${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
-        <!-- 1.4.x does not work in Java10+ -->
-        <!-- 2.0.x does not work in Java25+ -->
-        <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
         <!-- We need to use 1.8 as otherwise default methods are not picked up and so result in compile errors for
              our EventExecutorGroup implementations
         -->
@@ -224,17 +221,14 @@
       </properties>
     </profile>
     <profile>
-      <id>java25</id>
+      <id>java24</id>
       <activation>
-        <jdk>25</jdk>
+        <jdk>24</jdk>
       </activation>
       <properties>
         <argLine.java9.extras />
         <argLine.java9>${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
-        <!-- 1.4.x does not work in Java10+ -->
-        <!-- 2.0.x does not work in Java25+ -->
-        <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
         <!-- We need to use 1.8 as otherwise default methods are not picked up and so result in compile errors for
              our EventExecutorGroup implementations
         -->
@@ -256,8 +250,6 @@
         <!-- Export some stuff which is used during our tests -->
         <argLine.java9>${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
-        <!-- 1.4.x does not work in Java10+ -->
-        <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
         <!-- We need to use 1.8 as otherwise default methods are not picked up and so result in compile errors for
              our EventExecutorGroup implementations
         -->
@@ -279,8 +271,6 @@
         <!-- Export some stuff which is used during our tests -->
         <argLine.java9>${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
-        <!-- 1.4.x does not work in Java10+ -->
-        <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
 
         <!-- pax-exam does not work on latest Java12 EA 22 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
@@ -298,8 +288,6 @@
         <!-- Export some stuff which is used during our tests -->
         <argLine.java9>${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
-        <!-- 1.4.x does not work in Java10+ -->
-        <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
         <!-- pax-exam does not work on latest Java12 EA 22 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
         <revapi.skip>true</revapi.skip>
@@ -316,8 +304,6 @@
         <!-- Export some stuff which is used during our tests -->
         <argLine.java9>${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
-        <!-- 1.4.x does not work in Java10+ -->
-        <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
 
         <!-- pax-exam does not work on latest Java12 EA 22 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
@@ -335,8 +321,6 @@
         <!-- Export some stuff which is used during our tests -->
         <argLine.java9>${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
-        <!-- 1.4.x does not work in Java10+ -->
-        <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
 
         <!-- pax-exam does not work on latest Java12 EA 22 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
@@ -354,8 +338,6 @@
         <!-- Export some stuff which is used during our tests -->
         <argLine.java9>${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
-        <!-- 1.4.x does not work in Java10+ -->
-        <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
 
         <!-- pax-exam does not work on latest Java12 EA 22 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
@@ -373,8 +355,6 @@
         <!-- Export some stuff which is used during our tests -->
         <argLine.java9>${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
-        <!-- 1.4.x does not work in Java10+ -->
-        <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
 
         <!-- pax-exam does not work on latest Java12 EA 22 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
@@ -393,8 +373,6 @@
         <!-- Export some stuff which is used during our tests -->
         <argLine.java9>--illegal-access=deny ${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
-        <!-- 1.4.x does not work in Java10+ -->
-        <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
         <!-- pax-exam does not work on latest Java12 EA 22 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
       </properties>
@@ -412,8 +390,6 @@
         <!-- Export some stuff which is used during our tests -->
         <argLine.java9>--illegal-access=deny ${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
-        <!-- 1.4.x does not work in Java10+ -->
-        <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
         <!-- pax-exam does not work on latest Java12 EA 22 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
       </properties>
@@ -430,8 +406,6 @@
         <!-- Export some stuff which is used during our tests -->
         <argLine.java9>--illegal-access=deny ${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
-        <!-- 1.4.x does not work in Java10+ -->
-        <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
         <!-- pax-exam does not work on latest Java12 EA 22 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
       </properties>
@@ -448,8 +422,6 @@
         <!-- Export some stuff which is used during our tests -->
         <argLine.java9>--illegal-access=deny ${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
-        <!-- 1.4.x does not work in Java10+ -->
-        <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
         <!-- pax-exam does not work on latest Java12 EA 22 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
       </properties>
@@ -467,8 +439,6 @@
         <!-- Export some stuff which is used during our tests -->
         <argLine.java9>--illegal-access=deny ${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
-        <!-- 1.4.x does not work in Java10+ -->
-        <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
         <!-- pax-exam does not work on latest Java12 EA 22 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
       </properties>
@@ -486,8 +456,6 @@
         <!-- Export some stuff which is used during our tests -->
         <argLine.java9>--illegal-access=deny ${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
-        <!-- 1.4.x does not work in Java10+ -->
-        <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
         <!-- pax-exam does not work on latest Java11 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
       </properties>
@@ -507,8 +475,6 @@
         <forbiddenapis.skip>true</forbiddenapis.skip>
         <!-- Needed because of https://issues.apache.org/jira/browse/MENFORCER-275 -->
         <enforcer.plugin.version>3.0.0-M3</enforcer.plugin.version>
-        <!-- 1.4.x does not work in Java10+ -->
-        <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
       </properties>
     </profile>
 
@@ -719,7 +685,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <netty.build.version>31</netty.build.version>
-    <jboss.marshalling.version>1.4.11.Final</jboss.marshalling.version>
+    <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
     <bouncycastle.version>1.80</bouncycastle.version>
     <argLine.common>
       -server

--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,8 @@
         <argLine.java9>${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
         <!-- 1.4.x does not work in Java10+ -->
-        <jboss.marshalling.version>2.0.5.Final</jboss.marshalling.version>
+        <!-- 2.0.x does not work in Java25+ -->
+        <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
         <!-- We need to use 1.8 as otherwise default methods are not picked up and so result in compile errors for
              our EventExecutorGroup implementations
         -->

--- a/pom.xml
+++ b/pom.xml
@@ -257,7 +257,7 @@
         <argLine.java9>${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
         <!-- 1.4.x does not work in Java10+ -->
-        <jboss.marshalling.version>2.0.5.Final</jboss.marshalling.version>
+        <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
         <!-- We need to use 1.8 as otherwise default methods are not picked up and so result in compile errors for
              our EventExecutorGroup implementations
         -->
@@ -280,7 +280,7 @@
         <argLine.java9>${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
         <!-- 1.4.x does not work in Java10+ -->
-        <jboss.marshalling.version>2.0.5.Final</jboss.marshalling.version>
+        <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
 
         <!-- pax-exam does not work on latest Java12 EA 22 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
@@ -299,7 +299,7 @@
         <argLine.java9>${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
         <!-- 1.4.x does not work in Java10+ -->
-        <jboss.marshalling.version>2.0.5.Final</jboss.marshalling.version>
+        <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
         <!-- pax-exam does not work on latest Java12 EA 22 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
         <revapi.skip>true</revapi.skip>
@@ -317,7 +317,7 @@
         <argLine.java9>${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
         <!-- 1.4.x does not work in Java10+ -->
-        <jboss.marshalling.version>2.0.5.Final</jboss.marshalling.version>
+        <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
 
         <!-- pax-exam does not work on latest Java12 EA 22 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
@@ -336,7 +336,7 @@
         <argLine.java9>${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
         <!-- 1.4.x does not work in Java10+ -->
-        <jboss.marshalling.version>2.0.5.Final</jboss.marshalling.version>
+        <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
 
         <!-- pax-exam does not work on latest Java12 EA 22 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
@@ -355,7 +355,7 @@
         <argLine.java9>${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
         <!-- 1.4.x does not work in Java10+ -->
-        <jboss.marshalling.version>2.0.5.Final</jboss.marshalling.version>
+        <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
 
         <!-- pax-exam does not work on latest Java12 EA 22 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
@@ -374,7 +374,7 @@
         <argLine.java9>${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
         <!-- 1.4.x does not work in Java10+ -->
-        <jboss.marshalling.version>2.0.5.Final</jboss.marshalling.version>
+        <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
 
         <!-- pax-exam does not work on latest Java12 EA 22 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
@@ -394,7 +394,7 @@
         <argLine.java9>--illegal-access=deny ${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
         <!-- 1.4.x does not work in Java10+ -->
-        <jboss.marshalling.version>2.0.5.Final</jboss.marshalling.version>
+        <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
         <!-- pax-exam does not work on latest Java12 EA 22 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
       </properties>
@@ -413,7 +413,7 @@
         <argLine.java9>--illegal-access=deny ${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
         <!-- 1.4.x does not work in Java10+ -->
-        <jboss.marshalling.version>2.0.5.Final</jboss.marshalling.version>
+        <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
         <!-- pax-exam does not work on latest Java12 EA 22 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
       </properties>
@@ -431,7 +431,7 @@
         <argLine.java9>--illegal-access=deny ${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
         <!-- 1.4.x does not work in Java10+ -->
-        <jboss.marshalling.version>2.0.5.Final</jboss.marshalling.version>
+        <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
         <!-- pax-exam does not work on latest Java12 EA 22 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
       </properties>
@@ -449,7 +449,7 @@
         <argLine.java9>--illegal-access=deny ${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
         <!-- 1.4.x does not work in Java10+ -->
-        <jboss.marshalling.version>2.0.5.Final</jboss.marshalling.version>
+        <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
         <!-- pax-exam does not work on latest Java12 EA 22 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
       </properties>
@@ -468,7 +468,7 @@
         <argLine.java9>--illegal-access=deny ${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
         <!-- 1.4.x does not work in Java10+ -->
-        <jboss.marshalling.version>2.0.5.Final</jboss.marshalling.version>
+        <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
         <!-- pax-exam does not work on latest Java12 EA 22 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
       </properties>
@@ -487,7 +487,7 @@
         <argLine.java9>--illegal-access=deny ${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
         <!-- 1.4.x does not work in Java10+ -->
-        <jboss.marshalling.version>2.0.5.Final</jboss.marshalling.version>
+        <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
         <!-- pax-exam does not work on latest Java11 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
       </properties>
@@ -508,7 +508,7 @@
         <!-- Needed because of https://issues.apache.org/jira/browse/MENFORCER-275 -->
         <enforcer.plugin.version>3.0.0-M3</enforcer.plugin.version>
         <!-- 1.4.x does not work in Java10+ -->
-        <jboss.marshalling.version>2.0.5.Final</jboss.marshalling.version>
+        <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
       </properties>
     </profile>
 

--- a/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/CheckModuleDescriptorTest.java
+++ b/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/CheckModuleDescriptorTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class CheckModuleDescriptorTest {
 
     private static final Set<String> AUTOMATIC_MODULES_ALLOWED = Set.of(
-            "com.google.protobuf", "protobuf.javanano", "jboss.marshalling", "jboss.marshalling.serial");
+            "com.google.protobuf", "protobuf.javanano", "org.jboss.marshalling", "org.jboss.marshalling.serial");
 
     /**
      * Ensure that classpath is empty and all module are named and not automatic.

--- a/testsuite-jpms/src/test/java/module-info.java
+++ b/testsuite-jpms/src/test/java/module-info.java
@@ -42,7 +42,7 @@ open module io.netty.testsuite_jpms.test {
     requires io.netty.codec.http2;
     requires io.netty.codec.http3;
     requires io.netty.codec.classes.quic;
-    requires jboss.marshalling;
+    requires org.jboss.marshalling;
     requires org.bouncycastle.pkix;
 
     requires static org.slf4j;

--- a/transport-blockhound-tests/pom.xml
+++ b/transport-blockhound-tests/pom.xml
@@ -147,6 +147,7 @@
       </activation>
       <properties>
         <argLine.common>-XX:+AllowRedefinitionToAddDeleteMethods -XX:+EnableDynamicAgentLoading</argLine.common>
+        <skipTests>true</skipTests>
       </properties>
     </profile>
   </profiles>

--- a/transport-blockhound-tests/pom.xml
+++ b/transport-blockhound-tests/pom.xml
@@ -146,7 +146,7 @@
         <jdk>25</jdk>
       </activation>
       <properties>
-        <argLine.common>-XX:+AllowRedefinitionToAddDeleteMethods</argLine.common>
+        <argLine.common>-XX:+AllowRedefinitionToAddDeleteMethods -XX:+EnableDynamicAgentLoading</argLine.common>
       </properties>
     </profile>
   </profiles>

--- a/transport-blockhound-tests/pom.xml
+++ b/transport-blockhound-tests/pom.xml
@@ -140,6 +140,15 @@
         <argLine.common>-XX:+AllowRedefinitionToAddDeleteMethods</argLine.common>
       </properties>
     </profile>
+    <profile>
+      <id>java25</id>
+      <activation>
+        <jdk>25</jdk>
+      </activation>
+      <properties>
+        <argLine.common>-XX:+AllowRedefinitionToAddDeleteMethods</argLine.common>
+      </properties>
+    </profile>
   </profiles>
 
   <properties>


### PR DESCRIPTION
Motivation:
We wish to use memory segments for managing direct memory, as Unsafe is going away. However, we cannot use this feature unless the application is running on Java 25 or better due to the following JDK bugs:

- https://bugs.openjdk.org/browse/JDK-8357145
- https://bugs.openjdk.org/browse/JDK-8357268

In Netty, we can work around those bugs.
However, our downstream users are also getting `ByteBuffers` out of our `ByteBuf` instances, and making their own calls into the JDK APIs, and can thus also run into these bugs. Effectively, this breaks their systems when we enable memory segments on Java 24.

Modification:
Change CleanerJava24 to CleanerJava25, and only enable it on Java 25+.

Add a build to the PR matrix for Java 25 Early Access.

Add a nightly workflow that checks the latest Java 25 Early Access build version, which will fail if a new version is released. This workflow will help us stay up to date on the latest Java 25 Early Access version. We can remove it or disable it once Java 25 is released. Maybe we want something similar for Java 26 and so on, in the future.

Result:
We only use memory segments on Java versions where they don't run into buggy interactions.

Fixes https://github.com/netty/netty/issues/15324