### PR TITLE
IoUring: Add support for using huge pages for the buffer ring.

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -225,7 +225,9 @@ public final class IoUringIoHandler implements IoHandler {
         short bufferRingSize = bufferRingConfig.bufferRingSize();
         short bufferGroupId = bufferRingConfig.bufferGroupId();
         int flags = bufferRingConfig.isIncremental() ? Native.IOU_PBUF_RING_INC : 0;
-        long ioUringBufRingAddr = Native.ioUringRegisterBufRing(ringFd, bufferRingSize, bufferGroupId, flags);
+        boolean hugePages = bufferRingConfig.isUsingHugePages();
+        long ioUringBufRingAddr = Native.ioUringRegisterBufRing(
+                ringFd, bufferRingSize, bufferGroupId, flags, hugePages);
         if (ioUringBufRingAddr < 0) {
             throw Errors.newIOException("ioUringRegisterBufRing", (int) ioUringBufRingAddr);
         }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -453,11 +453,12 @@ final class Native {
     static boolean isRegisterBufferRingSupported(int ringFd, int flags) {
         int entries = 2;
         short bgid = 1;
-        long result = ioUringRegisterBufRing(ringFd, entries, bgid, flags);
+        long result = ioUringRegisterBufRing(ringFd, entries, bgid, flags, false);
         if (result >= 0) {
             ioUringUnRegisterBufRing(ringFd, result, entries, bgid);
             return true;
         }
+
         // This is not supported and so will return -EINVAL
         return false;
     }
@@ -515,7 +516,7 @@ final class Native {
     static native int ioUringRegisterEnableRings(int ringFd);
     static native int ioUringRegisterRingFds(int ringFds);
 
-    static native long ioUringRegisterBufRing(int ringFd, int entries, short bufferGroup, int flags);
+    static native long ioUringRegisterBufRing(int ringFd, int entries, short bufferGroup, int flags, boolean hugePages);
     static native int ioUringUnRegisterBufRing(int ringFd, long ioUringBufRingAddr, int entries, short bufferGroupId);
     static native int ioUringBufRingSize(int entries);
     static native int ioUringEnter(int ringFd, int toSubmit, int minComplete, int flags);

--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -62,6 +62,14 @@
 #define MSG_FASTOPEN 0x20000000
 #endif
 
+#ifndef MAP_HUGE_2MB
+#define MAP_HUGE_2MB    (21 << MAP_HUGE_SHIFT)
+#endif
+
+#ifndef MAP_HUGE_1GB
+#define MAP_HUGE_1GB    (30 << MAP_HUGE_SHIFT)
+#endif
+
 #define NATIVE_CLASSNAME "io/netty/channel/uring/Native"
 #define STATICALLY_CLASSNAME "io/netty/channel/uring/NativeStaticallyReferencedJniMethods"
 #define LIBRARYNAME "netty_transport_native_io_uring42"
@@ -392,14 +400,18 @@ static jint netty_io_uring_register_ring_fds(JNIEnv *env, jclass clazz, jint rin
 
 static jlong netty_io_uring_register_buf_ring(JNIEnv* env, jclass clazz,
                                            jint ringFd, jint nentries,
-                                           jshort bgid, jint flags) {
+                                           jshort bgid, jint flags, jboolean hugePages) {
     struct io_uring_buf_ring *br;
     struct io_uring_buf_reg reg;
     size_t ring_size;
 
     memset(&reg, 0, sizeof(reg));
     ring_size = nentries * sizeof(struct io_uring_buf);
-    br = mmap(NULL, ring_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+    if (hugePages == JNI_TRUE) {
+        br = mmap(NULL, ring_size, PROT_READ|PROT_WRITE,MAP_PRIVATE|MAP_HUGETLB|MAP_HUGE_2MB|MAP_ANONYMOUS, -1, 0);
+    } else {
+        br = mmap(NULL, ring_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+    }
     if (br == MAP_FAILED) {
         return -errno;
     }
@@ -824,7 +836,7 @@ static const JNINativeMethod method_table[] = {
     {"cmsghdrData", "(J)J", (void *) netty_io_uring_cmsghdrData},
     {"kernelVersion", "()Ljava/lang/String;", (void *) netty_io_uring_kernel_version },
     {"getFd0", "(Ljava/lang/Object;)I", (void *) netty_io_uring_getFd0 },
-    {"ioUringRegisterBufRing", "(IISI)J", (void *) netty_io_uring_register_buf_ring },
+    {"ioUringRegisterBufRing", "(IISIZ)J", (void *) netty_io_uring_register_buf_ring },
     {"ioUringUnRegisterBufRing", "(IJIS)I", (void *) netty_io_uring_unregister_buf_ring },
     {"ioUringBufRingSize", "(I)I", (void *) netty_io_uring_buf_ring_size }
 };

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
@@ -59,7 +59,7 @@ public class IoUringBufferRingTest {
         RingBuffer ringBuffer = Native.createRingBuffer(8, 15, 0);
         try {
             int ringFd = ringBuffer.fd();
-            long ioUringBufRingAddr = Native.ioUringRegisterBufRing(ringFd, 4, (short) 1, 0);
+            long ioUringBufRingAddr = Native.ioUringRegisterBufRing(ringFd, 4, (short) 1, 0, false);
             assumeTrue(
                     ioUringBufRingAddr > 0,
                     "ioUringSetupBufRing result must great than 0, but now result is " + ioUringBufRingAddr);


### PR DESCRIPTION
Modifications:

To reduce overhead it might be benefitial to use huge oages for the buffer ring. We should allow to do so.

Modifications:

Add new IoUringBufferRingConfig constructor that allows to enable the usage of huge pages

Result:

Be able to use huge-pages for the buffer ring.
