### PR TITLE
Use ChannelException wen DomainSocketChannelConfig method throws

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannelConfig.java
@@ -16,6 +16,7 @@
 package io.netty.channel.epoll;
 
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
@@ -185,7 +186,7 @@ public final class EpollDomainSocketChannelConfig extends EpollChannelConfig
         try {
             return ((EpollDomainSocketChannel) channel).socket.getSendBufferSize();
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new ChannelException(e);
         }
     }
 
@@ -194,7 +195,7 @@ public final class EpollDomainSocketChannelConfig extends EpollChannelConfig
             ((EpollDomainSocketChannel) channel).socket.setSendBufferSize(sendBufferSize);
             return this;
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new ChannelException(e);
         }
     }
 
@@ -202,7 +203,7 @@ public final class EpollDomainSocketChannelConfig extends EpollChannelConfig
         try {
             return ((EpollDomainSocketChannel) channel).socket.getReceiveBufferSize();
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new ChannelException(e);
         }
     }
 
@@ -211,7 +212,7 @@ public final class EpollDomainSocketChannelConfig extends EpollChannelConfig
             ((EpollDomainSocketChannel) channel).socket.setReceiveBufferSize(receiveBufferSize);
             return this;
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new ChannelException(e);
         }
     }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDomainSocketChannelConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDomainSocketChannelConfig.java
@@ -16,6 +16,7 @@
 package io.netty.channel.uring;
 
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
@@ -92,7 +93,7 @@ final class IoUringDomainSocketChannelConfig extends IoUringStreamChannelConfig
         try {
             return ((IoUringDomainSocketChannel) channel).socket.getSendBufferSize();
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new ChannelException(e);
         }
     }
 
@@ -101,7 +102,7 @@ final class IoUringDomainSocketChannelConfig extends IoUringStreamChannelConfig
             ((IoUringDomainSocketChannel) channel).socket.setSendBufferSize(sendBufferSize);
             return this;
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new ChannelException(e);
         }
     }
 
@@ -109,7 +110,7 @@ final class IoUringDomainSocketChannelConfig extends IoUringStreamChannelConfig
         try {
             return ((IoUringDomainSocketChannel) channel).socket.getReceiveBufferSize();
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new ChannelException(e);
         }
     }
 
@@ -118,7 +119,7 @@ final class IoUringDomainSocketChannelConfig extends IoUringStreamChannelConfig
             ((IoUringDomainSocketChannel) channel).socket.setReceiveBufferSize(receiveBufferSize);
             return this;
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new ChannelException(e);
         }
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannelConfig.java
@@ -16,6 +16,7 @@
 package io.netty.channel.kqueue;
 
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
@@ -174,7 +175,7 @@ public final class KQueueDomainSocketChannelConfig extends KQueueChannelConfig
         try {
             return ((KQueueDomainSocketChannel) channel).socket.getSendBufferSize();
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new ChannelException(e);
         }
     }
 
@@ -183,7 +184,7 @@ public final class KQueueDomainSocketChannelConfig extends KQueueChannelConfig
             ((KQueueDomainSocketChannel) channel).socket.setSendBufferSize(sendBufferSize);
             return this;
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new ChannelException(e);
         }
     }
 
@@ -191,7 +192,7 @@ public final class KQueueDomainSocketChannelConfig extends KQueueChannelConfig
         try {
             return ((KQueueDomainSocketChannel) channel).socket.getReceiveBufferSize();
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new ChannelException(e);
         }
     }
 
@@ -200,7 +201,7 @@ public final class KQueueDomainSocketChannelConfig extends KQueueChannelConfig
             ((KQueueDomainSocketChannel) channel).socket.setReceiveBufferSize(receiveBufferSize);
             return this;
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new ChannelException(e);
         }
     }
 


### PR DESCRIPTION
Motivation:

We usually use ChannelException if one of the ChannelConfig methods throw so we should do the same also for the DomainSocketChannelConfig implementations

Modifications:

- Replace RuntimeException with ChannelException

Result:

Cleanup and more consistent behaviour