### PR TITLE
[refactor] add error message to all `new Error()` calls

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractReferenceCountedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractReferenceCountedByteBuf.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import io.netty.util.internal.AtomicReferenceCountUpdater;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.ReferenceCountUpdater;
+import io.netty.util.internal.ReferenceCountUpdater.UpdaterType;
 import io.netty.util.internal.UnsafeReferenceCountUpdater;
 import io.netty.util.internal.VarHandleReferenceCountUpdater;
 
@@ -39,7 +40,8 @@ public abstract class AbstractReferenceCountedByteBuf extends AbstractByteBuf {
     private static final ReferenceCountUpdater<AbstractReferenceCountedByteBuf> updater;
 
     static {
-        switch (ReferenceCountUpdater.updaterTypeOf(AbstractReferenceCountedByteBuf.class, "refCnt")) {
+        UpdaterType updaterType = ReferenceCountUpdater.updaterTypeOf(AbstractReferenceCountedByteBuf.class, "refCnt");
+        switch (updaterType) {
             case Atomic:
                 AIF_UPDATER = newUpdater(AbstractReferenceCountedByteBuf.class, "refCnt");
                 REFCNT_FIELD_OFFSET = -1;
@@ -75,7 +77,7 @@ public abstract class AbstractReferenceCountedByteBuf extends AbstractByteBuf {
                 };
                 break;
             default:
-                throw new Error("Unknown updater type for AbstractReferenceCountedByteBuf");
+                throw new Error("Unexpected updater type for AbstractReferenceCountedByteBuf: " + updaterType);
         }
     }
 

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -1119,7 +1119,8 @@ final class AdaptivePoolingAllocator {
         private static final ReferenceCountUpdater<Chunk> updater;
 
         static {
-            switch (ReferenceCountUpdater.updaterTypeOf(Chunk.class, "refCnt")) {
+            ReferenceCountUpdater.UpdaterType updaterType = ReferenceCountUpdater.updaterTypeOf(Chunk.class, "refCnt");
+            switch (updaterType) {
                 case Atomic:
                     AIF_UPDATER = newUpdater(Chunk.class, "refCnt");
                     REFCNT_FIELD_OFFSET = -1;
@@ -1155,7 +1156,7 @@ final class AdaptivePoolingAllocator {
                     };
                     break;
                 default:
-                    throw new Error("Unknown updater type for Chunk");
+                    throw new Error("Unexpected updater type for Chunk: " + updaterType);
             }
         }
 

--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -272,7 +272,7 @@ abstract class PoolArena<T> implements PoolArenaMetric {
                         ++deallocationsSmall;
                         break;
                     default:
-                        throw new Error();
+                        throw new Error("Unexpected size class: " + sizeClass);
                 }
             }
             destroyChunk = !chunk.parent.free(chunk, handle, normCapacity, nioBuffer);

--- a/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
@@ -193,7 +193,7 @@ final class PoolThreadCache {
         case Small:
             return cacheForSmall(area, sizeIdx);
         default:
-            throw new Error();
+            throw new Error("Unexpected size class: " + sizeClass);
         }
     }
 

--- a/buffer/src/test/java/io/netty/buffer/ByteBufDerivationTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufDerivationTest.java
@@ -175,7 +175,8 @@ public class ByteBufDerivationTest {
         Random rnd = new Random();
         for (int i = 0; i < buf.capacity(); i ++) {
             ByteBuf newDerived;
-            switch (rnd.nextInt(4)) {
+            int randomNumber = rnd.nextInt(4);
+            switch (randomNumber) {
             case 0:
                 newDerived = derived.slice(1, derived.capacity() - 1);
                 break;
@@ -190,7 +191,7 @@ public class ByteBufDerivationTest {
                 newDerived = Unpooled.unmodifiableBuffer(derived);
                 break;
             default:
-                throw new Error();
+                throw new Error("Unexpected random number: " + randomNumber);
             }
 
             assertThat(nestLevel(newDerived)).isLessThanOrEqualTo(3);

--- a/codec-base/src/main/java/io/netty/handler/codec/AsciiHeadersEncoder.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/AsciiHeadersEncoder.java
@@ -90,7 +90,7 @@ public final class AsciiHeadersEncoder {
                 buf.setByte(offset ++, ' ');
                 break;
             default:
-                throw new Error();
+                throw new Error("Unexpected separator type: " + separatorType);
         }
 
         writeAscii(buf, offset, value);
@@ -105,7 +105,7 @@ public final class AsciiHeadersEncoder {
                 buf.setByte(offset ++, '\n');
                 break;
             default:
-                throw new Error();
+                throw new Error("Unexpected newline type: " + newlineType);
         }
 
         buf.writerIndex(offset);

--- a/codec-base/src/main/java/io/netty/handler/codec/LengthFieldPrepender.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/LengthFieldPrepender.java
@@ -195,7 +195,7 @@ public class LengthFieldPrepender extends MessageToMessageEncoder<ByteBuf> {
             out.add(ctx.alloc().buffer(8).order(byteOrder).writeLong(length));
             break;
         default:
-            throw new Error("should not reach here");
+            throw new Error("Unexpected length field length: " + lengthFieldLength);
         }
         out.add(msg.retain());
     }

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicSslContext.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicSslContext.java
@@ -323,7 +323,7 @@ final class QuicheQuicSslContext extends QuicSslContext {
             case OPTIONAL:
                 return BoringSSL.SSL_VERIFY_PEER;
             default:
-                throw new Error(mode.toString());
+                throw new Error("Unexpected mode: " + mode);
         }
     }
 

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicStreamChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicStreamChannel.java
@@ -980,13 +980,14 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
                         while (!finReceived && continueReading) {
                             byteBuf = allocHandle.allocate(allocator);
                             allocHandle.attemptedBytesRead(byteBuf.writableBytes());
-                            switch (parent.streamRecv(streamId(), byteBuf)) {
+                            QuicheQuicChannel.StreamRecvResult result = parent.streamRecv(streamId(), byteBuf);
+                            switch (result) {
                                 case DONE:
                                     // Nothing left to read;
                                     readable = false;
                                     break;
                                 case FIN:
-                                    // If we received a FIN we also should mark the channel as non readable as
+                                    // If we received a FIN we also should mark the channel as non-readable as
                                     // there is nothing left to read really.
                                     readable = false;
                                     finReceived = true;
@@ -995,7 +996,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
                                 case OK:
                                     break;
                                 default:
-                                    throw new Error();
+                                    throw new Error("Unexpected StreamRecvResult: " + result);
                             }
                             allocHandle.lastBytesRead(byteBuf.readableBytes());
                             if (allocHandle.lastBytesRead() <= 0) {

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/ZlibUtil.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/ZlibUtil.java
@@ -41,43 +41,32 @@ final class ZlibUtil {
     }
 
     static JZlib.WrapperType convertWrapperType(ZlibWrapper wrapper) {
-        JZlib.WrapperType convertedWrapperType;
         switch (wrapper) {
         case NONE:
-            convertedWrapperType = JZlib.W_NONE;
-            break;
+            return JZlib.W_NONE;
         case ZLIB:
-            convertedWrapperType = JZlib.W_ZLIB;
-            break;
+            return JZlib.W_ZLIB;
         case GZIP:
-            convertedWrapperType = JZlib.W_GZIP;
-            break;
+            return JZlib.W_GZIP;
         case ZLIB_OR_NONE:
-            convertedWrapperType = JZlib.W_ANY;
-            break;
+            return JZlib.W_ANY;
         default:
-            throw new Error();
+            throw new Error("Unexpected wrapper type: " + wrapper);
         }
-        return convertedWrapperType;
     }
 
     static int wrapperOverhead(ZlibWrapper wrapper) {
-        int overhead;
         switch (wrapper) {
         case NONE:
-            overhead = 0;
-            break;
+            return 0;
         case ZLIB:
         case ZLIB_OR_NONE:
-            overhead = 2;
-            break;
+            return 2;
         case GZIP:
-            overhead = 10;
-            break;
+            return 10;
         default:
-            throw new Error();
+            throw new Error("Unexpected wrapper type: " + wrapper);
         }
-        return overhead;
     }
 
     private ZlibUtil() {

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsMessage.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsMessage.java
@@ -426,10 +426,8 @@ public abstract class AbstractDnsMessage extends AbstractReferenceCounted implem
         case 3:
             return additionals;
         default:
-            break;
+            throw new Error("Unexpected section number: " + section);
         }
-
-        throw new Error(); // Should never reach here.
     }
 
     private void setSection(int section, Object value) {
@@ -447,10 +445,8 @@ public abstract class AbstractDnsMessage extends AbstractReferenceCounted implem
             additionals = value;
             return;
         default:
-            break;
+            throw new Error("Unexpected section number: " + section);
         }
-
-        throw new Error(); // Should never reach here.
     }
 
     private static int sectionOrdinal(DnsSection section) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
@@ -31,6 +31,7 @@ import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
 import static io.netty.handler.codec.http.HttpHeaderNames.EXPECT;
 import static io.netty.handler.codec.http.HttpUtil.getContentLength;
+import static io.netty.util.internal.StringUtil.className;
 
 /**
  * A {@link ChannelHandler} that aggregates an {@link HttpMessage}
@@ -206,15 +207,13 @@ public class HttpObjectAggregator
 
         HttpUtil.setTransferEncodingChunked(start, false);
 
-        AggregatedFullHttpMessage ret;
         if (start instanceof HttpRequest) {
-            ret = new AggregatedFullHttpRequest((HttpRequest) start, content, null);
+            return new AggregatedFullHttpRequest((HttpRequest) start, content, null);
         } else if (start instanceof HttpResponse) {
-            ret = new AggregatedFullHttpResponse((HttpResponse) start, content, null);
+            return new AggregatedFullHttpResponse((HttpResponse) start, content, null);
         } else {
-            throw new Error();
+            throw new Error("Unexpected http message type: " + className(start));
         }
-        return ret;
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectEncoder.java
@@ -223,7 +223,7 @@ public abstract class HttpObjectEncoder<H extends HttpMessage> extends MessageTo
                 encodeChunkedHttpContent(ctx, content, trailingHeaders, out);
                 break;
             default:
-                throw new Error();
+                throw new Error("Unexpected http object encoder state: " + state);
         }
     }
 
@@ -394,7 +394,7 @@ public abstract class HttpObjectEncoder<H extends HttpMessage> extends MessageTo
                     encodedChunkedFileRegionContent(ctx, msg, out);
                     break;
                 default:
-                    throw new Error();
+                    throw new Error("Unexpected http object encoder state: " + state);
             }
         } finally {
             msg.release();
@@ -438,7 +438,7 @@ public abstract class HttpObjectEncoder<H extends HttpMessage> extends MessageTo
                 out.add(ZERO_CRLF_CRLF_BUF.duplicate());
                 break;
             default:
-                throw new Error();
+                throw new Error("Unexpected http object encoder state: " + state);
         }
         return ST_INIT;
     }
@@ -481,7 +481,7 @@ public abstract class HttpObjectEncoder<H extends HttpMessage> extends MessageTo
                 encodeChunkedHttpContent(ctx, content, trailingHeaders, out);
                 break;
             default:
-                throw new Error();
+                throw new Error("Unexpected http object encoder state: " + state);
         }
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameDecoder.java
@@ -385,7 +385,7 @@ public class WebSocket08FrameDecoder extends ByteToMessageDecoder
             }
             return;
         default:
-            throw new Error("Shouldn't reach here.");
+            throw new Error("Shouldn't reach here (state: " + state + ")");
         }
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketFrameAggregator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketFrameAggregator.java
@@ -20,6 +20,8 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.MessageAggregator;
 import io.netty.handler.codec.TooLongFrameException;
 
+import static io.netty.util.internal.StringUtil.className;
+
 /**
  * Handler that aggregate fragmented WebSocketFrame's.
  *
@@ -94,6 +96,6 @@ public class WebSocketFrameAggregator
         }
 
         // Should not reach here.
-        throw new Error();
+        throw new Error("Unexpected websocket frame type: " + className(start));
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameDecoder.java
@@ -381,7 +381,7 @@ public class SpdyFrameDecoder {
                     return;
 
                 default:
-                    throw new Error("Shouldn't reach here.");
+                    throw new Error("Unexpected state: " + state);
             }
         }
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHeaderBlockRawDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHeaderBlockRawDecoder.java
@@ -275,7 +275,7 @@ public class SpdyHeaderBlockRawDecoder extends SpdyHeaderBlockDecoder {
                     return;
 
                 default:
-                    throw new Error("Shouldn't reach here.");
+                    throw new Error("Unexpected state: " + state);
             }
         }
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDecoder.java
@@ -443,7 +443,7 @@ final class HpackDecoder {
                 break;
 
             default:
-                throw new Error("should not reach here");
+                throw new Error("Unexpected index type: " + indexType);
         }
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackEncoder.java
@@ -329,7 +329,7 @@ final class HpackEncoder {
                 encodeInteger(out, 0x10, 4, nameIndexValid ? nameIndex : 0);
                 break;
             default:
-                throw new Error("should not reach here");
+                throw new Error("Unexpected index type: " + indexType);
         }
         if (!nameIndexValid) {
             encodeStringLiteral(out, name);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -717,7 +717,7 @@ public class Http2ConnectionRoundtripTest {
                                 (short) 16, false, 0, true, newPromise());
                         break;
                     default:
-                        throw new Error();
+                        throw new Error("Unexpected WriteEmptyBufferMode: " + mode);
                 }
                 http2Client.flush(ctx());
             }

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ConnectionHandler.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ConnectionHandler.java
@@ -174,7 +174,7 @@ public abstract class Http3ConnectionHandler extends ChannelInboundHandlerAdapte
                     initUnidirectionalStream(ctx, channel);
                     break;
                 default:
-                    throw new Error();
+                    throw new Error("Unexpected channel type: " + channel.type());
             }
         }
         ctx.fireChannelRead(msg);

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3RequestStreamEncodeStateValidator.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3RequestStreamEncodeStateValidator.java
@@ -102,7 +102,7 @@ final class Http3RequestStreamEncodeStateValidator extends ChannelOutboundHandle
             case Trailers:
                 return null;
             default:
-                throw new Error();
+                throw new Error("Unexpected frame state: " + state);
         }
     }
 

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheDecoder.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheDecoder.java
@@ -162,7 +162,7 @@ public abstract class AbstractBinaryMemcacheDecoder<M extends BinaryMemcacheMess
                 in.skipBytes(actualReadableBytes());
                 return;
             default:
-                throw new Error("Unknown state reached: " + state);
+                throw new Error("Unexpected state reached: " + state);
         }
     }
 

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheObjectAggregator.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheObjectAggregator.java
@@ -22,6 +22,8 @@ import io.netty.handler.codec.memcache.MemcacheContent;
 import io.netty.handler.codec.memcache.MemcacheObject;
 import io.netty.util.internal.UnstableApi;
 
+import static io.netty.util.internal.StringUtil.className;
+
 /**
  * An object aggregator for the memcache binary protocol.
  *
@@ -51,7 +53,7 @@ public class BinaryMemcacheObjectAggregator extends AbstractMemcacheObjectAggreg
         }
 
         // Should not reach here.
-        throw new Error();
+        throw new Error("Unexpected memcache message type: " + className(start));
     }
 
     private static FullBinaryMemcacheRequest toFullRequest(BinaryMemcacheRequest request, ByteBuf content) {

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
@@ -163,7 +163,7 @@ public final class MqttDecoder extends ReplayingDecoder<DecoderState> {
 
             default:
                 // Shouldn't reach here.
-                throw new Error();
+                throw new Error("Unexpected mqtt decoder state: " + state());
         }
     }
 

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksAuthRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksAuthRequestDecoder.java
@@ -58,7 +58,7 @@ public class SocksAuthRequestDecoder extends ReplayingDecoder<State> {
                 break;
             }
             default: {
-                throw new Error();
+                throw new Error("Unexpected request decoder state: " + state());
             }
         }
         ctx.pipeline().remove(this);

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksAuthResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksAuthResponseDecoder.java
@@ -50,7 +50,7 @@ public class SocksAuthResponseDecoder extends ReplayingDecoder<State> {
                 break;
             }
             default: {
-                throw new Error();
+                throw new Error("Unexpected response decoder state: " + state());
             }
         }
         channelHandlerContext.pipeline().remove(this);

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCmdRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCmdRequestDecoder.java
@@ -83,13 +83,13 @@ public class SocksCmdRequestDecoder extends ReplayingDecoder<State> {
                         break;
                     }
                     default: {
-                        throw new Error();
+                        throw new Error("Unexpected address type: " + addressType);
                     }
                 }
                 break;
             }
             default: {
-                throw new Error();
+                throw new Error("Unexpected request decoder type: " + state());
             }
         }
         ctx.pipeline().remove(this);

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCmdResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCmdResponseDecoder.java
@@ -83,13 +83,13 @@ public class SocksCmdResponseDecoder extends ReplayingDecoder<State> {
                         break;
                     }
                     default: {
-                        throw new Error();
+                        throw new Error("Unexpected address type: " + addressType);
                     }
                 }
                 break;
             }
             default: {
-                throw new Error();
+                throw new Error("Unexpected response decoder type: " + state());
             }
         }
         ctx.pipeline().remove(this);

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksInitRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksInitRequestDecoder.java
@@ -60,7 +60,7 @@ public class SocksInitRequestDecoder extends ReplayingDecoder<State> {
                 break;
             }
             default: {
-                throw new Error();
+                throw new Error("Unexpected request decoder type: " + state());
             }
         }
         ctx.pipeline().remove(this);

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksInitResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksInitResponseDecoder.java
@@ -49,7 +49,7 @@ public class SocksInitResponseDecoder extends ReplayingDecoder<State> {
                 break;
             }
             default: {
-                throw new Error();
+                throw new Error("Unexpected response decoder type: " + state());
             }
         }
         ctx.pipeline().remove(this);

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5PrivateAuthResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5PrivateAuthResponseDecoder.java
@@ -98,7 +98,7 @@ public final class Socks5PrivateAuthResponseDecoder extends ByteToMessageDecoder
                     in.skipBytes(in.readableBytes());
                     break;
                 default:
-                    throw new Error();
+                    throw new Error("Unexpected response decoder state: " + state);
             }
         } catch (Exception e) {
             fail(out, e);

--- a/common/src/main/java/io/netty/util/AbstractReferenceCounted.java
+++ b/common/src/main/java/io/netty/util/AbstractReferenceCounted.java
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import io.netty.util.internal.AtomicReferenceCountUpdater;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.ReferenceCountUpdater;
+import io.netty.util.internal.ReferenceCountUpdater.UpdaterType;
 import io.netty.util.internal.UnsafeReferenceCountUpdater;
 import io.netty.util.internal.VarHandleReferenceCountUpdater;
 
@@ -38,7 +39,8 @@ public abstract class AbstractReferenceCounted implements ReferenceCounted {
     private static final ReferenceCountUpdater<AbstractReferenceCounted> updater;
 
     static {
-        switch (ReferenceCountUpdater.updaterTypeOf(AbstractReferenceCounted.class, "refCnt")) {
+        UpdaterType updaterType = ReferenceCountUpdater.updaterTypeOf(AbstractReferenceCounted.class, "refCnt");
+        switch (updaterType) {
             case Atomic:
                 AIF_UPDATER = newUpdater(AbstractReferenceCounted.class, "refCnt");
                 REFCNT_FIELD_OFFSET = -1;
@@ -74,7 +76,7 @@ public abstract class AbstractReferenceCounted implements ReferenceCounted {
                 };
                 break;
             default:
-                throw new Error("Unknown updater type for AbstractReferenceCounted");
+                throw new Error("Unexpected updater type for AbstractReferenceCounted: " + updaterType);
         }
     }
 

--- a/common/src/main/java/io/netty/util/HashedWheelTimer.java
+++ b/common/src/main/java/io/netty/util/HashedWheelTimer.java
@@ -350,7 +350,8 @@ public class HashedWheelTimer implements Timer {
      *                               {@linkplain #stop() stopped} already
      */
     public void start() {
-        switch (WORKER_STATE_UPDATER.get(this)) {
+        int state = WORKER_STATE_UPDATER.get(this);
+        switch (state) {
             case WORKER_STATE_INIT:
                 if (WORKER_STATE_UPDATER.compareAndSet(this, WORKER_STATE_INIT, WORKER_STATE_STARTED)) {
                     workerThread.start();
@@ -361,7 +362,7 @@ public class HashedWheelTimer implements Timer {
             case WORKER_STATE_SHUTDOWN:
                 throw new IllegalStateException("cannot be started once stopped");
             default:
-                throw new Error("Invalid WorkerState");
+                throw new Error("Invalid WorkerState: " + state);
         }
 
         // Wait until the startTime is initialized by the worker.

--- a/common/src/main/java/io/netty/util/internal/StringUtil.java
+++ b/common/src/main/java/io/netty/util/internal/StringUtil.java
@@ -313,6 +313,17 @@ public final class StringUtil {
     }
 
     /**
+     * Generates a class name from a {@link Class}. Similar to {@link Class#getName()}, but null-safe.
+     */
+    public static String className(Object o) {
+        if (o == null) {
+            return "null_object";
+        } else {
+            return o.getClass().getName();
+        }
+    }
+
+    /**
      * The shortcut to {@link #simpleClassName(Class) simpleClassName(o.getClass())}.
      */
     public static String simpleClassName(Object o) {

--- a/common/src/main/java/io/netty/util/internal/logging/AbstractInternalLogger.java
+++ b/common/src/main/java/io/netty/util/internal/logging/AbstractInternalLogger.java
@@ -60,7 +60,7 @@ public abstract class AbstractInternalLogger implements InternalLogger, Serializ
         case ERROR:
             return isErrorEnabled();
         default:
-            throw new Error();
+            throw new Error("Unexpected log level: " + level);
         }
     }
 
@@ -108,7 +108,7 @@ public abstract class AbstractInternalLogger implements InternalLogger, Serializ
             error(msg, cause);
             break;
         default:
-            throw new Error();
+            throw new Error("Unexpected log level: " + level);
         }
     }
 
@@ -131,7 +131,7 @@ public abstract class AbstractInternalLogger implements InternalLogger, Serializ
                 error(cause);
                 break;
             default:
-                throw new Error();
+                throw new Error("Unexpected log level: " + level);
         }
     }
 
@@ -154,7 +154,7 @@ public abstract class AbstractInternalLogger implements InternalLogger, Serializ
             error(msg);
             break;
         default:
-            throw new Error();
+            throw new Error("Unexpected log level: " + level);
         }
     }
 
@@ -177,7 +177,7 @@ public abstract class AbstractInternalLogger implements InternalLogger, Serializ
             error(format, arg);
             break;
         default:
-            throw new Error();
+            throw new Error("Unexpected log level: " + level);
         }
     }
 
