### PR TITLE
Cleanup SocketSslClientRenegotiateTest with OpenSsl predicate

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -579,6 +579,17 @@ public final class OpenSsl {
     }
 
     /**
+     * Returns {@code true} if the used version of OpenSSL supports renegotiation.
+     * <p>
+     * Some implementations, such as BoringSSL and AWS-LC, intentionally do not support renegotiation.
+     *
+     * @return {@code true} if renegotiation is supported, otherwise {@code false}.
+     */
+    public static boolean isRenegotiationSupported() {
+        return !IS_BORINGSSL && !IS_AWSLC;
+    }
+
+    /**
      * Returns the version of the used available OpenSSL library or {@code -1} if {@link #isAvailable()}
      * returns {@code false}.
      */

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
@@ -58,7 +58,6 @@ import javax.net.ssl.SSLHandshakeException;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
@@ -129,8 +128,7 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
     @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
     public void testSslRenegotiationRejected(final SslContext serverCtx, final SslContext clientCtx,
                                              final boolean delegate, TestInfo testInfo) throws Throwable {
-        // BoringSSL does not support renegotiation intentionally.
-        assumeFalse("BoringSSL".equals(OpenSsl.versionString()) || OpenSsl.versionString().startsWith("AWS-LC"));
+        assumeTrue(OpenSsl.isRenegotiationSupported());
         assumeTrue(OpenSsl.isAvailable());
         run(testInfo, new Runner<ServerBootstrap, Bootstrap>() {
             @Override


### PR DESCRIPTION
Motivation:
Using the `OpenSsl.versionString()` to sniff features is fragile. Let's add a specific predicate for renegotiation instead.

Modification:
Add an `OpenSsl.isRenegotiationSupported` predicate, and use it in the `SocketSslClientRenegotiateTest`.

Result:
Cleaner code.