### PR TITLE
IoUring: Add the ability to allocate the buffers for the buffering in

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringBufferRingAllocator.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringBufferRingAllocator.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * Base class for {@link IoUringBufferRingAllocator} implementations which support large allocations.
+ */
+public abstract class AbstractIoUringBufferRingAllocator implements IoUringBufferRingAllocator {
+    private final ByteBufAllocator allocator;
+    private final boolean largeAllocation;
+
+    /**
+     * Creates new instance.
+     *
+     * @param allocator         the {@link ByteBufAllocator} to use for the allocations
+     * @param largeAllocation   {@code true} if we should do a large allocation for the whole buffer ring
+     *                          and then slice out the buffers or {@code false} if we should do one allocation
+     *                          per buffer.
+     */
+    protected AbstractIoUringBufferRingAllocator(ByteBufAllocator allocator, boolean largeAllocation) {
+        this.allocator = Objects.requireNonNull(allocator, "allocator");
+        this.largeAllocation = largeAllocation;
+    }
+
+    @Override
+    public final void allocateBatch(Consumer<ByteBuf> consumer, int number) {
+        if (largeAllocation) {
+            int bufferSize = nextBufferSize();
+            ByteBuf buffer = allocator.directBuffer(nextBufferSize() * number);
+            try {
+                for (int i = 0; i < number; i++) {
+                    consumer.accept(buffer
+                            .retainedSlice(i * bufferSize, bufferSize)
+                            .setIndex(0, 0)
+                    );
+                }
+            } finally {
+                buffer.release();
+            }
+        } else {
+            IoUringBufferRingAllocator.super.allocateBatch(consumer, number);
+        }
+    }
+
+    @Override
+    public final ByteBuf allocate() {
+        return allocator.directBuffer(nextBufferSize());
+    }
+
+    /**
+     * Does nothing by default, sub-classes might override this.
+     *
+     * @param attempted  the attempted bytes to read.
+     * @param actual     the number of bytes that could be read.
+     */
+    @Override
+    public void lastBytesRead(int attempted, int actual) {
+        // NOOP.
+    }
+
+    /**
+     * Return the next buffer size of each {@link ByteBuf} that is put into the buffer ring.
+     *
+     * @return  the next size.
+     */
+    protected abstract int nextBufferSize();
+}

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
@@ -195,7 +195,7 @@ final class IoUringBufferRing {
         ByteBuf buffer = byteBuf.retainedSlice(byteBuf.writerIndex(), read);
         byteBuf.writerIndex(byteBuf.writerIndex() + read);
 
-        if (incremental && more && byteBuf.writableBytes() > read) {
+        if (incremental && more && byteBuf.isWritable()) {
             // The buffer will be used later again, just slice out what we did read so far.
             return buffer;
         }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
@@ -23,6 +23,7 @@ import java.lang.invoke.VarHandle;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Arrays;
+import java.util.function.Consumer;
 
 final class IoUringBufferRing {
     private static final VarHandle SHORT_HANDLE =
@@ -30,37 +31,37 @@ final class IoUringBufferRing {
     private final ByteBuffer ioUringBufRing;
     private final int tailFieldPosition;
     private final short entries;
-    private final int batchSize;
     private final short mask;
     private final short bufferGroupId;
     private final int ringFd;
     private final ByteBuf[] buffers;
     private final IoUringBufferRingAllocator allocator;
     private final IoUringBufferRingExhaustedEvent exhaustedEvent;
+    private final RingConsumer ringConsumer;
     private final boolean incremental;
+    private final int batchSize;
     private boolean corrupted;
     private boolean closed;
-    private int numBuffers;
-    private boolean expanded;
-    private boolean needsLazyExpansion;
-    private short lastGeneratedBid;
-    private short lastAddedBid;
+    private int usableBuffers;
+    private int allocatedBuffers;
+    private boolean needExpand;
 
     IoUringBufferRing(int ringFd, ByteBuffer ioUringBufRing,
                       short entries, int batchSize, short bufferGroupId, boolean incremental,
                       IoUringBufferRingAllocator allocator) {
         assert entries % 2 == 0;
         assert batchSize % 2 == 0;
+        this.batchSize = batchSize;
         this.ioUringBufRing = ioUringBufRing;
         this.tailFieldPosition = Native.IO_URING_BUFFER_RING_TAIL;
         this.entries = entries;
-        this.batchSize = batchSize;
         this.mask = (short) (entries - 1);
         this.bufferGroupId = bufferGroupId;
         this.ringFd = ringFd;
         this.buffers = new ByteBuf[entries];
         this.incremental = incremental;
         this.allocator = allocator;
+        this.ringConsumer  = new RingConsumer();
         this.exhaustedEvent = new IoUringBufferRingExhaustedEvent(bufferGroupId);
     }
 
@@ -69,42 +70,91 @@ final class IoUringBufferRing {
     }
 
     void initialize() {
-        for (short i = 0; i < batchSize; i++) {
-            addBuffer(i);
-            numBuffers++;
-            lastGeneratedBid = i;
+        // We already validated that batchSize is <= ring length.
+        refill(batchSize);
+    }
+
+    private final class RingConsumer implements Consumer<ByteBuf> {
+        private int expectedBuffers;
+        private short num;
+        private short bid;
+        private short oldTail;
+
+        void fill(int numBuffers) {
+            // Fetch the tail once before allocate the batch.
+            oldTail = (short) SHORT_HANDLE.get(ioUringBufRing, tailFieldPosition);
+
+            // At the moment we always start with bid 0 and so num and bid is the same. As this is more of an
+            // implementation detail it is better to still keep both separated.
+            this.num = 0;
+            this.bid = 0;
+            this.expectedBuffers = numBuffers;
+            try {
+                allocator.allocateBatch(this, numBuffers);
+            } catch (Throwable t) {
+                corrupted = true;
+                for (int i = 0; i < buffers.length; i++) {
+                    ByteBuf buffer = buffers[i];
+                    if (buffer != null) {
+                        buffer.release();
+                        buffers[i] = null;
+                    }
+                }
+                throw t;
+            }
+            // Now advanced the tail by the number of buffers that we just added.
+            SHORT_HANDLE.setRelease(ioUringBufRing, tailFieldPosition, (short) (oldTail + num));
+
+            this.num = 0;
+            this.bid = 0;
         }
-        assert numBuffers % 2 == 0;
+
+        @Override
+        public void accept(ByteBuf byteBuf) {
+            if (corrupted || closed) {
+                byteBuf.release();
+                throw new IllegalStateException("Already closed");
+            }
+            if (expectedBuffers == num) {
+                byteBuf.release();
+                throw new IllegalStateException("Produced too many buffers");
+            }
+            short ringIndex = (short) ((oldTail + num) & mask);
+            assert buffers[bid] == null;
+
+            long memoryAddress = IoUring.memoryAddress(byteBuf) + byteBuf.writerIndex();
+            int writable = byteBuf.writableBytes();
+
+            //  see:
+            //  https://github.com/axboe/liburing/
+            //      blob/19134a8fffd406b22595a5813a3e319c19630ac9/src/include/liburing.h#L1561
+            int position = Native.SIZEOF_IOURING_BUF * ringIndex;
+            ioUringBufRing.putLong(position + Native.IOURING_BUFFER_OFFSETOF_ADDR, memoryAddress);
+            ioUringBufRing.putInt(position + Native.IOURING_BUFFER_OFFSETOF_LEN, writable);
+            ioUringBufRing.putShort(position + Native.IOURING_BUFFER_OFFSETOF_BID, bid);
+
+            buffers[bid] = byteBuf;
+
+            bid++;
+            num++;
+        }
     }
 
     /**
-     * Try to expand by adding more buffers to the ring if there is any space left.
-     * This method might be called multiple times before we call {@link #useBuffer(short, int, boolean)} again.
+     * Try to expand by adding more buffers to the ring if there is any space left, this will be done lazy.
      */
     void expand() {
-        if (!expanded) {
-            // Only expand once before we reset expanded in addBuffer() which is called once a buffer was completely
-            // used and moved out of the buffer ring.
-            tryExpand();
-        }
+        needExpand = true;
     }
 
-    private void tryExpand() {
-        // We only expand if the last added BID is the last generated BID. The reason for this is as we want to
-        // ensure we have a sequential ordering of BIDs as this is required for our nextBid(...) to work correctly when
-        // RECVSEND_BUNDLE is used.
-        if (lastAddedBid == lastGeneratedBid) {
-            needsLazyExpansion = false;
-            // TODO: We could also shrink the number of elements again if we find out we not use all of it frequently.
-            int num = Math.min(batchSize, entries - numBuffers);
-            assert num % 2 == 0;
-            for (short i = 0; i < num; i++) {
-                addBuffer(++lastGeneratedBid);
-                numBuffers++;
-            }
-        } else {
-            needsLazyExpansion = true;
+    private void refill(int buffers) {
+        if (corrupted || closed) {
+            return;
         }
+        assert buffers % 2 == 0;
+        assert usableBuffers == 0;
+        ringConsumer.fill(buffers);
+        allocatedBuffers = usableBuffers = buffers;
     }
 
     /**
@@ -115,47 +165,6 @@ final class IoUringBufferRing {
         return exhaustedEvent;
     }
 
-    private void addBuffer(short bid) {
-        if (corrupted || closed) {
-            return;
-        }
-        short oldTail = (short) SHORT_HANDLE.get(ioUringBufRing, tailFieldPosition);
-        short ringIndex = (short) (oldTail & mask);
-        assert buffers[bid] == null;
-        final ByteBuf byteBuf;
-        try {
-            byteBuf = allocator.allocate();
-        } catch (OutOfMemoryError e) {
-            // We did run out of memory, This buffer ring should be considered corrupted.
-            // TODO: In the future we could try to recover it later by trying to refill it after some time and so
-            //       bring it back to a non-corrupted state.
-            corrupted = true;
-            throw e;
-        }
-
-        byteBuf.writerIndex(byteBuf.capacity());
-
-        //  see:
-        //  https://github.com/axboe/liburing/
-        //      blob/19134a8fffd406b22595a5813a3e319c19630ac9/src/include/liburing.h#L1561
-        int position = Native.SIZEOF_IOURING_BUF * ringIndex;
-        ioUringBufRing.putLong(position + Native.IOURING_BUFFER_OFFSETOF_ADDR,
-                IoUring.memoryAddress(byteBuf) + byteBuf.readerIndex());
-        ioUringBufRing.putInt(position + Native.IOURING_BUFFER_OFFSETOF_LEN, byteBuf.readableBytes());
-        ioUringBufRing.putShort(position + Native.IOURING_BUFFER_OFFSETOF_BID, bid);
-
-        buffers[bid] = byteBuf;
-        lastAddedBid = bid;
-        // Now advanced the tail by the number of buffers that we just added.
-        SHORT_HANDLE.setRelease(ioUringBufRing, tailFieldPosition, (short) (oldTail + 1));
-        // We added a buffer to the ring, let's reset the expanded variable so we can expand it if we receive
-        // ENOBUFS.
-        expanded = false;
-        if (needsLazyExpansion) {
-            tryExpand();
-        }
-    }
-
     /**
      * Return the amount of bytes that we attempted to read for the given id.
      * This method must be called before {@link #useBuffer(short, int, boolean)}.
@@ -164,38 +173,51 @@ final class IoUringBufferRing {
      * @return      the attempted bytes.
      */
     int attemptedBytesRead(short bid) {
-        return buffers[bid].readableBytes();
+        return buffers[bid].writableBytes();
     }
 
     /**
      * Use the buffer for the given buffer id. The returned {@link ByteBuf} must be released once not used anymore.
      *
      * @param bid           the id of the buffer
-     * @param readableBytes the number of bytes that could be read. This value might be larger then what a single
+     * @param read          the number of bytes that could be read. This value might be larger then what a single
      *                      {@link ByteBuf} can hold. Because of this, the caller should call
      *                      @link #useBuffer(short, int, boolean)} in a loop (obtaining the next bid to use by calling
      *                      {@link #nextBid(short)}) until all buffers could be obtained.
      * @return              the buffer.
      */
-    ByteBuf useBuffer(short bid, int readableBytes, boolean more) {
-        assert readableBytes > 0;
+    ByteBuf useBuffer(short bid, int read, boolean more) {
+        assert read > 0;
         ByteBuf byteBuf = buffers[bid];
 
-        allocator.lastBytesRead(byteBuf.readableBytes(), readableBytes);
-        if (incremental && more && byteBuf.readableBytes() > readableBytes) {
+        allocator.lastBytesRead(byteBuf.writableBytes(), read);
+        // We always slice so the user will not mess up things later.
+        ByteBuf buffer = byteBuf.retainedSlice(byteBuf.writerIndex(), read);
+        byteBuf.writerIndex(byteBuf.writerIndex() + read);
+
+        if (incremental && more && byteBuf.writableBytes() > read) {
             // The buffer will be used later again, just slice out what we did read so far.
-            return byteBuf.readRetainedSlice(readableBytes);
+            return buffer;
         }
 
         // The buffer is considered to be used, null out the slot.
         buffers[bid] = null;
-        addBuffer(bid);
-        return byteBuf.writerIndex(byteBuf.readerIndex() +
-                Math.min(readableBytes, byteBuf.readableBytes()));
+        byteBuf.release();
+        if (--usableBuffers == 0) {
+            int numBuffers = allocatedBuffers;
+            if (needExpand) {
+                // We did get a signal that our buffer ring did not have enough buffers, let's see if we
+                // can grow it.
+                needExpand = false;
+                numBuffers += Math.min(batchSize, entries - allocatedBuffers);
+            }
+            refill(numBuffers);
+        }
+        return buffer;
     }
 
     short nextBid(short bid) {
-        return (short) ((bid + 1) & numBuffers - 1);
+        return (short) ((bid + 1) & allocatedBuffers - 1);
     }
 
     /**

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingAllocator.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingAllocator.java
@@ -17,10 +17,13 @@ package io.netty.channel.uring;
 
 import io.netty.buffer.ByteBuf;
 
+import java.util.function.Consumer;
+
 /**
  * Allocator that is responsible to allocate buffers for a buffer ring.
  */
 public interface IoUringBufferRingAllocator {
+
     /**
      * Creates a new receive buffer to use by the buffer ring. The returned {@link ByteBuf} must be direct.
      */
@@ -33,4 +36,17 @@ public interface IoUringBufferRingAllocator {
      * @param actual     the number of bytes that could be read.
      */
     void lastBytesRead(int attempted, int actual);
+
+    /**
+     * Fill in {@code num} of {@link ByteBuf}s.
+     * <strong>Important:</strong> The {@link Consumer} MUST not escape this method.
+     *
+     * @param consumer  the {@link Consumer} that will consume the buffers.
+     * @param num       the number of buffers that are passed to {@link Consumer#accept(Object)}.
+     */
+    default void allocateBatch(Consumer<ByteBuf> consumer, int num) {
+        for (int i = 0; i < num; i++) {
+            consumer.accept(allocate());
+        }
+    }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringFixedBufferRingAllocator.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringFixedBufferRingAllocator.java
@@ -15,19 +15,30 @@
  */
 package io.netty.channel.uring;
 
-import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.internal.ObjectUtil;
 
-import java.util.Objects;
 
 /**
  * {@link IoUringBufferRingAllocator} implementation which uses a fixed size for the buffers that are returned by
  * {@link #allocate()}.
  */
-public final class IoUringFixedBufferRingAllocator implements IoUringBufferRingAllocator {
-    private final ByteBufAllocator allocator;
+public final class IoUringFixedBufferRingAllocator extends AbstractIoUringBufferRingAllocator {
     private final int bufferSize;
+
+    /**
+     * Create a new instance
+     *
+     * @param allocator         the {@link ByteBufAllocator} to use.
+     * @param largeAllocation   {@code true} if we should do a large allocation for the whole buffer ring
+     *                          and then slice out the buffers or {@code false} if we should do one allocation
+     *                          per buffer.
+     * @param bufferSize        the size of the buffers that are allocated.
+     */
+    public IoUringFixedBufferRingAllocator(ByteBufAllocator allocator, boolean largeAllocation, int bufferSize) {
+        super(allocator, largeAllocation);
+        this.bufferSize = ObjectUtil.checkPositive(bufferSize, "bufferSize");
+    }
 
     /**
      * Create a new instance
@@ -36,8 +47,7 @@ public final class IoUringFixedBufferRingAllocator implements IoUringBufferRingA
      * @param bufferSize    the size of the buffers that are allocated.
      */
     public IoUringFixedBufferRingAllocator(ByteBufAllocator allocator, int bufferSize) {
-        this.allocator = Objects.requireNonNull(allocator, "allocator");
-        this.bufferSize = ObjectUtil.checkPositive(bufferSize, "bufferSize");
+        this(allocator, false, bufferSize);
     }
 
     /**
@@ -50,12 +60,7 @@ public final class IoUringFixedBufferRingAllocator implements IoUringBufferRingA
     }
 
     @Override
-    public ByteBuf allocate() {
-        return allocator.directBuffer(bufferSize);
-    }
-
-    @Override
-    public void lastBytesRead(int attempted, int actual) {
-        // NOOP.
+    protected int nextBufferSize() {
+        return bufferSize;
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
@@ -141,19 +141,7 @@ public class IoUringBufferRingTest {
         ByteBuf writeBuffer = Unpooled.directBuffer(randomStringLength);
         ByteBufUtil.writeAscii(writeBuffer, randomString);
         ByteBuf userspaceIoUringBufferElement1 = sendAndRecvMessage(clientChannel, writeBuffer, bufferSyncer);
-        if (incremental) {
-            // Need to unwrap as its a slice.
-            assertNotNull(unwrapLeakAware(userspaceIoUringBufferElement1).unwrap());
-        } else {
-            assertNull(unwrapLeakAware(userspaceIoUringBufferElement1).unwrap());
-        }
         ByteBuf userspaceIoUringBufferElement2 = sendAndRecvMessage(clientChannel, writeBuffer, bufferSyncer);
-        if (incremental) {
-            // Need to unwrap as its a slice.
-            assertNotNull(unwrapLeakAware(userspaceIoUringBufferElement2).unwrap());
-        } else {
-            assertNull(unwrapLeakAware(userspaceIoUringBufferElement2).unwrap());
-        }
         ByteBuf readBuffer = sendAndRecvMessage(clientChannel, writeBuffer, bufferSyncer);
         readBuffer.release();
 


### PR DESCRIPTION
bulk

Motivation:

Before we did fill in a new buffer as soon as soon as we used one. This resulted in having buffer allocations spread out and so we could observe multiple TLB misses when the kernel tried to use the buffer ring. To reduce this we should better fill the whole ring at once and so allow the user to do a large allocation for the whole ring and then slice out the buffers as need while also still allow to do one allocation per buffer.

Modifications:

- Introduce IoUringBufferRingAllocator.allocateBulk(...) and use it from the IoUringBufferRing
- Add abstract base class for IoUringBufferRingAllocator and extend it from our existing allocators. These now support large allocations or normal allocations

Result:

Better performance and much more flexibility