### PR TITLE
Skip testsuite-osgi by default

### DIFF
--- a/testsuite-osgi/pom.xml
+++ b/testsuite-osgi/pom.xml
@@ -34,6 +34,8 @@
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
     <maven.javadoc.skip>true</maven.javadoc.skip>
+    <!-- Skip OSGI testsuite by default -->
+    <skipOsgiTestsuite>true</skipOsgiTestsuite>
   </properties>
 
   <profiles>


### PR DESCRIPTION
Motivation:

Our osgi testsuite has problems with latest java versions, just skip it for now

Modifications:

Skip tests in testsuite-osgi by default

Result:

Build stability fix