### PR TITLE
Include the "noexec" message in the UnsatisfiedLinkError chain (#15415)

### DIFF
--- a/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
+++ b/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
@@ -224,10 +224,14 @@ public final class NativeLibraryLoader {
                     // Pass "io.netty.native.workdir" as an argument to allow shading tools to see
                     // the string. Since this is printed out to users to tell them what to do next,
                     // we want the value to be correct even when shading.
-                    logger.info("{} exists but cannot be executed even when execute permissions set; " +
-                                "check volume for \"noexec\" flag; use -D{}=[path] " +
-                                "to set native working directory separately.",
-                                tmpFile.getPath(), "io.netty.native.workdir");
+                    String message = String.format(
+                            "%s exists but cannot be executed even when execute permissions set; " +
+                                    "check volume for \"noexec\" flag; use -D%s=[path] " +
+                                    "to set native working directory separately.",
+                            tmpFile.getPath(), "io.netty.native.workdir");
+                    logger.info(message);
+                    suppressed.add(ThrowableUtil.unknownStackTrace(
+                            new UnsatisfiedLinkError(message), NativeLibraryLoader.class, "load"));
                 }
             } catch (Throwable t) {
                 suppressed.add(t);
@@ -410,7 +414,7 @@ public final class NativeLibraryLoader {
             @Override
             public Object run() {
                 try {
-                    // Invoke the helper to load the native library, if succeed, then the native
+                    // Invoke the helper to load the native library, if it succeeds, then the native
                     // library belong to the specified ClassLoader.
                     Method method = helper.getMethod("loadLibrary", String.class, boolean.class);
                     method.setAccessible(true);


### PR DESCRIPTION
Motivation:
A somewhat common cause of our native libraries failing to load is that `/tmp` is mounted with the "noexec" option.

We already log a message about this when we detect this is a likely cause for native libraries failing to load. However, modern deployments now typically funnel all log messages to systems like Splunk, and people only look at the specific log line that has the exception, filtering out other presumed irrelevant log messages nearby.

Modification:
Include the "noexec" error message in the exception chain, as well as logging it.

Result:
Make it easier for people to diagnose when native libraries cannot be loaded due to a volume being "noexec.