### PR TITLE
Update our Java 25 EA version to build 28

### DIFF
--- a/.github/scripts/check_java_ea_version.sh
+++ b/.github/scripts/check_java_ea_version.sh
@@ -16,18 +16,18 @@
 # ----------------------------------------------------------------------------
 set -e
 
-export EXPECTED_VERSION='25.ea.26'
+# Keep this version in sync with docker-compose.centos-7.25.yaml
+export EXPECTED_VERSION='25.ea.28'
 
 curl -s "https://get.sdkman.io" | bash
 source "$HOME/.sdkman/bin/sdkman-init.sh"
 export JAVA_VERSION=$(sdk list java | grep 25.*-open|head -n 1|cut -f 3 -d '|')
-# Keep this version in sync with docker-compose.centos-7.25.yaml
 echo "Java version: '$JAVA_VERSION'" | tee version.txt
 
 if fgrep -q $EXPECTED_VERSION version.txt ; then
-    echo "Version check failed"
-    exit 1
-else
     echo "Version check passed"
     exit 0
+else
+    echo "Version check failed"
+    exit 1
 fi

--- a/docker/docker-compose.centos-7.25.yaml
+++ b/docker/docker-compose.centos-7.25.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-7-25
     build:
       args:
-        java_version : "25.ea.26-open"
+        java_version : "25.ea.28-open"
 
   build:
     image: netty:centos-7-25


### PR DESCRIPTION
Motivation:
We should test Java 25 with the latest early access version.

Modification:
Bump the version from build 26 to build 28.
Fix the pass/fail condition in the version check script.

Result:
We now have a proper Java 25 EA version check.