### PR TITLE
Fix concurrent ByteBuffer access issue in AdaptiveByteBuf.getBytes (#…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -1339,13 +1339,17 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
         @Override
         public int getBytes(int index, GatheringByteChannel out, int length)
                 throws IOException {
-            return out.write(internalNioBuffer(index, length).duplicate());
+            ByteBuffer buf = internalNioBuffer().duplicate();
+            buf.clear().position(index).limit(index + length);
+            return out.write(buf);
         }
 
         @Override
         public int getBytes(int index, FileChannel out, long position, int length)
                 throws IOException {
-            return out.write(internalNioBuffer(index, length).duplicate(), position);
+            ByteBuffer buf = internalNioBuffer().duplicate();
+            buf.clear().position(index).limit(index + length);
+            return out.write(buf, position);
         }
 
         @Override

--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -1976,7 +1976,7 @@ public final class ByteBufUtil {
             out.write(buffer.array(), position + buffer.arrayOffset(), length);
         } else {
             int chunkLen = Math.min(length, WRITE_CHUNK_SIZE);
-            buffer.clear().position(position);
+            buffer.clear().position(position).limit(position + length);
 
             if (length <= MAX_TL_ARRAY_LEN || !allocator.isDirectBufferPooled()) {
                 getBytes(buffer, threadLocalTempArray(chunkLen), 0, chunkLen, out, length);


### PR DESCRIPTION
…15402)

Motivation:
The ByteBuf.getBytes methods should be thread-safe, as it is in theory non-mutating. However, their implementations access the internal NIO buffer and mutate the position and limit. The buffer is duplicated to try and counter this, but the duplication is done after the position and limit are changed on the potentially shared buffer.

Modification:
Make these methods duplicate the shared buffer first, then mutate the position and limit.

Result:
No more spooky position and limits on these buffers when AdaptiveByteBuf.getBytes is called concurrently on the same buffer by multiple threads.
