### PR TITLE
Reduce Unpooled Heap buffers bound checks

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -50,7 +50,7 @@ public abstract class AbstractByteBuf extends ByteBuf {
     private static final String PROP_CHECK_ACCESSIBLE = "io.netty.buffer.checkAccessible";
     static final boolean checkAccessible; // accessed from CompositeByteBuf
     private static final String PROP_CHECK_BOUNDS = "io.netty.buffer.checkBounds";
-    private static final boolean checkBounds;
+    static final boolean checkBounds;
 
     static {
         if (SystemPropertyUtil.contains(PROP_CHECK_ACCESSIBLE)) {
@@ -1462,7 +1462,7 @@ public abstract class AbstractByteBuf extends ByteBuf {
         }
     }
 
-    private void checkReadableBytes0(int minimumReadableBytes) {
+    protected void checkReadableBytes0(int minimumReadableBytes) {
         ensureAccessible();
         if (checkBounds && readerIndex > writerIndex - minimumReadableBytes) {
             throw new IndexOutOfBoundsException(String.format(

--- a/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
@@ -323,12 +323,12 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
-    public byte readByte() {
-        ensureAccessible();
-        int i = readerIndex;
-        byte b = _getByte(i);
-        readerIndex = i + 1;
-        return b;
+    protected void checkReadableBytes0(int minimumReadableBytes) {
+        if (!checkBounds || writerIndex == capacity()) {
+            ensureAccessible();
+        } else {
+            super.checkReadableBytes0(minimumReadableBytes);
+        }
     }
 
     @Override
@@ -343,15 +343,6 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
-    public short readShort() {
-        ensureAccessible();
-        int i = readerIndex;
-        short s = _getShort(i);
-        readerIndex = i + 2;
-        return s;
-    }
-
-    @Override
     public short getShort(int index) {
         ensureAccessible();
         return _getShort(index);
@@ -360,15 +351,6 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected short _getShort(int index) {
         return HeapByteBufUtil.getShort(array, index);
-    }
-
-    @Override
-    public short readShortLE() {
-        ensureAccessible();
-        int i = readerIndex;
-        short s = _getShortLE(i);
-        readerIndex = i + 2;
-        return s;
     }
 
     @Override
@@ -383,15 +365,6 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
-    public int readUnsignedMedium() {
-        ensureAccessible();
-        int i = readerIndex;
-        int m = _getUnsignedMedium(i);
-        readerIndex = i + 3;
-        return m;
-    }
-
-    @Override
     public int getUnsignedMedium(int index) {
         ensureAccessible();
         return _getUnsignedMedium(index);
@@ -400,15 +373,6 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected int _getUnsignedMedium(int index) {
         return HeapByteBufUtil.getUnsignedMedium(array, index);
-    }
-
-    @Override
-    public int readUnsignedMediumLE() {
-        ensureAccessible();
-        int i = readerIndex;
-        int m = _getUnsignedMediumLE(i);
-        readerIndex = i + 3;
-        return m;
     }
 
     @Override
@@ -423,15 +387,6 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
-    public int readInt() {
-        ensureAccessible();
-        int i = readerIndex;
-        int value = _getInt(i);
-        readerIndex = i + 4;
-        return value;
-    }
-
-    @Override
     public int getInt(int index) {
         ensureAccessible();
         return _getInt(index);
@@ -440,15 +395,6 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected int _getInt(int index) {
         return HeapByteBufUtil.getInt(array, index);
-    }
-
-    @Override
-    public int readIntLE() {
-        ensureAccessible();
-        int i = readerIndex;
-        int value = _getIntLE(i);
-        readerIndex = i + 4;
-        return value;
     }
 
     @Override
@@ -463,15 +409,6 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
-    public long readLong() {
-        ensureAccessible();
-        int i = readerIndex;
-        long value = _getLong(i);
-        readerIndex = i + 8;
-        return value;
-    }
-
-    @Override
     public long getLong(int index) {
         ensureAccessible();
         return _getLong(index);
@@ -483,15 +420,6 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
-    public long readLongLE() {
-        ensureAccessible();
-        int i = readerIndex;
-        long value = _getLongLE(i);
-        readerIndex = i + 8;
-        return value;
-    }
-
-    @Override
     public long getLongLE(int index) {
         ensureAccessible();
         return _getLongLE(index);
@@ -500,15 +428,6 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected long _getLongLE(int index) {
         return HeapByteBufUtil.getLongLE(array, index);
-    }
-
-    @Override
-    public ByteBuf writeByte(int value) {
-        ensureAccessible();
-        int wIndex = writerIndex;
-        _setByte(wIndex, value);
-        writerIndex = wIndex + 1;
-        return this;
     }
 
     @Override
@@ -524,15 +443,6 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
-    public ByteBuf writeShort(int value) {
-        ensureAccessible();
-        int wIndex = writerIndex;
-        _setShort(wIndex, value);
-        writerIndex = wIndex + 2;
-        return this;
-    }
-
-    @Override
     public ByteBuf setShort(int index, int value) {
         ensureAccessible();
         _setShort(index, value);
@@ -542,15 +452,6 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected void _setShort(int index, int value) {
         HeapByteBufUtil.setShort(array, index, value);
-    }
-
-    @Override
-    public ByteBuf writeShortLE(int value) {
-        ensureAccessible();
-        int wIndex = writerIndex;
-        _setShortLE(wIndex, value);
-        writerIndex = wIndex + 2;
-        return this;
     }
 
     @Override
@@ -566,15 +467,6 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
-    public ByteBuf writeMedium(int value) {
-        ensureAccessible();
-        int wIndex = writerIndex;
-        _setMedium(wIndex, value);
-        writerIndex = wIndex + 3;
-        return this;
-    }
-
-    @Override
     public ByteBuf setMedium(int index, int   value) {
         ensureAccessible();
         _setMedium(index, value);
@@ -584,15 +476,6 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected void _setMedium(int index, int value) {
         HeapByteBufUtil.setMedium(array, index, value);
-    }
-
-    @Override
-    public ByteBuf writeMediumLE(int value) {
-        ensureAccessible();
-        int wIndex = writerIndex;
-        _setMediumLE(wIndex, value);
-        writerIndex = wIndex + 3;
-        return this;
     }
 
     @Override
@@ -608,15 +491,6 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
-    public ByteBuf writeInt(int value) {
-        ensureAccessible();
-        int wIndex = writerIndex;
-        _setInt(wIndex, value);
-        writerIndex = wIndex + 4;
-        return this;
-    }
-
-    @Override
     public ByteBuf setInt(int index, int   value) {
         ensureAccessible();
         _setInt(index, value);
@@ -626,15 +500,6 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected void _setInt(int index, int value) {
         HeapByteBufUtil.setInt(array, index, value);
-    }
-
-    @Override
-    public ByteBuf writeIntLE(int value) {
-        ensureAccessible();
-        int wIndex = writerIndex;
-        _setIntLE(wIndex, value);
-        writerIndex = wIndex + 4;
-        return this;
     }
 
     @Override
@@ -650,15 +515,6 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
-    public ByteBuf writeLong(long value) {
-        ensureAccessible();
-        int wIndex = writerIndex;
-        _setLong(wIndex, value);
-        writerIndex = wIndex + 8;
-        return this;
-    }
-
-    @Override
     public ByteBuf setLong(int index, long  value) {
         ensureAccessible();
         _setLong(index, value);
@@ -668,15 +524,6 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected void _setLong(int index, long value) {
         HeapByteBufUtil.setLong(array, index, value);
-    }
-
-    @Override
-    public ByteBuf writeLongLE(long value) {
-        ensureAccessible();
-        int wIndex = writerIndex;
-        _setLongLE(wIndex, value);
-        writerIndex = wIndex + 8;
-        return this;
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
@@ -323,6 +323,15 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public byte readByte() {
+        ensureAccessible();
+        int i = readerIndex;
+        byte b = _getByte(i);
+        readerIndex = i + 1;
+        return b;
+    }
+
+    @Override
     public byte getByte(int index) {
         ensureAccessible();
         return _getByte(index);
@@ -331,6 +340,15 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected byte _getByte(int index) {
         return HeapByteBufUtil.getByte(array, index);
+    }
+
+    @Override
+    public short readShort() {
+        ensureAccessible();
+        int i = readerIndex;
+        short s = _getShort(i);
+        readerIndex = i + 2;
+        return s;
     }
 
     @Override
@@ -345,6 +363,15 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public short readShortLE() {
+        ensureAccessible();
+        int i = readerIndex;
+        short s = _getShortLE(i);
+        readerIndex = i + 2;
+        return s;
+    }
+
+    @Override
     public short getShortLE(int index) {
         ensureAccessible();
         return _getShortLE(index);
@@ -353,6 +380,15 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected short _getShortLE(int index) {
         return HeapByteBufUtil.getShortLE(array, index);
+    }
+
+    @Override
+    public int readUnsignedMedium() {
+        ensureAccessible();
+        int i = readerIndex;
+        int m = _getUnsignedMedium(i);
+        readerIndex = i + 3;
+        return m;
     }
 
     @Override
@@ -367,6 +403,15 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public int readUnsignedMediumLE() {
+        ensureAccessible();
+        int i = readerIndex;
+        int m = _getUnsignedMediumLE(i);
+        readerIndex = i + 3;
+        return m;
+    }
+
+    @Override
     public int getUnsignedMediumLE(int index) {
         ensureAccessible();
         return _getUnsignedMediumLE(index);
@@ -375,6 +420,15 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected int _getUnsignedMediumLE(int index) {
         return HeapByteBufUtil.getUnsignedMediumLE(array, index);
+    }
+
+    @Override
+    public int readInt() {
+        ensureAccessible();
+        int i = readerIndex;
+        int value = _getInt(i);
+        readerIndex = i + 4;
+        return value;
     }
 
     @Override
@@ -389,6 +443,15 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public int readIntLE() {
+        ensureAccessible();
+        int i = readerIndex;
+        int value = _getIntLE(i);
+        readerIndex = i + 4;
+        return value;
+    }
+
+    @Override
     public int getIntLE(int index) {
         ensureAccessible();
         return _getIntLE(index);
@@ -397,6 +460,15 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected int _getIntLE(int index) {
         return HeapByteBufUtil.getIntLE(array, index);
+    }
+
+    @Override
+    public long readLong() {
+        ensureAccessible();
+        int i = readerIndex;
+        long value = _getLong(i);
+        readerIndex = i + 8;
+        return value;
     }
 
     @Override
@@ -411,6 +483,15 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public long readLongLE() {
+        ensureAccessible();
+        int i = readerIndex;
+        long value = _getLongLE(i);
+        readerIndex = i + 8;
+        return value;
+    }
+
+    @Override
     public long getLongLE(int index) {
         ensureAccessible();
         return _getLongLE(index);
@@ -419,6 +500,15 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected long _getLongLE(int index) {
         return HeapByteBufUtil.getLongLE(array, index);
+    }
+
+    @Override
+    public ByteBuf writeByte(int value) {
+        ensureAccessible();
+        int wIndex = writerIndex;
+        _setByte(wIndex, value);
+        writerIndex = wIndex + 1;
+        return this;
     }
 
     @Override
@@ -434,6 +524,15 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public ByteBuf writeShort(int value) {
+        ensureAccessible();
+        int wIndex = writerIndex;
+        _setShort(wIndex, value);
+        writerIndex = wIndex + 2;
+        return this;
+    }
+
+    @Override
     public ByteBuf setShort(int index, int value) {
         ensureAccessible();
         _setShort(index, value);
@@ -443,6 +542,15 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected void _setShort(int index, int value) {
         HeapByteBufUtil.setShort(array, index, value);
+    }
+
+    @Override
+    public ByteBuf writeShortLE(int value) {
+        ensureAccessible();
+        int wIndex = writerIndex;
+        _setShortLE(wIndex, value);
+        writerIndex = wIndex + 2;
+        return this;
     }
 
     @Override
@@ -458,6 +566,15 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public ByteBuf writeMedium(int value) {
+        ensureAccessible();
+        int wIndex = writerIndex;
+        _setMedium(wIndex, value);
+        writerIndex = wIndex + 3;
+        return this;
+    }
+
+    @Override
     public ByteBuf setMedium(int index, int   value) {
         ensureAccessible();
         _setMedium(index, value);
@@ -467,6 +584,15 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected void _setMedium(int index, int value) {
         HeapByteBufUtil.setMedium(array, index, value);
+    }
+
+    @Override
+    public ByteBuf writeMediumLE(int value) {
+        ensureAccessible();
+        int wIndex = writerIndex;
+        _setMediumLE(wIndex, value);
+        writerIndex = wIndex + 3;
+        return this;
     }
 
     @Override
@@ -482,6 +608,15 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public ByteBuf writeInt(int value) {
+        ensureAccessible();
+        int wIndex = writerIndex;
+        _setInt(wIndex, value);
+        writerIndex = wIndex + 4;
+        return this;
+    }
+
+    @Override
     public ByteBuf setInt(int index, int   value) {
         ensureAccessible();
         _setInt(index, value);
@@ -491,6 +626,15 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected void _setInt(int index, int value) {
         HeapByteBufUtil.setInt(array, index, value);
+    }
+
+    @Override
+    public ByteBuf writeIntLE(int value) {
+        ensureAccessible();
+        int wIndex = writerIndex;
+        _setIntLE(wIndex, value);
+        writerIndex = wIndex + 4;
+        return this;
     }
 
     @Override
@@ -506,6 +650,15 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public ByteBuf writeLong(long value) {
+        ensureAccessible();
+        int wIndex = writerIndex;
+        _setLong(wIndex, value);
+        writerIndex = wIndex + 8;
+        return this;
+    }
+
+    @Override
     public ByteBuf setLong(int index, long  value) {
         ensureAccessible();
         _setLong(index, value);
@@ -515,6 +668,15 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected void _setLong(int index, long value) {
         HeapByteBufUtil.setLong(array, index, value);
+    }
+
+    @Override
+    public ByteBuf writeLongLE(long value) {
+        ensureAccessible();
+        int wIndex = writerIndex;
+        _setLongLE(wIndex, value);
+        writerIndex = wIndex + 8;
+        return this;
     }
 
     @Override

--- a/microbench/src/main/java/io/netty/buffer/ByteBufAccessBenchmark.java
+++ b/microbench/src/main/java/io/netty/buffer/ByteBufAccessBenchmark.java
@@ -108,8 +108,13 @@ public class ByteBufAccessBenchmark extends AbstractMicrobenchmark {
         HEAP {
             @Override
             ByteBuf newBuffer() {
-                return new UnpooledUnsafeHeapByteBuf(
-                        UnpooledByteBufAllocator.DEFAULT, 64, 64).setIndex(0,  64);
+                if (PlatformDependent.hasUnsafe()) {
+                    return new UnpooledUnsafeHeapByteBuf(
+                            UnpooledByteBufAllocator.DEFAULT, 64, 64).setIndex(0, 64);
+                } else {
+                    return new UnpooledHeapByteBuf(
+                            UnpooledByteBufAllocator.DEFAULT, 64, 64).setIndex(0, 64);
+                }
             }
         },
         COMPOSITE {


### PR DESCRIPTION
Motivation:
UnpooledHeapByteBuf uses the array's length as capacity meaning that they can just rely on IOOBE on safe array accesses

Modification:
Override readXYZ methods to just perform accessibility checks, similarly to what getXYZ methods already do.

Result:
Much faster unpooled heap buffers operations when Unsafe is not available