### PR TITLE
Always load BouncyCastle classes with the Netty classloader (#15533) …

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/BouncyCastleAlpnSslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/BouncyCastleAlpnSslUtils.java
@@ -208,23 +208,19 @@ final class BouncyCastleAlpnSslUtils {
         }
     }
 
-    @SuppressWarnings("unchecked")
     static BiFunction<SSLEngine, List<String>, String> getHandshakeApplicationProtocolSelector(SSLEngine engine) {
         try {
             final Object selector = GET_HANDSHAKE_APPLICATION_PROTOCOL_SELECTOR.invoke(engine);
             return new BiFunction<SSLEngine, List<String>, String>() {
-
                 @Override
                 public String apply(SSLEngine sslEngine, List<String> strings) {
                     try {
-                        return (String) BC_APPLICATION_PROTOCOL_SELECTOR_SELECT.invoke(selector, sslEngine,
-                                strings);
+                        return (String) BC_APPLICATION_PROTOCOL_SELECTOR_SELECT.invoke(selector, sslEngine, strings);
                     } catch (Exception e) {
                         throw new RuntimeException("Could not call getHandshakeApplicationProtocolSelector", e);
                     }
                 }
             };
-
         } catch (UnsupportedOperationException ex) {
             throw ex;
         } catch (Exception ex) {

--- a/handler/src/main/java/io/netty/handler/ssl/util/BouncyCastleUtil.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/BouncyCastleUtil.java
@@ -151,13 +151,13 @@ public final class BouncyCastleUtil {
         }
     }
 
+    @SuppressWarnings("unchecked")
     private static void tryLoading() {
-        AccessController.doPrivileged(new PrivilegedAction<Void>() {
-            @SuppressWarnings("unchecked")
+        AccessController.doPrivileged(new PrivilegedAction<Object>() {
             @Override
-            public Void run() {
+            public Object run() {
                 try {
-                    // Check for bcprov-jdk15on or bc-fips:
+                    // Check for bcprov-jdk18on or bc-fips:
                     Provider provider = Security.getProvider(BC_PROVIDER_NAME);
                     if (provider == null) {
                         provider = Security.getProvider(BC_FIPS_PROVIDER_NAME);
@@ -185,7 +185,7 @@ public final class BouncyCastleUtil {
                 }
 
                 try {
-                    // Check for bcpkix-jdk15on:
+                    // Check for bcpkix-jdk18on:
                     ClassLoader classLoader = BouncyCastleUtil.class.getClassLoader();
                     Provider provider = bcProviderJce;
                     if (provider != null) {
@@ -200,7 +200,7 @@ public final class BouncyCastleUtil {
                 }
 
                 try {
-                    // Check for bctls-jdk15on:
+                    // Check for bctls-jdk18on:
                     ClassLoader classLoader = BouncyCastleUtil.class.getClassLoader();
                     Provider provider = Security.getProvider(BC_JSSE_PROVIDER_NAME);
                     if (provider != null) {


### PR DESCRIPTION
…(#15569)

Motivation:
Between Java security settings, different classloaders, and native image compilation, loading the BouncyCastle classes are somewhat complicated.

Modification:
Collect all the BouncyCastle class loading and availability checking in a new BouncyCastleUtil class. Make use of this new class in our BouncyCastle implementations of ALPN, PEM reading, and self-signed certificate generation.

Result:
We should hopefully now be loading the classes correctly in all cases.

Fixes https://github.com/netty/netty/issues/15508