### PR TITLE
Merge commit from fork

### DIFF
--- a/codec-http/src/main/resources/META-INF/native-image/io.netty/netty-codec-http/generated/handlers/reflect-config.json
+++ b/codec-http/src/main/resources/META-INF/native-image/io.netty/netty-codec-http/generated/handlers/reflect-config.json
@@ -49,6 +49,13 @@
     "queryAllPublicMethods": true
   },
   {
+    "name": "io.netty.handler.codec.http.HttpContentDecoder$ByteBufForwarder",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http.HttpContentDecoder$ByteBufForwarder"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
     "name": "io.netty.handler.codec.http.HttpContentDecompressor",
     "condition": {
       "typeReachable": "io.netty.handler.codec.http.HttpContentDecompressor"

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentDecompressorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentDecompressorTest.java
@@ -15,13 +15,22 @@
  */
 package io.netty.handler.codec.http;
 
+import io.netty.buffer.AdaptiveByteBufAllocator;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.compression.Brotli;
+import io.netty.handler.codec.compression.Zstd;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -69,5 +78,94 @@ public class HttpContentDecompressorTest {
         // inbound handler.
         assertEquals(2, readCalled.get());
         assertFalse(channel.finishAndReleaseAll());
+    }
+
+    static String[] encodings() {
+        List<String> encodings = new ArrayList<String>();
+        encodings.add("gzip");
+        encodings.add("deflate");
+        if (Brotli.isAvailable()) {
+            encodings.add("br");
+        }
+        if (Zstd.isAvailable()) {
+            encodings.add("zstd");
+        }
+        encodings.add("snappy");
+        return encodings.toArray(new String[0]);
+    }
+
+    @ParameterizedTest
+    @MethodSource("encodings")
+    public void testZipBomb(String encoding) {
+        int chunkSize = 1024 * 1024;
+        int numberOfChunks = 256;
+        int memoryLimit = chunkSize * 128;
+
+        EmbeddedChannel compressionChannel = new EmbeddedChannel(new HttpContentCompressor());
+        DefaultFullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
+        req.headers().set(HttpHeaderNames.ACCEPT_ENCODING, encoding);
+        compressionChannel.writeInbound(req);
+
+        DefaultHttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        response.headers().set(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
+        compressionChannel.writeOutbound(response);
+
+        for (int i = 0; i < numberOfChunks; i++) {
+            ByteBuf buffer = compressionChannel.alloc().buffer(chunkSize);
+            buffer.writeZero(chunkSize);
+            compressionChannel.writeOutbound(new DefaultHttpContent(buffer));
+        }
+        compressionChannel.writeOutbound(LastHttpContent.EMPTY_LAST_CONTENT);
+        compressionChannel.finish();
+        compressionChannel.releaseInbound();
+
+        ByteBuf compressed = compressionChannel.alloc().buffer();
+        HttpMessage message = null;
+        while (true) {
+            HttpObject obj = compressionChannel.readOutbound();
+            if (obj == null) {
+                break;
+            }
+            if (obj instanceof HttpMessage) {
+                message = (HttpMessage) obj;
+            }
+            if (obj instanceof HttpContent) {
+                HttpContent content = (HttpContent) obj;
+                compressed.writeBytes(content.content());
+                content.release();
+            }
+        }
+
+        PooledByteBufAllocator allocator = new PooledByteBufAllocator(false);
+
+        ZipBombIncomingHandler incomingHandler = new ZipBombIncomingHandler(memoryLimit);
+        EmbeddedChannel decompressChannel = new EmbeddedChannel(new HttpContentDecompressor(0), incomingHandler);
+        decompressChannel.config().setAllocator(allocator);
+        decompressChannel.writeInbound(message);
+        decompressChannel.writeInbound(new DefaultLastHttpContent(compressed));
+
+        assertEquals((long) chunkSize * numberOfChunks, incomingHandler.total);
+    }
+
+    private static final class ZipBombIncomingHandler extends ChannelInboundHandlerAdapter {
+        final int memoryLimit;
+        long total;
+
+        ZipBombIncomingHandler(int memoryLimit) {
+            this.memoryLimit = memoryLimit;
+        }
+
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) {
+            PooledByteBufAllocator allocator = (PooledByteBufAllocator) ctx.alloc();
+            assertTrue(allocator.metric().usedHeapMemory() < memoryLimit);
+            assertTrue(allocator.metric().usedDirectMemory() < memoryLimit);
+
+            if (msg instanceof HttpContent) {
+                HttpContent buf = (HttpContent) msg;
+                total += buf.content().readableBytes();
+                buf.release();
+            }
+        }
     }
 }

--- a/codec-http2/src/main/resources/META-INF/native-image/io.netty/netty-codec-http2/generated/handlers/reflect-config.json
+++ b/codec-http2/src/main/resources/META-INF/native-image/io.netty/netty-codec-http2/generated/handlers/reflect-config.json
@@ -7,6 +7,13 @@
     "queryAllPublicMethods": true
   },
   {
+    "name": "io.netty.handler.codec.http2.DelegatingDecompressorFrameListener$Http2Decompressor$1",
+    "condition": {
+      "typeReachable": "io.netty.handler.codec.http2.DelegatingDecompressorFrameListener$Http2Decompressor$1"
+    },
+    "queryAllPublicMethods": true
+  },
+  {
     "name": "io.netty.handler.codec.http2.Http2ChannelDuplexHandler",
     "condition": {
       "typeReachable": "io.netty.handler.codec.http2.Http2ChannelDuplexHandler"

--- a/codec/src/test/java/io/netty/handler/codec/compression/AbstractIntegrationTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/AbstractIntegrationTest.java
@@ -17,7 +17,10 @@ package io.netty.handler.codec.compression;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
@@ -27,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Random;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -177,6 +181,65 @@ public abstract class AbstractIntegrationTest {
             decompressed.release();
             in.release();
             closeChannels();
+        }
+    }
+
+    @Test
+    public void testHugeDecompress() {
+        int chunkSize = 1024 * 1024;
+        int numberOfChunks = 256;
+        int memoryLimit = chunkSize * 128;
+
+        EmbeddedChannel compressChannel = createEncoder();
+        ByteBuf compressed = compressChannel.alloc().buffer();
+        for (int i = 0; i <= numberOfChunks; i++) {
+            if (i < numberOfChunks) {
+                ByteBuf in = compressChannel.alloc().buffer(chunkSize);
+                in.writeZero(chunkSize);
+                compressChannel.writeOutbound(in);
+            } else {
+                compressChannel.close();
+            }
+            while (true) {
+                ByteBuf buf = compressChannel.readOutbound();
+                if (buf == null) {
+                    break;
+                }
+                compressed.writeBytes(buf);
+                buf.release();
+            }
+        }
+
+        PooledByteBufAllocator allocator = new PooledByteBufAllocator(false);
+
+        HugeDecompressIncomingHandler endHandler = new HugeDecompressIncomingHandler(memoryLimit);
+        EmbeddedChannel decompressChannel = createDecoder();
+        decompressChannel.pipeline().addLast(endHandler);
+        decompressChannel.config().setAllocator(allocator);
+        decompressChannel.writeInbound(compressed);
+        decompressChannel.finishAndReleaseAll();
+        assertEquals((long) chunkSize * numberOfChunks, endHandler.total);
+    }
+
+    private static final class HugeDecompressIncomingHandler extends ChannelInboundHandlerAdapter {
+        final int memoryLimit;
+        long total;
+
+        HugeDecompressIncomingHandler(int memoryLimit) {
+            this.memoryLimit = memoryLimit;
+        }
+
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) {
+            ByteBuf buf = (ByteBuf) msg;
+            total += buf.readableBytes();
+            try {
+                PooledByteBufAllocator allocator = (PooledByteBufAllocator) ctx.alloc();
+                assertThat(allocator.metric().usedHeapMemory()).isLessThan(memoryLimit);
+                assertThat(allocator.metric().usedDirectMemory()).isLessThan(memoryLimit);
+            } finally {
+                buf.release();
+            }
         }
     }
 }

