### PR TITLE
IoUring: IoUringByteBuf must not let wrapped buffer escape

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
@@ -17,6 +17,7 @@ package io.netty.channel.uring;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.DuplicatedByteBuf;
+import io.netty.buffer.ReadOnlyByteBuf;
 import io.netty.buffer.SlicedByteBuf;
 import io.netty.buffer.SwappedByteBuf;
 import io.netty.buffer.WrappedByteBuf;
@@ -294,6 +295,15 @@ final class IoUringBufferRing {
                 throw cause;
             }
             return slice;
+        }
+
+        @SuppressWarnings("deprecation")
+        @Override
+        public ByteBuf asReadOnly() {
+            if (isReadOnly()) {
+                return this;
+            }
+            return new ReadOnlyByteBuf(this);
         }
 
         @SuppressWarnings("deprecation")


### PR DESCRIPTION
Motivation:

We need to ensure the wrapped buffer does not escape as otherwise we might not correctly hadle releases

Modifications:

Override asReadOnly()

Result:

Don't let wrapped buffer escape and so correctly handle releases