### PR TITLE
IoUring:  Reduce redundant system calls

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -202,17 +202,17 @@ public final class IoUringIoHandler implements IoHandler {
         // 128 here is just some sort of bound and another number might be ok as well.
         for (int i = 0; i < 128; i++) {
             int p = completionQueue.process(callback);
+            int sqCount = submissionQueue.count();
             if ((submissionQueue.flags() & Native.IORING_SQ_CQ_OVERFLOW) != 0) {
                 logger.warn("CompletionQueue overflow detected, consider increasing size: {} ",
                         completionQueue.ringEntries);
                 submitAndClearNow(submissionQueue);
-            } else if (p == 0 &&
-                    // Let's try to submit again and check if there are new completions to handle.
-                    // Only break the loop if there was nothing submitted and there are no new completions.
-                    submitAndClearNow(submissionQueue) == 0 && !completionQueue.hasCompletions()) {
-                break;
-            }
-
+            } else if (p == 0 && sqCount > 0 &&
+                // Let's try to submit again and check if there are new completions to handle.
+                // Only break the loop if there was nothing submitted and there are no new completions.
+                submitAndClearNow(submissionQueue) == 0 && !completionQueue.hasCompletions()) {
+                    break;
+                }
             processed += p;
         }
         return processed;


### PR DESCRIPTION

Motivation:


In order to fix this [issue](https://github.com/netty/netty/issues/15502) , [PR #15544](https://github.com/netty/netty/pull/15544)
 introduced some additional system calls. Based on our observations, about 60% of the submit operations are now coming from the newly introduced submitAndClearNow. This has a performance impact and also explains the performance regression we observed after upgrading to 4.2.4.

Our testing shows that adding `sqCount > 0`  effectively reduces system calls, lowering the extra submissions to just 20% of the total.

At the same time, the previous socket leak issue no longer exists

Modification:

Submit only when submissionQueue.count() > 0 to reduce redundant system calls

Result:

less syscall

