### PR TITLE
Improve check in PoolThreadCache.cache method

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
@@ -287,7 +287,7 @@ final class PoolThreadCache {
     }
 
     private static <T> MemoryRegionCache<T> cache(MemoryRegionCache<T>[] cache, int sizeIdx) {
-        if (cache == null || sizeIdx > cache.length - 1) {
+        if (cache == null || sizeIdx >= cache.length) {
             return null;
         }
         return cache[sizeIdx];


### PR DESCRIPTION
Motivation:

Avoid unnecessary subtraction operation.

Modification:

Replaced `> `operator with `>=` to avoid subtract operation.

Result:

-1 one operation in condition, easier to read.


