### PR TITLE
Update our ApacheDS Protocol DNS test dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1230,7 +1230,7 @@
       <dependency>
         <groupId>org.apache.directory.server</groupId>
         <artifactId>apacheds-protocol-dns</artifactId>
-        <version>1.5.7</version>
+        <version>2.0.0.AM27</version>
         <scope>test</scope>
       </dependency>
 

--- a/resolver-dns/pom.xml
+++ b/resolver-dns/pom.xml
@@ -72,22 +72,6 @@
       <groupId>org.apache.directory.server</groupId>
       <artifactId>apacheds-protocol-dns</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <!--
-          We need to use commons-lang 2.6 to be able to run the tests with java9
-          See https://github.com/apache/bookkeeper/issues/385
-        -->
-        <exclusion>
-          <groupId>commons-lang</groupId>
-          <artifactId>commons-lang</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
-      <scope>test</scope>
     </dependency>
 
     <!-- Automatic native-image reflection metadata generation for handlers dependencies -->


### PR DESCRIPTION
Motivation:
We're using a decades old version, which has security vulnerabilities. This is harmless because it's just a test dependency. However, scanners don't always take such fine details into account, and we might as well upgrade as there's no compatibility to worry about.

Modification:
Update our apacheds-protocol-dns test dependency from 1.5.7 to 2.0.0.AM27.

Result:
We're now testing with the latest ApacheDS Protocol DNS version.
