### PR TITLE
drop a bunch of unnessacary reflection

### DIFF
--- a/buffer/src/main/java/io/netty5/buffer/BufferAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/BufferAllocator.java
@@ -15,7 +15,6 @@
  */
 package io.netty5.buffer;
 
-import io.netty5.buffer.internal.InternalBufferUtils;
 import io.netty5.buffer.pool.PooledBufferAllocator;
 import io.netty5.util.SafeCloseable;
 import io.netty5.util.Send;
@@ -262,7 +261,7 @@ public interface BufferAllocator extends SafeCloseable {
             for (var c = iteration.firstWritable(); c != null; c = c.nextWritable()) {
                 ByteBuffer dest = c.writableBuffer();
                 int length = Math.min(dest.capacity(), duplicate.remaining());
-                InternalBufferUtils.bbput(dest, 0, duplicate, duplicate.position(), length);
+                dest.put(0, duplicate, duplicate.position(), length);
                 duplicate.position(length + duplicate.position());
             }
         }

--- a/buffer/src/main/java/io/netty5/buffer/adapt/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty5/buffer/adapt/AdaptivePoolingAllocator.java
@@ -47,7 +47,6 @@ import java.util.function.Supplier;
 
 import static io.netty5.buffer.internal.InternalBufferUtils.allocatorClosedException;
 import static io.netty5.buffer.internal.InternalBufferUtils.standardDrop;
-import static io.netty5.util.internal.PlatformDependent.threadId;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -220,7 +219,7 @@ public class AdaptivePoolingAllocator implements BufferAllocator {
                     return ((Magazine) mag).allocate(size, sizeBucket);
                 }
             }
