### PR TITLE
Reuse the same SizeClassedChunk if there're available segments

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -1341,6 +1341,21 @@ final class AdaptivePoolingAllocator {
         }
 
         @Override
+        public int remainingCapacity() {
+            int remainingCapacity = super.remainingCapacity();
+            if (remainingCapacity > segmentSize) {
+                return remainingCapacity;
+            }
+            int updatedRemainingCapacity = freeList.size() * segmentSize;
+            if (updatedRemainingCapacity == remainingCapacity) {
+                return remainingCapacity;
+            }
+            // update allocatedBytes based on what's available in the free list
+            allocatedBytes = capacity() - updatedRemainingCapacity;
+            return updatedRemainingCapacity;
+        }
+
+        @Override
         boolean releaseFromMagazine() {
             // Size-classed chunks can be reused before they become empty.
             // We can therefor put them in the shared queue as soon as the magazine is done with this chunk.


### PR DESCRIPTION
Motivation:

SizeClassedChunk is not using the freeList size to update the remaining capacity, prompting unnecessary chunk allocations

Modification:

Once approaching one or less segment left, update the remaining capacity, to save allocating a new chunk

Result:

Reduced fragmentation and allocation pressure for buffers which release later