### PR TITLE
Epoll: Correctly handle UDP packets with source port of 0. (#15528)

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/NativeDatagramPacketArray.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/NativeDatagramPacketArray.java
@@ -188,7 +188,7 @@ final class NativeDatagramPacketArray {
             this.segmentSize = segmentSize;
 
             this.senderScopeId = 0;
-            this.senderPort = 0;
+            this.senderPort = -1;
             this.senderAddrLen = 0;
 
             if (recipient == null) {
@@ -210,7 +210,7 @@ final class NativeDatagramPacketArray {
         }
 
         boolean hasSender() {
-            return senderPort > 0;
+            return senderPort >= 0;
         }
 
         DatagramPacket newDatagramPacket(ByteBuf buffer, InetSocketAddress recipient) throws UnknownHostException {


### PR DESCRIPTION
Motivation:

UDP / Datagram allows a source port of 0, so we should allow it. NIO already handles it correctly.

Modifications:

Use -1 to signal if we did have a source port or not.

Result:

Consistent behaviour between Epoll and Nio transport. Fixes https://github.com/netty/netty/issues/15526