### PR TITLE
Testsuite: Ensure counter is updated before write happens so lastIdx …

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/sctp/SctpEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/sctp/SctpEchoTest.java
@@ -172,11 +172,13 @@ public class SctpEchoTest extends AbstractSctpTest {
                 assertEquals(data[i + lastIdx], actual[i]);
             }
 
+            // Update the counter before calling write(...) as write could in theory trigger another channelRead(...)
+            // which then would use the wrong lastIdx.
+            counter += actual.length;
+
             if (channel.parent() != null) {
                 channel.writeAndFlush(randomBufferType(channel.alloc(), actual, 0, actual.length));
             }
-
-            counter += actual.length;
         }
 
         @Override

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketEchoTest.java
@@ -280,12 +280,13 @@ public class SocketEchoTest extends AbstractSocketTest {
                 assertEquals(data[i + lastIdx], actual[i]);
             }
 
-            if (channel.parent() != null) {
+            // Update the counter before calling write(...) as write could in theory trigger another channelRead(...)
+            // which then would use the wrong lastIdx.
+            counter += actual.length;
 
+            if (channel.parent() != null) {
                 channel.write(randomBufferType(channel.alloc(), actual, 0, actual.length));
             }
-
-            counter += actual.length;
         }
 
         @Override

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFixedLengthEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFixedLengthEchoTest.java
@@ -171,11 +171,13 @@ public class SocketFixedLengthEchoTest extends AbstractSocketTest {
                 assertEquals(data[i + lastIdx], actual[i]);
             }
 
+            // Update the counter before calling write(...) as write could in theory trigger another channelRead(...)
+            // which then would use the wrong lastIdx.
+            counter += actual.length;
+
             if (channel.parent() != null) {
                 channel.write(msg.retain());
             }
-
-            counter += actual.length;
         }
 
         @Override


### PR DESCRIPTION
…is always correct

Motivation:

We should increment the counter (which is used for the lastIdx) before we trigger another operation on the Channel. This is needed as any operation might result in having `fireChannelRead(...)` called at the end and so we could end up re-entrance into the `channelRead` method and then use the wrong value for the lastIdx.

Modifications:

Move counter update before channel.write(...)

Result:

More robust tests