@@ -200,7 +200,7 @@ public abstract class AbstractInternalLogger implements InternalLogger, Serializ
             error(format, argA, argB);
             break;
         default:
-            throw new Error();
+            throw new Error("Unexpected log level: " + level);
         }
     }
 
@@ -223,7 +223,7 @@ public abstract class AbstractInternalLogger implements InternalLogger, Serializ
             error(format, arguments);
             break;
         default:
-            throw new Error();
+            throw new Error("Unexpected log level: " + level);
         }
     }
 

--- a/common/src/main/java/io/netty/util/internal/logging/Log4J2Logger.java
+++ b/common/src/main/java/io/netty/util/internal/logging/Log4J2Logger.java
@@ -137,7 +137,7 @@ class Log4J2Logger extends ExtendedLoggerWrapper implements InternalLogger {
             case TRACE:
                 return Level.TRACE;
             default:
-                throw new Error();
+                throw new Error("Unexpected log level: " + level);
         }
     }
 }

--- a/example/src/main/java/io/netty/example/http/file/HttpStaticFileServerHandler.java
+++ b/example/src/main/java/io/netty/example/http/file/HttpStaticFileServerHandler.java
@@ -246,7 +246,7 @@ public class HttpStaticFileServerHandler extends SimpleChannelInboundHandler<Ful
         try {
             uri = URLDecoder.decode(uri, "UTF-8");
         } catch (UnsupportedEncodingException e) {
-            throw new Error(e);
+            throw new Error("Invalid URI: " + uri, e);
         }
 
         if (uri.isEmpty() || uri.charAt(0) != '/') {

--- a/handler-proxy/src/main/java/io/netty/handler/proxy/Socks5ProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/handler/proxy/Socks5ProxyHandler.java
@@ -205,7 +205,7 @@ public final class Socks5ProxyHandler extends ProxyHandler {
                 sendToProxyServer(new DefaultSocks5PrivateAuthRequest(privateToken));
             } else {
                 // Should never reach here.
-                throw new Error();
+                throw new Error("Unexpected authMethod: " + resAuthMethod);
             }
 
             return false;

--- a/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
@@ -376,7 +376,7 @@ public class JdkSslContext extends SslContext {
                 case NONE:
                     break; // exhaustive cases
                 default:
-                    throw new Error("Unknown auth " + clientAuth);
+                    throw new Error("Unexpected auth " + clientAuth);
             }
         }
         configureSSLParameters(engine);

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -417,7 +417,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
                         SSLContext.setAlpnProtos(ctx, appProtocols, selectorBehavior);
                         break;
                     default:
-                        throw new Error();
+                        throw new Error("Unexpected apn protocol: " + apn.protocol());
                 }
             }
 
@@ -482,7 +482,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
             case CHOOSE_MY_LAST_PROTOCOL:
                 return SSL.SSL_SELECTOR_FAILURE_CHOOSE_MY_LAST_PROTOCOL;
             default:
-                throw new Error();
+                throw new Error("Unexpected behavior: " + behavior);
         }
     }
 
@@ -780,7 +780,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
                                         " behavior");
                 }
             default:
-                throw new Error();
+                throw new Error("Unexpected protocol: " + config.protocol());
         }
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -1887,7 +1887,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                 calculateMaxWrapOverhead();
                 break;
             default:
-                throw new Error();
+                throw new Error("Unexpected handshake state: " + handshakeState);
         }
     }
 
@@ -2162,7 +2162,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                         SSL.setVerify(ssl, SSL.SSL_CVERIFY_OPTIONAL, ReferenceCountedOpenSslContext.VERIFY_DEPTH);
                         break;
                     default:
-                        throw new Error(mode.toString());
+                        throw new Error("Unexpected client auth mode: " + mode);
                 }
             }
             clientAuth = mode;
@@ -2314,7 +2314,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                 }
                 break;
             default:
-                throw new Error();
+                throw new Error("Unexpected apn protocol: " + apn.protocol());
         }
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContext.java
@@ -493,7 +493,7 @@ public abstract class SslContext {
                     keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout,
                     clientAuth, protocols, startTls, enableOcsp, keyStoreType, resumptionController, ctxOptions);
         default:
-            throw new Error(provider.toString());
+            throw new Error("Unexpected provider: " + provider);
         }
     }
 
@@ -862,7 +862,7 @@ public abstract class SslContext {
                         enableOcsp, keyStoreType, endpointIdentificationAlgorithm, serverNames, resumptionController,
                         options);
             default:
-                throw new Error(provider.toString());
+                throw new Error("Unexpected provider: " + provider);
         }
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/SslProvider.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslProvider.java
@@ -52,7 +52,7 @@ public enum SslProvider {
             case OPENSSL_REFCNT:
                 return OpenSsl.isAlpnSupported();
             default:
-                throw new Error("Unknown SslProvider: " + provider);
+                throw new Error("Unexpected SslProvider: " + provider);
         }
     }
 
@@ -76,7 +76,7 @@ public enum SslProvider {
             case OPENSSL_REFCNT:
                 return OpenSsl.isTlsv13Supported();
             default:
-                throw new Error("Unknown SslProvider: " + sslProvider);
+                throw new Error("Unexpected SslProvider: " + sslProvider);
         }
     }
 
@@ -93,7 +93,7 @@ public enum SslProvider {
             case OPENSSL_REFCNT:
                 return OpenSsl.isOptionSupported(option);
             default:
-                throw new Error("Unknown SslProvider: " + sslProvider);
+                throw new Error("Unexpected SslProvider: " + sslProvider);
         }
     }
 
