### PR TITLE
Remove usage of io.netty.build.junit.TimedOutTestsListener

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1557,25 +1557,11 @@
             <nativeimage.handlerMetadataArtifactId>${project.artifactId}</nativeimage.handlerMetadataArtifactId>
           </systemPropertyVariables>
           <argLine>${argLine.common} ${argLine.printGC} ${argLine.leak} ${argLine.coverage} ${argLine.noUnsafe} ${argLine.jni} ${argLine.java9} ${argLine.javaProperties} -Dio.netty.bootstrap.extensions=serviceload</argLine>
-          <properties>
-            <property>
-              <name>listener</name>
-              <value>io.netty.build.junit.TimedOutTestsListener</value>
-            </property>
-          </properties>
           <skipTests>${skipTests}</skipTests>
           <jvm>${testJvm}</jvm>
            <!-- Ensure the whole stacktrace is preserved when an exception is thrown. See https://issues.apache.org/jira/browse/SUREFIRE-1457 -->
           <trimStackTrace>false</trimStackTrace>
         </configuration>
-        <dependencies>
-          <!-- Needed for TimedOutTestsListener -->
-          <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>netty-build-common</artifactId>
-            <version>${netty.build.version}</version>
-          </dependency>
-        </dependencies>
       </plugin>
       <!-- always produce osgi bundles -->
       <plugin>

--- a/transport-native-io_uring/pom.xml
+++ b/transport-native-io_uring/pom.xml
@@ -216,12 +216,6 @@
                     <logback.configurationFile>src/test/resources/logback-test.xml</logback.configurationFile>
                     <logLevel>debug</logLevel>
                   </systemPropertyVariables>
-                  <properties>
-                    <property>
-                      <name>listener</name>
-                      <value>io.netty.build.junit.TimedOutTestsListener</value>
-                    </property>
-                  </properties>
                   <!-- Ensure the whole stacktrace is preserved when an exception is thrown. See https://issues.apache.org/jira/browse/SUREFIRE-1457 -->
                   <trimStackTrace>false</trimStackTrace>
                   <argLine>${test.argLine}</argLine>
@@ -249,12 +243,6 @@
                     <logback.configurationFile>src/test/resources/logback-test.xml</logback.configurationFile>
                     <logLevel>debug</logLevel>
                   </systemPropertyVariables>
-                  <properties>
-                    <property>
-                      <name>listener</name>
-                      <value>io.netty.build.junit.TimedOutTestsListener</value>
-                    </property>
-                  </properties>
                   <!-- Ensure the whole stacktrace is preserved when an exception is thrown. See https://issues.apache.org/jira/browse/SUREFIRE-1457 -->
                   <trimStackTrace>false</trimStackTrace>
                   <argLine>${test.argLine}</argLine>


### PR DESCRIPTION
Motivation:

io.netty.build.junit.TimedOutTestsListener does not exists in latest release of netty-build.

Modifications:

Remove usage of io.netty.build.junit.TimedOutTestsListener

Result:

Fix classloader issues during build