### PR TITLE
Add integration test showing how to use pkitesting to test TLS

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/PkiTestingTlsTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/PkiTestingTlsTest.java
@@ -22,100 +22,158 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
-import io.netty.channel.nio.NioIoHandler;
-import io.netty.channel.socket.ServerSocketChannel;
-import io.netty.channel.socket.nio.NioServerSocketChannel;
-import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.channel.local.LocalAddress;
+import io.netty.channel.local.LocalChannel;
+import io.netty.channel.local.LocalIoHandler;
+import io.netty.channel.local.LocalServerChannel;
 import io.netty.pkitesting.CertificateBuilder;
 import io.netty.pkitesting.X509Bundle;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.PlatformDependent;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.net.ssl.SNIHostName;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SNIHostName;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class PkiTestingTlsTest {
-    static List<Arguments> algorithms() {
-        List<Arguments> args = new ArrayList<>();
-        for (boolean openssl : new  boolean[]{true, false}) {
-            if (openssl) {
-                if (!OpenSsl.isAvailable() || !OpenSsl.isTlsv13Supported()) {
-                    continue;
-                }
-            } else {
-                if (!SslProvider.isTlsv13Supported(SslProvider.JDK)) {
-                    continue;
-                }
-            }
 
+    static List<Arguments> classicalAlgorithms() {
+        List<SslProvider> providers = new ArrayList<>();
+        if (SslProvider.isTlsv13Supported(SslProvider.JDK)) {
+            providers.add(SslProvider.JDK);
+        }
+        if (OpenSsl.isAvailable() && OpenSsl.supportsKeyManagerFactory()) {
+            providers.add(SslProvider.OPENSSL);
+        }
+
+        List<Arguments> args = new ArrayList<>();
+        for (SslProvider provider : providers) {
             List<CertificateBuilder.Algorithm> algs =  new ArrayList<>();
             algs.add(CertificateBuilder.Algorithm.rsa2048);
             algs.add(CertificateBuilder.Algorithm.ecp256);
+
             if (PlatformDependent.javaVersion() >= 15) {
                 algs.add(CertificateBuilder.Algorithm.ed25519);
             }
-            if (PlatformDependent.javaVersion() >= 24 && openssl && OpenSsl.versionString().startsWith("BoringSSL")) {
-                algs.add(CertificateBuilder.Algorithm.mlDsa44);
-                //algs.add(CertificateBuilder.Algorithm.mlKem512); needs a cert chain
-            }
 
             for (CertificateBuilder.Algorithm alg : algs) {
-                args.add(Arguments.of(openssl, alg));
+                args.add(Arguments.of(provider, alg));
             }
         }
         return args;
     }
 
+    /**
+     * A TLS connection with just classical algorithms.
+     */
     @ParameterizedTest
-    @MethodSource("algorithms")
-    public void test(boolean openssl, CertificateBuilder.Algorithm algorithm) throws Exception {
-        MultiThreadIoEventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
-        try {
-            X509Bundle cert = new CertificateBuilder()
-                    .algorithm(algorithm)
-                    .setIsCertificateAuthority(true)
-                    .subject("CN=localhost")
-                    .buildSelfSigned();
-            ServerSocketChannel ssc = (ServerSocketChannel) new ServerBootstrap()
-                    .channel(NioServerSocketChannel.class)
-                    .childHandler(new ChannelInitializer<Channel>() {
-                        final SslContext context = SslContextBuilder.forServer(cert.getKeyPair().getPrivate(), cert.getCertificatePath())
-                                .sslProvider(openssl ? SslProvider.OPENSSL : SslProvider.JDK)
-                                .build();
+    @MethodSource("classicalAlgorithms")
+    public void connectWithClassicalAlgorithms(SslProvider provider, CertificateBuilder.Algorithm algorithm)
+            throws Exception {
+        X509Bundle cert = new CertificateBuilder()
+                .algorithm(algorithm)
+                .setIsCertificateAuthority(true)
+                .subject("CN=localhost")
+                .buildSelfSigned();
 
+        final SslContext serverContext = SslContextBuilder.forServer(cert.toKeyManagerFactory())
+                .sslProvider(provider)
+                .build();
+
+        final SslContext clientContext = SslContextBuilder.forClient()
+                .trustManager(cert.toTrustManagerFactory())
+                .sslProvider(provider)
+                .serverName(new SNIHostName("localhost"))
+                .protocols("TLSv1.3")
+                .build();
+
+        testTlsConnection(serverContext, clientContext);
+    }
+
+    /**
+     * A TLS connection using the X25519MLKEM768 hybrid classical-and-quantum-safe key exchange.
+     * This protects the ephemeral TLS session key from harvest-now-decrypt-later attacks.
+     * <p>
+     * The ephemeral session key is used for the symmetric encryption algorithm.
+     * To make that quantum safe, we just need to double the bit-width, from AES-128 to AES-256.
+     */
+    @EnabledForJreRange(min = JRE.JAVA_24)
+    @Test
+    void connectWithX25519MLKEM768() throws Exception {
+        assumeTrue(OpenSsl.isBoringSSL());
+        X509Bundle cert = new CertificateBuilder()
+                .algorithm(CertificateBuilder.Algorithm.ecp256)
+                .setIsCertificateAuthority(true)
+                .subject("CN=localhost")
+                .buildSelfSigned();
+
+        // Disable 128-bit ciphers so only 256-bit ciphers remain.
+        String[] ciphers = {"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+                            "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+                            "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+                            "TLS_RSA_WITH_AES_256_CBC_SHA",
+                            "TLS_AES_256_GCM_SHA384",
+                            "TLS_CHACHA20_POLY1305_SHA256"};
+
+        final SslContext serverContext = SslContextBuilder.forServer(cert.toKeyManagerFactory())
+                .sslProvider(SslProvider.OPENSSL)
+                .option(OpenSslContextOption.GROUPS, new String[]{"X25519MLKEM768"})
+                .protocols("TLSv1.3")
+                .ciphers(Arrays.asList(ciphers))
+                .build();
+
+        final SslContext clientContext = SslContextBuilder.forClient()
+                .trustManager(cert.toTrustManagerFactory())
+                .sslProvider(SslProvider.OPENSSL)
+                .option(OpenSslContextOption.GROUPS, new String[]{"X25519MLKEM768"})
+                .serverName(new SNIHostName("localhost"))
+                .protocols("TLSv1.3")
+                .ciphers(Arrays.asList(ciphers))
+                .build();
+
+        testTlsConnection(serverContext, clientContext);
+    }
+
+    private void testTlsConnection(SslContext serverContext, SslContext clientContext) throws InterruptedException {
+        MultiThreadIoEventLoopGroup group = new MultiThreadIoEventLoopGroup(1, LocalIoHandler.newFactory());
+        LocalAddress serverAddress = new LocalAddress(getClass());
+
+        try {
+            new ServerBootstrap()
+                    .channel(LocalServerChannel.class)
+                    .childHandler(new ChannelInitializer<Channel>() {
                         @Override
                         protected void initChannel(Channel ch) throws Exception {
-                            ch.pipeline()
-                                    .addLast(context.newHandler(ch.alloc()));
+                            ch.pipeline().addLast(serverContext.newHandler(ch.alloc()));
                         }
                     })
                     .group(group)
-                    .bind(8443).sync().channel();
+                    .bind(serverAddress).sync().channel();
 
             Promise<SslHandshakeCompletionEvent> promise = group.next().newPromise();
 
             new Bootstrap()
-                    .channel(NioSocketChannel.class)
+                    .channel(LocalChannel.class)
                     .group(group)
                     .handler(new ChannelInitializer<Channel>() {
-                        final SslContext context = SslContextBuilder.forClient()
-                                .trustManager(cert.toTrustManagerFactory())
-                                .sslProvider(openssl ? SslProvider.OPENSSL : SslProvider.JDK)
-                                .serverName(new SNIHostName("localhost"))
-                                .protocols("TLSv1.3")
-                                .build();
-
                         @Override
                         protected void initChannel(Channel ch) throws Exception {
                             ch.pipeline()
-                                    .addLast(context.newHandler(ch.alloc()))
+                                    .addLast(clientContext.newHandler(ch.alloc(), "localhost", 0))
                                     .addLast(new ChannelInboundHandlerAdapter() {
                                         @Override
-                                        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                                        public void userEventTriggered(ChannelHandlerContext ctx, Object evt)
+                                                throws Exception {
                                             if (evt instanceof SslHandshakeCompletionEvent) {
                                                 SslHandshakeCompletionEvent shce = (SslHandshakeCompletionEvent) evt;
                                                 if (shce.isSuccess()) {
@@ -129,7 +187,8 @@ public class PkiTestingTlsTest {
                                         }
 
                                         @Override
-                                        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                                        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause)
+                                                throws Exception {
                                             if (!promise.tryFailure(cause)) {
                                                 ctx.fireExceptionCaught(cause);
                                             }
@@ -137,11 +196,12 @@ public class PkiTestingTlsTest {
                                     });
                         }
                     })
-                    .connect("localhost", ssc.localAddress().getPort()).sync();
+                    .connect(serverAddress).sync();
 
             promise.sync();
         } finally {
-            group.shutdownGracefully().syncUninterruptibly();
+            group.shutdownGracefully(10, 1000, TimeUnit.MILLISECONDS)
+                    .syncUninterruptibly();
         }
     }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/PkiTestingTlsTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/PkiTestingTlsTest.java
@@ -55,12 +55,12 @@ public class PkiTestingTlsTest {
             List<CertificateBuilder.Algorithm> algs =  new ArrayList<>();
             algs.add(CertificateBuilder.Algorithm.rsa2048);
             algs.add(CertificateBuilder.Algorithm.ecp256);
-            if (PlatformDependent.javaVersion() >= 24) {
+            if (PlatformDependent.javaVersion() >= 15) {
                 algs.add(CertificateBuilder.Algorithm.ed25519);
             }
-            if (openssl && OpenSsl.versionString().startsWith("BoringSSL")) {
+            if (PlatformDependent.javaVersion() >= 24 && openssl && OpenSsl.versionString().startsWith("BoringSSL")) {
                 algs.add(CertificateBuilder.Algorithm.mlDsa44);
-                algs.add(CertificateBuilder.Algorithm.mlKem512);
+                //algs.add(CertificateBuilder.Algorithm.mlKem512); needs a cert chain
             }
 
             for (CertificateBuilder.Algorithm alg : algs) {

--- a/handler/src/test/java/io/netty/handler/ssl/PkiTestingTlsTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/PkiTestingTlsTest.java
@@ -29,7 +29,6 @@ import io.netty.channel.local.LocalServerChannel;
 import io.netty.pkitesting.CertificateBuilder;
 import io.netty.pkitesting.X509Bundle;
 import io.netty.util.concurrent.Promise;
-import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
@@ -61,10 +60,6 @@ public class PkiTestingTlsTest {
             List<CertificateBuilder.Algorithm> algs =  new ArrayList<>();
             algs.add(CertificateBuilder.Algorithm.rsa2048);
             algs.add(CertificateBuilder.Algorithm.ecp256);
-
-            if (PlatformDependent.javaVersion() >= 15) {
-                algs.add(CertificateBuilder.Algorithm.ed25519);
-            }
 
             for (CertificateBuilder.Algorithm alg : algs) {
                 args.add(Arguments.of(provider, alg));

--- a/handler/src/test/java/io/netty/handler/ssl/PkiTestingTlsTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/PkiTestingTlsTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
+import io.netty.channel.socket.ServerSocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.pkitesting.CertificateBuilder;
+import io.netty.pkitesting.X509Bundle;
+import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.PlatformDependent;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.net.ssl.SNIHostName;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PkiTestingTlsTest {
+    static List<Arguments> algorithms() {
+        List<Arguments> args = new ArrayList<>();
+        for (boolean openssl : new  boolean[]{true, false}) {
+            if (openssl) {
+                if (!OpenSsl.isAvailable() || !OpenSsl.isTlsv13Supported()) {
+                    continue;
+                }
+            } else {
+                if (!SslProvider.isTlsv13Supported(SslProvider.JDK)) {
+                    continue;
+                }
+            }
+
+            List<CertificateBuilder.Algorithm> algs =  new ArrayList<>();
+            algs.add(CertificateBuilder.Algorithm.rsa2048);
+            algs.add(CertificateBuilder.Algorithm.ecp256);
+            if (PlatformDependent.javaVersion() >= 24) {
+                algs.add(CertificateBuilder.Algorithm.ed25519);
+            }
+            if (openssl && OpenSsl.versionString().startsWith("BoringSSL")) {
+                algs.add(CertificateBuilder.Algorithm.mlDsa44);
+                algs.add(CertificateBuilder.Algorithm.mlKem512);
+            }
+
+            for (CertificateBuilder.Algorithm alg : algs) {
+                args.add(Arguments.of(openssl, alg));
+            }
+        }
+        return args;
+    }
+
+    @ParameterizedTest
+    @MethodSource("algorithms")
+    public void test(boolean openssl, CertificateBuilder.Algorithm algorithm) throws Exception {
+        MultiThreadIoEventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        try {
+            X509Bundle cert = new CertificateBuilder()
+                    .algorithm(algorithm)
+                    .setIsCertificateAuthority(true)
+                    .subject("CN=localhost")
+                    .buildSelfSigned();
+            ServerSocketChannel ssc = (ServerSocketChannel) new ServerBootstrap()
+                    .channel(NioServerSocketChannel.class)
+                    .childHandler(new ChannelInitializer<Channel>() {
+                        final SslContext context = SslContextBuilder.forServer(cert.getKeyPair().getPrivate(), cert.getCertificatePath())
+                                .sslProvider(openssl ? SslProvider.OPENSSL : SslProvider.JDK)
+                                .build();
+
+                        @Override
+                        protected void initChannel(Channel ch) throws Exception {
+                            ch.pipeline()
+                                    .addLast(context.newHandler(ch.alloc()));
+                        }
+                    })
+                    .group(group)
+                    .bind(8443).sync().channel();
+
+            Promise<SslHandshakeCompletionEvent> promise = group.next().newPromise();
+
+            new Bootstrap()
+                    .channel(NioSocketChannel.class)
+                    .group(group)
+                    .handler(new ChannelInitializer<Channel>() {
+                        final SslContext context = SslContextBuilder.forClient()
+                                .trustManager(cert.toTrustManagerFactory())
+                                .sslProvider(openssl ? SslProvider.OPENSSL : SslProvider.JDK)
+                                .serverName(new SNIHostName("localhost"))
+                                .protocols("TLSv1.3")
+                                .build();
+
+                        @Override
+                        protected void initChannel(Channel ch) throws Exception {
+                            ch.pipeline()
+                                    .addLast(context.newHandler(ch.alloc()))
+                                    .addLast(new ChannelInboundHandlerAdapter() {
+                                        @Override
+                                        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                                            if (evt instanceof SslHandshakeCompletionEvent) {
+                                                SslHandshakeCompletionEvent shce = (SslHandshakeCompletionEvent) evt;
+                                                if (shce.isSuccess()) {
+                                                    promise.setSuccess(shce);
+                                                } else {
+                                                    promise.setFailure(shce.cause());
+                                                }
+                                                return;
+                                            }
+                                            super.userEventTriggered(ctx, evt);
+                                        }
+
+                                        @Override
+                                        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                                            if (!promise.tryFailure(cause)) {
+                                                ctx.fireExceptionCaught(cause);
+                                            }
+                                        }
+                                    });
+                        }
+                    })
+                    .connect("localhost", ssc.localAddress().getPort()).sync();
+
+            promise.sync();
+        } finally {
+            group.shutdownGracefully().syncUninterruptibly();
+        }
+    }
+}


### PR DESCRIPTION
This PR adds an integration test for the various algorithms supported by the PKI testing module.

The test covers the classical RSA and elliptic curve algorithms.

The test also includes an example of how to use the X25519MLKEM768 hybrid key exchange.