### PR TITLE
Android: Disable VarHandle usage in android

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -268,6 +268,11 @@ public final class PlatformDependent {
                 PlatformDependent0.isNativeImage()) {
             return false;
         }
+        if (isAndroid()) {
+            // See https://github.com/netty/netty/issues/15654
+            logger.debug("java.lang.invoke.VarHandle: unavailable, due buggy implementation in android");
+            return false;
+        }
         boolean varHandleAvailable = false;
         Throwable varHandleFailure;
         try {


### PR DESCRIPTION
Motivation:

Older version of Android have buggy VarHandle implementations that will most likely never been fixed. Let's just disable VarHandle usage in this case

Modifications:

Just disable VarHandle usage on Android

Result:

Workaround for https://github.com/netty/netty/issues/15654