### PR TITLE
Expand testsuite-karaf coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -743,6 +743,8 @@
     <skipHttp2Testsuite>false</skipHttp2Testsuite>
     <graalvm.version>19.3.6</graalvm.version>
     <brotli4j.version>1.16.0</brotli4j.version>
+    <aalto.version>1.3.3</aalto.version>
+    <rxtx.version>2.1.7</rxtx.version>
     <!-- By default skip native testsuite as it requires a custom environment with graalvm installed -->
     <skipNativeImageTestsuite>true</skipNativeImageTestsuite>
     <skipShadingTestsuite>false</skipShadingTestsuite>
@@ -954,7 +956,7 @@
       <dependency>
         <groupId>com.fasterxml</groupId>
         <artifactId>aalto-xml</artifactId>
-        <version>1.3.3</version>
+        <version>${aalto.version}</version>
       </dependency>
 
       <dependency>
@@ -1060,7 +1062,7 @@
       <dependency>
         <groupId>org.rxtx</groupId>
         <artifactId>rxtx</artifactId>
-        <version>2.1.7</version>
+        <version>${rxtx.version}</version>
       </dependency>
 
       <dependency>

--- a/testsuite-karaf/pom.xml
+++ b/testsuite-karaf/pom.xml
@@ -25,7 +25,7 @@
   </parent>
 
   <artifactId>testsuite-karaf</artifactId>
-  <packaging>kar</packaging>
+  <packaging>feature</packaging>
   <name>Netty/Testsuite/Karaf</name>
 
   <properties>
@@ -54,7 +54,97 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
+      <artifactId>netty-codec-base</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-compression</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-classes-quic</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-dns</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-haproxy</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-http</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-http2</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-marshalling</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-memcache</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-mqtt</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-redis</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-smtp</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-socks</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-stomp</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-xml</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler-proxy</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler-ssl-ocsp</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -62,6 +152,63 @@
       <artifactId>netty-resolver</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-resolver-dns</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-resolver-dns-classes-macos</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-classes-epoll</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-classes-io_uring</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-classes-kqueue</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-unix-common</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-rxtx</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-sctp</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- TODO: netty-codec-http3 requires a header fix -->
+    <!-- TODO: netty-codec-protobuf requires figuring out dependencies -->
+    <!-- TODO: netty-transport-udt: requires figuring out slf4j dependency -->
+    <!-- TODO: these require figuring out platform build
+        netty-codec-native-quic
+        netty-resolver-dns-native-macos
+        netty-transport-native-epoll
+        netty-transport-native-io_uring
+        netty-transport-native-kqueue
+        netty-transport-native-unix-common (with classifiers)
+    -->
 
     <!-- verify dependencies -->
     <dependency>
@@ -93,10 +240,41 @@
             <descriptor>file:${project.build.directory}/feature/feature.xml</descriptor>
           </descriptors>
           <features>
-            <feature>test</feature>
+            <feature>netty-java8</feature>
+            <feature>netty-aalto</feature>
+            <feature>netty-bc</feature>
+            <feature>netty-rxtx</feature>
           </features>
-          <javase>${maven.compiler.target}</javase>
+          <javase>1.8</javase>
         </configuration>
+        <executions>
+          <execution>
+            <id>verify-java9</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <features>
+                <feature>netty-java9</feature>
+              </features>
+              <javase>9</javase>
+            </configuration>
+          </execution>
+          <execution>
+            <id>verify-java11</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <features>
+                <feature>netty-jboss</feature>
+              </features>
+              <javase>11</javase>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/testsuite-karaf/src/main/feature/feature.xml
+++ b/testsuite-karaf/src/main/feature/feature.xml
@@ -14,10 +14,71 @@
   ~ License for the specific language governing permissions and limitations
   ~ under the License.
   -->
-<features xmlns="http://karaf.apache.org/xmlns/features/v1.6.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.6.0" name="test">
-  <feature name="test" version="${project.version}">
+<features xmlns="http://karaf.apache.org/xmlns/features/v1.6.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://karaf.apache.org/xmlns/features/v1.6.0" name="netty">
+  <!-- Artifacts requiring Java 8 and nothing else -->
+  <feature name="netty-java8" version="${project.version}">
     <bundle>mvn:io.netty/netty-buffer/${project.version}</bundle>