-            long threadId = threadId(currentThread);
+            long threadId = currentThread.threadId();
             int expansions = 0;
             Magazine[] mags;
             do {

--- a/buffer/src/main/java/io/netty5/buffer/bytebuffer/ByteBufferMemoryManager.java
+++ b/buffer/src/main/java/io/netty5/buffer/bytebuffer/ByteBufferMemoryManager.java
@@ -29,7 +29,6 @@ import io.netty5.buffer.internal.WrappingAllocation;
 import java.nio.ByteBuffer;
 import java.util.function.Function;
 
-import static io.netty5.buffer.internal.InternalBufferUtils.bbslice;
 import static io.netty5.buffer.internal.InternalBufferUtils.convert;
 
 /**
@@ -90,7 +89,7 @@ public final class ByteBufferMemoryManager implements MemoryManager {
     @Override
     public Object sliceMemory(Object memory, int offset, int length) {
         var buffer = (ByteBuffer) memory;
-        return bbslice(buffer, offset, length);
+        return buffer.slice(offset, length);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty5/buffer/unsafe/UnsafeBuffer.java
+++ b/buffer/src/main/java/io/netty5/buffer/unsafe/UnsafeBuffer.java
@@ -44,7 +44,6 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 
 import static io.netty5.buffer.internal.InternalBufferUtils.MAX_BUFFER_SIZE;
-import static io.netty5.buffer.internal.InternalBufferUtils.bbslice;
 import static io.netty5.buffer.internal.InternalBufferUtils.bufferIsReadOnly;
 import static io.netty5.buffer.internal.InternalBufferUtils.checkImplicitCapacity;
 import static io.netty5.buffer.internal.InternalBufferUtils.checkLength;
@@ -689,7 +688,7 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
     public ByteBuffer mutableReadableBuffer() {
         final ByteBuffer buf;
         if (hasReadableArray()) {
-            buf = bbslice(ByteBuffer.wrap(readableArray()), readableArrayOffset(), readableArrayLength());
+            buf = ByteBuffer.wrap(readableArray()).slice(readableArrayOffset(), readableArrayLength());
         } else {
             buf = PlatformDependent.directBuffer(address + roff, readableBytes(), memory);
         }
@@ -733,7 +732,7 @@ final class UnsafeBuffer extends AdaptableBuffer<UnsafeBuffer>
     public ByteBuffer writableBuffer() {
         final ByteBuffer buf;
         if (hasWritableArray()) {
-            buf = bbslice(ByteBuffer.wrap(writableArray()), writableArrayOffset(), writableArrayLength());
+            buf = ByteBuffer.wrap(writableArray()).slice(writableArrayOffset(), writableArrayLength());
         } else {
             buf = PlatformDependent.directBuffer(address + woff, writableBytes(), memory);
         }

--- a/common/src/main/java/io/netty5/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty5/util/internal/PlatformDependent.java
@@ -806,17 +806,6 @@ public final class PlatformDependent {
     }
 
     /**
-     * Get the ID of the given thread. This is {@code Thread.threadId()} on Java 19 and newer,
-     * or {@code Thread.getId()} on older Java versions.
-     *
-     * @param thread The thread to get the ID from.
-     * @return The ID of the given thread.
-     */
-    public static long threadId(Thread thread) {
-        return PlatformDependent0.threadId(thread);
-    }
-
-    /**
      * Compare two {@code byte} arrays for equality. For performance reasons no bounds checking on the
      * parameters is performed.
      *

--- a/common/src/main/java/io/netty5/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty5/util/internal/PlatformDependent0.java
@@ -50,7 +50,6 @@ final class PlatformDependent0 {
     private static final MethodHandle DIRECT_BUFFER_CONSTRUCTOR_HANDLE;
     private static final Throwable EXPLICIT_NO_UNSAFE_CAUSE = explicitNoUnsafeCause0();
     private static final MethodHandle ALLOCATE_ARRAY_HANDLE;
-    private static final MethodHandle THREAD_ID;
     private static final int JAVA_VERSION = javaVersion0();
     private static final boolean IS_ANDROID = isAndroid0();
 
@@ -351,18 +350,6 @@ final class PlatformDependent0 {
             ALLOCATE_ARRAY_HANDLE = allocateArrayHandle;
         }
 
-        MethodHandle threadId = null;
-        try {
-            if (PlatformDependent.javaVersion() < 19) {
-                threadId = lookup().findVirtual(Thread.class, "getId", MethodType.methodType(long.class));
-            } else {
-                threadId = lookup().findVirtual(Thread.class, "threadId", MethodType.methodType(long.class));
-            }
-        } catch (Exception e) {
-            logger.debug("threadId method handle unavailable", e);
-        }
-        THREAD_ID = threadId;
-
         logger.debug("java.nio.DirectByteBuffer.<init>(long, {int,long}): {}",
                 DIRECT_BUFFER_CONSTRUCTOR_HANDLE != null ? "available" : "unavailable");
     }
@@ -431,17 +418,6 @@ final class PlatformDependent0 {
         // Just use 1 to make it safe to use in all cases:
         // See: https://pubs.opengroup.org/onlinepubs/009695399/functions/malloc.html
         return newDirectBuffer(UNSAFE.allocateMemory(Math.max(1, capacity)), capacity, null);
-    }
-
-    static long threadId(Thread thread) {
-        if (THREAD_ID == null) {
-            return thread.getId();
-        }
-        try {
-            return (long) THREAD_ID.invokeExact(thread);
-        } catch (Throwable e) {
-            throw new Error(e);
-        }
     }
 
     static boolean hasAllocateArrayMethod() {

--- a/handler/src/main/java/io/netty5/handler/ssl/JdkAlpnApplicationProtocolNegotiator.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/JdkAlpnApplicationProtocolNegotiator.java
@@ -27,11 +27,7 @@ import javax.net.ssl.SSLEngine;
  */
 @Deprecated
 public final class JdkAlpnApplicationProtocolNegotiator extends JdkBaseApplicationProtocolNegotiator {
-    private static final boolean AVAILABLE = Conscrypt.isAvailable() ||
-                                             JdkAlpnSslUtils.supportsAlpn() ||
-                                             BouncyCastleUtil.isBcTlsAvailable();
-
-    private static final SslEngineWrapperFactory ALPN_WRAPPER = AVAILABLE ? new AlpnWrapper() : new FailureWrapper();
+    private static final SslEngineWrapperFactory ALPN_WRAPPER = new AlpnWrapper();
 
     /**
      * Create a new instance.
@@ -135,19 +131,7 @@ public final class JdkAlpnApplicationProtocolNegotiator extends JdkBaseApplicati
             if (BouncyCastleUtil.isBcJsseInUse(engine)) {
                 return new BouncyCastleAlpnSslEngine(engine, applicationNegotiator, isServer);
             }
-            // ALPN support was recently backported to Java8 as
-            // https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8230977.
-            // Because of this lets not do a Java version runtime check but just depend on if the required methods are
-            // present
-            if (JdkAlpnSslUtils.supportsAlpn()) {
-                return new JdkAlpnSslEngine(engine, applicationNegotiator, isServer);
-            }
-            throw new UnsupportedOperationException("ALPN not supported. Unable to wrap SSLEngine of type '"
-                    + engine.getClass().getName() + "')");
+            return new JdkAlpnSslEngine(engine, applicationNegotiator, isServer);
         }
-    }
-
-    static boolean isAlpnSupported() {
-        return AVAILABLE;
     }
 }

--- a/handler/src/main/java/io/netty5/handler/ssl/JdkAlpnApplicationProtocolNegotiator.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/JdkAlpnApplicationProtocolNegotiator.java
@@ -111,15 +111,6 @@ public final class JdkAlpnApplicationProtocolNegotiator extends JdkBaseApplicati
         super(ALPN_WRAPPER, selectorFactory, listenerFactory, protocols);
     }
 
-    private static final class FailureWrapper extends AllocatorAwareSslEngineWrapperFactory {
-        @Override
-        public SSLEngine wrapSslEngine(SSLEngine engine, BufferAllocator alloc,
-                                       JdkApplicationProtocolNegotiator applicationNegotiator, boolean isServer) {
-            throw new RuntimeException("ALPN unsupported. Does your JDK version support it?"
-                    + " For Conscrypt, add the appropriate Conscrypt JAR to classpath and set the security provider.");
-        }
-    }
-
     private static final class AlpnWrapper extends AllocatorAwareSslEngineWrapperFactory {
         @Override
         public SSLEngine wrapSslEngine(SSLEngine engine, BufferAllocator alloc,

--- a/handler/src/main/java/io/netty5/handler/ssl/JdkAlpnSslEngine.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/JdkAlpnSslEngine.java
@@ -99,7 +99,7 @@ class JdkAlpnSslEngine extends JdkSslEngine {
                      @SuppressWarnings("deprecation") JdkApplicationProtocolNegotiator applicationNegotiator,
                      boolean isServer) {
        this(engine, applicationNegotiator, isServer,
-               JdkAlpnSslUtils::setHandshakeApplicationProtocolSelector,
+               SSLEngine::setHandshakeApplicationProtocolSelector,
                JdkAlpnSslUtils::setApplicationProtocols);
     }
 
@@ -176,21 +176,21 @@ class JdkAlpnSslEngine extends JdkSslEngine {
 
     @Override
     public String getApplicationProtocol() {
-        return JdkAlpnSslUtils.getApplicationProtocol(getWrappedEngine());
+        return getWrappedEngine().getApplicationProtocol();
     }
 
     @Override
     public String getHandshakeApplicationProtocol() {
-        return JdkAlpnSslUtils.getHandshakeApplicationProtocol(getWrappedEngine());
+        return getWrappedEngine().getHandshakeApplicationProtocol();
     }
 
     @Override
     public void setHandshakeApplicationProtocolSelector(BiFunction<SSLEngine, List<String>, String> selector) {
-        JdkAlpnSslUtils.setHandshakeApplicationProtocolSelector(getWrappedEngine(), selector);
+        getWrappedEngine().setHandshakeApplicationProtocolSelector(selector);
     }
 
     @Override
     public BiFunction<SSLEngine, List<String>, String> getHandshakeApplicationProtocolSelector() {
-        return JdkAlpnSslUtils.getHandshakeApplicationProtocolSelector(getWrappedEngine());
+        return getWrappedEngine().getHandshakeApplicationProtocolSelector();
     }
 }

--- a/handler/src/main/java/io/netty5/handler/ssl/JdkAlpnSslUtils.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/JdkAlpnSslUtils.java
@@ -16,146 +16,20 @@
 package io.netty5.handler.ssl;
 
 import io.netty5.util.internal.EmptyArrays;
-import io.netty5.util.internal.PlatformDependent;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.util.List;
-import java.util.function.BiFunction;
 
 final class JdkAlpnSslUtils {
-    private static final Logger logger = LoggerFactory.getLogger(JdkAlpnSslUtils.class);
-    private static final MethodHandle SET_APPLICATION_PROTOCOLS;
-    private static final MethodHandle GET_APPLICATION_PROTOCOL;
-    private static final MethodHandle GET_HANDSHAKE_APPLICATION_PROTOCOL;
-    private static final MethodHandle SET_HANDSHAKE_APPLICATION_PROTOCOL_SELECTOR;
-    private static final MethodHandle GET_HANDSHAKE_APPLICATION_PROTOCOL_SELECTOR;
-
-    static {
-        MethodHandle getHandshakeApplicationProtocol;
-        MethodHandle getApplicationProtocol;
-        MethodHandle setApplicationProtocols;
-        MethodHandle setHandshakeApplicationProtocolSelector;
-        MethodHandle getHandshakeApplicationProtocolSelector;
-
-        try {
-            SSLContext context = SSLContext.getInstance(JdkSslContext.PROTOCOL);
-            context.init(null, null, null);
-            SSLEngine engine = context.createSSLEngine();
-            MethodHandles.Lookup lookup = MethodHandles.lookup();
-            getHandshakeApplicationProtocol = lookup.findVirtual(SSLEngine.class, "getHandshakeApplicationProtocol",
-                                                                 MethodType.methodType(String.class));
-            // Invoke and specify the return type so the compiler doesnt try to use void
-            String getHandshakeApplicationProtocolRes = (String) getHandshakeApplicationProtocol.invokeExact(engine);
-
-            getApplicationProtocol = lookup.findVirtual(SSLEngine.class, "getApplicationProtocol",
-                                                        MethodType.methodType(String.class));
-            // Invoke and specify the return type so the compiler doesnt try to use void
-            String getApplicationProtocolRes = (String) getApplicationProtocol.invokeExact(engine);
-
-            setApplicationProtocols = lookup.findVirtual(SSLParameters.class, "setApplicationProtocols",
-                                                         MethodType.methodType(void.class, String[].class));
-            setApplicationProtocols.invokeExact(engine.getSSLParameters(), EmptyArrays.EMPTY_STRINGS);
-
-            setHandshakeApplicationProtocolSelector =
-                    lookup.findVirtual(SSLEngine.class, "setHandshakeApplicationProtocolSelector",
-                                       MethodType.methodType(void.class, BiFunction.class));
-            setHandshakeApplicationProtocolSelector
-                    .invokeExact(engine,
-                                 (BiFunction<SSLEngine, List<String>, String>) (sslEngine, strings) -> null);
-
-            getHandshakeApplicationProtocolSelector =
-                    lookup.findVirtual(SSLEngine.class, "getHandshakeApplicationProtocolSelector",
-                                       MethodType.methodType(BiFunction.class));
-            // Invoke and specify the return type so the compiler doesn't try to use void
-            @SuppressWarnings("unchecked")
-            BiFunction<SSLEngine, List<String>, String> getHandshakeApplicationProtocolSelectorRes =
-                    (BiFunction<SSLEngine, List<String>, String>)
-                            getHandshakeApplicationProtocolSelector.invokeExact(engine);
-        } catch (Throwable t) {
-            // This is expected to work since Java 9, so log as error.
-            int version = PlatformDependent.javaVersion();
-            logger.error("Unable to initialize JdkAlpnSslUtils. Detected java version was: {}", version, t);
-            getHandshakeApplicationProtocol = null;
-            getApplicationProtocol = null;
-            setApplicationProtocols = null;
-            setHandshakeApplicationProtocolSelector = null;
-            getHandshakeApplicationProtocolSelector = null;
-        }
-        GET_HANDSHAKE_APPLICATION_PROTOCOL = getHandshakeApplicationProtocol;
-        GET_APPLICATION_PROTOCOL = getApplicationProtocol;
-        SET_APPLICATION_PROTOCOLS = setApplicationProtocols;
-        SET_HANDSHAKE_APPLICATION_PROTOCOL_SELECTOR = setHandshakeApplicationProtocolSelector;
-        GET_HANDSHAKE_APPLICATION_PROTOCOL_SELECTOR = getHandshakeApplicationProtocolSelector;
-    }
 
     private JdkAlpnSslUtils() {
     }
 
-    static boolean supportsAlpn() {
-        return GET_APPLICATION_PROTOCOL != null;
-    }
-
-    static String getApplicationProtocol(SSLEngine sslEngine) {
-        try {
-            return (String) GET_APPLICATION_PROTOCOL.invokeExact(sslEngine);
-        } catch (UnsupportedOperationException ex) {
-            throw ex;
-        } catch (Throwable ex) {
-            throw new IllegalStateException(ex);
-        }
-    }
-
-    static String getHandshakeApplicationProtocol(SSLEngine sslEngine) {
-        try {
-            return (String) GET_HANDSHAKE_APPLICATION_PROTOCOL.invokeExact(sslEngine);
-        } catch (UnsupportedOperationException ex) {
-            throw ex;
-        } catch (Throwable ex) {
-            throw new IllegalStateException(ex);
-        }
-    }
-
     static void setApplicationProtocols(SSLEngine engine, List<String> supportedProtocols) {
         SSLParameters parameters = engine.getSSLParameters();
-
         String[] protocolArray = supportedProtocols.toArray(EmptyArrays.EMPTY_STRINGS);
-        try {
-            SET_APPLICATION_PROTOCOLS.invokeExact(parameters, protocolArray);
-        } catch (UnsupportedOperationException ex) {
-            throw ex;
-        } catch (Throwable ex) {
-            throw new IllegalStateException(ex);
-        }
+        parameters.setApplicationProtocols(protocolArray);
         engine.setSSLParameters(parameters);
-    }
-
-    static void setHandshakeApplicationProtocolSelector(
-            SSLEngine engine, BiFunction<SSLEngine, List<String>, String> selector) {
-        try {
-            SET_HANDSHAKE_APPLICATION_PROTOCOL_SELECTOR.invokeExact(engine, selector);
-        } catch (UnsupportedOperationException ex) {
-            throw ex;
-        } catch (Throwable ex) {
-            throw new IllegalStateException(ex);
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    static BiFunction<SSLEngine, List<String>, String> getHandshakeApplicationProtocolSelector(SSLEngine engine) {
-        try {
-            return (BiFunction<SSLEngine, List<String>, String>)
-                    GET_HANDSHAKE_APPLICATION_PROTOCOL_SELECTOR.invokeExact(engine);
-        } catch (UnsupportedOperationException ex) {
-            throw ex;
-        } catch (Throwable ex) {
-            throw new IllegalStateException(ex);
-        }
     }
 }

--- a/handler/src/main/java/io/netty5/handler/ssl/SslProvider.java
+++ b/handler/src/main/java/io/netty5/handler/ssl/SslProvider.java
@@ -44,15 +44,10 @@ public enum SslProvider {
      */
     @SuppressWarnings("deprecation")
     public static boolean isAlpnSupported(final SslProvider provider) {
-        switch (provider) {
-            case JDK:
-                return JdkAlpnApplicationProtocolNegotiator.isAlpnSupported();
-            case OPENSSL:
-            case OPENSSL_REFCNT:
-                return OpenSsl.isAlpnSupported();
-            default:
-                throw new Error("Unknown SslProvider: " + provider);
-        }
+      return switch (provider) {
+        case JDK -> true;
+        case OPENSSL, OPENSSL_REFCNT -> OpenSsl.isAlpnSupported();
+      };
     }
 
     /**

--- a/handler/src/test/java/io/netty5/handler/ssl/JdkSslEngineTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/JdkSslEngineTest.java
@@ -58,7 +58,7 @@ public class JdkSslEngineTest extends SSLEngineTest {
         ALPN_JAVA {
             @Override
             boolean isAvailable() {
-                return JdkAlpnSslUtils.supportsAlpn();
+                return true;
             }
 
             @Override

--- a/handler/src/test/java/io/netty5/handler/ssl/OpenSslErrorStackAssertSSLEngine.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/OpenSslErrorStackAssertSSLEngine.java
@@ -339,7 +339,7 @@ final class OpenSslErrorStackAssertSSLEngine extends JdkSslEngine implements Ref
     @Override
     public String getApplicationProtocol() {
         try {
-            return JdkAlpnSslUtils.getApplicationProtocol(getWrappedEngine());
+            return getWrappedEngine().getApplicationProtocol();
         } finally {
             assertErrorStackEmpty();
         }
@@ -348,7 +348,7 @@ final class OpenSslErrorStackAssertSSLEngine extends JdkSslEngine implements Ref
     @Override
     public String getHandshakeApplicationProtocol() {
         try {
-            return JdkAlpnSslUtils.getHandshakeApplicationProtocol(getWrappedEngine());
+            return getWrappedEngine().getHandshakeApplicationProtocol();
         } finally {
             assertErrorStackEmpty();
         }
@@ -357,7 +357,7 @@ final class OpenSslErrorStackAssertSSLEngine extends JdkSslEngine implements Ref
     @Override
     public void setHandshakeApplicationProtocolSelector(BiFunction<SSLEngine, List<String>, String> selector) {
         try {
-            JdkAlpnSslUtils.setHandshakeApplicationProtocolSelector(getWrappedEngine(), selector);
+            getWrappedEngine().setHandshakeApplicationProtocolSelector(selector);
         } finally {
             assertErrorStackEmpty();
         }
@@ -366,7 +366,7 @@ final class OpenSslErrorStackAssertSSLEngine extends JdkSslEngine implements Ref
     @Override
     public BiFunction<SSLEngine, List<String>, String> getHandshakeApplicationProtocolSelector() {
         try {
-            return JdkAlpnSslUtils.getHandshakeApplicationProtocolSelector(getWrappedEngine());
+            return getWrappedEngine().getHandshakeApplicationProtocolSelector();
         } finally {
             assertErrorStackEmpty();
         }

--- a/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SSLEngineTest.java
@@ -44,7 +44,6 @@ import io.netty5.util.concurrent.Future;
 import io.netty5.util.concurrent.ImmediateEventExecutor;
 import io.netty5.util.concurrent.Promise;
 import io.netty5.util.internal.EmptyArrays;
-import io.netty5.util.internal.PlatformDependent;
 import io.netty5.util.internal.ResourcesUtil;
 import io.netty5.util.internal.StringUtil;
 import io.netty5.util.internal.SystemPropertyUtil;
@@ -3603,12 +3602,7 @@ public abstract class SSLEngineTest {
             assertTrue(serverSession.getPacketBufferSize() > 0);
 
             assertNotNull(clientSession.getSessionContext());
-
-            // Workaround for JDK 14 regression.
-            // See https://bugs.openjdk.java.net/browse/JDK-8242008
-            if (PlatformDependent.javaVersion() != 14) {
-                assertNotNull(serverSession.getSessionContext());
-            }
+            assertNotNull(serverSession.getSessionContext());
 
             Object value = new Object();
             // This is broken in conscrypt.

--- a/handler/src/test/java/io/netty5/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty5/handler/ssl/SniHandlerTest.java
@@ -116,7 +116,6 @@ public class SniHandlerTest {
                 assumeTrue(OpenSsl.isAlpnSupported());
                 break;
             case JDK:
-                assumeTrue(JdkAlpnSslUtils.supportsAlpn());
                 break;
             default:
                 throw new Error();

--- a/microbench/src/main/java/io/netty5/microbench/util/AbstractMicrobenchmark.java
+++ b/microbench/src/main/java/io/netty5/microbench/util/AbstractMicrobenchmark.java
@@ -21,7 +21,6 @@ import io.netty5.util.concurrent.EventExecutor;
 import io.netty5.util.concurrent.FastThreadLocalThread;
 import io.netty5.util.concurrent.Future;
 import io.netty5.util.internal.EmptyArrays;
-import io.netty5.util.internal.PlatformDependent;
 import io.netty5.util.internal.SystemPropertyUtil;
 import io.netty5.util.internal.ThreadExecutorMap;
 import org.openjdk.jmh.annotations.Fork;
@@ -139,9 +138,6 @@ public class AbstractMicrobenchmark extends AbstractMicrobenchmarkBase {
         jvmArgs.add("-Xms768m");
         jvmArgs.add("-Xmx768m");
         jvmArgs.add("-XX:MaxDirectMemorySize=768m");
-        if (PlatformDependent.javaVersion() < 15) { // not entirely sure when this option was removed, but
-            jvmArgs.add("-XX:BiasedLockingStartupDelay=0");
-        }
         if (!disableHarnessExecutor) {
             jvmArgs.add("-Djmh.executor=CUSTOM");
             jvmArgs.add("-Djmh.executor.class=" + HarnessExecutor.class.getName());

--- a/pkitesting/src/test/java/io/netty5/pkitesting/CertificateBuilderTest.java
+++ b/pkitesting/src/test/java/io/netty5/pkitesting/CertificateBuilderTest.java
@@ -272,14 +272,9 @@ class CertificateBuilderTest {
         assertThat(sans.get(5)).isEqualTo(Arrays.asList(8, "1.2.840.113635.100.1.2.42"));
         assertThat(sans.get(6)).isEqualTo(Arrays.asList(6, "spiffe://netty.io/example/san"));
         assertThat(sans.get(7).get(0)).isEqualTo(0);
-        if (PlatformDependent.javaVersion() >= 19) {
-            assertThat(sans.get(7).get(1)).isEqualTo(new byte[] {
-                    48, 17, 6, 10, 42, -122, 72, -122, -9, 99, 100, 1, 2, 42, -96, 3, 1, 1, 0 });
-        } else {
-            // Java versions older than 19 re-encode the value in an extra context-constructed tag, the {-96, 5} bit.
-            assertThat(sans.get(7).get(1)).isEqualTo(new byte[] {
-                    48, 19, 6, 10, 42, -122, 72, -122, -9, 99, 100, 1, 2, 42, -96, 5, -96, 3, 1, 1, 0 });
-        }
+        assertThat(sans.get(7).get(1)).isEqualTo(new byte[] {
+                48, 17, 6, 10, 42, -122, 72, -122, -9, 99, 100, 1, 2, 42, -96, 3, 1, 1, 0 });
+
         if (sans.get(7).size() > 2) {
             assertThat(sans.get(7).get(2)).isEqualTo("1.2.840.113635.100.1.2.42");
             assertThat(sans.get(7).get(3)).isEqualTo(new byte[]{0x01, 0x01, 0x00});

--- a/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramUnicastIPv6MappedTest.java
+++ b/testsuite/src/main/java/io/netty5/testsuite/transport/socket/DatagramUnicastIPv6MappedTest.java
@@ -15,10 +15,7 @@
  */
 package io.netty5.testsuite.transport.socket;
 
-import io.netty5.channel.socket.DatagramChannel;
-import io.netty5.channel.socket.nio.NioDatagramChannel;
 import io.netty5.util.NetUtil;
-import io.netty5.util.internal.PlatformDependent;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -38,14 +35,5 @@ public class DatagramUnicastIPv6MappedTest extends DatagramUnicastIPv6Test {
             return new InetSocketAddress(NetUtil.LOCALHOST4, serverAddress.getPort());
         }
         return serverAddress;
-    }
-
-    @Override
-    protected boolean disconnectMightFail(DatagramChannel channel) {
-        // See https://bugs.openjdk.org/browse/JDK-8285515
-        if (channel instanceof NioDatagramChannel && PlatformDependent.javaVersion() < 20) {
-            return true;
-        }
-        return super.disconnectMightFail(channel);
     }
 }

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioChannelUtil.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioChannelUtil.java
@@ -17,58 +17,14 @@ package io.netty5.channel.socket.nio;
 
 import io.netty5.channel.socket.DomainSocketAddress;
 import io.netty5.channel.socket.SocketProtocolFamily;
