### PR TITLE
Make DatagramMulticastTest handlers sharable

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramMulticastTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramMulticastTest.java
@@ -18,6 +18,7 @@ package io.netty.testsuite.transport.socket;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.SimpleChannelInboundHandler;
@@ -71,6 +72,11 @@ public class DatagramMulticastTest extends AbstractDatagramTest {
             @Override
             public void channelRead0(ChannelHandlerContext ctx, Object msg) throws Exception {
                 // Nothing will be sent.
+            }
+
+            @Override
+            public boolean isSharable() {
+                return true;
             }
         });
 
@@ -152,6 +158,7 @@ public class DatagramMulticastTest extends AbstractDatagramTest {
         fail();
     }
 
+    @ChannelHandler.Sharable
     private static final class MulticastTestHandler extends SimpleChannelInboundHandler<DatagramPacket> {
         private final CountDownLatch latch = new CountDownLatch(1);
 


### PR DESCRIPTION
Motivation:
The test has a retry loop, so the handlers need to be sharable.

Modification:
Make the two handlers used in the test sharable.

Result:
The test should no longer fail with exceptions like the following:

```
2025-08-20T21:27:15.4437273Z [ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.004 s <<< FAILURE! -- in io.netty.testsuite.transport.socket.DatagramMulticastTest
2025-08-20T21:27:15.4438772Z [ERROR] io.netty.testsuite.transport.socket.DatagramMulticastTest.testMulticast(TestInfo) -- Time elapsed: 0.004 s <<< ERROR!
2025-08-20T21:27:15.4440833Z io.netty.channel.ChannelPipelineException: io.netty.testsuite.transport.socket.DatagramMulticastTest$2 is not a @Sharable handler, so can't be added or removed multiple times.
2025-08-20T21:27:15.4442483Z 	at io.netty.channel.DefaultChannelPipeline.checkMultiplicity(DefaultChannelPipeline.java:549)
2025-08-20T21:27:15.4443649Z 	at io.netty.channel.DefaultChannelPipeline.internalAdd(DefaultChannelPipeline.java:166)
2025-08-20T21:27:15.4444995Z 	at io.netty.channel.DefaultChannelPipeline.addLast(DefaultChannelPipeline.java:227)
2025-08-20T21:27:15.4446024Z 	at io.netty.channel.DefaultChannelPipeline.addLast(DefaultChannelPipeline.java:330)
2025-08-20T21:27:15.4447045Z 	at io.netty.channel.DefaultChannelPipeline.addLast(DefaultChannelPipeline.java:319)
2025-08-20T21:27:15.4447883Z 	at io.netty.bootstrap.Bootstrap.init(Bootstrap.java:276)
2025-08-20T21:27:15.4448695Z 	at io.netty.bootstrap.AbstractBootstrap.initAndRegister(AbstractBootstrap.java:327)
2025-08-20T21:27:15.4449842Z 	at io.netty.bootstrap.AbstractBootstrap.doBind(AbstractBootstrap.java:288)
2025-08-20T21:27:15.4450714Z 	at io.netty.bootstrap.AbstractBootstrap.bind(AbstractBootstrap.java:284)
2025-08-20T21:27:15.4451792Z 	at io.netty.testsuite.transport.socket.DatagramMulticastTest.testMulticast(DatagramMulticastTest.java:93)
2025-08-20T21:27:15.4453100Z 	at io.netty.testsuite.transport.socket.DatagramMulticastTest$1.run(DatagramMulticastTest.java:58)
2025-08-20T21:27:15.4454240Z 	at io.netty.testsuite.transport.socket.DatagramMulticastTest$1.run(DatagramMulticastTest.java:55)
2025-08-20T21:27:15.4455378Z 	at io.netty.testsuite.transport.AbstractComboTestsuiteTest.run(AbstractComboTestsuiteTest.java:52)
2025-08-20T21:27:15.4456615Z 	at io.netty.testsuite.transport.socket.DatagramMulticastTest.testMulticast(DatagramMulticastTest.java:55)
2025-08-20T21:27:15.4457594Z 	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
2025-08-20T21:27:15.4458245Z 	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
2025-08-20T21:27:15.4459103Z 	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
2025-08-20T21:27:15.4459917Z 	Suppressed: java.util.concurrent.CompletionException: Rethrowing promise failure cause
2025-08-20T21:27:15.4460952Z 		at io.netty.util.concurrent.DefaultPromise.rethrowIfFailed(DefaultPromise.java:685)
2025-08-20T21:27:15.4461893Z 		at io.netty.util.concurrent.DefaultPromise.sync(DefaultPromise.java:419)
2025-08-20T21:27:15.4462736Z 		at io.netty.channel.DefaultChannelPromise.sync(DefaultChannelPromise.java:119)
2025-08-20T21:27:15.4463601Z 		at io.netty.channel.DefaultChannelPromise.sync(DefaultChannelPromise.java:30)
2025-08-20T21:27:15.4464208Z 		... 8 more
```

