### PR TITLE
Fix NPE and AssertionErrors when many tasks are scheduled and cancell…

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
@@ -334,7 +334,10 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
 
     final void scheduleFromEventLoop(final ScheduledFutureTask<?> task) {
         // nextTaskId a long and so there is no chance it will overflow back to 0
-        scheduledTaskQueue().add(task.setId(++nextTaskId));
+        if (task.getId() == 0L) {
+            task.setId(++nextTaskId);
+        }
+        scheduledTaskQueue().add(task);
     }
 
     private <V> ScheduledFuture<V> schedule(final ScheduledFutureTask<V> task) {

--- a/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
@@ -84,7 +84,7 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor im
     private final Future<?> terminationFuture;
 
     private GlobalEventExecutor() {
-        scheduledTaskQueue().add(quietPeriodTask);
+        scheduleFromEventLoop(quietPeriodTask);
         threadFactory = ThreadExecutorMap.apply(new DefaultThreadFactory(
                 DefaultThreadFactory.toPoolName(getClass()), false, Thread.NORM_PRIORITY, null), this);
 

--- a/common/src/main/java/io/netty/util/concurrent/ScheduledFutureTask.java
+++ b/common/src/main/java/io/netty/util/concurrent/ScheduledFutureTask.java
@@ -80,6 +80,10 @@ final class ScheduledFutureTask<V> extends PromiseTask<V> implements ScheduledFu
         return this;
     }
 
+    long getId() {
+        return id;
+    }
+
     @Override
     protected EventExecutor executor() {
         return super.executor();
@@ -167,7 +171,7 @@ final class ScheduledFutureTask<V> extends PromiseTask<V> implements ScheduledFu
                             deadlineNanos = scheduledExecutor().getCurrentTimeNanos() - periodNanos;
                         }
                         if (!isCancelled()) {
-                            scheduledExecutor().scheduledTaskQueue().add(this);
+                            scheduledExecutor().scheduleFromEventLoop(this);
                         }
                     }
                 }

--- a/common/src/test/java/io/netty/util/concurrent/SingleThreadEventExecutorTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/SingleThreadEventExecutorTest.java
@@ -17,7 +17,6 @@ package io.netty.util.concurrent;
 
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
-
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.function.Executable;
 


### PR DESCRIPTION
…ed (#15499)

Motivation:
The ScheduledFutureTask uses unique IDs to disambiguate tasks in the priority queue, but these IDs were not always set, leading the queue to break invariants and get into an invalid state.

Modification:
Ensure that scheduled tasks always have a valid ID before adding them to the scheduling priority queue.

Result:
No more NullPointerExceptions and AssertionErrors from our priority queue.

Fixes https://github.com/netty/netty/issues/15492