@@ -109,7 +109,7 @@ public enum SslProvider {
             case OPENSSL_REFCNT:
                 return OpenSsl.isTlsv13Supported();
             default:
-                throw new Error("Unknown SslProvider: " + sslProvider);
+                throw new Error("Unexpected SslProvider: " + sslProvider);
         }
     }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -317,7 +317,7 @@ public abstract class SSLEngineTest {
                 return ThreadLocalRandom.current().nextBoolean() ?
                         ByteBuffer.allocateDirect(len) : ByteBuffer.allocate(len);
             default:
-                throw new Error();
+                throw new Error("Unexpected buffer type: " + type);
         }
     }
 
@@ -342,7 +342,7 @@ public abstract class SSLEngineTest {
                     return ThreadLocalRandom.current().nextBoolean() ?
                             allocator.directBuffer() : allocator.heapBuffer();
                 default:
-                    throw new Error();
+                    throw new Error("Unexpected buffer type: " + type);
             }
         }
 
@@ -357,7 +357,7 @@ public abstract class SSLEngineTest {
                     return ThreadLocalRandom.current().nextBoolean() ?
                             allocator.directBuffer(initialCapacity) : allocator.heapBuffer(initialCapacity);
                 default:
-                    throw new Error();
+                    throw new Error("Unexpected buffer type: " + type);
             }
         }
 
