### PR TITLE
Fix codec-http3 dependency

### DIFF
--- a/codec-http3/pom.xml
+++ b/codec-http3/pom.xml
@@ -182,6 +182,7 @@
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <version>3.0.2</version>
+      <optional>true</optional>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/testsuite-karaf/pom.xml
+++ b/testsuite-karaf/pom.xml
@@ -89,6 +89,11 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
+      <artifactId>netty-codec-http3</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
       <artifactId>netty-codec-marshalling</artifactId>
       <scope>provided</scope>
     </dependency>
@@ -198,7 +203,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <!-- TODO: netty-codec-http3 requires a header fix -->
     <!-- TODO: netty-codec-protobuf requires figuring out dependencies -->
     <!-- TODO: netty-transport-udt: requires figuring out slf4j dependency -->
     <!-- TODO: these require figuring out platform build

--- a/testsuite-karaf/src/main/feature/feature.xml
+++ b/testsuite-karaf/src/main/feature/feature.xml
@@ -25,6 +25,7 @@
     <bundle>mvn:io.netty/netty-codec-haproxy/${project.version}</bundle>
     <bundle>mvn:io.netty/netty-codec-http/${project.version}</bundle>
     <bundle>mvn:io.netty/netty-codec-http2/${project.version}</bundle>
+    <bundle>mvn:io.netty/netty-codec-http3/${project.version}</bundle>
     <bundle>mvn:io.netty/netty-codec-memcache/${project.version}</bundle>
     <bundle>mvn:io.netty/netty-codec-mqtt/${project.version}</bundle>
     <bundle>mvn:io.netty/netty-codec-redis/${project.version}</bundle>


### PR DESCRIPTION
Motivation:

netty-codec-http3 fails to resolve in OSGi due to missing
javax.annotation.meta package.

Modification:

Mark jsr305 dependency as optional.

Result:

netty-codec-http3 can resolve in Karaf.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
