### PR TITLE
Support for AWS Libcrypto (AWS-LC) netty-tcnative build

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -220,16 +220,35 @@ jobs:
           - setup: linux-x86_64-java11-boringssl-jdk8-tests
             docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-7.111.yaml build"
             docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-7.111.yaml run build-boringssl-static-jdk8-tests"
+          - setup: linux-x86_64-java11-awslc
+            docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.al2023.yaml build"
+            docker-compose-install-tcnative: "-f docker/docker-compose.yaml -f docker/docker-compose.al2023.yaml run install-tcnative"
+            docker-compose-update-tcnative-version: "-f docker/docker-compose.yaml -f docker/docker-compose.al2023.yaml run update-tcnative-version"
+            docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.al2023.yaml run build"
 
     name: ${{ matrix.setup }} build
     needs: verify-pr
+    defaults:
+      run:
+        working-directory: netty
     steps:
       - uses: actions/checkout@v4
+        with:
+          path: netty
+
+      - uses: actions/checkout@v4
+        if: ${{ endsWith(matrix.setup, '-awslc') }}
+        with:
+          repository: netty/netty-tcnative
+          ref: main
+          path: netty-tcnative
+          fetch-depth: 0
 
       # Cache .m2/repository
       - name: Cache local Maven repository
         uses: actions/cache@v4
         continue-on-error: true
+        if: ${{ !endsWith(matrix.setup, '-awslc') }}
         with:
           path: ~/.m2/repository
           key: cache-maven-${{ hashFiles('**/pom.xml') }}
@@ -237,8 +256,27 @@ jobs:
             cache-maven-${{ hashFiles('**/pom.xml') }}
             cache-maven-
 
+      - name: Cache local Maven repository
+        uses: actions/cache@v4
+        continue-on-error: true
+        if: ${{ endsWith(matrix.setup, '-awslc') }}
+        with:
+          path: ~/.m2-al2023/repository
+          key: cache-maven-al2023-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            cache-maven-al2023-${{ hashFiles('**/pom.xml') }}
+            cache-maven-al2023-
+
       - name: Build docker image
         run: docker compose ${{ matrix.docker-compose-build }}
+
+      - name: Install custom netty-tcnative
+        if: ${{ endsWith(matrix.setup, '-awslc') }}
+        run: docker compose ${{ matrix.docker-compose-install-tcnative }}
+
+      - name: Update netty-tcnative version
+        if: ${{ endsWith(matrix.setup, '-awslc') }}
+        run: docker compose ${{ matrix.docker-compose-update-tcnative-version }}
 
       - name: Build project with leak detection
         run: docker compose ${{ matrix.docker-compose-run }} | tee build-leak.output
@@ -250,7 +288,7 @@ jobs:
         run: ./.github/scripts/check_leak.sh build-leak.output
 
       - name: print JVM thread dumps when cancelled
-        uses: ./.github/actions/thread-dump-jvms
+        uses: ./netty/.github/actions/thread-dump-jvms
         if: ${{ cancelled() }}
 
       - name: Upload Test Results
@@ -258,17 +296,17 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ matrix.setup }}
-          path: '**/target/surefire-reports/TEST-*.xml'
+          path: 'netty/**/target/surefire-reports/TEST-*.xml'
 
       - uses: actions/upload-artifact@v4
         if: ${{ failure() || cancelled() }}
         with:
           name: build-${{ matrix.setup }}-target
           path: |
-            **/target/surefire-reports/
-            **/target/autobahntestsuite-reports/
-            **/hs_err*.log
-            **/core.*
+            netty/**/target/surefire-reports/
+            netty/**/target/autobahntestsuite-reports/
+            netty/**/hs_err*.log
+            netty/**/core.*
 
   build-pr-macos:
     strategy:

