### PR TITLE
Add namespace to our JFR events

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AllocateBufferEvent.java
+++ b/buffer/src/main/java/io/netty/buffer/AllocateBufferEvent.java
@@ -21,9 +21,10 @@ import jdk.jfr.Name;
 
 @SuppressWarnings("Since15")
 @Label("Buffer Allocation")
-@Name("io.netty.AllocateBuffer")
+@Name(AllocateBufferEvent.NAME)
 @Description("Triggered when a buffer is allocated (or reallocated) from an allocator")
 final class AllocateBufferEvent extends AbstractBufferEvent {
+    static final String NAME = "io.netty.AllocateBuffer";
     private static final AllocateBufferEvent INSTANCE = new AllocateBufferEvent();
 
     /**

--- a/buffer/src/main/java/io/netty/buffer/AllocateBufferEvent.java
+++ b/buffer/src/main/java/io/netty/buffer/AllocateBufferEvent.java
@@ -21,7 +21,7 @@ import jdk.jfr.Name;
 
 @SuppressWarnings("Since15")
 @Label("Buffer Allocation")
-@Name("AllocateBufferEvent")
+@Name("io.netty.AllocateBufferEvent")
 @Description("Triggered when a buffer is allocated (or reallocated) from an allocator")
 final class AllocateBufferEvent extends AbstractBufferEvent {
     private static final AllocateBufferEvent INSTANCE = new AllocateBufferEvent();

--- a/buffer/src/main/java/io/netty/buffer/AllocateBufferEvent.java
+++ b/buffer/src/main/java/io/netty/buffer/AllocateBufferEvent.java
@@ -21,7 +21,7 @@ import jdk.jfr.Name;
 
 @SuppressWarnings("Since15")
 @Label("Buffer Allocation")
-@Name("io.netty.AllocateBufferEvent")
+@Name("io.netty.AllocateBuffer")
 @Description("Triggered when a buffer is allocated (or reallocated) from an allocator")
 final class AllocateBufferEvent extends AbstractBufferEvent {
     private static final AllocateBufferEvent INSTANCE = new AllocateBufferEvent();

--- a/buffer/src/main/java/io/netty/buffer/AllocateChunkEvent.java
+++ b/buffer/src/main/java/io/netty/buffer/AllocateChunkEvent.java
@@ -20,10 +20,11 @@ import jdk.jfr.Label;
 import jdk.jfr.Name;
 
 @SuppressWarnings("Since15")
-@Name("io.netty.AllocateChunk")
+@Name(AllocateChunkEvent.NAME)
 @Label("Chunk Allocation")
 @Description("Triggered when a new memory chunk is allocated for an allocator")
 final class AllocateChunkEvent extends AbstractChunkEvent {
+    static final String NAME = "io.netty.AllocateChunk";
     private static final AllocateChunkEvent INSTANCE = new AllocateChunkEvent();
 
     /**

--- a/buffer/src/main/java/io/netty/buffer/AllocateChunkEvent.java
+++ b/buffer/src/main/java/io/netty/buffer/AllocateChunkEvent.java
@@ -20,7 +20,7 @@ import jdk.jfr.Label;
 import jdk.jfr.Name;
 
 @SuppressWarnings("Since15")
-@Name("io.netty.AllocateChunkEvent")
+@Name("io.netty.AllocateChunk")
 @Label("Chunk Allocation")
 @Description("Triggered when a new memory chunk is allocated for an allocator")
 final class AllocateChunkEvent extends AbstractChunkEvent {

--- a/buffer/src/main/java/io/netty/buffer/AllocateChunkEvent.java
+++ b/buffer/src/main/java/io/netty/buffer/AllocateChunkEvent.java
@@ -20,7 +20,7 @@ import jdk.jfr.Label;
 import jdk.jfr.Name;
 
 @SuppressWarnings("Since15")
-@Name("AllocateChunkEvent")
+@Name("io.netty.AllocateChunkEvent")
 @Label("Chunk Allocation")
 @Description("Triggered when a new memory chunk is allocated for an allocator")
 final class AllocateChunkEvent extends AbstractChunkEvent {

--- a/buffer/src/main/java/io/netty/buffer/FreeBufferEvent.java
+++ b/buffer/src/main/java/io/netty/buffer/FreeBufferEvent.java
@@ -21,10 +21,11 @@ import jdk.jfr.Name;
 
 @SuppressWarnings("Since15")
 @Label("Buffer Deallocation")
-@Name("io.netty.FreeBuffer")
+@Name(FreeBufferEvent.NAME)
 @Description("Triggered when a buffer is freed from an allocator")
 final class FreeBufferEvent extends AbstractBufferEvent {
     private static final FreeBufferEvent INSTANCE = new FreeBufferEvent();
+    static final String NAME = "io.netty.FreeBuffer";
 
     /**
      * Statically check if this event is enabled.

--- a/buffer/src/main/java/io/netty/buffer/FreeBufferEvent.java
+++ b/buffer/src/main/java/io/netty/buffer/FreeBufferEvent.java
@@ -21,7 +21,7 @@ import jdk.jfr.Name;
 
 @SuppressWarnings("Since15")
 @Label("Buffer Deallocation")
-@Name("io.netty.FreeBufferEvent")
+@Name("io.netty.FreeBuffer")
 @Description("Triggered when a buffer is freed from an allocator")
 final class FreeBufferEvent extends AbstractBufferEvent {
     private static final FreeBufferEvent INSTANCE = new FreeBufferEvent();

--- a/buffer/src/main/java/io/netty/buffer/FreeBufferEvent.java
+++ b/buffer/src/main/java/io/netty/buffer/FreeBufferEvent.java
@@ -21,7 +21,7 @@ import jdk.jfr.Name;
 
 @SuppressWarnings("Since15")
 @Label("Buffer Deallocation")
-@Name("FreeBufferEvent")
+@Name("io.netty.FreeBufferEvent")
 @Description("Triggered when a buffer is freed from an allocator")
 final class FreeBufferEvent extends AbstractBufferEvent {
     private static final FreeBufferEvent INSTANCE = new FreeBufferEvent();

--- a/buffer/src/main/java/io/netty/buffer/FreeChunkEvent.java
+++ b/buffer/src/main/java/io/netty/buffer/FreeChunkEvent.java
@@ -21,7 +21,7 @@ import jdk.jfr.Name;
 
 @SuppressWarnings("Since15")
 @Label("Chunk Free")
-@Name("FreeChunkEvent")
+@Name("io.netty.FreeChunkEvent")
 @Description("Triggered when a memory chunk is freed from an allocator")
 final class FreeChunkEvent extends AbstractChunkEvent {
     private static final FreeChunkEvent INSTANCE = new FreeChunkEvent();

--- a/buffer/src/main/java/io/netty/buffer/FreeChunkEvent.java
+++ b/buffer/src/main/java/io/netty/buffer/FreeChunkEvent.java
@@ -21,7 +21,7 @@ import jdk.jfr.Name;
 
 @SuppressWarnings("Since15")
 @Label("Chunk Free")
-@Name("io.netty.FreeChunkEvent")
+@Name("io.netty.FreeChunk")
 @Description("Triggered when a memory chunk is freed from an allocator")
 final class FreeChunkEvent extends AbstractChunkEvent {
     private static final FreeChunkEvent INSTANCE = new FreeChunkEvent();

--- a/buffer/src/main/java/io/netty/buffer/FreeChunkEvent.java
+++ b/buffer/src/main/java/io/netty/buffer/FreeChunkEvent.java
@@ -21,9 +21,10 @@ import jdk.jfr.Name;
 
 @SuppressWarnings("Since15")
 @Label("Chunk Free")
-@Name("io.netty.FreeChunk")
+@Name(FreeChunkEvent.NAME)
 @Description("Triggered when a memory chunk is freed from an allocator")
 final class FreeChunkEvent extends AbstractChunkEvent {
+    static final String NAME = "io.netty.FreeChunk";
     private static final FreeChunkEvent INSTANCE = new FreeChunkEvent();
 
     /**

--- a/buffer/src/main/java/io/netty/buffer/ReallocateBufferEvent.java
+++ b/buffer/src/main/java/io/netty/buffer/ReallocateBufferEvent.java
@@ -22,10 +22,11 @@ import jdk.jfr.Name;
 
 @SuppressWarnings("Since15")
 @Label("Buffer Reallocation")
-@Name("io.netty.ReallocateBuffer")
+@Name(ReallocateBufferEvent.NAME)
 @Description("Triggered when a buffer is reallocated for resizing in an allocator. " +
         "Will be followed by an AllocateBufferEvent")
 final class ReallocateBufferEvent extends AbstractBufferEvent {
+    static final String NAME = "io.netty.ReallocateBuffer";
     private static final ReallocateBufferEvent INSTANCE = new ReallocateBufferEvent();
 
     /**

--- a/buffer/src/main/java/io/netty/buffer/ReallocateBufferEvent.java
+++ b/buffer/src/main/java/io/netty/buffer/ReallocateBufferEvent.java
@@ -22,7 +22,7 @@ import jdk.jfr.Name;
 
 @SuppressWarnings("Since15")
 @Label("Buffer Reallocation")
-@Name("ReallocateBufferEvent")
+@Name("io.netty.ReallocateBufferEvent")
 @Description("Triggered when a buffer is reallocated for resizing in an allocator. " +
         "Will be followed by an AllocateBufferEvent")
 final class ReallocateBufferEvent extends AbstractBufferEvent {

--- a/buffer/src/main/java/io/netty/buffer/ReallocateBufferEvent.java
+++ b/buffer/src/main/java/io/netty/buffer/ReallocateBufferEvent.java
@@ -22,7 +22,7 @@ import jdk.jfr.Name;
 
 @SuppressWarnings("Since15")
 @Label("Buffer Reallocation")
-@Name("io.netty.ReallocateBufferEvent")
+@Name("io.netty.ReallocateBuffer")
 @Description("Triggered when a buffer is reallocated for resizing in an allocator. " +
         "Will be followed by an AllocateBufferEvent")
 final class ReallocateBufferEvent extends AbstractBufferEvent {

--- a/buffer/src/main/java/io/netty/buffer/ReturnChunkEvent.java
+++ b/buffer/src/main/java/io/netty/buffer/ReturnChunkEvent.java
@@ -21,7 +21,7 @@ import jdk.jfr.Name;
 
 @SuppressWarnings("Since15")
 @Label("Chunk Return")
-@Name("ReturnChunkEvent")
+@Name("io.netty.ReturnChunkEvent")
 @Description("Triggered when a memory chunk is prepared for re-use by an allocator")
 final class ReturnChunkEvent extends AbstractChunkEvent {
     private static final FreeChunkEvent INSTANCE = new FreeChunkEvent();

--- a/buffer/src/main/java/io/netty/buffer/ReturnChunkEvent.java
+++ b/buffer/src/main/java/io/netty/buffer/ReturnChunkEvent.java
@@ -21,7 +21,7 @@ import jdk.jfr.Name;
 
 @SuppressWarnings("Since15")
 @Label("Chunk Return")
-@Name("io.netty.ReturnChunkEvent")
+@Name("io.netty.ReturnChunk")
 @Description("Triggered when a memory chunk is prepared for re-use by an allocator")
 final class ReturnChunkEvent extends AbstractChunkEvent {
     private static final FreeChunkEvent INSTANCE = new FreeChunkEvent();

--- a/buffer/src/main/java/io/netty/buffer/ReturnChunkEvent.java
+++ b/buffer/src/main/java/io/netty/buffer/ReturnChunkEvent.java
@@ -21,9 +21,10 @@ import jdk.jfr.Name;
 
 @SuppressWarnings("Since15")
 @Label("Chunk Return")
-@Name("io.netty.ReturnChunk")
+@Name(ReturnChunkEvent.NAME)
 @Description("Triggered when a memory chunk is prepared for re-use by an allocator")
 final class ReturnChunkEvent extends AbstractChunkEvent {
+    static final String NAME = "io.netty.ReturnChunk";
     private static final FreeChunkEvent INSTANCE = new FreeChunkEvent();
 
     /**

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
@@ -220,7 +220,7 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
             CompletableFuture<RecordedEvent> allocateFuture = new CompletableFuture<>();
 
             stream.enable(AllocateChunkEvent.class);
-            stream.onEvent(AllocateChunkEvent.class.getSimpleName(), allocateFuture::complete);
+            stream.onEvent(AllocateChunkEvent.NAME, allocateFuture::complete);
             stream.startAsync();
 
             AdaptiveByteBufAllocator alloc = new AdaptiveByteBufAllocator(true, false);
@@ -242,7 +242,7 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
         try (RecordingStream stream = new RecordingStream()) {
             final CountDownLatch eventsFlushed = new CountDownLatch(2);
             stream.enable(AllocateChunkEvent.class);
-            stream.onEvent(AllocateChunkEvent.class.getSimpleName(),
+            stream.onEvent(AllocateChunkEvent.NAME,
                            event -> {
                                 eventsFlushed.countDown();
                            });
@@ -274,7 +274,7 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
             final CountDownLatch eventsFlushed = new CountDownLatch(1);
             final AtomicInteger chunksAllocations = new AtomicInteger();
             stream.enable(AllocateChunkEvent.class);
-            stream.onEvent(AllocateChunkEvent.class.getSimpleName(),
+            stream.onEvent(AllocateChunkEvent.NAME,
                            event -> {
                                chunksAllocations.incrementAndGet();
                                eventsFlushed.countDown();
@@ -310,9 +310,9 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
             CompletableFuture<RecordedEvent> releaseFuture = new CompletableFuture<>();
 
             stream.enable(AllocateBufferEvent.class);
-            stream.onEvent(AllocateBufferEvent.class.getSimpleName(), allocateFuture::complete);
+            stream.onEvent(AllocateBufferEvent.NAME, allocateFuture::complete);
             stream.enable(FreeBufferEvent.class);
-            stream.onEvent(FreeBufferEvent.class.getSimpleName(), releaseFuture::complete);
+            stream.onEvent(FreeBufferEvent.NAME, releaseFuture::complete);
             stream.startAsync();
 
             AdaptiveByteBufAllocator alloc = new AdaptiveByteBufAllocator(true, false);
@@ -350,9 +350,9 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
                 alloc.directBuffer(128).release();
 
                 stream.enable(AllocateBufferEvent.class);
-                stream.onEvent(AllocateBufferEvent.class.getSimpleName(), allocateFuture::complete);
+                stream.onEvent(AllocateBufferEvent.NAME, allocateFuture::complete);
                 stream.enable(FreeBufferEvent.class);
-                stream.onEvent(FreeBufferEvent.class.getSimpleName(), releaseFuture::complete);
+                stream.onEvent(FreeBufferEvent.NAME, releaseFuture::complete);
                 stream.startAsync();
 
                 // Allocate out of the cache.

--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -1001,7 +1001,7 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
             CompletableFuture<RecordedEvent> allocateFuture = new CompletableFuture<>();
 
             stream.enable(AllocateChunkEvent.class);
-            stream.onEvent(AllocateChunkEvent.class.getSimpleName(), allocateFuture::complete);
+            stream.onEvent(AllocateChunkEvent.NAME, allocateFuture::complete);
             stream.startAsync();
 
             PooledByteBufAllocator alloc = newAllocator(true);
@@ -1023,7 +1023,7 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
         try (RecordingStream stream = new RecordingStream()) {
             final CountDownLatch eventsFlushed = new CountDownLatch(2);
             stream.enable(AllocateChunkEvent.class);
-            stream.onEvent(AllocateChunkEvent.class.getSimpleName(),
+            stream.onEvent(AllocateChunkEvent.NAME,
                            event -> {
                                 eventsFlushed.countDown();
                            });
@@ -1054,7 +1054,7 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
             final CountDownLatch eventsFlushed = new CountDownLatch(1);
             final AtomicInteger chunksAllocations = new AtomicInteger();
             stream.enable(AllocateChunkEvent.class);
-            stream.onEvent(AllocateChunkEvent.class.getSimpleName(),
+            stream.onEvent(AllocateChunkEvent.NAME,
                            event -> {
                                chunksAllocations.incrementAndGet();
                                eventsFlushed.countDown();
@@ -1094,9 +1094,9 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
             CompletableFuture<RecordedEvent> releaseFuture = new CompletableFuture<>();
 
             stream.enable(AllocateBufferEvent.class);
-            stream.onEvent(AllocateBufferEvent.class.getSimpleName(), allocateFuture::complete);
+            stream.onEvent(AllocateBufferEvent.NAME, allocateFuture::complete);
             stream.enable(FreeBufferEvent.class);
-            stream.onEvent(FreeBufferEvent.class.getSimpleName(), releaseFuture::complete);
+            stream.onEvent(FreeBufferEvent.NAME, releaseFuture::complete);
             stream.startAsync();
 
             PooledByteBufAllocator alloc = newAllocator(true);
@@ -1134,9 +1134,9 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
                 alloc.directBuffer(128).release();
 
                 stream.enable(AllocateBufferEvent.class);
-                stream.onEvent(AllocateBufferEvent.class.getSimpleName(), allocateFuture::complete);
+                stream.onEvent(AllocateBufferEvent.NAME, allocateFuture::complete);
                 stream.enable(FreeBufferEvent.class);
-                stream.onEvent(FreeBufferEvent.class.getSimpleName(), releaseFuture::complete);
+                stream.onEvent(FreeBufferEvent.NAME, releaseFuture::complete);
                 stream.startAsync();
 
                 // Allocate out of the cache.

--- a/jfr-stub/src/main/java/jdk/jfr/consumer/RecordedEvent.java
+++ b/jfr-stub/src/main/java/jdk/jfr/consumer/RecordedEvent.java
@@ -37,4 +37,8 @@ public final class RecordedEvent {
     public EventType getEventType() {
         throw new UnsupportedOperationException("Stub should only be used at compile time");
     }
+
+    public boolean hasField(String fieldName) {
+        throw new UnsupportedOperationException("Stub should only be used at compile time");
+    }
 }

--- a/microbench/src/main/java/io/netty/buffer/AllocationPatternSimulator.java
+++ b/microbench/src/main/java/io/netty/buffer/AllocationPatternSimulator.java
@@ -455,7 +455,8 @@ public class AllocationPatternSimulator {
             while (eventReader.hasMoreEvents()) {
                 RecordedEvent event = eventReader.readEvent();
                 String name = event.getEventType().getName();
-                if ("AllocateBufferEvent".equals(name)) {
+                if (("AllocateBufferEvent".equals(name) || "io.netty.AllocateBufferEvent".equals(name)) &&
+                        event.hasField("size")) {
                     int size = event.getInt("size");
                     summation.compute(size, (k, v) -> v == null ? 1 : v + 1);
                 }

--- a/microbench/src/main/java/io/netty/buffer/AllocationPatternSimulator.java
+++ b/microbench/src/main/java/io/netty/buffer/AllocationPatternSimulator.java
@@ -455,7 +455,7 @@ public class AllocationPatternSimulator {
             while (eventReader.hasMoreEvents()) {
                 RecordedEvent event = eventReader.readEvent();
                 String name = event.getEventType().getName();
-                if (("AllocateBufferEvent".equals(name) || "io.netty.AllocateBufferEvent".equals(name)) &&
+                if (("AllocateBufferEvent".equals(name) || "io.netty.AllocateBuffer".equals(name)) &&
                         event.hasField("size")) {
                     int size = event.getInt("size");
                     summation.compute(size, (k, v) -> v == null ? 1 : v + 1);

--- a/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/FlightRecorderTest.java
+++ b/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/FlightRecorderTest.java
@@ -56,8 +56,8 @@ public class FlightRecorderTest {
         try (AutoCloseable c = (AutoCloseable) recordingStream) {
             CompletableFuture<RecordedEvent> allocateFuture = new CompletableFuture<>();
             Consumer<RecordedEvent> complete = allocateFuture::complete;
-            enableMethod.invoke(recordingStream, "AllocateChunkEvent");
-            onEventMethod.invoke(recordingStream, "AllocateChunkEvent", complete);
+            enableMethod.invoke(recordingStream, "io.netty.AllocateChunk");
+            onEventMethod.invoke(recordingStream, "io.netty.AllocateChunk", complete);
             startAsyncMethod.invoke(recordingStream);
 
             AdaptiveByteBufAllocator alloc = new AdaptiveByteBufAllocator(true, false);


### PR DESCRIPTION
Motivation:
We should follow the recommendations in https://docs.oracle.com/en/java/javase/17/docs/api/jdk.jfr/jdk/jfr/Name.html and as pointed out by Erik Gahlin in https://github.com/netty/netty/issues/15379#issuecomment-3077504841

Modification:
Add an "io.netty" namespace to all event names.
I don't think we'll have enough events that we need to further break it down into individual packages. Also update the allocation simulator to read events with either qualified or unqualified name.

Result:
We follow JFR best practices.