### PR TITLE
JFR event support

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -99,6 +99,12 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-jfr-stub</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
     <!-- Add dependency on dev-tools as otherwise the build will fail if not installed first manually -->
     <!-- See https://github.com/netty/netty/issues/7842 -->
     <dependency>

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -127,6 +127,8 @@ public final class PlatformDependent {
     private static final String LINUX_ID_LIKE_PREFIX = "ID_LIKE=";
     public static final boolean BIG_ENDIAN_NATIVE_ORDER = ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN;
 
+    private static final boolean JFR;
+
     private static final Cleaner NOOP = new Cleaner() {
         @Override
         public CleanableDirectBuffer allocate(int capacity) {
@@ -231,6 +233,11 @@ public final class PlatformDependent {
             addFilesystemOsClassifiers(availableClassifiers);
         }
         LINUX_OS_CLASSIFIERS = Collections.unmodifiableSet(availableClassifiers);
+
+        JFR = SystemPropertyUtil.getBoolean("io.netty.jfr.enabled", javaVersion() >= 9);
+        if (logger.isDebugEnabled()) {
+            logger.debug("-Dio.netty.jfr.enabled: {}", JFR);
+        }
     }
 
     // For specifications, see https://www.freedesktop.org/software/systemd/man/os-release.html
@@ -1698,6 +1705,13 @@ public final class PlatformDependent {
         }
 
         return "unknown";
+    }
+
+    /**
+     * Check if {@link JfrEvent} is enabled on this platform.
+     */
+    public static boolean jfrEnabled() {
+        return JFR;
     }
 
     private PlatformDependent() {

--- a/common/src/test/java/io/netty/util/internal/JfrEventSafeTest.java
+++ b/common/src/test/java/io/netty/util/internal/JfrEventSafeTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal;
+
+import jdk.jfr.Enabled;
+import jdk.jfr.Event;
+import jdk.jfr.consumer.RecordingStream;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+@SuppressWarnings("Since15")
+public class JfrEventSafeTest {
+    @Test
+    public void test() {
+        // This code should work even on java 8. Other details are tested in JfrEventTest.
+        if (PlatformDependent.jfrEnabled()) {
+            MyEvent event = new MyEvent();
+            event.foo = "bar";
+            event.commit();
+        }
+    }
+
+    @Test
+    public void simple() throws Throwable {
+        assumeTrue(PlatformDependent.javaVersion() >= 17);
+
+        try (RecordingStream stream = new RecordingStream()) {
+            stream.enable(MyEvent.class.getName());
+            CompletableFuture<String> result = new CompletableFuture<>();
+            stream.onEvent(MyEvent.class.getName(), e -> result.complete(e.getString("foo")));
+            stream.startAsync();
+
+            MyEvent event = new MyEvent();
+            event.foo = "bar";
+            event.commit();
+
+            assertEquals("bar", result.get(10, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    public void enableDefaults() throws Throwable {
+        assumeTrue(PlatformDependent.javaVersion() >= 17);
+
+        try (RecordingStream stream = new RecordingStream()) {
+            CompletableFuture<String> result = new CompletableFuture<>();
+            stream.onEvent(DisabledEvent.class.getName(),
+                    e -> result.completeExceptionally(new Exception("Event mistakenly fired")));
+            stream.onEvent(MyEvent.class.getName(),
+                    e -> result.complete(e.getString("foo")));
+            stream.startAsync();
+
+            DisabledEvent disabled = new DisabledEvent();
+            disabled.foo = "baz";
+            disabled.commit();
+
+            MyEvent event = new MyEvent();
+            event.foo = "bar";
+            event.commit();
+
+            assertEquals("bar", result.get(10, TimeUnit.SECONDS));
+        }
+    }
+
+    static final class MyEvent extends Event {
+        String foo;
+    }
+
+    @Enabled(false)
+    static final class DisabledEvent extends Event {
+        String foo;
+    }
+}

--- a/jfr-stub/pom.xml
+++ b/jfr-stub/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2025 The Netty Project
+  ~
+  ~ The Netty Project licenses this file to you under the Apache License,
+  ~ version 2.0 (the "License"); you may not use this file except in compliance
+  ~ with the License. You may obtain a copy of the License at:
+  ~
+  ~   https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.netty</groupId>
+    <artifactId>netty-parent</artifactId>
+    <version>4.2.3.Final-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>netty-jfr-stub</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Netty/JFR Stub</name>
+
+  <properties>
+    <revapi.skip>true</revapi.skip>
+  </properties>
+</project>
+

--- a/jfr-stub/src/main/java/jdk/jfr/Enabled.java
+++ b/jfr-stub/src/main/java/jdk/jfr/Enabled.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package jdk.jfr;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface Enabled {
+    boolean value();
+}

--- a/jfr-stub/src/main/java/jdk/jfr/Event.java
+++ b/jfr-stub/src/main/java/jdk/jfr/Event.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package jdk.jfr;
+
+public abstract class Event {
+    public final void begin() {
+    }
+
+    public final void end() {
+    }
+
+    public final void commit() {
+    }
+
+    public final boolean isEnabled() {
+        return false;
+    }
+
+    public final boolean shouldCommit() {
+        return false;
+    }
+
+    public final void set(int index, Object value) {
+    }
+}

--- a/jfr-stub/src/main/java/jdk/jfr/EventSettings.java
+++ b/jfr-stub/src/main/java/jdk/jfr/EventSettings.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package jdk.jfr;
+
+public class EventSettings {
+}

--- a/jfr-stub/src/main/java/jdk/jfr/consumer/RecordedEvent.java
+++ b/jfr-stub/src/main/java/jdk/jfr/consumer/RecordedEvent.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package jdk.jfr.consumer;
+
+public class RecordedEvent {
+    public String getString(String fieldName) {
+        return null;
+    }
+}

--- a/jfr-stub/src/main/java/jdk/jfr/consumer/RecordingStream.java
+++ b/jfr-stub/src/main/java/jdk/jfr/consumer/RecordingStream.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package jdk.jfr.consumer;
+
+import jdk.jfr.EventSettings;
+
+import java.util.function.Consumer;
+
+@SuppressWarnings("Since15")
+public class RecordingStream implements AutoCloseable {
+    public void startAsync() {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    public EventSettings enable(String s) {
+        return null;
+    }
+
+    public void onEvent(String name, Consumer<RecordedEvent> consumer) {
+    }
+}

--- a/jfr-stub/src/main/java/jdk/jfr/consumer/package-info.java
+++ b/jfr-stub/src/main/java/jdk/jfr/consumer/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Stubs to compile JFR events on Java 8. Not guaranteed to be stable API!
+ */
+package jdk.jfr.consumer;

--- a/jfr-stub/src/main/java/jdk/jfr/package-info.java
+++ b/jfr-stub/src/main/java/jdk/jfr/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Stubs to compile JFR events on Java 8. Not guaranteed to be stable API!
+ */
+package jdk.jfr;

--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -173,6 +173,12 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-jfr-stub</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
       <version>${project.version}</version>

--- a/microbench/src/main/java/io/netty/util/JfrBenchmark.java
+++ b/microbench/src/main/java/io/netty/util/JfrBenchmark.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util;
+
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import jdk.jfr.Event;
+import jdk.jfr.consumer.RecordingStream;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.TearDown;
+
+import java.util.concurrent.TimeUnit;
+
+@SuppressWarnings("Since15")
+@Fork(1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Measurement(time = 10, timeUnit = TimeUnit.SECONDS)
+public class JfrBenchmark extends AbstractMicrobenchmark {
+    @Param({"true", "false"})
+    boolean enabled;
+
+    private RecordingStream stream;
+
+    @Setup
+    public void setup() {
+        stream = new RecordingStream();
+        if (enabled) {
+            stream.enable(NettyEvent.class.getName());
+        } else {
+            stream.disable(NettyEvent.class.getName());
+        }
+        stream.startAsync();
+    }
+
+    @TearDown
+    public void teardown() {
+        stream.close();
+    }
+
+    @Benchmark
+    public void nettyEvent() {
+        NettyEvent event = new NettyEvent();
+        event.begin();
+        event.end();
+        event.foo = "bar";
+        event.commit();
+    }
+
+    static final class NettyEvent extends Event {
+        String foo;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -799,6 +799,7 @@
     <module>testsuite-native-image-client-runtime-init</module>
     <module>transport-blockhound-tests</module>
     <module>microbench</module>
+    <module>jfr-stub</module>
     <module>bom</module>
   </modules>
 


### PR DESCRIPTION
Motivation:

JFR events offer a low-overhead approach to collecting application metrics. Unfortunately only supported since Java 9.

Modification:

Add a jfr-stub module that contains stubs of the JFR classes that we need, so that the project compiles. For the runtime check, add a `PlatformDependent.jfrEnabled()` method.

I also investigated but discarded two other approaches:

- A purely reflective approach is possible, but requires constructing events dynamically instead of through the normal extension pattern. Performance is worse with dynamic events: Even if the event is disabled, there's a few ns overhead, whereas for a normal event it's only about 0.5ns.
- I tried an approach where a JfrEvent class compiled with Java 9 was exposed that downstream code could extend, instead of directly extending jdk.jfr.Event. This turned out not to work because all netty projects are built with `javac -release 1.8`, which prevents extending from a class that in turn extends from a Java 9 class.

Result:

Allow using JFR events in netty.

Only a draft PR to test the build for now, next come allocation events.