--- a/docker/Dockerfile.al2023
+++ b/docker/Dockerfile.al2023
@@ -1,0 +1,70 @@
+FROM --platform=linux/amd64 amazonlinux:2023
+
+ARG java_version=11.0.27-amzn
+ARG aws_lc_version=v1.54.0
+ARG maven_version=3.9.10
+ENV JAVA_VERSION $java_version
+ENV AWS_LC_VERSION $aws_lc_version
+ENV MAVEN_VERSION $maven_version
+
+# install dependencies
+RUN dnf install -y \
+ apr-devel \
+ autoconf \
+ automake \
+ bzip2 \
+ cmake \
+ gcc \
+ gcc-c++ \
+ git \
+ glibc-devel \
+ golang \
+ libgcc \
+ libstdc++ \
+ libstdc++-devel \
+ libstdc++-static \
+ libtool \
+ make \
+ ninja-build \
+ patch \
+ perl \
+ perl-parent \
+ perl-devel \
+ tar \
+ unzip \
+ wget \
+ which \
+ zip
+
+# Downloading and installing SDKMAN!
+RUN curl -s "https://get.sdkman.io" | bash
+
+# Installing Java removing some unnecessary SDKMAN files
+RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && \
+    yes | sdk install java $JAVA_VERSION && \
+    yes | sdk install maven $MAVEN_VERSION && \
+    rm -rf $HOME/.sdkman/archives/* && \
+    rm -rf $HOME/.sdkman/tmp/*"
+
+RUN echo 'export JAVA_HOME="/root/.sdkman/candidates/java/current"' >> ~/.bashrc
+RUN echo 'export PATH=$JAVA_HOME/bin:$PATH' >> ~/.bashrc
+
+ENV PATH /root/.sdkman/candidates/java/current/bin:/root/.sdkman/candidates/maven/current/bin:$PATH
+ENV JAVA_HOME=/root/.sdkman/candidates/java/current
+
+# install rust and setup PATH
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+RUN echo 'PATH=$PATH:$HOME/.cargo/bin' >> ~/.bashrc
+
+RUN mkdir "$HOME/sources" && \
+    git clone https://github.com/aws/aws-lc.git "$HOME/sources/aws-lc" && \
+    cd "$HOME/sources/aws-lc" && \
+    git checkout $AWS_LC_VERSION && \
+    cmake -B build -S . -DCMAKE_INSTALL_PREFIX=/opt/aws-lc -DBUILD_SHARED_LIBS=1 -DBUILD_TESTING=0 && \
+    cmake --build build -- -j && \
+    cmake --install build
+
+# Cleanup
+RUN dnf clean all && \
+    rm -rf /var/cache/dnf && \
+    rm -rf "$HOME/sources"

--- a/docker/docker-compose.al2023.yaml
+++ b/docker/docker-compose.al2023.yaml
@@ -1,0 +1,65 @@
+services:
+
+  runtime-setup:
+    image: netty-al2023:x86_64
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile.al2023
+
+  common: &common
+    image: netty-al2023:x86_64
+    depends_on: [runtime-setup]
+    environment:
+      LD_LIBRARY_PATH: /opt/aws-lc/lib64
+    volumes:
+      # Use a separate directory for the AL2023 Maven repository
+      - ~/.m2-al2023:/root/.m2
+      - ..:/netty
+      - ../../netty-tcnative:/netty-tcnative
+    working_dir: /netty
+
+  common-tcnative: &common-tcnative
+    <<: *common
+    environment:
+      MAVEN_OPTS:
+      LD_LIBRARY_PATH: /opt/aws-lc/lib64
+      LDFLAGS: -L/opt/aws-lc/lib64 -lssl -lcrypto
+      CFLAGS: -I/opt/aws-lc/include  -DHAVE_OPENSSL -lssl -lcrypto
+      CXXFLAGS: -I/opt/aws-lc/include  -DHAVE_OPENSSL -lssl -lcrypto
+
+  install-tcnative:
+    <<: *common-tcnative
+    command: '/bin/bash -cl "
+      ./mvnw -am -pl openssl-dynamic clean install &&
+      env -u LDFLAGS -u CFLAGS -u CXXFLAGS -u LD_LIBRARY_PATH ./mvnw -am -pl boringssl-static clean install
+    "'
+    working_dir: /netty-tcnative
+
+  update-tcnative-version:
+    <<: *common
+    command: '/bin/bash -cl "
+      ./mvnw versions:update-property -Dproperty=tcnative.version -DnewVersion=$(cd /netty-tcnative && ./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout) -DallowSnapshots=true -DprocessParent=true -DgenerateBackupPoms=false
+    "'
+
+  build:
+    <<: *common
+    command: '/bin/bash -cl "
+      ./mvnw -B -ntp clean install -Dio.netty.testsuite.badHost=netty.io -Dtcnative.classifier=linux-x86_64-fedora -Drevapi.skip=true -Dcheckstyle.skip=true -Dforbiddenapis.skip=true
+    "'
+
+  build-leak:
+    <<: *common
+    command: '/bin/bash -cl "
+      ./mvnw -B -ntp -Pleak clean install -Dio.netty.testsuite.badHost=netty.io -Dtcnative.classifier=linux-x86_64-fedora -Drevapi.skip=true -Dcheckstyle.skip=true -Dforbiddenapis.skip=true
+    "'
+
+  shell:
+    <<: *common
+    volumes:
+      - ~/.m2-al2023:/root/.m2
+      - ~/.gitconfig:/root/.gitconfig
+      - ~/.gitignore:/root/.gitignore
+      - ..:/netty
+      - ../../netty-tcnative:/netty-tcnative
+    working_dir: /netty
+    entrypoint: /bin/bash -l

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -67,6 +67,7 @@ public final class OpenSsl {
     private static final boolean SUPPORTS_OCSP;
     private static final boolean TLSV13_SUPPORTED;
     private static final boolean IS_BORINGSSL;
+    private static final boolean IS_AWSLC;
     private static final Set<String> CLIENT_DEFAULT_PROTOCOLS;
     private static final Set<String> SERVER_DEFAULT_PROTOCOLS;
     static final Set<String> SUPPORTED_PROTOCOLS_SET;
@@ -161,6 +162,7 @@ public final class OpenSsl {
             }
 
             IS_BORINGSSL = "BoringSSL".equals(versionString());
+            IS_AWSLC = versionString().startsWith("AWS-LC");
             if (IS_BORINGSSL) {
                 EXTRA_SUPPORTED_TLS_1_3_CIPHERS = new String [] { "TLS_AES_128_GCM_SHA256",
                         "TLS_AES_256_GCM_SHA384" ,
@@ -268,7 +270,7 @@ public final class OpenSsl {
                             try {
                                 boolean propertySet = SystemPropertyUtil.contains(
                                         "io.netty.handler.ssl.openssl.useKeyManagerFactory");
-                                if (!IS_BORINGSSL) {
+                                if (!(IS_BORINGSSL || IS_AWSLC)) {
                                     useKeyManagerFactory = SystemPropertyUtil.getBoolean(
                                             "io.netty.handler.ssl.openssl.useKeyManagerFactory", true);
 
@@ -282,7 +284,7 @@ public final class OpenSsl {
                                     if (propertySet) {
                                         logger.info("System property " +
                                                 "'io.netty.handler.ssl.openssl.useKeyManagerFactory'" +
-                                                " is deprecated and will be ignored when using BoringSSL");
+                                                " is deprecated and will be ignored when using BoringSSL or AWS-LC");
                                     }
                                 }
                             } catch (Throwable ignore) {
@@ -453,6 +455,7 @@ public final class OpenSsl {
             SUPPORTS_OCSP = false;
             TLSV13_SUPPORTED = false;
             IS_BORINGSSL = false;
+            IS_AWSLC = false;
             EXTRA_SUPPORTED_TLS_1_3_CIPHERS = EmptyArrays.EMPTY_STRINGS;
             EXTRA_SUPPORTED_TLS_1_3_CIPHERS_STRING = StringUtil.EMPTY_STRING;
             NAMED_GROUPS = DEFAULT_NAMED_GROUPS;
@@ -738,7 +741,7 @@ public final class OpenSsl {
                 return true;
             }
             // Check for options that are only supported by BoringSSL atm.
-            if (isBoringSSL()) {
+            if (isBoringSSL() || isAWSLC()) {
                 return option == OpenSslContextOption.ASYNC_PRIVATE_KEY_METHOD ||
                         option == OpenSslContextOption.PRIVATE_KEY_METHOD ||
                         option == OpenSslContextOption.CERTIFICATE_COMPRESSION_ALGORITHMS ||
@@ -778,5 +781,9 @@ public final class OpenSsl {
 
     static boolean isBoringSSL() {
         return IS_BORINGSSL;
+    }
+
+    static boolean isAWSLC() {
+        return IS_AWSLC;
     }
 }

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -327,7 +327,8 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
                     }
                 } else {
                     CipherSuiteConverter.convertToCipherStrings(
-                            unmodifiableCiphers, cipherBuilder, cipherTLSv13Builder, OpenSsl.isBoringSSL());
+                            unmodifiableCiphers, cipherBuilder, cipherTLSv13Builder,
+                            OpenSsl.isBoringSSL());
 
                     // Set non TLSv1.3 ciphers.
                     SSLContext.setCipherSuite(ctx, cipherBuilder.toString(), false);

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -387,9 +387,9 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                     }
                 }
 
-                if (OpenSsl.isBoringSSL() && clientMode) {
-                    // If in client-mode and BoringSSL let's allow to renegotiate once as the server may use this
-                    // for client auth.
+                if ((OpenSsl.isBoringSSL() || OpenSsl.isAWSLC()) && clientMode) {
+                    // If in client-mode and provider is BoringSSL or AWS-LC let's allow to renegotiate once as the
+                    // server may use this for client auth.
                     //
                     // See https://github.com/netty/netty/issues/11529
                     SSL.setRenegotiateMode(ssl, SSL.SSL_RENEGOTIATE_ONCE);
@@ -1711,7 +1711,8 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
         final StringBuilder buf = new StringBuilder();
         final StringBuilder bufTLSv13 = new StringBuilder();
 
-        CipherSuiteConverter.convertToCipherStrings(Arrays.asList(cipherSuites), buf, bufTLSv13, OpenSsl.isBoringSSL());
+        CipherSuiteConverter.convertToCipherStrings(Arrays.asList(cipherSuites), buf, bufTLSv13,
+                OpenSsl.isBoringSSL());
         final String cipherSuiteSpec = buf.toString();
         final String cipherSuiteSpecTLSv13 = bufTLSv13.toString();
 

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslCertificateCompressionTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslCertificateCompressionTest.java
@@ -72,7 +72,7 @@ public class OpenSslCertificateCompressionTest {
 
     @Test
     public void testSimple() throws Throwable {
-        assumeTrue(OpenSsl.isBoringSSL());
+        assumeTrue(OpenSsl.isBoringSSL() || OpenSsl.isAWSLC());
         final SslContext clientSslContext = buildClientContext(
                 OpenSslCertificateCompressionConfig.newBuilder()
                         .addAlgorithm(testBrotliAlgoClient,
@@ -93,7 +93,7 @@ public class OpenSslCertificateCompressionTest {
 
     @Test
     public void testServerPriority() throws Throwable {
-        assumeTrue(OpenSsl.isBoringSSL());
+        assumeTrue(OpenSsl.isBoringSSL() || OpenSsl.isAWSLC());
         final SslContext clientSslContext = buildClientContext(
                 OpenSslCertificateCompressionConfig.newBuilder()
                         .addAlgorithm(testBrotliAlgoClient,
@@ -117,7 +117,7 @@ public class OpenSslCertificateCompressionTest {
 
     @Test
     public void testServerPriorityReverse() throws Throwable {
-        assumeTrue(OpenSsl.isBoringSSL());
+        assumeTrue(OpenSsl.isBoringSSL() || OpenSsl.isAWSLC());
         final SslContext clientSslContext = buildClientContext(
                 OpenSslCertificateCompressionConfig.newBuilder()
                         .addAlgorithm(testBrotliAlgoClient,
@@ -142,7 +142,7 @@ public class OpenSslCertificateCompressionTest {
 
     @Test
     public void testFailedNegotiation() throws Throwable {
-        assumeTrue(OpenSsl.isBoringSSL());
+        assumeTrue(OpenSsl.isBoringSSL() || OpenSsl.isAWSLC());
         final SslContext clientSslContext = buildClientContext(
                 OpenSslCertificateCompressionConfig.newBuilder()
                         .addAlgorithm(testBrotliAlgoClient,
@@ -163,7 +163,7 @@ public class OpenSslCertificateCompressionTest {
 
     @Test
     public void testAlgoFailure() throws Throwable {
-        assumeTrue(OpenSsl.isBoringSSL());
+        assumeTrue(OpenSsl.isBoringSSL() || OpenSsl.isAWSLC());
         TestCertCompressionAlgo badZlibAlgoClient =
                 new TestCertCompressionAlgo(CertificateCompressionAlgo.TLS_EXT_CERT_COMPRESSION_ZLIB) {
             @Override
@@ -192,7 +192,7 @@ public class OpenSslCertificateCompressionTest {
 
     @Test
     public void testAlgoException() throws Throwable {
-        assumeTrue(OpenSsl.isBoringSSL());
+        assumeTrue(OpenSsl.isBoringSSL() || OpenSsl.isAWSLC());
         TestCertCompressionAlgo badZlibAlgoClient =
                 new TestCertCompressionAlgo(CertificateCompressionAlgo.TLS_EXT_CERT_COMPRESSION_ZLIB) {
                     @Override
@@ -221,7 +221,7 @@ public class OpenSslCertificateCompressionTest {
 
     @Test
     public void testTlsLessThan13() throws Throwable {
-        assumeTrue(OpenSsl.isBoringSSL());
+        assumeTrue(OpenSsl.isBoringSSL() || OpenSsl.isAWSLC());
         final SslContext clientSslContext = SslContextBuilder.forClient()
              .sslProvider(SslProvider.OPENSSL)
              .protocols(SslProtocols.TLS_v1_2)
@@ -252,7 +252,7 @@ public class OpenSslCertificateCompressionTest {
     @Test
     public void testDuplicateAdd() throws Throwable {
         // Fails with "Failed trying to add certificate compression algorithm"
-        assumeTrue(OpenSsl.isBoringSSL());
+        assumeTrue(OpenSsl.isBoringSSL() || OpenSsl.isAWSLC());
         Assertions.assertThrows(Exception.class, new Executable() {
             @Override
             public void execute() throws Throwable {
@@ -284,7 +284,7 @@ public class OpenSslCertificateCompressionTest {
     @Test
     public void testNotBoringAdd() throws Throwable {
         // Fails with "TLS Cert Compression only supported by BoringSSL"
-        assumeTrue(!OpenSsl.isBoringSSL());
+        assumeTrue(!OpenSsl.isBoringSSL() && !OpenSsl.isAWSLC());
         Assertions.assertThrows(Exception.class, new Executable() {
             @Override
             public void execute() throws Throwable {

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTestParam.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTestParam.java
@@ -25,7 +25,7 @@ final class OpenSslEngineTestParam extends SSLEngineTest.SSLEngineTestParam {
                                    List<? super OpenSslEngineTestParam> output) {
         output.add(new OpenSslEngineTestParam(true, false, param));
         output.add(new OpenSslEngineTestParam(false, false, param));
-        if (OpenSsl.isBoringSSL()) {
+        if (OpenSsl.isBoringSSL() || OpenSsl.isAWSLC()) {
             output.add(new OpenSslEngineTestParam(true, true, param));
             output.add(new OpenSslEngineTestParam(false, true, param));
         }

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslPrivateKeyMethodTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslPrivateKeyMethodTest.java
@@ -92,7 +92,7 @@ public class OpenSslPrivateKeyMethodTest {
     public static void init() throws Exception {
         checkShouldUseKeyManagerFactory();
 
-        assumeTrue(OpenSsl.isBoringSSL());
+        assumeTrue(OpenSsl.isBoringSSL() || OpenSsl.isAWSLC());
         // Check if the cipher is supported at all which may not be the case for various JDK versions and OpenSSL API
         // implementations.
         assumeCipherAvailable(SslProvider.OPENSSL);
@@ -114,7 +114,7 @@ public class OpenSslPrivateKeyMethodTest {
 
     @AfterAll
     public static void destroy() {
-        if (OpenSsl.isBoringSSL()) {
+        if (OpenSsl.isBoringSSL() || OpenSsl.isAWSLC()) {
             GROUP.shutdownGracefully();
             EXECUTOR.shutdown();
         }

--- a/handler/src/test/java/io/netty/handler/ssl/SslContextBuilderTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslContextBuilderTest.java
@@ -126,18 +126,18 @@ public class SslContextBuilderTest {
 
     @Test
     public void testUnsupportedPrivateKeyFailsFastForServer() {
-        assumeTrue(OpenSsl.isBoringSSL());
+        assumeTrue(OpenSsl.isBoringSSL() || OpenSsl.isAWSLC());
         testUnsupportedPrivateKeyFailsFast(true);
     }
 
     @Test
     public void testUnsupportedPrivateKeyFailsFastForClient() {
-        assumeTrue(OpenSsl.isBoringSSL());
+        assumeTrue(OpenSsl.isBoringSSL() || OpenSsl.isAWSLC());
         testUnsupportedPrivateKeyFailsFast(false);
     }
 
     private static void testUnsupportedPrivateKeyFailsFast(boolean server) {
-        assumeTrue(OpenSsl.isBoringSSL());
+        assumeTrue(OpenSsl.isBoringSSL() || OpenSsl.isAWSLC());
         String cert = "-----BEGIN CERTIFICATE-----\n" +
                 "MIICODCCAY2gAwIBAgIEXKTrajAKBggqhkjOPQQDBDBUMQswCQYDVQQGEwJVUzEM\n" +
                 "MAoGA1UECAwDTi9hMQwwCgYDVQQHDANOL2ExDDAKBgNVBAoMA04vYTEMMAoGA1UE\n" +

--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -1581,7 +1581,8 @@ public class SslHandlerTest {
     public void testHandshakeFailureCipherMissmatchTLSv13OpenSsl() throws Exception {
         OpenSsl.ensureAvailability();
         assumeTrue(SslProvider.isTlsv13Supported(SslProvider.OPENSSL));
-        assumeFalse(OpenSsl.isBoringSSL(), "BoringSSL does not support setting ciphers for TLSv1.3 explicit");
+        assumeFalse(OpenSsl.isBoringSSL() || OpenSsl.isAWSLC(),
+                "Provider does not support setting ciphers for TLSv1.3 explicitly");
         testHandshakeFailureCipherMissmatch(SslProvider.OPENSSL, true);
     }
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
@@ -130,7 +130,7 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
     public void testSslRenegotiationRejected(final SslContext serverCtx, final SslContext clientCtx,
                                              final boolean delegate, TestInfo testInfo) throws Throwable {
         // BoringSSL does not support renegotiation intentionally.
-        assumeFalse("BoringSSL".equals(OpenSsl.versionString()));
+        assumeFalse("BoringSSL".equals(OpenSsl.versionString()) || OpenSsl.versionString().startsWith("AWS-LC"));
         assumeTrue(OpenSsl.isAvailable());
         run(testInfo, new Runner<ServerBootstrap, Bootstrap>() {
             @Override


### PR DESCRIPTION
#### Motivation:

This is a follow-up to https://github.com/netty/netty-tcnative/pull/929 adding support for AWS-LC to netty-tcnative as a build-only option. This adds necessary code changes to netty 4.2 to be able to leverage this appropriately.

To quote that PR description for what AWS-LC is:
> AWS's open-source fork of Google's BoringSSL. We would like to propose adding AWS-LC support to netty-tcnative, alongside its existing support for OpenSSL, BoringSSL, and LibreSSL.
>
> AWS-LC shares a similar API surface area to the existing BoringSSL integration within your library, while providing additional benefits for users.
We are committed to backwards compatibility and maintain extensive CI testing infrastructure that continuously validates compatibility with many open-source projects.
We plan to add netty-tcnative compatibility testing to this suite to ensure ongoing compatibility.
>
> Some of the highlights offered by this integration:
>
>    Performance optimizations specifically targeted for modern CPU architectures, including AWS Graviton processors, and Intel x86-64 with AVX-512 instructions
    Formal verification of critical cryptographic primitives, with ongoing investment in expanding verification coverage.
    FIPS 140-3 compliance support through a dedicated FIPS build mode.

#### Modification:

Adds necessary modifications to support using AWS-LC via the netty-tcnative bindings.
