### PR TITLE
Merge in changes from netty-incubator-codec-quic 0.0.73.Final

### DIFF
--- a/.github/workflows/ci-pr-reports.yml
+++ b/.github/workflows/ci-pr-reports.yml
@@ -31,6 +31,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Cancel running jobs when a new push happens to the same branch as otherwise it will
+# tie up too many resources without providing much value.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     permissions:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,6 +36,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Cancel running jobs when a new push happens to the same branch as otherwise it will
+# tie up too many resources without providing much value.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     permissions:

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/GroupsConverter.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/GroupsConverter.java
@@ -15,35 +15,28 @@
  */
 package io.netty.handler.codec.quic;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * Convert java naming to BoringSSL naming if possible and if not return the original name.
  */
 final class GroupsConverter {
 
-    private static final Map<String, String> mappings;
-
-    static {
-        // See https://tools.ietf.org/search/rfc4492#appendix-A and https://www.java.com/en/configure_crypto.html
-        Map<String, String> map = new HashMap<String, String>();
-        map.put("secp224r1", "P-224");
-        map.put("prime256v1", "P-256");
-        map.put("secp256r1", "P-256");
-        map.put("secp384r1", "P-384");
-        map.put("secp521r1", "P-521");
-        map.put("x25519", "X25519");
-        mappings = Collections.unmodifiableMap(map);
-    }
-
+    // See https://tools.ietf.org/search/rfc4492#appendix-A and https://www.java.com/en/configure_crypto.html
     static String toBoringSSL(String key) {
-        String mapping = mappings.get(key);
-        if (mapping == null) {
-            return key;
+        switch (key) {
+            case "secp224r1":
+                return "P-224";
+            case "prime256v1":
+            case "secp256r1":
+                return "P-256";
+            case "secp384r1":
+                return "P-384";
+            case "secp521r1":
+                return "P-521";
+            case "x25519":
+                return "X25519";
+            default:
+                return key;
         }
-        return mapping;
     }
 
     private GroupsConverter() { }

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/Quiche.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/Quiche.java
@@ -420,7 +420,7 @@ final class Quiche {
      * See
      * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L274">quiche_conn_stream_capacity</a>.
      */
-    static native int quiche_conn_stream_capacity(long connAddr, long streamId);
+    static native long quiche_conn_stream_capacity(long connAddr, long streamId);
 
     /**
      * See

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicChannel.java
@@ -1056,7 +1056,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         freeIfClosed();
     }
 
-    int streamCapacity(long streamId) {
+    long streamCapacity(long streamId) {
         QuicheQuicConnection conn = connection;
         if (conn.isClosed()) {
             return 0;
@@ -1087,7 +1087,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                             long streamId = writableStreams[i];
                             QuicheQuicStreamChannel streamChannel = streams.get(streamId);
                             if (streamChannel != null) {
-                                int capacity = Quiche.quiche_conn_stream_capacity(connAddr, streamId);
+                                long capacity = Quiche.quiche_conn_stream_capacity(connAddr, streamId);
                                 if (streamChannel.writable(capacity)) {
                                     mayNeedWrite = true;
                                 }

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicStreamChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicStreamChannel.java
@@ -75,7 +75,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
     private volatile boolean inputShutdown;
     private volatile boolean outputShutdown;
     private volatile QuicStreamPriority priority;
-    private volatile int capacity;
+    private volatile long capacity;
 
     QuicheQuicStreamChannel(QuicheQuicChannel parent, long streamId) {
         this.parent = parent;
@@ -412,7 +412,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
     /**
      * Stream writability changed.
      */
-    boolean writable(int capacity) {
+    boolean writable(long capacity) {
         assert eventLoop().inEventLoop();
         if (capacity < 0) {
             // If the value is negative its a quiche error.
@@ -423,7 +423,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
                         // If STOP_SENDING is received we should not close the channel but just fail all queued writes.
                         return false;
                     } else {
-                        queue.removeAndFailAll(Quiche.convertToException(capacity));
+                        queue.removeAndFailAll(Quiche.convertToException((int) capacity));
                     }
                 } else if (capacity == Quiche.QUICHE_ERR_STREAM_STOPPED) {
                     // If STOP_SENDING is received we should not close the channel
@@ -858,7 +858,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
                     int res = parent().streamSend(streamId(), buffer, fin);
 
                     // Update the capacity as well.
-                    int cap = parent.streamCapacity(streamId());
+                    long cap = parent.streamCapacity(streamId());
                     if (cap >= 0) {
                         capacity = cap;
                     }

--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -60,7 +60,7 @@
     <quicheHomeIncludeDir>${quicheHomeDir}/quiche/include</quicheHomeIncludeDir>
     <quicheRepository>https://github.com/cloudflare/quiche</quicheRepository>
     <quicheBranch>master</quicheBranch>
-    <quicheCommitSha>68c296009f87a10e1cb935c5879e53bcc412d00c</quicheCommitSha>
+    <quicheCommitSha>70d6d3e233568e906e66179a56c93cf9b0616899</quicheCommitSha>
     <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
     <templateDir>${project.build.directory}/template</templateDir>
     <cargoTarget />

--- a/codec-native-quic/src/main/c/netty_quic_boringssl.c
+++ b/codec-native-quic/src/main/c/netty_quic_boringssl.c
@@ -356,12 +356,12 @@ enum ssl_verify_result_t quic_SSL_cert_custom_verify(SSL* ssl, uint8_t *out_aler
     }
 
     const char* authentication_method = NULL;
-    STACK_OF(SSL_CIPHER) *ciphers = SSL_get_ciphers(ssl);
-    if (ciphers == NULL || sk_SSL_CIPHER_num(ciphers) <= 0) {
+    const SSL_CIPHER* cipher = SSL_get_current_cipher(ssl);
+    if (cipher == NULL) {
         // No cipher available so return UNKNOWN.
         authentication_method = "UNKNOWN";
     } else {
-        authentication_method = SSL_CIPHER_get_kx_name(sk_SSL_CIPHER_value(ciphers, 0));
+        authentication_method = SSL_CIPHER_get_kx_name(cipher);
         if (authentication_method == NULL) {
             authentication_method = "UNKNOWN";
         }

--- a/codec-native-quic/src/main/c/netty_quic_quiche.c
+++ b/codec-native-quic/src/main/c/netty_quic_quiche.c
@@ -504,8 +504,8 @@ static jint netty_quiche_conn_stream_shutdown(JNIEnv* env, jclass clazz, jlong c
     return (jint) quiche_conn_stream_shutdown((quiche_conn *) conn, (uint64_t) stream_id,  (enum quiche_shutdown) direction, (uint64_t) err);
 }
 
-static jint netty_quiche_conn_stream_capacity(JNIEnv* env, jclass clazz, jlong conn, jlong stream_id) {
-    return (jint) quiche_conn_stream_capacity((quiche_conn *) conn, (uint64_t) stream_id);
+static jlong netty_quiche_conn_stream_capacity(JNIEnv* env, jclass clazz, jlong conn, jlong stream_id) {
+    return (jlong) quiche_conn_stream_capacity((quiche_conn *) conn, (uint64_t) stream_id);
 }
 
 static jboolean netty_quiche_conn_stream_finished(JNIEnv* env, jclass clazz, jlong conn, jlong stream_id) {
@@ -1184,7 +1184,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "quiche_conn_stream_recv", "(JJJIJ)I", (void *) netty_quiche_conn_stream_recv },
   { "quiche_conn_stream_send", "(JJJIZ)I", (void *) netty_quiche_conn_stream_send },
   { "quiche_conn_stream_shutdown", "(JJIJ)I", (void *) netty_quiche_conn_stream_shutdown },
-  { "quiche_conn_stream_capacity", "(JJ)I", (void *) netty_quiche_conn_stream_capacity },
+  { "quiche_conn_stream_capacity", "(JJ)J", (void *) netty_quiche_conn_stream_capacity },
   { "quiche_conn_stream_finished", "(JJ)Z", (void *) netty_quiche_conn_stream_finished },
   { "quiche_conn_close", "(JZJJI)I", (void *) netty_quiche_conn_close },
   { "quiche_conn_is_established", "(J)Z", (void *) netty_quiche_conn_is_established },


### PR DESCRIPTION
Motivation:

This catches Netty 4.2 up on the latest changes from the incubator QUIC repository.

Modification:

Merge in the changes, then resolve the conflicts.

Result:

Up to date QUIC for Netty 4.2