### PR TITLE
Remove guava from dependencies

### DIFF
--- a/codec-base/pom.xml
+++ b/codec-base/pom.xml
@@ -97,11 +97,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/codec-dns/pom.xml
+++ b/codec-dns/pom.xml
@@ -96,11 +96,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/codec-haproxy/pom.xml
+++ b/codec-haproxy/pom.xml
@@ -85,11 +85,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/codec-http/pom.xml
+++ b/codec-http/pom.xml
@@ -153,11 +153,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/codec-http2/pom.xml
+++ b/codec-http2/pom.xml
@@ -180,11 +180,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/codec-memcache/pom.xml
+++ b/codec-memcache/pom.xml
@@ -90,11 +90,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/codec-mqtt/pom.xml
+++ b/codec-mqtt/pom.xml
@@ -94,11 +94,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/codec-redis/pom.xml
+++ b/codec-redis/pom.xml
@@ -90,11 +90,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/codec-smtp/pom.xml
+++ b/codec-smtp/pom.xml
@@ -90,11 +90,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/codec-socks/pom.xml
+++ b/codec-socks/pom.xml
@@ -90,11 +90,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/codec-stomp/pom.xml
+++ b/codec-stomp/pom.xml
@@ -90,11 +90,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/codec-xml/pom.xml
+++ b/codec-xml/pom.xml
@@ -89,11 +89,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/handler-proxy/pom.xml
+++ b/handler-proxy/pom.xml
@@ -124,11 +124,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -152,11 +152,6 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -1222,13 +1222,6 @@
         <scope>test</scope>
       </dependency>
 
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>33.4.8-jre</version>
-        <scope>test</scope>
-      </dependency>
-
       <!-- Test suite dependency for generating a compressed heap dump file -->
       <dependency>
         <groupId>org.tukaani</groupId>

--- a/resolver-dns/pom.xml
+++ b/resolver-dns/pom.xml
@@ -126,11 +126,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/testsuite-jpms/pom.xml
+++ b/testsuite-jpms/pom.xml
@@ -352,7 +352,7 @@
               <version>3.4.0</version>
               <configuration>
                 <!-- Exclude all dependencies which are automatic modules -->
-                <classpathDependencyExcludes>org.hamcrest:*,net.sf.saxon:Saxon-HE,org.checkerframework:checker-qual,commons-logging:commons-logging,com.google.errorprone:error_prone_annotations,io.netty:netty-build-common,antlr:antlr,org.antlr:antlr4-runtime,com.google.guava:*,com.puppycrawl.tools:checkstyle,commons-beanutils:commons-beanutils,commons-collections:commons-collections,com.google.code.findbugs:jsr305,com.google.j2objc:j2objc-annotations</classpathDependencyExcludes>
+                <classpathDependencyExcludes>org.hamcrest:*,net.sf.saxon:Saxon-HE,org.checkerframework:checker-qual,commons-logging:commons-logging,com.google.errorprone:error_prone_annotations,io.netty:netty-build-common,antlr:antlr,org.antlr:antlr4-runtime,com.puppycrawl.tools:checkstyle,commons-beanutils:commons-beanutils,commons-collections:commons-collections,com.google.code.findbugs:jsr305,com.google.j2objc:j2objc-annotations</classpathDependencyExcludes>
                 <useModulePath>${useTestModulePath}</useModulePath>
               </configuration>
               <executions>

--- a/transport-sctp/pom.xml
+++ b/transport-sctp/pom.xml
@@ -90,11 +90,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -86,11 +86,6 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Motivation:

guava is not used anymore, let's remove it from our dependencies

Modifications:

Remove unused dependency

Result:

Cleanup dependencies