### PR TITLE
Expose metrics from AutoScalingEventExecutorChooserFactory

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactory.java
+++ b/common/src/main/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactory.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -52,7 +53,7 @@ public final class AutoScalingEventExecutorChooserFactory implements EventExecut
      */
     public static final class AutoScalingUtilizationMetric {
         final EventExecutor executor;
-        private volatile double utilization;
+        private final AtomicLong utilizationBits = new AtomicLong();
 
         AutoScalingUtilizationMetric(EventExecutor executor) {
             this.executor = executor;
@@ -63,11 +64,12 @@ public final class AutoScalingEventExecutorChooserFactory implements EventExecut
          * @return a value from 0.0 to 1.0.
          */
         public double utilization() {
-            return utilization;
+            return Double.longBitsToDouble(utilizationBits.get());
         }
 
         void setUtilization(double utilization) {
-            this.utilization = utilization;
+            long bits = Double.doubleToRawLongBits(utilization);
+            utilizationBits.lazySet(bits);
         }
     }
 

--- a/common/src/main/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactory.java
+++ b/common/src/main/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactory.java
@@ -52,7 +52,7 @@ public final class AutoScalingEventExecutorChooserFactory implements EventExecut
      * field updated periodically.
      */
     public static final class AutoScalingUtilizationMetric {
-        final EventExecutor executor;
+        private final EventExecutor executor;
         private final AtomicLong utilizationBits = new AtomicLong();
 
         AutoScalingUtilizationMetric(EventExecutor executor) {
@@ -65,6 +65,14 @@ public final class AutoScalingEventExecutorChooserFactory implements EventExecut
          */
         public double utilization() {
             return Double.longBitsToDouble(utilizationBits.get());
+        }
+
+        /**
+         * Returns the {@link EventExecutor} this metric belongs too.
+         * @return the executor.
+         */
+        public EventExecutor executor() {
+            return executor;
         }
 
         void setUtilization(double utilization) {

--- a/common/src/main/java/io/netty/util/concurrent/EventExecutorChooserFactory.java
+++ b/common/src/main/java/io/netty/util/concurrent/EventExecutorChooserFactory.java
@@ -15,6 +15,10 @@
  */
 package io.netty.util.concurrent;
 
+import io.netty.util.concurrent.AutoScalingEventExecutorChooserFactory.AutoScalingUtilizationMetric;
+
+import java.util.List;
+
 /**
  * Factory that creates new {@link EventExecutorChooser}s.
  */
@@ -34,5 +38,25 @@ public interface EventExecutorChooserFactory {
          * Returns the new {@link EventExecutor} to use.
          */
         EventExecutor next();
+    }
+
+    /**
+     * An {@link EventExecutorChooser} that exposes metrics for observation.
+     */
+    interface ObservableEventExecutorChooser extends EventExecutorChooser {
+
+        /**
+         * Returns the current number of active {@link EventExecutor}s.
+         * @return the number of active executors.
+         */
+        int activeExecutorCount();
+
+        /**
+         * Returns a list containing the last calculated utilization for each
+         * {@link EventExecutor} in the group.
+         *
+         * @return an umodifiable view of the executor utilizations.
+         */
+        List<AutoScalingUtilizationMetric> executorUtilizations();
     }
 }

--- a/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java
@@ -15,16 +15,20 @@
  */
 package io.netty.util.concurrent;
 
-import static io.netty.util.internal.ObjectUtil.checkPositive;
+import io.netty.util.concurrent.AutoScalingEventExecutorChooserFactory.AutoScalingUtilizationMetric;
+import io.netty.util.concurrent.EventExecutorChooserFactory.ObservableEventExecutorChooser;
 
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.netty.util.internal.ObjectUtil.checkPositive;
 
 /**
  * Abstract base class for {@link EventExecutorGroup} implementations that handles their tasks with multiple threads at
@@ -148,6 +152,33 @@ public abstract class MultithreadEventExecutorGroup extends AbstractEventExecuto
      */
     public final int executorCount() {
         return children.length;
+    }
+
+    /**
+     * Returns the number of currently active threads if the group is using an
+     * {@link ObservableEventExecutorChooser}. Otherwise, for a non-scaling group,
+     * this method returns the total number of threads, as all are considered active.
+     *
+     * @return the count of active threads.
+     */
+    public int activeExecutorCount() {
+        if (chooser instanceof ObservableEventExecutorChooser) {
+            return ((ObservableEventExecutorChooser) chooser).activeExecutorCount();
+        }
+        return executorCount();
+    }
+
+    /**
+     * Returns a list of real-time utilization metrics if the group was configured
+     * with a compatible {@link EventExecutorChooserFactory}, otherwise an empty list.
+     *
+     * @return A list of {@link AutoScalingUtilizationMetric} objects.
+     */
+    public List<AutoScalingUtilizationMetric> executorUtilizations() {
+        if (chooser instanceof ObservableEventExecutorChooser) {
+            return ((ObservableEventExecutorChooser) chooser).executorUtilizations();
+        }
+        return Collections.emptyList();
     }
 
     /**

--- a/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
@@ -286,7 +286,7 @@ public class AutoScalingEventExecutorChooserFactoryTest {
                 List<AutoScalingUtilizationMetric> utilizationMetrics = group.executorUtilizations();
                 TestEventExecutor finalActiveExecutor = activeExecutor;
                 double utilization = utilizationMetrics.stream()
-                                                       .filter(metric -> metric.executor.equals(finalActiveExecutor))
+                                                       .filter(metric -> metric.executor().equals(finalActiveExecutor))
                                                        .findFirst()
                         .map(AutoScalingUtilizationMetric::utilization)
                         .orElse(0.0);
@@ -303,7 +303,8 @@ public class AutoScalingEventExecutorChooserFactoryTest {
 
             TestEventExecutor finalActiveExecutor2 = activeExecutor;
             double activeUtilization = utilizationMetrics.stream()
-                                                         .filter(metric -> metric.executor.equals(finalActiveExecutor2))
+                                                         .filter(metric -> metric.executor()
+                                                                                 .equals(finalActiveExecutor2))
                                                          .findFirst()
                                                          .map(AutoScalingUtilizationMetric::utilization)
                                                          .orElse(0.0);
@@ -313,9 +314,9 @@ public class AutoScalingEventExecutorChooserFactoryTest {
 
             TestEventExecutor finalActiveExecutor1 = activeExecutor;
             utilizationMetrics.stream()
-                              .filter(metric -> metric.executor != finalActiveExecutor1)
+                              .filter(metric -> metric.executor() != finalActiveExecutor1)
                               .forEach(metric -> {
-                                  assertTrue(metric.executor.isSuspended(), "Other executors should be suspended.");
+                                  assertTrue(metric.executor().isSuspended(), "Other executors should be suspended.");
                                   assertEquals(0.0, metric.utilization(),
                                                "Suspended executor should have 0.0 utilization.");
                               });

--- a/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
@@ -15,9 +15,11 @@
  */
 package io.netty.util.concurrent;
 
+import io.netty.util.concurrent.AutoScalingEventExecutorChooserFactory.AutoScalingUtilizationMetric;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -25,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class AutoScalingEventExecutorChooserFactoryTest {
@@ -108,11 +111,11 @@ public class AutoScalingEventExecutorChooserFactoryTest {
         TestEventExecutorGroup group = new TestEventExecutorGroup(1, 3, 50, TimeUnit.MILLISECONDS);
         try {
             startAllExecutors(group);
-            assertEquals(3, countActiveExecutors(group));
+            assertEquals(3, group.activeExecutorCount());
             Thread.sleep(200);
 
             // The monitor should have suspended 2 executors, leaving 1 active.
-            assertEquals(1, countActiveExecutors(group));
+            assertEquals(1, group.activeExecutorCount());
         } finally {
             group.shutdownGracefully().syncUninterruptibly();
         }
@@ -125,7 +128,7 @@ public class AutoScalingEventExecutorChooserFactoryTest {
         try {
             startAllExecutors(group);
             Thread.sleep(200);
-            assertEquals(1, countActiveExecutors(group));
+            assertEquals(1, group.activeExecutorCount());
 
             TestEventExecutor activeExecutor = null;
             for (EventExecutor exec : group) {
@@ -143,10 +146,10 @@ public class AutoScalingEventExecutorChooserFactoryTest {
             // The monitor will see high utilization on the active thread. After 2 cycles (100 ms),
             // it will decide to scale up.
             long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
-            while (countActiveExecutors(group) < 2 && System.nanoTime() < deadline) {
+            while (group.activeExecutorCount() < 2 && System.nanoTime() < deadline) {
                 Thread.sleep(50);
             }
-            assertEquals(2, countActiveExecutors(group),
+            assertEquals(2, group.activeExecutorCount(),
                          "Should scale up to 2 after stressing one executor.");
 
             for (EventExecutor exec : group) {
@@ -155,10 +158,10 @@ public class AutoScalingEventExecutorChooserFactoryTest {
                 }
             }
 
-            while (countActiveExecutors(group) < 3 && System.nanoTime() < deadline) {
+            while (group.activeExecutorCount() < 3 && System.nanoTime() < deadline) {
                 Thread.sleep(50);
             }
-            assertEquals(3, countActiveExecutors(group),
+            assertEquals(3, group.activeExecutorCount(),
                          "Should scale up to 3 after stressing two executors.");
         } finally {
             group.shutdownGracefully().syncUninterruptibly();
@@ -172,7 +175,7 @@ public class AutoScalingEventExecutorChooserFactoryTest {
         try {
             startAllExecutors(group);
             Thread.sleep(200);
-            assertEquals(2, countActiveExecutors(group), "Should not scale below minThreads");
+            assertEquals(2, group.activeExecutorCount(), "Should not scale below minThreads");
         } finally {
             group.shutdownGracefully().syncUninterruptibly();
         }
@@ -185,7 +188,7 @@ public class AutoScalingEventExecutorChooserFactoryTest {
         try {
             startAllExecutors(group);
             Thread.sleep(200); // Allow time for initial scale-down to minThreads
-            assertEquals(1, countActiveExecutors(group));
+            assertEquals(1, group.activeExecutorCount());
 
             TestEventExecutor activeExecutor = null;
             for (EventExecutor exec : group) {
@@ -201,10 +204,10 @@ public class AutoScalingEventExecutorChooserFactoryTest {
 
             // Wait for the UtilizationMonitor to react and scale up.
             long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
-            while (countActiveExecutors(group) < 2 && System.nanoTime() < deadline) {
+            while (group.activeExecutorCount() < 2 && System.nanoTime() < deadline) {
                 Thread.sleep(50);
             }
-            assertEquals(2, countActiveExecutors(group), "Should scale up to maxThreads");
+            assertEquals(2, group.activeExecutorCount(), "Should scale up to maxThreads");
 
             // Now that we have scaled up, put all active executors under a high load
             // to prevent the new one from being scaled back down immediately.
@@ -219,7 +222,7 @@ public class AutoScalingEventExecutorChooserFactoryTest {
             group.next();
             Thread.sleep(200); // Give the monitor time to check again.
 
-            assertEquals(2, countActiveExecutors(group),
+            assertEquals(2, group.activeExecutorCount(),
                          "Should not scale back down while load is high");
         } finally {
             group.shutdownGracefully().syncUninterruptibly();
@@ -234,10 +237,10 @@ public class AutoScalingEventExecutorChooserFactoryTest {
             startAllExecutors(group);
 
             long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
-            while (countActiveExecutors(group) > 1 && System.nanoTime() < deadline) {
+            while (group.activeExecutorCount() > 1 && System.nanoTime() < deadline) {
                 Thread.sleep(50);
             }
-            assertEquals(1, countActiveExecutors(group),
+            assertEquals(1, group.activeExecutorCount(),
                          "Group should scale down to 1 active executor");
 
             // Simulate a slow trickle of new work (e.g., new connections) by calling next() a few times.
@@ -246,9 +249,76 @@ public class AutoScalingEventExecutorChooserFactoryTest {
                 Thread.sleep(20);
             }
 
-            assertEquals(1, countActiveExecutors(group),
+            assertEquals(1, group.activeExecutorCount(),
                          "Should consolidate the trickle of work onto the single active executor, without" +
                          " waking up the suspended ones");
+        } finally {
+            group.shutdownGracefully().syncUninterruptibly();
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    void testMetricsProvideCorrectUtilizationAndActiveExecutorCount() throws InterruptedException {
+        TestEventExecutorGroup group = new TestEventExecutorGroup(1, 3, 50, TimeUnit.MILLISECONDS);
+        try {
+            startAllExecutors(group);
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+            while (group.activeExecutorCount() > 1 && System.nanoTime() < deadline) {
+                Thread.sleep(50);
+            }
+            assertEquals(1, group.activeExecutorCount(), "Should have scaled down to 1 active executor.");
+
+            TestEventExecutor activeExecutor = null;
+            for (EventExecutor exec : group) {
+                if (!exec.isSuspended()) {
+                    activeExecutor = (TestEventExecutor) exec;
+                    break;
+                }
+            }
+            if (activeExecutor == null) {
+                fail("Could not find an active executor.");
+            }
+
+            activeExecutor.setHighLoad(true);
+
+            while (System.nanoTime() < deadline) {
+                List<AutoScalingUtilizationMetric> utilizationMetrics = group.executorUtilizations();
+                TestEventExecutor finalActiveExecutor = activeExecutor;
+                double utilization = utilizationMetrics.stream()
+                                                       .filter(metric -> metric.executor.equals(finalActiveExecutor))
+                                                       .findFirst()
+                        .map(AutoScalingUtilizationMetric::utilization)
+                        .orElse(0.0);
+                if (utilization > 0.4) {
+                    break;
+                }
+                Thread.sleep(50);
+            }
+
+            assertEquals(1, group.activeExecutorCount(), "Active count should still be 1 before scaling up.");
+
+            List<AutoScalingUtilizationMetric> utilizationMetrics = group.executorUtilizations();
+            assertEquals(3, utilizationMetrics.size(), "Utilization list should report on all executors.");
+
+            TestEventExecutor finalActiveExecutor2 = activeExecutor;
+            double activeUtilization = utilizationMetrics.stream()
+                                                         .filter(metric -> metric.executor.equals(finalActiveExecutor2))
+                                                         .findFirst()
+                                                         .map(AutoScalingUtilizationMetric::utilization)
+                                                         .orElse(0.0);
+            assertTrue(activeUtilization > 0.4,
+                       "Active executor should have utilization above the scale-down threshold. " +
+                       "Was: " + activeUtilization);
+
+            TestEventExecutor finalActiveExecutor1 = activeExecutor;
+            utilizationMetrics.stream()
+                              .filter(metric -> metric.executor != finalActiveExecutor1)
+                              .forEach(metric -> {
+                                  assertTrue(metric.executor.isSuspended(), "Other executors should be suspended.");
+                                  assertEquals(0.0, metric.utilization(),
+                                               "Suspended executor should have 0.0 utilization.");
+                              });
         } finally {
             group.shutdownGracefully().syncUninterruptibly();
         }
@@ -260,15 +330,5 @@ public class AutoScalingEventExecutorChooserFactoryTest {
             executor.execute(startLatch::countDown);
         }
         startLatch.await();
-    }
-
-    private static int countActiveExecutors(MultithreadEventExecutorGroup group) {
-        int activeCount = 0;
-        for (EventExecutor executor : group) {
-            if (!executor.isSuspended()) {
-                activeCount++;
-            }
-        }
-        return activeCount;
     }
 }


### PR DESCRIPTION
Motivation:

The auto-scaling mechanism's internal state, such as thread utilization and active thread count, is not exposed. This makes it difficult for users to monitor and debug the auto-scaler's behavior in production environments.

Modifications:

- Defined a new `EventExecutorChooserFactory.ObservableEventExecutorChooser` interface for choosers that can expose metrics.
- Implemented the `ObservableEventExecutorChooser` interface in the internal `AutoScalingEventExecutorChooser` class.
- Added `activeExecutorCount()` and `executorUtilizations()` methods to MultithreadEventExecutorGroup to expose the metrics to the user.

Result:

Users can now programmatically access the active thread count and per-thread utilization, enabling integration with monitoring and observability systems.

Fixes #15617