### PR TITLE
Make org.graalvm.nativeimage:svm optional in netty-common

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -42,8 +42,8 @@
       <groupId>org.graalvm.nativeimage</groupId>
       <artifactId>svm</artifactId>
       <version>${graalvm.version}</version>
-      <!-- Provided scope as it is only needed for compiling the SVM substitution classes -->
-      <scope>provided</scope>
+      <!-- Optional so maven-bundle-plugin does not make com.oracle.svm.core.annotate a required import -->
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jctools</groupId>


### PR DESCRIPTION
Motivation:

The netty-common manifest lists com.oracle.svm.core.annotate as a hard OSGi dependency, preventing resolving netty-common in OSGi without also supplying org.graalvm.nativeimage:svm as a dependency.

Modifications:

Change the svm dependency to be 'optional' rather than 'provided', so that maven-bundle-plugin marks the related import entry for com.oracle.svm.core.annotate as optional in the manifest Import-Package declaration.

Result:

netty-common lists com.oracle.svm.core.annotate as an optional import and can be resolved without org.graalvm.nativeimage:svm dependency.

Fixes #15557 