### PR TITLE
Introduce size-classes for the adaptive allocator

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptiveByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptiveByteBufAllocator.java
@@ -15,7 +15,6 @@
  */
 package io.netty.buffer;
 
-import io.netty.buffer.AdaptivePoolingAllocator.MagazineCaching;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
@@ -54,10 +53,8 @@ public final class AdaptiveByteBufAllocator extends AbstractByteBufAllocator
 
     public AdaptiveByteBufAllocator(boolean preferDirect, boolean useCacheForNonEventLoopThreads) {
         super(preferDirect);
-        MagazineCaching magazineCaching = useCacheForNonEventLoopThreads?
-                MagazineCaching.FastThreadLocalThreads : MagazineCaching.EventLoopThreads;
-        direct = new AdaptivePoolingAllocator(new DirectChunkAllocator(this), magazineCaching);
-        heap = new AdaptivePoolingAllocator(new HeapChunkAllocator(this), magazineCaching);
+        direct = new AdaptivePoolingAllocator(new DirectChunkAllocator(this), useCacheForNonEventLoopThreads);
+        heap = new AdaptivePoolingAllocator(new HeapChunkAllocator(this), useCacheForNonEventLoopThreads);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -627,9 +627,7 @@ final class AdaptivePoolingAllocator {
             // Predict starting capacity from localUpperBufSize, but place limits on the max starting capacity
             // based on the requested size, because localUpperBufSize can potentially be quite large.
             int startCapLimits;
-            if (requestedSize <= 2048) { // Less than or equal to 2 KiB.
-                startCapLimits = 16384; // Use at most 16 KiB.
-            } else if (requestedSize <= 32768) { // Less than or equal to 32 KiB.
+            if (requestedSize <= 32768) { // Less than or equal to 32 KiB.
                 startCapLimits = 65536; // Use at most 64 KiB, which is also the AdaptiveRecvByteBufAllocator max.
             } else {
                 startCapLimits = requestedSize * 2; // Otherwise use at most twice the requested memory.
@@ -869,7 +867,6 @@ final class AdaptivePoolingAllocator {
         }
 
         private boolean allocate(int size, int maxCapacity, AdaptiveByteBuf buf, boolean reallocate) {
-
             int startingCapacity = chunkController.computeBufferCapacity(size, maxCapacity, buf.length, reallocate);
             Chunk curr = current;
             if (curr != null) {

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -510,7 +510,7 @@ final class AdaptivePoolingAllocator {
         /**
          * Compute the "fast max capacity" value for the buffer.
          */
-        int computeBufferCapacity(int requestedSize, int maxCapacity, int historicalSize, boolean isReallocation);
+        int computeBufferCapacity(int requestedSize, int maxCapacity, boolean isReallocation);
 
         /**
          * Initialize the given chunk factory with shared statistics state (if any) from this factory.
@@ -553,7 +553,7 @@ final class AdaptivePoolingAllocator {
 
         @Override
         public int computeBufferCapacity(
-                int requestedSize, int maxCapacity, int historicalSize, boolean isReallocation) {
+                int requestedSize, int maxCapacity, boolean isReallocation) {
             return Math.min(segmentSize, maxCapacity);
         }
 
@@ -617,11 +617,11 @@ final class AdaptivePoolingAllocator {
 
         @Override
         public int computeBufferCapacity(
-                int requestedSize, int maxCapacity, int historicalSize, boolean isReallocation) {
+                int requestedSize, int maxCapacity, boolean isReallocation) {
             if (!isReallocation) {
                 // Only record allocation size if it's not caused by a reallocation that was triggered by capacity
                 // change of the buffer.
-                recordAllocationSize(historicalSize);
+                recordAllocationSize(requestedSize);
             }
 
             // Predict starting capacity from localUpperBufSize, but place limits on the max starting capacity
@@ -848,7 +848,7 @@ final class AdaptivePoolingAllocator {
             boolean allocated = false;
             int remainingCapacity = curr.remainingCapacity();
             int startingCapacity = chunkController.computeBufferCapacity(
-                    size, maxCapacity, buf.length, true /* never update stats as we don't hold the magazine lock */);
+                    size, maxCapacity, true /* never update stats as we don't hold the magazine lock */);
             if (remainingCapacity >= size) {
                 curr.readInitInto(buf, size, Math.min(remainingCapacity, startingCapacity), maxCapacity);
                 allocated = true;
@@ -867,7 +867,7 @@ final class AdaptivePoolingAllocator {
         }
 
         private boolean allocate(int size, int maxCapacity, AdaptiveByteBuf buf, boolean reallocate) {
-            int startingCapacity = chunkController.computeBufferCapacity(size, maxCapacity, buf.length, reallocate);
+            int startingCapacity = chunkController.computeBufferCapacity(size, maxCapacity, reallocate);
             Chunk curr = current;
             if (curr != null) {
                 // We have a Chunk that has some space left.

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -1313,9 +1313,10 @@ final class AdaptivePoolingAllocator {
 
         @Override
         boolean releaseSegment(int segmentId) {
+            boolean released = release();
             boolean segmentReturned = freeList.offer(segmentId);
             assert segmentReturned: "Unable to return segment " + segmentId + " to free list";
-            return release();
+            return released;
         }
 
         boolean isEmpty() {

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -1191,7 +1191,7 @@ final class AdaptivePoolingAllocator {
         private void deallocate() {
             Magazine mag = magazine;
             int chunkSize = delegate.capacity();
-            if (!pooled || chunkReleasePredicate.shouldReleaseChunk(chunkSize)) {
+            if (!pooled || chunkReleasePredicate.shouldReleaseChunk(chunkSize) || mag == null) {
                 // Drop the chunk if the parent allocator is closed,
                 // or if the chunk deviates too much from the preferred chunk size.
                 detachFromMagazine();

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -373,7 +373,7 @@ final class AdaptivePoolingAllocator {
             }
         }
 
-        private AdaptiveByteBuf allocate(int size, int maxCapacity, Thread currentThread, AdaptiveByteBuf buf) {
+        public AdaptiveByteBuf allocate(int size, int maxCapacity, Thread currentThread, AdaptiveByteBuf buf) {
             boolean reallocate = buf != null;
 
             // Path for thread-local allocation.

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -23,6 +23,7 @@ import io.netty.util.Recycler.EnhancedHandle;
 import io.netty.util.ReferenceCounted;
 import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.concurrent.FastThreadLocalThread;
+import io.netty.util.concurrent.MpscIntQueue;
 import io.netty.util.internal.ObjectPool;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
@@ -58,6 +59,7 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.concurrent.locks.StampedLock;
+import java.util.function.IntSupplier;
 
 /**
  * An auto-tuning pooling allocator, that follows an anti-generational hypothesis.
@@ -87,13 +89,6 @@ import java.util.concurrent.locks.StampedLock;
  */
 @UnstableApi
 final class AdaptivePoolingAllocator {
-
-    enum MagazineCaching {
-        EventLoopThreads,
-        FastThreadLocalThreads,
-        None
-    }
-
     /**
      * The 128 KiB minimum chunk size is chosen to encourage the system allocator to delegate to mmap for chunk
      * allocations. For instance, glibc will do this.
@@ -113,7 +108,7 @@ final class AdaptivePoolingAllocator {
      * <p>
      * This number is 8 MiB, and is derived from the limitations of internal histograms.
      */
-    private static final int MAX_CHUNK_SIZE = 1 << AllocationStatistics.HISTO_MAX_BUCKET_SHIFT; // 8 MiB.
+    private static final int MAX_CHUNK_SIZE = 1 << HistogramChunkController.HISTO_MAX_BUCKET_SHIFT; // 8 MiB.
     private static final int MAX_POOLED_BUF_SIZE = MAX_CHUNK_SIZE / BUFS_PER_CHUNK;
 
     /**
@@ -134,15 +129,36 @@ final class AdaptivePoolingAllocator {
     private static final int MAGAZINE_BUFFER_QUEUE_CAPACITY = SystemPropertyUtil.getInt(
             "io.netty.allocator.magazineBufferQueueCapacity", 1024);
 
-    private static final Object NO_MAGAZINE = Boolean.TRUE;
-
-    private final ChunkAllocator chunkAllocator;
-    private final Queue<Chunk> centralQueue;
-    private final StampedLock magazineExpandLock;
-    private volatile Magazine[] magazines;
-    private final FastThreadLocal<Object> threadLocalMagazine;
-    private final Set<Magazine> liveCachedMagazines;
-    private volatile boolean freed;
+    /**
+     * The size classes are chosen based on the following observation:
+     * <p>
+     * Most allocations, particularly ones above 256 bytes, aim to be a power-of-2. However, many use cases, such
+     * as framing protocols, are themselves operating or moving power-of-2 sized payloads, to which they add a
+     * small amount of overhead, such as headers or checksums.
+     * This means we seem to get a lot of mileage out of having both power-of-2 sizes, and power-of-2-plus-a-bit.
+     * <p>
+     * On the conflicting requirements of both having as few chunks as possible, and having as little wasted
+     * memory within each chunk as possible, this seems to strike a surprisingly good balance for the use cases
+     * tested so far.
+     */
+    private static final int[] SIZE_CLASSES = {
+            32,
+            64,
+            128,
+            256,
+            512,
+            640, // 512 + 128
+            1024,
+            1152, // 1024 + 128
+            2048,
+            2304, // 2048 + 256
+            4096,
+            4352, // 4096 + 256
+            8192,
+            8704, // 8192 + 512
+            16384,
+            16896, // 16384 + 512
+    };
 
     static {
         if (MAGAZINE_BUFFER_QUEUE_CAPACITY < 2) {
@@ -151,50 +167,52 @@ final class AdaptivePoolingAllocator {
         }
     }
 
-    AdaptivePoolingAllocator(ChunkAllocator chunkAllocator, MagazineCaching magazineCaching) {
-        ObjectUtil.checkNotNull(chunkAllocator, "chunkAllocator");
-        ObjectUtil.checkNotNull(magazineCaching, "magazineCaching");
-        this.chunkAllocator = chunkAllocator;
-        centralQueue = ObjectUtil.checkNotNull(createSharedChunkQueue(), "centralQueue");
-        magazineExpandLock = new StampedLock();
-        if (magazineCaching != MagazineCaching.None) {
-            assert magazineCaching == MagazineCaching.EventLoopThreads ||
-                   magazineCaching == MagazineCaching.FastThreadLocalThreads;
-            final boolean cachedMagazinesNonEventLoopThreads =
-                    magazineCaching == MagazineCaching.FastThreadLocalThreads;
-            final Set<Magazine> liveMagazines = new CopyOnWriteArraySet<Magazine>();
-            threadLocalMagazine = new FastThreadLocal<Object>() {
-                @Override
-                protected Object initialValue() {
-                    if (cachedMagazinesNonEventLoopThreads || ThreadExecutorMap.currentExecutor() != null) {
-                        if (!FastThreadLocalThread.currentThreadWillCleanupFastThreadLocals()) {
-                            // To prevent a potential leak, we will not use thread-local magazine.
-                            return NO_MAGAZINE;
-                        }
-                        Magazine mag = new Magazine(AdaptivePoolingAllocator.this, false);
-                        liveMagazines.add(mag);
-                        return mag;
-                    }
-                    return NO_MAGAZINE;
-                }
+    private final ChunkAllocator chunkAllocator;
+    private final MagazineGroup[] sizeClassedMagazineGroups;
+    private final MagazineGroup largeBufferMagazineGroup;
+    private final FastThreadLocal<MagazineGroup[]> threadLocalGroup;
+    private final Set<MagazineGroup[]> allThreadLocalGroups;
 
-                @Override
-                protected void onRemoval(final Object value) throws Exception {
-                    if (value != NO_MAGAZINE) {
-                        liveMagazines.remove(value);
-                    }
+    AdaptivePoolingAllocator(ChunkAllocator chunkAllocator, boolean useCacheForNonEventLoopThreads) {
+        this.chunkAllocator = ObjectUtil.checkNotNull(chunkAllocator, "chunkAllocator");
+        sizeClassedMagazineGroups = createMagazineGroupSizeClasses(this, false);
+        largeBufferMagazineGroup = new MagazineGroup(
+                this, chunkAllocator, new HistogramChunkControllerFactory(true), false);
+
+        final Set<MagazineGroup[]> liveMagazines = new CopyOnWriteArraySet<>();
+        threadLocalGroup = new FastThreadLocal<MagazineGroup[]>() {
+            @Override
+            protected MagazineGroup[] initialValue() {
+                if (useCacheForNonEventLoopThreads || ThreadExecutorMap.currentExecutor() != null) {
+                    MagazineGroup[] groups = createMagazineGroupSizeClasses(AdaptivePoolingAllocator.this, true);
+                    liveMagazines.add(groups);
+                    return groups;
                 }
-            };
-            liveCachedMagazines = liveMagazines;
-        } else {
-            threadLocalMagazine = null;
-            liveCachedMagazines = null;
+                return null;
+            }
+
+            @Override
+            protected void onRemoval(final MagazineGroup[] groups) throws Exception {
+                if (groups != null) {
+                    for (MagazineGroup group : groups) {
+                        group.free();
+                    }
+                    liveMagazines.remove(groups);
+                }
+            }
+        };
+        allThreadLocalGroups = liveMagazines;
+    }
+
+    private static MagazineGroup[] createMagazineGroupSizeClasses(
+            AdaptivePoolingAllocator allocator, boolean isThreadLocal) {
+        MagazineGroup[] groups = new MagazineGroup[SIZE_CLASSES.length];
+        for (int i = 0; i < SIZE_CLASSES.length; i++) {
+            int segmentSize = SIZE_CLASSES[i];
+            groups[i] = new MagazineGroup(allocator, allocator.chunkAllocator,
+                    new SizeClassChunkControllerFactory(segmentSize), isThreadLocal);
         }
-        Magazine[] mags = new Magazine[INITIAL_MAGAZINES];
-        for (int i = 0; i < mags.length; i++) {
-            mags[i] = new Magazine(this);
-        }
-        magazines = mags;
+        return groups;
     }
 
     /**
@@ -226,21 +244,150 @@ final class AdaptivePoolingAllocator {
     }
 
     private AdaptiveByteBuf allocate(int size, int maxCapacity, Thread currentThread, AdaptiveByteBuf buf) {
-        boolean reallocate = buf != null;
+        AdaptiveByteBuf allocated = null;
         if (size <= MAX_POOLED_BUF_SIZE) {
-            FastThreadLocal<Object> threadLocalMagazine = this.threadLocalMagazine;
-            if (threadLocalMagazine != null && FastThreadLocalThread.currentThreadHasFastThreadLocal()) {
-                Object mag = threadLocalMagazine.get();
-                if (mag != NO_MAGAZINE) {
-                    Magazine magazine = (Magazine) mag;
-                    if (buf == null) {
-                        buf = magazine.newBuffer();
-                    }
-                    boolean allocated = magazine.tryAllocate(size, maxCapacity, buf, reallocate);
-                    assert allocated : "Allocation of threadLocalMagazine must always succeed";
-                    return buf;
-                }
+            int index = Arrays.binarySearch(SIZE_CLASSES, size);
+            if (index < 0) {
+                index = -(index + 1);
             }
+            MagazineGroup[] magazineGroups;
+            if (!FastThreadLocalThread.currentThreadWillCleanupFastThreadLocals() ||
+                    (magazineGroups = threadLocalGroup.get()) == null) {
+                magazineGroups =  sizeClassedMagazineGroups;
+            }
+            if (index < magazineGroups.length) {
+                allocated = magazineGroups[index].allocate(size, maxCapacity, currentThread, buf);
+            } else {
+                allocated = largeBufferMagazineGroup.allocate(size, maxCapacity, currentThread, buf);
+            }
+        }
+        if (allocated == null) {
+            allocated = allocateFallback(size, maxCapacity, currentThread, buf);
+        }
+        return allocated;
+    }
+
+    private AdaptiveByteBuf allocateFallback(int size, int maxCapacity, Thread currentThread,
+                                             AdaptiveByteBuf buf) {
+        // If we don't already have a buffer, obtain one from the most conveniently available magazine.
+        Magazine magazine;
+        if (buf != null) {
+            Chunk chunk = buf.chunk;
+            if (chunk == null || chunk == Magazine.MAGAZINE_FREED || (magazine = chunk.currentMagazine()) == null) {
+                magazine = getFallbackMagazine(currentThread);
+            }
+        } else {
+            magazine = getFallbackMagazine(currentThread);
+            buf = magazine.newBuffer();
+        }
+        // Create a one-off chunk for this allocation.
+        AbstractByteBuf innerChunk = chunkAllocator.allocate(size, maxCapacity);
+        Chunk chunk = new Chunk(innerChunk, magazine, false, chunkSize -> true);
+        try {
+            chunk.readInitInto(buf, size, size, maxCapacity);
+        } finally {
+            // As the chunk is an one-off we need to always call release explicitly as readInitInto(...)
+            // will take care of retain once when successful. Once The AdaptiveByteBuf is released it will
+            // completely release the Chunk and so the contained innerChunk.
+            chunk.release();
+        }
+        return buf;
+    }
+
+    private Magazine getFallbackMagazine(Thread currentThread) {
+        Magazine[] mags = largeBufferMagazineGroup.magazines;
+        return mags[(int) currentThread.getId() & mags.length - 1];
+    }
+
+    /**
+     * Allocate into the given buffer. Used by {@link AdaptiveByteBuf#capacity(int)}.
+     */
+    void reallocate(int size, int maxCapacity, AdaptiveByteBuf into) {
+        AdaptiveByteBuf result = allocate(size, maxCapacity, Thread.currentThread(), into);
+        assert result == into: "Re-allocation created separate buffer instance";
+    }
+
+    long usedMemory() {
+        long sum = largeBufferMagazineGroup.usedMemory();
+        for (MagazineGroup group : sizeClassedMagazineGroups) {
+            sum += group.usedMemory();
+        }
+        for (MagazineGroup[] groups : allThreadLocalGroups) {
+            for (MagazineGroup group : groups) {
+                sum += group.usedMemory();
+            }
+        }
+        return sum;
+    }
+
+    // Ensure that we release all previous pooled resources when this object is finalized. This is needed as otherwise
+    // we might end up with leaks. While these leaks are usually harmless in reality it would still at least be
+    // very confusing for users.
+    @SuppressWarnings({"FinalizeDeclaration", "deprecation"})
+    @Override
+    protected void finalize() throws Throwable {
+        try {
+            super.finalize();
+        } finally {
+            free();
+        }
+    }
+
+    private void free() {
+        largeBufferMagazineGroup.free();
+    }
+
+    static int sizeBucket(int size) {
+        return HistogramChunkController.sizeBucket(size);
+    }
+
+    private static class MagazineGroup {
+        private final AdaptivePoolingAllocator allocator;
+        private final ChunkAllocator chunkAllocator;
+        private final ChunkControllerFactory chunkControllerFactory;
+        private final Queue<Chunk> centralQueue;
+        private final StampedLock magazineExpandLock;
+        private final Magazine threadLocalMagazine;
+        private volatile Magazine[] magazines;
+        private volatile boolean freed;
+
+        MagazineGroup(AdaptivePoolingAllocator allocator,
+                      ChunkAllocator chunkAllocator,
+                      ChunkControllerFactory chunkControllerFactory,
+                      boolean isThreadLocal) {
+            this.allocator = allocator;
+            this.chunkAllocator = chunkAllocator;
+            this.chunkControllerFactory = chunkControllerFactory;
+            centralQueue = createSharedChunkQueue();
+            if (isThreadLocal) {
+                magazineExpandLock = null;
+                threadLocalMagazine = new Magazine(this, false, centralQueue, chunkControllerFactory.create(this));
+            } else {
+                magazineExpandLock = new StampedLock();
+                threadLocalMagazine = null;
+                Magazine[] mags = new Magazine[INITIAL_MAGAZINES];
+                for (int i = 0; i < mags.length; i++) {
+                    mags[i] = new Magazine(this, true, centralQueue, chunkControllerFactory.create(this));
+                }
+                magazines = mags;
+            }
+        }
+
+        private AdaptiveByteBuf allocate(int size, int maxCapacity, Thread currentThread, AdaptiveByteBuf buf) {
+            boolean reallocate = buf != null;
+
+            // Path for thread-local allocation.
+            Magazine tlMag = threadLocalMagazine;
+            if (tlMag != null) {
+                if (buf == null) {
+                    buf = tlMag.newBuffer();
+                }
+                boolean allocated = tlMag.tryAllocate(size, maxCapacity, buf, reallocate);
+                assert allocated : "Allocation of threadLocalMagazine must always succeed";
+                return buf;
+            }
+
+            // Path for concurrent allocation.
             long threadId = currentThread.getId();
             Magazine[] mags;
             int expansions = 0;
@@ -260,164 +407,179 @@ final class AdaptivePoolingAllocator {
                 }
                 expansions++;
             } while (expansions <= EXPANSION_ATTEMPTS && tryExpandMagazines(mags.length));
+
+            // The magazines failed us; contention too high and we don't want to spend more effort expanding the array.
+            return null;
         }
 
-        // The magazines failed us, or the buffer is too big to be pooled.
-        return allocateFallback(size, maxCapacity, currentThread, buf, reallocate);
-    }
-
-    private AdaptiveByteBuf allocateFallback(int size, int maxCapacity, Thread currentThread,
-                                             AdaptiveByteBuf buf, boolean reallocate) {
-        // If we don't already have a buffer, obtain one from the most conveniently available magazine.
-        Magazine magazine;
-        if (buf != null) {
-            Chunk chunk = buf.chunk;
-            if (chunk == null || chunk == Magazine.MAGAZINE_FREED || (magazine = chunk.currentMagazine()) == null) {
-                magazine = getFallbackMagazine(currentThread);
+        long usedMemory() {
+            long sum = 0;
+            for (Chunk chunk : centralQueue) {
+                sum += chunk.capacity();
             }
-        } else {
-            magazine = getFallbackMagazine(currentThread);
-            buf = magazine.newBuffer();
-        }
-        // Create a one-off chunk for this allocation.
-        AbstractByteBuf innerChunk = chunkAllocator.allocate(size, maxCapacity);
-        Chunk chunk = new Chunk(innerChunk, magazine, false);
-        try {
-            chunk.readInitInto(buf, size, size, maxCapacity);
-        } finally {
-            // As the chunk is an one-off we need to always call release explicitly as readInitInto(...)
-            // will take care of retain once when successful. Once The AdaptiveByteBuf is released it will
-            // completely release the Chunk and so the contained innerChunk.
-            chunk.release();
-        }
-        return buf;
-    }
-
-    private Magazine getFallbackMagazine(Thread currentThread) {
-        Object tlMag;
-        FastThreadLocal<Object> threadLocalMagazine = this.threadLocalMagazine;
-        if (threadLocalMagazine != null &&
-                FastThreadLocalThread.currentThreadHasFastThreadLocal() &&
-                (tlMag = threadLocalMagazine.get()) != NO_MAGAZINE) {
-            return (Magazine) tlMag;
-        }
-        Magazine[] mags = magazines;
-        return mags[(int) currentThread.getId() & mags.length - 1];
-    }
-
-    /**
-     * Allocate into the given buffer. Used by {@link AdaptiveByteBuf#capacity(int)}.
-     */
-    void reallocate(int size, int maxCapacity, AdaptiveByteBuf into) {
-        AdaptiveByteBuf result = allocate(size, maxCapacity, Thread.currentThread(), into);
-        assert result == into: "Re-allocation created separate buffer instance";
-    }
-
-    long usedMemory() {
-        long sum = 0;
-        for (Chunk chunk : centralQueue) {
-            sum += chunk.capacity();
-        }
-        for (Magazine magazine : magazines) {
-            sum += magazine.usedMemory.get();
-        }
-        if (liveCachedMagazines != null) {
-            for (Magazine magazine : liveCachedMagazines) {
-                sum += magazine.usedMemory.get();
+            if (threadLocalMagazine != null) {
+                sum += threadLocalMagazine.usedMemory.get();
+            } else {
+                for (Magazine magazine : magazines) {
+                    sum += magazine.usedMemory.get();
+                }
             }
+            return sum;
         }
-        return sum;
-    }
 
-    private boolean tryExpandMagazines(int currentLength) {
-        if (currentLength >= MAX_STRIPES) {
+        private boolean tryExpandMagazines(int currentLength) {
+            if (currentLength >= MAX_STRIPES) {
+                return true;
+            }
+            final Magazine[] mags;
+            long writeLock = magazineExpandLock.tryWriteLock();
+            if (writeLock != 0) {
+                try {
+                    mags = magazines;
+                    if (mags.length >= MAX_STRIPES || mags.length > currentLength || freed) {
+                        return true;
+                    }
+                    Magazine firstMagazine = mags[0];
+                    Magazine[] expanded = new Magazine[mags.length * 2];
+                    for (int i = 0, l = expanded.length; i < l; i++) {
+                        Magazine m = new Magazine(this, true, centralQueue, chunkControllerFactory.create(this));
+                        firstMagazine.initializeSharedStateIn(m);
+                        expanded[i] = m;
+                    }
+                    magazines = expanded;
+                } finally {
+                    magazineExpandLock.unlockWrite(writeLock);
+                }
+                for (Magazine magazine : mags) {
+                    magazine.free();
+                }
+            }
             return true;
         }
-        final Magazine[] mags;
-        long writeLock = magazineExpandLock.tryWriteLock();
-        if (writeLock != 0) {
+
+        boolean offerToQueue(Chunk buffer) {
+            if (freed) {
+                return false;
+            }
+            // The Buffer should not be used anymore, let's add an assert to so we guard against bugs in the future.
+            assert buffer.allocatedBytes == 0;
+            assert buffer.magazine == null;
+
+            boolean isAdded = centralQueue.offer(buffer);
+            if (freed && isAdded) {
+                // Help to free the centralQueue.
+                freeCentralQueue();
+            }
+            return isAdded;
+        }
+
+        private void free() {
+            freed = true;
+            long stamp = magazineExpandLock.writeLock();
             try {
-                mags = magazines;
-                if (mags.length >= MAX_STRIPES || mags.length > currentLength || freed) {
-                    return true;
+                Magazine[] mags = magazines;
+                for (Magazine magazine : mags) {
+                    magazine.free();
                 }
-                int preferredChunkSize = mags[0].sharedPrefChunkSize;
-                Magazine[] expanded = new Magazine[mags.length * 2];
-                for (int i = 0, l = expanded.length; i < l; i++) {
-                    Magazine m = new Magazine(this);
-                    m.localPrefChunkSize = preferredChunkSize;
-                    m.sharedPrefChunkSize = preferredChunkSize;
-                    expanded[i] = m;
-                }
-                magazines = expanded;
             } finally {
-                magazineExpandLock.unlockWrite(writeLock);
+                magazineExpandLock.unlockWrite(stamp);
             }
-            for (Magazine magazine : mags) {
-                magazine.free();
-            }
-        }
-        return true;
-    }
-
-    boolean offerToQueue(Chunk buffer) {
-        if (freed) {
-            return false;
-        }
-        // The Buffer should not be used anymore, let's add an assert to so we guard against bugs in the future.
-        assert buffer.allocatedBytes == 0;
-        assert buffer.magazine == null;
-
-        boolean isAdded = centralQueue.offer(buffer);
-        if (freed && isAdded) {
-            // Help to free the centralQueue.
             freeCentralQueue();
         }
-        return isAdded;
-    }
 
-    // Ensure that we release all previous pooled resources when this object is finalized. This is needed as otherwise
-    // we might end up with leaks. While these leaks are usually harmless in reality it would still at least be
-    // very confusing for users.
-    @Override
-    protected void finalize() throws Throwable {
-        try {
-            super.finalize();
-        } finally {
-            free();
-        }
-    }
-
-    private void free() {
-        freed = true;
-        long stamp = magazineExpandLock.writeLock();
-        try {
-            Magazine[] mags = magazines;
-            for (Magazine magazine : mags) {
-                magazine.free();
+        private void freeCentralQueue() {
+            for (;;) {
+                Chunk chunk = centralQueue.poll();
+                if (chunk == null) {
+                    break;
+                }
+                chunk.release();
             }
-        } finally {
-            magazineExpandLock.unlockWrite(stamp);
-        }
-        freeCentralQueue();
-    }
-
-    private void freeCentralQueue() {
-        for (;;) {
-            Chunk chunk = centralQueue.poll();
-            if (chunk == null) {
-                break;
-            }
-            chunk.release();
         }
     }
 
-    static int sizeBucket(int size) {
-        return AllocationStatistics.sizeBucket(size);
+    private interface ChunkControllerFactory {
+        ChunkController create(MagazineGroup group);
     }
 
-    @SuppressWarnings("checkstyle:finalclass") // Checkstyle mistakenly believes this class should be final.
-    private static class AllocationStatistics {
+    private interface ChunkController {
+        /**
+         * Compute the "fast max capacity" value for the buffer.
+         */
+        int computeBufferCapacity(int requestedSize, int maxCapacity, int historicalSize, boolean isReallocation);
+
+        /**
+         * Initialize the given chunk factory with shared statistics state (if any) from this factory.
+         */
+        void initializeSharedStateIn(ChunkController chunkController);
+
+        /**
+         * Allocate a new {@link Chunk} for the given {@link Magazine}.
+         */
+        Chunk newChunkAllocation(int promptingSize, Magazine magazine);
+    }
+
+    private interface ChunkReleasePredicate {
+        boolean shouldReleaseChunk(int chunkSize);
+    }
+
+    private static final class SizeClassChunkControllerFactory implements ChunkControllerFactory {
+        private final int segmentSize;
+
+        private SizeClassChunkControllerFactory(int segmentSize) {
+            this.segmentSize = segmentSize;
+        }
+
+        @Override
+        public ChunkController create(MagazineGroup group) {
+            return new SizeClassChunkController(group, segmentSize);
+        }
+    }
+
+    private static final class SizeClassChunkController implements ChunkController {
+        private final MagazineGroup group;
+        private final int segmentSize;
+        private final int chunkSize;
+
+        private SizeClassChunkController(MagazineGroup group, int segmentSize) {
+            this.group = group;
+            this.segmentSize = segmentSize;
+            chunkSize = Math.max(MIN_CHUNK_SIZE, segmentSize * 32);
+        }
+
+        @Override
+        public int computeBufferCapacity(
+                int requestedSize, int maxCapacity, int historicalSize, boolean isReallocation) {
+            return Math.min(segmentSize, maxCapacity);
+        }
+
+        @Override
+        public void initializeSharedStateIn(ChunkController chunkController) {
+            // NOOP
+        }
+
+        @Override
+        public Chunk newChunkAllocation(int promptingSize, Magazine magazine) {
+            ChunkAllocator chunkAllocator = group.chunkAllocator;
+            return new SizeClassedChunk(chunkAllocator.allocate(chunkSize, chunkSize),
+                    magazine, true, segmentSize, size -> false);
+        }
+    }
+
+    private static final class HistogramChunkControllerFactory implements ChunkControllerFactory {
+        private final boolean shareable;
+
+        private HistogramChunkControllerFactory(boolean shareable) {
+            this.shareable = shareable;
+        }
+
+        @Override
+        public ChunkController create(MagazineGroup group) {
+            return new HistogramChunkController(group, shareable);
+        }
+    }
+
+    private static final class HistogramChunkController implements ChunkController, ChunkReleasePredicate {
         private static final int MIN_DATUM_TARGET = 1024;
         private static final int MAX_DATUM_TARGET = 65534;
         private static final int INIT_DATUM_TARGET = 9;
@@ -427,7 +589,7 @@ final class AdaptivePoolingAllocator {
         private static final int HISTO_MAX_BUCKET_MASK = HISTO_BUCKET_COUNT - 1;
         private static final int SIZE_MAX_MASK = MAX_CHUNK_SIZE - 1;
 
-        protected final AdaptivePoolingAllocator parent;
+        private final MagazineGroup group;
         private final boolean shareable;
         private final short[][] histos = {
                 new short[HISTO_BUCKET_COUNT], new short[HISTO_BUCKET_COUNT],
@@ -439,17 +601,41 @@ final class AdaptivePoolingAllocator {
         private int histoIndex;
         private int datumCount;
         private int datumTarget = INIT_DATUM_TARGET;
-        protected boolean hasHadRotation;
-        protected volatile int sharedPrefChunkSize = MIN_CHUNK_SIZE;
-        protected volatile int localPrefChunkSize = MIN_CHUNK_SIZE;
-        protected volatile int localUpperBufSize;
+        private boolean hasHadRotation;
+        private volatile int sharedPrefChunkSize = MIN_CHUNK_SIZE;
+        private volatile int localPrefChunkSize = MIN_CHUNK_SIZE;
+        private volatile int localUpperBufSize;
 
-        private AllocationStatistics(AdaptivePoolingAllocator parent, boolean shareable) {
-            this.parent = parent;
+        private HistogramChunkController(MagazineGroup group, boolean shareable) {
+            this.group = group;
             this.shareable = shareable;
         }
 
-        protected void recordAllocationSize(int bufferSizeToRecord) {
+        @Override
+        public int computeBufferCapacity(
+                int requestedSize, int maxCapacity, int historicalSize, boolean isReallocation) {
+            if (!isReallocation) {
+                // Only record allocation size if it's not caused by a reallocation that was triggered by capacity
+                // change of the buffer.
+                recordAllocationSize(historicalSize);
+            }
+
+            // Predict starting capacity from localUpperBufSize, but place limits on the max starting capacity
+            // based on the requested size, because localUpperBufSize can potentially be quite large.
+            int startCapLimits;
+            if (requestedSize <= 2048) { // Less than or equal to 2 KiB.
+                startCapLimits = 16384; // Use at most 16 KiB.
+            } else if (requestedSize <= 32768) { // Less than or equal to 32 KiB.
+                startCapLimits = 65536; // Use at most 64 KiB, which is also the AdaptiveRecvByteBufAllocator max.
+            } else {
+                startCapLimits = requestedSize * 2; // Otherwise use at most twice the requested memory.
+            }
+            int startingCapacity = Math.min(startCapLimits, localUpperBufSize);
+            startingCapacity = Math.max(requestedSize, Math.min(maxCapacity, startingCapacity));
+            return startingCapacity;
+        }
+
+        private void recordAllocationSize(int bufferSizeToRecord) {
             // Use the preserved size from the reused AdaptiveByteBuf, if available.
             // Otherwise, use the requested buffer size.
             // This way, we better take into account
@@ -498,8 +684,9 @@ final class AdaptivePoolingAllocator {
             localUpperBufSize = percentileSize;
             localPrefChunkSize = prefChunkSize;
             if (shareable) {
-                for (Magazine mag : parent.magazines) {
-                    prefChunkSize = Math.max(prefChunkSize, mag.localPrefChunkSize);
+                for (Magazine mag : group.magazines) {
+                    HistogramChunkController statistics = (HistogramChunkController) mag.chunkController;
+                    prefChunkSize = Math.max(prefChunkSize, statistics.localPrefChunkSize);
                 }
             }
             if (sharedPrefChunkSize != prefChunkSize) {
@@ -525,12 +712,56 @@ final class AdaptivePoolingAllocator {
          *
          * @return The currently preferred chunk allocation size.
          */
-        protected int preferredChunkSize() {
+        int preferredChunkSize() {
             return sharedPrefChunkSize;
+        }
+
+        @Override
+        public void initializeSharedStateIn(ChunkController chunkController) {
+            HistogramChunkController statistics = (HistogramChunkController) chunkController;
+            int sharedPrefChunkSize = this.sharedPrefChunkSize;
+            statistics.localPrefChunkSize = sharedPrefChunkSize;
+            statistics.sharedPrefChunkSize = sharedPrefChunkSize;
+        }
+
+        @Override
+        public Chunk newChunkAllocation(int promptingSize, Magazine magazine) {
+            int size = Math.max(promptingSize * BUFS_PER_CHUNK, preferredChunkSize());
+            int minChunks = size / MIN_CHUNK_SIZE;
+            if (MIN_CHUNK_SIZE * minChunks < size) {
+                // Round up to nearest whole MIN_CHUNK_SIZE unit. The MIN_CHUNK_SIZE is an even multiple of many
+                // popular small page sizes, like 4k, 16k, and 64k, which makes it easier for the system allocator
+                // to manage the memory in terms of whole pages. This reduces memory fragmentation,
+                // but without the potentially high overhead that power-of-2 chunk sizes would bring.
+                size = MIN_CHUNK_SIZE * (1 + minChunks);
+            }
+
+            // Limit chunks to the max size, even if the histogram suggests to go above it.
+            size = Math.min(size, MAX_CHUNK_SIZE);
+
+            // If we haven't rotated the histogram yet, optimisticly record this chunk size as our preferred.
+            if (!hasHadRotation && sharedPrefChunkSize == MIN_CHUNK_SIZE) {
+                sharedPrefChunkSize = size;
+            }
+
+            ChunkAllocator chunkAllocator = group.chunkAllocator;
+            return new Chunk(chunkAllocator.allocate(size, size), magazine, true, this);
+        }
+
+        @Override
+        public boolean shouldReleaseChunk(int chunkSize) {
+            int preferredSize = preferredChunkSize();
+            int givenChunks = chunkSize / MIN_CHUNK_SIZE;
+            int preferredChunks = preferredSize / MIN_CHUNK_SIZE;
+            int deviation = Math.abs(givenChunks - preferredChunks);
+
+            // Retire chunks with a 5% probability per unit of MIN_CHUNK_SIZE deviation from preference.
+            return deviation != 0 &&
+                    ThreadLocalRandom.current().nextDouble() * 20.0 < deviation;
         }
     }
 
-    private static final class Magazine extends AllocationStatistics {
+    private static final class Magazine {
         private static final AtomicReferenceFieldUpdater<Magazine, Chunk> NEXT_IN_LINE;
         static {
             NEXT_IN_LINE = AtomicReferenceFieldUpdater.newUpdater(Magazine.class, Chunk.class, "nextInLine");
@@ -548,17 +779,18 @@ final class AdaptivePoolingAllocator {
         private Chunk current;
         @SuppressWarnings("unused") // updated via NEXT_IN_LINE
         private volatile Chunk nextInLine;
+        private final MagazineGroup group;
+        private final ChunkController chunkController;
         private final AtomicLong usedMemory;
         private final StampedLock allocationLock;
         private final Queue<AdaptiveByteBuf> bufferQueue;
         private final ObjectPool.Handle<AdaptiveByteBuf> handle;
+        private final Queue<Chunk> sharedChunkQueue;
 
-        Magazine(AdaptivePoolingAllocator parent) {
-            this(parent, true);
-        }
-
-        Magazine(AdaptivePoolingAllocator parent, boolean shareable) {
-            super(parent, shareable);
+        Magazine(MagazineGroup group, boolean shareable, Queue<Chunk> sharedChunkQueue,
+                 ChunkController chunkController) {
+            this.group = group;
+            this.chunkController = chunkController;
 
             if (shareable) {
                 // We only need the StampedLock if this Magazine will be shared across threads.
@@ -576,6 +808,7 @@ final class AdaptivePoolingAllocator {
                 handle = null;
             }
             usedMemory = new AtomicLong();
+            this.sharedChunkQueue = sharedChunkQueue;
         }
 
         public boolean tryAllocate(int size, int maxCapacity, AdaptiveByteBuf buf, boolean reallocate) {
@@ -604,7 +837,7 @@ final class AdaptivePoolingAllocator {
                 return false;
             }
             if (curr == null) {
-                curr = parent.centralQueue.poll();
+                curr = sharedChunkQueue.poll();
                 if (curr == null) {
                     return false;
                 }
@@ -612,7 +845,8 @@ final class AdaptivePoolingAllocator {
             }
             boolean allocated = false;
             int remainingCapacity = curr.remainingCapacity();
-            int startingCapacity = getStartingCapacity(size, maxCapacity);
+            int startingCapacity = chunkController.computeBufferCapacity(
+                    size, maxCapacity, buf.length, true /* never update stats as we don't hold the magazine lock */);
             if (remainingCapacity >= size) {
                 curr.readInitInto(buf, size, Math.min(remainingCapacity, startingCapacity), maxCapacity);
                 allocated = true;
@@ -631,12 +865,8 @@ final class AdaptivePoolingAllocator {
         }
 
         private boolean allocate(int size, int maxCapacity, AdaptiveByteBuf buf, boolean reallocate) {
-            if (!reallocate) {
-                // Only record allocation size if it's not caused by a reallocation that was triggered by capacity
-                // change of the buffer.
-                recordAllocationSize(buf.length);
-            }
-            int startingCapacity = getStartingCapacity(size, maxCapacity);
+
+            int startingCapacity = chunkController.computeBufferCapacity(size, maxCapacity, buf.length, reallocate);
             Chunk curr = current;
             if (curr != null) {
                 // We have a Chunk that has some space left.
@@ -712,9 +942,9 @@ final class AdaptivePoolingAllocator {
             }
 
             // Now try to poll from the central queue first
-            curr = parent.centralQueue.poll();
+            curr = sharedChunkQueue.poll();
             if (curr == null) {
-                curr = newChunkAllocation(size);
+                curr = chunkController.newChunkAllocation(size, this);
             } else {
                 curr.attachToMagazine(this);
 
@@ -728,7 +958,7 @@ final class AdaptivePoolingAllocator {
                         // This method will release curr if this is not the case
                         transferToNextInLineOrRelease(curr);
                     }
-                    curr = newChunkAllocation(size);
+                    curr = chunkController.newChunkAllocation(size, this);
                 }
             }
 
@@ -751,22 +981,6 @@ final class AdaptivePoolingAllocator {
                 }
             }
             return true;
-        }
-
-        private int getStartingCapacity(int size, int maxCapacity) {
-            // Predict starting capacity from localUpperBufSize, but place limits on the max starting capacity
-            // based on the requested size, because localUpperBufSize can potentially be quite large.
-            int startCapLimits;
-            if (size <= 2048) { // Less than or equal to 2 KiB.
-                startCapLimits = 16384; // Use at most 16 KiB.
-            } else if (size <= 32768) { // Less than or equal to 32 KiB.
-                startCapLimits = 65536; // Use at most 64 KiB, which is also the AdaptiveRecvByteBufAllocator max.
-            } else {
-                startCapLimits = size * 2; // Otherwise use at most twice the requested memory.
-            }
-            int startingCapacity = Math.min(startCapLimits, localUpperBufSize);
-            startingCapacity = Math.max(size, Math.min(maxCapacity, startingCapacity));
-            return startingCapacity;
         }
 
         private void restoreMagazineFreed() {
@@ -794,29 +1008,6 @@ final class AdaptivePoolingAllocator {
             // Once a Chunk is completely released by Chunk.release() it will try to move itself to the queue
             // as last resort.
             chunk.release();
-        }
-
-        private Chunk newChunkAllocation(int promptingSize) {
-            int size = Math.max(promptingSize * BUFS_PER_CHUNK, preferredChunkSize());
-            int minChunks = size / MIN_CHUNK_SIZE;
-            if (MIN_CHUNK_SIZE * minChunks < size) {
-                // Round up to nearest whole MIN_CHUNK_SIZE unit. The MIN_CHUNK_SIZE is an even multiple of many
-                // popular small page sizes, like 4k, 16k, and 64k, which makes it easier for the system allocator
-                // to manage the memory in terms of whole pages. This reduces memory fragmentation,
-                // but without the potentially high overhead that power-of-2 chunk sizes would bring.
-                size = MIN_CHUNK_SIZE * (1 + minChunks);
-            }
-
-            // Limit chunks to the max size, even if the histogram suggests to go above it.
-            size = Math.min(size, MAX_CHUNK_SIZE);
-
-            // If we haven't rotated the histogram yet, optimisticly record this chunk size as our preferred.
-            if (!hasHadRotation && sharedPrefChunkSize == MIN_CHUNK_SIZE) {
-                sharedPrefChunkSize = size;
-            }
-
-            ChunkAllocator chunkAllocator = parent.chunkAllocator;
-            return new Chunk(chunkAllocator.allocate(size, size), this, true);
         }
 
         boolean trySetNextInLine(Chunk chunk) {
@@ -851,20 +1042,29 @@ final class AdaptivePoolingAllocator {
             buf.discardMarks();
             return buf;
         }
+
+        boolean offerToQueue(Chunk chunk) {
+            return group.offerToQueue(chunk);
+        }
+
+        public void initializeSharedStateIn(Magazine other) {
+            chunkController.initializeSharedStateIn(other.chunkController);
+        }
     }
 
-    private static final class Chunk implements ReferenceCounted {
-
-        private final AbstractByteBuf delegate;
-        private Magazine magazine;
-        private final AdaptivePoolingAllocator allocator;
-        private final int capacity;
-        private final boolean pooled;
-        private int allocatedBytes;
+    private static class Chunk implements ReferenceCounted {
         private static final long REFCNT_FIELD_OFFSET =
                 ReferenceCountUpdater.getUnsafeOffset(Chunk.class, "refCnt");
         private static final AtomicIntegerFieldUpdater<Chunk> AIF_UPDATER =
                 AtomicIntegerFieldUpdater.newUpdater(Chunk.class, "refCnt");
+
+        protected final AbstractByteBuf delegate;
+        private Magazine magazine;
+        private final AdaptivePoolingAllocator allocator;
+        private final ChunkReleasePredicate chunkReleasePredicate;
+        private final int capacity;
+        private final boolean pooled;
+        protected int allocatedBytes;
 
         private static final ReferenceCountUpdater<Chunk> updater =
                 new ReferenceCountUpdater<Chunk>() {
@@ -889,17 +1089,23 @@ final class AdaptivePoolingAllocator {
             delegate = null;
             magazine = null;
             allocator = null;
+            chunkReleasePredicate = null;
             capacity = 0;
             pooled = false;
         }
 
-        Chunk(AbstractByteBuf delegate, Magazine magazine, boolean pooled) {
+        Chunk(AbstractByteBuf delegate, Magazine magazine, boolean pooled,
+              ChunkReleasePredicate chunkReleasePredicate) {
             this.delegate = delegate;
             this.pooled = pooled;
             capacity = delegate.capacity();
             updater.setInitialValue(this);
-            allocator = magazine.parent;
             attachToMagazine(magazine);
+
+            // We need the top-level allocator so ByteBuf.capacity(int) can call reallocate()
+            allocator = magazine.group.allocator;
+
+            this.chunkReleasePredicate = chunkReleasePredicate;
 
             if (PlatformDependent.isJfrEnabled() && AllocateChunkEvent.INSTANCE.isEnabled()) {
                 AllocateChunkEvent event = new AllocateChunkEvent();
@@ -972,12 +1178,14 @@ final class AdaptivePoolingAllocator {
             return false;
         }
 
+        boolean releaseSegment(int ignoredSegmentId) {
+            return release();
+        }
+
         private void deallocate() {
             Magazine mag = magazine;
-            AdaptivePoolingAllocator parent = mag.parent;
-            int chunkSize = mag.preferredChunkSize();
-            int memSize = delegate.capacity();
-            if (!pooled || shouldReleaseSuboptimalChunkSize(memSize, chunkSize)) {
+            int chunkSize = delegate.capacity();
+            if (!pooled || chunkReleasePredicate.shouldReleaseChunk(chunkSize)) {
                 // Drop the chunk if the parent allocator is closed,
                 // or if the chunk deviates too much from the preferred chunk size.
                 detachFromMagazine();
@@ -990,7 +1198,7 @@ final class AdaptivePoolingAllocator {
                 if (!mag.trySetNextInLine(this)) {
                     // As this Chunk does not belong to the mag anymore we need to decrease the used memory .
                     detachFromMagazine();
-                    if (!parent.offerToQueue(this)) {
+                    if (!mag.offerToQueue(this)) {
                         // The central queue is full. Ensure we release again as we previously did use resetRefCnt()
                         // which did increase the reference count by 1.
                         boolean released = updater.release(this);
@@ -1028,23 +1236,13 @@ final class AdaptivePoolingAllocator {
             }
         }
 
-        private static boolean shouldReleaseSuboptimalChunkSize(int givenSize, int preferredSize) {
-            int givenChunks = givenSize / MIN_CHUNK_SIZE;
-            int preferredChunks = preferredSize / MIN_CHUNK_SIZE;
-            int deviation = Math.abs(givenChunks - preferredChunks);
-
-            // Retire chunks with a 5% probability per unit of MIN_CHUNK_SIZE deviation from preference.
-            return deviation != 0 &&
-                    ThreadLocalRandom.current().nextDouble() * 20.0 < deviation;
-        }
-
         public void readInitInto(AdaptiveByteBuf buf, int size, int startingCapacity, int maxCapacity) {
             int startIndex = allocatedBytes;
             allocatedBytes = startIndex + startingCapacity;
             Chunk chunk = this;
             chunk.retain();
             try {
-                buf.init(delegate, chunk, 0, 0, startIndex, size, startingCapacity, maxCapacity);
+                buf.init(delegate, chunk, 0, 0, startIndex, size, startingCapacity, maxCapacity, 0);
                 chunk = null;
             } finally {
                 if (chunk != null) {
@@ -1063,6 +1261,65 @@ final class AdaptivePoolingAllocator {
 
         public int capacity() {
             return capacity;
+        }
+    }
+
+    private static class SizeClassedChunk extends Chunk {
+        private static final int FREE_LIST_EMPTY = -1;
+        private final int segmentSize;
+        private final MpscIntQueue freeList;
+
+        SizeClassedChunk(AbstractByteBuf delegate, Magazine magazine, boolean pooled, int segmentSize,
+                         ChunkReleasePredicate shouldReleaseChunk) {
+            super(delegate, magazine, pooled, shouldReleaseChunk);
+            int capacity = delegate.capacity();
+            this.segmentSize = segmentSize;
+            int segmentCount = capacity / segmentSize;
+            assert segmentCount > 0: "Chunk must have a positive number of segments";
+            freeList = MpscIntQueue.create(segmentCount, FREE_LIST_EMPTY);
+            freeList.fill(segmentCount, new IntSupplier() {
+                int counter;
+                @Override
+                public int getAsInt() {
+                    return counter++;
+                }
+            });
+        }
+
+        @Override
+        public void readInitInto(AdaptiveByteBuf buf, int size, int startingCapacity, int maxCapacity) {
+            int segmentId = freeList.poll();
+            if (segmentId == FREE_LIST_EMPTY) {
+                throw new IllegalStateException("Free list is empty");
+            }
+
+            int startIndex = segmentId * segmentSize;
+            allocatedBytes += segmentSize;
+            Chunk chunk = this;
+            chunk.retain();
+            try {
+                buf.init(delegate, chunk, 0, 0, startIndex, size, startingCapacity, maxCapacity, segmentId);
+                chunk = null;
+            } finally {
+                if (chunk != null) {
+                    // If chunk is not null we know that buf.init(...) failed and so we need to manually release
+                    // the chunk again as we retained it before calling buf.init(...). Beside this we also need to
+                    // restore the old allocatedBytes value.
+                    allocatedBytes -= segmentSize;
+                    chunk.releaseSegment(segmentId);
+                }
+            }
+        }
+
+        @Override
+        boolean releaseSegment(int segmentId) {
+            boolean segmentReturned = freeList.offer(segmentId);
+            assert segmentReturned: "Unable to return segment " + segmentId + " to free list";
+            return release();
+        }
+
+        boolean isEmpty() {
+            return freeList.isEmpty();
         }
     }
 
@@ -1134,6 +1391,7 @@ final class AdaptivePoolingAllocator {
         Chunk chunk;
         private int length;
         private int maxFastCapacity;
+        private int segmentId;
         private ByteBuffer tmpNioBuf;
         private boolean hasArray;
         private boolean hasMemoryAddress;
@@ -1144,13 +1402,14 @@ final class AdaptivePoolingAllocator {
         }
 
         void init(AbstractByteBuf unwrapped, Chunk wrapped, int readerIndex, int writerIndex,
-                  int adjustment, int size, int capacity, int maxCapacity) {
+                  int adjustment, int size, int capacity, int maxCapacity, int segmentId) {
             this.adjustment = adjustment;
             chunk = wrapped;
             length = size;
             maxFastCapacity = capacity;
             maxCapacity(maxCapacity);
             setIndex0(readerIndex, writerIndex);
+            this.segmentId = segmentId;
             hasArray = unwrapped.hasArray();
             hasMemoryAddress = unwrapped.hasMemoryAddress();
             rootParent = unwrapped;
@@ -1216,10 +1475,11 @@ final class AdaptivePoolingAllocator {
             int writerIndex = this.writerIndex;
             int baseOldRootIndex = adjustment;
             int oldCapacity = length;
+            int oldSegmentId = segmentId;
             AbstractByteBuf oldRoot = rootParent();
             allocator.reallocate(newCapacity, maxCapacity(), this);
             oldRoot.getBytes(baseOldRootIndex, this, 0, oldCapacity);
-            chunk.release();
+            chunk.releaseSegment(oldSegmentId);
             this.readerIndex = readerIndex;
             this.writerIndex = writerIndex;
             return this;
@@ -1606,7 +1866,7 @@ final class AdaptivePoolingAllocator {
             }
 
             if (chunk != null) {
-                chunk.release();
+                chunk.releaseSegment(segmentId);
             }
             tmpNioBuf = null;
             chunk = null;

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
@@ -16,7 +16,6 @@
 package io.netty.buffer;
 
 import io.netty.util.NettyRuntime;
-import io.netty.util.internal.PlatformDependent;
 import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.consumer.RecordingStream;
 import org.junit.jupiter.api.Test;
@@ -74,27 +73,69 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
         heapBuffer.release();
     }
 
+    @Override
     @Test
-    void chunkMustDeallocateOrReuseWthBufferRelease() throws Exception {
+    public void testUsedDirectMemory() {
+        AdaptiveByteBufAllocator allocator =  newAllocator(true);
+        ByteBufAllocatorMetric metric = allocator.metric();
+        assertEquals(0, metric.usedDirectMemory());
+        ByteBuf buffer = allocator.directBuffer(1024, 4096);
+        int capacity = buffer.capacity();
+        assertEquals(expectedUsedMemory(allocator, capacity), metric.usedDirectMemory());
+
+        // Double the size of the buffer
+        buffer.capacity(capacity << 1);
+        capacity = buffer.capacity();
+        // This is a new size class, and a new magazine with a new chunk
+        assertEquals(2 * expectedUsedMemory(allocator, capacity), metric.usedDirectMemory(), buffer.toString());
+
+        buffer.release();
+        // Memory is still held by the magazines
+        assertEquals(2 * expectedUsedMemory(allocator, capacity), metric.usedDirectMemory());
+    }
+
+    @Override
+    @Test
+    public void testUsedHeapMemory() {
+        AdaptiveByteBufAllocator allocator =  newAllocator(true);
+        ByteBufAllocatorMetric metric = allocator.metric();
+        assertEquals(0, metric.usedHeapMemory());
+        ByteBuf buffer = allocator.heapBuffer(1024, 4096);
+        int capacity = buffer.capacity();
+        assertEquals(expectedUsedMemory(allocator, capacity), metric.usedHeapMemory());
+
+        // Double the size of the buffer
+        buffer.capacity(capacity << 1);
+        capacity = buffer.capacity();
+        // This is a new size class, and a new magazine with a new chunk
+        assertEquals(2 * expectedUsedMemory(allocator, capacity), metric.usedHeapMemory(), buffer.toString());
+
+        buffer.release();
+        // Memory is still held by the magazines
+        assertEquals(2 * expectedUsedMemory(allocator, capacity), metric.usedHeapMemory());
+    }
+
+    @Test
+    void adaptiveChunkMustDeallocateOrReuseWthBufferRelease() throws Exception {
         AdaptiveByteBufAllocator allocator = newAllocator(false);
-        ByteBuf a = allocator.heapBuffer(8192);
-        assertEquals(128 * 1024, allocator.usedHeapMemory());
-        ByteBuf b = allocator.heapBuffer(120 * 1024);
-        assertEquals(128 * 1024, allocator.usedHeapMemory());
+        ByteBuf a = allocator.heapBuffer(28 * 1024);
+        assertEquals(262144, allocator.usedHeapMemory());
+        ByteBuf b = allocator.heapBuffer(100 * 1024);
+        assertEquals(262144, allocator.usedHeapMemory());
         b.release();
         a.release();
-        assertEquals(128 * 1024, allocator.usedHeapMemory());
-        a = allocator.heapBuffer(8192);
-        assertEquals(128 * 1024, allocator.usedHeapMemory());
-        b = allocator.heapBuffer(120 * 1024);
-        assertEquals(128 * 1024, allocator.usedHeapMemory());
+        assertEquals(262144, allocator.usedHeapMemory());
+        a = allocator.heapBuffer(28 * 1024);
+        assertEquals(262144, allocator.usedHeapMemory());
+        b = allocator.heapBuffer(100 * 1024);
+        assertEquals(262144, allocator.usedHeapMemory());
         a.release();
-        ByteBuf c = allocator.heapBuffer(8192);
-        assertEquals(2 * 128 * 1024, allocator.usedHeapMemory());
+        ByteBuf c = allocator.heapBuffer(28 * 1024);
+        assertEquals(2 * 262144, allocator.usedHeapMemory());
         c.release();
-        assertEquals(2 * 128 * 1024, allocator.usedHeapMemory());
+        assertEquals(2 * 262144, allocator.usedHeapMemory());
         b.release();
-        assertEquals(2 * 128 * 1024, allocator.usedHeapMemory());
+        assertEquals(2 * 262144, allocator.usedHeapMemory());
     }
 
     @ParameterizedTest

--- a/buffer/src/test/java/io/netty/buffer/AdaptivePoolingAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptivePoolingAllocatorTest.java
@@ -37,23 +37,24 @@ class AdaptivePoolingAllocatorTest implements Supplier<String> {
 
     @Test
     void sizeBucketComputations() throws Exception {
-        assertSizeBucket(0, 256);
-        assertSizeBucket(1, 512);
-        assertSizeBucket(2, 1024);
-        assertSizeBucket(3, 2048);
-        assertSizeBucket(4, 4096);
-        assertSizeBucket(5, 8 * 1024);
-        assertSizeBucket(6, 16 * 1024);
-        assertSizeBucket(7, 32 * 1024);
-        assertSizeBucket(8, 64 * 1024);
-        assertSizeBucket(9, 128 * 1024);
-        assertSizeBucket(10, 256 * 1024);
-        assertSizeBucket(11, 512 * 1024);
+        assertSizeBucket(0, 16 * 1024);
+        assertSizeBucket(1, 24 * 1024);
+        assertSizeBucket(2, 32 * 1024);
+        assertSizeBucket(3, 48 * 1024);
+        assertSizeBucket(4, 64 * 1024);
+        assertSizeBucket(5, 96 * 1024);
+        assertSizeBucket(6, 128 * 1024);
+        assertSizeBucket(7, 192 * 1024);
+        assertSizeBucket(8, 256 * 1024);
+        assertSizeBucket(9, 384 * 1024);
+        assertSizeBucket(10, 512 * 1024);
+        assertSizeBucket(11, 768 * 1024);
         assertSizeBucket(12, 1024 * 1024);
+        assertSizeBucket(13, 1792 * 1024);
+        assertSizeBucket(14, 2048 * 1024);
+        assertSizeBucket(15, 3072 * 1024);
         // The sizeBucket function will be used for sizes up to 8 MiB
-        assertSizeBucket(13, 2 * 1024 * 1024);
-        assertSizeBucket(14, 3 * 1024 * 1024);
-        assertSizeBucket(14, 4 * 1024 * 1024);
+        assertSizeBucket(15, 4 * 1024 * 1024);
         assertSizeBucket(15, 5 * 1024 * 1024);
         assertSizeBucket(15, 6 * 1024 * 1024);
         assertSizeBucket(15, 7 * 1024 * 1024);
@@ -62,7 +63,7 @@ class AdaptivePoolingAllocatorTest implements Supplier<String> {
 
     private void assertSizeBucket(int expectedSizeBucket, int maxSizeIncluded) {
         for (; i <= maxSizeIncluded; i++) {
-            assertEquals(expectedSizeBucket, AdaptivePoolingAllocator.sizeBucket(i), this);
+            assertEquals(expectedSizeBucket, AdaptivePoolingAllocator.sizeToBucket(i), this);
         }
     }
 }

--- a/common/src/main/java/io/netty/util/concurrent/MpscIntQueue.java
+++ b/common/src/main/java/io/netty/util/concurrent/MpscIntQueue.java
@@ -26,8 +26,7 @@ import java.util.function.IntSupplier;
 
 /**
  * A multi-producer (concurrent and thread-safe {@code offer} and {@code fill}),
- * single-consumer (single-threaded {@code poll} and {@code drain}) queue of primitive integers,
- * internally represented as an array for space efficiency.
+ * single-consumer (single-threaded {@code poll} and {@code drain}) queue of primitive integers.
  */
 public interface MpscIntQueue {
     /**

--- a/common/src/main/java/io/netty/util/concurrent/MpscIntQueue.java
+++ b/common/src/main/java/io/netty/util/concurrent/MpscIntQueue.java
@@ -24,21 +24,71 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.function.IntConsumer;
 import java.util.function.IntSupplier;
 
+/**
+ * A multi-producer (concurrent and thread-safe {@code offer} and {@code fill}),
+ * single-consumer (single-threaded {@code poll} and {@code drain}) queue of primitive integers,
+ * internally represented as an array for space efficiency.
+ */
 public interface MpscIntQueue {
+    /**
+     * Create a new queue instance of the given size.
+     * <p>
+     * Note: the size of the queue may be rounded up to nearest power-of-2.
+     *
+     * @param size The required fixed size of the queue.
+     * @param emptyValue The special value that the queue should use to signal the "empty" case.
+     * This value will be returned from {@link #poll()} when the queue is empty,
+     * and giving this value to {@link #offer(int)} will cause an exception to be thrown.
+     * @return The queue instance.
+     */
     static MpscIntQueue create(int size, int emptyValue) {
         return new MpscAtomicIntegerArrayQueue(size, emptyValue);
     }
 
+    /**
+     * Offer the given value to the queue. This will throw an exception if the given value is the "empty" value.
+     * @param value The value to add to the queue.
+     * @return {@code true} if the value was added to the queue,
+     * or {@code false} if the value could not be added because the queue is full.
+     */
     boolean offer(int value);
 
+    /**
+     * Remove and return the next value from the queue, or return the "empty" value if the queue is empty.
+     * @return The next value or the "empty" value.
+     */
     int poll();
 
+    /**
+     * Remove up to the given limit of elements from the queue, and pass them to the consumer in order.
+     * @param limit The maximum number of elements to dequeue.
+     * @param consumer The consumer to pass the removed elements to.
+     * @return The actual number of elements removed.
+     */
     int drain(int limit, IntConsumer consumer);
 
+    /**
+     * Add up to the given limit of elements to this queue, from the given supplier.
+     * @param limit The maximum number of elements to enqueue.
+     * @param supplier The supplier to obtain the elements from.
+     * @return The actual number of elements added.
+     */
     int fill(int limit, IntSupplier supplier);
 
+    /**
+     * Query if the queue is empty or not.
+     * <p>
+     * This method is inherently racy and the result may be out of date by the time the method returns.
+     * @return {@code true} if the queue was observed to be empty, otherwise {@code false.
+     */
     boolean isEmpty();
 
+    /**
+     * Query the number of elements currently in the queue.
+     * <p>
+     * This method is inherently racy and the result may be out of date by the time the method returns.
+     * @return An estimate of the number of elements observed in the queue.
+     */
     int size();
 
     /**

--- a/common/src/main/java/io/netty/util/concurrent/MpscIntQueue.java
+++ b/common/src/main/java/io/netty/util/concurrent/MpscIntQueue.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.concurrent;
+
+import io.netty.util.internal.MathUtil;
+import io.netty.util.internal.ObjectUtil;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicIntegerArray;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.function.IntConsumer;
+import java.util.function.IntSupplier;
+
+public interface MpscIntQueue {
+    static MpscIntQueue create(int size, int emptyValue) {
+        return new MpscAtomicIntegerArrayQueue(size, emptyValue);
+    }
+
+    boolean offer(int value);
+
+    int poll();
+
+    int drain(int limit, IntConsumer consumer);
+
+    int fill(int limit, IntSupplier supplier);
+
+    boolean isEmpty();
+
+    int size();
+
+    /**
+     * This implementation is based on MpscAtomicUnpaddedArrayQueue from JCTools.
+     */
+    final class MpscAtomicIntegerArrayQueue extends AtomicIntegerArray implements MpscIntQueue {
+        private static final long serialVersionUID = 8740338425124821455L;
+        private static final AtomicLongFieldUpdater<MpscAtomicIntegerArrayQueue> PRODUCER_INDEX =
+                AtomicLongFieldUpdater.newUpdater(MpscAtomicIntegerArrayQueue.class, "producerIndex");
+        private static final AtomicLongFieldUpdater<MpscAtomicIntegerArrayQueue> PRODUCER_LIMIT =
+                AtomicLongFieldUpdater.newUpdater(MpscAtomicIntegerArrayQueue.class, "producerLimit");
+        private static final AtomicLongFieldUpdater<MpscAtomicIntegerArrayQueue> CONSUMER_INDEX =
+                AtomicLongFieldUpdater.newUpdater(MpscAtomicIntegerArrayQueue.class, "consumerIndex");
+        private final int mask;
+        private final int emptyValue;
+        private volatile long producerIndex;
+        private volatile long producerLimit;
+        private volatile long consumerIndex;
+
+        public MpscAtomicIntegerArrayQueue(int capacity, int emptyValue) {
+            super(MathUtil.safeFindNextPositivePowerOfTwo(capacity));
+            if (emptyValue != 0) {
+                this.emptyValue = emptyValue;
+                int end = capacity - 1;
+                for (int i = 0; i < end; i++) {
+                    lazySet(i, emptyValue);
+                }
+                getAndSet(end, emptyValue); // 'getAndSet' acts as a full barrier, giving us initialization safety.
+            } else {
+                this.emptyValue = 0;
+            }
+            mask = length() - 1;
+        }
+
+        @Override
+        public boolean offer(int value) {
+            if (value == emptyValue) {
+                throw new IllegalArgumentException("Cannot offer the \"empty\" value: " + emptyValue);
+            }
+            // use a cached view on consumer index (potentially updated in loop)
+            final int mask = this.mask;
+            long producerLimit = this.producerLimit;
+            long pIndex;
+            do {
+                pIndex = producerIndex;
+                if (pIndex >= producerLimit) {
+                    final long cIndex = consumerIndex;
+                    producerLimit = cIndex + mask + 1;
+                    if (pIndex >= producerLimit) {
+                        // FULL :(
+                        return false;
+                    } else {
+                        // update producer limit to the next index that we must recheck the consumer index
+                        // this is racy, but the race is benign
+                        PRODUCER_LIMIT.lazySet(this, producerLimit);
+                    }
+                }
+            } while (!PRODUCER_INDEX.compareAndSet(this, pIndex, pIndex + 1));
+            /*
+             * NOTE: the new producer index value is made visible BEFORE the element in the array. If we relied on
+             * the index visibility to poll() we would need to handle the case where the element is not visible.
+             */
+            // Won CAS, move on to storing
+            final int offset = (int) (pIndex & mask);
+            lazySet(offset, value);
+            // AWESOME :)
+            return true;
+        }
+
+        @Override
+        public int poll() {
+            final long cIndex = consumerIndex;
+            final int offset = (int) (cIndex & mask);
+            // If we can't see the next available element we can't poll
+            int value = get(offset);
+            if (emptyValue == value) {
+                /*
+                 * NOTE: Queue may not actually be empty in the case of a producer (P1) being interrupted after
+                 * winning the CAS on offer but before storing the element in the queue. Other producers may go on
+                 * to fill up the queue after this element.
+                 */
+                if (cIndex != producerIndex) {
+                    do {
+                        value = get(offset);
+                    } while (emptyValue == value);
+                } else {
+                    return emptyValue;
+                }
+            }
+            lazySet(offset, emptyValue);
+            CONSUMER_INDEX.lazySet(this, cIndex + 1);
+            return value;
+        }
+
+        @Override
+        public int drain(int limit, IntConsumer consumer) {
+            Objects.requireNonNull(consumer, "consumer");
+            ObjectUtil.checkPositiveOrZero(limit, "limit");
+            if (limit == 0) {
+                return 0;
+            }
+            final int mask = this.mask;
+            final long cIndex = consumerIndex; // Note: could be weakened to plain-load.
+            for (int i = 0; i < limit; i++) {
+                final long index = cIndex + i;
+                final int offset = (int) (index & mask);
+                final int value = get(offset);
+                if (emptyValue == value) {
+                    return i;
+                }
+                lazySet(offset, emptyValue); // Note: could be weakened to plain-store.
+                // ordered store -> atomic and ordered for size()
+                CONSUMER_INDEX.lazySet(this, index + 1);
+                consumer.accept(value);
+            }
+            return limit;
+        }
+
+        @Override
+        public int fill(int limit, IntSupplier supplier) {
+            Objects.requireNonNull(supplier, "supplier");
+            ObjectUtil.checkPositiveOrZero(limit, "limit");
+            if (limit == 0) {
+                return 0;
+            }
+            final int mask = this.mask;
+            final long capacity = mask + 1;
+            long producerLimit = this.producerLimit;
+            long pIndex;
+            int actualLimit;
+            do {
+                pIndex = producerIndex;
+                long available = producerLimit - pIndex;
+                if (available <= 0) {
+                    final long cIndex = consumerIndex;
+                    producerLimit = cIndex + capacity;
+                    available = producerLimit - pIndex;
+                    if (available <= 0) {
+                        // FULL :(
+                        return 0;
+                    } else {
+                        // update producer limit to the next index that we must recheck the consumer index
+                        PRODUCER_LIMIT.lazySet(this, producerLimit);
+                    }
+                }
+                actualLimit = Math.min((int) available, limit);
+            } while (!PRODUCER_INDEX.compareAndSet(this, pIndex, pIndex + actualLimit));
+            // right, now we claimed a few slots and can fill them with goodness
+            for (int i = 0; i < actualLimit; i++) {
+                // Won CAS, move on to storing
+                final int offset = (int) (pIndex + i & mask);
+                lazySet(offset, supplier.getAsInt());
+            }
+            return actualLimit;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            // Load consumer index before producer index, so our check is conservative.
+            long cIndex = consumerIndex;
+            long pIndex = producerIndex;
+            return cIndex >= pIndex;
+        }
+
+        @Override
+        public int size() {
+            // Loop until we get a consistent read of both the consumer and producer indices.
+            long after = consumerIndex;
+            long size;
+            for (;;) {
+                long before = after;
+                long pIndex = producerIndex;
+                after = consumerIndex;
+                if (before == after) {
+                    size = pIndex - after;
+                    break;
+                }
+            }
+            return size < 0 ? 0 : size > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) size;
+        }
+    }
+}


### PR DESCRIPTION
Motivation:
The histograms in the adaptive allocator are best at looking for a single, good chunk size.
However, in practice, we have a lot of sizes that follow various patterns.
The histograms then tend to bias toward large sizes, which is wasteful in space.
It also turns out to be wasteful in time, in the sense that a small allocation can stick around for a long time, and prevent a large chunk from being reused when the rest of it has been deallocated.
As such, the histogram-based magazines works best for fewer, larger allocations, and we need something else for small and plentiful allocations.

Modification:
- Refactor the internals to detangle the magazines from the histogram implementation.
- Introduce abstractions so the choice of recording and choosing buffer sizes, and the chunk allocation, is moved out of the magazines and into a chunk controller.
- Move the allocation statistics into a histogram chunk controller, and introduce a separate size-classed chunk controller.
- The size-classes are chosen from the observation that 1) most allocations aim to be power-of-2 sized, but 2) a lot of such allocations end up in framing protocols that add headers, checksums, etc. so the actual desired size is a power-of-2-plus-a-bit.
- Introduce magazine groups. The group holds the magazine array and deals with contention by expanding the array. We will have a group per size class, along size a histogram-based group for large allocations.
- Introduce a size-classed chunk which allocates out of a free-list instead of pointer-bump allocation. This greatly enhances the space reuse of such chunks and allows them to absorb a lot of the memory fragmentation that small allocations are prone to.
- Add an MpscIntQueue class that we use for said free-list. This is based on the implementations found in JCTools.
- Fix a concurrent-access bug in AdaptiveByteBuf.getBytes methods, where the internalNioBuffer had position and limit concurrently modified.

Result:
This should greatly reduce memory usage caused by chunks that hang around too long due to fragmentation.

Fixes https://github.com/netty/netty/issues/15311