### PR TITLE
AdaptiveByteBuf: Fix AdaptiveByteBuf.maxFastWritableBytes() to take w…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -1066,7 +1066,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
 
         @Override
         public int maxFastWritableBytes() {
-            return maxFastCapacity;
+            return Math.min(maxFastCapacity, maxCapacity()) - writerIndex;
         }
 
         @Override

--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
@@ -6280,4 +6280,13 @@ public abstract class AbstractByteBufTest {
             assertTrue(nioBuffer.isReadOnly());
         }
     }
+
+    @Test
+    public void testMaxFastWritableBytesTracksWrittenBytes() {
+        final ByteBuf buf = newBuffer(4, 10);
+        int max = buf.maxFastWritableBytes();
+        buf.writeByte(1);
+        assertEquals(max - 1, buf.maxFastWritableBytes());
+        buf.release();
+    }
 }


### PR DESCRIPTION
…… (#15373)

…riterIndex() into account

Motivation:

AdaptiveByteBuf.maxFastWritableBytes() must take into account how many bytes were already written before as otherwise it might return a too large value.

Modifications:

- Correctly take writerIndex into account
- Add unit test

Result:

Fix AdaptiveByteBuf.maxFastWritableBytes() implementation