### PR TITLE
Improve adaptive free list performance

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -1295,7 +1295,7 @@ final class AdaptivePoolingAllocator {
         /**
          * Called when a ByteBuf is done using its allocation in this chunk.
          */
-        boolean releaseSegment(int segmentId) {
+        boolean releaseSegment(int ignoredSegmentId) {
             return release();
         }
 


### PR DESCRIPTION
Motivation:

Resolves #15419. Improve the performance of thread-local allocations.

Modifications:

- Added a non-atomic LIFO cache (`IntStack`) to each thread-local `Magazine`. This serves as a fast path for segment reuse.
- `SizeClassedChunk` has been updated to prioritize this cache. On allocation, it first attempts to `pop` from the magazine's local `IntStack`. On deallocation, it first attempts to `push` to it.
- The existing MPSC Queue remains as a fallback for shared magazines and for when the local `IntStack` cache is full.

Result:

For thread-local allocations, the performance of size-classed buffers is improved due to:
1. Better locality from the LIFO behavior of the new `IntStack` class.
2. Elimination of atomic operations on the primary allocation/deallocation hot path.