### PR TITLE
drop security-manager related deprecated methods

### DIFF
--- a/codec-dns/src/test/java/io/netty5/handler/codec/dns/DefaultDnsRecordEncoderTest.java
+++ b/codec-dns/src/test/java/io/netty5/handler/codec/dns/DefaultDnsRecordEncoderTest.java
@@ -17,7 +17,6 @@ package io.netty5.handler.codec.dns;
 
 import io.netty5.buffer.Buffer;
 import io.netty5.channel.socket.SocketProtocolFamily;
-import io.netty5.util.internal.SocketUtils;
 import io.netty5.util.internal.StringUtil;
 import org.junit.jupiter.api.Test;
 
@@ -98,14 +97,14 @@ public class DefaultDnsRecordEncoderTest {
 
     @Test
     public void testOptEcsRecordIpv4() throws Exception {
-        testOptEcsRecordIp(SocketUtils.addressByName("1.2.3.4"));
-        testOptEcsRecordIp(SocketUtils.addressByName("1.2.3.255"));
+        testOptEcsRecordIp(InetAddress.getByName("1.2.3.4"));
+        testOptEcsRecordIp(InetAddress.getByName("1.2.3.255"));
     }
 
     @Test
     public void testOptEcsRecordIpv6() throws Exception {
-        testOptEcsRecordIp(SocketUtils.addressByName("::0"));
-        testOptEcsRecordIp(SocketUtils.addressByName("::FF"));
+        testOptEcsRecordIp(InetAddress.getByName("::0"));
+        testOptEcsRecordIp(InetAddress.getByName("::FF"));
     }
 
     private static void testOptEcsRecordIp(InetAddress address) throws Exception {

--- a/codec-dns/src/test/java/io/netty5/handler/codec/dns/DnsQueryTest.java
+++ b/codec-dns/src/test/java/io/netty5/handler/codec/dns/DnsQueryTest.java
@@ -17,7 +17,6 @@ package io.netty5.handler.codec.dns;
 
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.channel.socket.DatagramPacket;
-import io.netty5.util.internal.SocketUtils;
 import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
@@ -33,7 +32,7 @@ public class DnsQueryTest {
 
     @Test
     public void testEncodeAndDecodeQuery() {
-        InetSocketAddress addr = SocketUtils.socketAddress("8.8.8.8", 53);
+        InetSocketAddress addr = new InetSocketAddress("8.8.8.8", 53);
         EmbeddedChannel writeChannel = new EmbeddedChannel(new DatagramDnsQueryEncoder());
         EmbeddedChannel readChannel = new EmbeddedChannel(new DatagramDnsQueryDecoder());
 

--- a/codec/src/main/java/io/netty5/handler/codec/compression/Brotli.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/Brotli.java
@@ -17,7 +17,6 @@
 package io.netty5.handler.codec.compression;
 
 import com.aayushatharva.brotli4j.Brotli4jLoader;
-import io.netty5.util.internal.PlatformDependent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,8 +30,7 @@ public final class Brotli {
         ClassNotFoundException cnfe = null;
 
         try {
-            Class.forName("com.aayushatharva.brotli4j.Brotli4jLoader", false,
-                PlatformDependent.getClassLoader(Brotli.class));
+            Class.forName("com.aayushatharva.brotli4j.Brotli4jLoader", false, Brotli.class.getClassLoader());
         } catch (ClassNotFoundException t) {
             cnfe = t;
             logger.debug(

--- a/codec/src/main/java/io/netty5/handler/codec/compression/Zstd.java
+++ b/codec/src/main/java/io/netty5/handler/codec/compression/Zstd.java
@@ -16,7 +16,6 @@
 
 package io.netty5.handler.codec.compression;
 
-import io.netty5.util.internal.PlatformDependent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,8 +28,7 @@ public final class Zstd {
         Throwable t = null;
 
         try {
-            Class.forName("com.github.luben.zstd.Zstd", false,
-                PlatformDependent.getClassLoader(Zstd.class));
+            Class.forName("com.github.luben.zstd.Zstd", false, Zstd.class.getClassLoader());
         } catch (ClassNotFoundException e) {
             t = e;
             logger.debug(

--- a/codec/src/test/java/io/netty5/handler/codec/DatagramPacketDecoderTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/DatagramPacketDecoderTest.java
@@ -21,7 +21,6 @@ import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.channel.socket.DatagramPacket;
 import io.netty5.handler.codec.string.StringDecoder;
-import io.netty5.util.internal.SocketUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -51,8 +50,8 @@ public class DatagramPacketDecoderTest {
 
     @Test
     public void testDecode() {
-        InetSocketAddress recipient = SocketUtils.socketAddress("127.0.0.1", 10000);
-        InetSocketAddress sender = SocketUtils.socketAddress("127.0.0.1", 20000);
+        InetSocketAddress recipient = new InetSocketAddress("127.0.0.1", 10000);
+        InetSocketAddress sender = new InetSocketAddress("127.0.0.1", 20000);
         Buffer content = DefaultBufferAllocators.preferredAllocator().copyOf("netty", StandardCharsets.UTF_8);
         assertTrue(channel.writeInbound(new DatagramPacket(content, recipient, sender)));
         assertEquals("netty", channel.readInbound());

--- a/codec/src/test/java/io/netty5/handler/codec/DatagramPacketEncoderTest.java
+++ b/codec/src/test/java/io/netty5/handler/codec/DatagramPacketEncoderTest.java
@@ -22,7 +22,6 @@ import io.netty5.channel.DefaultAddressedEnvelope;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.channel.socket.DatagramPacket;
 import io.netty5.handler.codec.string.StringEncoder;
-import io.netty5.util.internal.SocketUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -63,8 +62,8 @@ public class DatagramPacketEncoderTest {
     }
 
     private void testEncode(boolean senderIsNull) {
-        InetSocketAddress recipient = SocketUtils.socketAddress("127.0.0.1", 10000);
-        InetSocketAddress sender = senderIsNull ? null : SocketUtils.socketAddress("127.0.0.1", 20000);
+        InetSocketAddress recipient = new InetSocketAddress("127.0.0.1", 10000);
+        InetSocketAddress sender = senderIsNull ? null : new InetSocketAddress("127.0.0.1", 20000);
         assertTrue(channel.writeOutbound(
                 new DefaultAddressedEnvelope<>("netty", recipient, sender)));
         try (DatagramPacket packet = channel.readOutbound()) {
@@ -76,8 +75,8 @@ public class DatagramPacketEncoderTest {
 
     @Test
     public void testUnmatchedMessageType() {
-        InetSocketAddress recipient = SocketUtils.socketAddress("127.0.0.1", 10000);
-        InetSocketAddress sender = SocketUtils.socketAddress("127.0.0.1", 20000);
+        InetSocketAddress recipient = new InetSocketAddress("127.0.0.1", 10000);
+        InetSocketAddress sender = new InetSocketAddress("127.0.0.1", 20000);
         DefaultAddressedEnvelope<Long, InetSocketAddress> envelope =
                 new DefaultAddressedEnvelope<>(1L, recipient, sender);
         assertTrue(channel.writeOutbound(envelope));

--- a/common/src/main/java/io/netty5/util/ResourceLeakDetectorFactory.java
+++ b/common/src/main/java/io/netty5/util/ResourceLeakDetectorFactory.java
@@ -17,7 +17,6 @@
 package io.netty5.util;
 
 import io.netty5.util.internal.ObjectUtil;
-import io.netty5.util.internal.PlatformDependent;
 import io.netty5.util.internal.SystemPropertyUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -100,7 +99,7 @@ public abstract class ResourceLeakDetectorFactory {
         private static Constructor<?> customClassConstructor(String customLeakDetector) {
             try {
                 final Class<?> detectorClass = Class.forName(customLeakDetector, true,
-                        PlatformDependent.getSystemClassLoader());
+                        ClassLoader.getSystemClassLoader());
 
                 if (ResourceLeakDetector.class.isAssignableFrom(detectorClass)) {
                     return detectorClass.getConstructor(Class.class, int.class);

--- a/common/src/main/java/io/netty5/util/Version.java
+++ b/common/src/main/java/io/netty5/util/Version.java
@@ -16,8 +16,6 @@
 
 package io.netty5.util;
 
-import io.netty5.util.internal.PlatformDependent;
-
 import java.io.InputStream;
 import java.net.URL;
 import java.text.ParseException;
@@ -34,7 +32,7 @@ import java.util.TreeMap;
  * <p>
  * This class retrieves the version information from {@code META-INF/io.netty5.versions.properties}, which is
  * generated in build time.  Note that it may not be possible to retrieve the information completely, depending on
- * your environment, such as the specified {@link ClassLoader}, the current {@link SecurityManager}.
+ * your environment, such as the specified {@link ClassLoader}.
  * </p>
  */
 public final class Version {
@@ -63,7 +61,7 @@ public final class Version {
      */
     public static Map<String, Version> identify(ClassLoader classLoader) {
         if (classLoader == null) {
-            classLoader = PlatformDependent.getContextClassLoader();
+            classLoader = Thread.currentThread().getContextClassLoader();
         }
 
         // Collect all properties.

--- a/common/src/main/java/io/netty5/util/internal/ClassInitializerUtil.java
+++ b/common/src/main/java/io/netty5/util/internal/ClassInitializerUtil.java
@@ -29,7 +29,7 @@ public final class ClassInitializerUtil {
      * @param classes           the classes to load.
      */
     public static void tryLoadClasses(Class<?> loadingClass, Class<?>... classes) {
-        ClassLoader loader = PlatformDependent.getClassLoader(loadingClass);
+        ClassLoader loader = loadingClass.getClassLoader();
         for (Class<?> clazz: classes) {
             tryLoadClass(loader, clazz.getName());
         }

--- a/common/src/main/java/io/netty5/util/internal/MacAddressUtil.java
+++ b/common/src/main/java/io/netty5/util/internal/MacAddressUtil.java
@@ -73,7 +73,7 @@ public final class MacAddressUtil {
 
             byte[] macAddr;
             try {
-                macAddr = SocketUtils.hardwareAddressFromNetworkInterface(iface);
+                macAddr = iface.getHardwareAddress();
             } catch (SocketException e) {
                 logger.debug("Failed to get the hardware address of a network interface: {}", iface, e);
                 continue;

--- a/common/src/main/java/io/netty5/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty5/util/internal/PlatformDependent.java
@@ -1043,30 +1043,6 @@ public final class PlatformDependent {
     }
 
     /**
-     * Return the {@link ClassLoader} for the given {@link Class}.
-     */
-    @Deprecated
-    public static ClassLoader getClassLoader(final Class<?> clazz) {
-        return PlatformDependent0.getClassLoader(clazz);
-    }
-
-    /**
-     * Return the context {@link ClassLoader} for the current {@link Thread}.
-     */
-    @Deprecated
-    public static ClassLoader getContextClassLoader() {
-        return PlatformDependent0.getContextClassLoader();
-    }
-
-    /**
-     * Return the system {@link ClassLoader}.
-     */
-    @Deprecated
-    public static ClassLoader getSystemClassLoader() {
-        return PlatformDependent0.getSystemClassLoader();
-    }
-
-    /**
      * Returns a new concurrent {@link Deque}.
      */
     public static <C> Deque<C> newConcurrentDeque() {
@@ -1188,7 +1164,7 @@ public final class PlatformDependent {
 
         ClassLoader systemClassLoader = null;
         try {
-            systemClassLoader = getSystemClassLoader();
+            systemClassLoader = ClassLoader.getSystemClassLoader();
 
             // When using IBM J9 / Eclipse OpenJ9 we should not use VM.maxDirectMemory() as it not reflects the
             // correct value.

--- a/common/src/main/java/io/netty5/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty5/util/internal/PlatformDependent0.java
@@ -263,7 +263,7 @@ final class PlatformDependent0 {
             Object maybeUnaligned = null;
             try {
                 Class<?> bitsClass =
-                        Class.forName("java.nio.Bits", false, getSystemClassLoader());
+                        Class.forName("java.nio.Bits", false, ClassLoader.getSystemClassLoader());
                 if (unsafeStaticFieldOffsetSupported()) {
                     try {
                         Field maxMemoryField = bitsClass.getDeclaredField("MAX_MEMORY");
@@ -324,7 +324,7 @@ final class PlatformDependent0 {
             try {
                 // Java9 has jdk.internal.misc.Unsafe and not all methods are propagated to
                 // sun.misc.Unsafe
-                Class<?> internalUnsafeClass = getClassLoader(PlatformDependent0.class)
+                Class<?> internalUnsafeClass = PlatformDependent0.class.getClassLoader()
                         .loadClass("jdk.internal.misc.Unsafe");
                 Method method = internalUnsafeClass.getDeclaredMethod("getUnsafe");
                 Object theInternalUnsafe = method.invoke(null);
@@ -777,21 +777,6 @@ final class PlatformDependent0 {
 
     static int hashCodeAsciiSanitize(byte value) {
         return value & 0x1f;
-    }
-
-    @Deprecated
-    static ClassLoader getClassLoader(final Class<?> clazz) {
-        return clazz.getClassLoader();
-    }
-
-    @Deprecated
-    static ClassLoader getContextClassLoader() {
-        return Thread.currentThread().getContextClassLoader();
-    }
-
-    @Deprecated
-    static ClassLoader getSystemClassLoader() {
-        return ClassLoader.getSystemClassLoader();
     }
 
     static int addressSize() {

--- a/common/src/main/java/io/netty5/util/internal/SocketUtils.java
+++ b/common/src/main/java/io/netty5/util/internal/SocketUtils.java
@@ -15,26 +15,13 @@
  */
 package io.netty5.util.internal;
 
-import java.io.IOException;
 import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
-import java.net.Socket;
-import java.net.SocketAddress;
-import java.net.SocketException;
-import java.net.SocketPermission;
-import java.net.UnknownHostException;
-import java.nio.channels.DatagramChannel;
-import java.nio.channels.ServerSocketChannel;
-import java.nio.channels.SocketChannel;
 import java.util.Collections;
 import java.util.Enumeration;
 
 /**
- * Provides socket operations with privileges enabled. This is necessary for applications that use the
- * {@link SecurityManager} to restrict {@link SocketPermission} to their application. By asserting that these
- * operations are privileged, the operations can proceed even if some code in the calling chain lacks the appropriate
- * {@link SocketPermission}.
+ * Provides utlity operations related to sockets.
  */
 public final class SocketUtils {
 
@@ -48,53 +35,6 @@ public final class SocketUtils {
         return (Enumeration<T>) EMPTY;
     }
 
-    @Deprecated
-    public static void connect(final Socket socket, final SocketAddress remoteAddress, final int timeout)
-            throws IOException {
-        socket.connect(remoteAddress, timeout);
-    }
-
-    @Deprecated
-    public static void bind(final Socket socket, final SocketAddress bindpoint) throws IOException {
-        socket.bind(bindpoint);
-    }
-
-    @Deprecated
-    public static boolean connect(final SocketChannel socketChannel, final SocketAddress remoteAddress)
-            throws IOException {
-        return socketChannel.connect(remoteAddress);
-    }
-
-    @Deprecated
-    public static void bind(final SocketChannel socketChannel, final SocketAddress address) throws IOException {
-        socketChannel.bind(address);
-    }
-
-    @Deprecated
-    public static SocketChannel accept(final ServerSocketChannel serverSocketChannel) throws IOException {
-        return serverSocketChannel.accept();
-    }
-
-    @Deprecated
-    public static void bind(final DatagramChannel networkChannel, final SocketAddress address) throws IOException {
-        networkChannel.bind(address);
-    }
-
-    @Deprecated
-    public static InetAddress addressByName(final String hostname) throws UnknownHostException {
-        return InetAddress.getByName(hostname);
-    }
-
-    @Deprecated
-    public static InetAddress[] allAddressesByName(final String hostname) throws UnknownHostException {
-        return InetAddress.getAllByName(hostname);
-    }
-
-    @Deprecated
-    public static InetSocketAddress socketAddress(final String hostname, final int port) {
-        return new InetSocketAddress(hostname, port);
-    }
-
     public static Enumeration<InetAddress> addressesFromNetworkInterface(final NetworkInterface intf) {
         Enumeration<InetAddress> addresses = intf.getInetAddresses();
         // Android seems to sometimes return null even if this is not a valid return value by the api docs.
@@ -104,10 +44,5 @@ public final class SocketUtils {
             return empty();
         }
         return addresses;
-    }
-
-    @Deprecated
-    public static byte[] hardwareAddressFromNetworkInterface(final NetworkInterface intf) throws SocketException {
-        return intf.getHardwareAddress();
     }
 }

--- a/example/src/main/java/io/netty5/example/qotm/QuoteOfTheMomentClient.java
+++ b/example/src/main/java/io/netty5/example/qotm/QuoteOfTheMomentClient.java
@@ -25,8 +25,8 @@ import io.netty5.channel.MultithreadEventLoopGroup;
 import io.netty5.channel.nio.NioIoHandler;
 import io.netty5.channel.socket.DatagramPacket;
 import io.netty5.channel.socket.nio.NioDatagramChannel;
-import io.netty5.util.internal.SocketUtils;
 
+import java.net.InetSocketAddress;
 import java.util.concurrent.TimeUnit;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -55,7 +55,7 @@ public final class QuoteOfTheMomentClient {
 
             // Broadcast the QOTM request to port 8080.
             Buffer message = DefaultBufferAllocators.preferredAllocator().copyOf("QOTM?", UTF_8);
-            ch.writeAndFlush(new DatagramPacket(message, SocketUtils.socketAddress("255.255.255.255", PORT)))
+            ch.writeAndFlush(new DatagramPacket(message, new InetSocketAddress("255.255.255.255", PORT)))
               .asStage().sync();
 
             // QuoteOfTheMomentClientHandler will close the DatagramChannel when a

--- a/handler/src/main/java/io/netty5/handler/ipfilter/IpSubnetFilterRule.java
+++ b/handler/src/main/java/io/netty5/handler/ipfilter/IpSubnetFilterRule.java
@@ -16,7 +16,6 @@
 package io.netty5.handler.ipfilter;
 
 import io.netty5.util.NetUtil;
-import io.netty5.util.internal.SocketUtils;
 
 import java.math.BigInteger;
 import java.net.Inet4Address;
@@ -52,7 +51,7 @@ public final class IpSubnetFilterRule implements IpFilterRule, Comparable<IpSubn
 
             ipAddress = ipAndCidr[0];
             int cidrPrefix = Integer.parseInt(ipAndCidr[1]);
-            filterRule = selectFilterRule(SocketUtils.addressByName(ipAddress), cidrPrefix, ruleType);
+            filterRule = selectFilterRule(InetAddress.getByName(ipAddress), cidrPrefix, ruleType);
         } catch (UnknownHostException e) {
             throw new IllegalArgumentException("ipAddressWithCidr", e);
         }
@@ -68,7 +67,7 @@ public final class IpSubnetFilterRule implements IpFilterRule, Comparable<IpSubn
     public IpSubnetFilterRule(String ipAddress, int cidrPrefix, IpFilterRuleType ruleType) {
         try {
             this.ipAddress = ipAddress;
-            filterRule = selectFilterRule(SocketUtils.addressByName(ipAddress), cidrPrefix, ruleType);
+            filterRule = selectFilterRule(InetAddress.getByName(ipAddress), cidrPrefix, ruleType);
         } catch (UnknownHostException e) {
             throw new IllegalArgumentException("ipAddress", e);
         }

--- a/handler/src/main/java/io/netty5/handler/ssl/Conscrypt.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/Conscrypt.java
@@ -39,11 +39,11 @@ final class Conscrypt {
             try {
                 MethodHandles.Lookup lookup = MethodHandles.lookup();
                 Class<?> providerClass = Class.forName("org.conscrypt.OpenSSLProvider", true,
-                        PlatformDependent.getClassLoader(ConscryptAlpnSslEngine.class));
+                                                       ConscryptAlpnSslEngine.class.getClassLoader());
                 lookup.findConstructor(providerClass, MethodType.methodType(void.class)).invoke();
 
                 Class<?> conscryptClass = Class.forName("org.conscrypt.Conscrypt", true,
-                        PlatformDependent.getClassLoader(ConscryptAlpnSslEngine.class));
+                                                        ConscryptAlpnSslEngine.class.getClassLoader());
                 isConscryptSSLEngine = lookup.findStatic(conscryptClass, "isConscrypt",
                         MethodType.methodType(boolean.class, SSLEngine.class));
             } catch (Throwable ignore) {

--- a/handler/src/main/java/io/netty5/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/OpenSsl.java
@@ -90,8 +90,7 @@ public final class OpenSsl {
         } else {
             // Test if netty-tcnative is in the classpath first.
             try {
-                Class.forName("io.netty.internal.tcnative.SSLContext", false,
-                        PlatformDependent.getClassLoader(OpenSsl.class));
+                Class.forName("io.netty.internal.tcnative.SSLContext", false, OpenSsl.class.getClassLoader());
             } catch (ClassNotFoundException t) {
                 cause = t;
                 logger.debug(
@@ -652,7 +651,7 @@ public final class OpenSsl {
         libNames.add(staticLibName + '_' + arch);
         libNames.add(staticLibName);
 
-        NativeLibraryLoader.loadFirstAvailable(PlatformDependent.getClassLoader(SSLContext.class),
+        NativeLibraryLoader.loadFirstAvailable(SSLContext.class.getClassLoader(),
             libNames.toArray(EmptyArrays.EMPTY_STRINGS));
     }
 

--- a/handler/src/main/java/io/netty5/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslHandler.java
@@ -1110,7 +1110,7 @@ public class SslHandler extends ByteToMessageDecoder {
                     // No match by now.. Try to load the class via classloader and inspect it.
                     // This is mainly done as other JDK implementations may differ in name of
                     // the impl.
-                    Class<?> clazz = PlatformDependent.getClassLoader(getClass()).loadClass(classname);
+                    Class<?> clazz = getClass().getClassLoader().loadClass(classname);
 
                     if (SocketChannel.class.isAssignableFrom(clazz)
                             || DatagramChannel.class.isAssignableFrom(clazz)) {

--- a/handler/src/test/java/io/netty5/handler/ipfilter/IpSubnetFilterTest.java
+++ b/handler/src/test/java/io/netty5/handler/ipfilter/IpSubnetFilterTest.java
@@ -20,7 +20,6 @@ import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.embedded.EmbeddedChannel;
 import io.netty5.util.concurrent.Future;
-import io.netty5.util.internal.SocketUtils;
 import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
@@ -209,12 +208,12 @@ public class IpSubnetFilterTest {
         return new EmbeddedChannel(handlers) {
             @Override
             protected SocketAddress remoteAddress0() {
-                return isActive()? SocketUtils.socketAddress(ipAddress, 5421) : null;
+                return isActive()? new InetSocketAddress(ipAddress, 5421) : null;
             }
         };
     }
 
     private static InetSocketAddress newSockAddress(String ipAddress) {
-        return SocketUtils.socketAddress(ipAddress, 1234);
+        return new InetSocketAddress(ipAddress, 1234);
     }
 }

--- a/handler/src/test/java/io/netty5/handler/ipfilter/UniqueIpFilterTest.java
+++ b/handler/src/test/java/io/netty5/handler/ipfilter/UniqueIpFilterTest.java
@@ -17,9 +17,9 @@ package io.netty5.handler.ipfilter;
 
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.embedded.EmbeddedChannel;
-import io.netty5.util.internal.SocketUtils;
 import org.junit.jupiter.api.Test;
 
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
@@ -62,7 +62,7 @@ public class UniqueIpFilterTest {
             return new EmbeddedChannel(handler) {
                 @Override
                 protected SocketAddress remoteAddress0() {
-                    return isActive() ? SocketUtils.socketAddress("91.92.93.1", 5421) : null;
+                    return isActive() ? new InetSocketAddress("91.92.93.1", 5421) : null;
                 }
             };
         });

--- a/resolver-dns-classes-macos/src/main/java/io/netty5/resolver/dns/macos/MacOSDnsServerAddressStreamProvider.java
+++ b/resolver-dns-classes-macos/src/main/java/io/netty5/resolver/dns/macos/MacOSDnsServerAddressStreamProvider.java
@@ -83,7 +83,7 @@ public final class MacOSDnsServerAddressStreamProvider implements DnsServerAddre
         }
         String staticLibName = "netty5_resolver_dns_native_macos";
         String sharedLibName = staticLibName + '_' + PlatformDependent.normalizedArch();
-        ClassLoader cl = PlatformDependent.getClassLoader(MacOSDnsServerAddressStreamProvider.class);
+        ClassLoader cl = MacOSDnsServerAddressStreamProvider.class.getClassLoader();
         try {
             NativeLibraryLoader.load(sharedLibName, cl);
         } catch (UnsatisfiedLinkError e1) {

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/DefaultDnsServerAddressStreamProvider.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/DefaultDnsServerAddressStreamProvider.java
@@ -17,7 +17,6 @@ package io.netty5.resolver.dns;
 
 import io.netty5.util.NetUtil;
 import io.netty5.util.internal.PlatformDependent;
-import io.netty5.util.internal.SocketUtils;
 import io.netty5.util.internal.SystemPropertyUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,7 +82,7 @@ public final class DefaultDnsServerAddressStreamProvider implements DnsServerAdd
                         throw new ExceptionInInitializerError(DEFAULT_FALLBACK_SERVER_PROPERTY + " doesn't" +
                                 " contain a valid list of NameServers: " + defaultNameserverString);
                     }
-                    defaultNameServers.add(SocketUtils.socketAddress(server.trim(), DNS_PORT));
+                    defaultNameServers.add(new InetSocketAddress(server.trim(), DNS_PORT));
                 }
                 if (defaultNameServers.isEmpty()) {
                     throw new ExceptionInInitializerError(DEFAULT_FALLBACK_SERVER_PROPERTY + " doesn't" +
@@ -103,13 +102,13 @@ public final class DefaultDnsServerAddressStreamProvider implements DnsServerAdd
                         (NetUtil.LOCALHOST instanceof Inet6Address && !NetUtil.isIpV4StackPreferred())) {
                     Collections.addAll(
                             defaultNameServers,
-                            SocketUtils.socketAddress("2001:4860:4860::8888", DNS_PORT),
-                            SocketUtils.socketAddress("2001:4860:4860::8844", DNS_PORT));
+                            new InetSocketAddress("2001:4860:4860::8888", DNS_PORT),
+                            new InetSocketAddress("2001:4860:4860::8844", DNS_PORT));
                 } else {
                     Collections.addAll(
                             defaultNameServers,
-                            SocketUtils.socketAddress("8.8.8.8", DNS_PORT),
-                            SocketUtils.socketAddress("8.8.4.4", DNS_PORT));
+                            new InetSocketAddress("8.8.8.8", DNS_PORT),
+                            new InetSocketAddress("8.8.4.4", DNS_PORT));
                 }
 
                 if (logger.isWarnEnabled()) {

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/DirContextUtils.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/DirContextUtils.java
@@ -15,7 +15,6 @@
  */
 package io.netty5.resolver.dns;
 
-import io.netty5.util.internal.SocketUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,7 +59,7 @@ final class DirContextUtils {
                             continue;
                         }
                         int port  = uri.getPort();
-                        defaultNameServers.add(SocketUtils.socketAddress(uri.getHost(), port == -1 ?
+                        defaultNameServers.add(new InetSocketAddress(uri.getHost(), port == -1 ?
                                 defaultPort : port));
                     } catch (URISyntaxException e) {
                         logger.debug("Skipping a malformed nameserver URI: {}", server, e);

--- a/resolver-dns/src/main/java/io/netty5/resolver/dns/UnixResolverDnsServerAddressStreamProvider.java
+++ b/resolver-dns/src/main/java/io/netty5/resolver/dns/UnixResolverDnsServerAddressStreamProvider.java
@@ -16,7 +16,6 @@
 package io.netty5.resolver.dns;
 
 import io.netty5.util.NetUtil;
-import io.netty5.util.internal.SocketUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -211,7 +210,7 @@ public final class UnixResolverDnsServerAddressStreamProvider implements DnsServ
                                 port = Integer.parseInt(maybeIP.substring(i + 1));
                                 maybeIP = maybeIP.substring(0, i);
                             }
-                            InetSocketAddress addr = SocketUtils.socketAddress(maybeIP, port);
+                            InetSocketAddress addr = new InetSocketAddress(maybeIP, port);
                             // Check if the address is resolved and only if this is the case use it. Otherwise just
                             // ignore it. This is needed to filter out invalid entries, as if for example an ipv6
                             // address is used with a scope that represent a network interface that does not exists

--- a/resolver-dns/src/test/java/io/netty5/resolver/dns/DnsNameResolverClientSubnetTest.java
+++ b/resolver-dns/src/test/java/io/netty5/resolver/dns/DnsNameResolverClientSubnetTest.java
@@ -21,11 +21,11 @@ import io.netty5.channel.nio.NioIoHandler;
 import io.netty5.channel.socket.nio.NioDatagramChannel;
 import io.netty5.handler.codec.dns.DefaultDnsOptEcsRecord;
 import io.netty5.util.concurrent.Future;
-import io.netty5.util.internal.SocketUtils;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -47,7 +47,7 @@ public class DnsNameResolverClientSubnetTest {
                             // Suggest max payload size of 1024
                             // 157.88.0.0 / 24
                             new DefaultDnsOptEcsRecord(1024, 24,
-                                                       SocketUtils.addressByName("157.88.0.0").getAddress())));
+                                                       InetAddress.getByName("157.88.0.0").getAddress())));
             for (InetAddress address: future.asStage().get()) {
                 System.out.println(address);
             }
@@ -61,7 +61,7 @@ public class DnsNameResolverClientSubnetTest {
         return new DnsNameResolverBuilder(group.next())
                 .datagramChannelType(NioDatagramChannel.class)
                 .nameServerProvider(
-                        new SingletonDnsServerAddressStreamProvider(SocketUtils.socketAddress("8.8.8.8", 53)))
+                        new SingletonDnsServerAddressStreamProvider(new InetSocketAddress("8.8.8.8", 53)))
                 .maxQueriesPerResolve(1)
                 .optResourceEnabled(false)
                 .ndots(1);

--- a/resolver-dns/src/test/java/io/netty5/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty5/resolver/dns/DnsNameResolverTest.java
@@ -47,7 +47,6 @@ import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.ImmediateEventExecutor;
 import io.netty5.util.concurrent.Promise;
 import io.netty5.util.internal.PlatformDependent;
-import io.netty5.util.internal.SocketUtils;
 import io.netty5.util.internal.StringUtil;
 
 import org.apache.directory.server.dns.DnsException;
@@ -580,7 +579,7 @@ public class DnsNameResolverTest {
         DnsNameResolver resolver = newNonCachedResolver(ResolvedAddressTypes.IPV4_ONLY).build();
         try {
             InetAddress addr = resolver.resolve(inetHost).asStage().get();
-            assertEquals(SocketUtils.addressByName(inetHost), addr);
+            assertEquals(InetAddress.getByName(inetHost), addr);
         } finally {
             resolver.close();
         }
@@ -603,7 +602,7 @@ public class DnsNameResolverTest {
         try {
             List<InetAddress> addrs = resolver.resolveAll(inetHost).asStage().get();
             assertEquals(asList(
-                    SocketUtils.allAddressesByName(inetHost)), addrs);
+                    InetAddress.getAllByName(inetHost)), addrs);
         } finally {
             resolver.close();
         }

--- a/resolver/src/main/java/io/netty5/resolver/DefaultNameResolver.java
+++ b/resolver/src/main/java/io/netty5/resolver/DefaultNameResolver.java
@@ -18,7 +18,6 @@ package io.netty5.resolver;
 
 import io.netty5.util.concurrent.EventExecutor;
 import io.netty5.util.concurrent.Promise;
-import io.netty5.util.internal.SocketUtils;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -38,7 +37,7 @@ public class DefaultNameResolver extends InetNameResolver {
     @Override
     protected void doResolve(String inetHost, Promise<InetAddress> promise) throws Exception {
         try {
-            promise.setSuccess(SocketUtils.addressByName(inetHost));
+            promise.setSuccess(InetAddress.getByName(inetHost));
         } catch (UnknownHostException e) {
             promise.setFailure(e);
         }
@@ -47,7 +46,7 @@ public class DefaultNameResolver extends InetNameResolver {
     @Override
     protected void doResolveAll(String inetHost, Promise<List<InetAddress>> promise) throws Exception {
         try {
-            promise.setSuccess(Arrays.asList(SocketUtils.allAddressesByName(inetHost)));
+            promise.setSuccess(Arrays.asList(InetAddress.getAllByName(inetHost)));
         } catch (UnknownHostException e) {
             promise.setFailure(e);
         }

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramMulticastTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramMulticastTest.java
@@ -25,7 +25,6 @@ import io.netty5.channel.socket.DatagramChannel;
 import io.netty5.channel.socket.SocketProtocolFamily;
 import io.netty5.testsuite.transport.TestsuitePermutation;
 import io.netty5.util.NetUtil;
-import io.netty5.util.internal.SocketUtils;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -86,7 +85,7 @@ public class DatagramMulticastTest extends AbstractDatagramTest {
         DatagramChannel cc = (DatagramChannel) cb.bind().asStage().get();
         assertEquals(iface, cc.getOption(ChannelOption.IP_MULTICAST_IF));
 
-        InetAddress groupAddress = SocketUtils.addressByName(groupAddress());
+        InetAddress groupAddress = InetAddress.getByName(groupAddress());
         cc.joinGroup(groupAddress, iface, null).asStage().sync();
 
         InetSocketAddress destAddress = new InetSocketAddress(groupAddress, addr.getPort());

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/ServerSocketSuspendTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/ServerSocketSuspendTest.java
@@ -20,7 +20,6 @@ import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelHandler;
 import io.netty5.channel.ChannelHandlerContext;
 import io.netty5.channel.ChannelOption;
-import io.netty5.util.internal.SocketUtils;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -58,7 +57,7 @@ public class ServerSocketSuspendTest extends AbstractServerSocketTest {
             long startTime = System.nanoTime();
             for (int i = 0; i < NUM_CHANNELS; i ++) {
                 Socket s = new Socket();
-                SocketUtils.connect(s, sc.localAddress(), 10000);
+                s.connect(sc.localAddress(), 10000);
                 sockets.add(s);
             }
 

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConnectionAttemptTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketConnectionAttemptTest.java
@@ -25,13 +25,13 @@ import io.netty5.util.NetUtil;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.GlobalEventExecutor;
 import io.netty5.util.concurrent.Promise;
-import io.netty5.util.internal.SocketUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.LoggerFactory;
 
 import java.net.ConnectException;
+import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
@@ -105,7 +105,7 @@ public class SocketConnectionAttemptTest extends AbstractClientSocketTest {
         // See https://github.com/netty/netty/issues/1474
         boolean badHostTimedOut = true;
         try (Socket socket = new Socket()) {
-            SocketUtils.connect(socket, SocketUtils.socketAddress(BAD_HOST, BAD_PORT), 10);
+            socket.connect(new InetSocketAddress(BAD_HOST, BAD_PORT), 10);
         } catch (ConnectException e) {
             badHostTimedOut = false;
             // is thrown for no route to host when using Socket connect

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketShutdownOutputByPeerTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/SocketShutdownOutputByPeerTest.java
@@ -15,8 +15,6 @@
  */
 package io.netty5.testsuite.transport.socket;
 
-import io.netty5.util.internal.SocketUtils;
-
 import java.io.IOException;
 import java.net.Socket;
 import java.net.SocketAddress;
@@ -30,7 +28,7 @@ public class SocketShutdownOutputByPeerTest extends AbstractSocketShutdownOutput
 
     @Override
     protected void connect(Socket s, SocketAddress address) throws IOException {
-        SocketUtils.connect(s, address, 10000);
+        s.connect(address, 10000);
     }
 
     @Override

--- a/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/Native.java
+++ b/transport-classes-epoll/src/main/java/io/netty5/channel/epoll/Native.java
@@ -295,7 +295,7 @@ public final class Native {
         }
         String staticLibName = "netty5_transport_native_epoll";
         String sharedLibName = staticLibName + '_' + PlatformDependent.normalizedArch();
-        ClassLoader cl = PlatformDependent.getClassLoader(Native.class);
+        ClassLoader cl = Native.class.getClassLoader();
         try {
             NativeLibraryLoader.load(sharedLibName, cl);
         } catch (UnsatisfiedLinkError e1) {

--- a/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty5/channel/uring/Native.java
@@ -393,7 +393,7 @@ final class Native {
         }
         String staticLibName = "netty5_transport_native_io_uring";
         String sharedLibName = staticLibName + '_' + PlatformDependent.normalizedArch();
-        ClassLoader cl = PlatformDependent.getClassLoader(Native.class);
+        ClassLoader cl = Native.class.getClassLoader();
         try {
             NativeLibraryLoader.load(sharedLibName, cl);
         } catch (UnsatisfiedLinkError e1) {

--- a/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/Native.java
+++ b/transport-classes-kqueue/src/main/java/io/netty5/channel/kqueue/Native.java
@@ -146,7 +146,7 @@ final class Native {
         }
         String staticLibName = "netty5_transport_native_kqueue";
         String sharedLibName = staticLibName + '_' + PlatformDependent.normalizedArch();
-        ClassLoader cl = PlatformDependent.getClassLoader(Native.class);
+        ClassLoader cl = Native.class.getClassLoader();
         try {
             NativeLibraryLoader.load(sharedLibName, cl);
         } catch (UnsatisfiedLinkError e1) {

--- a/transport/src/main/java/io/netty5/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty5/bootstrap/AbstractBootstrap.java
@@ -25,7 +25,6 @@ import io.netty5.channel.EventLoopGroup;
 import io.netty5.util.AttributeKey;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.Promise;
-import io.netty5.util.internal.SocketUtils;
 import io.netty5.util.internal.StringUtil;
 import org.slf4j.Logger;
 
@@ -117,7 +116,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C, F>, C 
      * @see #localAddress(SocketAddress)
      */
     public B localAddress(String inetHost, int inetPort) {
-        return localAddress(SocketUtils.socketAddress(inetHost, inetPort));
+        return localAddress(new InetSocketAddress(inetHost, inetPort));
     }
 
     /**
@@ -232,7 +231,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C, F>, C 
      * Create a new {@link Channel} and bind it.
      */
     public Future<Channel> bind(String inetHost, int inetPort) {
-        return bind(SocketUtils.socketAddress(inetHost, inetPort));
+        return bind(new InetSocketAddress(inetHost, inetPort));
     }
 
     /**

--- a/transport/src/main/java/io/netty5/channel/nio/NioIoHandler.java
+++ b/transport/src/main/java/io/netty5/channel/nio/NioIoHandler.java
@@ -172,7 +172,7 @@ public final class NioIoHandler implements IoHandler {
             maybeSelectorImplClass = Class.forName(
                     "sun.nio.ch.SelectorImpl",
                     false,
-                    PlatformDependent.getSystemClassLoader());
+                    ClassLoader.getSystemClassLoader());
         } catch (Throwable cause) {
             maybeSelectorImplClass = cause;
         }

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioChannelUtil.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioChannelUtil.java
@@ -47,7 +47,7 @@ final class NioChannelUtil {
         if (PlatformDependent.javaVersion() >= 16) {
             try {
                 Class<?> clazz = Class.forName("java.net.UnixDomainSocketAddress", false,
-                        PlatformDependent.getClassLoader(NioChannelUtil.class));
+                                               NioChannelUtil.class.getClassLoader());
                 MethodHandles.Lookup lookup = MethodHandles.lookup();
                 MethodType type = MethodType.methodType(clazz, String.class);
                 ofMethodHandle = lookup.findStatic(clazz, "of", type);

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioDatagramChannel.java
@@ -31,7 +31,6 @@ import io.netty5.channel.socket.DatagramPacket;
 import io.netty5.util.Resource;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.internal.PlatformDependent;
-import io.netty5.util.internal.SocketUtils;
 import io.netty5.util.internal.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -334,7 +333,7 @@ public final class NioDatagramChannel
         if (isDomainSocket(family)) {
             localAddress = toUnixDomainSocketAddress(localAddress);
         }
-        SocketUtils.bind(javaChannel(), localAddress);
+        javaChannel().bind(localAddress);
         bound = true;
     }
 

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioServerSocketChannel.java
@@ -28,7 +28,6 @@ import io.netty5.channel.nio.AbstractNioMessageChannel;
 import io.netty5.channel.nio.NioIoHandle;
 import io.netty5.channel.nio.NioIoOps;
 import io.netty5.util.NetUtil;
-import io.netty5.util.internal.SocketUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -240,7 +239,7 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel<Channel, S
 
     @Override
     protected int doReadMessages(ReadSink readSink) throws Exception {
-        SocketChannel ch = SocketUtils.accept(javaChannel());
+        SocketChannel ch = javaChannel().accept();
         try {
             if (ch != null) {
                 readSink.processRead(0, 0,

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioSocketChannel.java
@@ -29,7 +29,6 @@ import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.GlobalEventExecutor;
 import io.netty5.util.concurrent.Promise;
 import io.netty5.util.internal.PlatformDependent;
-import io.netty5.util.internal.SocketUtils;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
@@ -229,7 +228,7 @@ public class NioSocketChannel
         if (isDomainSocket(family)) {
             localAddress = toUnixDomainSocketAddress(localAddress);
         }
-        SocketUtils.bind(javaChannel(), localAddress);
+        javaChannel().bind(localAddress);
     }
 
     @Override
@@ -243,7 +242,7 @@ public class NioSocketChannel
             if (isDomainSocket(family)) {
                 remoteAddress = toUnixDomainSocketAddress(remoteAddress);
             }
-            boolean connected = SocketUtils.connect(javaChannel(), remoteAddress);
+            boolean connected = javaChannel().connect(remoteAddress);
             if (!connected) {
                 addAndSubmit(NioIoOps.CONNECT);
             }


### PR DESCRIPTION
Motivation:
While removing usages of the SecurityManager in #15209, some methods were just deprecated to keep the diff smaller. These methods are no longer needed.

Modification:
Inline all deprecated methods.

Result:
No more unnecessary deprecated methods.
