### PR TITLE
Remove guava from dependencies (#15348)

### DIFF
--- a/codec-dns/pom.xml
+++ b/codec-dns/pom.xml
@@ -96,11 +96,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>
 

--- a/codec-haproxy/pom.xml
+++ b/codec-haproxy/pom.xml
@@ -85,11 +85,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>
 

--- a/codec-http/pom.xml
+++ b/codec-http/pom.xml
@@ -148,11 +148,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>
 

--- a/codec-http2/pom.xml
+++ b/codec-http2/pom.xml
@@ -168,11 +168,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>
 

--- a/codec-memcache/pom.xml
+++ b/codec-memcache/pom.xml
@@ -90,11 +90,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
 </project>

--- a/codec-mqtt/pom.xml
+++ b/codec-mqtt/pom.xml
@@ -94,10 +94,5 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/codec-redis/pom.xml
+++ b/codec-redis/pom.xml
@@ -90,11 +90,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
 </project>

--- a/codec-smtp/pom.xml
+++ b/codec-smtp/pom.xml
@@ -90,11 +90,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>
 

--- a/codec-socks/pom.xml
+++ b/codec-socks/pom.xml
@@ -90,11 +90,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>
 

--- a/codec-stomp/pom.xml
+++ b/codec-stomp/pom.xml
@@ -90,11 +90,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>
 

--- a/codec-xml/pom.xml
+++ b/codec-xml/pom.xml
@@ -89,11 +89,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>
 

--- a/codec/pom.xml
+++ b/codec/pom.xml
@@ -184,11 +184,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>
 

--- a/handler-proxy/pom.xml
+++ b/handler-proxy/pom.xml
@@ -119,11 +119,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>
 

--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -156,11 +156,6 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1239,13 +1239,6 @@
         <scope>test</scope>
       </dependency>
 
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>33.4.8-jre</version>
-        <scope>test</scope>
-      </dependency>
-
       <!-- Test suite dependency for generating a compressed heap dump file -->
       <dependency>
         <groupId>org.tukaani</groupId>

--- a/resolver-dns/pom.xml
+++ b/resolver-dns/pom.xml
@@ -126,11 +126,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>
 

--- a/transport-sctp/pom.xml
+++ b/transport-sctp/pom.xml
@@ -90,11 +90,6 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -86,11 +86,6 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>
 


### PR DESCRIPTION
Motivation:

guava is not used anymore, let's remove it from our dependencies

Modifications:

Remove unused dependency

Result:

Cleanup dependencies
