### PR TITLE
Skip testsuite-osgi by default (#15549)

### DIFF
--- a/testsuite-osgi/pom.xml
+++ b/testsuite-osgi/pom.xml
@@ -36,6 +36,8 @@
     <!-- Do not deploy this module -->
     <skipDeploy>true</skipDeploy>
     <javaModuleName>io.netty.testsuite_osgi</javaModuleName>
+    <!-- Skip OSGI testsuite by default -->
+    <skipOsgiTestsuite>true</skipOsgiTestsuite>
   </properties>
 
   <profiles>


### PR DESCRIPTION
Motivation:

Our osgi testsuite has problems with latest java versions, just skip it for now

Modifications:

Skip tests in testsuite-osgi by default

Result:

Build stability fix