### PR TITLE
Cache the result of ioUringProbe to speed up the initialization of IoUring

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
@@ -95,16 +95,17 @@ public final class IoUring {
                         // 160kb.
                         numElementsIoVec = SystemPropertyUtil.getInt(
                                 "io.netty.iouring.numElementsIoVec", 10 * Limits.IOV_MAX);
-                        Native.checkAllIOSupported(ringBuffer.fd());
-                        socketNonEmptySupported = Native.isCqeFSockNonEmptySupported(ringBuffer.fd());
-                        spliceSupported = Native.isSpliceSupported(ringBuffer.fd());
+                        Native.IoUringProbe ioUringProbe = Native.ioUringProbe(ringBuffer.fd());
+                        Native.checkAllIOSupported(ioUringProbe);
+                        socketNonEmptySupported = Native.isCqeFSockNonEmptySupported(ioUringProbe);
+                        spliceSupported = Native.isSpliceSupported(ioUringProbe);
                         recvsendBundleSupported = (ringBuffer.features() & Native.IORING_FEAT_RECVSEND_BUNDLE) != 0;
                         // IORING_FEAT_RECVSEND_BUNDLE was added in the same release.
                         acceptSupportNoWait = recvsendBundleSupported;
 
-                        acceptMultishotSupported = Native.isAcceptMultishotSupported(ringBuffer.fd());
+                        acceptMultishotSupported = Native.isAcceptMultishotSupported(ioUringProbe);
                         recvMultishotSupported = Native.isRecvMultishotSupported();
-                        pollAddMultishotSupported = Native.isPollAddMultiShotSupported(ringBuffer.fd());
+                        pollAddMultishotSupported = Native.isPollAddMultiShotSupported(ioUringProbe);
                         registerIowqWorkersSupported = Native.isRegisterIoWqWorkerSupported(ringBuffer.fd());
                         submitAllSupported = Native.ioUringSetupSupportsFlags(Native.IORING_SETUP_SUBMIT_ALL);
                         setUpCqSizeSupported = Native.ioUringSetupSupportsFlags(Native.IORING_SETUP_CQSIZE);

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/SubmissionQueueTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/SubmissionQueueTest.java
@@ -118,4 +118,14 @@ public class SubmissionQueueTest {
     private static boolean setUpCQSizeUnavailable() {
         return !IoUring.isSetupCqeSizeSupported();
     }
+
+    @Test
+    public void testIoUringProbe() {
+        RingBuffer ringBuffer = Native.createRingBuffer(8, 0);
+        Native.IoUringProbe ioUringProbe = Native.ioUringProbe(ringBuffer.fd());
+        assertNotNull(ioUringProbe);
+        assertTrue(ioUringProbe.lastOp != 0);
+        assertTrue(ioUringProbe.opsLen != 0);
+        assertNotNull(ioUringProbe.ops);
+    }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/SubmissionQueueTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/SubmissionQueueTest.java
@@ -127,5 +127,10 @@ public class SubmissionQueueTest {
         assertTrue(ioUringProbe.lastOp != 0);
         assertTrue(ioUringProbe.opsLen != 0);
         assertNotNull(ioUringProbe.ops);
+        assertFalse(Native.ioUringProbe(ioUringProbe, new int[] {Integer.MAX_VALUE}));
+        assertDoesNotThrow(() -> Native.checkAllIOSupported(ioUringProbe));
+        ioUringProbe.ops[Native.IORING_OP_READ].flags = 0;
+        assertFalse(Native.ioUringProbe(ioUringProbe, new int[] {Native.IORING_OP_READ}));
+        assertThrows(UnsupportedOperationException.class, () -> Native.checkAllIOSupported(ioUringProbe));
     }
 }


### PR DESCRIPTION
Motivation:

Cache the result of ioUringProbe to speed up the initialization of the io.netty.channel.uring.Native class.
Modification:

Describe the modifications you've done.

Result:


