### PR TITLE
Fix EpollEventLoopTest.testSubmittingTaskWakesUpSuspendedExecutor flaky test

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactory.java
+++ b/common/src/main/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactory.java
@@ -326,6 +326,10 @@ public final class AutoScalingEventExecutorChooserFactory implements EventExecut
 
                 for (int i = 0; i < executors.length; i++) {
                     EventExecutor child = executors[i];
+
+                    // Give a grace period to newly woken executors.
+                    // By skipping them entirely for one cycle, we prevent them from being
+                    // immediately re-suspended due to near-zero initial utilization.
                     if (newlyWokenExecutors.contains(child)) {
                         utilizationMetrics.get(i).setUtilization(0.0);
                         continue;

--- a/common/src/main/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactory.java
+++ b/common/src/main/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactory.java
@@ -306,7 +306,7 @@ public final class AutoScalingEventExecutorChooserFactory implements EventExecut
                     }
                 }
 
-                // If a scale-down occurred, or if the actual state differs from our view, rebuild.
+                // If a scale-down occurred, rebuild.
                 if (changed) {
                     rebuildActiveExecutors();
                 } else {

--- a/common/src/main/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactory.java
+++ b/common/src/main/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactory.java
@@ -298,7 +298,7 @@ public final class AutoScalingEventExecutorChooserFactory implements EventExecut
                     // The number of active children changed due to an external event (e.g., a task was
                     // submitted to a suspended executor). It's safer to wait for the next cycle to
                     // gather fresh utilization data before making a scaling decision.
-                    //return;
+                    return;
                 }
 
                 // Calculate the actual elapsed time since the last run.

--- a/common/src/main/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactory.java
+++ b/common/src/main/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactory.java
@@ -407,8 +407,8 @@ public final class AutoScalingEventExecutorChooserFactory implements EventExecut
                     }
                 }
 
-                // If a scale-down occurred, or if the actual state differs from our view, rebuild.
-                if (changed || currentActive != currentState.activeExecutors.length) {
+                // If a scale-down occurred, rebuild.
+                if (changed) {
                     rebuildActiveExecutors();
                 }
             }

--- a/common/src/main/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactory.java
+++ b/common/src/main/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactory.java
@@ -298,7 +298,7 @@ public final class AutoScalingEventExecutorChooserFactory implements EventExecut
                     // The number of active children changed due to an external event (e.g., a task was
                     // submitted to a suspended executor). It's safer to wait for the next cycle to
                     // gather fresh utilization data before making a scaling decision.
-                    return;
+                    //return;
                 }
 
                 // Calculate the actual elapsed time since the last run.

--- a/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
@@ -123,7 +123,7 @@ public class AutoScalingEventExecutorChooserFactoryTest {
         }
     }
 
-    @RepeatedTest(9)
+    @RepeatedTest(10)
     @Timeout(30)
     void testScaleUp() throws Exception {
         TestEventExecutorGroup group = new TestEventExecutorGroup(1, 3, 50, TimeUnit.MILLISECONDS);

--- a/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
@@ -15,6 +15,7 @@
  */
 package io.netty.util.concurrent;
 
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -119,7 +120,7 @@ public class AutoScalingEventExecutorChooserFactoryTest {
         }
     }
 
-    @Test
+    @RepeatedTest(10)
     @Timeout(30)
     void testScaleUp() throws Exception {
         TestEventExecutorGroup group = new TestEventExecutorGroup(1, 3, 50, TimeUnit.MILLISECONDS);

--- a/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
@@ -16,7 +16,6 @@
 package io.netty.util.concurrent;
 
 import io.netty.util.concurrent.AutoScalingEventExecutorChooserFactory.AutoScalingUtilizationMetric;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -123,7 +122,7 @@ public class AutoScalingEventExecutorChooserFactoryTest {
         }
     }
 
-    @RepeatedTest(9)
+    @Test
     @Timeout(30)
     void testScaleUp() throws Exception {
         TestEventExecutorGroup group = new TestEventExecutorGroup(1, 3, 50, TimeUnit.MILLISECONDS);

--- a/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
@@ -123,7 +123,7 @@ public class AutoScalingEventExecutorChooserFactoryTest {
         }
     }
 
-    @RepeatedTest(5)
+    @RepeatedTest(6)
     @Timeout(30)
     void testScaleUp() throws Exception {
         TestEventExecutorGroup group = new TestEventExecutorGroup(1, 3, 50, TimeUnit.MILLISECONDS);

--- a/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
@@ -120,7 +120,7 @@ public class AutoScalingEventExecutorChooserFactoryTest {
         }
     }
 