-import io.netty5.util.internal.PlatformDependent;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.net.ProtocolFamily;
 import java.net.SocketAddress;
 import java.net.StandardProtocolFamily;
-import java.nio.channels.Channel;
-import java.nio.channels.spi.SelectorProvider;
+import java.net.UnixDomainSocketAddress;
 import java.nio.file.Path;
 
 final class NioChannelUtil {
-    private static final Logger logger = LoggerFactory.getLogger(NioChannelUtil.class);
-
-    private static final MethodHandle OF_METHOD_HANDLE;
-    private static final MethodHandle GET_PATH_METHOD_HANDLE;
-
-    static {
-        MethodHandle ofMethodHandle = null;
-        MethodHandle getPathMethodHandle = null;
-
-        if (PlatformDependent.javaVersion() >= 16) {
-            try {
-                Class<?> clazz = Class.forName("java.net.UnixDomainSocketAddress", false,
-                                               NioChannelUtil.class.getClassLoader());
-                MethodHandles.Lookup lookup = MethodHandles.lookup();
-                MethodType type = MethodType.methodType(clazz, String.class);
-                ofMethodHandle = lookup.findStatic(clazz, "of", type);
-
-                type = MethodType.methodType(Path.class);
-                getPathMethodHandle = lookup.findVirtual(clazz, "getPath", type);
-            } catch (ClassNotFoundException t) {
-                ofMethodHandle = null;
-                getPathMethodHandle = null;
-                logger.debug(
-                        "java.net.UnixDomainSocketAddress not found", t);
-            } catch (NoSuchMethodException | IllegalAccessException e) {
-                ofMethodHandle = null;
-                getPathMethodHandle = null;
-                logger.debug(
-                        "Could not access methods of java.net.UnixDomainSocketAddress", e);
-            }
-        }
-        OF_METHOD_HANDLE = ofMethodHandle;
-        GET_PATH_METHOD_HANDLE = getPathMethodHandle;
-    }
 
     static boolean isDomainSocket(ProtocolFamily family) {
         if (family instanceof StandardProtocolFamily) {
@@ -81,64 +37,20 @@ final class NioChannelUtil {
     }
 
     static SocketAddress toDomainSocketAddress(SocketAddress address) {
-        if (GET_PATH_METHOD_HANDLE != null) {
-            try {
-                Path path = (Path) GET_PATH_METHOD_HANDLE.invoke(address);
-                return new DomainSocketAddress(path.toFile());
-            } catch (RuntimeException e) {
-                throw e;
-            } catch (Throwable cause) {
-                return null;
-            }
+        if (address instanceof UnixDomainSocketAddress unixDomainSocketAddress) {
+            Path path = unixDomainSocketAddress.getPath();
+            return new DomainSocketAddress(path.toFile());
         }
+
         return address;
     }
 
     static SocketAddress toUnixDomainSocketAddress(SocketAddress address) {
-        if (OF_METHOD_HANDLE != null) {
-            if (address instanceof DomainSocketAddress) {
-                try {
-                    return (SocketAddress) OF_METHOD_HANDLE.invoke(((DomainSocketAddress) address).path());
-                } catch (RuntimeException e) {
-                    throw e;
-                } catch (Throwable cause) {
-                    return null;
-                }
-            }
+        if (address instanceof DomainSocketAddress domainSocketAddress) {
+            return UnixDomainSocketAddress.of(domainSocketAddress.path());
         }
+
         return address;
-    }
-
-    static Method findOpenMethod(String methodName) {
-        if (PlatformDependent.javaVersion() >= 15) {
-            try {
-                return SelectorProvider.class.getMethod(methodName, ProtocolFamily.class);
-            } catch (Throwable e) {
-                logger.debug("SelectorProvider.{}(ProtocolFamily) not available, will use default", methodName, e);
-            }
-        }
-        return null;
-    }
-
-    static <C extends Channel> C newChannel(Method method, SelectorProvider provider,
-                                            ProtocolFamily family) throws IOException {
-        /*
-         *  Use the {@link SelectorProvider} to open {@link SocketChannel} and so remove condition in
-         *  {@link SelectorProvider#provider()} which is called by each SocketChannel.open() otherwise.
-         *
-         *  See <a href="https://github.com/netty/netty/issues/2308">#2308</a>.
-         */
-        if (family != null && method != null) {
-            try {
-                @SuppressWarnings("unchecked")
-                C channel = (C) method.invoke(
-                        provider, family);
-                return channel;
-            } catch (InvocationTargetException | IllegalAccessException e) {
-                throw new IOException(e);
-            }
-        }
-        return null;
     }
 
     static ProtocolFamily toJdkFamily(ProtocolFamily family) {

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioServerSocketChannel.java
@@ -32,11 +32,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.lang.reflect.Method;
 import java.net.ProtocolFamily;
 import java.net.SocketAddress;
 import java.net.SocketOption;
-import java.nio.channels.SelectionKey;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.nio.channels.spi.SelectorProvider;
@@ -75,14 +73,9 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel<Channel, S
 
     private static final Logger logger = LoggerFactory.getLogger(NioServerSocketChannel.class);
 
-    private static final Method OPEN_SERVER_SOCKET_CHANNEL_WITH_FAMILY =
-            NioChannelUtil.findOpenMethod("openServerSocketChannel");
-
     private static ServerSocketChannel newChannel(SelectorProvider provider, ProtocolFamily family) {
         try {
-            ServerSocketChannel channel =
-                    NioChannelUtil.newChannel(OPEN_SERVER_SOCKET_CHANNEL_WITH_FAMILY, provider, family);
-            return channel == null ? provider.openServerSocketChannel() : channel;
+            return family == null? provider.openServerSocketChannel() : provider.openServerSocketChannel(family);
         } catch (IOException e) {
             throw new ChannelException("Failed to open a socket.", e);
         }

--- a/transport/src/main/java/io/netty5/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty5/channel/socket/nio/NioSocketChannel.java
@@ -31,7 +31,6 @@ import io.netty5.util.concurrent.Promise;
 import io.netty5.util.internal.PlatformDependent;
 
 import java.io.IOException;
-import java.lang.reflect.Method;
 import java.net.ProtocolFamily;
 import java.net.SocketAddress;
 import java.net.SocketOption;
@@ -70,13 +69,9 @@ public class NioSocketChannel
         implements io.netty5.channel.socket.SocketChannel {
     private static final SelectorProvider DEFAULT_SELECTOR_PROVIDER = SelectorProvider.provider();
 
-    private static final Method OPEN_SOCKET_CHANNEL_WITH_FAMILY =
-            NioChannelUtil.findOpenMethod("openSocketChannel");
-
     private static SocketChannel newChannel(SelectorProvider provider, ProtocolFamily family) {
         try {
-            SocketChannel channel = NioChannelUtil.newChannel(OPEN_SOCKET_CHANNEL_WITH_FAMILY, provider, family);
-            return channel == null ? provider.openSocketChannel() : channel;
+            return family == null? provider.openSocketChannel() : provider.openSocketChannel(family);
         } catch (IOException e) {
             throw new ChannelException("Failed to open a socket.", e);
         }


### PR DESCRIPTION
Motivation:
With the bump of the main branch to java 22 a bunch of reflection and java version guards are no longer needed as the relevant methods can be used directly.

Modification:
Remove the relevant reflection calls java version guards.

Result:
No more unnessacary reflection and java version guards that just make the code harder to read.
