### PR TITLE
IoUring: Only fire IoUringBufferRingExhaustedEvent if we could not

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -433,7 +433,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                     if (res == Native.ERRNO_NOBUFS_NEGATIVE) {
                         // try to expand the buffer ring by adding more buffers to it if there is any space left.
                         if (!bufferRing.expand()) {
-                            // Why couldn't expand the ring anymore so notify the user that we did run out of buffers
+                            // We couldn't expand the ring anymore so notify the user that we did run out of buffers
                             // without the ability to expand it.
                             // If this happens to often the user should most likely increase the buffer ring size.
                             pipeline.fireUserEventTriggered(bufferRing.getExhaustedEvent());

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
@@ -159,9 +159,12 @@ final class IoUringBufferRing {
 
     /**
      * Try to expand by adding more buffers to the ring if there is any space left, this will be done lazy.
+     *
+     * @return {@code true} if we can expand the number of buffers in the ring, {@code false} otherwise.
      */
-    void expand() {
+    boolean expand() {
         needExpand = true;
+        return allocatedBuffers < buffers.length;
     }
 
     private void fill(short startBid, int buffers) {


### PR DESCRIPTION
expand the ring

Motivation:

When we use a buffer ring we usually increase its size up to a maximum in batches. Because of this it can happen that we see an ENOBUF but still can increase the number of buffers in the ring, which means we did not hit the hard limit yet. If this happens we should better NOT fire an IoUringBufferRingExhaustedEvent as in reality its not exhausted yet but just not completely filled to the max.

Modifications:

Only fire IoUringBufferRingExhaustedEvent if we real hit the limit of the number of buffers that we can put in the ring.

Result:

Less confusing event propagation