### PR TITLE
JFR event cleanup

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractAllocatorEvent.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractAllocatorEvent.java
@@ -15,19 +15,18 @@
  */
 package io.netty.buffer;
 
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Enabled;
 import jdk.jfr.Event;
 
 /**
  * An abstract memory allocator event.
  */
+@Enabled(false)
+@Category("Netty")
 @SuppressWarnings("Since15")
 abstract class AbstractAllocatorEvent extends Event {
-    /**
-     * Obtain the memory address of the given buffer, if it has any.
-     * This method is safe to call even on buffers that has a zero reference count,
-     * but the returned address must not be used to access memory.
-     */
-    protected long getMemoryAddressOf(AbstractByteBuf buf) {
-        return buf._memoryAddress();
-    }
+    @Description("The type of allocator this event is for")
+    public AllocatorType allocatorType;
 }

--- a/buffer/src/main/java/io/netty/buffer/AbstractBufferEvent.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractBufferEvent.java
@@ -21,8 +21,6 @@ import jdk.jfr.MemoryAddress;
 
 @SuppressWarnings("Since15")
 abstract class AbstractBufferEvent extends AbstractAllocatorEvent {
-    @Description("The type of allocator this event is for")
-    public AllocatorType allocatorType;
     @DataAmount
     @Description("Configured buffer capacity")
     public int size;
@@ -44,6 +42,6 @@ abstract class AbstractBufferEvent extends AbstractAllocatorEvent {
         maxFastCapacity = buf.maxFastWritableBytes() + buf.writerIndex();
         maxCapacity = buf.maxCapacity();
         direct = buf.isDirect();
-        address = getMemoryAddressOf(buf);
+        address = buf._memoryAddress();
     }
 }

--- a/buffer/src/main/java/io/netty/buffer/AbstractChunkEvent.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractChunkEvent.java
@@ -21,8 +21,6 @@ import jdk.jfr.MemoryAddress;
 
 @SuppressWarnings("Since15")
 abstract class AbstractChunkEvent extends AbstractAllocatorEvent {
-    @Description("The type of allocator this event is for")
-    public AllocatorType allocatorType;
     @DataAmount
     @Description("Size of the chunk")
     public int capacity;

--- a/buffer/src/main/java/io/netty/buffer/AllocateBufferEvent.java
+++ b/buffer/src/main/java/io/netty/buffer/AllocateBufferEvent.java
@@ -15,12 +15,12 @@
  */
 package io.netty.buffer;
 
+import jdk.jfr.Category;
 import jdk.jfr.Description;
 import jdk.jfr.Enabled;
 import jdk.jfr.Label;
 import jdk.jfr.Name;
 
-@Enabled(false)
 @SuppressWarnings("Since15")
 @Label("Buffer Allocation")
 @Name("AllocateBufferEvent")

--- a/buffer/src/main/java/io/netty/buffer/AllocateChunkEvent.java
+++ b/buffer/src/main/java/io/netty/buffer/AllocateChunkEvent.java
@@ -21,9 +21,7 @@ import jdk.jfr.Enabled;
 import jdk.jfr.Label;
 import jdk.jfr.Name;
 
-@Enabled(false)
 @SuppressWarnings("Since15")
-@Category("Netty")
 @Name("AllocateChunkEvent")
 @Label("Chunk Allocation")
 @Description("Triggered when a new memory chunk is allocated for an allocator")

--- a/buffer/src/main/java/io/netty/buffer/FreeBufferEvent.java
+++ b/buffer/src/main/java/io/netty/buffer/FreeBufferEvent.java
@@ -15,12 +15,12 @@
  */
 package io.netty.buffer;
 
+import jdk.jfr.Category;
 import jdk.jfr.Description;
 import jdk.jfr.Enabled;
 import jdk.jfr.Label;
 import jdk.jfr.Name;
 
-@Enabled(false)
 @SuppressWarnings("Since15")
 @Label("Buffer Deallocation")
 @Name("FreeBufferEvent")

--- a/buffer/src/main/java/io/netty/buffer/FreeChunkEvent.java
+++ b/buffer/src/main/java/io/netty/buffer/FreeChunkEvent.java
@@ -21,9 +21,7 @@ import jdk.jfr.Enabled;
 import jdk.jfr.Label;
 import jdk.jfr.Name;
 
-@Enabled(false)
 @SuppressWarnings("Since15")
-@Category("Netty")
 @Label("Chunk Free")
 @Name("FreeChunkEvent")
 @Description("Triggered when a memory chunk is freed from an allocator")

--- a/buffer/src/main/java/io/netty/buffer/ReallocateBufferEvent.java
+++ b/buffer/src/main/java/io/netty/buffer/ReallocateBufferEvent.java
@@ -15,13 +15,13 @@
  */
 package io.netty.buffer;
 
+import jdk.jfr.Category;
 import jdk.jfr.DataAmount;
 import jdk.jfr.Description;
 import jdk.jfr.Enabled;
 import jdk.jfr.Label;
 import jdk.jfr.Name;
 
-@Enabled(false)
 @SuppressWarnings("Since15")
 @Label("Buffer Reallocation")
 @Name("ReallocateBufferEvent")

--- a/buffer/src/main/java/io/netty/buffer/ReturnChunkEvent.java
+++ b/buffer/src/main/java/io/netty/buffer/ReturnChunkEvent.java
@@ -21,9 +21,7 @@ import jdk.jfr.Enabled;
 import jdk.jfr.Label;
 import jdk.jfr.Name;
 
-@Enabled(false)
 @SuppressWarnings("Since15")
-@Category("Netty")
 @Label("Chunk Return")
 @Name("ReturnChunkEvent")
 @Description("Triggered when a memory chunk is freed from an allocator")


### PR DESCRIPTION
Motivation:

Metadata was a bit jumbled.

Modification:

- Move `@Category` and `@Enabled` to base AbstractAllocatorEvent
- This also adds `@Category` to the buffer events where it was missing
- Move allocatorType to AbstractAllocatorEvent
- Remove getMemoryAddressOf now that all events are in the buffer package

Result:

Cleaner code, proper category metadata.