### PR TITLE
fix type token import (#15342) (#15347)

### DIFF
--- a/transport/src/test/java/io/netty/nativeimage/ChannelHandlerMetadataUtil.java
+++ b/transport/src/test/java/io/netty/nativeimage/ChannelHandlerMetadataUtil.java
@@ -15,9 +15,9 @@
  */
 package io.netty.nativeimage;
 
-import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.NativeImageHandlerMetadataTest;
 import org.junit.jupiter.api.Assertions;
@@ -48,7 +48,6 @@ import java.util.Set;
  */
 public final class ChannelHandlerMetadataUtil {
 
-    @SuppressWarnings("UnstableApiUsage")
     private static final Type HANDLER_METADATA_LIST_TYPE = new TypeToken<List<HandlerMetadata>>() {
     }.getType();
     private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();


### PR DESCRIPTION
Motivation:
The ChannelHandlerMetadataUtil is using a TypeToken import from guava which is no longer available.

Modification:
Use the gson TypeToken class instead of the guava one.

Result:
No more test failures due to the missing class.