+    <bundle>mvn:io.netty/netty-codec-base/${project.version}</bundle>
+    <bundle>mvn:io.netty/netty-codec-classes-quic/${project.version}</bundle>
+    <bundle>mvn:io.netty/netty-codec-compression/${project.version}</bundle>
+    <bundle>mvn:io.netty/netty-codec-dns/${project.version}</bundle>
+    <bundle>mvn:io.netty/netty-codec-haproxy/${project.version}</bundle>
+    <bundle>mvn:io.netty/netty-codec-http/${project.version}</bundle>
+    <bundle>mvn:io.netty/netty-codec-http2/${project.version}</bundle>
+    <bundle>mvn:io.netty/netty-codec-memcache/${project.version}</bundle>
+    <bundle>mvn:io.netty/netty-codec-mqtt/${project.version}</bundle>
+    <bundle>mvn:io.netty/netty-codec-redis/${project.version}</bundle>
+    <bundle>mvn:io.netty/netty-codec-smtp/${project.version}</bundle>
+    <bundle>mvn:io.netty/netty-codec-socks/${project.version}</bundle>
+    <bundle>mvn:io.netty/netty-codec-stomp/${project.version}</bundle>
     <bundle>mvn:io.netty/netty-common/${project.version}</bundle>
+    <bundle>mvn:io.netty/netty-handler/${project.version}</bundle>
+    <bundle>mvn:io.netty/netty-handler-proxy/${project.version}</bundle>
     <bundle>mvn:io.netty/netty-resolver/${project.version}</bundle>
+    <bundle>mvn:io.netty/netty-resolver-dns/${project.version}</bundle>
+    <bundle>mvn:io.netty/netty-resolver-dns-classes-macos/${project.version}</bundle>
+    <bundle>mvn:io.netty/netty-transport/${project.version}</bundle>
+    <bundle>mvn:io.netty/netty-transport-classes-epoll/${project.version}</bundle>
+    <bundle>mvn:io.netty/netty-transport-classes-kqueue/${project.version}</bundle>
+    <bundle>mvn:io.netty/netty-transport-native-unix-common/${project.version}</bundle>
+    <bundle>mvn:io.netty/netty-transport-sctp/${project.version}</bundle>
+  </feature>
+
+  <!-- Artifacts requiring Java 9+ and nothing else -->
+  <feature name="netty-java9" version="${project.version}">
+    <feature>netty-java8</feature>
+    <bundle>mvn:io.netty/netty-transport-classes-io_uring/${project.version}</bundle>
+  </feature>
+
+  <!-- Artifacts requiring FasterXML AAlto -->
+  <feature name="netty-aalto" version="${project.version}">
+    <feature>netty-java8</feature>
+    <bundle dependency="true">mvn:org.codehaus.woodstox/stax2-api/4.2.2</bundle>
+    <bundle dependency="true">mvn:com.fasterxml/aalto-xml/${aalto.version}</bundle>
+    <bundle>mvn:io.netty/netty-codec-xml/${project.version}</bundle>
+  </feature>
+
+  <!-- Artifacts requiring Bouncy Castle -->
+  <feature name="netty-bc" version="${project.version}">
+    <feature>netty-java8</feature>
+    <bundle dependency="true">mvn:org.bouncycastle/bcpkix-jdk18on/${bouncycastle.version}</bundle>
+    <bundle dependency="true">mvn:org.bouncycastle/bcprov-jdk18on/${bouncycastle.version}</bundle>
+    <bundle dependency="true">mvn:org.bouncycastle/bcutil-jdk18on/${bouncycastle.version}</bundle>
+    <bundle>mvn:io.netty/netty-handler-ssl-ocsp/${project.version}</bundle>
+  </feature>
+
+  <!-- Artifacts requiring JBoss Marshalling -->
+  <feature name="netty-jboss" version="${project.version}">
+    <feature>netty-java8</feature>
+    <!-- Note: requires Java 11 as of https://issues.redhat.com/browse/JBMAR-253 -->
+    <bundle dependency="true">wrap:mvn:org.jboss.marshalling/jboss-marshalling/${jboss.marshalling.version}</bundle>
+    <bundle>mvn:io.netty/netty-codec-marshalling/${project.version}</bundle>
+  </feature>
+
+  <!-- Artifacts requiring RXTX -->
+  <feature name="netty-rxtx" version="${project.version}">
+    <feature>netty-java8</feature>
+    <bundle dependency="true">wrap:mvn:org.rxtx/rxtx/${rxtx.version}</bundle>
+    <bundle>mvn:io.netty/netty-transport-rxtx/${project.version}</bundle>
   </feature>
 </features>


### PR DESCRIPTION
Motivation:

We are oftentimes faced with artifacts' OSGi metadata not being on par
with expectations.

Modification:

Expand testsuite-karaf to cover artifacts which can be easily tested and
are currently passing testing.

Result:

Most of artifacts are now tested to ensure they can be resolved by
Apache Karaf.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
