### PR TITLE
IoUring: Explicit set CQSIZE by default and use a much saner default …

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
@@ -49,6 +49,9 @@ public final class IoUring {
     private static final boolean IORING_RECVSEND_BUNDLE_ENABLED;
     private static final boolean IORING_POLL_ADD_MULTISHOT_ENABLED;
     static final int NUM_ELEMENTS_IOVEC;
+    static final int DEFAULT_RING_SIZE;
+    static final int DEFAULT_CQ_SIZE;
+    static final int DISABLE_SETUP_CQ_SIZE = -1;
 
     private static final InternalLogger logger;
 
@@ -188,6 +191,15 @@ public final class IoUring {
         IORING_POLL_ADD_MULTISHOT_ENABLED = IORING_POLL_ADD_MULTISHOT_SUPPORTED && SystemPropertyUtil.getBoolean(
                "io.netty.iouring.pollAddMultishotEnabled", true);
         NUM_ELEMENTS_IOVEC = numElementsIoVec;
+
+        DEFAULT_RING_SIZE =  Math.max(64, SystemPropertyUtil.getInt("io.netty.iouring.ringSize", 128));
+
+        if (IORING_SETUP_CQ_SIZE_SUPPORTED) {
+            DEFAULT_CQ_SIZE = Math.max(DEFAULT_RING_SIZE,
+                    SystemPropertyUtil.getInt("io.netty.iouring.cqSize", 4096));
+        } else {
+            DEFAULT_CQ_SIZE = DISABLE_SETUP_CQ_SIZE;
+        }
     }
 
     public static boolean isAvailable() {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
@@ -192,7 +192,7 @@ public final class IoUring {
                "io.netty.iouring.pollAddMultishotEnabled", true);
         NUM_ELEMENTS_IOVEC = numElementsIoVec;
 
-        DEFAULT_RING_SIZE =  Math.max(64, SystemPropertyUtil.getInt("io.netty.iouring.ringSize", 128));
+        DEFAULT_RING_SIZE =  Math.max(16, SystemPropertyUtil.getInt("io.netty.iouring.ringSize", 128));
 
         if (IORING_SETUP_CQ_SIZE_SUPPORTED) {
             DEFAULT_CQ_SIZE = Math.max(DEFAULT_RING_SIZE,

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandlerConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandlerConfig.java
@@ -97,10 +97,9 @@ import java.util.Set;
  */
 
 public final class IoUringIoHandlerConfig {
-    private static final int DISABLE_SETUP_CQ_SIZE = -1;
 
-    private int ringSize = Native.DEFAULT_RING_SIZE;
-    private int cqSize = DISABLE_SETUP_CQ_SIZE;
+    private int ringSize = IoUring.DEFAULT_RING_SIZE;
+    private int cqSize = IoUring.DEFAULT_CQ_SIZE;
 
     private int maxBoundedWorker;
 
@@ -227,7 +226,7 @@ public final class IoUringIoHandlerConfig {
     }
 
     boolean needSetupCqeSize() {
-        return cqSize != DISABLE_SETUP_CQ_SIZE;
+        return cqSize != IoUring.DISABLE_SETUP_CQ_SIZE;
     }
 
     Set<IoUringBufferRingConfig> getInternBufferRingConfigs() {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -38,7 +38,6 @@ import java.util.Locale;
 
 final class Native {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(Native.class);
-    static final int DEFAULT_RING_SIZE = Math.max(64, SystemPropertyUtil.getInt("io.netty.iouring.ringSize", 4096));
 
     static {
         Selector selector = null;


### PR DESCRIPTION
…value for the submission ring

Motivation:

As default we used a size of 4096 for the submission ring which these days does not make a lot of sense anymore as you can size the submission queue and completion queue seperately. Generally speaking usually you see much more completions compared to submissions, especially as we enable multishot by default these days. Beside this you should also not batch too much in general before submission as this will affect latency. Because of this we should use a more sane default value for the submission queue which will also ensure we submit fast enough while still get some batching to reduce syscalls. Also we need to size the completion queue big enough to be able to receive enough completioms per batch.

Modifications:

- Change the default submission queue size to 128
- Change the default completion queue size to 4096

Result:

Better defaults
