### PR TITLE
Fix Java EA version check workflow

### DIFF
--- a/.github/workflows/check-jdk.ea-version.yml
+++ b/.github/workflows/check-jdk.ea-version.yml
@@ -10,7 +10,7 @@ jobs:
       - name: "Install SDK Man"
         run: |
           curl -s "https://get.sdkman.io" | bash
-          source "/root/.sdkman/bin/sdkman-init.sh"
+          source "$HOME/.sdkman/bin/sdkman-init.sh"
           # Make sure sdkman works
           sdk help > /dev/null
       - name: "Check latest JDK 25 EA version"


### PR DESCRIPTION
Motivation:
The home directory of the script is unpredictable and cannot be hard coded.

Modification:
Use the $HOME environment variable to locate the SDKMAN init script.

Result:
Workflow no longer runs into permission issues because now we init the script at the right location.