### PR TITLE
IoUring: Just make use of our VarHandle stubs for io_uring to simplif…

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -678,6 +678,20 @@ public final class PlatformDependent {
         return null;
     }
 
+    public static VarHandle intNeBufferView() {
+        if (VAR_HANDLE) {
+            return VarHandleFactory.intNeBufferView();
+        }
+        return null;
+    }
+
+    public static VarHandle shortNeBufferView() {
+        if (VAR_HANDLE) {
+            return VarHandleFactory.shortNeBufferView();
+        }
+        return null;
+    }
+
     public static Object getObject(Object object, long fieldOffset) {
         return PlatformDependent0.getObject(object, fieldOffset);
     }

--- a/common/src/main/java/io/netty/util/internal/VarHandleFactory.java
+++ b/common/src/main/java/io/netty/util/internal/VarHandleFactory.java
@@ -35,6 +35,9 @@ final class VarHandleFactory {
     private static final VarHandle INT_BE_ARRAY_VIEW;
     private static final VarHandle SHORT_LE_ARRAY_VIEW;
     private static final VarHandle SHORT_BE_ARRAY_VIEW;
+    private static final VarHandle INT_NE_BUFFER_VIEW;
+    private static final VarHandle SHORT_NE_BUFFER_VIEW;
+
     private static final Throwable UNAVAILABILITY_CAUSE;
 
     static {
@@ -46,6 +49,9 @@ final class VarHandleFactory {
         VarHandle intBeArrayViewHandle = null;
         VarHandle shortLeArrayViewHandle = null;
         VarHandle shortBeArrayViewHandle = null;
+        VarHandle intNeBufferViewHandle = null;
+        VarHandle shortNeBufferViewHandle = null;
+
         Throwable error = null;
         try {
             MethodHandles.Lookup lookup = MethodHandles.lookup();
@@ -62,6 +68,15 @@ final class VarHandleFactory {
             shortLeArrayViewHandle = (VarHandle) byteArrayViewHandle.invokeExact(
                     short[].class, ByteOrder.LITTLE_ENDIAN);
             shortBeArrayViewHandle = (VarHandle) byteArrayViewHandle.invokeExact(short[].class, ByteOrder.BIG_ENDIAN);
+
+            MethodHandle byteBufferViewHandle = lookup.findStatic(MethodHandles.class, "byteBufferViewVarHandle",
+                    MethodType.methodType(VarHandle.class, Class.class, ByteOrder.class));
+
+            intNeBufferViewHandle = (VarHandle)
+                    byteBufferViewHandle.invokeExact(int[].class, ByteOrder.nativeOrder());
+
+            shortNeBufferViewHandle = (VarHandle)
+                    byteBufferViewHandle.invokeExact(short[].class, ByteOrder.nativeOrder());
             error = null;
         } catch (Throwable e) {
             error = e;
@@ -81,6 +96,8 @@ final class VarHandleFactory {
             INT_BE_ARRAY_VIEW = intBeArrayViewHandle;
             SHORT_LE_ARRAY_VIEW = shortLeArrayViewHandle;
             SHORT_BE_ARRAY_VIEW = shortBeArrayViewHandle;
+            INT_NE_BUFFER_VIEW = intNeBufferViewHandle;
+            SHORT_NE_BUFFER_VIEW = shortNeBufferViewHandle;
             UNAVAILABILITY_CAUSE = error;
         }
     }
@@ -133,5 +150,13 @@ final class VarHandleFactory {
 
     public static VarHandle shortBeArrayView() {
         return SHORT_BE_ARRAY_VIEW;
+    }
+
+    public static VarHandle intNeBufferView() {
+        return INT_NE_BUFFER_VIEW;
+    }
+
+    public static VarHandle shortNeBufferView() {
+        return SHORT_NE_BUFFER_VIEW;
     }
 }

--- a/transport-classes-io_uring/pom.xml
+++ b/transport-classes-io_uring/pom.xml
@@ -28,12 +28,15 @@
 
   <properties>
     <javaModuleName>io.netty.transport.classes.io_uring</javaModuleName>
-    <maven.compiler.source>1.9</maven.compiler.source>
-    <maven.compiler.target>1.9</maven.compiler.target>
-    <maven.compiler.release>9</maven.compiler.release>
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-varhandle-stub</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
@@ -58,62 +61,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <!--
-          We need to compile everything except the IoUring class with Java9+
-          The reason for this is that we want still be able to use IoUring.ensureAvaibility() on Java8.
-        -->
-        <executions>
-          <execution>
-            <id>default-compile</id>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-            <configuration>
-              <compilerVersion>1.9</compilerVersion>
-              <fork>true</fork>
-              <source>${maven.compiler.source}</source>
-              <target>${maven.compiler.target}</target>
-              <release>${maven.compiler.release}</release>
-              <debug>true</debug>
-              <optimize>true</optimize>
-              <showDeprecation>true</showDeprecation>
-              <showWarnings>true</showWarnings>
-              <compilerArgument>-Xlint:-options</compilerArgument>
-              <meminitial>256m</meminitial>
-              <maxmem>1024m</maxmem>
-              <excludes>
-                <exclude>**/package-info.java</exclude>
-              </excludes>
-            </configuration>
-          </execution>
-          <execution>
-            <id>compile-jdk8</id>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-            <configuration>
-              <compilerVersion>1.8</compilerVersion>
-              <fork>true</fork>
-              <source>1.8</source>
-              <target>1.8</target>
-              <release>8</release>
-              <debug>true</debug>
-              <optimize>true</optimize>
-              <showDeprecation>true</showDeprecation>
-              <showWarnings>true</showWarnings>
-              <compilerArgument>-Xlint:-options</compilerArgument>
-              <meminitial>256m</meminitial>
-              <maxmem>1024m</maxmem>
-              <includes>
-                <include>**/IoUring.java</include>
-              </includes>
-            </configuration>
-          </execution>
-        </executions>
-
-      </plugin>
       <plugin>
         <groupId>io.github.dmlloyd.module-info</groupId>
         <artifactId>module-info</artifactId>

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionQueue.java
@@ -15,18 +15,17 @@
  */
 package io.netty.channel.uring;
 
-import java.lang.invoke.MethodHandles;
+import io.netty.util.internal.PlatformDependent;
+
 import java.lang.invoke.VarHandle;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.util.StringJoiner;
 
 /**
  * Completion queue implementation for io_uring.
  */
 final class CompletionQueue {
-    private static final VarHandle INT_HANDLE =
-            MethodHandles.byteBufferViewVarHandle(int[].class, ByteOrder.nativeOrder());
+    private static final VarHandle INT_HANDLE = PlatformDependent.intNeBufferView();
 
     //these offsets are used to access specific properties
     //CQE (https://github.com/axboe/liburing/blob/master/src/include/liburing/io_uring.h#L162)

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringBufferRing.java
@@ -17,17 +17,15 @@ package io.netty.channel.uring;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.unix.Buffer;
+import io.netty.util.internal.PlatformDependent;
 
-import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.function.Consumer;
 
 final class IoUringBufferRing {
-    private static final VarHandle SHORT_HANDLE =
-            MethodHandles.byteBufferViewVarHandle(short[].class, ByteOrder.nativeOrder());
+    private static final VarHandle SHORT_HANDLE = PlatformDependent.shortNeBufferView();
     private final ByteBuffer ioUringBufRing;
     private final int tailFieldPosition;
     private final short entries;

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/SubmissionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/SubmissionQueue.java
@@ -16,13 +16,12 @@
 package io.netty.channel.uring;
 
 import io.netty.channel.unix.Buffer;
+import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
-import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.util.StringJoiner;
 
 final class SubmissionQueue {
@@ -48,8 +47,7 @@ final class SubmissionQueue {
 
     // These unsigned integer pointers(shared with the kernel) will be changed by the kernel and us
     // using a VarHandle.
-    private static final VarHandle INT_HANDLE =
-            MethodHandles.byteBufferViewVarHandle(int[].class, ByteOrder.nativeOrder());
+    private static final VarHandle INT_HANDLE = PlatformDependent.intNeBufferView();
     private final ByteBuffer kHead;
     private final ByteBuffer kTail;
     private final ByteBuffer kflags;

--- a/varhandle-stub/src/main/java/java/lang/invoke/VarHandle.java
+++ b/varhandle-stub/src/main/java/java/lang/invoke/VarHandle.java
@@ -87,6 +87,12 @@ public class VarHandle {
     public native Object getAcquire(Object... args);
 
     @MethodHandle.PolymorphicSignature
+    public native Object getVolatile(Object... args);
+
+    @MethodHandle.PolymorphicSignature
+    public native Object getOpaque(Object... args);
+
+    @MethodHandle.PolymorphicSignature
     public native void set(Object... args);
 
     @MethodHandle.PolymorphicSignature


### PR DESCRIPTION
…y compilation

Motivation:

We used some hack to be able to compile io_uring transport while still be able to call IoUring itself from Java8. We can remove this hack by just depend on the new varhandle stub

Modification:

- Remove hack that we used to compile
- Make use of our stub

Result:

Simplify maven setup and be consistent with other VarHandle usage