### PR TITLE
Fix IllegalReferenceCountException on invalid upgrade response

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientUpgradeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientUpgradeHandler.java
@@ -252,7 +252,6 @@ public class HttpClientUpgradeHandler extends HttpObjectAggregator implements Ch
             out.clear();
             removeThisHandler(ctx);
         } catch (Throwable t) {
-            release(response);
             ctx.fireExceptionCaught(t);
             removeThisHandler(ctx);
         }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpClientUpgradeHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpClientUpgradeHandlerTest.java
@@ -241,4 +241,27 @@ public class HttpClientUpgradeHandlerTest {
         assertEquals(0, secondReq.refCnt());
         assertFalse(channel.finish());
     }
+
+    @Test
+    public void forwardOnFailure() {
+        HttpClientUpgradeHandler.SourceCodec sourceCodec = new FakeSourceCodec();
+        HttpClientUpgradeHandler.UpgradeCodec upgradeCodec = new FakeUpgradeCodec();
+        HttpClientUpgradeHandler handler = new HttpClientUpgradeHandler(sourceCodec, upgradeCodec, 1024);
+        final EmbeddedChannel channel = new EmbeddedChannel();
+        channel.pipeline().addFirst("upgrade", handler);
+
+        assertTrue(channel.writeOutbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "netty.io")));
+        FullHttpRequest request = channel.readOutbound();
+        assertTrue(request.release());
+
+        DefaultHttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.SWITCHING_PROTOCOLS);
+        response.headers().add(HttpHeaderNames.UPGRADE, "");
+        assertFalse(channel.writeInbound(response));
+        assertThrows(IllegalStateException.class, () -> channel.writeInbound(LastHttpContent.EMPTY_LAST_CONTENT));
+
+        FullHttpResponse full = channel.readInbound();
+        assertTrue(full.release());
+
+        assertFalse(channel.finish());
+    }
 }


### PR DESCRIPTION
Motivation:

When HttpClientUpgradeHandler receives a response with an invalid upgrade header, it would release the response but still keep it in the `out` list. Downstream code would then get an IllegalReferenceCountException when releasing the response.

Modification:

Remove unnecessary release. I don't think it's ever appropriate.

Result:

No IllegalReferenceCountException.

Found by fuzzing