### PR TITLE
Avoid String[] allocation in HttpContentCompressor.determineEncoding

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
@@ -294,7 +294,15 @@ public class HttpContentCompressor extends HttpContentEncoder {
         float snappyQ = -1.0f;
         float gzipQ = -1.0f;
         float deflateQ = -1.0f;
-        for (String encoding : acceptEncoding.split(",")) {
+
+        int start = 0;
+        int length = acceptEncoding.length();
+        while (start < length) {
+            int comma = acceptEncoding.indexOf(',', start);
+            if (comma == -1) {
+                comma = length;
+            }
+            String encoding = acceptEncoding.substring(start, comma).trim();
             float q = 1.0f;
             int equalsPos = encoding.indexOf('=');
             if (equalsPos != -1) {
@@ -318,6 +326,7 @@ public class HttpContentCompressor extends HttpContentEncoder {
             } else if (encoding.contains("deflate") && q > deflateQ) {
                 deflateQ = q;
             }
+            start = comma + 1;
         }
         if (brQ > 0.0f || zstdQ > 0.0f || snappyQ > 0.0f || gzipQ > 0.0f || deflateQ > 0.0f) {
             if (brQ != -1.0f && brQ >= zstdQ && this.brotliOptions != null) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
@@ -302,7 +302,7 @@ public class HttpContentCompressor extends HttpContentEncoder {
             if (comma == -1) {
                 comma = length;
             }
-            String encoding = acceptEncoding.substring(start, comma).trim();
+            String encoding = acceptEncoding.substring(start, comma);
             float q = 1.0f;
             int equalsPos = encoding.indexOf('=');
             if (equalsPos != -1) {


### PR DESCRIPTION
Motivation:

We can easily avoid `String[]` allocation by manually searching for a comma.

Modification:

Replaced `split(",")` with manual search.

Result:

No more `String[]` allocation in `HttpContentCompressor.determineEncoding`