-    @RepeatedTest(10)
+    @RepeatedTest(11)
     @Timeout(30)
     void testScaleUp() throws Exception {
         TestEventExecutorGroup group = new TestEventExecutorGroup(1, 3, 50, TimeUnit.MILLISECONDS);

--- a/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
@@ -123,7 +123,7 @@ public class AutoScalingEventExecutorChooserFactoryTest {
         }
     }
 
-    @RepeatedTest(7)
+    @RepeatedTest(8)
     @Timeout(30)
     void testScaleUp() throws Exception {
         TestEventExecutorGroup group = new TestEventExecutorGroup(1, 3, 50, TimeUnit.MILLISECONDS);

--- a/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
@@ -120,7 +120,7 @@ public class AutoScalingEventExecutorChooserFactoryTest {
         }
     }
 
-    @RepeatedTest(10)
+    @RepeatedTest(9)
     @Timeout(30)
     void testScaleUp() throws Exception {
         TestEventExecutorGroup group = new TestEventExecutorGroup(1, 3, 50, TimeUnit.MILLISECONDS);

--- a/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
@@ -120,7 +120,7 @@ public class AutoScalingEventExecutorChooserFactoryTest {
         }
     }
 
-    @RepeatedTest(11)
+    @RepeatedTest(10)
     @Timeout(30)
     void testScaleUp() throws Exception {
         TestEventExecutorGroup group = new TestEventExecutorGroup(1, 3, 50, TimeUnit.MILLISECONDS);

--- a/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
@@ -123,7 +123,7 @@ public class AutoScalingEventExecutorChooserFactoryTest {
         }
     }
 
-    @RepeatedTest(10)
+    @RepeatedTest(9)
     @Timeout(30)
     void testScaleUp() throws Exception {
         TestEventExecutorGroup group = new TestEventExecutorGroup(1, 3, 50, TimeUnit.MILLISECONDS);

--- a/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
@@ -123,7 +123,7 @@ public class AutoScalingEventExecutorChooserFactoryTest {
         }
     }
 
-    @RepeatedTest(8)
+    @RepeatedTest(9)
     @Timeout(30)
     void testScaleUp() throws Exception {
         TestEventExecutorGroup group = new TestEventExecutorGroup(1, 3, 50, TimeUnit.MILLISECONDS);

--- a/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
@@ -15,7 +15,6 @@
  */
 package io.netty.util.concurrent;
 
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -120,7 +119,7 @@ public class AutoScalingEventExecutorChooserFactoryTest {
         }
     }
 
-    @RepeatedTest(20)
+    @Test
     @Timeout(30)
     void testScaleUp() throws Exception {
         TestEventExecutorGroup group = new TestEventExecutorGroup(1, 3, 50, TimeUnit.MILLISECONDS);

--- a/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
@@ -120,7 +120,7 @@ public class AutoScalingEventExecutorChooserFactoryTest {
         }
     }
 
-    @RepeatedTest(9)
+    @RepeatedTest(10)
     @Timeout(30)
     void testScaleUp() throws Exception {
         TestEventExecutorGroup group = new TestEventExecutorGroup(1, 3, 50, TimeUnit.MILLISECONDS);

--- a/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
@@ -123,7 +123,7 @@ public class AutoScalingEventExecutorChooserFactoryTest {
         }
     }
 
-    @RepeatedTest(10)
+    @RepeatedTest(5)
     @Timeout(30)
     void testScaleUp() throws Exception {
         TestEventExecutorGroup group = new TestEventExecutorGroup(1, 3, 50, TimeUnit.MILLISECONDS);

--- a/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
@@ -120,7 +120,7 @@ public class AutoScalingEventExecutorChooserFactoryTest {
         }
     }
 
-    @RepeatedTest(12)
+    @RepeatedTest(10)
     @Timeout(30)
     void testScaleUp() throws Exception {
         TestEventExecutorGroup group = new TestEventExecutorGroup(1, 3, 50, TimeUnit.MILLISECONDS);

--- a/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
@@ -123,7 +123,7 @@ public class AutoScalingEventExecutorChooserFactoryTest {
         }
     }
 
-    @RepeatedTest(11)
+    @RepeatedTest(10)
     @Timeout(30)
     void testScaleUp() throws Exception {
         TestEventExecutorGroup group = new TestEventExecutorGroup(1, 3, 50, TimeUnit.MILLISECONDS);

--- a/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
@@ -120,7 +120,7 @@ public class AutoScalingEventExecutorChooserFactoryTest {
         }
     }
 
