### PR TITLE
BouncyCastleAlpnSslUtils needs to use the correct SSLEngine class as …

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/JdkAlpnApplicationProtocolNegotiator.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkAlpnApplicationProtocolNegotiator.java
@@ -29,7 +29,7 @@ import javax.net.ssl.SSLEngine;
 public final class JdkAlpnApplicationProtocolNegotiator extends JdkBaseApplicationProtocolNegotiator {
     private static final boolean AVAILABLE = Conscrypt.isAvailable() ||
                                              JdkAlpnSslUtils.supportsAlpn() ||
-                                             BouncyCastleUtil.isBcTlsAvailable();
+            (BouncyCastleUtil.isBcTlsAvailable() && BouncyCastleAlpnSslUtils.isAlpnSupported());
 
     private static final SslEngineWrapperFactory ALPN_WRAPPER = AVAILABLE ? new AlpnWrapper() : new FailureWrapper();
 
@@ -132,7 +132,7 @@ public final class JdkAlpnApplicationProtocolNegotiator extends JdkBaseApplicati
                 return isServer ? ConscryptAlpnSslEngine.newServerEngine(engine, alloc, applicationNegotiator)
                         : ConscryptAlpnSslEngine.newClientEngine(engine, alloc, applicationNegotiator);
             }
-            if (BouncyCastleUtil.isBcJsseInUse(engine)) {
+            if (BouncyCastleUtil.isBcJsseInUse(engine) && BouncyCastleAlpnSslUtils.isAlpnSupported()) {
                 return new BouncyCastleAlpnSslEngine(engine, applicationNegotiator, isServer);
             }
             // ALPN support was recently backported to Java8 as

--- a/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
@@ -34,6 +34,7 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.Provider;
+import java.security.SecureRandom;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -272,13 +273,18 @@ final class SslUtils {
 
     static SSLContext getSSLContext(Provider provider)
             throws NoSuchAlgorithmException, KeyManagementException, NoSuchProviderException {
+        return getSSLContext(provider, null);
+    }
+
+    static SSLContext getSSLContext(Provider provider, SecureRandom secureRandom)
+            throws NoSuchAlgorithmException, KeyManagementException, NoSuchProviderException {
         final SSLContext context;
         if (provider == null) {
             context = SSLContext.getInstance(getTlsVersion());
         } else {
             context = SSLContext.getInstance(getTlsVersion(), provider);
         }
-        context.init(null, new TrustManager[0], null);
+        context.init(null, new TrustManager[0], secureRandom);
         return context;
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/util/BouncyCastleUtil.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/BouncyCastleUtil.java
@@ -133,6 +133,17 @@ public final class BouncyCastleUtil {
     }
 
     /**
+     * Returns the public {@link SSLEngine} sub-class that is used by bouncy-castle or {@code null} if
+     * it can't be loaded.
+     *
+     * @return engine class.
+     */
+    public static Class<? extends SSLEngine> getBcSSLEngineClass() {
+        ensureLoaded();
+        return bcSSLEngineClass;
+    }
+
+    /**
      * Reset the loaded providers. Useful for testing, to redo the loading under different conditions.
      */
     static void reset() {

--- a/handler/src/test/java/io/netty/handler/ssl/BouncyCastleEngineAlpnTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/BouncyCastleEngineAlpnTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import io.netty.handler.ssl.util.BouncyCastleUtil;
+import org.bouncycastle.jsse.provider.BouncyCastleJsseProvider;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import java.security.Provider;
+import java.security.SecureRandom;
+import java.util.List;
+import java.util.function.BiFunction;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BouncyCastleEngineAlpnTest {
+
+    @Test
+    public void testBouncyCastleSSLEngineSupportsAlpn() throws Exception {
+        Provider bouncyCastleProvider = new BouncyCastleJsseProvider();
+        SSLContext context = SslUtils.getSSLContext(bouncyCastleProvider, new SecureRandom());
+        SSLEngine engine = context.createSSLEngine();
+        assertTrue(BouncyCastleUtil.isBcJsseInUse(engine));
+        assertTrue(BouncyCastleAlpnSslUtils.isAlpnSupported());
+
+        BouncyCastleAlpnSslEngine alpnSslEngine = new BouncyCastleAlpnSslEngine(
+                engine, new JdkAlpnApplicationProtocolNegotiator("fake"), true);
+
+        // Call methods to ensure these not throw.
+        alpnSslEngine.setHandshakeApplicationProtocolSelector(new BiFunction<SSLEngine, List<String>, String>() {
+            @Override
+            public String apply(SSLEngine sslEngine, List<String> strings) {
+                return "fake";
+            }
+        });
+        // Check that none of the methods will throw.
+        alpnSslEngine.getHandshakeApplicationProtocolSelector();
+        alpnSslEngine.setNegotiatedApplicationProtocol("fake");
+        alpnSslEngine.getNegotiatedApplicationProtocol();
+    }
+}


### PR DESCRIPTION
…otherwise it will fail to init static fields.

Motivation:

We recently did some changes related to how BouncyCastle is loaded and while doing so introduce a regression which would cause NPE's later on once BouncyCastle was detected and used and we tried to apply ALPN later on. This regression was introduced by https://github.com/netty/netty/pull/15533

The problem was that we used the wrong class to try to obtain the Method instances via reflection. This failed as the class itself is package-private and so did not allow to access the methods. To fix this we need to ensure we use the public interface that is used by BouncyCastle and not the implemention class itself. Beside this we also should be more defensive and only try to use ALPN via BouncyCastle if we can obtain the Methods in the first place.

Modifications:

- Fix refelective access
- Add more guards
- Add unit test

Result:

Fixes https://github.com/netty/netty/issues/15627