### PR TITLE
Don't try to handle incomplete upgrade request

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerUpgradeHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerUpgradeHandlerTest.java
@@ -258,4 +258,28 @@ public class HttpServerUpgradeHandlerTest {
         channel.checkException();
         assertTrue(channel.finishAndReleaseAll());
     }
+
+    @Test
+    public void upgradePrematureClose() throws Exception {
+        final HttpServerCodec httpServerCodec = new HttpServerCodec();
+        final UpgradeCodecFactory factory = new UpgradeCodecFactory() {
+            @Override
+            public UpgradeCodec newUpgradeCodec(CharSequence protocol) {
+                return new TestUpgradeCodec();
+            }
+        };
+
+        HttpServerUpgradeHandler upgradeHandler = new HttpServerUpgradeHandler(httpServerCodec, factory);
+
+        EmbeddedChannel channel = new EmbeddedChannel(httpServerCodec, upgradeHandler);
+
+        channel.writeInbound(Unpooled.copiedBuffer("POST / HTTP/1.1\n" +
+                "Upgrade:\n" +
+                "Expect:\n" +
+                "Content-Length: 8\n" +
+                "\n" +
+                "GET / HTTP/1.1\n", CharsetUtil.US_ASCII));
+        channel.checkException();
+        assertTrue(channel.finishAndReleaseAll());
+    }
 }


### PR DESCRIPTION
Motivation:

HttpServerUpgradeHandler checks whether a request is an upgrade request, and if the upgrade request is incomplete, uses HttpObjectAggregator to aggregate it. When aggregation is complete, the upgrade is performed, under the assumption that the aggregated request is an upgrade request.

In certain scenarios, HttpObjectAggregator can refuse to aggregate a request, but HttpServerUpgradeHandler does not realize this. If a new request comes in afterwards and is aggregated, that new request does not have to be an upgrade request. This leads to an NPE in the upgrade method because the `Upgrade` header is missing.

In this PR's test case, the first request fails to aggregate because it has an invalid `Expect` header. I'm not sure if there are other cases, but HttpObjectAggregator has a lot of escape hatches.

Modification:

In HttpServerUpgradeHandler, override beginAggregation. This method is called once the final decision to aggregate has been made. This now sets a flag that tells HttpServerUpgradeHandler that it really should handle the request as an upgrade.

Result:

No NPE.

Discovered by fuzzing.