### PR TITLE
Exposed encoderEnforceMaxRstFramesPerWindow for HttpToHttp2ConnectionHandlerBuilder

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2ConnectionHandlerBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2ConnectionHandlerBuilder.java
@@ -459,7 +459,7 @@ public abstract class AbstractHttp2ConnectionHandlerBuilder<T extends Http2Conne
      * {@code 0} for any of the parameters means no protection should be applied.
      */
     protected B encoderEnforceMaxRstFramesPerWindow(int maxRstFramesPerWindow, int secondsPerWindow) {
-        enforceNonCodecConstraints("decoderEnforceMaxRstFramesPerWindow");
+        enforceNonCodecConstraints("encoderEnforceMaxRstFramesPerWindow");
         this.maxEncodedRstFramesPerWindow = checkPositiveOrZero(
                 maxRstFramesPerWindow, "maxRstFramesPerWindow");
         this.maxEncodedRstFramesSecondsPerWindow = checkPositiveOrZero(secondsPerWindow, "secondsPerWindow");

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerBuilder.java
@@ -99,6 +99,12 @@ public final class HttpToHttp2ConnectionHandlerBuilder extends
     }
 
     @Override
+    public HttpToHttp2ConnectionHandlerBuilder encoderEnforceMaxRstFramesPerWindow(int maxRstFramesPerWindow,
+            int secondsPerWindow) {
+        return super.encoderEnforceMaxRstFramesPerWindow(maxRstFramesPerWindow, secondsPerWindow);
+    }
+
+    @Override
     @Deprecated
     public HttpToHttp2ConnectionHandlerBuilder initialHuffmanDecodeCapacity(int initialHuffmanDecodeCapacity) {
         return super.initialHuffmanDecodeCapacity(initialHuffmanDecodeCapacity);


### PR DESCRIPTION
### Motivation:
To expose APIs under AbstractHttp2ConnectionHandlerBuilder to be able to use with the HttpToHttp2ConnectionHandlerBuilder

### Modification:
Exposed encoderEnforceMaxRstFramesPerWindow under HttpToHttp2ConnectionHandlerBuilder, updated enforceNonCodecConstraints for AbstractHttp2ConnectionHandlerBuilder, and updated pom.xml for ignoring API change


### Result:
Fixes #15559

