### PR TITLE
IoUring: Add support for IORING_SETUP_CQE32

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionCallback.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionCallback.java
@@ -15,14 +15,19 @@
  */
 package io.netty.channel.uring;
 
+import java.nio.ByteBuffer;
+
 interface CompletionCallback {
     /**
      * Called for a completion event that was put into the {@link CompletionQueue}.
      *
-     * @param res   the result of the completion event.
-     * @param flags the flags
-     * @param udata the user data that was provided as part of the submission
-     * @return      {@code true} if we more data (in a loop) can be handled be this callback, {@code false} otherwise.
+     * @param res           the result of the completion event.
+     * @param flags         the flags
+     * @param udata         the user data that was provided as part of the submission
+     * @param extraCqeData  the extra data for the CQE. This will only be non-null of the ring was setup with
+     *                      {@code IORING_SETUP_CQE32}.
+     * @return              {@code true} if we more data (in a loop) can be handled be this callback, {@code false}
+     *                      otherwise.
      */
-    boolean handle(int res, int flags, long udata);
+    boolean handle(int res, int flags, long udata, ByteBuffer extraCqeData);
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionQueue.java
@@ -148,7 +148,7 @@ final class CompletionQueue {
             return null;
         }
         ByteBuffer buffer = extraCqeData[cqeIdx];
-        buffer.position(0).limit(buffer.capacity());
+        buffer.clear();
         return buffer;
     }
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionQueue.java
@@ -34,19 +34,19 @@ final class CompletionQueue {
     private static final int CQE_RES_FIELD = 8;
     private static final int CQE_FLAGS_FIELD = 12;
 
-    static final int CQE_SIZE = 16;
-
     //these unsigned integer pointers(shared with the kernel) will be changed by the kernel and us
     // using a VarHandle.
     private final ByteBuffer khead;
     private final ByteBuffer ktail;
     private final ByteBuffer completionQueueArray;
+    private final ByteBuffer[] extraCqeData;
 
     final int ringSize;
     final long ringAddress;
     final int ringFd;
     final int ringEntries;
     final int ringCapacity;
+    private final int cqeLength;
 
     private final int ringMask;
     private int ringHead;
@@ -54,7 +54,7 @@ final class CompletionQueue {
 
     CompletionQueue(ByteBuffer kHead, ByteBuffer kTail, int ringMask, int ringEntries,
                     ByteBuffer completionQueueArray, int ringSize, long ringAddress,
-                    int ringFd, int ringCapacity) {
+                    int ringFd, int ringCapacity, int cqeLength) {
         this.khead = kHead;
         this.ktail = kTail;
         this.completionQueueArray = completionQueueArray;
@@ -62,10 +62,26 @@ final class CompletionQueue {
         this.ringAddress = ringAddress;
         this.ringFd = ringFd;
         this.ringCapacity = ringCapacity;
-
+        this.cqeLength = cqeLength;
         this.ringEntries = ringEntries;
         this.ringMask = ringMask;
         ringHead = (int) INT_HANDLE.getVolatile(kHead, 0);
+
+        if (cqeLength == Native.CQE32_SIZE) {
+            // Let's create the slices up front to reduce GC-pressure and also ensure that the user
+            // can not escape the memory range.
+            this.extraCqeData = new ByteBuffer[ringEntries];
+            for (int i = 0; i < ringEntries; i++) {
+                int position = i * cqeLength + Native.CQE_SIZE;
+                completionQueueArray.position(position).limit(position + Native.CQE_SIZE);
+                extraCqeData[i] = completionQueueArray.slice();
+                completionQueueArray.clear();
+            }
+            completionQueueArray.clear();
+        } else {
+            assert cqeLength == Native.CQE_SIZE;
+            this.extraCqeData = null;
+        }
     }
 
     void close() {
@@ -99,7 +115,8 @@ final class CompletionQueue {
         try {
             int i = 0;
             while (ringHead != tail) {
-                int cqePosition = cqeIdx(ringHead, ringMask);
+                int cqeIdx = cqeIdx(ringHead, ringMask);
+                int cqePosition = cqeIdx *  cqeLength;
 
                 long udata = completionQueueArray.getLong(cqePosition + CQE_USER_DATA_FIELD);
                 int res = completionQueueArray.getInt(cqePosition + CQE_RES_FIELD);
@@ -108,7 +125,7 @@ final class CompletionQueue {
                 ringHead++;
 
                 i++;
-                if (!callback.handle(res, flags, udata)) {
+                if (!callback.handle(res, flags, udata, extraCqeData(cqeIdx))) {
                     // Stop processing. as the callback can not handle any more completions for now,
                     break;
                 }
@@ -126,6 +143,15 @@ final class CompletionQueue {
         }
     }
 
+    private ByteBuffer extraCqeData(int cqeIdx) {
+        if (extraCqeData == null) {
+            return null;
+        }
+        ByteBuffer buffer = extraCqeData[cqeIdx];
+        buffer.position(0).limit(buffer.capacity());
+        return buffer;
+    }
+
     @Override
     public String toString() {
         StringJoiner sb = new StringJoiner(", ", "CompletionQueue [", "]");
@@ -135,7 +161,7 @@ final class CompletionQueue {
             int tail = (int) INT_HANDLE.getVolatile(ktail, 0);
             int head = ringHead;
             while (head != tail) {
-                int cqePosition = cqeIdx(head++, ringMask);
+                int cqePosition = cqeIdx(head++, ringMask) * cqeLength;
                 long udata = completionQueueArray.getLong(cqePosition + CQE_USER_DATA_FIELD);
                 int res = completionQueueArray.getInt(cqePosition + CQE_RES_FIELD);
                 int flags = completionQueueArray.getInt(cqePosition + CQE_FLAGS_FIELD);
@@ -147,6 +173,6 @@ final class CompletionQueue {
     }
 
     private static int cqeIdx(int ringHead, int ringMask) {
-        return (ringHead & ringMask) * CQE_SIZE;
+        return ringHead & ringMask;
     }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoEvent.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoEvent.java
@@ -16,6 +16,9 @@
 package io.netty.channel.uring;
 
 import io.netty.channel.IoEvent;
+import io.netty.channel.IoRegistration;
+
+import java.nio.ByteBuffer;
 
 /**
  * {@link IoEvent} that will be produced as an result of a {@link IoUringIoOps}.
@@ -26,6 +29,7 @@ public final class IoUringIoEvent implements IoEvent {
     private int res;
     private int flags;
     private short data;
+    private ByteBuffer extraCqeData;
 
     /**
      * Create a new instance
@@ -43,11 +47,12 @@ public final class IoUringIoEvent implements IoEvent {
     }
 
     // Used internally to reduce object creation
-    void update(int res, int flags, byte opcode, short data) {
+    void update(int res, int flags, byte opcode, short data, ByteBuffer extraCqeData) {
         this.res = res;
         this.flags = flags;
         this.opcode = opcode;
         this.data = data;
+        this.extraCqeData = extraCqeData;
     }
 
     /**
@@ -84,7 +89,18 @@ public final class IoUringIoEvent implements IoEvent {
      */
     public short data() {
         return data;
-    };
+    }
+
+    /**
+     * Returns the extra data for the CQE. This will only be non-null of the ring was setup with
+     * {@code IORING_SETUP_CQE32}. As this {@link ByteBuffer} maps into the shared completion queue its important
+     * to not hold any reference to it outside of the {@link IoUringIoHandle#handle(IoRegistration, IoEvent)} method.
+     *
+     * @return extra data for the CQE or {@code null}.
+     */
+    public ByteBuffer extraCqeData() {
+        return extraCqeData;
+    }
 
     @Override
     public String toString() {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -223,6 +223,8 @@ final class Native {
 
     static final int IORING_SETUP_R_DISABLED = 1 << 6;
     static final int IORING_SETUP_SUBMIT_ALL = 1 << 7;
+    static final int IORING_SETUP_CQE32 = 1 << 11;
+
     static final int IORING_SETUP_SINGLE_ISSUER = 1 << 12;
     static final int IORING_SETUP_DEFER_TASKRUN = 1 << 13;
     static final int IORING_SETUP_NO_SQARRAY = 1 << 16;
@@ -244,8 +246,11 @@ final class Native {
     static final int SPLICE_F_MOVE = 1;
 
     static final int IOU_PBUF_RING_INC = 2;
-
     static final int IO_URING_OP_SUPPORTED = 1;
+
+    static final int CQE_SIZE = 16;
+    static final int CQE32_SIZE = 32;
+
     static String opToStr(byte op) {
         switch (op) {
             case IORING_OP_NOP: return "NOP";
@@ -379,16 +384,17 @@ final class Native {
         long cqringAddress = values[6];
         int cqringFd = (int) values[7];
         int cqringCapacity = (int) values[8];
+        int cqeLength = (setupFlags & IORING_SETUP_CQE32) == 0 ? CQE_SIZE : CQE32_SIZE;
         CompletionQueue completionQueue = new CompletionQueue(
                 Buffer.wrapMemoryAddressWithNativeOrder(cqkhead, Integer.BYTES),
                 Buffer.wrapMemoryAddressWithNativeOrder(cqktail, Integer.BYTES),
                 cqringMask,
                 cqringEntries,
-                Buffer.wrapMemoryAddressWithNativeOrder(cqArrayAddress, cqringEntries * CompletionQueue.CQE_SIZE),
+                Buffer.wrapMemoryAddressWithNativeOrder(cqArrayAddress, cqringEntries * cqeLength),
                 cqringSize,
                 cqringAddress,
                 cqringFd,
-                cqringCapacity);
+                cqringCapacity, cqeLength);
 
         long sqkhead = values[9];
         long sqktail = values[10];


### PR DESCRIPTION
Motivation:

To support some operations we need to support IORING_SETUP_CQE32 as we need extra space to pass informations back as part of the completion event.

Modifications:

- Add extra field to IoUringIoEvent to be able to represent extra data that is provided when IORING_SETUP_CQE32 is used.
- Pass through the extra data when needed
- Add testcase

Result:

Be able to use IORING_SETUP_CQE32 which is also a requirement for https://github.com/netty/netty/issues/15475