@@ -373,7 +373,7 @@ public abstract class SSLEngineTest {
                             allocator.directBuffer(initialCapacity, maxCapacity) :
                             allocator.heapBuffer(initialCapacity, maxCapacity);
                 default:
-                    throw new Error();
+                    throw new Error("Unexpected buffer type: " + type);
             }
         }
 
@@ -434,7 +434,7 @@ public abstract class SSLEngineTest {
                             allocator.compositeDirectBuffer() :
                             allocator.compositeHeapBuffer();
                 default:
-                    throw new Error();
+                    throw new Error("Unexpected buffer type: " + type);
             }
         }
 
@@ -450,7 +450,7 @@ public abstract class SSLEngineTest {
                             allocator.compositeDirectBuffer(maxNumComponents) :
                             allocator.compositeHeapBuffer(maxNumComponents);
                 default:
-                    throw new Error();
+                    throw new Error("Unexpected buffer type: " + type);
             }
         }
 

--- a/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
@@ -102,7 +102,7 @@ public class SniHandlerTest {
             case JDK:
                 break;
             default:
-                throw new Error();
+                throw new Error("Unexpected alpn provider: " + provider);
         }
     }
 
@@ -603,7 +603,7 @@ public class SniHandlerTest {
             case JDK:
                 return;
             default:
-                throw new Error();
+                throw new Error("Unexpected ssl provider: " + provider);
         }
     }
 

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressDecoder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressDecoder.java
@@ -59,7 +59,7 @@ final class DnsAddressDecoder {
             return InetAddress.getByAddress(decodeIdn ? IDN.toUnicode(name) : name, addrBytes);
         } catch (UnknownHostException e) {
             // Should never reach here.
-            throw new Error(e);
+            throw new Error("Failed to decode address \"" + name + '"', e);
         }
     }
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastInetTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastInetTest.java
@@ -164,7 +164,7 @@ public class DatagramUnicastInetTest extends DatagramUnicastTest {
             case NONE:
                 return cc.write(new DatagramPacket(buf.retain(), (InetSocketAddress) remote));
             default:
-                throw new Error("unknown wrap type: " + wrapType);
+                throw new Error("Unexpected wrap type: " + wrapType);
         }
     }
 }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
