### PR TITLE
Fix adjust some unnecessary typos in ByteBuf

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBuf.java
@@ -96,7 +96,7 @@ import java.nio.charset.UnsupportedCharsetException;
  *
  * <h4>Writable bytes</h4>
  *
- * This segment is a undefined space which needs to be filled.  Any operation
+ * This segment is an undefined space which needs to be filled.  Any operation
  * whose name starts with {@code write} will write the data at the current
  * {@link #writerIndex() writerIndex} and increase it by the number of written
  * bytes.  If the argument of the write operation is also a {@link ByteBuf},
@@ -1293,7 +1293,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf>, 
      * @param length the maximum number of bytes to transfer
      *
      * @return the actual number of bytes read in from the specified channel.
-     *         {@code -1} if the specified channel is closed or it reached EOF.
+     *         {@code -1} if the specified channel is closed or reached EOF.
      *
      * @throws IndexOutOfBoundsException
      *         if the specified {@code index} is less than {@code 0} or
@@ -1313,7 +1313,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf>, 
      * @param length the maximum number of bytes to transfer
      *
      * @return the actual number of bytes read in from the specified channel.
-     *         {@code -1} if the specified channel is closed or it reached EOF.
+     *         {@code -1} if the specified channel is closed or reached EOF.
      *
      * @throws IndexOutOfBoundsException
      *         if the specified {@code index} is less than {@code 0} or
@@ -2028,7 +2028,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf>, 
      * @param length the maximum number of bytes to transfer
      *
      * @return the actual number of bytes read in from the specified channel.
-     *         {@code -1} if the specified channel is closed or it reached EOF.
+     *         {@code -1} if the specified channel is closed or reached EOF.
      *
      * @throws IOException
      *         if the specified channel threw an exception during I/O
@@ -2047,7 +2047,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf>, 
      * @param length the maximum number of bytes to transfer
      *
      * @return the actual number of bytes read in from the specified channel.
-     *         {@code -1} if the specified channel is closed or it reached EOF.
+     *         {@code -1} if the specified channel is closed or reached EOF.
      *
      * @throws IOException
      *         if the specified channel threw an exception during I/O
@@ -2068,7 +2068,6 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf>, 
     /**
      * Writes the specified {@link CharSequence} at the current {@code writerIndex} and increases
      * the {@code writerIndex} by the written bytes.
-     * in this buffer.
      * If {@code this.writableBytes} is not large enough to write the whole sequence,
      * {@link #ensureWritable(int)} will be called in an attempt to expand capacity to accommodate.
      *


### PR DESCRIPTION
Motivation:

Fix adjust some unnecessary typos in ByteBuf

Modification:

Fix adjust some unnecessary typos in ByteBuf

Result:

adjust some grammar errors and remove uncessary "in this buffer."
