### PR TITLE
Guard recomputed offset access with hasUnsafe

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -860,7 +860,9 @@ final class AdaptivePoolingAllocator {
                     }
                     @Override
                     protected long unsafeOffset() {
-                        return REFCNT_FIELD_OFFSET;
+                        // on native image, REFCNT_FIELD_OFFSET can be recomputed even with Unsafe unavailable, so we
+                        // need to guard here
+                        return PlatformDependent.hasUnsafe() ? REFCNT_FIELD_OFFSET : -1;
                     }
                 };
 


### PR DESCRIPTION
Motivation:

On native image, REFCNT_FIELD_OFFSET is recomputed at build time as declared in `AdaptivePoolingAllocatorSubstitution`. The value will be set even when hasUnsafe is false, which would normally lead to `getUnsafeOffset` returning -1. That makes ReferenceCountUpdater assume unsafe is available, and attempt to use it, causing this NPE:

```
java.lang.NullPointerException: null
        at io.netty.util.internal.PlatformDependent0.safeConstructPutInt(PlatformDependent0.java:681)
        at io.netty.util.internal.PlatformDependent.safeConstructPutInt(PlatformDependent.java:569)
        at io.netty.util.internal.ReferenceCountUpdater.setInitialValue(ReferenceCountUpdater.java:67)
        at io.netty.buffer.AdaptivePoolingAllocator$Chunk.<init>(AdaptivePoolingAllocator.java:884)
        at io.netty.buffer.AdaptivePoolingAllocator$Magazine.newChunkAllocation(AdaptivePoolingAllocator.java:805)
        at io.netty.buffer.AdaptivePoolingAllocator$Magazine.allocate(AdaptivePoolingAllocator.java:703)
        at io.netty.buffer.AdaptivePoolingAllocator$Magazine.tryAllocate(AdaptivePoolingAllocator.java:581)
        at io.netty.buffer.AdaptivePoolingAllocator.allocate(AdaptivePoolingAllocator.java:247)
        at io.netty.buffer.AdaptivePoolingAllocator.allocate(AdaptivePoolingAllocator.java:217)
        at io.netty.buffer.AdaptiveByteBufAllocator.newHeapBuffer(AdaptiveByteBufAllocator.java:65)
        at io.netty.buffer.AbstractByteBufAllocator.heapBuffer(AbstractByteBufAllocator.java:169)
        at io.netty.buffer.AbstractByteBufAllocator.heapBuffer(AbstractByteBufAllocator.java:155)
        at io.netty.buffer.AbstractByteBufAllocator.buffer(AbstractByteBufAllocator.java:110)
        at io.micronaut.http.server.tck.netty.tests.Test.test(Test.java:15)
```

Modification:

Guard access to REFCNT_FIELD_OFFSET with a further hasUnsafe call.

Result:

No exception.