### PR TITLE
Drop unknown frame on missing stream in first packet

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -230,11 +230,6 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
         connection.goAwayReceived(lastStreamId, errorCode, debugData);
     }
 
-    void onUnknownFrame0(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags,
-            ByteBuf payload) throws Http2Exception {
-        listener.onUnknownFrame(ctx, frameType, streamId, flags, payload);
-    }
-
     // See https://tools.ietf.org/html/rfc7540#section-8.1.2.6
     private void verifyContentLength(Http2Stream stream, int data, boolean isEnd) throws Http2Exception {
         ContentLength contentLength = stream.getProperty(contentLengthKey);
@@ -626,7 +621,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
                 return;
             }
 
-            onUnknownFrame0(ctx, frameType, streamId, flags, payload);
+            listener.onUnknownFrame(ctx, frameType, streamId, flags, payload);
         }
 
         /**
@@ -797,7 +792,8 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
         @Override
         public void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags,
                 ByteBuf payload) throws Http2Exception {
-            onUnknownFrame0(ctx, frameType, streamId, flags, payload);
+            verifyPrefaceReceived();
+            internalFrameListener.onUnknownFrame(ctx, frameType, streamId, flags, payload);
         }
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
@@ -15,6 +15,7 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
@@ -119,6 +120,11 @@ public class Http2FrameCodecTest {
     }
 
     private void setUp(Http2FrameCodecBuilder frameCodecBuilder, Http2Settings initialRemoteSettings) throws Exception {
+        setUp(frameCodecBuilder, initialRemoteSettings, true);
+    }
+
+    private void setUp(Http2FrameCodecBuilder frameCodecBuilder, Http2Settings initialRemoteSettings, boolean preface)
+            throws Exception {
         /*
          * Some tests call this method twice. Once with JUnit's @Before and once directly to pass special settings.
          * This call ensures that in case of two consecutive calls to setUp(), the previous channel is shutdown and
@@ -142,18 +148,21 @@ public class Http2FrameCodecTest {
         // Handshake
         verify(frameWriter).writeSettings(eqFrameCodecCtx(), anyHttp2Settings(), anyChannelPromise());
         verifyNoMoreInteractions(frameWriter);
-        channel.writeInbound(Http2CodecUtil.connectionPrefaceBuf());
 
-        frameInboundWriter.writeInboundSettings(initialRemoteSettings);
+        if (preface) {
+            channel.writeInbound(Http2CodecUtil.connectionPrefaceBuf());
 
-        verify(frameWriter).writeSettingsAck(eqFrameCodecCtx(), anyChannelPromise());
+            frameInboundWriter.writeInboundSettings(initialRemoteSettings);
 
-        frameInboundWriter.writeInboundSettingsAck();
+            verify(frameWriter).writeSettingsAck(eqFrameCodecCtx(), anyChannelPromise());
 
-        Http2SettingsFrame settingsFrame = inboundHandler.readInbound();
-        assertNotNull(settingsFrame);
-        Http2SettingsAckFrame settingsAckFrame = inboundHandler.readInbound();
-        assertNotNull(settingsAckFrame);
+            frameInboundWriter.writeInboundSettingsAck();
+
+            Http2SettingsFrame settingsFrame = inboundHandler.readInbound();
+            assertNotNull(settingsFrame);
+            Http2SettingsAckFrame settingsAckFrame = inboundHandler.readInbound();
+            assertNotNull(settingsAckFrame);
+        }
     }
 
     @Test
@@ -410,6 +419,43 @@ public class Http2FrameCodecTest {
         ByteBuf debugData = bb("debug");
         frameInboundWriter.writeInboundFrame((byte) 0xb, 101, new Http2Flags(), debugData);
         channel.flush();
+
+        assertEquals(0, debugData.refCnt());
+        assertTrue(channel.isActive());
+    }
+
+    @Test
+    public void unknownFrameOnMissingStreamFirstPacket() throws Exception {
+        setUp(Http2FrameCodecBuilder.forClient(), new Http2Settings(), false);
+
+        // SETTINGS and UNKNOWN must come in on the same packet to trigger the bug
+        channel.pipeline().addFirst("combine", new ChannelInboundHandlerAdapter() {
+            CompositeByteBuf accumulate;
+
+            @Override
+            public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                if (accumulate == null) {
+                    accumulate = ctx.alloc().compositeBuffer();
+                }
+                accumulate.addComponent(true, (ByteBuf) msg);
+            }
+
+            @Override
+            public void handlerRemoved(ChannelHandlerContext ctx) {
+                if (accumulate != null) {
+                    ctx.fireChannelRead(accumulate);
+                    ctx.fireChannelReadComplete();
+                }
+            }
+        });
+
+        frameInboundWriter.writeInboundSettings(new Http2Settings());
+
+        ByteBuf debugData = bb("debug");
+        frameInboundWriter.writeInboundFrame((byte) 0xb, 101, new Http2Flags(), debugData);
+
+        channel.pipeline().remove("combine");
+        channel.flushInbound();
 
         assertEquals(0, debugData.refCnt());
         assertTrue(channel.isActive());


### PR DESCRIPTION
Motivation:

If an unknown frame with an unknown stream is received in the first packet, the PrefaceFrameListener is called instead of the normal frame listener. This means that the fix in #15592 is bypassed.

Modification:

Modify PrefaceFrameListener to require the preface has come in (this is checked by the decoder already) and delegate to the current listener.

Inline onUnknownFrame0 because it's only used in the normal listener, now.

Result:

No NPE.

Found by fuzzing