### PR TITLE
IoUring: Correctly refetch completions that were produced because of …

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionQueue.java
@@ -112,6 +112,12 @@ final class CompletionQueue {
                     // Stop processing. as the callback can not handle any more completions for now,
                     break;
                 }
+                if (ringHead == tail) {
+                    // Let's fetch the tail one more time as it might have changed because a completion might have
+                    // triggered a submission (io_uring_enter). This can happen as we automatically submit once we
+                    // run out of space in the submission queue.
+                    tail = (int) INT_HANDLE.getVolatile(ktail, 0);
+                }
             }
             return i;
         } finally {


### PR DESCRIPTION
…inline submissions

Motivation:

We should ensure we refetch the tail of the completion queue and compare it to the current head before stop processing because a completion might trigger a submission and so produce more completions.

Modifications:

Refetch tail one more time before exit while loop

Result:

Process completions that were caused by an inline submission without delay