-    @RepeatedTest(10)
+    @RepeatedTest(12)
     @Timeout(30)
     void testScaleUp() throws Exception {
         TestEventExecutorGroup group = new TestEventExecutorGroup(1, 3, 50, TimeUnit.MILLISECONDS);

--- a/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
@@ -123,7 +123,7 @@ public class AutoScalingEventExecutorChooserFactoryTest {
         }
     }
 
-    @RepeatedTest(6)
+    @RepeatedTest(7)
     @Timeout(30)
     void testScaleUp() throws Exception {
         TestEventExecutorGroup group = new TestEventExecutorGroup(1, 3, 50, TimeUnit.MILLISECONDS);

--- a/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactoryTest.java
@@ -123,7 +123,7 @@ public class AutoScalingEventExecutorChooserFactoryTest {
         }
     }
 
-    @RepeatedTest(10)
+    @RepeatedTest(11)
     @Timeout(30)
     void testScaleUp() throws Exception {
         TestEventExecutorGroup group = new TestEventExecutorGroup(1, 3, 50, TimeUnit.MILLISECONDS);

--- a/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
@@ -346,7 +346,7 @@ public abstract class AbstractSingleThreadEventLoopTest {
         }
     }
 
-    @RepeatedTest(8)
+    @RepeatedTest(9)
     @Timeout(30)
     public void testSubmittingTaskWakesUpSuspendedExecutor() throws Exception {
         EventLoopGroup group = newAutoScalingEventLoopGroup();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
@@ -32,6 +32,7 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.ScheduledFuture;
 import io.netty.util.internal.PlatformDependent;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.function.Executable;
@@ -344,7 +345,7 @@ public abstract class AbstractSingleThreadEventLoopTest {
         }
     }
 
-    @Test
+    @RepeatedTest(10)
     @Timeout(30)
     public void testSubmittingTaskWakesUpSuspendedExecutor() throws Exception {
         EventLoopGroup group = newAutoScalingEventLoopGroup();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
@@ -346,7 +346,7 @@ public abstract class AbstractSingleThreadEventLoopTest {
         }
     }
 
-    @RepeatedTest(10)
+    @RepeatedTest(11)
     @Timeout(30)
     public void testSubmittingTaskWakesUpSuspendedExecutor() throws Exception {
         EventLoopGroup group = newAutoScalingEventLoopGroup();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
@@ -346,7 +346,7 @@ public abstract class AbstractSingleThreadEventLoopTest {
         }
     }
 
-    @RepeatedTest(7)
+    @RepeatedTest(8)
     @Timeout(30)
     public void testSubmittingTaskWakesUpSuspendedExecutor() throws Exception {
         EventLoopGroup group = newAutoScalingEventLoopGroup();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
@@ -345,7 +345,7 @@ public abstract class AbstractSingleThreadEventLoopTest {
         }
     }
 
