### PR TITLE
Optimize capacity bumping for adaptive ByteBufs (#15080)

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/AdaptivePoolingAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptivePoolingAllocatorTest.java
@@ -37,24 +37,27 @@ class AdaptivePoolingAllocatorTest implements Supplier<String> {
 
     @Test
     void sizeBucketComputations() throws Exception {
-        assertSizeBucket(0, 8 * 1024);
-        assertSizeBucket(1, 16 * 1024);
-        assertSizeBucket(2, 32 * 1024);
-        assertSizeBucket(3, 64 * 1024);
-        assertSizeBucket(4, 128 * 1024);
-        assertSizeBucket(5, 256 * 1024);
-        assertSizeBucket(6, 512 * 1024);
-        assertSizeBucket(7, 1024 * 1024);
-        // The sizeBucket function will be used for sizes up to 10 MiB
-        assertSizeBucket(7, 2 * 1024 * 1024);
-        assertSizeBucket(7, 3 * 1024 * 1024);
-        assertSizeBucket(7, 4 * 1024 * 1024);
-        assertSizeBucket(7, 5 * 1024 * 1024);
-        assertSizeBucket(7, 6 * 1024 * 1024);
-        assertSizeBucket(7, 7 * 1024 * 1024);
-        assertSizeBucket(7, 8 * 1024 * 1024);
-        assertSizeBucket(7, 9 * 1024 * 1024);
-        assertSizeBucket(7, 10 * 1024 * 1024);
+        assertSizeBucket(0, 256);
+        assertSizeBucket(1, 512);
+        assertSizeBucket(2, 1024);
+        assertSizeBucket(3, 2048);
+        assertSizeBucket(4, 4096);
+        assertSizeBucket(5, 8 * 1024);
+        assertSizeBucket(6, 16 * 1024);
+        assertSizeBucket(7, 32 * 1024);
+        assertSizeBucket(8, 64 * 1024);
+        assertSizeBucket(9, 128 * 1024);
+        assertSizeBucket(10, 256 * 1024);
+        assertSizeBucket(11, 512 * 1024);
+        assertSizeBucket(12, 1024 * 1024);
+        // The sizeBucket function will be used for sizes up to 8 MiB
+        assertSizeBucket(13, 2 * 1024 * 1024);
+        assertSizeBucket(14, 3 * 1024 * 1024);
+        assertSizeBucket(14, 4 * 1024 * 1024);
+        assertSizeBucket(15, 5 * 1024 * 1024);
+        assertSizeBucket(15, 6 * 1024 * 1024);
+        assertSizeBucket(15, 7 * 1024 * 1024);
+        assertSizeBucket(15, 8 * 1024 * 1024);
     }
 
     private void assertSizeBucket(int expectedSizeBucket, int maxSizeIncluded) {

--- a/microbench/src/main/java/io/netty/microbench/buffer/ByteBufAllocateAndGrowBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/ByteBufAllocateAndGrowBenchmark.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.buffer;
+
+import io.netty.buffer.AdaptiveByteBufAllocator;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import org.openjdk.jmh.annotations.AuxCounters;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * This class benchmarks different allocators with different allocation sizes.
+ */
+@State(Scope.Benchmark)
+public class ByteBufAllocateAndGrowBenchmark extends AbstractMicrobenchmark {
+
+    private static final ByteBufAllocator pooledAllocator = PooledByteBufAllocator.DEFAULT;
+    private static final ByteBufAllocator adaptiveAllocator = new AdaptiveByteBufAllocator();
+
+    private static final int MAX_LIVE_BUFFERS = 2048;
+    private static final Random rand = new Random();
+    private static final ByteBuf[] pooledDirectBuffers = new ByteBuf[MAX_LIVE_BUFFERS];
+    private static final ByteBuf[] adaptiveDirectBuffers = new ByteBuf[MAX_LIVE_BUFFERS];
+
+    @Param({
+            "00256",
+            "01024",
+            "04096",
+            "16384",
+            "65536",
+    })
+    public int size;
+
+    @TearDown
+    public void releaseBuffers() {
+        List<ByteBuf[]> bufferLists = Arrays.asList(
+                pooledDirectBuffers,
+                adaptiveDirectBuffers);
+        for (ByteBuf[] bufs : bufferLists) {
+            for (ByteBuf buf : bufs) {
+                if (buf != null && buf.refCnt() > 0) {
+                    buf.release();
+                }
+            }
+            Arrays.fill(bufs, null);
+        }
+    }
+
+    @Benchmark
+    public void pooledDirectAllocAndFree(BufStats stats) {
+        int idx = rand.nextInt(pooledDirectBuffers.length);
+        ByteBuf oldBuf = pooledDirectBuffers[idx];
+        if (oldBuf != null) {
+            oldBuf.release();
+        }
+        ByteBuf buf = pooledAllocator.directBuffer();
+        expandBuffer(buf, stats);
+        pooledDirectBuffers[idx] = buf;
+    }
+
+    @Benchmark
+    public void adaptiveDirectAllocAndFree(BufStats stats) {
+        int idx = rand.nextInt(adaptiveDirectBuffers.length);
+        ByteBuf oldBuf = adaptiveDirectBuffers[idx];
+        if (oldBuf != null) {
+            oldBuf.release();
+        }
+        ByteBuf buf = adaptiveAllocator.directBuffer();
+        expandBuffer(buf, stats);
+        adaptiveDirectBuffers[idx] = buf;
+    }
+
+    private void expandBuffer(ByteBuf buf, BufStats stats) {
+        stats.record(buf);
+        while (buf.capacity() < size) {
+            buf.capacity(2 * buf.capacity());
+            stats.record(buf);
+        }
+    }
+
+    @State(Scope.Thread)
+    @AuxCounters
+    public static class BufStats {
+        long bufCounts;
+        long bufSizeSum;
+        long bufFastCapSum;
+
+        void record(ByteBuf byteBuf) {
+            bufCounts++;
+            bufSizeSum += byteBuf.capacity();
+            bufFastCapSum += byteBuf.maxFastWritableBytes();
+        }
+
+        public double avgSize() {
+            return bufSizeSum / (double) bufCounts;
+        }
+
+        public double avgFastCap() {
+            return bufFastCapSum / (double) bufCounts;
+        }
+    }
+}

--- a/microbench/src/main/java/io/netty/microbench/buffer/ByteBufAllocatorBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/ByteBufAllocatorBenchmark.java
@@ -22,12 +22,13 @@ import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.microbench.util.AbstractMicrobenchmark;
 import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.annotations.TearDown;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
 
 /**
@@ -61,6 +62,27 @@ public class ByteBufAllocatorBenchmark extends AbstractMicrobenchmark {
             "65536",
     })
     public int size;
+
+    @TearDown
+    public void releaseBuffers() {
+        List<ByteBuf[]> bufferLists = Arrays.asList(
+                unpooledHeapBuffers,
+                unpooledDirectBuffers,
+                pooledHeapBuffers,
+                pooledDirectBuffers,
+                defaultPooledHeapBuffers,
+                defaultPooledDirectBuffers,
+                adaptiveHeapBuffers,
+                adaptiveDirectBuffers);
+        for (ByteBuf[] bufs : bufferLists) {
+            for (ByteBuf buf : bufs) {
+                if (buf != null && buf.refCnt() > 0) {
+                    buf.release();
+                }
+            }
+            Arrays.fill(bufs, null);
+        }
+    }
 
     @Benchmark
     public void unpooledHeapAllocAndFree() {


### PR DESCRIPTION
Motivation:
It is quite common in downstream code to not specify a buffer size when allocating.
People instead rely on the ByteBuf ability to increase its size automatically.
The ByteBufs allocated by the adaptive allocator also support this, but has thus far required a round-trip through the allocator every time. In contrast, the pooled allocator is reserving the chunk run-size when allocating buffers, and very cheaply allow smaller buffers to bump up to the run-size limit.
This is an important performance optimisation in practice. We can do something similar in the adaptive allocator, because we keep statistics about the buffer sizes that we allocate.

Modification:
The adaptive allocator now reserves space equal to the 99-percentile buffer size (though with some reasonable heuristic limits for smaller buffers), when allocating buffers, and allow its ByteBufs to cheaply bump their capacities up to this limit.
We already compute this percentile during histogram rotation, so it is simply a matter of storing this value in the magazine, and then using it when reserving space out of chunks.

The collection of buffer size statistics is now also delayed and moved to when the `ByteBuf` instances are reused. This way, we collect statistics about the _final_ buffer size, rather than the requested sizes or the sizes of capacity bumps.
This prevents oscillations that would otherwise be caused by undersized buffers producing a lot of statistics as they resize to their final size, and then no statistics being produced for the final buffer sizes if they are correctly predicted at allocation time.

Result:
Calls like `ByteBuf.ensureWritable()` will now on average be much cheaper when using the adaptive allocator.

Based on https://github.com/netty/netty/pull/15062