@@ -458,7 +458,7 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
             case NONE:
                 return cc.write(buf.retain());
             default:
-                throw new Error("unknown wrap type: " + wrapType);
+                throw new Error("Unexpected wrap type: " + wrapType);
         }
     }
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
@@ -180,7 +180,7 @@ public class SocketSslEchoTest extends AbstractSocketTest {
                             r = new Renegotiation(rt, cc.cipherSuites().get(cc.cipherSuites().size() - 1));
                             break;
                         default:
-                            throw new Error();
+                            throw new Error("Unexpected renegotiation type: " + rt);
                     }
 
                     for (int i = 0; i < 32; i++) {

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -53,6 +53,7 @@ import static io.netty.channel.internal.ChannelUtils.WRITE_STATUS_SNDBUF_FULL;
 import static io.netty.channel.unix.FileDescriptor.pipe;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
+import static io.netty.util.internal.StringUtil.className;
 
 public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel implements DuplexChannel {
     private static final ChannelMetadata METADATA = new ChannelMetadata(false, 16);
@@ -480,7 +481,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
             return 1;
         } else {
             // Should never reach here.
-            throw new Error();
+            throw new Error("Unexpected message type: " + className(msg));
         }
     }
 

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannel.java
@@ -141,7 +141,7 @@ public final class EpollDomainSocketChannel extends AbstractEpollStreamChannel i
                     epollInReadFd();
                     break;
                 default:
-                    throw new Error();
+                    throw new Error("Unexpected read mode: " + config().getReadMode());
             }
         }
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -66,6 +66,7 @@ import static io.netty.channel.unix.Errors.ERRNO_EINPROGRESS_NEGATIVE;
 import static io.netty.channel.unix.Errors.ERROR_EALREADY_NEGATIVE;
 import static io.netty.channel.unix.UnixChannelUtil.computeRemoteAddr;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static io.netty.util.internal.StringUtil.className;
 
 
 abstract class AbstractIoUringChannel extends AbstractChannel implements UnixChannel {
@@ -1134,7 +1135,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
                     DomainSocketAddress unixDomainSocketAddress = (DomainSocketAddress) remoteAddress;
                     submitConnect(unixDomainSocketAddress);
                 } else {
-                    throw new Error("Unexpected SocketAddress implementation " + remoteAddress);
+                    throw new Error("Unexpected SocketAddress implementation " + className(remoteAddress));
                 }
 
                 if (connectId != 0) {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDomainSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDomainSocketChannel.java
@@ -167,7 +167,7 @@ public final class IoUringDomainSocketChannel extends AbstractIoUringStreamChann
                 case BYTES:
                     return super.scheduleRead0(first, socketIsEmpty);
                 default:
-                    throw new Error();
+                    throw new Error("Unexpected read mode: " + readMode);
             }
         }
 
@@ -261,7 +261,7 @@ public final class IoUringDomainSocketChannel extends AbstractIoUringStreamChann
             case FILE_DESCRIPTORS:
                 return false;
             default:
-                throw new Error();
+                throw new Error("Unexpected read mode: " + readMode);
         }
     }
 }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
@@ -46,6 +46,7 @@ import java.util.concurrent.Executor;
 
 import static io.netty.channel.internal.ChannelUtils.MAX_BYTES_PER_GATHERING_WRITE_ATTEMPTED_LOW_THRESHOLD;
 import static io.netty.channel.internal.ChannelUtils.WRITE_STATUS_SNDBUF_FULL;
+import static io.netty.util.internal.StringUtil.className;
 
 public abstract class AbstractKQueueStreamChannel extends AbstractKQueueChannel implements DuplexChannel {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(AbstractKQueueStreamChannel.class);
@@ -326,7 +327,7 @@ public abstract class AbstractKQueueStreamChannel extends AbstractKQueueChannel 
             return writeFileRegion(in, (FileRegion) msg);
         } else {
             // Should never reach here.
-            throw new Error();
+            throw new Error("Unexpected message type: " + className(msg));
         }
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannel.java
@@ -135,7 +135,7 @@ public final class KQueueDomainSocketChannel extends AbstractKQueueStreamChannel
                     readReadyFd();
                     break;
                 default:
-                    throw new Error();
+                    throw new Error("Unexpected read mode: " + config().getReadMode());
             }
         }
 

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainDatagramUnicastTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainDatagramUnicastTest.java
@@ -162,7 +162,7 @@ class EpollDomainDatagramUnicastTest extends DatagramUnicastTest {
             case NONE:
                 return cc.write(new DomainDatagramPacket(buf.retain(), (DomainSocketAddress) remote));
             default:
-                throw new Error("unknown wrap type: " + wrapType);
+                throw new Error("Unexpected wrap type: " + wrapType);
         }
     }
 }

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainDatagramUnicastTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainDatagramUnicastTest.java
@@ -162,7 +162,7 @@ class KQueueDomainDatagramUnicastTest extends DatagramUnicastTest {
             case NONE:
                 return cc.write(new DomainDatagramPacket(buf.retain(), (DomainSocketAddress) remote));
             default:
-                throw new Error("unknown wrap type: " + wrapType);
+                throw new Error("Unexpected wrap type: " + wrapType);
         }
     }
 }

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/NativeInetAddress.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/NativeInetAddress.java
@@ -100,11 +100,11 @@ public final class NativeInetAddress {
                     }
                     break;
                 default:
