### PR TITLE
Silence harmless security warnings

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/HeapByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/HeapByteBufUtil.java
@@ -129,7 +129,7 @@ final class HeapByteBufUtil {
     }
 
     static void setByte(byte[] memory, int index, int value) {
-        memory[index] = (byte) value;
+        memory[index] = (byte) (value & 0xFF);
     }
 
     static void setShort(byte[] memory, int index, int value) {

--- a/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
@@ -437,7 +437,7 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     protected void _setByte(int index, int value) {
-        buffer.put(index, (byte) value);
+        buffer.put(index, (byte) (value & 0xFF));
     }
 
     @Override
@@ -461,7 +461,7 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
             varHandle.set(buffer, index, (short) value);
             return;
         }
-        buffer.putShort(index, (short) value);
+        buffer.putShort(index, (short) (value & 0xFFFF));
     }
 
     @Override

--- a/microbench/src/main/java/io/netty/buffer/AllocationPatternSimulator.java
+++ b/microbench/src/main/java/io/netty/buffer/AllocationPatternSimulator.java
@@ -449,7 +449,7 @@ public class AllocationPatternSimulator {
     }
 
     private static int[] buildPattern(String jfrFile) throws IOException {
-        Path path = Paths.get(jfrFile).toAbsolutePath();
+        Path path = toAbsolutePath(jfrFile);
         TreeMap<Integer, Integer> summation = new TreeMap<>();
         try (RecordingFile eventReader = new RecordingFile(path)) {
             while (eventReader.hasMoreEvents()) {
@@ -472,6 +472,11 @@ public class AllocationPatternSimulator {
             pattern[index++] = entry.getValue();
         }
         return pattern;
+    }
+
+    @SuppressWarnings("JvmTaintAnalysis")
+    private static Path toAbsolutePath(String jfrFile) {
+        return Paths.get(jfrFile).toAbsolutePath();
     }
 
     void setUp(int[] pattern) {


### PR DESCRIPTION
Motivation:
We get a few warnings about integer truncation through ByteBuf.setByte methods. And we get a warning about path traversal in AllocationPatternSimulator.

Both are harmless. The setByte method will only receive byte-domain values, and truncation is otherwise intentional since it'll only ever write one byte. The path traversal is harmless because the AllocationPatternSimulator is a debugging tool and not part of our product code.

Modification:
Truncate the ints before the byte cast to highlight its intentional. Silence the path traversal warning.

Result:
No more harmless security warnings.