### PR TITLE
IoUring: Move batchAllocation setting to an extra method

### DIFF
--- a/testsuite-native-image/src/main/java/io/netty/testsuite/svm/HttpNativeServer.java
+++ b/testsuite-native-image/src/main/java/io/netty/testsuite/svm/HttpNativeServer.java
@@ -124,7 +124,8 @@ public final class HttpNativeServer {
                                 .bufferGroupId((short) 0)
                                 .bufferRingSize((short) 16)
                                 .batchSize(16)
-                                .allocator(new IoUringFixedBufferRingAllocator(1024), false)
+                                .allocator(new IoUringFixedBufferRingAllocator(1024))
+                                .batchAllocation(false)
                                 .build()
                 );
             }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRingConfig.java
@@ -226,16 +226,24 @@ public final class IoUringBufferRingConfig {
         }
 
         /**
-         * Set the {@link IoUringBufferRingAllocator} to use to allocate {@link io.netty.buffer.ByteBuf}s.
+         * Set the {@link IoUringBufferRingAllocator} to use to allocate {@link ByteBuf}s.
          *
          * @param allocator         The allocator.
+         */
+        public Builder allocator(IoUringBufferRingAllocator allocator) {
+            this.allocator = allocator;
+            return this;
+        }
+
+        /**
+         * Set allocation strategy that is used to allocate {@link ByteBuf}s.
+         *
          * @param batchAllocation   {@code true} if the ring should always be filled via a batch allocation or
-         *                          {@code false} if we will try to allocate a new {@link ByteBuf} as soon as
+         *                          {@code false} if we will try to allocate a new {@link ByteBuf} as soon
          *                          as we used a buffer from the ring.
          * @return                  This builder.
          */
-        public Builder allocator(IoUringBufferRingAllocator allocator, boolean batchAllocation) {
-            this.allocator = allocator;
+        public Builder batchAllocation(boolean batchAllocation) {
             this.batchAllocation = batchAllocation;
             return this;
         }
@@ -245,8 +253,8 @@ public final class IoUringBufferRingConfig {
          * What's-new-with-io_uring-in-6.11-and-6.12#incremental-provided-buffer-consumption">incremental mode</a>
          * should be used for the buffer ring.
          *
-         * @param incremental  {@code true} if incremental mode is used, {@code false} otherwise.
-         * @return          This builder.
+         * @param incremental   {@code true} if incremental mode is used, {@code false} otherwise.
+         * @return              This builder.
          */
         public Builder incremental(boolean incremental) {
             this.incremental = incremental;

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingTest.java
@@ -41,8 +41,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -97,7 +95,8 @@ public class IoUringBufferRingTest {
                         .bufferGroupId((short) 1)
                         .bufferRingSize((short) 2)
                         .batchSize(2).incremental(incremental)
-                        .allocator(new IoUringFixedBufferRingAllocator(1024), false)
+                        .allocator(new IoUringFixedBufferRingAllocator(1024))
+                        .batchAllocation(false)
                         .build();
 
         IoUringBufferRingConfig bufferRingConfig1 =
@@ -106,7 +105,8 @@ public class IoUringBufferRingTest {
                         .bufferRingSize((short) 16)
                         .batchSize(8)
                         .incremental(incremental)
-                        .allocator(new IoUringFixedBufferRingAllocator(1024), true)
+                        .allocator(new IoUringFixedBufferRingAllocator(1024))
+                        .batchAllocation(true)
                         .build();
         ioUringIoHandlerConfiguration.setBufferRingConfig(bufferRingConfig, bufferRingConfig1);
 

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketTestPermutation.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketTestPermutation.java
@@ -56,9 +56,9 @@ public class IoUringSocketTestPermutation extends SocketTestPermutation {
                             .bufferRingSize((short) 16)
                             .batchSize(8)
                             .incremental(incremental)
-                            .allocator(new IoUringFixedBufferRingAllocator(1024),
-                                    // Ensure we test both variants
-                                    ThreadLocalRandom.current().nextBoolean())
+                            .allocator(new IoUringFixedBufferRingAllocator(1024))
+                            // Ensure we test both variants
+                            .batchAllocation(ThreadLocalRandom.current().nextBoolean())
                             .build()
             );
         }


### PR DESCRIPTION
Motivation:

Before we passed the allocator and the batchAllocation setting into one builder method, this is kind of inconsistent with the rest.

Modifications:

Add extra builder method

Result:

Cleanup and more consistent API
