### PR TITLE
OpenSSL: Retain context before using it in the engine constructor

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -411,7 +411,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
             // Something did go wrong which means we will not be able to release the context later on. Release it
             // now to prevent leaks.
             context.release();
-             PlatformDependent.throwException(cause);
+            PlatformDependent.throwException(cause);
         }
         parentContext = context;
 


### PR DESCRIPTION
Motivation:

We should better retain the context as soon as possible before trying to use it in the engine constructor as otherwise it might be possible that a user would destroy the context by calling release() before we had a chance to finish the construction. This could lead to crashes / undefined behavior

Modifications:

retain as soon as possible and just release manually if we fail because of an exception Result:

Safer construction of native engine