### PR TITLE
Reduce magazine proliferation eagerness

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -98,7 +98,7 @@ final class AdaptivePoolingAllocator {
      */
     static final int MIN_CHUNK_SIZE = 128 * 1024;
     private static final int EXPANSION_ATTEMPTS = 3;
-    private static final int INITIAL_MAGAZINES = 4;
+    private static final int INITIAL_MAGAZINES = 1;
     private static final int RETIRE_CAPACITY = 256;
     private static final int MAX_STRIPES = NettyRuntime.availableProcessors() * 2;
     private static final int BUFS_PER_CHUNK = 8; // For large buffers, aim to have about this many buffers per chunk.
@@ -396,7 +396,7 @@ final class AdaptivePoolingAllocator {
                 mags = magazines;
                 int mask = mags.length - 1;
                 int index = (int) (threadId & mask);
-                for (int i = 0, m = Integer.numberOfTrailingZeros(~mask); i < m; i++) {
+                for (int i = 0, m = mags.length << 1; i < m; i++) {
                     Magazine mag = mags[index + i & mask];
                     if (buf == null) {
                         buf = mag.newBuffer();


### PR DESCRIPTION
Motivation:
By adding size-classes to the adaptive allocator, we inherently start out with many more magazines as a consequence of all our magazine groups. This naturally spreads out contention a bit.
To avoid creating too many magazines in general, we should also be less eager to expand our magazine group arrays.

Modification:
- Start our magazine arrays with a size of 1 instead of 4. If there is true contention, it will grow quickly anyway.
- Increase the number of attempts to allocate from a magazine array from a fraction of the array length to twice the array length. This discourages expansion, and also gives the lockless allocation fallback a lot more attempts at succeeding.

Result:
In my synthetic workload, I see a ~15% reduction in memory waste, and negligible performance overhead.