### PR TITLE
Upgrade Blockhound to fix usage on Java25+ (#15356)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1273,7 +1273,7 @@
       <dependency>
         <groupId>io.projectreactor.tools</groupId>
         <artifactId>blockhound</artifactId>
-        <version>1.0.11.RELEASE</version>
+        <version>1.0.13.RELEASE</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/transport-blockhound-tests/pom.xml
+++ b/transport-blockhound-tests/pom.xml
@@ -131,6 +131,24 @@
         <argLine.common>-XX:+AllowRedefinitionToAddDeleteMethods</argLine.common>
       </properties>
     </profile>
+    <profile>
+      <id>java24</id>
+      <activation>
+        <jdk>24</jdk>
+      </activation>
+      <properties>
+        <argLine.common>-XX:+AllowRedefinitionToAddDeleteMethods</argLine.common>
+      </properties>
+    </profile>
+    <profile>
+      <id>java25</id>
+      <activation>
+        <jdk>25</jdk>
+      </activation>
+      <properties>
+        <argLine.common>-XX:+AllowRedefinitionToAddDeleteMethods -XX:+EnableDynamicAgentLoading</argLine.common>
+      </properties>
+    </profile>
   </profiles>
 
   <properties>


### PR DESCRIPTION
Motivation:

We need to upgrade blockhound to be able to use it on Java25+

Modifications:

- Upgrade blockhound
- Enable blockhound test for Java25

Result:

Be able to use blockhound on java25+