### PR TITLE
Clean up netty-buffer Import-Package

### DIFF
--- a/buffer/pom.xml
+++ b/buffer/pom.xml
@@ -125,6 +125,28 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>generate-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+            <configuration>
+              <instructions>
+                <Import-Package>
+                  <!-- JFR is available only in JDK9+ and is optional -->
+                  jdk.jfr;resolution:=optional,
+                  *
+                </Import-Package>
+              </instructions>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>io.github.dmlloyd.module-info</groupId>
         <artifactId>module-info</artifactId>
         <executions>

--- a/testsuite-karaf/pom.xml
+++ b/testsuite-karaf/pom.xml
@@ -49,6 +49,11 @@
   <dependencies>
     <dependency>
       <groupId>io.netty</groupId>
+      <artifactId>netty-buffer</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
       <scope>provided</scope>
     </dependency>

--- a/testsuite-karaf/src/main/feature/feature.xml
+++ b/testsuite-karaf/src/main/feature/feature.xml
@@ -16,6 +16,7 @@
   -->
 <features xmlns="http://karaf.apache.org/xmlns/features/v1.6.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.6.0" name="test">
   <feature name="test" version="${project.version}">
+    <bundle>mvn:io.netty/netty-buffer/${project.version}</bundle>
     <bundle>mvn:io.netty/netty-common/${project.version}</bundle>
     <bundle>mvn:io.netty/netty-resolver/${project.version}</bundle>
   </feature>


### PR DESCRIPTION
Motivation:

netty-buffer contains the following Import-Package declaration:
```
  com.oracle.svm.core.annotate;resolution:=optional
  io.netty.util.concurrent;version="[4.2,5)"
  io.netty.util.internal.logging;version="[4.2,5)"
  io.netty.util.internal;version="[4.2,5)"
  io.netty.util;version="[4.2,5)"
  jdk.jfr
  org.bouncycastle.jcajce.provider;version="[1.0,2)";resolution:=optional
  sun.nio.ch;resolution:=optional
```

Of these, the last two are completely unused. The jdk.jfr is a
questionable one.

Modification:

Override bundle-plugin configuration to make jdk.jfr import optional,
resulting in the following Import-Package declaration:
```
    com.oracle.svm.core.annotate;resolution:=optional
    io.netty.util.concurrent;version="[4.2,5)"
    io.netty.util.internal.logging;version="[4.2,5)
    io.netty.util.internal;version="[4.2,5)"
    io.netty.util;version="[4.2,5)"
    jdk.jfr;resolution:=optional
```

Result:

netty-buffer an be loaded in Karaf-4.4.8.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
