### PR TITLE
Simplify code in JdkZlibDecoder/Encoder

### DIFF
--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/JdkZlibDecoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/JdkZlibDecoder.java
@@ -460,10 +460,7 @@ public class JdkZlibDecoder extends ZlibDecoder {
         assert enoughData;
 
         // read ISIZE and verify
-        int dataLength = 0;
-        for (int i = 0; i < 4; ++i) {
-            dataLength |= in.readUnsignedByte() << i * 8;
-        }
+        int dataLength = in.readIntLE();
         int readLength = inflater.getTotalOut();
         if (dataLength != readLength) {
             throw new DecompressionException(
@@ -483,10 +480,8 @@ public class JdkZlibDecoder extends ZlibDecoder {
         if (in.readableBytes() < 4) {
             return false;
         }
-        long crcValue = 0;
-        for (int i = 0; i < 4; ++i) {
-            crcValue |= (long) in.readUnsignedByte() << i * 8;
-        }
+        long crcValue = in.readUnsignedIntLE();
+
         long readCrc = crc.getValue();
         if (crcValue != readCrc) {
             throw new DecompressionException(
@@ -499,13 +494,10 @@ public class JdkZlibDecoder extends ZlibDecoder {
         if (in.readableBytes() < 2) {
             return false;
         }
-        long readCrc32 = crc.getValue();
-        long crc16Value = 0;
-        long readCrc16 = 0; // the two least significant bytes from the CRC32
-        for (int i = 0; i < 2; ++i) {
-            crc16Value |= (long) in.readUnsignedByte() << (i * 8);
-            readCrc16 |= ((readCrc32 >> (i * 8)) & 0xff) << (i * 8);
-        }
+
+        int crc16Value = in.readUnsignedShortLE();
+        // the two least significant bytes from the CRC32
+        int readCrc16 = (int) (crc.getValue() & 0xFFFF);
 
         if (crc16Value != readCrc16) {
             throw new DecompressionException(

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
@@ -187,12 +187,9 @@ public class JdkZlibEncoder extends ZlibEncoder {
             return finishEncode(ctx, promise);
         } else {
             final ChannelPromise p = ctx.newPromise();
-            executor.execute(new Runnable() {
-                @Override
-                public void run() {
-                    ChannelFuture f = finishEncode(ctx(), p);
-                    PromiseNotifier.cascade(f, promise);
-                }
+            executor.execute(() -> {
+                ChannelFuture f = finishEncode(ctx(), p);
+                PromiseNotifier.cascade(f, promise);
             });
             return p;
         }

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
@@ -333,14 +333,8 @@ public class JdkZlibEncoder extends ZlibEncoder {
         if (wrapper == ZlibWrapper.GZIP) {
             int crcValue = (int) crc.getValue();
             int uncBytes = deflater.getTotalIn();
-            footer.writeByte(crcValue);
-            footer.writeByte(crcValue >>> 8);
-            footer.writeByte(crcValue >>> 16);
-            footer.writeByte(crcValue >>> 24);
-            footer.writeByte(uncBytes);
-            footer.writeByte(uncBytes >>> 8);
-            footer.writeByte(uncBytes >>> 16);
-            footer.writeByte(uncBytes >>> 24);
+            footer.writeIntLE(crcValue);
+            footer.writeIntLE(uncBytes);
         }
         deflater.end();
         return ctx.writeAndFlush(footer, promise);


### PR DESCRIPTION
Motivation:

JdkZlibDecoder/Encoder uses many manual `readByte()` calls, which could be replaced with a single `readIntLE` and alternative commands.

Modification:

Replace multiple `readByte()` commands with a single `readIntLE`

Result:

Code is easier to read and more effective, + added a bunch of tests.