### PR TITLE
Merge commit from fork

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpDecoderConfig.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpDecoderConfig.java
@@ -34,6 +34,7 @@ public final class HttpDecoderConfig implements Cloneable {
     private int maxInitialLineLength = HttpObjectDecoder.DEFAULT_MAX_INITIAL_LINE_LENGTH;
     private int maxHeaderSize = HttpObjectDecoder.DEFAULT_MAX_HEADER_SIZE;
     private int initialBufferSize = HttpObjectDecoder.DEFAULT_INITIAL_BUFFER_SIZE;
+    private boolean strictLineParsing = HttpObjectDecoder.DEFAULT_STRICT_LINE_PARSING;
 
     public int getInitialBufferSize() {
         return initialBufferSize;
@@ -214,6 +215,35 @@ public final class HttpDecoderConfig implements Cloneable {
     public HttpDecoderConfig setTrailersFactory(HttpHeadersFactory trailersFactory) {
         checkNotNull(trailersFactory, "trailersFactory");
         this.trailersFactory = trailersFactory;
+        return this;
+    }
+
+    public boolean isStrictLineParsing() {
+        return strictLineParsing;
+    }
+
+    /**
+     * The RFC 9112 specification for the HTTP protocol says that the initial start-line, and the following header
+     * field-lines, must be separated by a Carriage Return (CR) and Line Feed (LF) octet pair, but also offers that
+     * implementations "MAY" accept just a Line Feed octet as a separator.
+     * <p>
+     * Parsing leniencies can increase compatibility with a wider range of implementations, but can also cause
+     * security vulnerabilities, when multiple systems disagree on the meaning of leniently parsed messages.
+     * <p>
+     * When <em>strict line parsing</em> is enabled ({@code true}), then Netty will enforce that start- and header
+     * field-lines MUST be separated by a CR LF octet pair, and will produce messagas with failed
+     * {@link io.netty.handler.codec.DecoderResult}s.
+     * <p>
+     * When <em>strict line parsing</em> is disabled ({@code false}), then Netty will accept lone LF octets as line
+     * seperators for the start- and header field-lines.
+     * <p>
+     * See <a href="https://datatracker.ietf.org/doc/html/rfc9112#name-message-format">RFC 9112 Section 2.1</a>.
+     * @param strictLineParsing Whether <em>strict line parsing</em> should be enabled ({@code true}),
+     * or not ({@code false}).
+     * @return This decoder config.
+     */
+    public HttpDecoderConfig setStrictLineParsing(boolean strictLineParsing) {
+        this.strictLineParsing = strictLineParsing;
         return this;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/InvalidChunkExtensionException.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/InvalidChunkExtensionException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http;
+
+import io.netty.handler.codec.CorruptedFrameException;
+
+/**
+ * Thrown when HTTP chunk extensions could not be parsed, typically due to incorrect use of CR LF delimiters.
+ * <p>
+ * <a href="https://datatracker.ietf.org/doc/html/rfc9112#name-chunked-transfer-coding">RFC 9112</a>
+ * specifies that chunk header lines must be terminated in a CR LF pair,
+ * and that a lone LF octet is not allowed within the chunk header line.
+ */
+public final class InvalidChunkExtensionException extends CorruptedFrameException {
+    private static final long serialVersionUID = 536224937231200736L;
+
+    public InvalidChunkExtensionException() {
+        super("Line Feed must be preceded by Carriage Return when terminating HTTP chunk header lines");
+    }
+
+    public InvalidChunkExtensionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InvalidChunkExtensionException(String message) {
+        super(message);
+    }
+
+    public InvalidChunkExtensionException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/InvalidChunkTerminationException.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/InvalidChunkTerminationException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http;
+
+import io.netty.handler.codec.CorruptedFrameException;
+
+/**
+ * Thrown when HTTP chunks could not be parsed, typically due to incorrect use of CR LF delimiters.
+ * <p>
+ * <a href="https://datatracker.ietf.org/doc/html/rfc9112#name-chunked-transfer-coding">RFC 9112</a>
+ * specifies that chunk bodies must be terminated in a CR LF pair,
+ * and that the delimiter must follow the given chunk-size number of octets in chunk-data.
+ */
+public final class InvalidChunkTerminationException extends CorruptedFrameException {
+    private static final long serialVersionUID = 536224937231200736L;
+
+    public InvalidChunkTerminationException() {
+        super("Chunk data sections must be terminated by a CR LF octet pair");
+    }
+
+    public InvalidChunkTerminationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InvalidChunkTerminationException(String message) {
+        super(message);
+    }
+
+    public InvalidChunkTerminationException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/InvalidLineSeparatorException.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/InvalidLineSeparatorException.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http;
+
+import io.netty.handler.codec.DecoderException;
+
+/**
+ * Thrown when {@linkplain HttpDecoderConfig#isStrictLineParsing() strict line parsing} is enabled,
+ * and HTTP start- and header field-lines are not seperated by CR LF octet pairs.
+ * <p>
+ * Strict line parsing is enabled by default since Netty 4.1.124 and 4.2.4.
+ * This default can be overridden by setting the {@value HttpObjectDecoder#PROP_DEFAULT_STRICT_LINE_PARSING} system
+ * property to {@code false}.
+ * <p>
+ * See <a href="https://datatracker.ietf.org/doc/html/rfc9112#name-message-format">RFC 9112 Section 2.1</a>.
+ */
+public final class InvalidLineSeparatorException extends DecoderException {
+    private static final long serialVersionUID = 536224937231200736L;
+
+    public InvalidLineSeparatorException() {
+        super("Line Feed must be preceded by Carriage Return when terminating HTTP start- and header field-lines");
+    }
+
+    public InvalidLineSeparatorException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InvalidLineSeparatorException(String message) {
+        super(message);
+    }
+
+    public InvalidLineSeparatorException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/codec-http/src/test/java/io/netty/handler/codec/http/MultipleContentLengthHeadersTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/MultipleContentLengthHeadersTest.java
@@ -26,11 +26,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import static io.netty.handler.codec.http.HttpObjectDecoder.DEFAULT_INITIAL_BUFFER_SIZE;
-import static io.netty.handler.codec.http.HttpObjectDecoder.DEFAULT_MAX_CHUNK_SIZE;
-import static io.netty.handler.codec.http.HttpObjectDecoder.DEFAULT_MAX_HEADER_SIZE;
-import static io.netty.handler.codec.http.HttpObjectDecoder.DEFAULT_MAX_INITIAL_LINE_LENGTH;
-import static io.netty.handler.codec.http.HttpObjectDecoder.DEFAULT_VALIDATE_HEADERS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -53,13 +48,9 @@ public class MultipleContentLengthHeadersTest {
     }
 
     private static EmbeddedChannel newChannel(boolean allowDuplicateContentLengths) {
-        HttpRequestDecoder decoder = new HttpRequestDecoder(
-                DEFAULT_MAX_INITIAL_LINE_LENGTH,
-                DEFAULT_MAX_HEADER_SIZE,
-                DEFAULT_MAX_CHUNK_SIZE,
-                DEFAULT_VALIDATE_HEADERS,
-                DEFAULT_INITIAL_BUFFER_SIZE,
-                allowDuplicateContentLengths);
+        HttpDecoderConfig config = new HttpDecoderConfig()
+                .setAllowDuplicateContentLengths(allowDuplicateContentLengths);
+        HttpRequestDecoder decoder = new HttpRequestDecoder(config);
         return new EmbeddedChannel(decoder);
     }
 
@@ -109,7 +100,7 @@ public class MultipleContentLengthHeadersTest {
         EmbeddedChannel channel = newChannel(false);
         String requestStr = "GET /some/path HTTP/1.1\r\n" +
                             "Content-Length: 1,\r\n" +
-                            "Connection: close\n\n" +
+                            "Connection: close\r\n\r\n" +
                             "ab";
         assertTrue(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
         HttpRequest request = channel.readInbound();


### PR DESCRIPTION
* Prevent HTTP request/response smuggling via chunk encoding

Motivation:
Transfer-Encoding: chunked has some strict rules around parsing CR LF delimiters. If we are too lenient, it can cause request/response smuggling issues when combined with proxies that are lenient in different ways. See https://w4ke.info/2025/06/18/funky-chunks.html for the details.

Modification:
- Make sure that we reject chunks with chunk-extensions that contain lone Line Feed octets without their preceding Carriage Return octet.
- Make sure that we issue HttpContent objects with decoding failures, if we decode a chunk and it isn't immediately followed by a CR LF octet pair.

Result:
Smuggling requests/responses is no longer possible.

Fixes https://github.com/netty/netty/issues/15522

* Enforce CR LF line separators for HTTP messages by default

But also make it configurable through `HttpDecoderConfig`, and add a system property opt-out to change the default back.

* Remove property for the name of the strict line parsing property

* Remove HeaderParser.parse overload that only takes a buffer argument

