### PR TITLE
Avoid duplicate size class declarations

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -161,6 +161,7 @@ final class AdaptivePoolingAllocator {
         int lastIndex = 0;
         for (int i = 0; i < SIZE_CLASSES_COUNT; i++) {
             int sizeClass = SIZE_CLASSES[i];
+            //noinspection ConstantValue
             assert (sizeClass & 5) == 0 : "Size class must be a multiple of 32";
             int sizeIndex = sizeIndexOf(sizeClass);
             Arrays.fill(SIZE_INDEXES, lastIndex + 1, sizeIndex + 1, (byte) i);
@@ -263,7 +264,7 @@ final class AdaptivePoolingAllocator {
 
     private static int sizeIndexOf(final int size) {
         // this is aligning the size to the next multiple of 32 and dividing by 32 to get the size index.
-        return (size + 31) >> 5;
+        return size + 31 >> 5;
     }
 
     static int sizeClassIndexOf(int size) {
@@ -274,11 +275,8 @@ final class AdaptivePoolingAllocator {
         return SIZE_CLASSES_COUNT;
     }
 
-    private static int binarySearchInsertionPoint(int index) {
-        if (index < 0) {
-            index = -(index + 1);
-        }
-        return index;
+    static int[] getSizeClasses() {
+        return SIZE_CLASSES.clone();
     }
 
     private AdaptiveByteBuf allocateFallback(int size, int maxCapacity, Thread currentThread,
@@ -671,6 +669,13 @@ final class AdaptivePoolingAllocator {
         static int sizeToBucket(int size) {
             int index = binarySearchInsertionPoint(Arrays.binarySearch(HISTO_BUCKETS, size));
             return index >= HISTO_BUCKETS.length ? HISTO_BUCKETS.length - 1 : index;
+        }
+
+        private static int binarySearchInsertionPoint(int index) {
+            if (index < 0) {
+                index = -(index + 1);
+            }
+            return index;
         }
 
         static int bucketToSize(int sizeBucket) {

--- a/buffer/src/test/java/io/netty/buffer/AdaptivePoolingAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptivePoolingAllocatorTest.java
@@ -63,26 +63,9 @@ class AdaptivePoolingAllocatorTest implements Supplier<String> {
 
     @Test
     void sizeClassComputations() throws Exception {
-        final int[] sizeClasses = {
-                32,
-                64,
-                128,
-                256,
-                512,
-                640, // 512 + 128
-                1024,
-                1152, // 1024 + 128
-                2048,
-                2304, // 2048 + 256
-                4096,
-                4352, // 4096 + 256
-                8192,
-                8704, // 8192 + 512
-                16384,
-                16896, // 16384 + 512
-        };
+        final int[] sizeClasses = AdaptivePoolingAllocator.getSizeClasses();
         for (int sizeClassIndex = 0; sizeClassIndex < sizeClasses.length; sizeClassIndex++) {
-            final int previousSizeIncluded = sizeClassIndex == 0? 0 : (sizeClasses[sizeClassIndex - 1] + 1);
+            final int previousSizeIncluded = sizeClassIndex == 0? 0 : sizeClasses[sizeClassIndex - 1] + 1;
             assertSizeClassOf(sizeClassIndex, previousSizeIncluded, sizeClasses[sizeClassIndex]);
         }
         // beyond the last size class, we return the size class array's length


### PR DESCRIPTION
Motivation:
We should not have multiple copies of the adaptive size class array, as it will be harder to maintain if we want to change it.

Modification:
Add a package-protected getter that returns a clone, which the test can use. Also did a little code clean up to silence some warnings.

Result:
The AdaptivePoolingAllocatorTest is now always in sync with the real size class array.