### PR TITLE
IoUring: Add IoUringBufferRingConfig.Builder

### DIFF
--- a/testsuite-native-image/src/main/java/io/netty/testsuite/svm/HttpNativeServer.java
+++ b/testsuite-native-image/src/main/java/io/netty/testsuite/svm/HttpNativeServer.java
@@ -119,10 +119,14 @@ public final class HttpNativeServer {
         if (ioType == TransportType.IO_URING) {
             IoUringIoHandlerConfig config = new IoUringIoHandlerConfig();
             if (IoUring.isRegisterBufferRingSupported()) {
-                config.setBufferRingConfig(new IoUringBufferRingConfig(
-                        (short) 0, (short) 16,
-                        new IoUringFixedBufferRingAllocator(1024)
-                ));
+                config.setBufferRingConfig(
+                        IoUringBufferRingConfig.builder()
+                                .bufferGroupId((short) 0)
+                                .bufferRingSize((short) 16)
+                                .batchSize(16)
+                                .allocator(new IoUringFixedBufferRingAllocator(1024))
+                                .build()
+                );
             }
 
            return IoUringIoHandler.newFactory(config);

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingConfig.java
@@ -37,22 +37,10 @@ public final class IoUringBufferRingConfig {
      *
      * @param bgId                  the buffer group id to use (must be non-negative).
      * @param bufferRingSize        the size of the ring
-     * @param allocator             the {@link IoUringBufferRingAllocator} to use to allocate
-     *                              {@link io.netty.buffer.ByteBuf}s.
-     */
-    public IoUringBufferRingConfig(short bgId, short bufferRingSize,
-                                   IoUringBufferRingAllocator allocator) {
-        this(bgId, bufferRingSize, Integer.MAX_VALUE, allocator);
-    }
-
-    /**
-     * Create a new configuration.
-     *
-     * @param bgId                  the buffer group id to use (must be non-negative).
-     * @param bufferRingSize        the size of the ring
      * @param maxUnreleasedBuffers  this parameter is ignored by the buffer ring.
      * @param allocator             the {@link IoUringBufferRingAllocator} to use to allocate
      *                              {@link io.netty.buffer.ByteBuf}s.
+     * @deprecated                  use {@link Builder}.
      */
     @Deprecated
     public IoUringBufferRingConfig(short bgId, short bufferRingSize, int maxUnreleasedBuffers,
@@ -68,26 +56,11 @@ public final class IoUringBufferRingConfig {
      * @param bufferRingSize        the size of the ring
      * @param batchSize             the size of the batch on how many buffers are added everytime we need to expand the
      *                              buffer ring.
-     * @param incremental           {@code true} if the buffer ring is using incremental buffer consumption.
-     * @param allocator             the {@link IoUringBufferRingAllocator} to use to allocate
-     *                              {@link io.netty.buffer.ByteBuf}s.
-     */
-    public IoUringBufferRingConfig(short bgId, short bufferRingSize, int batchSize,
-                                   boolean incremental, IoUringBufferRingAllocator allocator) {
-        this(bgId, bufferRingSize, batchSize, Integer.MAX_VALUE, incremental, allocator);
-    }
-
-    /**
-     * Create a new configuration.
-     *
-     * @param bgId                  the buffer group id to use (must be non-negative).
-     * @param bufferRingSize        the size of the ring
-     * @param batchSize             the size of the batch on how many buffers are added everytime we need to expand the
-     *                              buffer ring.
      * @param maxUnreleasedBuffers  this parameter is ignored by the buffer ring.
      * @param incremental           {@code true} if the buffer ring is using incremental buffer consumption.
      * @param allocator             the {@link IoUringBufferRingAllocator} to use to allocate
      *                              {@link io.netty.buffer.ByteBuf}s.
+     * @deprecated                  use {@link Builder}.
      */
     @Deprecated
     public IoUringBufferRingConfig(short bgId, short bufferRingSize, int batchSize, int maxUnreleasedBuffers,
@@ -188,5 +161,84 @@ public final class IoUringBufferRingConfig {
     @Override
     public int hashCode() {
         return Objects.hashCode(bgId);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private short bgId = -1;
+        private short bufferRingSize = -1;
+        private int batchSize = -1;
+        private boolean incremental = IoUring.isRegisterBufferRingIncSupported();
+        private IoUringBufferRingAllocator allocator;
+
+        /**
+         * Set the buffer group id to use.
+         *
+         * @param bgId  The buffer group id to use.
+         * @return      This builder.
+         */
+        public Builder bufferGroupId(short bgId) {
+            this.bgId = bgId;
+            return this;
+        }
+
+        /**
+         * Set the size of the ring.
+         *
+         * @param bufferRingSize    The size of the ring.
+         * @return                  This builder.
+         */
+        public Builder bufferRingSize(short bufferRingSize) {
+            this.bufferRingSize = bufferRingSize;
+            return this;
+        }
+
+        /**
+         * Set the size of the batch on how many buffers are added everytime we need to expand the buffer ring.
+         *
+         * @param batchSize The batch size.
+         * @return          This builder.
+         */
+        public Builder batchSize(int batchSize) {
+            this.batchSize = batchSize;
+            return this;
+        }
+
+        /**
+         * Set the {@link IoUringBufferRingAllocator} to use to allocate {@link io.netty.buffer.ByteBuf}s.
+         *
+         * @param allocator The allocator.
+         * @return          This builder.
+         */
+        public Builder allocator(IoUringBufferRingAllocator allocator) {
+            this.allocator = allocator;
+            return this;
+        }
+
+        /**
+         * Set if <a href="https://github.com/axboe/liburing/wiki/
+         * What's-new-with-io_uring-in-6.11-and-6.12#incremental-provided-buffer-consumption">incremental mode</a>
+         * should be used for the buffer ring.
+         *
+         * @param incremental  {@code true} if incremental mode is used, {@code false} otherwise.
+         * @return          This builder.
+         */
+        public Builder incremental(boolean incremental) {
+            this.incremental = incremental;
+            return this;
+        }
+
+        /**
+         * Create a new {@link IoUringBufferRingConfig}.
+         *
+         * @return a new config.
+         */
+        public IoUringBufferRingConfig build() {
+            return new IoUringBufferRingConfig(
+                    bgId, bufferRingSize, batchSize, Integer.MAX_VALUE, incremental, allocator);
+        }
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
@@ -92,12 +92,22 @@ public class IoUringBufferRingTest {
         }
         final BlockingQueue<ByteBuf> bufferSyncer = new LinkedBlockingQueue<>();
         IoUringIoHandlerConfig ioUringIoHandlerConfiguration = new IoUringIoHandlerConfig();
-        IoUringBufferRingConfig bufferRingConfig = new IoUringBufferRingConfig(
-                (short) 1, (short) 2, 2, incremental, new IoUringFixedBufferRingAllocator(1024));
+        IoUringBufferRingConfig bufferRingConfig =
+                IoUringBufferRingConfig.builder()
+                        .bufferGroupId((short) 1)
+                        .bufferRingSize((short) 2)
+                        .batchSize(2).incremental(incremental)
+                        .allocator(new IoUringFixedBufferRingAllocator(1024))
+                        .build();
 
-        IoUringBufferRingConfig bufferRingConfig1 = new IoUringBufferRingConfig(
-                (short) 2, (short) 16, 8, incremental, new IoUringFixedBufferRingAllocator(1024)
-        );
+        IoUringBufferRingConfig bufferRingConfig1 =
+                IoUringBufferRingConfig.builder()
+                        .bufferGroupId((short) 2)
+                        .bufferRingSize((short) 16)
+                        .batchSize(8)
+                        .incremental(incremental)
+                        .allocator(new IoUringFixedBufferRingAllocator(1024))
+                        .build();
         ioUringIoHandlerConfiguration.setBufferRingConfig(bufferRingConfig, bufferRingConfig1);
 
         MultiThreadIoEventLoopGroup group = new MultiThreadIoEventLoopGroup(1,

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketTestPermutation.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketTestPermutation.java
@@ -50,8 +50,14 @@ public class IoUringSocketTestPermutation extends SocketTestPermutation {
         IoUringIoHandlerConfig config = new IoUringIoHandlerConfig();
         if (IoUring.isRegisterBufferRingSupported()) {
             config.setBufferRingConfig(
-                    new IoUringBufferRingConfig(BGID, (short) 16, 8,
-                            incremental, new IoUringFixedBufferRingAllocator(1024)));
+                    IoUringBufferRingConfig.builder()
+                            .bufferGroupId(BGID)
+                            .bufferRingSize((short) 16)
+                            .batchSize(8)
+                            .incremental(incremental)
+                            .allocator(new IoUringFixedBufferRingAllocator(1024))
+                            .build()
+            );
         }
         return config;
     }


### PR DESCRIPTION
Motivation:

There are already too many constructor arguments for IoUringBufferRingConfig, so better to introduce a builder

Modifications:

Add new builder for IoUringBufferRingConfig

Result:

Easier to configure the buffer ring