### PR TITLE
Add test for OpenJdkSelfSignedCertGenerator

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/util/OpenJdkSelfSignedCertGeneratorTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/util/OpenJdkSelfSignedCertGeneratorTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.ssl.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.SecureRandom;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class OpenJdkSelfSignedCertGeneratorTest {
+
+    @Test
+    @EnabledOnJre({ JRE.JAVA_8, JRE.JAVA_9, JRE.JAVA_10, JRE.JAVA_11 })
+    public void testGenerate() throws Exception {
+        SecureRandom random = new SecureRandom();
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(2048, random);
+        KeyPair keypair = keyGen.generateKeyPair();
+
+        String[] generated = OpenJdkSelfSignedCertGenerator.generate("netty.io", keypair, random,
+                new Date(), new Date(253402300799000L), "RSA");
+        assertEquals(2, generated.length);
+        assertNotEquals(0, generated[0].length());
+        assertNotEquals(0, generated[1].length());
+    }
+}


### PR DESCRIPTION
Motivation:

We recently had a problem where we run into issues when we ported some changes to 4.2 that made the OpenJdkSelfSignedCertGenerator not work at all anymore. We should test that it works on the expected JDK versions

Modifications:

Add unit test

Result:

Better coverage