### PR TITLE
Improve JFR availability check

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -253,8 +253,10 @@ public final class PlatformDependent {
             jfrAvailable = false;
         }
         JFR = SystemPropertyUtil.getBoolean("io.netty.jfr.enabled", jfrAvailable);
-        if (logger.isDebugEnabled()) {
+        if (logger.isTraceEnabled() && jfrFailure != null) {
             logger.debug("-Dio.netty.jfr.enabled: {}", JFR, jfrFailure);
+        } else if (logger.isDebugEnabled()) {
+            logger.debug("-Dio.netty.jfr.enabled: {}", JFR);
         }
     }
 

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -17,6 +17,7 @@ package io.netty.util.internal;
 
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
+import jdk.jfr.FlightRecorder;
 import org.jctools.queues.MpmcArrayQueue;
 import org.jctools.queues.MpscArrayQueue;
 import org.jctools.queues.MpscChunkedArrayQueue;
@@ -242,9 +243,18 @@ public final class PlatformDependent {
         }
         LINUX_OS_CLASSIFIERS = Collections.unmodifiableSet(availableClassifiers);
 
-        JFR = SystemPropertyUtil.getBoolean("io.netty.jfr.enabled", javaVersion() >= 9);
+        boolean jfrAvailable;
+        Throwable jfrFailure = null;
+        try {
+            //noinspection Since15
+            jfrAvailable = FlightRecorder.isAvailable();
+        } catch (Throwable t) {
+            jfrFailure = t;
+            jfrAvailable = false;
+        }
+        JFR = SystemPropertyUtil.getBoolean("io.netty.jfr.enabled", jfrAvailable);
         if (logger.isDebugEnabled()) {
-            logger.debug("-Dio.netty.jfr.enabled: {}", JFR);
+            logger.debug("-Dio.netty.jfr.enabled: {}", JFR, jfrFailure);
         }
     }
 

--- a/jfr-stub/src/main/java/jdk/jfr/FlightRecorder.java
+++ b/jfr-stub/src/main/java/jdk/jfr/FlightRecorder.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package jdk.jfr;
+
+public final class FlightRecorder {
+    private FlightRecorder() {
+        throw new UnsupportedOperationException("Stub should only be used at compile time");
+    }
+
+    public static boolean isAvailable() {
+        throw new UnsupportedOperationException("Stub should only be used at compile time");
+    }
+}


### PR DESCRIPTION
Motivation:

Using the javaVersion to determine the default value for `io.netty.jfr.enabled` was not ideal. It did not work on JDK 8 versions with backported JFR, and it did not work on certain GraalVM versions without JFR support.

Modification:

Instead of the javaVersion, call `FlightRecorder.isAvailable()`, as discussed in #15397.

Result:

More reliable JFR detection.

Fixes #15382
Fixes #15397

(both untested unfortunately, I don't know exactly which versions to test with)