### PR TITLE
Adaptive: Fix possible buffer corruption caused by incorrect setCharS…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -16,6 +16,7 @@
 package io.netty.buffer;
 
 import io.netty.util.ByteProcessor;
+import io.netty.util.CharsetUtil;
 import io.netty.util.IllegalReferenceCountException;
 import io.netty.util.NettyRuntime;
 import io.netty.util.Recycler.EnhancedHandle;
@@ -1503,8 +1504,46 @@ final class AdaptivePoolingAllocator {
 
         @Override
         public int setCharSequence(int index, CharSequence sequence, Charset charset) {
-            checkIndex(index, sequence.length());
-            return rootParent().setCharSequence(idx(index), sequence, charset);
+            return setCharSequence0(index, sequence, charset, false);
+        }
+
+        private int setCharSequence0(int index, CharSequence sequence, Charset charset, boolean expand) {
+            if (charset.equals(CharsetUtil.UTF_8)) {
+                int length = ByteBufUtil.utf8MaxBytes(sequence);
+                if (expand) {
+                    ensureWritable0(length);
+                    checkIndex0(index, length);
+                } else {
+                    checkIndex(index, length);
+                }
+                // Directly pass in the rootParent() with the adjusted index
+                return ByteBufUtil.writeUtf8(rootParent(), idx(index), length, sequence, sequence.length());
+            }
+            if (charset.equals(CharsetUtil.US_ASCII) || charset.equals(CharsetUtil.ISO_8859_1)) {
+                int length = sequence.length();
+                if (expand) {
+                    ensureWritable0(length);
+                    checkIndex0(index, length);
+                } else {
+                    checkIndex(index, length);
+                }
+                // Directly pass in the rootParent() with the adjusted index
+                return ByteBufUtil.writeAscii(rootParent(), idx(index), sequence, length);
+            }
+            byte[] bytes = sequence.toString().getBytes(charset);
+            if (expand) {
+                ensureWritable0(bytes.length);
+                // setBytes(...) will take care of checking the indices.
+            }
+            setBytes(index, bytes);
+            return bytes.length;
+        }
+
+        @Override
+        public int writeCharSequence(CharSequence sequence, Charset charset) {
+            int written = setCharSequence0(writerIndex, sequence, charset, true);
+            writerIndex += written;
+            return written;
         }
 
         @Override

--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
@@ -40,6 +40,7 @@ import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.ScatteringByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -60,9 +61,11 @@ import static io.netty.buffer.Unpooled.directBuffer;
 import static io.netty.buffer.Unpooled.unreleasableBuffer;
 import static io.netty.buffer.Unpooled.wrappedBuffer;
 import static io.netty.util.internal.EmptyArrays.EMPTY_BYTES;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -6320,5 +6323,29 @@ public abstract class AbstractByteBufTest {
         buf.writeByte(1);
         assertEquals(max - 1, buf.maxFastWritableBytes());
         buf.release();
+    }
+
+    @Test
+    public void testSetCharSequenceWithTooLongSequence() {
+        ByteBuf buffer = buffer(4, 128);
+        CharSequence sequence = "ÖÄÜ€";
+        int maxBytes = ByteBufUtil.utf8MaxBytes(sequence);
+        assertThat(buffer.writableBytes()).isLessThan(maxBytes);
+        assertThrows(IndexOutOfBoundsException.class,
+                () -> buffer.setCharSequence(0, sequence, StandardCharsets.UTF_8));
+        buffer.release();
+    }
+
+    @Test
+    public void testWriteCharSequence() {
+        ByteBuf buffer = buffer(4, 128);
+        CharSequence sequence = "ÖÄÜ€";
+        int maxBytes = ByteBufUtil.utf8MaxBytes(sequence);
+        assertThat(buffer.writableBytes()).isLessThan(maxBytes);
+        int capacity = buffer.capacity();
+        // This should expand the buffer.
+        buffer.writeCharSequence(sequence, StandardCharsets.UTF_8);
+        assertNotSame(capacity, buffer.capacity());
+        buffer.release();
     }
 }


### PR DESCRIPTION
…equence(...) implementation

Motivation:

https://github.com/netty/netty/commit/31c033a1d95eb4a74002c5f17ea01c967b07add9 introduced a regression that can lead to data corruption when calling setCharSequence(...) with a Charset that needs more bytes to encode the sequence than CharSequence.length(). The problem is that we just delegate to rootParent() without checking if the AdapativeByteBuf has enough capacity itself. If this is not the case we might still end up to write the CharSequence into the rootParent() and so override the content of another ByteBuf that also uses the same parent.

Modifications:

- Correctly implement setCharSequence and also ensure writeCharSequence is consistent
- Add unit tests

Result:

Fix regression introduced by https://github.com/netty/netty/commit/31c033a1d95eb4a74002c5f17ea01c967b07add9
