### PR TITLE
Fix chunk reuse bug in adaptive allocator (#15424)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -898,13 +898,13 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                         curr.readInitInto(buf, size, remainingCapacity, maxCapacity);
                         return true;
                     } finally {
-                        curr.release();
+                        curr.releaseFromMagazine();
                     }
                 }
 
                 // Check if we either retain the chunk in the nextInLine cache or releasing it.
                 if (remainingCapacity < RETIRE_CAPACITY) {
-                    curr.release();
+                    curr.releaseFromMagazine();
                 } else {
                     // See if it makes sense to transfer the Chunk to the nextInLine cache for later usage.
                     // This method will release curr if this is not the case
@@ -946,11 +946,11 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                     } finally {
                         // Release in a finally block so even if readInitInto(...) would throw we would still correctly
                         // release the current chunk before null it out.
-                        curr.release();
+                        curr.releaseFromMagazine();
                     }
                 } else {
                     // Release it as it's too small.
-                    curr.release();
+                    curr.releaseFromMagazine();
                 }
             }
 
@@ -965,7 +965,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                 if (remainingCapacity < size) {
                     // Check if we either retain the chunk in the nextInLine cache or releasing it.
                     if (remainingCapacity < RETIRE_CAPACITY) {
-                        curr.release();
+                        curr.releaseFromMagazine();
                     } else {
                         // See if it makes sense to transfer the Chunk to the nextInLine cache for later usage.
                         // This method will release curr if this is not the case
@@ -989,7 +989,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                 if (curr != null) {
                     // Release in a finally block so even if readInitInto(...) would throw we would still correctly
                     // release the current chunk before null it out.
-                    curr.release();
+                    curr.releaseFromMagazine();
                     current = null;
                 }
             }


### PR DESCRIPTION
Motivation:
In the original PR adding size classes to the adaptive allocator, I missed a few places where we release chunks in the allocation path. Chunks now need to be released from a magazine using the new `releaseFromMagazine` method, which for the size-classed chunks will attempt to return the chunks to the shared queue immediately.

Modification:
Change the remaining `Chunk.release()` calls in the magazine allocation path to `Chunk.releaseFromMagazine()`, like they should've been to begin with.

Result:
This greatly enhances chunk reuse, especially so the more in-use ByteBufs we have at any one time.

In my local testing I see up to a 60% reduction in memory usage, depending on the use case.