### PR TITLE
Do no check length parameter of ByteBufOutputStream.write(byte[], int…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufOutputStream.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufOutputStream.java
@@ -72,10 +72,6 @@ public class ByteBufOutputStream extends OutputStream implements DataOutput {
 
     @Override
     public void write(byte[] b, int off, int len) throws IOException {
-        if (len == 0) {
-            return;
-        }
-
         buffer.writeBytes(b, off, len);
     }
 

--- a/buffer/src/test/java/io/netty/buffer/ByteBufStreamTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufStreamTest.java
@@ -48,8 +48,14 @@ public class ByteBufStreamTest {
             // Expected
         }
 
-        ByteBufOutputStream out = new ByteBufOutputStream(buf);
+        final ByteBufOutputStream out = new ByteBufOutputStream(buf);
         try {
+            assertThrows(IndexOutOfBoundsException.class, new Executable() {
+                @Override
+                public void execute() throws Throwable {
+                    out.write(EMPTY_BYTES, -1, 0);
+                }
+            });
             assertSame(buf, out.buffer());
             out.writeBoolean(true);
             out.writeBoolean(false);


### PR DESCRIPTION
…, int); method (#15527)

Motivation:

ByteBufOutputStream#write(byte[], int, int); method should respect the contract of the DataOutput interface and of the OutputStream class. In particular, throwing an IndexOutOfBoundsException if offset is negative. See
[DataOutput](https://docs.oracle.com/en/java/javase/21/docs//api/java.base/java/io/DataOutput.html#write(byte%5B%5D,int,int)) and
[OutputStream](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/io/OutputStream.html#write(byte%5B%5D,int,int)). This doesn't happen when the given length is 0. In this case, the method just return.

Modifications:

Removing the check of length parameter preventing enter in buffer.writeBytes(b, off, len);
Add a test, checking the method throws an IndexOutOfBoundsException when offset is negative even if the length parameter is 0.

Result:

The ByteBufOutputStream#write(byte[], int, int); method will throw an IndexOutOfBoundsException when offset is negative even if the length parameter is 0.