--- a/codec/src/test/java/io/netty/handler/codec/compression/BrotliIntegrationTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/BrotliIntegrationTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+
+public class BrotliIntegrationTest extends AbstractIntegrationTest {
+
+    @Override
+    protected EmbeddedChannel createEncoder() {
+        return new EmbeddedChannel(new BrotliEncoder());
+    }
+
+    @Override
+    protected EmbeddedChannel createDecoder() {
+        return new EmbeddedChannel(new BrotliDecoder());
+    }
+}

--- a/codec/src/test/java/io/netty/handler/codec/compression/JZlibIntegrationTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/JZlibIntegrationTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+
+public class JZlibIntegrationTest extends AbstractIntegrationTest {
+
+    @Override
+    protected EmbeddedChannel createEncoder() {
+        return new EmbeddedChannel(new JZlibEncoder());
+    }
+
+    @Override
+    protected EmbeddedChannel createDecoder() {
+        return new EmbeddedChannel(new JZlibDecoder(0));
+    }
+}

--- a/codec/src/test/java/io/netty/handler/codec/compression/JdkZlibIntegrationTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/JdkZlibIntegrationTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+
+public class JdkZlibIntegrationTest extends AbstractIntegrationTest {
+
+    @Override
+    protected EmbeddedChannel createEncoder() {
+        return new EmbeddedChannel(new JdkZlibEncoder());
+    }
+
+    @Override
+    protected EmbeddedChannel createDecoder() {
+        return new EmbeddedChannel(new JdkZlibDecoder(0));
+    }
+}


### PR DESCRIPTION
Motivation:

We should ensure our decompressing decoders will fire their buffers through the pipeliner as fast as possible and so allow the user to take ownership of these as fast as possible. This is needed to reduce the risk of OOME as otherwise a small input might produce a large amount of data that can't be processed until all the data was decompressed in a loop. Beside this we also should ensure that other handlers that uses these decompressors will not buffer all of the produced data before processing it, which was true for HTTP and HTTP2.

Modifications:

- Adjust affected decoders (Brotli, Zstd and  ZLib) to fire buffers through the pipeline as soon as possible
- Adjust HTTP / HTTP2 decompressors to do the same
- Add testcase.

Result:

Less risk of OOME when doing decompressing