### PR TITLE
ByteBufOutputStream.writeBytes should only write lower-order bytes

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufOutputStream.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufOutputStream.java
@@ -15,7 +15,6 @@
  */
 package io.netty.buffer;
 
-import io.netty.util.CharsetUtil;
 import io.netty.util.internal.ObjectUtil;
 
 import java.io.DataOutput;
@@ -102,7 +101,13 @@ public class ByteBufOutputStream extends OutputStream implements DataOutput {
 
     @Override
     public void writeBytes(String s) throws IOException {
-        buffer.writeCharSequence(s, CharsetUtil.US_ASCII);
+        int length = s.length();
+        buffer.ensureWritable(length);
+        int offset = buffer.writerIndex();
+        for (int i = 0; i < length; i++) {
+            buffer.setByte(offset + i, (byte) s.charAt(i));
+        }
+        buffer.writerIndex(offset + length);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/ByteBufOutputStream.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufOutputStream.java
@@ -101,6 +101,9 @@ public class ByteBufOutputStream extends OutputStream implements DataOutput {
 
     @Override
     public void writeBytes(String s) throws IOException {
+        // We don't use `ByteBuf.writeCharSequence` here, because `writeBytes` is specified to only write the
+        // lower-order by of multibyte characters (exactly one byte per character in the string), while
+        // `writeCharSequence` will instead write a '?' replacement character.
         int length = s.length();
         buffer.ensureWritable(length);
         int offset = buffer.writerIndex();

--- a/buffer/src/test/java/io/netty/buffer/ByteBufStreamTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufStreamTest.java
@@ -15,7 +15,6 @@
  */
 package io.netty.buffer;
 
-import io.netty.util.ReferenceCountUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
@@ -350,5 +349,19 @@ public class ByteBufStreamTest {
         // When releaseOnClose is not set or releaseOnClose is false, ByteBuf must be released manually.
         out.buffer().release();
         assertEquals(0, out.buffer().refCnt());
+    }
+
+    @Test
+    void writeStringMustIgnoreHigherOrderByte() throws Exception {
+        ByteBuf buf = Unpooled.buffer();
+        ByteBufOutputStream out = new ByteBufOutputStream(buf, false);
+        try {
+            out.writeBytes("√");
+        } finally {
+            out.close();
+        }
+        assertEquals(0x221A, '√'); // This is a multibyte character
+        assertEquals(0x1A, buf.readByte()); // Only the lower-order byte is written
+        assertEquals(0, buf.readableBytes());
     }
 }


### PR DESCRIPTION
Motivation:
This is specified by the `DataOutput` interface.

Modification:
Reimplement `writeString` to not use `writeCharSequence` which adds substitute characters instead.

Result:
Fixes https://github.com/netty/netty/issues/15513