### PR TITLE
Drop unknown frame on missing stream (#15592)

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -628,6 +628,11 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
         @Override
         public void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags,
                 ByteBuf payload) throws Http2Exception {
+            Http2Stream stream = connection.stream(streamId);
+            if (stream == null) {
+                return;
+            }
+
             onUnknownFrame0(ctx, frameType, streamId, flags, payload);
         }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
@@ -406,6 +406,16 @@ public class Http2FrameCodecTest {
     }
 
     @Test
+    public void unknownFrameOnMissingStream() throws Exception {
+        ByteBuf debugData = bb("debug");
+        frameInboundWriter.writeInboundFrame((byte) 0xb, 101, new Http2Flags(), debugData);
+        channel.flush();
+
+        assertEquals(0, debugData.refCnt());
+        assertTrue(channel.isActive());
+    }
+
+    @Test
     public void goAwayLastStreamIdOverflowed() throws Exception {
         frameInboundWriter.writeInboundHeaders(5, request, 31, false);
 


### PR DESCRIPTION
Motivation:

Receiving an unknown frame on a stream that is in 'idle' state (i.e. not created) would produce a NullPointerException.

Modification:

If an unknown frame is received and there is no associated stream, drop that frame. This is in accordance with [RFC
9113](https://httpwg.org/specs/rfc9113.html#StreamStates):

> Receipt of frames for which the semantics are unknown cannot be
treated as an error, as the conditions for sending and receiving those frames are also unknown

Another option would be to create the stream.

Result:

No NPE.

Found by fuzzing.