-                    throw new Error();
+                    throw new IllegalArgumentException("Unsupported length: " + len + " (allowed: 8 or 24)");
             }
             return new InetSocketAddress(address, port);
         } catch (UnknownHostException e) {
-            throw new Error("Should never happen", e);
+            throw new Error(e); // Should never happen
         }
     }
 

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/Socket.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/Socket.java
@@ -39,6 +39,7 @@ import static io.netty.channel.unix.Errors.ioResult;
 import static io.netty.channel.unix.Errors.newIOException;
 import static io.netty.channel.unix.NativeInetAddress.address;
 import static io.netty.channel.unix.NativeInetAddress.ipv4MappedIpv6Address;
+import static io.netty.util.internal.StringUtil.className;
 
 /**
  * Provides a JNI bridge to native socket operations.
@@ -346,7 +347,7 @@ public class Socket extends FileDescriptor {
             DomainSocketAddress unixDomainSocketAddress = (DomainSocketAddress) socketAddress;
             res = connectDomainSocket(fd, unixDomainSocketAddress.path().getBytes(CharsetUtil.UTF_8));
         } else {
-            throw new Error("Unexpected SocketAddress implementation " + socketAddress);
+            throw new Error("Unexpected SocketAddress implementation: " + className(socketAddress));
         }
         if (res < 0) {
             return handleConnectErrno("connect", res);
@@ -385,7 +386,7 @@ public class Socket extends FileDescriptor {
                 throw newIOException("bind", res);
             }
         } else {
-            throw new Error("Unexpected SocketAddress implementation " + socketAddress);
+            throw new Error("Unexpected SocketAddress implementation: " + className(socketAddress));
         }
     }
 

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
@@ -247,7 +247,7 @@ public class NioSctpChannel extends AbstractNioMessageChannel implements io.nett
     @Override
     protected void doFinishConnect() throws Exception {
         if (!javaChannel().finishConnect()) {
-            throw new Error();
+            throw new UnsupportedOperationException("finishConnect is not supported for " + getClass().getName());
         }
     }
 

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
@@ -37,6 +37,7 @@ import java.nio.channels.SelectableChannel;
 import java.nio.channels.SelectionKey;
 
 import static io.netty.channel.internal.ChannelUtils.WRITE_STATUS_SNDBUF_FULL;
+import static io.netty.util.internal.StringUtil.className;
 
 /**
  * {@link AbstractNioChannel} base class for {@link Channel}s that operate on bytes.
@@ -246,7 +247,7 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
             }
         } else {
             // Should not reach here.
-            throw new Error();
+            throw new Error("Unexpected message type: " + className(msg));
         }
         return WRITE_STATUS_SNDBUF_FULL;
     }

--- a/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
@@ -209,7 +209,7 @@ public class FixedChannelPool extends SimpleChannelPool {
                 };
                 break;
             default:
-                throw new Error();
+                throw new Error("Unexpected AcquireTimeoutAction: " + action);
             }
         }
         executor = bootstrap.config().group().next();

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
@@ -236,7 +236,7 @@ public final class NioDatagramChannel
 
     @Override
     protected void doFinishConnect() throws Exception {
-        throw new Error();
+        throw new UnsupportedOperationException("finishConnect is not supported for " + getClass().getName());
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDomainSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDomainSocketChannel.java
@@ -327,7 +327,7 @@ public final class NioDomainSocketChannel extends AbstractNioByteChannel
     @Override
     protected void doFinishConnect() throws Exception {
         if (!javaChannel().finishConnect()) {
-            throw new Error();
+            throw new UnsupportedOperationException("finishConnect is not supported for " + getClass().getName());
         }
     }
 

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
@@ -328,7 +328,7 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
     @Override
     protected void doFinishConnect() throws Exception {
         if (!javaChannel().finishConnect()) {
-            throw new Error();
+            throw new UnsupportedOperationException("finishConnect is not supported for " + getClass().getName());
         }
     }
 

--- a/transport/src/test/java/io/netty/channel/CompleteChannelFutureTest.java
+++ b/transport/src/test/java/io/netty/channel/CompleteChannelFutureTest.java
@@ -71,22 +71,22 @@ public class CompleteChannelFutureTest {
 
         @Override
         public Throwable cause() {
-            throw new Error();
+            throw new UnsupportedOperationException("cause is not supported for " + getClass().getName());
         }
 
         @Override
         public boolean isSuccess() {
-            throw new Error();
+            throw new UnsupportedOperationException("isSuccess is not supported for " + getClass().getName());
         }
 
         @Override
-        public ChannelFuture sync() throws InterruptedException {
-            throw new Error();
+        public ChannelFuture sync() {
+            throw new UnsupportedOperationException("sync is not supported for " + getClass().getName());
         }
 
         @Override
         public ChannelFuture syncUninterruptibly() {
-            throw new Error();
+            throw new UnsupportedOperationException("syncUninterruptibly is not supported for " + getClass().getName());
         }
     }
 }


### PR DESCRIPTION
It's treated a bad practices to create exceptions without error message. 

Motivation:

Even if it seems that the error can never happen, it still can - for example, when someone adds an enum value and forgets to update all switches.

Modification:

Replaced all calls of `new Error()` by `new Error("Unexpected something: " + value)`.

