### PR TITLE
Wait for EventLoopGroup to shutdown in tests and examples

### DIFF
--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/Lz4FrameEncoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/Lz4FrameEncoderTest.java
@@ -301,12 +301,12 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
             }
         } finally {
             if (serverChannel != null) {
-                serverChannel.close();
+                serverChannel.close().sync();
             }
             if (clientChannel != null) {
-                clientChannel.close();
+                clientChannel.close().sync();
             }
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpClientCodecTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpClientCodecTest.java
@@ -202,9 +202,9 @@ public class HttpClientCodecTest {
             clientChannel.writeAndFlush(new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/"));
             assertTrue(responseReceivedLatch.await(5, SECONDS));
         } finally {
-            sb.config().group().shutdownGracefully();
-            sb.config().childGroup().shutdownGracefully();
-            cb.config().group().shutdownGracefully();
+            sb.config().group().shutdownGracefully().sync();
+            sb.config().childGroup().shutdownGracefully().sync();
+            cb.config().group().shutdownGracefully().sync();
         }
     }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorTest.java
@@ -512,8 +512,8 @@ public class HttpContentCompressorTest {
             if (server != null) {
                 server.close().sync();
             }
-            compressorGroup.shutdownGracefully();
-            localGroup.shutdownGracefully();
+            compressorGroup.shutdownGracefully().sync();
+            localGroup.shutdownGracefully().sync();
         }
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
@@ -75,8 +75,8 @@ public class DefaultHttp2ConnectionTest {
     }
 
     @AfterAll
-    public static void afterClass() {
-        group.shutdownGracefully();
+    public static void afterClass() throws Exception {
+        group.shutdownGracefully().sync();
     }
 
     @BeforeEach

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2PushPromiseFrameTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2PushPromiseFrameTest.java
@@ -97,8 +97,8 @@ public class DefaultHttp2PushPromiseFrameTest {
     }
 
     @AfterEach
-    public void shutdown() {
-        eventLoopGroup.shutdownGracefully();
+    public void shutdown() throws Exception {
+        eventLoopGroup.shutdownGracefully().sync();
     }
 
     private final class ServerHandler extends Http2ChannelDuplexHandler {

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3FrameToHttpObjectCodecTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3FrameToHttpObjectCodecTest.java
@@ -1071,7 +1071,7 @@ data.release();
             assertThat(last, notNullValue());
             last.release();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3SpecTestServer.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3SpecTestServer.java
@@ -112,7 +112,7 @@ public final class Http3SpecTestServer {
             channel.eventLoop().submit(() -> System.out.println("H3SPEC_SERVER_READY"));
             channel.closeFuture().sync();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/example/Http3ClientExample.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/example/Http3ClientExample.java
@@ -106,7 +106,7 @@ public final class Http3ClientExample {
             quicChannel.close().sync();
             channel.close().sync();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/example/Http3ServerExample.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/example/Http3ServerExample.java
@@ -117,7 +117,7 @@ public final class Http3ServerExample {
                     .bind(new InetSocketAddress(port)).sync().channel();
             channel.closeFuture().sync();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/example/QuicClientExample.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/example/QuicClientExample.java
@@ -105,7 +105,7 @@ public final class QuicClientExample {
             quicChannel.closeFuture().sync();
             channel.close().sync();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/example/QuicClientZeroRTTExample.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/example/QuicClientZeroRTTExample.java
@@ -113,7 +113,7 @@ public final class QuicClientZeroRTTExample {
             quicChannel.closeFuture().sync();
             channel.close().sync();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/example/QuicServerExample.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/example/QuicServerExample.java
@@ -118,7 +118,7 @@ public final class QuicServerExample {
                     .bind(new InetSocketAddress(9999)).sync().channel();
             channel.closeFuture().sync();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/example/QuicServerSoReusePortExample.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/example/QuicServerSoReusePortExample.java
@@ -150,7 +150,7 @@ public final class QuicServerSoReusePortExample {
                 channel.closeFuture().sync();
             }
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/example/QuicServerZeroRTTExample.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/example/QuicServerZeroRTTExample.java
@@ -114,7 +114,7 @@ public final class QuicServerZeroRTTExample {
                     .bind(new InetSocketAddress(9999)).sync().channel();
             channel.closeFuture().sync();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/common/src/test/java/io/netty/util/concurrent/DefaultPromiseTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/DefaultPromiseTest.java
@@ -330,7 +330,7 @@ public class DefaultPromiseTest {
     }
 
     @Test
-    public void testSignalRace() {
+    public void testSignalRace() throws Exception {
         final long wait = TimeUnit.NANOSECONDS.convert(10, TimeUnit.SECONDS);
         EventExecutor executor = null;
         try {
@@ -357,7 +357,7 @@ public class DefaultPromiseTest {
             }
         } finally {
             if (executor != null) {
-                executor.shutdownGracefully();
+                executor.shutdownGracefully().sync();
             }
         }
     }

--- a/common/src/test/java/io/netty/util/concurrent/NonStickyEventExecutorGroupTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/NonStickyEventExecutorGroupTest.java
@@ -38,7 +38,7 @@ public class NonStickyEventExecutorGroupTest {
     private static final String PARAMETERIZED_NAME = "{index}: maxTaskExecutePerRun = {0}";
 
     @Test
-    public void testInvalidGroup() {
+    public void testInvalidGroup() throws Exception {
         final EventExecutorGroup group = new DefaultEventExecutorGroup(1);
         try {
             assertThrows(IllegalArgumentException.class, new Executable() {
@@ -48,7 +48,7 @@ public class NonStickyEventExecutorGroupTest {
                 }
             });
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
@@ -95,7 +95,7 @@ public class NonStickyEventExecutorGroupTest {
                 throw cause;
             }
         } finally {
-            nonStickyGroup.shutdownGracefully();
+            nonStickyGroup.shutdownGracefully().sync();
         }
     }
 
@@ -125,7 +125,7 @@ public class NonStickyEventExecutorGroupTest {
                 assertTrue(latch.await(5, TimeUnit.SECONDS));
             }
         } finally {
-            nonStickyGroup.shutdownGracefully();
+            nonStickyGroup.shutdownGracefully().sync();
         }
     }
 

--- a/common/src/test/java/io/netty/util/concurrent/UnorderedThreadPoolEventExecutorTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/UnorderedThreadPoolEventExecutorTest.java
@@ -74,7 +74,7 @@ public class UnorderedThreadPoolEventExecutorTest {
                 assertTrue(executor.getQueue().isEmpty());
             }
         } finally {
-            executor.shutdownGracefully();
+            executor.shutdownGracefully().sync();
         }
     }
 
@@ -93,7 +93,7 @@ public class UnorderedThreadPoolEventExecutorTest {
             latch.await();
         } finally {
             future.cancel(true);
-            executor.shutdownGracefully();
+            executor.shutdownGracefully().sync();
         }
     }
 
@@ -111,7 +111,7 @@ public class UnorderedThreadPoolEventExecutorTest {
 
             assertEquals(expected, f.get());
         } finally {
-            executor.shutdownGracefully();
+            executor.shutdownGracefully().sync();
         }
     }
 
@@ -129,7 +129,7 @@ public class UnorderedThreadPoolEventExecutorTest {
 
             assertSame(cause, f.await().cause());
         } finally {
-            executor.shutdownGracefully();
+            executor.shutdownGracefully().sync();
         }
     }
 
@@ -140,7 +140,7 @@ public class UnorderedThreadPoolEventExecutorTest {
             Future<Boolean> future = executor.submit(() -> executor.inEventLoop());
             assertTrue(future.get());
         } finally {
-            executor.shutdownGracefully();
+            executor.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/discard/DiscardClient.java
+++ b/example/src/main/java/io/netty/example/discard/DiscardClient.java
@@ -62,7 +62,7 @@ public final class DiscardClient {
             // Wait until the connection is closed.
             f.channel().closeFuture().sync();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/discard/DiscardServer.java
+++ b/example/src/main/java/io/netty/example/discard/DiscardServer.java
@@ -66,8 +66,8 @@ public final class DiscardServer {
             // shut down your server.
             f.channel().closeFuture().sync();
         } finally {
-            workerGroup.shutdownGracefully();
-            bossGroup.shutdownGracefully();
+            workerGroup.shutdownGracefully().sync();
+            bossGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/dns/dot/DoTClient.java
+++ b/example/src/main/java/io/netty/example/dns/dot/DoTClient.java
@@ -112,7 +112,7 @@ public final class DoTClient {
                 ch.close().sync();
             }
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/dns/tcp/TcpDnsClient.java
+++ b/example/src/main/java/io/netty/example/dns/tcp/TcpDnsClient.java
@@ -106,7 +106,7 @@ public final class TcpDnsClient {
                 ch.close().sync();
             }
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/dns/tcp/TcpDnsServer.java
+++ b/example/src/main/java/io/netty/example/dns/tcp/TcpDnsServer.java
@@ -148,7 +148,7 @@ public final class TcpDnsServer {
                 ch.close().sync();
             }
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 

--- a/example/src/main/java/io/netty/example/dns/udp/DnsClient.java
+++ b/example/src/main/java/io/netty/example/dns/udp/DnsClient.java
@@ -102,7 +102,7 @@ public final class DnsClient {
                 ch.close().sync();
             }
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/echo/EchoClient.java
+++ b/example/src/main/java/io/netty/example/echo/EchoClient.java
@@ -70,7 +70,7 @@ public final class EchoClient {
             f.channel().closeFuture().sync();
         } finally {
             // Shut down the event loop to terminate all threads.
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/echo/EchoServer.java
+++ b/example/src/main/java/io/netty/example/echo/EchoServer.java
@@ -70,8 +70,8 @@ public final class EchoServer {
             f.channel().closeFuture().sync();
         } finally {
             // Shut down all event loops to terminate all threads.
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully().sync();
+            workerGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/factorial/FactorialClient.java
+++ b/example/src/main/java/io/netty/example/factorial/FactorialClient.java
@@ -55,7 +55,7 @@ public final class FactorialClient {
             // Print out the answer.
             System.err.format("Factorial of %,d is: %,d", COUNT, handler.getFactorial());
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/factorial/FactorialServer.java
+++ b/example/src/main/java/io/netty/example/factorial/FactorialServer.java
@@ -48,8 +48,8 @@ public final class FactorialServer {
 
             b.bind(PORT).sync().channel().closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully().sync();
+            workerGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/file/FileServer.java
+++ b/example/src/main/java/io/netty/example/file/FileServer.java
@@ -80,8 +80,8 @@ public final class FileServer {
             f.channel().closeFuture().sync();
         } finally {
             // Shut down all event loops to terminate all threads.
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully().sync();
+            workerGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/haproxy/HAProxyClient.java
+++ b/example/src/main/java/io/netty/example/haproxy/HAProxyClient.java
@@ -55,7 +55,7 @@ public final class HAProxyClient {
             ch.writeAndFlush(Unpooled.copiedBuffer("Bye now!", CharsetUtil.US_ASCII)).sync();
             ch.close().sync();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/haproxy/HAProxyServer.java
+++ b/example/src/main/java/io/netty/example/haproxy/HAProxyServer.java
@@ -47,8 +47,8 @@ public final class HAProxyServer {
              .childHandler(new HAProxyServerInitializer());
             b.bind(PORT).sync().channel().closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully().sync();
+            workerGroup.shutdownGracefully().sync();
         }
     }
 

--- a/example/src/main/java/io/netty/example/http/cors/HttpCorsServer.java
+++ b/example/src/main/java/io/netty/example/http/cors/HttpCorsServer.java
@@ -91,8 +91,8 @@ public final class HttpCorsServer {
 
             b.bind(PORT).sync().channel().closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully().sync();
+            workerGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/http/file/HttpStaticFileServer.java
+++ b/example/src/main/java/io/netty/example/http/file/HttpStaticFileServer.java
@@ -51,8 +51,8 @@ public final class HttpStaticFileServer {
 
             ch.closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully().sync();
+            workerGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/http/helloworld/HttpHelloWorldServer.java
+++ b/example/src/main/java/io/netty/example/http/helloworld/HttpHelloWorldServer.java
@@ -58,8 +58,8 @@ public final class HttpHelloWorldServer {
 
             ch.closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully().sync();
+            workerGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/http/snoop/HttpSnoopClient.java
+++ b/example/src/main/java/io/netty/example/http/snoop/HttpSnoopClient.java
@@ -104,7 +104,7 @@ public final class HttpSnoopClient {
             ch.closeFuture().sync();
         } finally {
             // Shut down executor threads to exit.
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/http/snoop/HttpSnoopServer.java
+++ b/example/src/main/java/io/netty/example/http/snoop/HttpSnoopServer.java
@@ -56,8 +56,8 @@ public final class HttpSnoopServer {
 
             ch.closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully().sync();
+            workerGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/http/upload/HttpUploadClient.java
+++ b/example/src/main/java/io/netty/example/http/upload/HttpUploadClient.java
@@ -135,7 +135,7 @@ public final class HttpUploadClient {
             formpostmultipart(b, host, port, uriFile, factory, headers, bodylist);
         } finally {
             // Shut down executor threads to exit.
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
 
             // Really clean all temporary files if they still exist
             factory.cleanAllHttpData();

--- a/example/src/main/java/io/netty/example/http/upload/HttpUploadServer.java
+++ b/example/src/main/java/io/netty/example/http/upload/HttpUploadServer.java
@@ -54,8 +54,8 @@ public final class HttpUploadServer {
 
             ch.closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully().sync();
+            workerGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/http/websocketx/benchmarkserver/WebSocketServer.java
+++ b/example/src/main/java/io/netty/example/http/websocketx/benchmarkserver/WebSocketServer.java
@@ -56,8 +56,8 @@ public final class WebSocketServer {
 
             ch.closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully().sync();
+            workerGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/http/websocketx/client/WebSocketClient.java
+++ b/example/src/main/java/io/netty/example/http/websocketx/client/WebSocketClient.java
@@ -141,7 +141,7 @@ public final class WebSocketClient {
                 }
             }
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/http/websocketx/server/WebSocketServer.java
+++ b/example/src/main/java/io/netty/example/http/websocketx/server/WebSocketServer.java
@@ -70,8 +70,8 @@ public final class WebSocketServer {
 
             ch.closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully().sync();
+            workerGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/http2/file/Http2StaticFileServer.java
+++ b/example/src/main/java/io/netty/example/http2/file/Http2StaticFileServer.java
@@ -71,8 +71,8 @@ public final class Http2StaticFileServer {
 
             ch.closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully().sync();
+            workerGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/http2/helloworld/client/Http2Client.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/client/Http2Client.java
@@ -144,7 +144,7 @@ public final class Http2Client {
             // Wait until the connection is closed.
             channel.close().syncUninterruptibly();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/http2/helloworld/frame/client/Http2FrameClient.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/frame/client/Http2FrameClient.java
@@ -118,7 +118,7 @@ public final class Http2FrameClient {
             // Wait until the connection is closed.
             channel.close().syncUninterruptibly();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 

--- a/example/src/main/java/io/netty/example/http2/helloworld/frame/server/Http2Server.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/frame/server/Http2Server.java
@@ -95,7 +95,7 @@ public final class Http2Server {
 
             ch.closeFuture().sync();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/http2/helloworld/multiplex/server/Http2Server.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/multiplex/server/Http2Server.java
@@ -95,7 +95,7 @@ public final class Http2Server {
 
             ch.closeFuture().sync();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/http2/helloworld/server/Http2Server.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/server/Http2Server.java
@@ -92,7 +92,7 @@ public final class Http2Server {
 
             ch.closeFuture().sync();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/http2/tiles/Launcher.java
+++ b/example/src/main/java/io/netty/example/http2/tiles/Launcher.java
@@ -36,7 +36,7 @@ import io.netty.channel.nio.NioIoHandler;
  */
 public final class Launcher {
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception{
         EventLoopGroup group = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
         Http2Server http2 = new Http2Server(group);
         HttpServer http = new HttpServer(group);
@@ -47,7 +47,7 @@ public final class Launcher {
         } catch (Exception e) {
             e.printStackTrace();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/http2/tiles/Launcher.java
+++ b/example/src/main/java/io/netty/example/http2/tiles/Launcher.java
@@ -36,7 +36,7 @@ import io.netty.channel.nio.NioIoHandler;
  */
 public final class Launcher {
 
-    public static void main(String[] args) throws Exception{
+    public static void main(String[] args) throws Exception {
         EventLoopGroup group = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
         Http2Server http2 = new Http2Server(group);
         HttpServer http = new HttpServer(group);

--- a/example/src/main/java/io/netty/example/ipfilter/IpSubnetFilterExample.java
+++ b/example/src/main/java/io/netty/example/ipfilter/IpSubnetFilterExample.java
@@ -84,8 +84,8 @@ public final class IpSubnetFilterExample {
             // shut down your server.
             f.channel().closeFuture().sync();
         } finally {
-            workerGroup.shutdownGracefully();
-            bossGroup.shutdownGracefully();
+            workerGroup.shutdownGracefully().sync();
+            bossGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/localecho/LocalEcho.java
+++ b/example/src/main/java/io/netty/example/localecho/LocalEcho.java
@@ -101,8 +101,8 @@ public final class LocalEcho {
                 lastWriteFuture.awaitUninterruptibly();
             }
         } finally {
-            serverGroup.shutdownGracefully();
-            clientGroup.shutdownGracefully();
+            serverGroup.shutdownGracefully().sync();
+            clientGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/memcache/binary/MemcacheClient.java
+++ b/example/src/main/java/io/netty/example/memcache/binary/MemcacheClient.java
@@ -98,7 +98,7 @@ public final class MemcacheClient {
                 lastWriteFuture.sync();
             }
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/mqtt/heartBeat/MqttHeartBeatBroker.java
+++ b/example/src/main/java/io/netty/example/mqtt/heartBeat/MqttHeartBeatBroker.java
@@ -59,8 +59,8 @@ public final class MqttHeartBeatBroker {
 
             f.channel().closeFuture().sync();
         } finally {
-            workerGroup.shutdownGracefully();
-            bossGroup.shutdownGracefully();
+            workerGroup.shutdownGracefully().sync();
+            bossGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/mqtt/heartBeat/MqttHeartBeatClient.java
+++ b/example/src/main/java/io/netty/example/mqtt/heartBeat/MqttHeartBeatClient.java
@@ -60,7 +60,7 @@ public final class MqttHeartBeatClient {
             System.out.println("Client connected");
             f.channel().closeFuture().sync();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/objectecho/ObjectEchoClient.java
+++ b/example/src/main/java/io/netty/example/objectecho/ObjectEchoClient.java
@@ -73,7 +73,7 @@ public final class ObjectEchoClient {
             // Start the connection attempt.
             b.connect(HOST, PORT).sync().channel().closeFuture().sync();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/objectecho/ObjectEchoServer.java
+++ b/example/src/main/java/io/netty/example/objectecho/ObjectEchoServer.java
@@ -68,8 +68,8 @@ public final class ObjectEchoServer {
             // Bind and start to accept incoming connections.
             b.bind(PORT).sync().channel().closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully().sync();
+            workerGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/ocsp/OcspClientExample.java
+++ b/example/src/main/java/io/netty/example/ocsp/OcspClientExample.java
@@ -110,7 +110,7 @@ public class OcspClientExample {
                     channel.close();
                 }
             } finally {
-                group.shutdownGracefully();
+                group.shutdownGracefully().sync();
             }
         } finally {
             context.release();

--- a/example/src/main/java/io/netty/example/portunification/PortUnificationServer.java
+++ b/example/src/main/java/io/netty/example/portunification/PortUnificationServer.java
@@ -66,8 +66,8 @@ public final class PortUnificationServer {
             // Bind and start to accept incoming connections.
             b.bind(PORT).sync().channel().closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully().sync();
+            workerGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/proxy/HexDumpProxy.java
+++ b/example/src/main/java/io/netty/example/proxy/HexDumpProxy.java
@@ -45,8 +45,8 @@ public final class HexDumpProxy {
              .childOption(ChannelOption.AUTO_READ, false)
              .bind(LOCAL_PORT).sync().channel().closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully().sync();
+            workerGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/qotm/QuoteOfTheMomentClient.java
+++ b/example/src/main/java/io/netty/example/qotm/QuoteOfTheMomentClient.java
@@ -61,7 +61,7 @@ public final class QuoteOfTheMomentClient {
                 System.err.println("QOTM request timed out.");
             }
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/qotm/QuoteOfTheMomentServer.java
+++ b/example/src/main/java/io/netty/example/qotm/QuoteOfTheMomentServer.java
@@ -43,7 +43,7 @@ public final class QuoteOfTheMomentServer {
 
             b.bind(PORT).sync().channel().closeFuture().await();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/redis/RedisClient.java
+++ b/example/src/main/java/io/netty/example/redis/RedisClient.java
@@ -93,7 +93,7 @@ public class RedisClient {
                 lastWriteFuture.sync();
             }
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/rxtx/RxtxClient.java
+++ b/example/src/main/java/io/netty/example/rxtx/RxtxClient.java
@@ -55,7 +55,7 @@ public final class RxtxClient {
 
             f.channel().closeFuture().sync();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/sctp/SctpEchoClient.java
+++ b/example/src/main/java/io/netty/example/sctp/SctpEchoClient.java
@@ -63,7 +63,7 @@ public final class SctpEchoClient {
             f.channel().closeFuture().sync();
         } finally {
             // Shut down the event loop to terminate all threads.
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/sctp/SctpEchoServer.java
+++ b/example/src/main/java/io/netty/example/sctp/SctpEchoServer.java
@@ -61,8 +61,8 @@ public final class SctpEchoServer {
             f.channel().closeFuture().sync();
         } finally {
             // Shut down all event loops to terminate all threads.
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully().sync();
+            workerGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/sctp/multihoming/SctpMultiHomingEchoClient.java
+++ b/example/src/main/java/io/netty/example/sctp/multihoming/SctpMultiHomingEchoClient.java
@@ -83,7 +83,7 @@ public final class SctpMultiHomingEchoClient {
             connectFuture.channel().closeFuture().sync();
         } finally {
             // Shut down the event loop to terminate all threads.
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/sctp/multihoming/SctpMultiHomingEchoServer.java
+++ b/example/src/main/java/io/netty/example/sctp/multihoming/SctpMultiHomingEchoServer.java
@@ -78,8 +78,8 @@ public final class SctpMultiHomingEchoServer {
             connectFuture.channel().closeFuture().sync();
         } finally {
             // Shut down all event loops to terminate all threads.
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully().sync();
+            workerGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/securechat/SecureChatClient.java
+++ b/example/src/main/java/io/netty/example/securechat/SecureChatClient.java
@@ -79,7 +79,7 @@ public final class SecureChatClient {
             }
         } finally {
             // The connection is closed automatically on shutdown.
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/securechat/SecureChatServer.java
+++ b/example/src/main/java/io/netty/example/securechat/SecureChatServer.java
@@ -54,8 +54,8 @@ public final class SecureChatServer {
 
             b.bind(PORT).sync().channel().closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully().sync();
+            workerGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/socksproxy/SocksServer.java
+++ b/example/src/main/java/io/netty/example/socksproxy/SocksServer.java
@@ -38,8 +38,8 @@ public final class SocksServer {
              .childHandler(new SocksServerInitializer());
             b.bind(PORT).sync().channel().closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully().sync();
+            workerGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/spdy/client/SpdyClient.java
+++ b/example/src/main/java/io/netty/example/spdy/client/SpdyClient.java
@@ -96,7 +96,7 @@ public final class SpdyClient {
             // Wait until the connection is closed.
             channel.close().syncUninterruptibly();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/spdy/server/SpdyServer.java
+++ b/example/src/main/java/io/netty/example/spdy/server/SpdyServer.java
@@ -85,8 +85,8 @@ public final class SpdyServer {
 
             ch.closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully().sync();
+            workerGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/stomp/StompClient.java
+++ b/example/src/main/java/io/netty/example/stomp/StompClient.java
@@ -59,7 +59,7 @@ public final class StompClient {
 
             b.connect(HOST, PORT).sync().channel().closeFuture().sync();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/stomp/websocket/StompWebSocketChatServer.java
+++ b/example/src/main/java/io/netty/example/stomp/websocket/StompWebSocketChatServer.java
@@ -46,8 +46,8 @@ public class StompWebSocketChatServer {
                 }
             }).channel().closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully().sync();
+            workerGroup.shutdownGracefully().sync();
         }
     }
 

--- a/example/src/main/java/io/netty/example/telnet/TelnetClient.java
+++ b/example/src/main/java/io/netty/example/telnet/TelnetClient.java
@@ -76,7 +76,7 @@ public final class TelnetClient {
                 lastWriteFuture.sync();
             }
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/telnet/TelnetServer.java
+++ b/example/src/main/java/io/netty/example/telnet/TelnetServer.java
@@ -48,8 +48,8 @@ public final class TelnetServer {
 
             b.bind(PORT).sync().channel().closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully().sync();
+            workerGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/udt/echo/bytes/ByteEchoClient.java
+++ b/example/src/main/java/io/netty/example/udt/echo/bytes/ByteEchoClient.java
@@ -67,7 +67,7 @@ public final class ByteEchoClient {
             f.channel().closeFuture().sync();
         } finally {
             // Shut down the event loop to terminate all threads.
-            connectGroup.shutdownGracefully();
+            connectGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/udt/echo/bytes/ByteEchoServer.java
+++ b/example/src/main/java/io/netty/example/udt/echo/bytes/ByteEchoServer.java
@@ -69,8 +69,8 @@ public final class ByteEchoServer {
             future.channel().closeFuture().sync();
         } finally {
             // Shut down all event loops to terminate all threads.
-            acceptGroup.shutdownGracefully();
-            connectGroup.shutdownGracefully();
+            acceptGroup.shutdownGracefully().sync();
+            connectGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/udt/echo/message/MsgEchoClient.java
+++ b/example/src/main/java/io/netty/example/udt/echo/message/MsgEchoClient.java
@@ -71,7 +71,7 @@ public final class MsgEchoClient {
             f.channel().closeFuture().sync();
         } finally {
             // Shut down the event loop to terminate all threads.
-            connectGroup.shutdownGracefully();
+            connectGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/udt/echo/message/MsgEchoServer.java
+++ b/example/src/main/java/io/netty/example/udt/echo/message/MsgEchoServer.java
@@ -71,8 +71,8 @@ public final class MsgEchoServer {
             future.channel().closeFuture().sync();
         } finally {
             // Shut down all event loops to terminate all threads.
-            acceptGroup.shutdownGracefully();
-            connectGroup.shutdownGracefully();
+            acceptGroup.shutdownGracefully().sync();
+            connectGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/udt/echo/rendezvous/MsgEchoPeerBase.java
+++ b/example/src/main/java/io/netty/example/udt/echo/rendezvous/MsgEchoPeerBase.java
@@ -72,7 +72,7 @@ public abstract class MsgEchoPeerBase {
             f.channel().closeFuture().sync();
         } finally {
             // Shut down the event loop to terminate all threads.
-            connectGroup.shutdownGracefully();
+            connectGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/udt/echo/rendezvousBytes/ByteEchoPeerBase.java
+++ b/example/src/main/java/io/netty/example/udt/echo/rendezvousBytes/ByteEchoPeerBase.java
@@ -70,7 +70,7 @@ public class ByteEchoPeerBase {
             final ChannelFuture future = bootstrap.connect(peerAddress, myAddress).sync();
             future.channel().closeFuture().sync();
         } finally {
-            connectGroup.shutdownGracefully();
+            connectGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/uptime/UptimeServer.java
+++ b/example/src/main/java/io/netty/example/uptime/UptimeServer.java
@@ -61,8 +61,8 @@ public final class UptimeServer {
             // shut down your server.
             f.channel().closeFuture().sync();
         } finally {
-            workerGroup.shutdownGracefully();
-            bossGroup.shutdownGracefully();
+            workerGroup.shutdownGracefully().sync();
+            bossGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/worldclock/WorldClockClient.java
+++ b/example/src/main/java/io/netty/example/worldclock/WorldClockClient.java
@@ -66,7 +66,7 @@ public final class WorldClockClient {
                 System.out.format("%28s: %s%n", CITIES.get(i), response.get(i));
             }
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/worldclock/WorldClockServer.java
+++ b/example/src/main/java/io/netty/example/worldclock/WorldClockServer.java
@@ -45,8 +45,8 @@ public final class WorldClockServer {
 
             b.bind(PORT).sync().channel().closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully().sync();
+            workerGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/handler-proxy/src/test/java/io/netty/handler/proxy/HttpProxyHandlerTest.java
+++ b/handler-proxy/src/test/java/io/netty/handler/proxy/HttpProxyHandlerTest.java
@@ -229,7 +229,7 @@ public class HttpProxyHandlerTest {
                 serverChannel.close();
             }
             if (group != null) {
-                group.shutdownGracefully();
+                group.shutdownGracefully().sync();
             }
         }
     }

--- a/handler-ssl-ocsp/src/test/java/io/netty/handler/ssl/ocsp/OcspServerCertificateValidatorTest.java
+++ b/handler-ssl-ocsp/src/test/java/io/netty/handler/ssl/ocsp/OcspServerCertificateValidatorTest.java
@@ -91,7 +91,7 @@ class OcspServerCertificateValidatorTest {
             // Wait for Channel to be closed
             channelFuture.channel().closeFuture().sync();
         } finally {
-            eventLoopGroup.shutdownGracefully();
+            eventLoopGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/handler/src/test/java/io/netty/handler/address/ResolveAddressHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/address/ResolveAddressHandlerTest.java
@@ -59,7 +59,7 @@ public class ResolveAddressHandlerTest {
     }
 
     @AfterAll
-    public static void destroyEventLoop() throws Exception{
+    public static void destroyEventLoop() throws Exception {
         if (group != null) {
             group.shutdownGracefully().sync();
         }

--- a/handler/src/test/java/io/netty/handler/address/ResolveAddressHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/address/ResolveAddressHandlerTest.java
@@ -59,9 +59,9 @@ public class ResolveAddressHandlerTest {
     }
 
     @AfterAll
-    public static void destroyEventLoop() {
+    public static void destroyEventLoop() throws Exception{
         if (group != null) {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 

--- a/handler/src/test/java/io/netty/handler/flow/FlowControlHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/flow/FlowControlHandlerTest.java
@@ -67,8 +67,8 @@ public class FlowControlHandlerTest {
     }
 
     @AfterAll
-    public static void destroy() {
-        GROUP.shutdownGracefully();
+    public static void destroy() throws Exception{
+        GROUP.shutdownGracefully().sync();
     }
 
     /**

--- a/handler/src/test/java/io/netty/handler/flow/FlowControlHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/flow/FlowControlHandlerTest.java
@@ -67,7 +67,7 @@ public class FlowControlHandlerTest {
     }
 
     @AfterAll
-    public static void destroy() throws Exception{
+    public static void destroy() throws Exception {
         GROUP.shutdownGracefully().sync();
     }
 

--- a/handler/src/test/java/io/netty/handler/ssl/CipherSuiteCanaryTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/CipherSuiteCanaryTest.java
@@ -86,8 +86,8 @@ public class CipherSuiteCanaryTest {
     }
 
     @AfterAll
-    public static void destroy() {
-        GROUP.shutdownGracefully();
+    public static void destroy() throws Exception {
+        GROUP.shutdownGracefully().sync();
     }
 
     private static void assumeCipherAvailable(SslProvider provider, String cipher) throws NoSuchAlgorithmException {

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslCertificateCompressionTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslCertificateCompressionTest.java
@@ -334,7 +334,7 @@ public class OpenSslCertificateCompressionTest {
             clientChannel.close().syncUninterruptibly();
             serverChannel.close().syncUninterruptibly();
         } finally  {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslPrivateKeyMethodTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslPrivateKeyMethodTest.java
@@ -113,9 +113,9 @@ public class OpenSslPrivateKeyMethodTest {
     }
 
     @AfterAll
-    public static void destroy() {
+    public static void destroy() throws Exception {
         if (OpenSsl.isBoringSSL()) {
-            GROUP.shutdownGracefully();
+            GROUP.shutdownGracefully().sync();
             EXECUTOR.shutdown();
         }
     }

--- a/handler/src/test/java/io/netty/handler/ssl/ParameterizedSslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ParameterizedSslHandlerTest.java
@@ -273,7 +273,7 @@ public class ParameterizedSslHandlerTest {
             if (sc != null) {
                 sc.close().syncUninterruptibly();
             }
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
 
             ReferenceCountUtil.release(sslServerCtx);
             ReferenceCountUtil.release(sslClientCtx);
@@ -373,7 +373,7 @@ public class ParameterizedSslHandlerTest {
             if (sc != null) {
                 sc.close().syncUninterruptibly();
             }
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
 
             ReferenceCountUtil.release(sslServerCtx);
             ReferenceCountUtil.release(sslClientCtx);
@@ -513,7 +513,7 @@ public class ParameterizedSslHandlerTest {
             if (sc != null) {
                 sc.close().syncUninterruptibly();
             }
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
 
             ReferenceCountUtil.release(sslServerCtx);
             ReferenceCountUtil.release(sslClientCtx);
@@ -539,7 +539,7 @@ public class ParameterizedSslHandlerTest {
             reentryOnHandshakeComplete(clientProvider, serverProvider, group, bindAddress,
                     serverClass, clientClass, true, true);
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
@@ -563,7 +563,7 @@ public class ParameterizedSslHandlerTest {
             reentryOnHandshakeComplete(clientProvider, serverProvider, group, bindAddress,
                     serverClass, clientClass, true, true);
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 

--- a/handler/src/test/java/io/netty/handler/ssl/RenegotiateTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/RenegotiateTest.java
@@ -141,7 +141,7 @@ public abstract class RenegotiateTest {
             channel.close().syncUninterruptibly();
             verifyResult(error);
         } finally  {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 

--- a/handler/src/test/java/io/netty/handler/ssl/SniClientJava8TestUtil.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniClientJava8TestUtil.java
@@ -163,7 +163,7 @@ final class SniClientJava8TestUtil {
             ReferenceCountUtil.release(sslServerContext);
             ReferenceCountUtil.release(sslClientContext);
 
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 

--- a/handler/src/test/java/io/netty/handler/ssl/SniClientTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniClientTest.java
@@ -158,7 +158,7 @@ public class SniClientTest {
             ReferenceCountUtil.release(sslServerContext);
             ReferenceCountUtil.release(sslClientContext);
 
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
@@ -598,7 +598,7 @@ public class SniHandlerTest {
                     if (sslContext != null) {
                         ReferenceCountUtil.release(sslContext);
                     }
-                    group.shutdownGracefully();
+                    group.shutdownGracefully().sync();
                 }
             case JDK:
                 return;

--- a/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
@@ -194,7 +194,7 @@ public class SslErrorTest {
             if (serverChannel != null) {
                 serverChannel.close().syncUninterruptibly();
             }
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
 
             ReferenceCountUtil.release(sslServerCtx);
             ReferenceCountUtil.release(sslClientCtx);

--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -504,7 +504,7 @@ public class SslHandlerTest {
             if (sc != null) {
                 sc.close().syncUninterruptibly();
             }
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
@@ -685,7 +685,7 @@ public class SslHandlerTest {
             if (clientChannel != null) {
                 clientChannel.close();
             }
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
@@ -752,7 +752,7 @@ public class SslHandlerTest {
             if (sc != null) {
                 sc.close().syncUninterruptibly();
             }
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
 
             ReferenceCountUtil.release(sslServerCtx);
             ReferenceCountUtil.release(sslClientCtx);
@@ -818,7 +818,7 @@ public class SslHandlerTest {
             if (sc != null) {
                 sc.close().syncUninterruptibly();
             }
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
 
             ReferenceCountUtil.release(sslServerCtx);
             ReferenceCountUtil.release(sslClientCtx);
@@ -906,7 +906,7 @@ public class SslHandlerTest {
             if (sc != null) {
                 sc.close().syncUninterruptibly();
             }
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
 
             ReferenceCountUtil.release(sslClientCtx);
         }
@@ -981,7 +981,7 @@ public class SslHandlerTest {
             if (sc != null) {
                 sc.close().syncUninterruptibly();
             }
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
             ReferenceCountUtil.release(sslClientCtx);
         }
     }
@@ -1173,7 +1173,7 @@ public class SslHandlerTest {
             if (sc != null) {
                 sc.close().syncUninterruptibly();
             }
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
             ReferenceCountUtil.release(sslClientCtx);
         }
     }
@@ -1258,7 +1258,7 @@ public class SslHandlerTest {
             if (sc != null) {
                 sc.close().syncUninterruptibly();
             }
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
             ReferenceCountUtil.release(sslClientCtx);
         }
     }
@@ -1373,7 +1373,7 @@ public class SslHandlerTest {
             if (sc != null) {
                 sc.close().syncUninterruptibly();
             }
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
             ReferenceCountUtil.release(sslClientCtx);
         }
     }
@@ -1556,7 +1556,7 @@ public class SslHandlerTest {
             if (sc != null) {
                 sc.close().syncUninterruptibly();
             }
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
@@ -1678,7 +1678,7 @@ public class SslHandlerTest {
             assertInstanceOf(SSLException.class, serverEventCause);
             assertNull(serverEventCause.getCause());
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
             ReferenceCountUtil.release(sslClientCtx);
         }
     }
@@ -1875,7 +1875,7 @@ public class SslHandlerTest {
             assertEquals(0, clientCloseCompletionEvents.size());
             assertEquals(0, serverCloseCompletionEvents.size());
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
             ReferenceCountUtil.release(sslClientCtx);
             ReferenceCountUtil.release(sslServerCtx);
         }

--- a/handler/src/test/java/io/netty/handler/timeout/WriteTimeoutHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/timeout/WriteTimeoutHandlerTest.java
@@ -54,8 +54,8 @@ public class WriteTimeoutHandlerTest {
             latch.await();
             assertTrue(channel.finishAndReleaseAll());
         } finally {
-            group1.shutdownGracefully();
-            group2.shutdownGracefully();
+            group1.shutdownGracefully().sync();
+            group2.shutdownGracefully().sync();
         }
     }
 }

--- a/handler/src/test/java/io/netty/handler/traffic/FileRegionThrottleTest.java
+++ b/handler/src/test/java/io/netty/handler/traffic/FileRegionThrottleTest.java
@@ -80,8 +80,8 @@ public class FileRegionThrottleTest {
     }
 
     @AfterEach
-    public void tearDown() {
-        group.shutdownGracefully();
+    public void tearDown() throws Exception {
+        group.shutdownGracefully().sync();
     }
 
     @Disabled("This test is flaky, need more investigation")

--- a/handler/src/test/java/io/netty/handler/traffic/TrafficShapingHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/traffic/TrafficShapingHandlerTest.java
@@ -47,8 +47,8 @@ public class TrafficShapingHandlerTest {
     private static final EventLoopGroup GROUP = new MultiThreadIoEventLoopGroup(1, LocalIoHandler.newFactory());
 
     @AfterAll
-    public static void destroy() {
-        GROUP.shutdownGracefully();
+    public static void destroy() throws Exception {
+        GROUP.shutdownGracefully().sync();
         SES.shutdown();
     }
 

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DefaultAuthoritativeDnsServerCacheTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DefaultAuthoritativeDnsServerCacheTest.java
@@ -68,13 +68,13 @@ public class DefaultAuthoritativeDnsServerCacheTest {
     }
 
     @Test
-    public void testExpireWithDifferentTTLs() {
+    public void testExpireWithDifferentTTLs() throws Exception {
         testExpireWithTTL0(1);
         testExpireWithTTL0(1000);
         testExpireWithTTL0(1000000);
     }
 
-    private static void testExpireWithTTL0(int days) {
+    private static void testExpireWithTTL0(int days) throws InterruptedException {
         EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, LocalIoHandler.newFactory());
 
         try {

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DefaultAuthoritativeDnsServerCacheTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DefaultAuthoritativeDnsServerCacheTest.java
@@ -63,7 +63,7 @@ public class DefaultAuthoritativeDnsServerCacheTest {
                 throw error;
             }
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
@@ -82,7 +82,7 @@ public class DefaultAuthoritativeDnsServerCacheTest {
             final DefaultAuthoritativeDnsServerCache cache = new DefaultAuthoritativeDnsServerCache();
             cache.cache("netty.io", new InetSocketAddress(NetUtil.LOCALHOST, 53), days, loop);
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
@@ -105,7 +105,7 @@ public class DefaultAuthoritativeDnsServerCacheTest {
             assertEquals(resolved1, entries.next());
             assertEquals(resolved2, entries.next());
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
@@ -136,7 +136,7 @@ public class DefaultAuthoritativeDnsServerCacheTest {
             assertEquals(resolved2, entries2.next());
             assertEquals(resolved1, entries2.next());
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
@@ -192,7 +192,7 @@ public class DefaultAuthoritativeDnsServerCacheTest {
                 assertEquals(unresolved, entries.next());
             }
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DefaultDnsCacheTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DefaultDnsCacheTest.java
@@ -68,18 +68,18 @@ public class DefaultDnsCacheTest {
                 throw error;
             }
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
     @Test
-    public void testExpireWithDifferentTTLs() {
+    public void testExpireWithDifferentTTLs() throws Exception {
         testExpireWithTTL0(1);
         testExpireWithTTL0(1000);
         testExpireWithTTL0(1000000);
     }
 
-    private static void testExpireWithTTL0(int days) {
+    private static void testExpireWithTTL0(int days) throws Exception {
         EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
 
         try {
@@ -87,12 +87,12 @@ public class DefaultDnsCacheTest {
             final DefaultDnsCache cache = new DefaultDnsCache();
             assertNotNull(cache.cache("netty.io", null, NetUtil.LOCALHOST, days, loop));
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
     @Test
-    public void testExpireWithToBigMinTTL() {
+    public void testExpireWithToBigMinTTL() throws Exception {
         EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
 
         try {
@@ -100,7 +100,7 @@ public class DefaultDnsCacheTest {
             final DefaultDnsCache cache = new DefaultDnsCache(Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE);
             assertNotNull(cache.cache("netty.io", null, NetUtil.LOCALHOST, 100, loop));
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
@@ -121,7 +121,7 @@ public class DefaultDnsCacheTest {
             assertEntry(entries.get(0), addr1);
             assertEntry(entries.get(1), addr2);
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
@@ -140,7 +140,7 @@ public class DefaultDnsCacheTest {
             assertEquals(1, entries.size());
             assertEntry(entries.get(0), addr1);
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
@@ -174,7 +174,7 @@ public class DefaultDnsCacheTest {
             assertThrowable(exception, entry.cause());
             assertNull(entry.address());
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
@@ -200,7 +200,7 @@ public class DefaultDnsCacheTest {
             assertEntry(entries2.get(0), addr1);
             assertEntry(entries2.get(1), addr2);
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
@@ -215,7 +215,7 @@ public class DefaultDnsCacheTest {
             testSuppressed(cache, new UnknownHostException("test"), loop);
             testSuppressed(cache, new Throwable("test"), loop);
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DefaultDnsCnameCacheTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DefaultDnsCnameCacheTest.java
@@ -54,7 +54,7 @@ public class DefaultDnsCnameCacheTest {
                 throw error;
             }
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
@@ -74,7 +74,7 @@ public class DefaultDnsCnameCacheTest {
             cache.cache("netty.io", "mapping.netty.io", TimeUnit.DAYS.toSeconds(days), loop);
             assertEquals("mapping.netty.io", cache.get("netty.io"));
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
@@ -90,7 +90,7 @@ public class DefaultDnsCnameCacheTest {
 
             assertEquals("mapping2.netty.io", cache.get("netty.io"));
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
@@ -106,7 +106,7 @@ public class DefaultDnsCnameCacheTest {
 
             assertEquals("mapping.netty.io", cache.get("netty.io"));
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
@@ -129,7 +129,7 @@ public class DefaultDnsCnameCacheTest {
             cache.clear();
             assertNull(cache.get("y.netty.io"));
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DefaultDnsCnameCacheTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DefaultDnsCnameCacheTest.java
@@ -59,13 +59,13 @@ public class DefaultDnsCnameCacheTest {
     }
 
     @Test
-    public void testExpireWithDifferentTTLs() {
+    public void testExpireWithDifferentTTLs() throws Exception {
         testExpireWithTTL0(1);
         testExpireWithTTL0(1000);
         testExpireWithTTL0(1000000);
     }
 
-    private static void testExpireWithTTL0(int days) {
+    private static void testExpireWithTTL0(int days) throws Exception {
         EventLoopGroup group = new DefaultEventLoopGroup(1);
 
         try {

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsAddressResolverGroupTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsAddressResolverGroupTest.java
@@ -67,8 +67,8 @@ public class DnsAddressResolverGroupTest {
             promise.sync();
         } finally {
             resolverGroup.close();
-            group.shutdownGracefully();
-            defaultEventLoopGroup.shutdownGracefully();
+            group.shutdownGracefully().sync();
+            defaultEventLoopGroup.shutdownGracefully().sync();
         }
     }
 
@@ -94,8 +94,8 @@ public class DnsAddressResolverGroupTest {
             assertSame(address1, address2);
         } finally {
             resolverGroup.close();
-            group.shutdownGracefully();
-            defaultEventLoopGroup.shutdownGracefully();
+            group.shutdownGracefully().sync();
+            defaultEventLoopGroup.shutdownGracefully().sync();
         }
     }
 

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverBuilderTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverBuilderTest.java
@@ -52,8 +52,8 @@ class DnsNameResolverBuilderTest {
     }
 
     @AfterAll
-    static void shutdownEventLoopGroup() {
-        GROUP.shutdownGracefully();
+    static void shutdownEventLoopGroup() throws Exception {
+        GROUP.shutdownGracefully().sync();
     }
 
     @Test

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -433,9 +433,9 @@ public class DnsNameResolverTest {
     }
 
     @AfterAll
-    public static void destroy() {
+    public static void destroy() throws Exception {
         dnsServer.stop();
-        group.shutdownGracefully();
+        group.shutdownGracefully().sync();
     }
 
     @ParameterizedTest

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/SearchDomainTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/SearchDomainTest.java
@@ -61,7 +61,7 @@ public class SearchDomainTest {
     }
 
     @AfterEach
-    public void destroy() {
+    public void destroy() throws Exception {
         if (dnsServer != null) {
             dnsServer.stop();
             dnsServer = null;
@@ -69,7 +69,7 @@ public class SearchDomainTest {
         if (resolver != null) {
             resolver.close();
         }
-        group.shutdownGracefully();
+        group.shutdownGracefully().sync();
     }
 
     @Test

--- a/testsuite-autobahn/src/main/java/io/netty/testsuite/autobahn/AutobahnServer.java
+++ b/testsuite-autobahn/src/main/java/io/netty/testsuite/autobahn/AutobahnServer.java
@@ -50,8 +50,8 @@ public class AutobahnServer {
             System.out.println("Web Socket Server started at port " + port);
             f.channel().closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully().sync();
+            workerGroup.shutdownGracefully().sync();
         }
     }
 

--- a/testsuite-http2/src/main/java/io/netty/testsuite/http2/Http2Server.java
+++ b/testsuite-http2/src/main/java/io/netty/testsuite/http2/Http2Server.java
@@ -53,7 +53,7 @@ public final class Http2Server {
 
             ch.closeFuture().sync();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 

--- a/testsuite-jpms/src/main/java/io/netty/testsuite_jpms/main/HttpHelloWorldServer.java
+++ b/testsuite-jpms/src/main/java/io/netty/testsuite_jpms/main/HttpHelloWorldServer.java
@@ -213,8 +213,8 @@ public final class HttpHelloWorldServer {
 
             ch.closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully().sync();
+            workerGroup.shutdownGracefully().sync();
         }
     }
 

--- a/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/CodecHttp2Test.java
+++ b/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/CodecHttp2Test.java
@@ -159,7 +159,7 @@ public class CodecHttp2Test {
             server.channel().close().syncUninterruptibly();
             client.close().syncUninterruptibly();
         } finally {
-            eventLoopGroup.shutdownGracefully();
+            eventLoopGroup.shutdownGracefully().sync();
         }
     }
 }

--- a/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/CodecHttp3Test.java
+++ b/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/CodecHttp3Test.java
@@ -68,7 +68,7 @@ public class CodecHttp3Test {
             runClient(group, port);
             serverChannel.close().sync();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 

--- a/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/OCSPTest.java
+++ b/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/OCSPTest.java
@@ -94,7 +94,7 @@ public class OCSPTest {
             // Wait for Channel to be closed
             channelFuture.channel().closeFuture().sync();
         } finally {
-            eventLoopGroup.shutdownGracefully();
+            eventLoopGroup.shutdownGracefully().sync();
         }
     }
 

--- a/testsuite-native-image/src/main/java/io/netty/testsuite/svm/HttpNativeServer.java
+++ b/testsuite-native-image/src/main/java/io/netty/testsuite/svm/HttpNativeServer.java
@@ -107,8 +107,8 @@ public final class HttpNativeServer {
             httpClient.close().sync();
             serverStartSucess = true;
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully().sync();
+            workerGroup.shutdownGracefully().sync();
         }
         return serverStartSucess;
     }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
@@ -78,7 +78,7 @@ public abstract class AbstractSingleThreadEventLoopTest {
                 checkNumRegisteredChannels(loop, 1);
             }
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
@@ -187,7 +187,7 @@ public abstract class AbstractSingleThreadEventLoopTest {
                 }
             });
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
@@ -234,7 +234,7 @@ public abstract class AbstractSingleThreadEventLoopTest {
                 }
             });
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
@@ -262,7 +262,7 @@ public abstract class AbstractSingleThreadEventLoopTest {
                 }
             });
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/DefaultEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/DefaultEventLoopTest.java
@@ -47,7 +47,7 @@ public class DefaultEventLoopTest extends AbstractSingleThreadEventLoopTest {
                 }
             });
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/udt/UDTClientServerConnectionTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/udt/UDTClientServerConnectionTest.java
@@ -236,11 +236,8 @@ public class UDTClientServerConnectionTest {
             } catch (final Throwable e) {
                 log.error("Server failure.", e);
             } finally {
-                acceptGroup.shutdownGracefully();
-                connectGroup.shutdownGracefully();
-
-                acceptGroup.terminationFuture().syncUninterruptibly();
-                connectGroup.terminationFuture().syncUninterruptibly();
+                acceptGroup.shutdownGracefully().syncUninterruptibly();
+                connectGroup.shutdownGracefully().syncUninterruptibly();
             }
         }
 

--- a/transport-blockhound-tests/src/test/java/io/netty/util/internal/NettyBlockHoundIntegrationTest.java
+++ b/transport-blockhound-tests/src/test/java/io/netty/util/internal/NettyBlockHoundIntegrationTest.java
@@ -355,7 +355,7 @@ public class NettyBlockHoundIntegrationTest {
             if (sc != null) {
                 sc.close().syncUninterruptibly();
             }
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
             ReferenceCountUtil.release(sslClientCtx);
         }
     }
@@ -412,7 +412,7 @@ public class NettyBlockHoundIntegrationTest {
                     .datagramChannelFactory(NioDatagramChannel::new);
             doTestParseResolverFilesAllowsBlockingCalls(builder::build);
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
@@ -446,7 +446,7 @@ public class NettyBlockHoundIntegrationTest {
             assertEquals(0, error.size());
             assertEquals(1, result.size());
         } finally {
-            executor.shutdownGracefully();
+            executor.shutdownGracefully().sync();
         }
     }
 
@@ -535,7 +535,7 @@ public class NettyBlockHoundIntegrationTest {
             if (sc != null) {
                 sc.close().syncUninterruptibly();
             }
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
             ReferenceCountUtil.release(sslClientCtx);
         }
     }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramChannelTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramChannelTest.java
@@ -92,7 +92,7 @@ public class EpollDatagramChannelTest {
 
             future.channel().close().syncUninterruptibly();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramChannelTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramChannelTest.java
@@ -69,7 +69,7 @@ public class EpollDatagramChannelTest {
     }
 
     @Test
-    public void testLocalAddressBeforeAndAfterBind() {
+    public void testLocalAddressBeforeAndAfterBind() throws Exception {
         EventLoopGroup group = new EpollEventLoopGroup(1);
         try {
             TestHandler handler = new TestHandler();

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollEventLoopTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollEventLoopTest.java
@@ -60,7 +60,7 @@ public class EpollEventLoopTest extends AbstractSingleThreadEventLoopTest {
     }
 
     @Test
-    public void testScheduleBigDelayNotOverflow() {
+    public void testScheduleBigDelayNotOverflow() throws Exception {
         final AtomicReference<Throwable> capture = new AtomicReference<Throwable>();
 
         final EventLoopGroup group = new EpollEventLoop(null,

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollEventLoopTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollEventLoopTest.java
@@ -86,7 +86,7 @@ public class EpollEventLoopTest extends AbstractSingleThreadEventLoopTest {
             assertTrue(future.cancel(true));
             assertNull(capture.get());
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollServerSocketChannelConfigTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollServerSocketChannelConfigTest.java
@@ -49,11 +49,11 @@ public class EpollServerSocketChannelConfigTest {
     }
 
     @AfterAll
-    public static void after() {
+    public static void after() throws Exception {
         try {
             ch.close().syncUninterruptibly();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelConfigTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelConfigTest.java
@@ -54,8 +54,8 @@ public class EpollSocketChannelConfigTest {
     }
 
     @AfterAll
-    public static void afterClass() {
-        group.shutdownGracefully();
+    public static void afterClass() throws Exception {
+        group.shutdownGracefully().sync();
     }
 
     @BeforeEach

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelTest.java
@@ -43,7 +43,7 @@ public class EpollSocketChannelTest {
             assertTcpInfo0(info);
             ch.close().syncUninterruptibly();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
@@ -62,7 +62,7 @@ public class EpollSocketChannelTest {
             assertTcpInfo0(info);
             ch.close().syncUninterruptibly();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
@@ -117,7 +117,7 @@ public class EpollSocketChannelTest {
                     .bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
             ch.close().syncUninterruptibly();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketStringEchoBusyWaitTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketStringEchoBusyWaitTest.java
@@ -55,7 +55,7 @@ public class EpollSocketStringEchoBusyWaitTest extends SocketStringEchoTest {
     @AfterAll
     public static void teardown() throws Exception {
         if (EPOLL_LOOP != null) {
-            EPOLL_LOOP.shutdownGracefully();
+            EPOLL_LOOP.shutdownGracefully().sync();
         }
     }
 

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTcpMd5Test.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTcpMd5Test.java
@@ -49,8 +49,8 @@ public class EpollSocketTcpMd5Test {
     }
 
     @AfterAll
-    public static void afterClass() {
-        GROUP.shutdownGracefully();
+    public static void afterClass() throws Exception {
+        GROUP.shutdownGracefully().sync();
     }
 
     @BeforeEach

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSpliceTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSpliceTest.java
@@ -168,7 +168,7 @@ public class EpollSpliceTest {
         ch.channel.close().sync();
         sc.close().sync();
         pc.close().sync();
-        group.shutdownGracefully();
+        group.shutdownGracefully().sync();
 
         if (sh.exception.get() != null && !(sh.exception.get() instanceof IOException)) {
             throw sh.exception.get();
@@ -231,7 +231,7 @@ public class EpollSpliceTest {
             assertEquals(written.length, in.read(written));
             assertArrayEquals(data, written);
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringAutoReadTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringAutoReadTest.java
@@ -75,7 +75,7 @@ public class IoUringAutoReadTest {
                 Assertions.assertEquals(2, in.read());
             }
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
@@ -162,7 +162,7 @@ public class IoUringBufferRingTest {
 
         serverChannel.close().syncUninterruptibly();
         clientChannel.close().syncUninterruptibly();
-        group.shutdownGracefully();
+        group.shutdownGracefully().sync();
     }
 
     static boolean recvsendBundleEnabled() {
@@ -233,7 +233,7 @@ public class IoUringBufferRingTest {
             assertEquals(writeBuffer, received);
             serverChannel.close().syncUninterruptibly();
             clientChannel.close().syncUninterruptibly();
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
             assertTrue(buffers.isEmpty());
         } finally {
             writeBuffer.release();

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringEventLoopTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringEventLoopTest.java
@@ -71,7 +71,7 @@ public class IoUringEventLoopTest extends AbstractSingleThreadEventLoopTest {
             loop.submit(EMPTY_RUNNABLE).sync();
             loop.submit(EMPTY_RUNNABLE).sync();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
@@ -99,7 +99,7 @@ public class IoUringEventLoopTest extends AbstractSingleThreadEventLoopTest {
             EventLoop loop = group.next();
             loop.schedule(EMPTY_RUNNABLE, 1, TimeUnit.SECONDS).sync();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringFileRegionTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringFileRegionTest.java
@@ -98,7 +98,7 @@ public class IoUringFileRegionTest {
 
         serverChannel.close().syncUninterruptibly();
         clientChannel.close().syncUninterruptibly();
-        group.shutdownGracefully();
+        group.shutdownGracefully().sync();
     }
 }
 

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringRemoteIpTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringRemoteIpTest.java
@@ -108,7 +108,7 @@ public class IoUringRemoteIpTest {
             f.channel().close().sync();
         } finally {
             // Shut down all event loops to terminate all threads.
-            bossGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully().sync();
 
             socket.close();
         }

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueChannelConfigTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueChannelConfigTest.java
@@ -81,7 +81,7 @@ public class KQueueChannelConfigTest {
                     .bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
             ch.close().syncUninterruptibly();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueEventLoopTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueEventLoopTest.java
@@ -51,7 +51,7 @@ public class KQueueEventLoopTest extends AbstractSingleThreadEventLoopTest {
     }
 
     @Test
-    public void testScheduleBigDelayNotOverflow() {
+    public void testScheduleBigDelayNotOverflow() throws Exception {
         EventLoopGroup group = new KQueueEventLoopGroup(1);
 
         final EventLoop el = group.next();

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueEventLoopTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueEventLoopTest.java
@@ -64,6 +64,6 @@ public class KQueueEventLoopTest extends AbstractSingleThreadEventLoopTest {
 
         assertFalse(future.awaitUninterruptibly(1000));
         assertTrue(future.cancel(true));
-        group.shutdownGracefully();
+        group.shutdownGracefully().sync();
     }
 }

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueServerSocketChannelConfigTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueServerSocketChannelConfigTest.java
@@ -46,11 +46,11 @@ public class KQueueServerSocketChannelConfigTest {
     }
 
     @AfterAll
-    public static void after() {
+    public static void after() throws Exception {
         try {
             ch.close().syncUninterruptibly();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketChannelConfigTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketChannelConfigTest.java
@@ -50,8 +50,8 @@ public class KQueueSocketChannelConfigTest {
     }
 
     @AfterAll
-    public static void afterClass() {
-        group.shutdownGracefully();
+    public static void afterClass() throws Exception{
+        group.shutdownGracefully().sync();
     }
 
     @BeforeEach

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketChannelConfigTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketChannelConfigTest.java
@@ -50,7 +50,7 @@ public class KQueueSocketChannelConfigTest {
     }
 
     @AfterAll
-    public static void afterClass() throws Exception{
+    public static void afterClass() throws Exception {
         group.shutdownGracefully().sync();
     }
 

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KqueueRegistrationTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KqueueRegistrationTest.java
@@ -65,7 +65,7 @@ public class KqueueRegistrationTest {
             Throwable cause = promise.sync().getNow();
             assertInstanceOf(ConnectException.class, cause);
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 }

--- a/transport-native-unix-common-tests/src/main/java/io/netty/channel/unix/tests/DetectPeerCloseWithoutReadTest.java
+++ b/transport-native-unix-common-tests/src/main/java/io/netty/channel/unix/tests/DetectPeerCloseWithoutReadTest.java
@@ -99,10 +99,10 @@ public abstract class DetectPeerCloseWithoutReadTest {
                 serverChannel.close().syncUninterruptibly();
             }
             if (serverGroup != null) {
-                serverGroup.shutdownGracefully();
+                serverGroup.shutdownGracefully().sync();
             }
             if (clientGroup != null) {
-                clientGroup.shutdownGracefully();
+                clientGroup.shutdownGracefully().sync();
             }
         }
     }
@@ -176,10 +176,10 @@ public abstract class DetectPeerCloseWithoutReadTest {
                 clientChannel.close().syncUninterruptibly();
             }
             if (serverGroup != null) {
-                serverGroup.shutdownGracefully();
+                serverGroup.shutdownGracefully().sync();
             }
             if (clientGroup != null) {
-                clientGroup.shutdownGracefully();
+                clientGroup.shutdownGracefully().sync();
             }
         }
     }

--- a/transport-sctp/src/test/java/io/netty/channel/sctp/SctpLimitStreamsTest.java
+++ b/transport-sctp/src/test/java/io/netty/channel/sctp/SctpLimitStreamsTest.java
@@ -72,7 +72,7 @@ public abstract class SctpLimitStreamsTest {
             serverChannel.close().syncUninterruptibly();
             clientChannel.close().syncUninterruptibly();
         } finally {
-            loop.shutdownGracefully();
+            loop.shutdownGracefully().sync();
         }
     }
 

--- a/transport-udt/src/test/java/io/netty/test/udt/bench/xfer/UdtNetty.java
+++ b/transport-udt/src/test/java/io/netty/test/udt/bench/xfer/UdtNetty.java
@@ -125,8 +125,8 @@ public final class UdtNetty {
 
         Thread.sleep(1000);
 
-        group1.shutdownGracefully();
-        group2.shutdownGracefully();
+        group1.shutdownGracefully().sync();
+        group2.shutdownGracefully().sync();
 
         Metrics.defaultRegistry().shutdown();
 

--- a/transport-udt/src/test/java/io/netty/test/udt/nio/NioUdtByteRendezvousChannelTest.java
+++ b/transport-udt/src/test/java/io/netty/test/udt/nio/NioUdtByteRendezvousChannelTest.java
@@ -118,8 +118,8 @@ public class NioUdtByteRendezvousChannelTest extends AbstractUdtTest {
 
         assertEquals(handler1.meter().count(), handler2.meter().count());
 
-        group1.shutdownGracefully();
-        group2.shutdownGracefully();
+        group1.shutdownGracefully().sync();
+        group2.shutdownGracefully().sync();
 
         group1.terminationFuture().sync();
         group2.terminationFuture().sync();

--- a/transport-udt/src/test/java/io/netty/test/udt/nio/NioUdtMessageRendezvousChannelTest.java
+++ b/transport-udt/src/test/java/io/netty/test/udt/nio/NioUdtMessageRendezvousChannelTest.java
@@ -117,8 +117,8 @@ public class NioUdtMessageRendezvousChannelTest extends AbstractUdtTest {
 
         assertEquals(handler1.meter().count(), handler2.meter().count());
 
-        group1.shutdownGracefully();
-        group2.shutdownGracefully();
+        group1.shutdownGracefully().sync();
+        group2.shutdownGracefully().sync();
 
         group1.terminationFuture().sync();
         group2.terminationFuture().sync();

--- a/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
@@ -79,8 +79,8 @@ public class BootstrapTest {
 
     @AfterAll
     public static void destroy() {
-        groupA.shutdownGracefully();
-        groupB.shutdownGracefully();
+        groupA.shutdownGracefully().syncUninterruptibly();
+        groupB.shutdownGracefully().syncUninterruptibly();
         groupA.terminationFuture().syncUninterruptibly();
         groupB.terminationFuture().syncUninterruptibly();
     }
@@ -223,7 +223,7 @@ public class BootstrapTest {
             assertTrue(queue.take());
             assertTrue(queue.take());
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
             group.terminationFuture().sync();
         }
     }
@@ -272,7 +272,7 @@ public class BootstrapTest {
             assertTrue(queue.take());
             assertFalse(queue.take());
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
             group.terminationFuture().sync();
         }
     }
@@ -293,7 +293,7 @@ public class BootstrapTest {
                 }
             });
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 

--- a/transport/src/test/java/io/netty/bootstrap/ServerBootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/ServerBootstrapTest.java
@@ -73,7 +73,7 @@ public class ServerBootstrapTest {
             latch.await();
             assertNull(error.get());
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
@@ -145,7 +145,7 @@ public class ServerBootstrapTest {
             if (cch != null) {
                 cch.close().syncUninterruptibly();
             }
-            group.shutdownGracefully();
+            group.shutdownGracefully().syncUninterruptibly();
         }
     }
 
@@ -178,7 +178,7 @@ public class ServerBootstrapTest {
         Channel clientChannel = cb.connect(addr).syncUninterruptibly().channel();
         serverChannel.close().syncUninterruptibly();
         clientChannel.close().syncUninterruptibly();
-        group.shutdownGracefully();
+        group.shutdownGracefully().syncUninterruptibly();
         assertTrue(requestServed.get());
     }
 
@@ -238,6 +238,6 @@ public class ServerBootstrapTest {
 
         serverChannel.close().syncUninterruptibly();
         clientChannel.close().syncUninterruptibly();
-        group.shutdownGracefully();
+        group.shutdownGracefully().syncUninterruptibly();
     }
 }

--- a/transport/src/test/java/io/netty/channel/AbstractChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/AbstractChannelTest.java
@@ -162,7 +162,7 @@ public class AbstractChannelTest {
             assertClosedChannelException(channel.bind(new InetSocketAddress(NetUtil.LOCALHOST, 8888)), ioException);
         } finally {
             channel.close();
-            loop.shutdownGracefully();
+            loop.shutdownGracefully().syncUninterruptibly();
         }
     }
 

--- a/transport/src/test/java/io/netty/channel/AbstractEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/AbstractEventLoopTest.java
@@ -131,8 +131,8 @@ public abstract class AbstractEventLoopTest {
                 fail(caughtThrowable);
             }
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully().syncUninterruptibly();
+            workerGroup.shutdownGracefully().syncUninterruptibly();
         }
     }
 

--- a/transport/src/test/java/io/netty/channel/ChannelOutboundBufferTest.java
+++ b/transport/src/test/java/io/netty/channel/ChannelOutboundBufferTest.java
@@ -522,7 +522,7 @@ public class ChannelOutboundBufferTest {
 
         safeClose(ch);
 
-        executor.shutdownGracefully();
+        executor.shutdownGracefully().sync();
     }
 
     private static void safeClose(EmbeddedChannel ch) {

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTailTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTailTest.java
@@ -41,8 +41,8 @@ public class DefaultChannelPipelineTailTest {
     }
 
     @AfterAll
-    public static void destroy() {
-        GROUP.shutdownGracefully();
+    public static void destroy() throws Exception {
+        GROUP.shutdownGracefully().sync();
     }
 
     @Test

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
@@ -1006,14 +1006,14 @@ public class DefaultChannelPipelineTest {
             assertHandler(removedQueue.take(), handler1);
             assertTrue(removedQueue.isEmpty());
         } finally {
-            group1.shutdownGracefully();
-            group2.shutdownGracefully();
+            group1.shutdownGracefully().sync();
+            group2.shutdownGracefully().sync();
         }
     }
 
     @Test
     @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
-    public void testHandlerAddedExceptionFromChildHandlerIsPropagated() {
+    public void testHandlerAddedExceptionFromChildHandlerIsPropagated() throws Exception {
         final EventExecutorGroup group1 = new MultiThreadIoEventLoopGroup(1, LocalIoHandler.newFactory());
         try {
             final Promise<Void> promise = group1.next().newPromise();
@@ -1032,13 +1032,13 @@ public class DefaultChannelPipelineTest {
             group.register(pipeline.channel());
             promise.syncUninterruptibly();
         } finally {
-            group1.shutdownGracefully();
+            group1.shutdownGracefully().sync();
         }
     }
 
     @Test
     @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
-    public void testHandlerRemovedExceptionFromChildHandlerIsPropagated() {
+    public void testHandlerRemovedExceptionFromChildHandlerIsPropagated() throws Exception {
         final EventExecutorGroup group1 = new MultiThreadIoEventLoopGroup(1, LocalIoHandler.newFactory());
         try {
             final Promise<Void> promise = group1.next().newPromise();
@@ -1056,7 +1056,7 @@ public class DefaultChannelPipelineTest {
             pipeline.remove(handlerName);
             promise.syncUninterruptibly();
         } finally {
-            group1.shutdownGracefully();
+            group1.shutdownGracefully().sync();
         }
     }
 
@@ -1095,7 +1095,7 @@ public class DefaultChannelPipelineTest {
             assertNull(pipeline.context(handlerName));
             promise.syncUninterruptibly();
         } finally {
-            group1.shutdownGracefully();
+            group1.shutdownGracefully().sync();
         }
     }
 
@@ -1177,7 +1177,7 @@ public class DefaultChannelPipelineTest {
             }
             latch.await();
         } finally {
-            defaultGroup.shutdownGracefully();
+            defaultGroup.shutdownGracefully().sync();
         }
     }
 
@@ -1237,7 +1237,7 @@ public class DefaultChannelPipelineTest {
             assertSame(event, promise.syncUninterruptibly().getNow());
         } finally {
             pipeline1.channel().close().syncUninterruptibly();
-            group.shutdownGracefully();
+            group.shutdownGracefully().syncUninterruptibly();
         }
     }
 
@@ -1351,7 +1351,7 @@ public class DefaultChannelPipelineTest {
             assertSame(exception, promise.syncUninterruptibly().getNow());
         } finally {
             pipeline1.channel().close().syncUninterruptibly();
-            defaultGroup.shutdownGracefully();
+            defaultGroup.shutdownGracefully().syncUninterruptibly();
         }
     }
 
@@ -1417,7 +1417,7 @@ public class DefaultChannelPipelineTest {
                 }
             }
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
@@ -1874,7 +1874,7 @@ public class DefaultChannelPipelineTest {
                 assertNull(channel.pipeline().get("h" + i));
             }
         } finally {
-            executorGroup.shutdownGracefully();
+            executorGroup.shutdownGracefully().sync();
         }
     }
 

--- a/transport/src/test/java/io/netty/channel/ManualIoEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/ManualIoEventLoopTest.java
@@ -244,7 +244,7 @@ public class ManualIoEventLoopTest {
         thread.start();
         cf.get();
 
-        eventLoop.shutdownGracefully();
+        eventLoop.shutdownGracefully().sync();
         thread.join();
     }
 
@@ -260,11 +260,11 @@ public class ManualIoEventLoopTest {
 
         eventLoop.runNow(); // runs fine
 
-        eventLoop.shutdownGracefully();
+        eventLoop.shutdownGracefully().sync();
     }
 
     @Test
-    public void testRunNonIoTasksSetupEventExecutor() {
+    public void testRunNonIoTasksSetupEventExecutor() throws Exception {
         MockTicker ticker = Ticker.newMockTicker();
         ManualIoEventLoop eventLoop = new ManualIoEventLoop(
                 null, Thread.currentThread(), LocalIoHandler.newFactory(), ticker);
@@ -276,7 +276,7 @@ public class ManualIoEventLoopTest {
         });
         assertEquals(1, eventLoop.runNonBlockingTasks(0));
         assertTrue(executed.get());
-        eventLoop.shutdownGracefully();
+        eventLoop.shutdownGracefully().sync();
     }
 
     private enum RunMode {
@@ -300,7 +300,7 @@ public class ManualIoEventLoopTest {
 
     @ParameterizedTest
     @EnumSource(RunMode.class)
-    public void testTasksWhileExpiringTimeout(RunMode mode) {
+    public void testTasksWhileExpiringTimeout(RunMode mode) throws Exception {
         MockTicker ticker = Ticker.newMockTicker();
         ManualIoEventLoop eventLoop = new ManualIoEventLoop(
                 null, Thread.currentThread(), LocalIoHandler.newFactory(), ticker);
@@ -323,21 +323,21 @@ public class ManualIoEventLoopTest {
         assertFalse(executedSecond.get());
         canExecute.set(true);
         assertEquals(1, mode.runWith(eventLoop, 1));
-        eventLoop.shutdownGracefully();
+        eventLoop.shutdownGracefully().sync();
     }
 
     @Test
-    public void testSetOwnerMultipleTimes() {
+    public void testSetOwnerMultipleTimes() throws Exception {
         ManualIoEventLoop eventLoop = new ManualIoEventLoop(null, executor ->
                 new TestIoHandler(new Semaphore(0)));
         eventLoop.setOwningThread(Thread.currentThread());
         assertThrows(IllegalStateException.class, () -> eventLoop.setOwningThread(Thread.currentThread()));
 
-        eventLoop.shutdownGracefully();
+        eventLoop.shutdownGracefully().sync();
     }
 
     @Test
-    public void testTicker() {
+    public void testTicker() throws Exception {
         MockTicker ticker = Ticker.newMockTicker();
         ManualIoEventLoop eventLoop = new ManualIoEventLoop(
                 null, Thread.currentThread(), NioIoHandler.newFactory(), ticker);
@@ -356,7 +356,7 @@ public class ManualIoEventLoopTest {
         eventLoop.runNow();
         assertEquals(1, counter.get());
 
-        eventLoop.shutdownGracefully();
+        eventLoop.shutdownGracefully().sync();
     }
 
     private static final class TestRunnable implements Runnable {

--- a/transport/src/test/java/io/netty/channel/SingleThreadIoEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/SingleThreadIoEventLoopTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class SingleThreadIoEventLoopTest {
 
     @Test
-    void testIsIoType() {
+    void testIsIoType() throws Exception {
         class TestIoHandler2 extends TestIoHandler {
             TestIoHandler2(ThreadAwareExecutor executor) {
                 super(executor);
@@ -41,7 +41,7 @@ public class SingleThreadIoEventLoopTest {
                 Executors.defaultThreadFactory(), TestIoHandler::new);
         assertTrue(group.isIoType(TestIoHandler.class));
         assertFalse(group.isIoType(TestIoHandler2.class));
-        group.shutdownGracefully();
+        group.shutdownGracefully().sync();
     }
 
     static final class CompatibleTestIoHandler extends TestIoHandler {
@@ -56,14 +56,13 @@ public class SingleThreadIoEventLoopTest {
     }
 
     @Test
-    void testIsCompatible() {
-
+    void testIsCompatible() throws Exception {
         IoHandle handle = new TestIoHandle() { };
         IoEventLoopGroup group = new SingleThreadIoEventLoop(null,
                 Executors.defaultThreadFactory(), CompatibleTestIoHandler::new);
         assertTrue(group.isCompatible(TestIoHandle.class));
         assertFalse(group.isCompatible(handle.getClass()));
-        group.shutdownGracefully();
+        group.shutdownGracefully().sync();
     }
 
     private static final class TestThreadFactory implements ThreadFactory {
@@ -103,7 +102,7 @@ public class SingleThreadIoEventLoopTest {
         currentThread.join();
 
         assertTrue(threadFactory.threads.isEmpty());
-        loop.shutdownGracefully();
+        loop.shutdownGracefully().sync();
     }
 
     private static class TestIoHandler implements IoHandler {

--- a/transport/src/test/java/io/netty/channel/group/DefaultChannelGroupTest.java
+++ b/transport/src/test/java/io/netty/channel/group/DefaultChannelGroupTest.java
@@ -53,8 +53,8 @@ public class DefaultChannelGroupTest {
             allChannels.close().awaitUninterruptibly();
         }
 
-        bossGroup.shutdownGracefully();
-        workerGroup.shutdownGracefully();
+        bossGroup.shutdownGracefully().sync();
+        workerGroup.shutdownGracefully().sync();
         bossGroup.terminationFuture().sync();
         workerGroup.terminationFuture().sync();
     }

--- a/transport/src/test/java/io/netty/channel/local/LocalTransportThreadModelTest.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalTransportThreadModelTest.java
@@ -223,9 +223,9 @@ public class LocalTransportThreadModelTest {
             System.out.println("H3R: " + h3.removalThreadNames);
             throw e;
         } finally {
-            l.shutdownGracefully();
-            e1.shutdownGracefully();
-            e2.shutdownGracefully();
+            l.shutdownGracefully().sync();
+            e1.shutdownGracefully().sync();
+            e2.shutdownGracefully().sync();
 
             l.terminationFuture().sync();
             e1.terminationFuture().sync();
@@ -347,12 +347,12 @@ public class LocalTransportThreadModelTest {
 
             ch.close().sync();
         } finally {
-            l.shutdownGracefully();
-            e1.shutdownGracefully();
-            e2.shutdownGracefully();
-            e3.shutdownGracefully();
-            e4.shutdownGracefully();
-            e5.shutdownGracefully();
+            l.shutdownGracefully().sync();
+            e1.shutdownGracefully().sync();
+            e2.shutdownGracefully().sync();
+            e3.shutdownGracefully().sync();
+            e4.shutdownGracefully().sync();
+            e5.shutdownGracefully().sync();
 
             l.terminationFuture().sync();
             e1.terminationFuture().sync();

--- a/transport/src/test/java/io/netty/channel/local/LocalTransportThreadModelTest3.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalTransportThreadModelTest3.java
@@ -225,12 +225,12 @@ public class LocalTransportThreadModelTest3 {
                 assertEquals(event, expectedEvents.poll());
             }
         } finally {
-            l.shutdownGracefully();
-            e1.shutdownGracefully();
-            e2.shutdownGracefully();
-            e3.shutdownGracefully();
-            e4.shutdownGracefully();
-            e5.shutdownGracefully();
+            l.shutdownGracefully().sync();
+            e1.shutdownGracefully().sync();
+            e2.shutdownGracefully().sync();
+            e3.shutdownGracefully().sync();
+            e4.shutdownGracefully().sync();
+            e5.shutdownGracefully().sync();
 
             l.terminationFuture().sync();
             e1.terminationFuture().sync();

--- a/transport/src/test/java/io/netty/channel/nio/NioEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/nio/NioEventLoopTest.java
@@ -73,7 +73,7 @@ public class NioEventLoopTest extends AbstractEventLoopTest {
     }
 
     @Test
-    public void testRebuildSelector() {
+    public void testRebuildSelector() throws Exception {
         EventLoopGroup group = new NioEventLoopGroup(1);
         final NioEventLoop loop = (NioEventLoop) group.next();
         try {
@@ -99,12 +99,12 @@ public class NioEventLoopTest extends AbstractEventLoopTest {
 
             channel.close().syncUninterruptibly();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
     @Test
-    public void testScheduleBigDelayNotOverflow() {
+    public void testScheduleBigDelayNotOverflow() throws Exception {
         EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
 
         final EventLoop el = group.next();
@@ -117,7 +117,7 @@ public class NioEventLoopTest extends AbstractEventLoopTest {
 
         assertFalse(future.awaitUninterruptibly(1000));
         assertTrue(future.cancel(true));
-        group.shutdownGracefully();
+        group.shutdownGracefully().sync();
     }
 
     @Test
@@ -159,7 +159,7 @@ public class NioEventLoopTest extends AbstractEventLoopTest {
             assertSame(selector, loop.unwrappedSelector());
             assertTrue(selector.isOpen());
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
@@ -195,7 +195,7 @@ public class NioEventLoopTest extends AbstractEventLoopTest {
             selectableChannel.close();
             channel.close().syncUninterruptibly();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
@@ -236,7 +236,7 @@ public class NioEventLoopTest extends AbstractEventLoopTest {
     }
 
     @Test
-    public void testRebuildSelectorOnIOException() {
+    public void testRebuildSelectorOnIOException() throws Exception {
         SelectStrategyFactory selectStrategyFactory = new SelectStrategyFactory() {
             @Override
             public SelectStrategy newSelectStrategy() {
@@ -272,7 +272,7 @@ public class NioEventLoopTest extends AbstractEventLoopTest {
 
             channel.close().syncUninterruptibly();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
@@ -301,7 +301,7 @@ public class NioEventLoopTest extends AbstractEventLoopTest {
             }
             assertEquals(1, registered);
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 

--- a/transport/src/test/java/io/netty/channel/oio/OioEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/oio/OioEventLoopTest.java
@@ -62,7 +62,7 @@ public class OioEventLoopTest {
         });
 
         notified.await();
-        g.shutdownGracefully();
+        g.shutdownGracefully().sync();
     }
 
     @Test
@@ -94,7 +94,7 @@ public class OioEventLoopTest {
         });
 
         notified.await();
-        g.shutdownGracefully();
+        g.shutdownGracefully().sync();
     }
 
     @Test
@@ -111,6 +111,6 @@ public class OioEventLoopTest {
         assertEquals(-1, s.getInputStream().read());
         s.close();
 
-        g.shutdownGracefully();
+        g.shutdownGracefully().sync();
     }
 }

--- a/transport/src/test/java/io/netty/channel/pool/FixedChannelPoolTest.java
+++ b/transport/src/test/java/io/netty/channel/pool/FixedChannelPoolTest.java
@@ -61,9 +61,9 @@ public class FixedChannelPoolTest {
     }
 
     @AfterAll
-    public static void destroyEventLoop() {
+    public static void destroyEventLoop() throws Exception {
         if (group != null) {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 

--- a/transport/src/test/java/io/netty/channel/pool/SimpleChannelPoolTest.java
+++ b/transport/src/test/java/io/netty/channel/pool/SimpleChannelPoolTest.java
@@ -91,7 +91,7 @@ public class SimpleChannelPoolTest {
 
         sc.close().sync();
         pool.close();
-        group.shutdownGracefully();
+        group.shutdownGracefully().sync();
     }
 
     @Test
@@ -150,7 +150,7 @@ public class SimpleChannelPoolTest {
         channel.close().sync();
         channel2.close().sync();
         pool.close();
-        group.shutdownGracefully();
+        group.shutdownGracefully().sync();
     }
 
     /**
@@ -196,7 +196,7 @@ public class SimpleChannelPoolTest {
         sc.close().syncUninterruptibly();
         channel3.close().syncUninterruptibly();
         pool.close();
-        group.shutdownGracefully();
+        group.shutdownGracefully().sync();
     }
 
     /**
@@ -240,7 +240,7 @@ public class SimpleChannelPoolTest {
         sc.close().syncUninterruptibly();
         channel2.close().syncUninterruptibly();
         pool.close();
-        group.shutdownGracefully();
+        group.shutdownGracefully().sync();
     }
 
     @Test
@@ -349,7 +349,7 @@ public class SimpleChannelPoolTest {
 
         sc.close().sync();
         pool.close();
-        group.shutdownGracefully();
+        group.shutdownGracefully().sync();
     }
 
     @Test
@@ -394,6 +394,6 @@ public class SimpleChannelPoolTest {
 
         sc.close().sync();
         pool.close();
-        group.shutdownGracefully();
+        group.shutdownGracefully().sync();
     }
 }

--- a/transport/src/test/java/io/netty/channel/socket/nio/NioServerDomainSocketChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/nio/NioServerDomainSocketChannelTest.java
@@ -56,7 +56,7 @@ public class NioServerDomainSocketChannelTest extends AbstractNioDomainChannelTe
             assertFalse(serverSocketChannel.closeOnReadError(new IOException()));
             serverSocketChannel.close().syncUninterruptibly();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
             file.delete();
         }
     }
@@ -77,7 +77,7 @@ public class NioServerDomainSocketChannelTest extends AbstractNioDomainChannelTe
             assertFalse(channel.isOpen());
             assertFalse(channel.isActive());
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
             file.delete();
         }
     }
@@ -103,7 +103,7 @@ public class NioServerDomainSocketChannelTest extends AbstractNioDomainChannelTe
             assertFalse(serverSocketChannel.isOpen());
             assertFalse(serverSocketChannel.isActive());
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
             file.delete();
         }
     }

--- a/transport/src/test/java/io/netty/channel/socket/nio/NioServerSocketChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/nio/NioServerSocketChannelTest.java
@@ -46,12 +46,12 @@ public class NioServerSocketChannelTest extends AbstractNioChannelTest<NioServer
             assertTrue(serverSocketChannel.closeOnReadError(new IllegalArgumentException()));
             serverSocketChannel.close().syncUninterruptibly();
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
     @Test
-    public void testIsActiveFalseAfterClose()  {
+    public void testIsActiveFalseAfterClose() throws Exception {
         NioServerSocketChannel serverSocketChannel = new NioServerSocketChannel();
         EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
         try {
@@ -63,7 +63,7 @@ public class NioServerSocketChannelTest extends AbstractNioChannelTest<NioServer
             assertFalse(channel.isOpen());
             assertFalse(channel.isActive());
         } finally {
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 

--- a/transport/src/test/java/io/netty/channel/socket/nio/NioSocketChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/nio/NioSocketChannelTest.java
@@ -250,13 +250,13 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
             if (sc != null) {
                 sc.close();
             }
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
     @Test
     @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
-    public void testShutdownOutputAndClose() throws IOException {
+    public void testShutdownOutputAndClose() throws Exception {
         EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
         ServerSocket socket = new ServerSocket();
         socket.bind(new InetSocketAddress(0));
@@ -286,7 +286,7 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
             } catch (IOException ignore) {
                 // ignore
             }
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 


### PR DESCRIPTION
Motivation:

We should better wait for the EventLoopGroup to shutdown so we not end up overwhelming the CI by creating to many threads while the others did not exit yet.

Modifications:

Wait on the shutdownGracefully() future

Result:

Less resources use on CI while running tests and also show best-practice in examples