### PR TITLE
Skip huge decompression test with leak detection (#15616)

### DIFF
--- a/codec/src/test/java/io/netty/handler/codec/compression/AbstractIntegrationTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/AbstractIntegrationTest.java
@@ -26,6 +26,7 @@ import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.EmptyArrays;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
 
 import java.util.Arrays;
 import java.util.Random;
@@ -184,6 +185,7 @@ public abstract class AbstractIntegrationTest {
         }
     }
 
+    @DisabledIf("io.netty.util.ResourceLeakDetector#isEnabled")
     @Test
     public void testHugeDecompress() {
         int chunkSize = 1024 * 1024;


### PR DESCRIPTION
Motivation:
The `AbstractIntegrationTest#testHugeDecompress` test in `codec-compress` runs incredibly slowly when leak detection is enabled, taking multiple hours when it normally takes just a few minutes with leak detection disabled.

Modification:
Disable this test when the resource leak detector is enabled.

Result:
Our leak detecting builds no longer time out.