-    @RepeatedTest(10)
+    @RepeatedTest(11)
     @Timeout(30)
     public void testSubmittingTaskWakesUpSuspendedExecutor() throws Exception {
         EventLoopGroup group = newAutoScalingEventLoopGroup();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
@@ -376,6 +376,12 @@ public abstract class AbstractSingleThreadEventLoopTest {
             Future<?> future = suspendedLoop.submit(() -> { });
             future.syncUninterruptibly();
 
+            // Poll for a short period to allow the state to be updated.
+            deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+            while (suspendedLoop.isSuspended() && System.nanoTime() < deadline) {
+                Thread.sleep(50);
+            }
+
             assertFalse(suspendedLoop.isSuspended(), "Executor should wake up after task submission.");
             assertEquals(SCALING_MAX_THREADS, countActiveExecutors(group),
                          "Active executor count should increase after wake-up.");

--- a/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
@@ -346,7 +346,7 @@ public abstract class AbstractSingleThreadEventLoopTest {
         }
     }
 
-    @RepeatedTest(6)
+    @RepeatedTest(7)
     @Timeout(30)
     public void testSubmittingTaskWakesUpSuspendedExecutor() throws Exception {
         EventLoopGroup group = newAutoScalingEventLoopGroup();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
@@ -346,7 +346,7 @@ public abstract class AbstractSingleThreadEventLoopTest {
         }
     }
 
-    @RepeatedTest(5)
+    @RepeatedTest(6)
     @Timeout(30)
     public void testSubmittingTaskWakesUpSuspendedExecutor() throws Exception {
         EventLoopGroup group = newAutoScalingEventLoopGroup();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
@@ -380,7 +380,13 @@ public abstract class AbstractSingleThreadEventLoopTest {
 
             // Start a keep-alive task on the original active loop to prevent the monitor
             // from suspending it while we test the wake-up logic on the other loop.
-            keepAliveTask = activeLoop.scheduleAtFixedRate(() -> { }, 0, SCALING_WINDOW / 2, SCALING_WINDOW_UNIT);
+            final long keepAliveWorkNanos = TimeUnit.MILLISECONDS.toNanos(SCALING_WINDOW / 2);
+            keepAliveTask = activeLoop.scheduleAtFixedRate(() -> {
+                long workDeadline = System.nanoTime() + keepAliveWorkNanos;
+                while (System.nanoTime() < workDeadline) {
+                    // Busy-wait to generate CPU utilization.
+                }
+            }, 0, SCALING_WINDOW, SCALING_WINDOW_UNIT);
 
             final CountDownLatch taskStartedLatch = new CountDownLatch(1);
             final long workDurationNanos = TimeUnit.MILLISECONDS.toNanos(SCALING_WINDOW * 3);

--- a/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
@@ -346,7 +346,7 @@ public abstract class AbstractSingleThreadEventLoopTest {
         }
     }
 
-    @RepeatedTest(11)
+    @RepeatedTest(10)
     @Timeout(30)
     public void testSubmittingTaskWakesUpSuspendedExecutor() throws Exception {
         EventLoopGroup group = newAutoScalingEventLoopGroup();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
@@ -346,7 +346,7 @@ public abstract class AbstractSingleThreadEventLoopTest {
         }
     }
 
-    @RepeatedTest(10)
+    @RepeatedTest(5)
     @Timeout(30)
     public void testSubmittingTaskWakesUpSuspendedExecutor() throws Exception {
         EventLoopGroup group = newAutoScalingEventLoopGroup();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
@@ -406,9 +406,9 @@ public abstract class AbstractSingleThreadEventLoopTest {
             assertTrue(taskStartedLatch.await(5, TimeUnit.SECONDS), "Task did not start in time.");
 
             final int expectedActiveCount = SCALING_MIN_THREADS + 1;
-            deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+            deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
             while (countActiveExecutors(group) < expectedActiveCount && System.nanoTime() < deadline) {
-                Thread.sleep(50);
+                Thread.sleep(100);
             }
 
             assertEquals(expectedActiveCount, countActiveExecutors(group),

--- a/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
@@ -345,7 +345,7 @@ public abstract class AbstractSingleThreadEventLoopTest {
         }
     }
 
-    @RepeatedTest(15)
+    @RepeatedTest(10)
     @Timeout(30)
     public void testSubmittingTaskWakesUpSuspendedExecutor() throws Exception {
         EventLoopGroup group = newAutoScalingEventLoopGroup();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
@@ -346,7 +346,7 @@ public abstract class AbstractSingleThreadEventLoopTest {
         }
     }
 
-    @RepeatedTest(9)
+    @RepeatedTest(10)
     @Timeout(30)
     public void testSubmittingTaskWakesUpSuspendedExecutor() throws Exception {
         EventLoopGroup group = newAutoScalingEventLoopGroup();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
@@ -345,7 +345,7 @@ public abstract class AbstractSingleThreadEventLoopTest {
         }
     }
 
-    @RepeatedTest(11)
+    @RepeatedTest(9)
     @Timeout(30)
     public void testSubmittingTaskWakesUpSuspendedExecutor() throws Exception {
         EventLoopGroup group = newAutoScalingEventLoopGroup();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
@@ -346,7 +346,7 @@ public abstract class AbstractSingleThreadEventLoopTest {
         }
     }
 
-    @RepeatedTest(10)
+    @RepeatedTest(9)
     @Timeout(30)
     public void testSubmittingTaskWakesUpSuspendedExecutor() throws Exception {
         EventLoopGroup group = newAutoScalingEventLoopGroup();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
@@ -415,13 +415,13 @@ public abstract class AbstractSingleThreadEventLoopTest {
             assertFalse(suspendedLoop.isSuspended(), "Executor should be active after monitor reconciliation.");
 
             keepBusyLatch.countDown();
-            future.syncUninterruptibly();
+            future.sync();
         } finally {
             keepAliveRunning.set(false);
             if (keepAliveFuture != null) {
-                keepAliveFuture.syncUninterruptibly();
+                keepAliveFuture.sync();
             }
-            group.shutdownGracefully().syncUninterruptibly();
+            group.shutdownGracefully().sync();
         }
     }
 


### PR DESCRIPTION
Motivation:

The `testSubmittingTaskWakesUpSuspendedExecutor` test was failing due to a race condition where the test would check the executor's `isSuspended` status before its thread had time to update the state flag after waking up.

Modifications:
Instead of asserting the state immediately after the task's future completes, the test now polls for a short period, waiting for the flag to become true.

Result:
Fix flaky test.
