### PR TITLE
Cleanup: Correctly shutdown EventLoopGroup after test run

### DIFF
--- a/transport/src/test/java/io/netty/channel/local/LocalTransportThreadModelTest2.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalTransportThreadModelTest2.java
@@ -71,6 +71,8 @@ public class LocalTransportThreadModelTest2 {
 
         assertEquals(count * 2 * messageCountPerRun, serverHandler.count.get() +
                 clientHandler.count.get());
+        serverBootstrap.config().group().shutdownGracefully().sync();
+        clientBootstrap.config().group().shutdownGracefully().sync();
     }
 
     public void close(final Channel localChannel, final LocalHandler localRegistrationHandler) {


### PR DESCRIPTION
Motivation:

We missed to shutdown the EventLoopGroup after testing

Modifications:

Shutdwon the EventLoop after test run

Result:

Cleanup