### PR TITLE
Make construction method of Http2ServerUpgradeCodec to be public (#15…

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ServerUpgradeCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ServerUpgradeCodec.java
@@ -106,7 +106,7 @@ public class Http2ServerUpgradeCodec implements HttpServerUpgradeHandler.Upgrade
         this(null, http2Codec, handlers);
     }
 
-    private Http2ServerUpgradeCodec(String handlerName, Http2ConnectionHandler connectionHandler,
+    public Http2ServerUpgradeCodec(String handlerName, Http2ConnectionHandler connectionHandler,
             ChannelHandler... handlers) {
         this.handlerName = handlerName;
         this.connectionHandler = connectionHandler;


### PR DESCRIPTION
…484)

Motivation:
The last construction method of Http2ServerUpgradeCodec should also be set to public

Modifications:

- Change constructor to public

Result:
Fixes  https://github.com/netty/netty/issues/15483