### PR TITLE
Add ReadOnlyAbstractByteBuf to reduce bounds-checks

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyAbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyAbstractByteBuf.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+/**
+ * Specialized {@link ReadOnlyByteBuf} sub-type which allows fast access to parent
+ * without extra bound-checks.
+ */
+final class ReadOnlyAbstractByteBuf extends ReadOnlyByteBuf {
+
+    ReadOnlyAbstractByteBuf(AbstractByteBuf buffer) {
+        super(buffer);
+    }
+
+    @Override
+    public AbstractByteBuf unwrap() {
+        return (AbstractByteBuf) super.unwrap();
+    }
+
+    @Override
+    protected byte _getByte(int index) {
+        return unwrap()._getByte(index);
+    }
+
+    @Override
+    protected short _getShort(int index) {
+        return unwrap()._getShort(index);
+    }
+
+    @Override
+    protected short _getShortLE(int index) {
+        return unwrap()._getShortLE(index);
+    }
+
+    @Override
+    protected int _getUnsignedMedium(int index) {
+        return unwrap()._getUnsignedMedium(index);
+    }
+
+    @Override
+    protected int _getUnsignedMediumLE(int index) {
+        return unwrap()._getUnsignedMediumLE(index);
+    }
+
+    @Override
+    protected int _getInt(int index) {
+        return unwrap()._getInt(index);
+    }
+
+    @Override
+    protected int _getIntLE(int index) {
+        return unwrap()._getIntLE(index);
+    }
+
+    @Override
+    protected long _getLong(int index) {
+        return unwrap()._getLong(index);
+    }
+
+    @Override
+    protected long _getLongLE(int index) {
+        return unwrap()._getLongLE(index);
+    }
+}

--- a/buffer/src/main/java/io/netty/buffer/Unpooled.java
+++ b/buffer/src/main/java/io/netty/buffer/Unpooled.java
@@ -694,10 +694,16 @@ public final class Unpooled {
     public static ByteBuf unmodifiableBuffer(ByteBuf buffer) {
         ByteOrder endianness = buffer.order();
         if (endianness == BIG_ENDIAN) {
-            return new ReadOnlyByteBuf(buffer);
+            return newReadyOnlyBuffer(buffer);
         }
 
-        return new ReadOnlyByteBuf(buffer.order(BIG_ENDIAN)).order(LITTLE_ENDIAN);
+        return newReadyOnlyBuffer(buffer.order(BIG_ENDIAN)).order(LITTLE_ENDIAN);
+    }
+
+    private static ReadOnlyByteBuf newReadyOnlyBuffer(ByteBuf buffer) {
+        return buffer instanceof AbstractByteBuf ?
+                new ReadOnlyAbstractByteBuf((AbstractByteBuf) buffer) :
+                new ReadOnlyByteBuf(buffer);
     }
 
     /**


### PR DESCRIPTION
Motiviation:

Currently ReadOnlyByteBuf needs to to do extra bounds checks for some situation where in reality we can skip these when the wrapped ByteBuf is a sub-type of AbstractByteBuf.

Modification:

- Add ReadOnlyAbstractByteBuf and use it if the wrapped ByteBuf is a sub-type of AbstractByteBuf

Result:

Less bounds check for read only ByteBufs in most cases