### PR TITLE
Create stream when unknown frame is received

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -621,6 +621,16 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
         @Override
         public void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags,
                 ByteBuf payload) throws Http2Exception {
+            try {
+                Http2Stream stream = connection.stream(streamId);
+                if (stream == null && !connection.streamMayHaveExisted(streamId)) {
+                    connection.remote().createStream(streamId, false);
+                }
+            } catch (Http2Exception e) {
+                payload.release();
+                throw e;
+            }
+
             onUnknownFrame0(ctx, frameType, streamId, flags, payload);
         }
 


### PR DESCRIPTION
Motivation:

Receiving an unknown frame on a stream that is in 'idle' state (i.e. not created) would produce a NullPointerException.

Modification:

If an unknown frame is received, create the associated stream if necessary. This is in accordance with [RFC 9113](https://httpwg.org/specs/rfc9113.html#StreamStates):

> Receipt of frames for which the semantics are unknown cannot be treated as an error, as the conditions for sending and receiving those frames are also unknown

Technically it would be better to use the frame without a stream, but Http2UnknownFrame needs a Http2FrameStream to access the stream at all.

Result:

No NPE, user can handle unknown frame as normal.

Found by fuzzing.