### PR TITLE
IoUring: Submit and process completions in a loop to ensure timely processing.

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -184,7 +184,9 @@ public final class IoUringIoHandler implements IoHandler {
     private int processCompletionsAndHandleOverflow(SubmissionQueue submissionQueue, CompletionQueue completionQueue,
                                          CompletionCallback callback) {
         int processed = 0;
-        for (;;) {
+        // Bound the maximum number of times this will loop before we return and so execute some non IO stuff.
+        // 128 here is just some sort of bound and another number might be ok as well.
+        for (int i = 0; i < 128; i++) {
             int p = completionQueue.process(callback);
             if ((submissionQueue.flags() & Native.IORING_SQ_CQ_OVERFLOW) != 0) {
                 logger.warn("CompletionQueue overflow detected, consider increasing size: {} ",


### PR DESCRIPTION
Motivation:
    
We should contine to submit and proccess completions in a loop to ensure timely execution before return and start to process tasks. This is also more inline with other transports like epoll / nio etc.
    
Modifications:
    
Only return from method once we could not submit anything new and did not see anymore completions.
    
Result:
    
More timely processing of io. Fixes https://github.com/netty/netty/issues/15502