### PR TITLE
Improve Direct Buffer accesses via VarHandle

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
@@ -22,6 +22,7 @@ import io.netty.util.internal.PlatformDependent;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.invoke.VarHandle;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.ClosedChannelException;
@@ -246,6 +247,12 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public short getShortLE(int index) {
+        ensureAccessible();
+        return _getShortLE(index);
+    }
+
+    @Override
     public short getShort(int index) {
         ensureAccessible();
         return _getShort(index);
@@ -253,11 +260,19 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     protected short _getShort(int index) {
+        VarHandle varHandle = PlatformDependent.shortBeByteBufferView();
+        if (varHandle != null) {
+            return (short) varHandle.get(buffer, index);
+        }
         return buffer.getShort(index);
     }
 
     @Override
     protected short _getShortLE(int index) {
+        VarHandle varHandle = PlatformDependent.shortLeByteBufferView();
+        if (varHandle != null) {
+            return (short) varHandle.get(buffer, index);
+        }
         return ByteBufUtil.swapShort(buffer.getShort(index));
     }
 
@@ -282,6 +297,12 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public int getIntLE(int index) {
+        ensureAccessible();
+        return _getIntLE(index);
+    }
+
+    @Override
     public int getInt(int index) {
         ensureAccessible();
         return _getInt(index);
@@ -289,12 +310,26 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     protected int _getInt(int index) {
+        VarHandle varHandle = PlatformDependent.intBeByteBufferView();
+        if (varHandle != null) {
+            return (int) varHandle.get(buffer, index);
+        }
         return buffer.getInt(index);
     }
 
     @Override
     protected int _getIntLE(int index) {
+        VarHandle varHandle = PlatformDependent.intLeByteBufferView();
+        if (varHandle != null) {
+            return (int) varHandle.get(buffer, index);
+        }
         return ByteBufUtil.swapInt(buffer.getInt(index));
+    }
+
+    @Override
+    public long getLongLE(int index) {
+        ensureAccessible();
+        return _getLongLE(index);
     }
 
     @Override
@@ -305,11 +340,19 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     protected long _getLong(int index) {
+        VarHandle varHandle = PlatformDependent.longBeByteBufferView();
+        if (varHandle != null) {
+            return (long) varHandle.get(buffer, index);
+        }
         return buffer.getLong(index);
     }
 
     @Override
     protected long _getLongLE(int index) {
+        VarHandle varHandle = PlatformDependent.longLeByteBufferView();
+        if (varHandle != null) {
+            return (long) varHandle.get(buffer, index);
+        }
         return ByteBufUtil.swapLong(buffer.getLong(index));
     }
 
@@ -398,6 +441,13 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public ByteBuf setShortLE(int index, int value) {
+        ensureAccessible();
+        _setShortLE(index, value);
+        return this;
+    }
+
+    @Override
     public ByteBuf setShort(int index, int value) {
         ensureAccessible();
         _setShort(index, value);
@@ -406,12 +456,29 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     protected void _setShort(int index, int value) {
+        VarHandle varHandle = PlatformDependent.shortBeByteBufferView();
+        if (varHandle != null) {
+            varHandle.set(buffer, index, (short) value);
+            return;
+        }
         buffer.putShort(index, (short) value);
     }
 
     @Override
     protected void _setShortLE(int index, int value) {
+        VarHandle varHandle = PlatformDependent.shortLeByteBufferView();
+        if (varHandle != null) {
+            varHandle.set(buffer, index, (short) value);
+            return;
+        }
         buffer.putShort(index, ByteBufUtil.swapShort((short) value));
+    }
+
+    @Override
+    public ByteBuf setMediumLE(int index, int value) {
+        ensureAccessible();
+        _setMediumLE(index, value);
+        return this;
     }
 
     @Override
@@ -436,6 +503,13 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public ByteBuf setIntLE(int index, int value) {
+        ensureAccessible();
+        _setIntLE(index, value);
+        return this;
+    }
+
+    @Override
     public ByteBuf setInt(int index, int value) {
         ensureAccessible();
         _setInt(index, value);
@@ -444,11 +518,21 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     protected void _setInt(int index, int value) {
+        VarHandle varHandle = PlatformDependent.intBeByteBufferView();
+        if (varHandle != null) {
+            varHandle.set(buffer, index, value);
+            return;
+        }
         buffer.putInt(index, value);
     }
 
     @Override
     protected void _setIntLE(int index, int value) {
+        VarHandle varHandle = PlatformDependent.intLeByteBufferView();
+        if (varHandle != null) {
+            varHandle.set(buffer, index, value);
+            return;
+        }
         buffer.putInt(index, ByteBufUtil.swapInt(value));
     }
 
@@ -460,12 +544,29 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public ByteBuf setLongLE(int index, long value) {
+        ensureAccessible();
+        _setLongLE(index, value);
+        return this;
+    }
+
+    @Override
     protected void _setLong(int index, long value) {
+        VarHandle varHandle = PlatformDependent.longBeByteBufferView();
+        if (varHandle != null) {
+            varHandle.set(buffer, index, value);
+            return;
+        }
         buffer.putLong(index, value);
     }
 
     @Override
     protected void _setLongLE(int index, long value) {
+        VarHandle varHandle = PlatformDependent.longLeByteBufferView();
+        if (varHandle != null) {
+            varHandle.set(buffer, index, value);
+            return;
+        }
         buffer.putLong(index, ByteBufUtil.swapLong(value));
     }
 

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -678,6 +678,48 @@ public final class PlatformDependent {
         return null;
     }
 
+    public static VarHandle longBeByteBufferView() {
+        if (VAR_HANDLE) {
+            return VarHandleFactory.longBeByteBufferView();
+        }
+        return null;
+    }
+
+    public static VarHandle longLeByteBufferView() {
+        if (VAR_HANDLE) {
+            return VarHandleFactory.longLeByteBufferView();
+        }
+        return null;
+    }
+
+    public static VarHandle intBeByteBufferView() {
+        if (VAR_HANDLE) {
+            return VarHandleFactory.intBeByteBufferView();
+        }
+        return null;
+    }
+
+    public static VarHandle intLeByteBufferView() {
+        if (VAR_HANDLE) {
+            return VarHandleFactory.intLeByteBufferView();
+        }
+        return null;
+    }
+
+    public static VarHandle shortBeByteBufferView() {
+        if (VAR_HANDLE) {
+            return VarHandleFactory.shortBeByteBufferView();
+        }
+        return null;
+    }
+
+    public static VarHandle shortLeByteBufferView() {
+        if (VAR_HANDLE) {
+            return VarHandleFactory.shortLeByteBufferView();
+        }
+        return null;
+    }
+
     public static Object getObject(Object object, long fieldOffset) {
         return PlatformDependent0.getObject(object, fieldOffset);
     }

--- a/common/src/main/java/io/netty/util/internal/VarHandleFactory.java
+++ b/common/src/main/java/io/netty/util/internal/VarHandleFactory.java
@@ -35,6 +35,12 @@ final class VarHandleFactory {
     private static final VarHandle INT_BE_ARRAY_VIEW;
     private static final VarHandle SHORT_LE_ARRAY_VIEW;
     private static final VarHandle SHORT_BE_ARRAY_VIEW;
+    private static final VarHandle LONG_LE_BYTE_BUFFER_VIEW;
+    private static final VarHandle LONG_BE_BYTE_BUFFER_VIEW;
+    private static final VarHandle INT_LE_BYTE_BUFFER_VIEW;
+    private static final VarHandle INT_BE_BYTE_BUFFER_VIEW;
+    private static final VarHandle SHORT_LE_BYTE_BUFFER_VIEW;
+    private static final VarHandle SHORT_BE_BYTE_BUFFER_VIEW;
     private static final Throwable UNAVAILABILITY_CAUSE;
 
     static {
@@ -46,6 +52,12 @@ final class VarHandleFactory {
         VarHandle intBeArrayViewHandle = null;
         VarHandle shortLeArrayViewHandle = null;
         VarHandle shortBeArrayViewHandle = null;
+        VarHandle longLeByteBufferViewHandle = null;
+        VarHandle longBeByteBufferViewHandle = null;
+        VarHandle intLeByteBufferViewHandle = null;
+        VarHandle intBeByteBufferViewHandle = null;
+        VarHandle shortLeByteBufferViewHandle = null;
+        VarHandle shortBeByteBufferViewHandle = null;
         Throwable error = null;
         try {
             MethodHandles.Lookup lookup = MethodHandles.lookup();
@@ -62,6 +74,20 @@ final class VarHandleFactory {
             shortLeArrayViewHandle = (VarHandle) byteArrayViewHandle.invokeExact(
                     short[].class, ByteOrder.LITTLE_ENDIAN);
             shortBeArrayViewHandle = (VarHandle) byteArrayViewHandle.invokeExact(short[].class, ByteOrder.BIG_ENDIAN);
+            MethodHandle byteBufferViewHandle = lookup.findStatic(MethodHandles.class, "byteBufferViewVarHandle",
+                    MethodType.methodType(VarHandle.class, Class.class, ByteOrder.class));
+            longLeByteBufferViewHandle = (VarHandle) byteBufferViewHandle.invokeExact(
+                    long[].class, ByteOrder.LITTLE_ENDIAN);
+            longBeByteBufferViewHandle = (VarHandle) byteBufferViewHandle.invokeExact(
+                    long[].class, ByteOrder.BIG_ENDIAN);
+            intLeByteBufferViewHandle = (VarHandle) byteBufferViewHandle.invokeExact(
+                    int[].class, ByteOrder.LITTLE_ENDIAN);
+            intBeByteBufferViewHandle = (VarHandle) byteBufferViewHandle.invokeExact(
+                    int[].class, ByteOrder.BIG_ENDIAN);
+            shortLeByteBufferViewHandle = (VarHandle) byteBufferViewHandle.invokeExact(
+                    short[].class, ByteOrder.LITTLE_ENDIAN);
+            shortBeByteBufferViewHandle = (VarHandle) byteBufferViewHandle.invokeExact(
+                    short[].class, ByteOrder.BIG_ENDIAN);
             error = null;
         } catch (Throwable e) {
             error = e;
@@ -72,6 +98,12 @@ final class VarHandleFactory {
             intLeArrayViewHandle = null;
             intBeArrayViewHandle = null;
             shortLeArrayViewHandle = null;
+            longLeByteBufferViewHandle = null;
+            longBeByteBufferViewHandle = null;
+            intLeByteBufferViewHandle = null;
+            intBeByteBufferViewHandle = null;
+            shortLeByteBufferViewHandle = null;
+            shortBeByteBufferViewHandle = null;
         } finally {
             FIND_VAR_HANDLE = findVarHandle;
             PRIVATE_LOOKUP_IN = privateLookupIn;
@@ -81,6 +113,12 @@ final class VarHandleFactory {
             INT_BE_ARRAY_VIEW = intBeArrayViewHandle;
             SHORT_LE_ARRAY_VIEW = shortLeArrayViewHandle;
             SHORT_BE_ARRAY_VIEW = shortBeArrayViewHandle;
+            LONG_LE_BYTE_BUFFER_VIEW = longLeByteBufferViewHandle;
+            LONG_BE_BYTE_BUFFER_VIEW = longBeByteBufferViewHandle;
+            INT_LE_BYTE_BUFFER_VIEW = intLeByteBufferViewHandle;
+            INT_BE_BYTE_BUFFER_VIEW = intBeByteBufferViewHandle;
+            SHORT_LE_BYTE_BUFFER_VIEW = shortLeByteBufferViewHandle;
+            SHORT_BE_BYTE_BUFFER_VIEW = shortBeByteBufferViewHandle;
             UNAVAILABILITY_CAUSE = error;
         }
     }
@@ -133,5 +171,29 @@ final class VarHandleFactory {
 
     public static VarHandle shortBeArrayView() {
         return SHORT_BE_ARRAY_VIEW;
+    }
+
+    public static VarHandle longLeByteBufferView() {
+        return LONG_LE_BYTE_BUFFER_VIEW;
+    }
+
+    public static VarHandle longBeByteBufferView() {
+        return LONG_BE_BYTE_BUFFER_VIEW;
+    }
+
+    public static VarHandle intLeByteBufferView() {
+        return INT_LE_BYTE_BUFFER_VIEW;
+    }
+
+    public static VarHandle intBeByteBufferView() {
+        return INT_BE_BYTE_BUFFER_VIEW;
+    }
+
+    public static VarHandle shortLeByteBufferView() {
+        return SHORT_LE_BYTE_BUFFER_VIEW;
+    }
+
+    public static VarHandle shortBeByteBufferView() {
+        return SHORT_BE_BYTE_BUFFER_VIEW;
     }
 }


### PR DESCRIPTION
Motivation:

With Unsafe gone the existing Direct's ByteBuf have too much overhead compared to the unsafe versions

Modifications:

Removed redundant bound checks and byte swapping conversions by using VarHandle

Result:

Faster safe Direct ByteBuffers (Fixes https://github.com/netty/netty/issues/15503)