### PR TITLE
Fix QUIC linking in HTTP3

### DIFF
--- a/codec-http3/pom.xml
+++ b/codec-http3/pom.xml
@@ -131,7 +131,6 @@
       <version>${project.version}</version>
       <classifier>${netty.quic.classifier}</classifier>
       <scope>runtime</scope>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Motivation:
When downstream projects depend only on the codec-http3 module, and don't have direct dependencies on a native QUIC module, we should still load a variant of QUIC that works on the platform where their build runs.

Modification:
Make the QUIC dependency with a customer-build-time computed classifier a non-optional dependency.

Result:
Downstream projects that depend on the codec-http3 module will now also transitively depend on a native QUIC that works for their build.

This fixes https://github.com/netty/netty/issues/15306