### PR TITLE
Fix bug in capacity(int) for the adaptive allocator (#15367)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -1092,7 +1092,14 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
             int oldCapacity = length;
             AbstractByteBuf oldRoot = rootParent();
             length = 0; // Don't record buffer size statistics for this allocation.
-            allocator.allocate(newCapacity, maxCapacity(), this);
+            try {
+                allocator.allocate(newCapacity, maxCapacity(), this);
+            } finally {
+                if (length == 0) {
+                    // Allocation failed. Restore capacity.
+                    length = oldCapacity;
+                }
+            }
             oldRoot.getBytes(baseOldRootIndex, this, 0, oldCapacity);
             chunk.release();
             this.readerIndex = readerIndex;


### PR DESCRIPTION
Motivation:
Calling `ByteBuf.capacity(int)` may cause internal allocation as the buffer is expanded. This allocation can fail, and we should not leave the buffer in an inconsistent state if that happens.

Modification:
Restore the temporarily overwritten capacity if the internal allocation fails.

Result:
It's no longer possible to end up with zero-capacity buffers if internal allocation fails.

Fixes https://github.com/netty/netty/issues/15341