### PR TITLE
Add testsuite-karaf

### DIFF
--- a/nohttp-checkstyle-suppressions.xml
+++ b/nohttp-checkstyle-suppressions.xml
@@ -57,6 +57,9 @@
   <suppress message="http://www.w3.org/2001/XMLSchema-instance" checks="NoHttp"/>
   <suppress message="http://maven.apache.org/POM/4.0.0" checks="NoHttp"/>
 
+  <!-- Karaf feature namespaces -->
+  <suppress message="http://karaf.apache.org/xmlns/features/v1.6.0" checks="NoHttp"/>
+
   <!-- These files are generated during the build and not under git -->
   <suppress files="testsuite-shading[/\\]dependency-reduced-pom\.xml" checks="NoHttp"/>
   <suppress files="common[/\\]dependency-reduced-pom\.xml" checks="NoHttp"/>

--- a/pom.xml
+++ b/pom.xml
@@ -800,6 +800,7 @@
     <module>testsuite-autobahn</module>
     <module>testsuite-http2</module>
     <module>testsuite-jpms</module>
+    <module>testsuite-karaf</module>
     <module>testsuite-osgi</module>
     <module>testsuite-shading</module>
     <module>testsuite-native</module>

--- a/testsuite-karaf/README.md
+++ b/testsuite-karaf/README.md
@@ -1,0 +1,46 @@
+# Netty/Karaf integration test suite
+
+This directory contains a simple test to ensure Netty bundles can be resolved
+in an Apache Karaf environment.
+
+## Design
+
+This test is structured as a Karaf Feature, hosted in `src/main/feature/feature.xml`, which lists tested budles
+and contains instructions for `karaf-maven-plugin` to build an Karaf Archive. This includes a quick test ensuring
+the bundles can be resolved in a plain Karaf environment when run with `maven.compiler.target`.
+
+Please note that both `pom.xml` and `feature.xml` need to be list the bundles to be verified. The former ensures
+the bundle is built before test and the latter ensures it is tested.
+
+## Diagnostics
+
+A typical failure without `mvn -e` looks like this:
+
+    [ERROR] Failed to execute goal org.apache.karaf.tooling:karaf-maven-plugin:4.4.8:verify (default-verify) on project testsuite-karaf: Verification failures: Verification failures:
+    [ERROR]         Feature resolution failed for [test/4.2.5.Final-SNAPSHOT]
+    [ERROR] Message: Unable to resolve root: missing requirement [root] osgi.identity; osgi.identity=test; type=karaf.feature; version=4.2.5.Final-SNAPSHOT; filter:="(&(osgi.identity=test)(type=karaf.feature)(version>=4.2.5.Final-SNAPSHOT))" [caused by: Unable to resolve test/4.2.5.Final-SNAPSHOT: missing requirement [test/4.2.5.Final-SNAPSHOT] osgi.identity; osgi.identity=io.netty.buffer; type=osgi.bundle; version="[4.2.5.Final-SNAPSHOT,4.2.5.Final-SNAPSHOT]"; resolution:=mandatory [caused by: Unable to resolve io.netty.buffer/4.2.5.Final-SNAPSHOT: missing requirement [io.netty.buffer/4.2.5.Final-SNAPSHOT] osgi.wiring.package; filter:="(osgi.wiring.package=jdk.jfr)"]]
+    [ERROR] Repositories: {
+    [ERROR]         file:/home/nite/prj/netty/testsuite-karaf/target/feature/feature.xml
+    [ERROR]         mvn:org.apache.karaf.features/framework/4.4.8/xml/features
+    [ERROR] }
+    [ERROR] Resources: {
+    [ERROR]         mvn:io.netty/netty-buffer/4.2.5.Final-SNAPSHOT
+    [ERROR]         mvn:io.netty/netty-common/4.2.5.Final-SNAPSHOT
+    [ERROR]         mvn:io.netty/netty-resolver/4.2.5.Final-SNAPSHOT
+    [ERROR] }
+
+Here the `Message` shows the underlying problem, but it is a bit hard to read, because it is encoding an causality
+stack. The last part indicates what went wrong:
+
+    Unable to resolve io.netty.buffer/4.2.5.Final-SNAPSHOT: missing requirement [io.netty.buffer/4.2.5.Final-SNAPSHOT] osgi.wiring.package; filter:="(osgi.wiring.package=jdk.jfr)"
+
+What this is telling us is that `netty-buffer` cannot be installed because it requires the `jdk.jfr` Java package,
+which is not provided by Karaf.
+
+Note that the `filter` part looks simple above, but can look quite arcane, perhaps like
+
+    filter:="(&(osgi.ee=JavaSE)(version=1.8))"
+
+This is not that difficult, as it really is just an RFC1960 LDAP search filter. As such, it is using Polish Notation
+to say that the [execution environment](https://docs.osgi.org/specification/osgi.core/8.0.0/framework.module.html#framework.module-execution.environment)
+needs to be compatible with `JavaSE-1.8`.

--- a/testsuite-karaf/pom.xml
+++ b/testsuite-karaf/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2025 The Netty Project
+  ~
+  ~ The Netty Project licenses this file to you under the Apache License,
+  ~ version 2.0 (the "License"); you may not use this file except in compliance
+  ~ with the License. You may obtain a copy of the License at:
+  ~
+  ~   https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.netty</groupId>
+    <artifactId>netty-parent</artifactId>
+    <version>4.2.5.Final-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>testsuite-karaf</artifactId>
+  <packaging>kar</packaging>
+  <name>Netty/Testsuite/Karaf</name>
+
+  <properties>
+    <org.apache.karaf.version>4.4.8</org.apache.karaf.version>
+    <skipDeploy>true</skipDeploy>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${project.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-common</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-resolver</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- verify dependencies -->
+    <dependency>
+      <groupId>org.apache.karaf.features</groupId>
+      <artifactId>framework</artifactId>
+      <version>${org.apache.karaf.version}</version>
+      <type>kar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.karaf.features</groupId>
+      <artifactId>framework</artifactId>
+      <version>${org.apache.karaf.version}</version>
+      <classifier>features</classifier>
+      <type>xml</type>
+      <scope>runtime</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.karaf.tooling</groupId>
+        <artifactId>karaf-maven-plugin</artifactId>
+        <version>${org.apache.karaf.version}</version>
+        <extensions>true</extensions>
+        <configuration>
+          <descriptors>
+            <descriptor>mvn:org.apache.karaf.features/framework/${org.apache.karaf.version}/xml/features</descriptor>
+            <descriptor>file:${project.build.directory}/feature/feature.xml</descriptor>
+          </descriptors>
+          <features>
+            <feature>test</feature>
+          </features>
+          <javase>${maven.compiler.target}</javase>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/testsuite-karaf/src/main/feature/feature.xml
+++ b/testsuite-karaf/src/main/feature/feature.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2025 The Netty Project
+  ~
+  ~ The Netty Project licenses this file to you under the Apache License,
+  ~ version 2.0 (the "License"); you may not use this file except in compliance
+  ~ with the License. You may obtain a copy of the License at:
+  ~
+  ~   https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<features xmlns="http://karaf.apache.org/xmlns/features/v1.6.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.6.0" name="test">
+  <feature name="test" version="${project.version}">
+    <bundle>mvn:io.netty/netty-common/${project.version}</bundle>
+    <bundle>mvn:io.netty/netty-resolver/${project.version}</bundle>
+  </feature>
+</features>


### PR DESCRIPTION
Motivation:

OSGi metadata keeps getting broken and the testsuite-osgi part does not
seem to catch thes.e

Modification:

Introduce a test based on Apache Karaf, which verifies resolution of
listed bundles against Karaf's expectations.

Result:

Import-Package instructions are validated, catching Karaf/Netty
integration issues.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
