### PR TITLE
Skip generation of javadocs for stubs

### DIFF
--- a/jfr-stub/pom.xml
+++ b/jfr-stub/pom.xml
@@ -30,6 +30,7 @@
 
   <properties>
     <revapi.skip>true</revapi.skip>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 </project>
 

--- a/varhandle-stub/pom.xml
+++ b/varhandle-stub/pom.xml
@@ -30,6 +30,7 @@
 
   <properties>
     <revapi.skip>true</revapi.skip>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 </project>
 


### PR DESCRIPTION
Motivation:

We need to skip the gneration of the javadocs for the stubs as otherwise we will fail generation the aggregated javadocs

Modifications:

Add property to skip generation

Result:

generate javadocs script works again