### PR TITLE
HTTP: Allow to configure HttpServerUpgradeHandler to remove itself af…

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerUpgradeHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerUpgradeHandlerTest.java
@@ -33,6 +33,8 @@ import io.netty.handler.codec.http.HttpServerUpgradeHandler.UpgradeCodecFactory;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -192,8 +194,9 @@ public class HttpServerUpgradeHandlerTest {
         assertFalse(channel.finishAndReleaseAll());
     }
 
-    @Test
-    public void upgradeFail() {
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    public void upgradeFail(boolean removeAfterFirst) {
         final HttpServerCodec httpServerCodec = new HttpServerCodec();
         final UpgradeCodecFactory factory = new UpgradeCodecFactory() {
             @Override
@@ -202,7 +205,9 @@ public class HttpServerUpgradeHandlerTest {
             }
         };
 
-        HttpServerUpgradeHandler upgradeHandler = new HttpServerUpgradeHandler(httpServerCodec, factory);
+        HttpServerUpgradeHandler upgradeHandler = new HttpServerUpgradeHandler(httpServerCodec, factory, 0,
+                DefaultHttpHeadersFactory.headersFactory(), DefaultHttpHeadersFactory.trailersFactory(),
+                removeAfterFirst);
 
         EmbeddedChannel channel = new EmbeddedChannel(httpServerCodec, upgradeHandler);
 
@@ -214,7 +219,11 @@ public class HttpServerUpgradeHandlerTest {
 
         assertTrue(channel.writeInbound(upgrade));
         assertNotNull(channel.pipeline().get(HttpServerCodec.class));
-        assertNotNull(channel.pipeline().get(HttpServerUpgradeHandler.class)); // Should not be removed.
+        if (removeAfterFirst) {
+            assertNull(channel.pipeline().get(HttpServerUpgradeHandler.class)); // Should be removed.
+        } else {
+            assertNotNull(channel.pipeline().get(HttpServerUpgradeHandler.class)); // Should not be removed.
+        }
         assertNull(channel.pipeline().get("marker"));
 
         HttpRequest req = channel.readInbound();


### PR DESCRIPTION
…ter the first request on a connection

Motivation:

While it is not strictly required that the first request must be the upgrade request it is usually what is the case in real world and it is even required by some protocols. We should allow to configure the HttpServerUpgradeHandler to remove itself and so reduce overhead.

Modifications:

- Add new constructor which allows to specify that we remove the handler after the first request even if its not an upgrade
- Adjust unit test

Result:

Fixes https://github.com/netty/netty/issues/15489