### PR TITLE
Branchless and O(1) size class look-up

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -157,10 +157,21 @@ final class AdaptivePoolingAllocator {
             16896, // 16384 + 512
     };
 
+    private static final int SIZE_CLASSES_COUNT = SIZE_CLASSES.length;
+    private static final byte[] SIZE_INDEXES = new byte[(SIZE_CLASSES[SIZE_CLASSES_COUNT - 1] / 32) + 1];
+
     static {
         if (MAGAZINE_BUFFER_QUEUE_CAPACITY < 2) {
             throw new IllegalArgumentException("MAGAZINE_BUFFER_QUEUE_CAPACITY: " + MAGAZINE_BUFFER_QUEUE_CAPACITY
                     + " (expected: >= " + 2 + ')');
+        }
+        int lastIndex = 0;
+        for (int i = 0; i < SIZE_CLASSES_COUNT; i++) {
+            int sizeClass = SIZE_CLASSES[i];
+            assert (sizeClass & 5) == 0 : "Size class must be a multiple of 32";
+            int sizeIndex = sizeIndexOf(sizeClass);
+            Arrays.fill(SIZE_INDEXES, lastIndex + 1, sizeIndex + 1, (byte) i);
+            lastIndex = sizeIndex;
         }
     }
 
@@ -239,7 +250,7 @@ final class AdaptivePoolingAllocator {
     private AdaptiveByteBuf allocate(int size, int maxCapacity, Thread currentThread, AdaptiveByteBuf buf) {
         AdaptiveByteBuf allocated = null;
         if (size <= MAX_POOLED_BUF_SIZE) {
-            int index = binarySearchInsertionPoint(Arrays.binarySearch(SIZE_CLASSES, size));
+            final int index = sizeClassIndexOf(size);
             MagazineGroup[] magazineGroups;
             if (!FastThreadLocalThread.currentThreadWillCleanupFastThreadLocals() ||
                     (magazineGroups = threadLocalGroup.get()) == null) {
@@ -255,6 +266,19 @@ final class AdaptivePoolingAllocator {
             allocated = allocateFallback(size, maxCapacity, currentThread, buf);
         }
         return allocated;
+    }
+
+    private static int sizeIndexOf(final int size) {
+        // this is aligning the size to the next multiple of 32 and dividing by 32 to get the size index.
+        return (size + 31) >> 5;
+    }
+
+    static int sizeClassIndexOf(int size) {
+        int sizeIndex = sizeIndexOf(size);
+        if (sizeIndex < SIZE_INDEXES.length) {
+            return SIZE_INDEXES[sizeIndex];
+        }
+        return SIZE_CLASSES_COUNT;
     }
 
     private static int binarySearchInsertionPoint(int index) {

--- a/buffer/src/test/java/io/netty/buffer/AdaptivePoolingAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptivePoolingAllocatorTest.java
@@ -61,6 +61,43 @@ class AdaptivePoolingAllocatorTest implements Supplier<String> {
         assertSizeBucket(15, 8 * 1024 * 1024);
     }
 
+    @Test
+    void sizeClassComputations() throws Exception {
+        final int[] sizeClasses = {
+                32,
+                64,
+                128,
+                256,
+                512,
+                640, // 512 + 128
+                1024,
+                1152, // 1024 + 128
+                2048,
+                2304, // 2048 + 256
+                4096,
+                4352, // 4096 + 256
+                8192,
+                8704, // 8192 + 512
+                16384,
+                16896, // 16384 + 512
+        };
+        for (int sizeClassIndex = 0; sizeClassIndex < sizeClasses.length; sizeClassIndex++) {
+            final int previousSizeIncluded = sizeClassIndex == 0? 0 : (sizeClasses[sizeClassIndex - 1] + 1);
+            assertSizeClassOf(sizeClassIndex, previousSizeIncluded, sizeClasses[sizeClassIndex]);
+        }
+        // beyond the last size class, we return the size class array's length
+        assertSizeClassOf(sizeClasses.length, sizeClasses[sizeClasses.length - 1] + 1,
+                          sizeClasses[sizeClasses.length - 1] + 1);
+    }
+
+    private static void assertSizeClassOf(int expectedSizeClass, int previousSizeIncluded, int maxSizeIncluded) {
+        for (int size = previousSizeIncluded; size <= maxSizeIncluded; size++) {
+            int sizeToTest = size;
+            assertEquals(expectedSizeClass, AdaptivePoolingAllocator.sizeClassIndexOf(size),
+                         () -> "size = " + sizeToTest);
+        }
+    }
+
     private void assertSizeBucket(int expectedSizeBucket, int maxSizeIncluded) {
         for (; i <= maxSizeIncluded; i++) {
             assertEquals(expectedSizeBucket, AdaptivePoolingAllocator.sizeToBucket(i), this);

--- a/microbench/src/main/java/io/netty/microbench/buffer/RandomSizeByteBufAllocationBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/RandomSizeByteBufAllocationBenchmark.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.buffer;
+
+import io.netty.buffer.AdaptiveByteBufAllocator;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import io.netty.util.ResourceLeakDetector;
+import io.netty.util.concurrent.FastThreadLocalThread;
+import io.netty.util.internal.MathUtil;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.SplittableRandom;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Thread)
+@Warmup(iterations = 10, time = 1)
+@Measurement(iterations = 10, time = 1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class RandomSizeByteBufAllocationBenchmark extends AbstractMicrobenchmark {
+
+    private static final int SEED = 42;
+    // see adaptive allocator size classes
+    private static final int[] SIZE_CLASSES = {
+            32,
+            64,
+            128,
+            256,
+            512,
+            640, // 512 + 128
+            1024,
+            1152, // 1024 + 128
+            2048,
+            2304, // 2048 + 256
+            4096,
+            4352, // 4096 + 256
+            8192,
+            8704, // 8192 + 512
+            16384,
+            16896, // 16384 + 512
+    };
+
+    public enum AllocatorType {
+        JEMALLOC,
+        ADAPTIVE
+    }
+
+    @Param({ "ADAPTIVE" })
+    public AllocatorType allocatorType = AllocatorType.ADAPTIVE;
+    @Param({ "128", "128000" })
+    public int samples;
+
+    private ByteBufAllocator allocator;
+    private short[] sizeSamples;
+    private int sampleMask;
+    private int nextSampleIndex;
+
+    static {
+        ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.DISABLED);
+    }
+
+    @Setup
+    public void init() {
+        if (!(Thread.currentThread() instanceof FastThreadLocalThread)) {
+            throw new IllegalStateException("This benchmark must be run with FastThreadLocalThread: run it with: " +
+        "-Djmh.executor=CUSTOM -Djmh.executor.class=io.netty.microbench.util.AbstractMicrobenchmark$HarnessExecutor");
+        }
+        switch (allocatorType) {
+        case JEMALLOC:
+            allocator = new PooledByteBufAllocator(true);
+            break;
+        case ADAPTIVE:
+            allocator = new AdaptiveByteBufAllocator(true, true);
+            break;
+        default:
+            throw new IllegalArgumentException("Unknown allocator type: " + allocatorType);
+        }
+        samples = MathUtil.findNextPositivePowerOfTwo(samples);
+        sampleMask = samples - 1;
+        sizeSamples = new short[samples];
+        SplittableRandom rnd = new SplittableRandom(SEED);
+        // here we're not using random size [0, 16896] because if the size class is too large
+        // it has more chances to be picked!
+        for (int i = 0; i < samples; i++) {
+            // pick a random size class
+            int sizeClass = rnd.nextInt(SIZE_CLASSES.length);
+            // now pick a random size within the size class
+            short size =
+                    (short) rnd.nextInt(sizeClass == 0? 0 : SIZE_CLASSES[sizeClass - 1] + 1, SIZE_CLASSES[sizeClass]);
+            if (size < 0) {
+                throw new IllegalArgumentException("Size sample out of range: " + size);
+            }
+            sizeSamples[i] = size;
+        }
+    }
+
+    private int nextSize() {
+        int index = nextSampleIndex;
+        nextSampleIndex = (nextSampleIndex + 1) & sampleMask;
+        return sizeSamples[index];
+    }
+
+    @Benchmark
+    public void allocateAndRelease(Blackhole bh) {
+        int size = nextSize();
+        ByteBuf buffer = allocator.buffer(size);
+        bh.consume(buffer);
+        buffer.release();
+    }
+}


### PR DESCRIPTION
Motivation:

Searching the size class can involve few branches, which can lead to branch-misses, hurting IPC in the hot path

Modification:

Uses a branchless approach to compute the size class

Result:

Reduced branch-misses on size classes allocation