### PR TITLE
`TimeoutException`: include description with timeout value

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/AbstractFuture.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractFuture.java
@@ -15,6 +15,7 @@
  */
 package io.netty.util.concurrent;
 
+import java.util.Locale;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -53,6 +54,6 @@ public abstract class AbstractFuture<V> implements Future<V> {
             }
             throw new ExecutionException(cause);
         }
-        throw new TimeoutException();
+        throw new TimeoutException("timeout after " + timeout + " " + unit.name().toLowerCase(Locale.ENGLISH));
     }
 }

--- a/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
@@ -23,6 +23,7 @@ import io.netty.util.internal.ThrowableUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
+import java.util.Locale;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
@@ -370,7 +371,7 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
         Object result = this.result;
         if (!isDone0(result)) {
             if (!await(timeout, unit)) {
-                throw new TimeoutException();
+                throw new TimeoutException("timeout after " + timeout + " " + unit.name().toLowerCase(Locale.ENGLISH));
             }
             result = this.result;
         }


### PR DESCRIPTION
Motivation:

When `TimeoutException` is thrown, it's hard to know how long it was waiting.

Modifications:
- Add timeout value in description for `TimeoutException` in `AbstractFuture` and `DefaultPromise`.

Result:

Users can see how long they waited before `TimeoutException`.