### PR TITLE
Discourage usage of ServerBootstrap.group(EventLoopGroup, EventLoopGr…

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
@@ -449,7 +449,7 @@ public class DataCompressionHttp2Test {
                 any(ByteBuf.class), anyInt(), anyBoolean());
 
         final CountDownLatch serverChannelLatch = new CountDownLatch(1);
-        sb.group(new NioEventLoopGroup(), new NioEventLoopGroup());
+        sb.group(new NioEventLoopGroup());
         sb.channel(NioServerSocketChannel.class);
         sb.childHandler(new ChannelInitializer<Channel>() {
             @Override

--- a/example/src/main/java/io/netty/example/discard/DiscardServer.java
+++ b/example/src/main/java/io/netty/example/discard/DiscardServer.java
@@ -39,11 +39,10 @@ public final class DiscardServer {
         // Configure SSL.
         final SslContext sslCtx = ServerUtil.buildSslContext();
 
-        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
-        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        EventLoopGroup group = new NioEventLoopGroup();
         try {
             ServerBootstrap b = new ServerBootstrap();
-            b.group(bossGroup, workerGroup)
+            b.group(group)
              .channel(NioServerSocketChannel.class)
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new ChannelInitializer<SocketChannel>() {
@@ -65,8 +64,7 @@ public final class DiscardServer {
             // shut down your server.
             f.channel().closeFuture().sync();
         } finally {
-            workerGroup.shutdownGracefully();
-            bossGroup.shutdownGracefully();
+            group.shutdownGracefully();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/dns/tcp/TcpDnsServer.java
+++ b/example/src/main/java/io/netty/example/dns/tcp/TcpDnsServer.java
@@ -57,8 +57,7 @@ public final class TcpDnsServer {
     private static final byte[] QUERY_RESULT = new byte[]{(byte) 192, (byte) 168, 1, 1};
 
     public static void main(String[] args) throws Exception {
-        ServerBootstrap bootstrap = new ServerBootstrap().group(new NioEventLoopGroup(1),
-                new NioEventLoopGroup())
+        ServerBootstrap bootstrap = new ServerBootstrap().group(new NioEventLoopGroup())
                 .channel(NioServerSocketChannel.class)
                 .handler(new LoggingHandler(LogLevel.INFO))
                 .childHandler(new ChannelInitializer<Channel>() {

--- a/example/src/main/java/io/netty/example/echo/EchoServer.java
+++ b/example/src/main/java/io/netty/example/echo/EchoServer.java
@@ -41,12 +41,11 @@ public final class EchoServer {
         final SslContext sslCtx = ServerUtil.buildSslContext();
 
         // Configure the server.
-        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
-        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        EventLoopGroup group = new NioEventLoopGroup();
         final EchoServerHandler serverHandler = new EchoServerHandler();
         try {
             ServerBootstrap b = new ServerBootstrap();
-            b.group(bossGroup, workerGroup)
+            b.group(group)
              .channel(NioServerSocketChannel.class)
              .option(ChannelOption.SO_BACKLOG, 100)
              .handler(new LoggingHandler(LogLevel.INFO))
@@ -69,8 +68,7 @@ public final class EchoServer {
             f.channel().closeFuture().sync();
         } finally {
             // Shut down all event loops to terminate all threads.
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            group.shutdownGracefully();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/factorial/FactorialServer.java
+++ b/example/src/main/java/io/netty/example/factorial/FactorialServer.java
@@ -36,19 +36,17 @@ public final class FactorialServer {
         // Configure SSL.
         final SslContext sslCtx = ServerUtil.buildSslContext();
 
-        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
-        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        EventLoopGroup group = new NioEventLoopGroup();
         try {
             ServerBootstrap b = new ServerBootstrap();
-            b.group(bossGroup, workerGroup)
+            b.group(group)
              .channel(NioServerSocketChannel.class)
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new FactorialServerInitializer(sslCtx));
 
             b.bind(PORT).sync().channel().closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            group.shutdownGracefully();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/file/FileServer.java
+++ b/example/src/main/java/io/netty/example/file/FileServer.java
@@ -48,11 +48,10 @@ public final class FileServer {
         final SslContext sslCtx = ServerUtil.buildSslContext();
 
         // Configure the server.
-        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
-        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        EventLoopGroup group = new NioEventLoopGroup();
         try {
             ServerBootstrap b = new ServerBootstrap();
-            b.group(bossGroup, workerGroup)
+            b.group(group)
              .channel(NioServerSocketChannel.class)
              .option(ChannelOption.SO_BACKLOG, 100)
              .handler(new LoggingHandler(LogLevel.INFO))
@@ -79,8 +78,7 @@ public final class FileServer {
             f.channel().closeFuture().sync();
         } finally {
             // Shut down all event loops to terminate all threads.
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            group.shutdownGracefully();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/haproxy/HAProxyServer.java
+++ b/example/src/main/java/io/netty/example/haproxy/HAProxyServer.java
@@ -36,18 +36,16 @@ public final class HAProxyServer {
     static final int PORT = Integer.parseInt(System.getProperty("port", "8080"));
 
     public static void main(String[] args) throws Exception {
-        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
-        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        EventLoopGroup group = new NioEventLoopGroup();
         try {
             ServerBootstrap b = new ServerBootstrap();
-            b.group(bossGroup, workerGroup)
+            b.group(group)
              .channel(NioServerSocketChannel.class)
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new HAProxyServerInitializer());
             b.bind(PORT).sync().channel().closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            group.shutdownGracefully();
         }
     }
 

--- a/example/src/main/java/io/netty/example/http/cors/HttpCorsServer.java
+++ b/example/src/main/java/io/netty/example/http/cors/HttpCorsServer.java
@@ -79,19 +79,17 @@ public final class HttpCorsServer {
         // Configure SSL.
         final SslContext sslCtx = ServerUtil.buildSslContext();
 
-        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
-        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        EventLoopGroup group = new NioEventLoopGroup();
         try {
             ServerBootstrap b = new ServerBootstrap();
-            b.group(bossGroup, workerGroup)
+            b.group(group)
              .channel(NioServerSocketChannel.class)
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new HttpCorsServerInitializer(sslCtx));
 
             b.bind(PORT).sync().channel().closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            group.shutdownGracefully();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/http/file/HttpStaticFileServer.java
+++ b/example/src/main/java/io/netty/example/http/file/HttpStaticFileServer.java
@@ -34,11 +34,10 @@ public final class HttpStaticFileServer {
         // Configure SSL.
         final SslContext sslCtx = ServerUtil.buildSslContext();
 
-        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
-        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        EventLoopGroup group = new NioEventLoopGroup();
         try {
             ServerBootstrap b = new ServerBootstrap();
-            b.group(bossGroup, workerGroup)
+            b.group(group)
              .channel(NioServerSocketChannel.class)
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new HttpStaticFileServerInitializer(sslCtx));
@@ -50,8 +49,7 @@ public final class HttpStaticFileServer {
 
             ch.closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            group.shutdownGracefully();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/http/helloworld/HttpHelloWorldServer.java
+++ b/example/src/main/java/io/netty/example/http/helloworld/HttpHelloWorldServer.java
@@ -40,12 +40,11 @@ public final class HttpHelloWorldServer {
         final SslContext sslCtx = ServerUtil.buildSslContext();
 
         // Configure the server.
-        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
-        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        EventLoopGroup group = new NioEventLoopGroup();
         try {
             ServerBootstrap b = new ServerBootstrap();
             b.option(ChannelOption.SO_BACKLOG, 1024);
-            b.group(bossGroup, workerGroup)
+            b.group(group)
              .channel(NioServerSocketChannel.class)
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new HttpHelloWorldServerInitializer(sslCtx));
@@ -57,8 +56,7 @@ public final class HttpHelloWorldServer {
 
             ch.closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            group.shutdownGracefully();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/http/snoop/HttpSnoopServer.java
+++ b/example/src/main/java/io/netty/example/http/snoop/HttpSnoopServer.java
@@ -39,11 +39,10 @@ public final class HttpSnoopServer {
         final SslContext sslCtx = ServerUtil.buildSslContext();
 
         // Configure the server.
-        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
-        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        EventLoopGroup group = new NioEventLoopGroup();
         try {
             ServerBootstrap b = new ServerBootstrap();
-            b.group(bossGroup, workerGroup)
+            b.group(group)
              .channel(NioServerSocketChannel.class)
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new HttpSnoopServerInitializer(sslCtx));
@@ -55,8 +54,7 @@ public final class HttpSnoopServer {
 
             ch.closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            group.shutdownGracefully();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/http/upload/HttpUploadServer.java
+++ b/example/src/main/java/io/netty/example/http/upload/HttpUploadServer.java
@@ -37,11 +37,10 @@ public final class HttpUploadServer {
         // Configure SSL.
         final SslContext sslCtx = ServerUtil.buildSslContext();
 
-        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
-        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        EventLoopGroup group = new NioEventLoopGroup();
         try {
             ServerBootstrap b = new ServerBootstrap();
-            b.group(bossGroup, workerGroup);
+            b.group(group);
             b.channel(NioServerSocketChannel.class);
             b.handler(new LoggingHandler(LogLevel.INFO));
             b.childHandler(new HttpUploadServerInitializer(sslCtx));
@@ -53,8 +52,7 @@ public final class HttpUploadServer {
 
             ch.closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            group.shutdownGracefully();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/http/websocketx/benchmarkserver/WebSocketServer.java
+++ b/example/src/main/java/io/netty/example/http/websocketx/benchmarkserver/WebSocketServer.java
@@ -40,11 +40,10 @@ public final class WebSocketServer {
         // Configure SSL.
         final SslContext sslCtx = ServerUtil.buildSslContext();
 
-        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
-        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        EventLoopGroup group = new NioEventLoopGroup();
         try {
             ServerBootstrap b = new ServerBootstrap();
-            b.group(bossGroup, workerGroup)
+            b.group(group)
              .channel(NioServerSocketChannel.class)
              .childHandler(new WebSocketServerInitializer(sslCtx));
 
@@ -55,8 +54,7 @@ public final class WebSocketServer {
 
             ch.closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            group.shutdownGracefully();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/http/websocketx/server/WebSocketServer.java
+++ b/example/src/main/java/io/netty/example/http/websocketx/server/WebSocketServer.java
@@ -53,11 +53,10 @@ public final class WebSocketServer {
         // Configure SSL.
         final SslContext sslCtx = ServerUtil.buildSslContext();
 
-        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
-        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        EventLoopGroup group = new NioEventLoopGroup();
         try {
             ServerBootstrap b = new ServerBootstrap();
-            b.group(bossGroup, workerGroup)
+            b.group(group)
              .channel(NioServerSocketChannel.class)
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new WebSocketServerInitializer(sslCtx));
@@ -69,8 +68,7 @@ public final class WebSocketServer {
 
             ch.closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            group.shutdownGracefully();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/http2/file/Http2StaticFileServer.java
+++ b/example/src/main/java/io/netty/example/http2/file/Http2StaticFileServer.java
@@ -50,11 +50,10 @@ public final class Http2StaticFileServer {
                         ApplicationProtocolNames.HTTP_1_1))
                 .build();
 
-        EventLoopGroup bossGroup = new NioEventLoopGroup(2);
-        EventLoopGroup workerGroup = new NioEventLoopGroup(4);
+        EventLoopGroup group = new NioEventLoopGroup();
         try {
             ServerBootstrap b = new ServerBootstrap();
-            b.group(bossGroup, workerGroup)
+            b.group(group)
                     .channel(NioServerSocketChannel.class)
                     .handler(new LoggingHandler(LogLevel.INFO))
                     .childHandler(new Http2StaticFileServerInitializer(sslCtx));
@@ -65,8 +64,7 @@ public final class Http2StaticFileServer {
 
             ch.closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            group.shutdownGracefully();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/ipfilter/IpSubnetFilterExample.java
+++ b/example/src/main/java/io/netty/example/ipfilter/IpSubnetFilterExample.java
@@ -43,9 +43,7 @@ public final class IpSubnetFilterExample {
     static final int PORT = Integer.parseInt(System.getProperty("port", "8009"));
 
     public static void main(String[] args) throws Exception {
-        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
-        EventLoopGroup workerGroup = new NioEventLoopGroup(1);
-
+        EventLoopGroup group = new NioEventLoopGroup();
         try {
             List<IpSubnetFilterRule> rules = new ArrayList<IpSubnetFilterRule>();
 
@@ -57,7 +55,7 @@ public final class IpSubnetFilterExample {
             final IpSubnetFilter ipFilter = new IpSubnetFilter(rules);
 
             ServerBootstrap b = new ServerBootstrap();
-            b.group(bossGroup, workerGroup)
+            b.group(group)
                     .channel(NioServerSocketChannel.class)
                     .handler(new LoggingHandler(LogLevel.INFO))
                     .childHandler(new ChannelInitializer<SocketChannel>() {
@@ -83,8 +81,7 @@ public final class IpSubnetFilterExample {
             // shut down your server.
             f.channel().closeFuture().sync();
         } finally {
-            workerGroup.shutdownGracefully();
-            bossGroup.shutdownGracefully();
+            group.shutdownGracefully();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/mqtt/heartBeat/MqttHeartBeatBroker.java
+++ b/example/src/main/java/io/netty/example/mqtt/heartBeat/MqttHeartBeatBroker.java
@@ -35,12 +35,10 @@ public final class MqttHeartBeatBroker {
     }
 
     public static void main(String[] args) throws Exception {
-        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
-        EventLoopGroup workerGroup = new NioEventLoopGroup();
-
+        EventLoopGroup group = new NioEventLoopGroup();
         try {
             ServerBootstrap b = new ServerBootstrap();
-            b.group(bossGroup, workerGroup);
+            b.group(group);
             b.option(ChannelOption.SO_BACKLOG, 1024);
             b.channel(NioServerSocketChannel.class);
             b.childHandler(new ChannelInitializer<SocketChannel>() {
@@ -58,8 +56,7 @@ public final class MqttHeartBeatBroker {
 
             f.channel().closeFuture().sync();
         } finally {
-            workerGroup.shutdownGracefully();
-            bossGroup.shutdownGracefully();
+            group.shutdownGracefully();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/objectecho/ObjectEchoServer.java
+++ b/example/src/main/java/io/netty/example/objectecho/ObjectEchoServer.java
@@ -43,11 +43,10 @@ public final class ObjectEchoServer {
         // Configure SSL.
         final SslContext sslCtx = ServerUtil.buildSslContext();
 
-        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
-        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        EventLoopGroup group = new NioEventLoopGroup();
         try {
             ServerBootstrap b = new ServerBootstrap();
-            b.group(bossGroup, workerGroup)
+            b.group(group)
              .channel(NioServerSocketChannel.class)
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new ChannelInitializer<SocketChannel>() {
@@ -67,8 +66,7 @@ public final class ObjectEchoServer {
             // Bind and start to accept incoming connections.
             b.bind(PORT).sync().channel().closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            group.shutdownGracefully();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/portunification/PortUnificationServer.java
+++ b/example/src/main/java/io/netty/example/portunification/PortUnificationServer.java
@@ -44,11 +44,10 @@ public final class PortUnificationServer {
         final SslContext sslCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
             .build();
 
-        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
-        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        EventLoopGroup group = new NioEventLoopGroup();
         try {
             ServerBootstrap b = new ServerBootstrap();
-            b.group(bossGroup, workerGroup)
+            b.group(group)
              .channel(NioServerSocketChannel.class)
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new ChannelInitializer<SocketChannel>() {
@@ -61,8 +60,7 @@ public final class PortUnificationServer {
             // Bind and start to accept incoming connections.
             b.bind(PORT).sync().channel().closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            group.shutdownGracefully();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/proxy/HexDumpProxy.java
+++ b/example/src/main/java/io/netty/example/proxy/HexDumpProxy.java
@@ -33,19 +33,17 @@ public final class HexDumpProxy {
         System.err.println("Proxying *:" + LOCAL_PORT + " to " + REMOTE_HOST + ':' + REMOTE_PORT + " ...");
 
         // Configure the bootstrap.
-        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
-        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        EventLoopGroup group = new NioEventLoopGroup();
         try {
             ServerBootstrap b = new ServerBootstrap();
-            b.group(bossGroup, workerGroup)
+            b.group(group)
              .channel(NioServerSocketChannel.class)
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new HexDumpProxyInitializer(REMOTE_HOST, REMOTE_PORT))
              .childOption(ChannelOption.AUTO_READ, false)
              .bind(LOCAL_PORT).sync().channel().closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            group.shutdownGracefully();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/sctp/SctpEchoServer.java
+++ b/example/src/main/java/io/netty/example/sctp/SctpEchoServer.java
@@ -35,12 +35,11 @@ public final class SctpEchoServer {
 
     public static void main(String[] args) throws Exception {
         // Configure the server.
-        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
-        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        EventLoopGroup group = new NioEventLoopGroup();
         final SctpEchoServerHandler serverHandler = new SctpEchoServerHandler();
         try {
             ServerBootstrap b = new ServerBootstrap();
-            b.group(bossGroup, workerGroup)
+            b.group(group)
              .channel(NioSctpServerChannel.class)
              .option(ChannelOption.SO_BACKLOG, 100)
              .handler(new LoggingHandler(LogLevel.INFO))
@@ -60,8 +59,7 @@ public final class SctpEchoServer {
             f.channel().closeFuture().sync();
         } finally {
             // Shut down all event loops to terminate all threads.
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            group.shutdownGracefully();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/sctp/multihoming/SctpMultiHomingEchoServer.java
+++ b/example/src/main/java/io/netty/example/sctp/multihoming/SctpMultiHomingEchoServer.java
@@ -44,11 +44,10 @@ public final class SctpMultiHomingEchoServer {
 
     public static void main(String[] args) throws Exception {
         // Configure the server.
-        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
-        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        EventLoopGroup group = new NioEventLoopGroup();
         try {
             ServerBootstrap b = new ServerBootstrap();
-            b.group(bossGroup, workerGroup)
+            b.group(group)
              .channel(NioSctpServerChannel.class)
              .option(ChannelOption.SO_BACKLOG, 100)
              .handler(new LoggingHandler(LogLevel.INFO))
@@ -77,8 +76,7 @@ public final class SctpMultiHomingEchoServer {
             connectFuture.channel().closeFuture().sync();
         } finally {
             // Shut down all event loops to terminate all threads.
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            group.shutdownGracefully();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/securechat/SecureChatServer.java
+++ b/example/src/main/java/io/netty/example/securechat/SecureChatServer.java
@@ -38,19 +38,17 @@ public final class SecureChatServer {
         SslContext sslCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
             .build();
 
-        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
-        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        EventLoopGroup group = new NioEventLoopGroup();
         try {
             ServerBootstrap b = new ServerBootstrap();
-            b.group(bossGroup, workerGroup)
+            b.group(group)
              .channel(NioServerSocketChannel.class)
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new SecureChatServerInitializer(sslCtx));
 
             b.bind(PORT).sync().channel().closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            group.shutdownGracefully();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/socksproxy/SocksServer.java
+++ b/example/src/main/java/io/netty/example/socksproxy/SocksServer.java
@@ -27,18 +27,16 @@ public final class SocksServer {
     static final int PORT = Integer.parseInt(System.getProperty("port", "1080"));
 
     public static void main(String[] args) throws Exception {
-        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
-        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        EventLoopGroup group = new NioEventLoopGroup();
         try {
             ServerBootstrap b = new ServerBootstrap();
-            b.group(bossGroup, workerGroup)
+            b.group(group)
              .channel(NioServerSocketChannel.class)
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new SocksServerInitializer());
             b.bind(PORT).sync().channel().closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            group.shutdownGracefully();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/spdy/server/SpdyServer.java
+++ b/example/src/main/java/io/netty/example/spdy/server/SpdyServer.java
@@ -69,12 +69,11 @@ public final class SpdyServer {
             .build();
 
         // Configure the server.
-        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
-        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        EventLoopGroup group = new NioEventLoopGroup();
         try {
             ServerBootstrap b = new ServerBootstrap();
             b.option(ChannelOption.SO_BACKLOG, 1024);
-            b.group(bossGroup, workerGroup)
+            b.group(group)
              .channel(NioServerSocketChannel.class)
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new SpdyServerInitializer(sslCtx));
@@ -86,8 +85,7 @@ public final class SpdyServer {
 
             ch.closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            group.shutdownGracefully();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/stomp/websocket/StompWebSocketChatServer.java
+++ b/example/src/main/java/io/netty/example/stomp/websocket/StompWebSocketChatServer.java
@@ -18,6 +18,7 @@ package io.netty.example.stomp.websocket;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 
@@ -26,11 +27,10 @@ public class StompWebSocketChatServer {
     static final int PORT = Integer.parseInt(System.getProperty("port", "8080"));
 
     public void start(final int port) throws Exception {
-        NioEventLoopGroup boosGroup = new NioEventLoopGroup(1);
-        NioEventLoopGroup workerGroup = new NioEventLoopGroup();
+        EventLoopGroup group = new NioEventLoopGroup();
         try {
             ServerBootstrap bootstrap = new ServerBootstrap()
-                    .group(boosGroup, workerGroup)
+                    .group(group)
                     .channel(NioServerSocketChannel.class)
                     .childHandler(new StompWebSocketChatServerInitializer("/chat"));
             bootstrap.bind(port).addListener(new ChannelFutureListener() {
@@ -44,8 +44,7 @@ public class StompWebSocketChatServer {
                 }
             }).channel().closeFuture().sync();
         } finally {
-            boosGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            group.shutdownGracefully();
         }
     }
 

--- a/example/src/main/java/io/netty/example/telnet/TelnetServer.java
+++ b/example/src/main/java/io/netty/example/telnet/TelnetServer.java
@@ -36,19 +36,17 @@ public final class TelnetServer {
         // Configure SSL.
         final SslContext sslCtx = ServerUtil.buildSslContext();
 
-        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
-        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        EventLoopGroup group = new NioEventLoopGroup();
         try {
             ServerBootstrap b = new ServerBootstrap();
-            b.group(bossGroup, workerGroup)
+            b.group(group)
              .channel(NioServerSocketChannel.class)
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new TelnetServerInitializer(sslCtx));
 
             b.bind(PORT).sync().channel().closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            group.shutdownGracefully();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/udt/echo/bytes/ByteEchoServer.java
+++ b/example/src/main/java/io/netty/example/udt/echo/bytes/ByteEchoServer.java
@@ -38,15 +38,12 @@ public final class ByteEchoServer {
     static final int PORT = Integer.parseInt(System.getProperty("port", "8007"));
 
     public static void main(String[] args) throws Exception {
-        final ThreadFactory acceptFactory = new DefaultThreadFactory("accept");
-        final ThreadFactory connectFactory = new DefaultThreadFactory("connect");
-        final NioEventLoopGroup acceptGroup = new NioEventLoopGroup(1, acceptFactory, NioUdtProvider.BYTE_PROVIDER);
-        final NioEventLoopGroup connectGroup = new NioEventLoopGroup(1, connectFactory, NioUdtProvider.BYTE_PROVIDER);
-
+        final ThreadFactory factory = new DefaultThreadFactory("udt");
+        final NioEventLoopGroup group = new NioEventLoopGroup(1, factory, NioUdtProvider.BYTE_PROVIDER);
         // Configure the server.
         try {
             final ServerBootstrap boot = new ServerBootstrap();
-            boot.group(acceptGroup, connectGroup)
+            boot.group(group)
                     .channelFactory(NioUdtProvider.BYTE_ACCEPTOR)
                     .option(ChannelOption.SO_BACKLOG, 10)
                     .handler(new LoggingHandler(LogLevel.INFO))
@@ -65,8 +62,7 @@ public final class ByteEchoServer {
             future.channel().closeFuture().sync();
         } finally {
             // Shut down all event loops to terminate all threads.
-            acceptGroup.shutdownGracefully();
-            connectGroup.shutdownGracefully();
+            group.shutdownGracefully();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/uptime/UptimeServer.java
+++ b/example/src/main/java/io/netty/example/uptime/UptimeServer.java
@@ -37,12 +37,10 @@ public final class UptimeServer {
     }
 
     public static void main(String[] args) throws Exception {
-
-        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
-        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        EventLoopGroup group = new NioEventLoopGroup();
         try {
             ServerBootstrap b = new ServerBootstrap();
-            b.group(bossGroup, workerGroup)
+            b.group(group)
                     .channel(NioServerSocketChannel.class)
                     .handler(new LoggingHandler(LogLevel.INFO))
                     .childHandler(new ChannelInitializer<SocketChannel>() {
@@ -60,8 +58,7 @@ public final class UptimeServer {
             // shut down your server.
             f.channel().closeFuture().sync();
         } finally {
-            workerGroup.shutdownGracefully();
-            bossGroup.shutdownGracefully();
+            group.shutdownGracefully();
         }
     }
 }

--- a/example/src/main/java/io/netty/example/worldclock/WorldClockServer.java
+++ b/example/src/main/java/io/netty/example/worldclock/WorldClockServer.java
@@ -33,19 +33,17 @@ public final class WorldClockServer {
 
     public static void main(String[] args) throws Exception {
 
-        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
-        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        EventLoopGroup group = new NioEventLoopGroup();
         try {
             ServerBootstrap b = new ServerBootstrap();
-            b.group(bossGroup, workerGroup)
+            b.group(group)
              .channel(NioServerSocketChannel.class)
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new WorldClockServerInitializer(ServerUtil.buildSslContext()));
 
             b.bind(PORT).sync().channel().closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            group.shutdownGracefully();
         }
     }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -845,7 +845,7 @@ public abstract class SSLEngineTest {
         sb = new ServerBootstrap();
         cb = new Bootstrap();
 
-        sb.group(new NioEventLoopGroup(), new NioEventLoopGroup());
+        sb.group(new NioEventLoopGroup());
         sb.channel(NioServerSocketChannel.class);
         sb.childHandler(new ChannelInitializer<Channel>() {
             @Override
@@ -1012,7 +1012,7 @@ public abstract class SSLEngineTest {
         sb = new ServerBootstrap();
         cb = new Bootstrap();
 
-        sb.group(new NioEventLoopGroup(), new NioEventLoopGroup());
+        sb.group(new NioEventLoopGroup());
         sb.channel(NioServerSocketChannel.class);
         sb.childHandler(new ChannelInitializer<Channel>() {
             @Override
@@ -1200,7 +1200,7 @@ public abstract class SSLEngineTest {
         sb = new ServerBootstrap();
         cb = new Bootstrap();
 
-        sb.group(new NioEventLoopGroup(), new NioEventLoopGroup());
+        sb.group(new NioEventLoopGroup());
         sb.channel(NioServerSocketChannel.class);
         sb.childHandler(new ChannelInitializer<Channel>() {
             @Override
@@ -1899,7 +1899,7 @@ public abstract class SSLEngineTest {
     private void setupServer(final BufferType type, final boolean delegate) {
         serverConnectedChannel = null;
         sb = new ServerBootstrap();
-        sb.group(new NioEventLoopGroup(), new NioEventLoopGroup());
+        sb.group(new NioEventLoopGroup());
         sb.channel(NioServerSocketChannel.class);
         sb.childHandler(new ChannelInitializer<Channel>() {
             @Override
@@ -1991,7 +1991,7 @@ public abstract class SSLEngineTest {
                                  .ciphers(param.ciphers()).build());
 
         sb = new ServerBootstrap();
-        sb.group(new NioEventLoopGroup(), new NioEventLoopGroup());
+        sb.group(new NioEventLoopGroup());
         sb.channel(NioServerSocketChannel.class);
 
         final Promise<String> promise = sb.config().group().next().newPromise();
@@ -4515,7 +4515,7 @@ public abstract class SSLEngineTest {
 
         try {
             sb = new ServerBootstrap();
-            sb.group(new NioEventLoopGroup(), new NioEventLoopGroup());
+            sb.group(new NioEventLoopGroup());
             sb.channel(NioServerSocketChannel.class);
 
             final Promise<SecretKey> promise = sb.config().group().next().newPromise();

--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -485,7 +485,7 @@ public class SslHandlerTest {
             SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
             final Promise<Void> serverPromise = group.next().newPromise();
             ServerBootstrap serverBootstrap = new ServerBootstrap()
-                    .group(group, group)
+                    .group(group)
                     .channel(NioServerSocketChannel.class)
                     .childHandler(newHandler(SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey()).build(),
                             serverPromise));

--- a/handler/src/test/java/io/netty/handler/traffic/TrafficShapingHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/traffic/TrafficShapingHandlerTest.java
@@ -76,7 +76,7 @@ public class TrafficShapingHandlerTest {
         Channel ch = null;
         try {
             ServerBootstrap serverBootstrap = new ServerBootstrap();
-            serverBootstrap.channel(LocalServerChannel.class).group(GROUP, GROUP)
+            serverBootstrap.channel(LocalServerChannel.class).group(GROUP)
                     .childHandler(new ChannelInitializer<Channel>() {
                         @Override
                         protected void initChannel(Channel ch) throws Exception {

--- a/testsuite-autobahn/src/main/java/io/netty/testsuite/autobahn/AutobahnServer.java
+++ b/testsuite-autobahn/src/main/java/io/netty/testsuite/autobahn/AutobahnServer.java
@@ -36,11 +36,10 @@ public class AutobahnServer {
     }
 
     public void run() throws Exception {
-        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
-        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        EventLoopGroup group = new NioEventLoopGroup();
         try {
             ServerBootstrap b = new ServerBootstrap();
-            b.group(bossGroup, workerGroup)
+            b.group(group)
              .channel(NioServerSocketChannel.class)
              .childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
              .childHandler(new AutobahnServerInitializer());
@@ -49,8 +48,7 @@ public class AutobahnServer {
             System.out.println("Web Socket Server started at port " + port);
             f.channel().closeFuture().sync();
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            group.shutdownGracefully();
         }
     }
 

--- a/testsuite-native-image/src/main/java/io/netty/testsuite/svm/HttpNativeServer.java
+++ b/testsuite-native-image/src/main/java/io/netty/testsuite/svm/HttpNativeServer.java
@@ -38,25 +38,24 @@ public final class HttpNativeServer {
 
     public static void main(String[] args) throws Exception {
         // Configure the server.
-        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
-        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        EventLoopGroup group = new NioEventLoopGroup();
         // Control status.
         boolean serverStartSucess = false;
         try {
             ServerBootstrap b = new ServerBootstrap();
             b.option(ChannelOption.SO_BACKLOG, 1024);
-            b.group(bossGroup, workerGroup)
+            b.group(group)
              .channel(NioServerSocketChannel.class)
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new HttpNativeServerInitializer());
 
             Channel channel = b.bind(0).sync().channel();
             System.err.println("Server started, will shutdown now.");
+
             channel.close().sync();
             serverStartSucess = true;
         } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
+            group.shutdownGracefully();
         }
         // return the right system exit code to signal success
         System.exit(serverStartSucess ? 0 : 1);

--- a/testsuite/src/main/java/io/netty/testsuite/transport/sctp/SctpTestPermutation.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/sctp/SctpTestPermutation.java
@@ -35,16 +35,11 @@ import java.util.List;
 
 public final class SctpTestPermutation {
 
-    private static final int BOSSES = 2;
-    private static final int WORKERS = 3;
-    private static final EventLoopGroup nioBossGroup =
-            new NioEventLoopGroup(BOSSES, new DefaultThreadFactory("testsuite-sctp-nio-boss", true));
-    private static final EventLoopGroup nioWorkerGroup =
-            new NioEventLoopGroup(WORKERS, new DefaultThreadFactory("testsuite-sctp-nio-worker", true));
-    private static final EventLoopGroup oioBossGroup =
-            new OioEventLoopGroup(Integer.MAX_VALUE, new DefaultThreadFactory("testsuite-sctp-oio-boss", true));
-    private static final EventLoopGroup oioWorkerGroup =
-            new OioEventLoopGroup(Integer.MAX_VALUE, new DefaultThreadFactory("testsuite-sctp-oio-worker", true));
+    private static final int NUM_THREADS = 4;
+    private static final EventLoopGroup NIO_GROUP = new NioEventLoopGroup(
+            NUM_THREADS, new DefaultThreadFactory("testsuite-sctp-nio", true));
+    private static final EventLoopGroup OIO_GROUP =
+            new OioEventLoopGroup(Integer.MAX_VALUE, new DefaultThreadFactory("testsuite-sctp-oio", true));
 
     static List<BootstrapFactory<ServerBootstrap>> sctpServerChannel() {
         if (!TestUtils.isSctpSupported()) {
@@ -57,7 +52,7 @@ public final class SctpTestPermutation {
             @Override
             public ServerBootstrap newInstance() {
                 return new ServerBootstrap().
-                        group(nioBossGroup, nioWorkerGroup).
+                        group(NIO_GROUP).
                         channel(NioSctpServerChannel.class);
             }
         });
@@ -65,7 +60,7 @@ public final class SctpTestPermutation {
             @Override
             public ServerBootstrap newInstance() {
                 return new ServerBootstrap().
-                        group(oioBossGroup, oioWorkerGroup).
+                        group(OIO_GROUP).
                         channel(OioSctpServerChannel.class);
             }
         });
@@ -82,13 +77,13 @@ public final class SctpTestPermutation {
         list.add(new BootstrapFactory<Bootstrap>() {
             @Override
             public Bootstrap newInstance() {
-                return new Bootstrap().group(nioWorkerGroup).channel(NioSctpChannel.class);
+                return new Bootstrap().group(NIO_GROUP).channel(NioSctpChannel.class);
             }
         });
         list.add(new BootstrapFactory<Bootstrap>() {
             @Override
             public Bootstrap newInstance() {
-                return new Bootstrap().group(oioWorkerGroup).channel(OioSctpChannel.class);
+                return new Bootstrap().group(OIO_GROUP).channel(OioSctpChannel.class);
             }
         });
         return list;

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketTestPermutation.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketTestPermutation.java
@@ -58,19 +58,14 @@ public class SocketTestPermutation {
 
     static final SocketTestPermutation INSTANCE = new SocketTestPermutation();
 
-    protected static final int BOSSES = 2;
-    protected static final int WORKERS = 3;
+    protected static final int NUM_THREADS = 4;
 
     protected static final int OIO_SO_TIMEOUT = 10;  // Use short timeout for faster runs.
 
-    protected final EventLoopGroup nioBossGroup =
-            new NioEventLoopGroup(BOSSES, new DefaultThreadFactory("testsuite-nio-boss", true));
-    protected final EventLoopGroup nioWorkerGroup =
-            new NioEventLoopGroup(WORKERS, new DefaultThreadFactory("testsuite-nio-worker", true));
-    protected final EventLoopGroup oioBossGroup =
-            new OioEventLoopGroup(Integer.MAX_VALUE, new DefaultThreadFactory("testsuite-oio-boss", true));
-    protected final EventLoopGroup oioWorkerGroup =
-            new OioEventLoopGroup(Integer.MAX_VALUE, new DefaultThreadFactory("testsuite-oio-worker", true));
+    protected final EventLoopGroup NIO_GROUP = new NioEventLoopGroup(
+            NUM_THREADS, new DefaultThreadFactory("testsuite-nio", true));
+    protected final EventLoopGroup OIO_GROUP =
+            new OioEventLoopGroup(Integer.MAX_VALUE, new DefaultThreadFactory("testsuite-oio", true));
 
     protected <A extends AbstractBootstrap<?, ?>, B extends AbstractBootstrap<?, ?>>
 
@@ -143,7 +138,7 @@ public class SocketTestPermutation {
         bfs.add(new BootstrapFactory<Bootstrap>() {
             @Override
             public Bootstrap newInstance() {
-                return new Bootstrap().group(nioWorkerGroup).channelFactory(new ChannelFactory<Channel>() {
+                return new Bootstrap().group(NIO_GROUP).channelFactory(new ChannelFactory<Channel>() {
                     @Override
                     public Channel newChannel() {
                         return new NioDatagramChannel(family);
@@ -160,7 +155,7 @@ public class SocketTestPermutation {
             bfs.add(new BootstrapFactory<Bootstrap>() {
                 @Override
                 public Bootstrap newInstance() {
-                    return new Bootstrap().group(oioWorkerGroup).channel(OioDatagramChannel.class)
+                    return new Bootstrap().group(OIO_GROUP).channel(OioDatagramChannel.class)
                             .option(ChannelOption.SO_TIMEOUT, OIO_SO_TIMEOUT);
                 }
             });
@@ -175,7 +170,7 @@ public class SocketTestPermutation {
         factories.add(new BootstrapFactory<ServerBootstrap>() {
             @Override
             public ServerBootstrap newInstance() {
-                return new ServerBootstrap().group(nioBossGroup, nioWorkerGroup)
+                return new ServerBootstrap().group(NIO_GROUP)
                         .channel(NioServerSocketChannel.class);
             }
         });
@@ -183,7 +178,7 @@ public class SocketTestPermutation {
             factories.add(new BootstrapFactory<ServerBootstrap>() {
                 @Override
                 public ServerBootstrap newInstance() {
-                    return new ServerBootstrap().group(oioBossGroup, oioWorkerGroup)
+                    return new ServerBootstrap().group(OIO_GROUP)
                             .channel(OioServerSocketChannel.class)
                             .option(ChannelOption.SO_TIMEOUT, OIO_SO_TIMEOUT);
                 }
@@ -198,14 +193,14 @@ public class SocketTestPermutation {
         factories.add(new BootstrapFactory<Bootstrap>() {
             @Override
             public Bootstrap newInstance() {
-                return new Bootstrap().group(nioWorkerGroup).channel(NioSocketChannel.class);
+                return new Bootstrap().group(NIO_GROUP).channel(NioSocketChannel.class);
             }
         });
         if (INCLUDE_OIO) {
             factories.add(new BootstrapFactory<Bootstrap>() {
                 @Override
                 public Bootstrap newInstance() {
-                    return new Bootstrap().group(oioWorkerGroup).channel(OioSocketChannel.class)
+                    return new Bootstrap().group(OIO_GROUP).channel(OioSocketChannel.class)
                             .option(ChannelOption.SO_TIMEOUT, OIO_SO_TIMEOUT);
                 }
             });
@@ -222,14 +217,14 @@ public class SocketTestPermutation {
         factories.add(new BootstrapFactory<Bootstrap>() {
             @Override
             public Bootstrap newInstance() {
-                return new Bootstrap().group(nioWorkerGroup).channel(NioDatagramChannel.class);
+                return new Bootstrap().group(NIO_GROUP).channel(NioDatagramChannel.class);
             }
         });
         if (INCLUDE_OIO) {
             factories.add(new BootstrapFactory<Bootstrap>() {
                 @Override
                 public Bootstrap newInstance() {
-                    return new Bootstrap().group(oioWorkerGroup).channel(OioDatagramChannel.class)
+                    return new Bootstrap().group(OIO_GROUP).channel(OioDatagramChannel.class)
                             .option(ChannelOption.SO_TIMEOUT, OIO_SO_TIMEOUT);
                 }
             });

--- a/testsuite/src/main/java/io/netty/testsuite/transport/udt/UDTClientServerConnectionTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/udt/UDTClientServerConnectionTest.java
@@ -196,14 +196,11 @@ public class UDTClientServerConnectionTest {
         @Override
         public void run() {
             final ServerBootstrap boot = new ServerBootstrap();
-            final ThreadFactory acceptFactory = new DefaultThreadFactory("accept");
-            final ThreadFactory serverFactory = new DefaultThreadFactory("server");
-            final NioEventLoopGroup acceptGroup = new NioEventLoopGroup(1,
-                    acceptFactory, NioUdtProvider.BYTE_PROVIDER);
-            final NioEventLoopGroup connectGroup = new NioEventLoopGroup(1,
-                    serverFactory, NioUdtProvider.BYTE_PROVIDER);
+            final ThreadFactory factory = new DefaultThreadFactory("udp");
+            final NioEventLoopGroup eventLoopGroup = new NioEventLoopGroup(1,
+                    factory, NioUdtProvider.BYTE_PROVIDER);
             try {
-                boot.group(acceptGroup, connectGroup)
+                boot.group(eventLoopGroup)
                         .channelFactory(NioUdtProvider.BYTE_ACCEPTOR)
                         .childHandler(new ChannelInitializer<UdtChannel>() {
                             @Override
@@ -234,11 +231,8 @@ public class UDTClientServerConnectionTest {
             } catch (final Throwable e) {
                 log.error("Server failure.", e);
             } finally {
-                acceptGroup.shutdownGracefully();
-                connectGroup.shutdownGracefully();
-
-                acceptGroup.terminationFuture().syncUninterruptibly();
-                connectGroup.terminationFuture().syncUninterruptibly();
+                eventLoopGroup.shutdownGracefully();
+                eventLoopGroup.terminationFuture().syncUninterruptibly();
             }
         }
 

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollReuseAddrTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollReuseAddrTest.java
@@ -195,7 +195,7 @@ public class EpollReuseAddrTest {
 
     private static ServerBootstrap createServerBootstrap() {
         ServerBootstrap bootstrap = new ServerBootstrap();
-        bootstrap.group(EpollSocketTestPermutation.EPOLL_BOSS_GROUP, EpollSocketTestPermutation.EPOLL_WORKER_GROUP);
+        bootstrap.group(EpollSocketTestPermutation.EPOLL_GROUP);
         bootstrap.channel(EpollServerSocketChannel.class);
         bootstrap.childHandler(new DummyHandler());
         InetSocketAddress address = new InetSocketAddress(NetUtil.LOCALHOST, 0);
@@ -205,7 +205,7 @@ public class EpollReuseAddrTest {
 
     private static Bootstrap createBootstrap() {
         Bootstrap bootstrap = new Bootstrap();
-        bootstrap.group(EpollSocketTestPermutation.EPOLL_WORKER_GROUP);
+        bootstrap.group(EpollSocketTestPermutation.EPOLL_GROUP);
         bootstrap.channel(EpollDatagramChannel.class);
         InetSocketAddress address = new InetSocketAddress(NetUtil.LOCALHOST, 0);
         bootstrap.localAddress(address);

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketStringEchoBusyWaitTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketStringEchoBusyWaitTest.java
@@ -84,7 +84,7 @@ public class EpollSocketStringEchoBusyWaitTest extends SocketStringEchoTest {
         return new BootstrapFactory<ServerBootstrap>() {
             @Override
             public ServerBootstrap newInstance() {
-                return new ServerBootstrap().group(EPOLL_LOOP, EPOLL_LOOP).channel(EpollServerSocketChannel.class);
+                return new ServerBootstrap().group(EPOLL_LOOP).channel(EpollServerSocketChannel.class);
             }
         };
     }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTestPermutation.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTestPermutation.java
@@ -41,10 +41,8 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
 
     static final EpollSocketTestPermutation INSTANCE = new EpollSocketTestPermutation();
 
-    static final EventLoopGroup EPOLL_BOSS_GROUP =
-            new EpollEventLoopGroup(BOSSES, new DefaultThreadFactory("testsuite-epoll-boss", true));
-    static final EventLoopGroup EPOLL_WORKER_GROUP =
-            new EpollEventLoopGroup(WORKERS, new DefaultThreadFactory("testsuite-epoll-worker", true));
+    static final EventLoopGroup EPOLL_GROUP = new EpollEventLoopGroup(
+            NUM_THREADS, new DefaultThreadFactory("testsuite-epoll", true));
 
     @Override
     public List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> socket() {
@@ -71,7 +69,7 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
         toReturn.add(new BootstrapFactory<ServerBootstrap>() {
             @Override
             public ServerBootstrap newInstance() {
-                return new ServerBootstrap().group(EPOLL_BOSS_GROUP, EPOLL_WORKER_GROUP)
+                return new ServerBootstrap().group(EPOLL_GROUP)
                                             .channel(EpollServerSocketChannel.class);
             }
         });
@@ -79,7 +77,7 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
             toReturn.add(new BootstrapFactory<ServerBootstrap>() {
                 @Override
                 public ServerBootstrap newInstance() {
-                    ServerBootstrap serverBootstrap = new ServerBootstrap().group(EPOLL_BOSS_GROUP, EPOLL_WORKER_GROUP)
+                    ServerBootstrap serverBootstrap = new ServerBootstrap().group(EPOLL_GROUP)
                                                                            .channel(EpollServerSocketChannel.class);
                     serverBootstrap.option(ChannelOption.TCP_FASTOPEN, 5);
                     return serverBootstrap;
@@ -89,7 +87,7 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
         toReturn.add(new BootstrapFactory<ServerBootstrap>() {
             @Override
             public ServerBootstrap newInstance() {
-                return new ServerBootstrap().group(nioBossGroup, nioWorkerGroup)
+                return new ServerBootstrap().group(NIO_GROUP)
                                             .channel(NioServerSocketChannel.class);
             }
         });
@@ -104,14 +102,14 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
         toReturn.add(new BootstrapFactory<Bootstrap>() {
             @Override
             public Bootstrap newInstance() {
-                return new Bootstrap().group(EPOLL_WORKER_GROUP).channel(EpollSocketChannel.class);
+                return new Bootstrap().group(EPOLL_GROUP).channel(EpollSocketChannel.class);
             }
         });
 
         toReturn.add(new BootstrapFactory<Bootstrap>() {
             @Override
             public Bootstrap newInstance() {
-                return new Bootstrap().group(nioWorkerGroup).channel(NioSocketChannel.class);
+                return new Bootstrap().group(NIO_GROUP).channel(NioSocketChannel.class);
             }
         });
 
@@ -127,7 +125,7 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
             factories.add(insertIndex, new BootstrapFactory<Bootstrap>() {
                 @Override
                 public Bootstrap newInstance() {
-                    return new Bootstrap().group(EPOLL_WORKER_GROUP).channel(EpollSocketChannel.class)
+                    return new Bootstrap().group(EPOLL_GROUP).channel(EpollSocketChannel.class)
                             .option(ChannelOption.TCP_FASTOPEN_CONNECT, true);
                 }
             });
@@ -144,7 +142,7 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
                 new BootstrapFactory<Bootstrap>() {
                     @Override
                     public Bootstrap newInstance() {
-                        return new Bootstrap().group(nioWorkerGroup).channelFactory(new ChannelFactory<Channel>() {
+                        return new Bootstrap().group(NIO_GROUP).channelFactory(new ChannelFactory<Channel>() {
                             @Override
                             public Channel newChannel() {
                                 return new NioDatagramChannel(family);
@@ -160,7 +158,7 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
                 new BootstrapFactory<Bootstrap>() {
                     @Override
                     public Bootstrap newInstance() {
-                        return new Bootstrap().group(EPOLL_WORKER_GROUP).channelFactory(new ChannelFactory<Channel>() {
+                        return new Bootstrap().group(EPOLL_GROUP).channelFactory(new ChannelFactory<Channel>() {
                             @Override
                             public Channel newChannel() {
                                 return new EpollDatagramChannel(family);
@@ -187,7 +185,7 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
         return new BootstrapFactory<Bootstrap>() {
             @Override
             public Bootstrap newInstance() {
-                return new Bootstrap().group(EPOLL_WORKER_GROUP).channelFactory(new ChannelFactory<Channel>() {
+                return new Bootstrap().group(EPOLL_GROUP).channelFactory(new ChannelFactory<Channel>() {
                     @Override
                     public Channel newChannel() {
                         return new EpollDatagramChannel(family);
@@ -211,7 +209,7 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
                 new BootstrapFactory<ServerBootstrap>() {
                     @Override
                     public ServerBootstrap newInstance() {
-                        return new ServerBootstrap().group(EPOLL_BOSS_GROUP, EPOLL_WORKER_GROUP)
+                        return new ServerBootstrap().group(EPOLL_GROUP)
                                 .channel(EpollServerDomainSocketChannel.class);
                     }
                 }
@@ -223,7 +221,7 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
                 new BootstrapFactory<Bootstrap>() {
                     @Override
                     public Bootstrap newInstance() {
-                        return new Bootstrap().group(EPOLL_WORKER_GROUP).channel(EpollDomainSocketChannel.class);
+                        return new Bootstrap().group(EPOLL_GROUP).channel(EpollDomainSocketChannel.class);
                     }
                 }
         );
@@ -235,7 +233,7 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
                 new BootstrapFactory<Bootstrap>() {
                     @Override
                     public Bootstrap newInstance() {
-                        return new Bootstrap().group(EPOLL_WORKER_GROUP).channel(EpollDatagramChannel.class);
+                        return new Bootstrap().group(EPOLL_GROUP).channel(EpollDatagramChannel.class);
                     }
                 }
         );
@@ -250,7 +248,7 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
                 new BootstrapFactory<Bootstrap>() {
                     @Override
                     public Bootstrap newInstance() {
-                        return new Bootstrap().group(EPOLL_WORKER_GROUP).channel(EpollDomainDatagramChannel.class);
+                        return new Bootstrap().group(EPOLL_GROUP).channel(EpollDomainDatagramChannel.class);
                     }
                 }
         );

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTestPermutation.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTestPermutation.java
@@ -40,11 +40,8 @@ import java.util.List;
 class KQueueSocketTestPermutation extends SocketTestPermutation {
 
     static final KQueueSocketTestPermutation INSTANCE = new KQueueSocketTestPermutation();
-
-    static final EventLoopGroup KQUEUE_BOSS_GROUP =
-            new KQueueEventLoopGroup(BOSSES, new DefaultThreadFactory("testsuite-KQueue-boss", true));
-    static final EventLoopGroup KQUEUE_WORKER_GROUP =
-            new KQueueEventLoopGroup(WORKERS, new DefaultThreadFactory("testsuite-KQueue-worker", true));
+    static final EventLoopGroup KQUEUE_GROUP = new KQueueEventLoopGroup(
+            NUM_THREADS, new DefaultThreadFactory("testsuite-KQueue-group", true));
 
     @Override
     public List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> socket() {
@@ -63,7 +60,7 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
         toReturn.add(new BootstrapFactory<ServerBootstrap>() {
             @Override
             public ServerBootstrap newInstance() {
-                return new ServerBootstrap().group(KQUEUE_BOSS_GROUP, KQUEUE_WORKER_GROUP)
+                return new ServerBootstrap().group(KQUEUE_GROUP)
                                             .channel(KQueueServerSocketChannel.class);
             }
         });
@@ -72,7 +69,7 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
                 @Override
                 public ServerBootstrap newInstance() {
                     ServerBootstrap serverBootstrap = new ServerBootstrap()
-                            .group(KQUEUE_BOSS_GROUP, KQUEUE_WORKER_GROUP)
+                            .group(KQUEUE_GROUP)
                             .channel(KQueueServerSocketChannel.class);
                     serverBootstrap.option(ChannelOption.TCP_FASTOPEN, 1);
                     return serverBootstrap;
@@ -83,7 +80,7 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
         toReturn.add(new BootstrapFactory<ServerBootstrap>() {
             @Override
             public ServerBootstrap newInstance() {
-                return new ServerBootstrap().group(nioBossGroup, nioWorkerGroup)
+                return new ServerBootstrap().group(NIO_GROUP)
                                             .channel(NioServerSocketChannel.class);
             }
         });
@@ -98,14 +95,14 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
         toReturn.add(new BootstrapFactory<Bootstrap>() {
             @Override
             public Bootstrap newInstance() {
-                return new Bootstrap().group(KQUEUE_WORKER_GROUP).channel(KQueueSocketChannel.class);
+                return new Bootstrap().group(KQUEUE_GROUP).channel(KQueueSocketChannel.class);
             }
         });
 
         toReturn.add(new BootstrapFactory<Bootstrap>() {
             @Override
             public Bootstrap newInstance() {
-                return new Bootstrap().group(nioWorkerGroup).channel(NioSocketChannel.class);
+                return new Bootstrap().group(NIO_GROUP).channel(NioSocketChannel.class);
             }
         });
 
@@ -121,7 +118,7 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
             factories.add(insertIndex, new BootstrapFactory<Bootstrap>() {
                 @Override
                 public Bootstrap newInstance() {
-                    return new Bootstrap().group(KQUEUE_WORKER_GROUP).channel(KQueueSocketChannel.class)
+                    return new Bootstrap().group(KQUEUE_GROUP).channel(KQueueSocketChannel.class)
                             .option(ChannelOption.TCP_FASTOPEN_CONNECT, true);
                 }
             });
@@ -138,7 +135,7 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
                 new BootstrapFactory<Bootstrap>() {
                     @Override
                     public Bootstrap newInstance() {
-                        return new Bootstrap().group(nioWorkerGroup).channelFactory(new ChannelFactory<Channel>() {
+                        return new Bootstrap().group(NIO_GROUP).channelFactory(new ChannelFactory<Channel>() {
                             @Override
                             public Channel newChannel() {
                                 return new NioDatagramChannel(family);
@@ -154,7 +151,7 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
                 new BootstrapFactory<Bootstrap>() {
                     @Override
                     public Bootstrap newInstance() {
-                        return new Bootstrap().group(KQUEUE_WORKER_GROUP).channel(KQueueDatagramChannel.class);
+                        return new Bootstrap().group(KQUEUE_GROUP).channel(KQueueDatagramChannel.class);
                     }
                 }
         );
@@ -170,7 +167,7 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
                 new BootstrapFactory<ServerBootstrap>() {
                     @Override
                     public ServerBootstrap newInstance() {
-                        return new ServerBootstrap().group(KQUEUE_BOSS_GROUP, KQUEUE_WORKER_GROUP)
+                        return new ServerBootstrap().group(KQUEUE_GROUP)
                                 .channel(KQueueServerDomainSocketChannel.class);
                     }
                 }
@@ -182,7 +179,7 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
                 new BootstrapFactory<Bootstrap>() {
                     @Override
                     public Bootstrap newInstance() {
-                        return new Bootstrap().group(KQUEUE_WORKER_GROUP).channel(KQueueDomainSocketChannel.class);
+                        return new Bootstrap().group(KQUEUE_GROUP).channel(KQueueDomainSocketChannel.class);
                     }
                 }
         );
@@ -194,7 +191,7 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
                 new BootstrapFactory<Bootstrap>() {
                     @Override
                     public Bootstrap newInstance() {
-                        return new Bootstrap().group(KQUEUE_WORKER_GROUP).channel(KQueueDatagramChannel.class);
+                        return new Bootstrap().group(KQUEUE_GROUP).channel(KQueueDatagramChannel.class);
                     }
                 }
         );
@@ -209,7 +206,7 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
                 new BootstrapFactory<Bootstrap>() {
                     @Override
                     public Bootstrap newInstance() {
-                        return new Bootstrap().group(KQUEUE_WORKER_GROUP).channel(KQueueDomainDatagramChannel.class);
+                        return new Bootstrap().group(KQUEUE_GROUP).channel(KQueueDomainDatagramChannel.class);
                     }
                 }
         );

--- a/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
@@ -79,6 +79,9 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
      * Set the {@link EventLoopGroup} for the parent (acceptor) and the child (client). These
      * {@link EventLoopGroup}'s are used to handle all the events and IO for {@link ServerChannel} and
      * {@link Channel}'s.
+     * <p>
+     * <strong>Important:</strong> Usually this is only useful for advanced use-cases and usually
+     * {@link #group(EventLoopGroup)} is the preferred way to configure the group.
      */
     public ServerBootstrap group(EventLoopGroup parentGroup, EventLoopGroup childGroup) {
         super.group(parentGroup);

--- a/transport/src/test/java/io/netty/channel/group/DefaultChannelGroupTest.java
+++ b/transport/src/test/java/io/netty/channel/group/DefaultChannelGroupTest.java
@@ -30,13 +30,11 @@ public class DefaultChannelGroupTest {
     // Test for #1183
     @Test
     public void testNotThrowBlockingOperationException() throws Exception {
-        EventLoopGroup bossGroup = new NioEventLoopGroup();
-        EventLoopGroup workerGroup = new NioEventLoopGroup();
-
+        EventLoopGroup group = new NioEventLoopGroup();
         final ChannelGroup allChannels = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);
 
         ServerBootstrap b = new ServerBootstrap();
-        b.group(bossGroup, workerGroup);
+        b.group(group);
         b.childHandler(new ChannelInboundHandlerAdapter() {
             @Override
             public void channelActive(ChannelHandlerContext ctx) {
@@ -52,9 +50,7 @@ public class DefaultChannelGroupTest {
             allChannels.close().awaitUninterruptibly();
         }
 
-        bossGroup.shutdownGracefully();
-        workerGroup.shutdownGracefully();
-        bossGroup.terminationFuture().sync();
-        workerGroup.terminationFuture().sync();
+        group.shutdownGracefully();
+        group.terminationFuture().sync();
     }
 }

--- a/transport/src/test/java/io/netty/channel/local/LocalTransportThreadModelTest2.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalTransportThreadModelTest2.java
@@ -44,7 +44,7 @@ public class LocalTransportThreadModelTest2 {
         ServerBootstrap serverBootstrap = new ServerBootstrap();
         LocalHandler serverHandler = new LocalHandler("SERVER");
         serverBootstrap
-                .group(new DefaultEventLoopGroup(), new DefaultEventLoopGroup())
+                .group(new DefaultEventLoopGroup())
                 .channel(LocalServerChannel.class)
                 .childHandler(serverHandler);
 


### PR DESCRIPTION
…… (#15394)

…oup)

Motivation:

While it is possible to use different EventLoopGroups for the ServerChannel and accepted Channel it is almost never the right thing to do as it will just waste resources. Because of this we should better not do this in examples and also don't do it in tests

Modifications:

Just use ServerBootstrap.group(EventLoopGroup) in our examples and tests

Result:

Better examples that reflect best-practices and less resource usage on CI during running tests