### PR TITLE
IoUring: Use IORING_SETUP_NO_SQARRAY by default

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
@@ -41,6 +41,7 @@ public final class IoUring {
     private static final boolean IORING_SETUP_CQ_SIZE_SUPPORTED;
     private static final boolean IORING_SETUP_SINGLE_ISSUER_SUPPORTED;
     private static final boolean IORING_SETUP_DEFER_TASKRUN_SUPPORTED;
+    private static final boolean IORING_SETUP_NO_SQARRAY_SUPPORTED;
     private static final boolean IORING_REGISTER_BUFFER_RING_SUPPORTED;
     private static final boolean IORING_REGISTER_BUFFER_RING_INC_SUPPORTED;
     private static final boolean IORING_ACCEPT_MULTISHOT_ENABLED;
@@ -66,6 +67,7 @@ public final class IoUring {
         boolean setUpCqSizeSupported = false;
         boolean singleIssuerSupported = false;
         boolean deferTaskrunSupported = false;
+        boolean noSqarraySupported = false;
         boolean registerBufferRingSupported = false;
         boolean registerBufferRingIncSupported = false;
         int numElementsIoVec = 10;
@@ -108,6 +110,7 @@ public final class IoUring {
                         // See https://manpages.debian.org/unstable/liburing-dev/io_uring_setup.2.en.html
                         deferTaskrunSupported = Native.ioUringSetupSupportsFlags(
                                 Native.IORING_SETUP_SINGLE_ISSUER | Native.IORING_SETUP_DEFER_TASKRUN);
+                        noSqarraySupported = Native.ioUringSetupSupportsFlags(Native.IORING_SETUP_NO_SQARRAY);
                         registerBufferRingSupported = Native.isRegisterBufferRingSupported(ringBuffer.fd(), 0);
                         registerBufferRingIncSupported = Native.isRegisterBufferRingSupported(ringBuffer.fd(),
                                 Native.IOU_PBUF_RING_INC);
@@ -169,6 +172,7 @@ public final class IoUring {
         IORING_SETUP_CQ_SIZE_SUPPORTED = setUpCqSizeSupported;
         IORING_SETUP_SINGLE_ISSUER_SUPPORTED = singleIssuerSupported;
         IORING_SETUP_DEFER_TASKRUN_SUPPORTED = deferTaskrunSupported;
+        IORING_SETUP_NO_SQARRAY_SUPPORTED = noSqarraySupported;
         IORING_REGISTER_BUFFER_RING_SUPPORTED = registerBufferRingSupported;
         IORING_REGISTER_BUFFER_RING_INC_SUPPORTED = registerBufferRingIncSupported;
 
@@ -263,6 +267,9 @@ public final class IoUring {
         return IORING_SETUP_DEFER_TASKRUN_SUPPORTED;
     }
 
+    static boolean isIoringSetupNoSqarraySupported() {
+        return IORING_SETUP_NO_SQARRAY_SUPPORTED;
+    }
     /**
      * Returns if it is supported to use a buffer ring.
      *

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -226,6 +226,7 @@ final class Native {
     static final int IORING_SETUP_SUBMIT_ALL = 1 << 7;
     static final int IORING_SETUP_SINGLE_ISSUER = 1 << 12;
     static final int IORING_SETUP_DEFER_TASKRUN = 1 << 13;
+    static final int IORING_SETUP_NO_SQARRAY = 1 << 16;
     static final int IORING_CQE_BUFFER_SHIFT = 16;
 
     static final short IORING_POLL_ADD_MULTI = 1 << 0;
@@ -350,6 +351,11 @@ final class Native {
         }
         if (IoUring.isSetupDeferTaskrunSupported()) {
             flags |= Native.IORING_SETUP_DEFER_TASKRUN;
+        }
+        // liburing uses IORING_SETUP_NO_SQARRAY by default these days, we should do the same by default if possible.
+        // See https://github.com/axboe/liburing/releases/tag/liburing-2.6
+        if (IoUring.isIoringSetupNoSqarraySupported()) {
+            flags  |= Native.IORING_SETUP_NO_SQARRAY;
         }
         return flags;
     }

--- a/transport-native-io_uring/src/main/c/netty_io_uring.h
+++ b/transport-native-io_uring/src/main/c/netty_io_uring.h
@@ -29,37 +29,62 @@
 #ifndef NETTY_IO_URING
 #define NETTY_IO_URING
 
+// See https://github.com/axboe/liburing/blob/liburing-2.11/src/include/liburing.h#L78
 struct io_uring_sq {
-    unsigned *khead;
-    unsigned *ktail;
-    unsigned *kring_mask;
-    unsigned *kring_entries;
-    unsigned *kflags;
-    unsigned *kdropped;
-    unsigned *array;
-    struct io_uring_sqe *sqes;
+	unsigned *khead;
+	unsigned *ktail;
+	// Deprecated: use `ring_mask` instead of `*kring_mask`
+	unsigned *kring_mask;
+	// Deprecated: use `ring_entries` instead of `*kring_entries`
+	unsigned *kring_entries;
+	unsigned *kflags;
+	unsigned *kdropped;
+	unsigned *array;
+	struct io_uring_sqe *sqes;
 
-    size_t ring_sz;
-    void *ring_ptr;
+	unsigned sqe_head;
+	unsigned sqe_tail;
+
+	size_t ring_sz;
+	void *ring_ptr;
+
+	unsigned ring_mask;
+	unsigned ring_entries;
+
+	unsigned pad[2];
 };
 
 struct io_uring_cq {
-    unsigned *khead;
-    unsigned *ktail;
-    unsigned *kring_mask;
-    unsigned *kring_entries;
-    unsigned *koverflow;
-    struct io_uring_cqe *cqes;
+	unsigned *khead;
+	unsigned *ktail;
+	// Deprecated: use `ring_mask` instead of `*kring_mask`
+	unsigned *kring_mask;
+	// Deprecated: use `ring_entries` instead of `*kring_entries`
+	unsigned *kring_entries;
+	unsigned *kflags;
+	unsigned *koverflow;
+	struct io_uring_cqe *cqes;
 
-    size_t ring_sz;
-    void *ring_ptr;
+	size_t ring_sz;
+	void *ring_ptr;
+
+	unsigned ring_mask;
+	unsigned ring_entries;
+
+	unsigned pad[2];
 };
 
 struct io_uring {
-    struct io_uring_sq sq;
-    struct io_uring_cq cq;
-    unsigned flags;
-    int ring_fd;
+	struct io_uring_sq sq;
+	struct io_uring_cq cq;
+	unsigned flags;
+	int ring_fd;
+
+	unsigned features;
+	int enter_ring_fd;
+	__u8 int_flags;
+	__u8 pad[3];
+	unsigned pad2;
 };
 
 struct io_uring_buf {

--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -84,6 +84,37 @@ static void netty_io_uring_native_JNI_OnUnLoad(JNIEnv* env, const char* packageP
     NETTY_JNI_UTIL_UNLOAD_CLASS(env, longArrayClass);
 }
 
+void io_uring_setup_ring_pointers(struct io_uring_params *p,
+				  struct io_uring_sq *sq,
+				  struct io_uring_cq *cq)
+{
+	sq->khead = sq->ring_ptr + p->sq_off.head;
+	sq->ktail = sq->ring_ptr + p->sq_off.tail;
+	sq->kring_mask = sq->ring_ptr + p->sq_off.ring_mask;
+	sq->kring_entries = sq->ring_ptr + p->sq_off.ring_entries;
+	sq->kflags = sq->ring_ptr + p->sq_off.flags;
+	sq->kdropped = sq->ring_ptr + p->sq_off.dropped;
+
+	if (!(p->flags & IORING_SETUP_NO_SQARRAY)) {
+		sq->array = sq->ring_ptr + p->sq_off.array;
+	}
+
+	cq->khead = cq->ring_ptr + p->cq_off.head;
+	cq->ktail = cq->ring_ptr + p->cq_off.tail;
+	cq->kring_mask = cq->ring_ptr + p->cq_off.ring_mask;
+	cq->kring_entries = cq->ring_ptr + p->cq_off.ring_entries;
+	cq->koverflow = cq->ring_ptr + p->cq_off.overflow;
+	cq->cqes = cq->ring_ptr + p->cq_off.cqes;
+	if (p->cq_off.flags) {
+		cq->kflags = cq->ring_ptr + p->cq_off.flags;
+	}
+
+	sq->ring_mask = *sq->kring_mask;
+	sq->ring_entries = *sq->kring_entries;
+	cq->ring_mask = *cq->kring_mask;
+	cq->ring_entries = *cq->kring_entries;
+}
+
 static void io_uring_unmap_rings(struct io_uring_sq *sq, struct io_uring_cq *cq) {
     if (sq->ring_ptr != NULL) {
         munmap(sq->ring_ptr, sq->ring_sz);
@@ -96,7 +127,6 @@ static void io_uring_unmap_rings(struct io_uring_sq *sq, struct io_uring_cq *cq)
 static int io_uring_mmap(int fd, struct io_uring_params *p, struct io_uring_sq *sq, struct io_uring_cq *cq) {
     size_t size;
     int ret;
-    int index;
 
     sq->ring_sz = p->sq_off.array + p->sq_entries * sizeof(unsigned);
     cq->ring_sz = p->cq_off.cqes + p->cq_entries * sizeof(struct io_uring_cqe);
@@ -123,13 +153,6 @@ static int io_uring_mmap(int fd, struct io_uring_params *p, struct io_uring_sq *
         }
     }
 
-    sq->khead = sq->ring_ptr + p->sq_off.head;
-    sq->ktail = sq->ring_ptr + p->sq_off.tail;
-    sq->kring_mask = sq->ring_ptr + p->sq_off.ring_mask;
-    sq->kring_entries = sq->ring_ptr + p->sq_off.ring_entries;
-    sq->kflags = sq->ring_ptr + p->sq_off.flags;
-    sq->kdropped = sq->ring_ptr + p->sq_off.dropped;
-    sq->array = sq->ring_ptr + p->sq_off.array;
     size = p->sq_entries * sizeof(struct io_uring_sqe);
     sq->sqes = mmap(0, size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_POPULATE, fd, IORING_OFF_SQES);
     if (sq->sqes == MAP_FAILED) {
@@ -137,18 +160,7 @@ static int io_uring_mmap(int fd, struct io_uring_params *p, struct io_uring_sq *
         goto err;
     }
 
-    cq->khead = cq->ring_ptr + p->cq_off.head;
-    cq->ktail = cq->ring_ptr + p->cq_off.tail;
-    cq->kring_mask = cq->ring_ptr + p->cq_off.ring_mask;
-    cq->kring_entries = cq->ring_ptr + p->cq_off.ring_entries;
-    cq->koverflow = cq->ring_ptr + p->cq_off.overflow;
-    cq->cqes = cq->ring_ptr + p->cq_off.cqes;
-
-    if (!(p->flags & IORING_SETUP_NO_SQARRAY)) {
-        for (index = 0; index < p->sq_entries; index++) {
-            sq->array[index] = index;
-        }
-    }
+    io_uring_setup_ring_pointers(p, sq, cq);
 
     return 0;
 err:
@@ -331,6 +343,12 @@ static jlongArray netty_io_uring_setup(JNIEnv *env, jclass clazz, jint entries, 
         close(ring_fd);
         netty_unix_errors_throwRuntimeExceptionErrorNo(env, "failed to mmap io_uring ring buffer: ", ret);
         return NULL;
+    }
+
+    if (!(p.flags & IORING_SETUP_NO_SQARRAY)) {
+        for (int index = 0; index < p.sq_entries; index++) {
+            io_uring_ring.sq.array[index] = index;
+        }
     }
 
     jlong completionArrayElements[] = {


### PR DESCRIPTION
Motivation:

To reduce indirection (and so overhead) we should use IORING_SETUP_NO_SQARRAY if possible. This is also done by liburing since 2.6)

Modifications:

- Add code to support IORING_SETUP_NO_SQARRAY and use it by default if possible
- Refactor native code to be more inline with liburing which makes it easier to maintain
- Update io_uring structs to match latest

Result:

Less indirection by default when running on a 6.6+ kernel.
