### PR TITLE
Add property to turn off pinned memory tracker in PoolChunk

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunk.java
@@ -140,7 +140,7 @@ final class PoolChunk<T> implements PoolChunkMetric {
     private static final int SUBPAGE_BIT_LENGTH = 1;
     private static final int BITMAP_IDX_BIT_LENGTH = 32;
 
-    private final static boolean trackPinnedMemory =
+    private static final boolean trackPinnedMemory =
             SystemPropertyUtil.getBoolean("io.netty.trackPinnedMemory", true);
 
     static final int IS_SUBPAGE_SHIFT = BITMAP_IDX_BIT_LENGTH;

--- a/buffer/src/main/java/io/netty/buffer/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunk.java
@@ -140,6 +140,9 @@ final class PoolChunk<T> implements PoolChunkMetric {
     private static final int SUBPAGE_BIT_LENGTH = 1;
     private static final int BITMAP_IDX_BIT_LENGTH = 32;
 
+    private final static boolean trackPinnedMemory =
+            SystemPropertyUtil.getBoolean("io.netty.trackPinnedMemory", true);
+
     static final int IS_SUBPAGE_SHIFT = BITMAP_IDX_BIT_LENGTH;
     static final int IS_USED_SHIFT = SUBPAGE_BIT_LENGTH + IS_SUBPAGE_SHIFT;
     static final int SIZE_SHIFT = INUSED_BIT_LENGTH + IS_USED_SHIFT;
@@ -190,9 +193,6 @@ final class PoolChunk<T> implements PoolChunkMetric {
     PoolChunkList<T> parent;
     PoolChunk<T> prev;
     PoolChunk<T> next;
-
-    private final static boolean trackPinnedMemory =
-            SystemPropertyUtil.getBoolean("io.netty.trackPinnedMemory", true);
 
     @SuppressWarnings("unchecked")
     PoolChunk(PoolArena<T> arena, CleanableDirectBuffer cleanable, Object base, T memory, int pageSize, int pageShifts,


### PR DESCRIPTION
Motivation:

`PoolChunk.pinnedBytes` is used only for monitoring purposes, however, it consumes a visible amount of the CPU:

![image](https://github.com/user-attachments/assets/6732bff0-41d8-481a-9cfe-60aff59eca8c)

I think it makes sense to have the ability to turn it off, or maybe even to disable it by default.

Modification:

Added `io.netty.trackPinnedMemory` property to control `PoolChunk.pinnedBytes`.

Result:

Now, we can turn off `PoolChunk.pinnedBytes` tracker.
