### PR TITLE
IoUring: Allow to configure what allocation strategy the buffer ring

### DIFF
--- a/testsuite-native-image/src/main/java/io/netty/testsuite/svm/HttpNativeServer.java
+++ b/testsuite-native-image/src/main/java/io/netty/testsuite/svm/HttpNativeServer.java
@@ -124,7 +124,7 @@ public final class HttpNativeServer {
                                 .bufferGroupId((short) 0)
                                 .bufferRingSize((short) 16)
                                 .batchSize(16)
-                                .allocator(new IoUringFixedBufferRingAllocator(1024))
+                                .allocator(new IoUringFixedBufferRingAllocator(1024), false)
                                 .build()
                 );
             }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
@@ -36,6 +36,7 @@ final class IoUringBufferRing {
     private final int ringFd;
     private final ByteBuf[] buffers;
     private final IoUringBufferRingAllocator allocator;
+    private final boolean batchAllocation;
     private final IoUringBufferRingExhaustedEvent exhaustedEvent;
     private final RingConsumer ringConsumer;
     private final boolean incremental;
@@ -45,10 +46,11 @@ final class IoUringBufferRing {
     private int usableBuffers;
     private int allocatedBuffers;
     private boolean needExpand;
+    private short lastGeneratedBid;
 
     IoUringBufferRing(int ringFd, ByteBuffer ioUringBufRing,
                       short entries, int batchSize, short bufferGroupId, boolean incremental,
-                      IoUringBufferRingAllocator allocator) {
+                      IoUringBufferRingAllocator allocator, boolean batchAllocation) {
         assert entries % 2 == 0;
         assert batchSize % 2 == 0;
         this.batchSize = batchSize;
@@ -61,6 +63,7 @@ final class IoUringBufferRing {
         this.buffers = new ByteBuf[entries];
         this.incremental = incremental;
         this.allocator = allocator;
+        this.batchAllocation = batchAllocation;
         this.ringConsumer  = new RingConsumer();
         this.exhaustedEvent = new IoUringBufferRingExhaustedEvent(bufferGroupId);
     }
@@ -71,7 +74,8 @@ final class IoUringBufferRing {
 
     void initialize() {
         // We already validated that batchSize is <= ring length.
-        refill(batchSize);
+        fill((short) 0, batchSize);
+        allocatedBuffers = batchSize;
     }
 
     private final class RingConsumer implements Consumer<ByteBuf> {
@@ -80,17 +84,23 @@ final class IoUringBufferRing {
         private short bid;
         private short oldTail;
 
-        void fill(int numBuffers) {
+        short fill(short startBid, int numBuffers) {
             // Fetch the tail once before allocate the batch.
             oldTail = (short) SHORT_HANDLE.get(ioUringBufRing, tailFieldPosition);
 
             // At the moment we always start with bid 0 and so num and bid is the same. As this is more of an
             // implementation detail it is better to still keep both separated.
             this.num = 0;
-            this.bid = 0;
+            this.bid = startBid;
             this.expectedBuffers = numBuffers;
             try {
-                allocator.allocateBatch(this, numBuffers);
+                if (batchAllocation) {
+                    allocator.allocateBatch(this, numBuffers);
+                } else {
+                    for (int i = 0; i < numBuffers; i++) {
+                        add(oldTail, bid++, num++, allocator.allocate());
+                    }
+                }
             } catch (Throwable t) {
                 corrupted = true;
                 for (int i = 0; i < buffers.length; i++) {
@@ -105,8 +115,14 @@ final class IoUringBufferRing {
             // Now advanced the tail by the number of buffers that we just added.
             SHORT_HANDLE.setRelease(ioUringBufRing, tailFieldPosition, (short) (oldTail + num));
 
-            this.num = 0;
-            this.bid = 0;
+            return (short) (bid - 1);
+        }
+
+        void fill(short bid) {
+            short tail = (short) SHORT_HANDLE.get(ioUringBufRing, tailFieldPosition);
+            add(tail, bid, 0, allocator.allocate());
+            // Now advanced the tail by one
+            SHORT_HANDLE.setRelease(ioUringBufRing, tailFieldPosition, (short) (tail + 1));
         }
 
         @Override
@@ -119,7 +135,11 @@ final class IoUringBufferRing {
                 byteBuf.release();
                 throw new IllegalStateException("Produced too many buffers");
             }
-            short ringIndex = (short) ((oldTail + num) & mask);
+            add(oldTail, bid++, num++, byteBuf);
+        }
+
+        private void add(int tail, short bid, int offset, ByteBuf byteBuf) {
+            short ringIndex = (short) ((tail + offset) & mask);
             assert buffers[bid] == null;
 
             long memoryAddress = IoUring.memoryAddress(byteBuf) + byteBuf.writerIndex();
@@ -134,9 +154,6 @@ final class IoUringBufferRing {
             ioUringBufRing.putShort(position + Native.IOURING_BUFFER_OFFSETOF_BID, bid);
 
             buffers[bid] = byteBuf;
-
-            bid++;
-            num++;
         }
     }
 
@@ -147,14 +164,21 @@ final class IoUringBufferRing {
         needExpand = true;
     }
 
-    private void refill(int buffers) {
+    private void fill(short startBid, int buffers) {
         if (corrupted || closed) {
             return;
         }
         assert buffers % 2 == 0;
-        assert usableBuffers == 0;
-        ringConsumer.fill(buffers);
-        allocatedBuffers = usableBuffers = buffers;
+        lastGeneratedBid = ringConsumer.fill(startBid, buffers);
+        usableBuffers += buffers;
+    }
+
+    private void fill(short bid) {
+        if (corrupted || closed) {
+            return;
+        }
+        ringConsumer.fill(bid);
+        usableBuffers++;
     }
 
     /**
@@ -174,6 +198,10 @@ final class IoUringBufferRing {
      */
     int attemptedBytesRead(short bid) {
         return buffers[bid].writableBytes();
+    }
+
+    private int calculateNextBufferBatch() {
+        return Math.min(batchSize, entries - allocatedBuffers);
     }
 
     /**
@@ -209,9 +237,26 @@ final class IoUringBufferRing {
                 // We did get a signal that our buffer ring did not have enough buffers, let's see if we
                 // can grow it.
                 needExpand = false;
-                numBuffers += Math.min(batchSize, entries - allocatedBuffers);
+                numBuffers += calculateNextBufferBatch();
             }
-            refill(numBuffers);
+            fill((short) 0, numBuffers);
+            allocatedBuffers = numBuffers;
+            assert allocatedBuffers % 2 == 0;
+        } else if (!batchAllocation) {
+            // If we don'T do bulk allocations to refill the buffer ring we need to fill in the just used bid again
+            // if we didn't get a signal that we need expansion.
+            fill(bid);
+
+            if (needExpand && lastGeneratedBid == bid) {
+                // We did get a signal that our buffer ring did not have enough buffers and we just did add the last
+                // generated bid at the tail of the ring. Now its safe to grow the buffer ring and still guarantee
+                // sequential ordering which is needed for our RECVSEND_BUNDLE implementation.
+                needExpand = false;
+                int numBuffers = calculateNextBufferBatch();
+                fill((short) (bid + 1), numBuffers);
+                allocatedBuffers += numBuffers;
+                assert allocatedBuffers % 2 == 0;
+            }
         }
         return buffer;
     }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingConfig.java
@@ -15,6 +15,7 @@
  */
 package io.netty.channel.uring;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.util.internal.MathUtil;
 import io.netty.util.internal.ObjectUtil;
 
@@ -31,6 +32,7 @@ public final class IoUringBufferRingConfig {
     private final int maxUnreleasedBuffers;
     private final boolean incremental;
     private final IoUringBufferRingAllocator allocator;
+    private final boolean batchAllocation;
 
     /**
      * Create a new configuration.
@@ -65,6 +67,11 @@ public final class IoUringBufferRingConfig {
     @Deprecated
     public IoUringBufferRingConfig(short bgId, short bufferRingSize, int batchSize, int maxUnreleasedBuffers,
                                    boolean incremental, IoUringBufferRingAllocator allocator) {
+        this(bgId, bufferRingSize, batchSize, maxUnreleasedBuffers, incremental, allocator, false);
+    }
+
+    private IoUringBufferRingConfig(short bgId, short bufferRingSize, int batchSize, int maxUnreleasedBuffers,
+                                   boolean incremental, IoUringBufferRingAllocator allocator, boolean batchAllocation) {
         this.bgId = (short) ObjectUtil.checkPositiveOrZero(bgId, "bgId");
         this.bufferRingSize = checkBufferRingSize(bufferRingSize);
         this.batchSize = MathUtil.findNextPositivePowerOfTwo(
@@ -76,6 +83,7 @@ public final class IoUringBufferRingConfig {
         }
         this.incremental = incremental;
         this.allocator = ObjectUtil.checkNotNull(allocator, "allocator");
+        this.batchAllocation = batchAllocation;
     }
 
     /**
@@ -127,6 +135,15 @@ public final class IoUringBufferRingConfig {
     }
 
     /**
+     * Returns {@code true} if the ring should always be filled via a batch allocation or
+     * {@code false} if we will try to allocate a new {@link ByteBuf} as we used a buffer from the ring.
+     * @return {@code true} if the ring should always be filled via a batch allocation.
+     */
+    public boolean isBatchAllocation() {
+        return batchAllocation;
+    }
+
+    /**
      * Returns true if <a href="https://github.com/axboe/liburing/wiki/
      * What's-new-with-io_uring-in-6.11-and-6.12#incremental-provided-buffer-consumption">incremental mode</a>
      * should be used for the buffer ring.
@@ -173,6 +190,7 @@ public final class IoUringBufferRingConfig {
         private int batchSize = -1;
         private boolean incremental = IoUring.isRegisterBufferRingIncSupported();
         private IoUringBufferRingAllocator allocator;
+        private boolean batchAllocation;
 
         /**
          * Set the buffer group id to use.
@@ -210,11 +228,15 @@ public final class IoUringBufferRingConfig {
         /**
          * Set the {@link IoUringBufferRingAllocator} to use to allocate {@link io.netty.buffer.ByteBuf}s.
          *
-         * @param allocator The allocator.
-         * @return          This builder.
+         * @param allocator         The allocator.
+         * @param batchAllocation   {@code true} if the ring should always be filled via a batch allocation or
+         *                          {@code false} if we will try to allocate a new {@link ByteBuf} as soon as
+         *                          as we used a buffer from the ring.
+         * @return                  This builder.
          */
-        public Builder allocator(IoUringBufferRingAllocator allocator) {
+        public Builder allocator(IoUringBufferRingAllocator allocator, boolean batchAllocation) {
             this.allocator = allocator;
+            this.batchAllocation = batchAllocation;
             return this;
         }
 
@@ -238,7 +260,7 @@ public final class IoUringBufferRingConfig {
          */
         public IoUringBufferRingConfig build() {
             return new IoUringBufferRingConfig(
-                    bgId, bufferRingSize, batchSize, Integer.MAX_VALUE, incremental, allocator);
+                    bgId, bufferRingSize, batchSize, Integer.MAX_VALUE, incremental, allocator, batchAllocation);
         }
     }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -217,7 +217,8 @@ public final class IoUringIoHandler implements IoHandler {
         return new IoUringBufferRing(ringFd,
                 Buffer.wrapMemoryAddressWithNativeOrder(ioUringBufRingAddr, Native.ioUringBufRingSize(bufferRingSize)),
                 bufferRingSize, bufferRingConfig.batchSize(),
-                bufferGroupId, bufferRingConfig.isIncremental(), bufferRingConfig.allocator()
+                bufferGroupId, bufferRingConfig.isIncremental(), bufferRingConfig.allocator(),
+                bufferRingConfig.isBatchAllocation()
         );
     }
 

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
@@ -97,7 +97,7 @@ public class IoUringBufferRingTest {
                         .bufferGroupId((short) 1)
                         .bufferRingSize((short) 2)
                         .batchSize(2).incremental(incremental)
-                        .allocator(new IoUringFixedBufferRingAllocator(1024))
+                        .allocator(new IoUringFixedBufferRingAllocator(1024), false)
                         .build();
 
         IoUringBufferRingConfig bufferRingConfig1 =
@@ -106,7 +106,7 @@ public class IoUringBufferRingTest {
                         .bufferRingSize((short) 16)
                         .batchSize(8)
                         .incremental(incremental)
-                        .allocator(new IoUringFixedBufferRingAllocator(1024))
+                        .allocator(new IoUringFixedBufferRingAllocator(1024), true)
                         .build();
         ioUringIoHandlerConfiguration.setBufferRingConfig(bufferRingConfig, bufferRingConfig1);
 

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketTestPermutation.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketTestPermutation.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class IoUringSocketTestPermutation extends SocketTestPermutation {
 
@@ -55,7 +56,9 @@ public class IoUringSocketTestPermutation extends SocketTestPermutation {
                             .bufferRingSize((short) 16)
                             .batchSize(8)
                             .incremental(incremental)
-                            .allocator(new IoUringFixedBufferRingAllocator(1024))
+                            .allocator(new IoUringFixedBufferRingAllocator(1024),
+                                    // Ensure we test both variants
+                                    ThreadLocalRandom.current().nextBoolean())
                             .build()
             );
         }


### PR DESCRIPTION
uses

Motivation:

We recently changed the buffer ring to use batch allocations for the buffer ring as this might reduce TLB misses. That said it also comes with some downside and so produce more memory usage. We should let the user decide which strategy these want to use.

Modifications:

- Change IoUringBufferRingConfig.Builder to allow to specify if we should use batch allocations or not
- Adjust implementation to support both
- Adjust testsuite to test both strategies.

Result:

More flexible buffer ring configuration