### PR TITLE
Fix User-controlled data in numeric cast Http3CodecUtils 

### DIFF
--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3CodecUtils.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3CodecUtils.java
@@ -142,17 +142,29 @@ final class Http3CodecUtils {
         int writerIndex = out.writerIndex();
         switch (numBytes) {
             case 1:
+                if (value < 0 || value > 0x3F) {
+                    throw new IllegalArgumentException("Value " + value + " out of range for 1-byte QUIC variable integer (0-63)");
+                }
                 out.writeByte((byte) value);
                 break;
             case 2:
+                if (value < 0 || value > 0x3FFF) {
+                    throw new IllegalArgumentException("Value " + value + " out of range for 2-byte QUIC variable integer (0-16383)");
+                }
                 out.writeShort((short) value);
                 encodeLengthIntoBuffer(out, writerIndex, (byte) 0x40);
                 break;
             case 4:
+                if (value < 0 || value > 0x3FFFFFFF) {
+                    throw new IllegalArgumentException("Value " + value + " out of range for 4-byte QUIC variable integer (0-1073741823)");
+                }
                 out.writeInt((int) value);
                 encodeLengthIntoBuffer(out, writerIndex, (byte) 0x80);
                 break;
             case 8:
+                if (value < 0 || value > 0x3FFFFFFFFFFFFFFFL) {
+                    throw new IllegalArgumentException("Value " + value + " out of range for 8-byte QUIC variable integer (0-4611686018427387903)");
+                }
                 out.writeLong(value);
                 encodeLengthIntoBuffer(out, writerIndex, (byte) 0xc0);
                 break;


### PR DESCRIPTION


The problem is that `writeVariableLengthInteger` performs casts from `long` to `int`, `short`, or `byte` based on the required encoding length, without first ensuring that the `value` fits into the target type's bit-width, according to the expectation of QUIC variable-length integer encoding. The general fix is to assert (and, defensively, throw an exception if not met) that `value` is within the correct range for the width being encoded, immediately before performing the narrowing cast. For the 4-byte case, ensure `value` is between `0` and `0x3FFFFFFF` (`1073741823`) before casting to `int`; for the 2-byte case, ensure it is between `0` and `0x3FFF` (`16383`), etc.

Casting a user-controlled numeric value to a narrower type can result in truncated values unless the input is validated. Narrowing conversions may cause potentially unintended results. For example, casting the positive integer value 128 to type byte yields the negative value -128.


A minimal-impact fix is to add explicit range checks or assertions for each case in `writeVariableLengthInteger`. If the check fails, throw an `IllegalArgumentException` to prevent incorrect data from being encoded, maintaining the method's documented contract. No import or method changes are needed, just inline validation logic. `codec-http3/src/main/java/io/netty/handler/codec/http3/Http3CodecUtils.java`:** In the method `writeVariableLengthInteger(ByteBuf out, long value, int numBytes)`, before each narrowing cast, add explicit range guards for `value` appropriate to the intended target type. The fixed code should closely follow style and error handling conventions of surrounding code.


#### References
SEI CERT Oracle Coding Standard for Java: [NUM12-J. Ensure conversions of numeric types to narrower types do not result in lost or misinterpreted data](https://wiki.sei.cmu.edu/confluence/display/java/NUM12-J.+Ensure+conversions+of+numeric+types+to+narrower+types+do+not+result+in+lost+or+misinterpreted+data)