### PR TITLE
Fix netty-common OSGi Import-Package header

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -237,8 +237,16 @@
                 <!-- NativeLibraryLoader can be used to manually load native libraries from other bundles that this bundle does not depend on,
                 hence use DynamicImport-Package instruction to ensure the loading is successful -->
                 <DynamicImport-Package>*</DynamicImport-Package>
-                <!-- JCTools is shaded -->
-                <Import-Package>!org.jctools.*;sun.misc;resolution:=optional;*</Import-Package>
+                <Import-Package>
+                  <!-- JCTools is shaded -->
+                  !org.jctools.*,
+                  <!-- JFR is available only in JDK9+ and is optional -->
+                  jdk.jfr;resolution:=optional,
+                  <!-- JVM vendor packages are optional -->
+                  sun.misc;resolution:=optional,
+                  sun.nio.ch;resolution:=optional,
+                  *
+                </Import-Package>
               </instructions>
             </configuration>
           </execution>


### PR DESCRIPTION
Motivation:

Import-Package specification has a typo, using ';' instead of ',' to
separate packages, which results in all packages to be imported as
optional:
    com.oracle.svm.core.annotate;resolution:=optional,
    io.netty.util;resolution:=optional,
    io.netty.util.concurrent;resolution:=optional,
    io.netty.util.internal;resolution:=optional,
    io.netty.util.internal.logging;resolution:=optional,
    javax.security.cert;resolution:=optional,
    jdk.jfr;resolution:=optional,
    org.apache.commons.logging;resolution:=optional;version="[1.3,2)",
    org.apache.log4j;resolution:=optional;version="[2.20,3)",
    org.apache.logging.log4j.message;resolution:=optional;version="[2.22,3)",
    org.apache.logging.log4j;resolution:=optional;version="[2.20,3)",
    org.apache.logging.log4j.spi;resolution:=optional;version="[2.20,3)",
    org.slf4j.helpers;resolution:=optional;version="[2.0,3)",
    org.slf4j;resolution:=optional;version="[2.0,3)",
    org.slf4j.spi;resolution:=optional;version="[2.0,3)",
    reactor.blockhound.integration;resolution:=optional,
    reactor.blockhound;resolution:=optional,
    sun.misc;resolution:=optional,
    sun.nio.ch;resolution:=optional

Modifications:

Fix the typo and list only a single package on each line.

Result:

Import-Package gets generated as:
    com.oracle.svm.core.annotate;resolution:=optional,
    io.netty.util,
    io.netty.util.concurrent,
    io.netty.util.internal,
    io.netty.util.internal.logging,
    javax.security.cert,
    jdk.jfr;resolution:=optional,
    org.apache.commons.logging;version="[1.3,2)";resolution:=optional,
    org.apache.log4j;version="[2.20,3)";resolution:=optional,
    org.apache.logging.log4j.message;version="[2.22,3)";resolution:=optional,
    org.apache.logging.log4j.spi;version="[2.20,3)";resolution:=optional,
    org.apache.logging.log4j;version="[2.20,3)";resolution:=optional,
    org.slf4j.helpers;version="[2.0,3)";resolution:=optional,
    org.slf4j.spi;version="[2.0,3)";resolution:=optional,
    org.slf4j;version="[2.0,3)";resolution:=optional,
    reactor.blockhound.integration;resolution:=optional,
    reactor.blockhound;resolution:=optional,
    sun.misc;resolution:=optional,
    sun.nio.ch;resolution:=optional

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
