### PR TITLE
direct buffer preference should not depend on unsafe presence

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBufAllocator.java
@@ -98,7 +98,7 @@ public abstract class AbstractByteBufAllocator implements ByteBufAllocator {
      *                     a heap buffer
      */
     protected AbstractByteBufAllocator(boolean preferDirect) {
-        directByDefault = preferDirect && PlatformDependent.hasUnsafe();
+        directByDefault = preferDirect && PlatformDependent.canReliabilyFreeDirectBuffers();
         emptyBuf = new EmptyByteBuf(this);
     }
 
@@ -128,7 +128,7 @@ public abstract class AbstractByteBufAllocator implements ByteBufAllocator {
 
     @Override
     public ByteBuf ioBuffer() {
-        if (PlatformDependent.hasUnsafe() || isDirectBufferPooled()) {
+        if (PlatformDependent.canReliabilyFreeDirectBuffers() || isDirectBufferPooled()) {
             return directBuffer(DEFAULT_INITIAL_CAPACITY);
         }
         return heapBuffer(DEFAULT_INITIAL_CAPACITY);
@@ -136,7 +136,7 @@ public abstract class AbstractByteBufAllocator implements ByteBufAllocator {
 
     @Override
     public ByteBuf ioBuffer(int initialCapacity) {
-        if (PlatformDependent.hasUnsafe() || isDirectBufferPooled()) {
+        if (PlatformDependent.canReliabilyFreeDirectBuffers() || isDirectBufferPooled()) {
             return directBuffer(initialCapacity);
         }
         return heapBuffer(initialCapacity);
@@ -144,7 +144,7 @@ public abstract class AbstractByteBufAllocator implements ByteBufAllocator {
 
     @Override
     public ByteBuf ioBuffer(int initialCapacity, int maxCapacity) {
-        if (PlatformDependent.hasUnsafe() || isDirectBufferPooled()) {
+        if (PlatformDependent.canReliabilyFreeDirectBuffers() || isDirectBufferPooled()) {
             return directBuffer(initialCapacity, maxCapacity);
         }
         return heapBuffer(initialCapacity, maxCapacity);

--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufAllocatorTest.java
@@ -41,7 +41,7 @@ public abstract class AbstractByteBufAllocatorTest<T extends AbstractByteBufAllo
 
     @Override
     protected boolean isDirectExpected(boolean preferDirect) {
-        return preferDirect && PlatformDependent.hasUnsafe();
+        return preferDirect && PlatformDependent.canReliabilyFreeDirectBuffers();
     }
 
     @Override

--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -107,7 +107,7 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
     }
 
     @Test
-    public void testIOBuffersAreDirectWhenUnsafeAvailableOrDirectBuffersPooled() {
+    public void testIOBuffersAreDirectWhenCleanerAvailableOrDirectBuffersPooled() {
         PooledByteBufAllocator allocator = newAllocator(true);
         ByteBuf ioBuffer = allocator.ioBuffer();
 
@@ -117,7 +117,7 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
         PooledByteBufAllocator unpooledAllocator = newUnpooledAllocator();
         ioBuffer = unpooledAllocator.ioBuffer();
 
-        if (PlatformDependent.hasUnsafe()) {
+        if (PlatformDependent.canReliabilyFreeDirectBuffers()) {
             assertTrue(ioBuffer.isDirect());
         } else {
             assertFalse(ioBuffer.isDirect());

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -425,6 +425,15 @@ public final class PlatformDependent {
     }
 
     /**
+     * Return {@code true} if the selected cleaner can free direct buffers in a controlled way. This guarantee only
+     * applies for buffers allocated via {@link #allocateDirect(int)} and when using the {@code clean} method of the
+     * returned {@link CleanableDirectBuffer}.
+     */
+    public static boolean canReliabilyFreeDirectBuffers() {
+        return CLEANER != NOOP;
+    }
+
+    /**
      * Returns the maximum memory reserved for direct buffer allocation.
      */
     public static long maxDirectMemory() {


### PR DESCRIPTION
Motivation:
Currently, the preference if a direct buffer should be allocated by, for example, `ByteBufAllocator.buffer()` or `ByteBufAllocator.ioBuffer()` depends on the fact if unsafe is available. It seems like this was originally introduced as only with unsafe it was possible to get the cleaner of a ByteBuffer to clean it. However, with the changes introduced in #15231, it doesn't make sense anymore to depend on this as unsafe could be unavailable but MemorySegments will still be freeable.

Modification:
Switch the check for unsafe to a check that validates if the current cleaner implementation is able to free the allocated buffers (each implementation can do this except the no-op one). This ensures that direct buffers are actually preferred when they're backed by something cleanable and still unpreferred when unsafe is unavailable and buffers cannot be freed in a controlled way.

Result:
Direct buffers will be preferred when they're cleanable in a controlled way unrelated to the fact if unsafe is available.
