### PR TITLE
Avoid expensive native calls in ReferenceCountedOpenSslEngine.rejectRemoteInitiatedRenegotiation for TLSv1.3

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -1436,7 +1436,8 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
     private void rejectRemoteInitiatedRenegotiation() throws SSLHandshakeException {
         // Avoid NPE: SSL.getHandshakeCount(ssl) must not be called if destroyed.
         // TLS 1.3 forbids renegotiation by spec.
-        if (destroyed || SslProtocols.TLS_v1_3.equals(session.getProtocol()) || handshakeState != HandshakeState.FINISHED) {
+        if (destroyed || SslProtocols.TLS_v1_3.equals(session.getProtocol())
+                || handshakeState != HandshakeState.FINISHED) {
             return;
         }
 


### PR DESCRIPTION
Motivation:

While profiling, we found a few strange places in the SSLHandler logic, specifically `SSL.getHandshakeCount` calls:

![image](https://github.com/user-attachments/assets/3a27de6b-8dea-4679-a07c-c099e4b60d7f)

So, first of all, it seems like this method is called too much, secondly, in the current implementation, we can avoid this call for tlsv1.3.

Modification:

Regroup logical checks to delay `getHandshakeCount` calls. This change fully eliminates `getHandshakeCount` calls for TLSv1.3 and make code easier to read.

Result:

No more `getHandshakeCount` calls for TLSv1.3
