### PR TITLE
Update JDK releases to latest patch release

### DIFF
--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -8,7 +8,7 @@ services:
       context: ../
       dockerfile: docker/Dockerfile.centos6
       args:
-        java_version : "8.0.442-zulu"
+        java_version : "8.0.462-zulu"
 
   build:
     image: netty:centos-6-1.8

--- a/docker/docker-compose.centos-7.111.yaml
+++ b/docker/docker-compose.centos-7.111.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-7-1.11
     build:
       args:
-        java_version : "11.0.26-zulu"
+        java_version : "11.0.28-zulu"
 
   build:
     image: netty:centos-7-1.11

--- a/docker/docker-compose.centos-7.117.yaml
+++ b/docker/docker-compose.centos-7.117.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-7-1.17
     build:
       args:
-        java_version : "17.0.14-zulu"
+        java_version : "17.0.16-zulu"
 
   build:
     image: netty:centos-7-1.17

--- a/docker/docker-compose.centos-7.18.yaml
+++ b/docker/docker-compose.centos-7.18.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-7-1.8
     build:
       args:
-        java_version : "8.0.442-zulu"
+        java_version : "8.0.462-zulu"
 
   build:
     image: netty:centos-7-1.8

--- a/docker/docker-compose.centos-7.21.yaml
+++ b/docker/docker-compose.centos-7.21.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-7-21
     build:
       args:
-        java_version : "21.0.6-zulu"
+        java_version : "21.0.8-zulu"
 
   build:
     image: netty:centos-7-21

--- a/docker/docker-compose.centos-7.24.yaml
+++ b/docker/docker-compose.centos-7.24.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-7-24
     build:
       args:
-        java_version : "24.0.1-zulu"
+        java_version : "24.0.2-zulu"
 
   build:
     image: netty:centos-7-24

--- a/docker/docker-compose.centos-7.cross.yaml
+++ b/docker/docker-compose.centos-7.cross.yaml
@@ -9,7 +9,7 @@ services:
       dockerfile: docker/Dockerfile.cross_compile_aarch64
       args:
         gcc_version: "10.2-2020.11"
-        java_version: "8.0.422-zulu"
+        java_version: "8.0.462-zulu"
 
   cross-compile-aarch64-common: &cross-compile-aarch64-common
     depends_on: [ cross-compile-aarch64-runtime-setup ]


### PR DESCRIPTION
Motivation:

We should use latest JDK releases on CI

Modifications:

Update to latest versions

Result:

Use latest JDK releases while building on CI