### PR TITLE
Move polymorphic VarHandle calls to separate class to avoid Android v…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
@@ -22,7 +22,6 @@ import io.netty.util.internal.PlatformDependent;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.lang.invoke.VarHandle;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.ClosedChannelException;
@@ -277,18 +276,16 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     protected short _getShort(int index) {
-        VarHandle varHandle = PlatformDependent.shortBeByteBufferView();
-        if (varHandle != null) {
-            return (short) varHandle.get(buffer, index);
+        if (PlatformDependent.hasVarHandle()) {
+            return VarHandleByteBufferAccess.getShortBE(buffer, index);
         }
         return buffer.getShort(index);
     }
 
     @Override
     protected short _getShortLE(int index) {
-        VarHandle varHandle = PlatformDependent.shortLeByteBufferView();
-        if (varHandle != null) {
-            return (short) varHandle.get(buffer, index);
+        if (PlatformDependent.hasVarHandle()) {
+            return VarHandleByteBufferAccess.getShortLE(buffer, index);
         }
         return ByteBufUtil.swapShort(buffer.getShort(index));
     }
@@ -327,18 +324,16 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     protected int _getInt(int index) {
-        VarHandle varHandle = PlatformDependent.intBeByteBufferView();
-        if (varHandle != null) {
-            return (int) varHandle.get(buffer, index);
+        if (PlatformDependent.hasVarHandle()) {
+            return VarHandleByteBufferAccess.getIntBE(buffer, index);
         }
         return buffer.getInt(index);
     }
 
     @Override
     protected int _getIntLE(int index) {
-        VarHandle varHandle = PlatformDependent.intLeByteBufferView();
-        if (varHandle != null) {
-            return (int) varHandle.get(buffer, index);
+        if (PlatformDependent.hasVarHandle()) {
+            return VarHandleByteBufferAccess.getIntLE(buffer, index);
         }
         return ByteBufUtil.swapInt(buffer.getInt(index));
     }
@@ -357,18 +352,16 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     protected long _getLong(int index) {
-        VarHandle varHandle = PlatformDependent.longBeByteBufferView();
-        if (varHandle != null) {
-            return (long) varHandle.get(buffer, index);
+        if (PlatformDependent.hasVarHandle()) {
+            return VarHandleByteBufferAccess.getLongBE(buffer, index);
         }
         return buffer.getLong(index);
     }
 
     @Override
     protected long _getLongLE(int index) {
-        VarHandle varHandle = PlatformDependent.longLeByteBufferView();
-        if (varHandle != null) {
-            return (long) varHandle.get(buffer, index);
+        if (PlatformDependent.hasVarHandle()) {
+            return VarHandleByteBufferAccess.getLongLE(buffer, index);
         }
         return ByteBufUtil.swapLong(buffer.getLong(index));
     }
@@ -471,9 +464,8 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     protected void _setShort(int index, int value) {
-        VarHandle varHandle = PlatformDependent.shortBeByteBufferView();
-        if (varHandle != null) {
-            varHandle.set(buffer, index, (short) value);
+        if (PlatformDependent.hasVarHandle()) {
+            VarHandleByteBufferAccess.setShortBE(buffer, index, value);
             return;
         }
         buffer.putShort(index, (short) (value & 0xFFFF));
@@ -481,9 +473,8 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     protected void _setShortLE(int index, int value) {
-        VarHandle varHandle = PlatformDependent.shortLeByteBufferView();
-        if (varHandle != null) {
-            varHandle.set(buffer, index, (short) value);
+        if (PlatformDependent.hasVarHandle()) {
+            VarHandleByteBufferAccess.setShortLE(buffer, index, value);
             return;
         }
         buffer.putShort(index, ByteBufUtil.swapShort((short) value));
@@ -533,9 +524,8 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     protected void _setInt(int index, int value) {
-        VarHandle varHandle = PlatformDependent.intBeByteBufferView();
-        if (varHandle != null) {
-            varHandle.set(buffer, index, value);
+        if (PlatformDependent.hasVarHandle()) {
+            VarHandleByteBufferAccess.setIntBE(buffer, index, value);
             return;
         }
         buffer.putInt(index, value);
@@ -543,9 +533,8 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     protected void _setIntLE(int index, int value) {
-        VarHandle varHandle = PlatformDependent.intLeByteBufferView();
-        if (varHandle != null) {
-            varHandle.set(buffer, index, value);
+        if (PlatformDependent.hasVarHandle()) {
+            VarHandleByteBufferAccess.setIntLE(buffer, index, value);
             return;
         }
         buffer.putInt(index, ByteBufUtil.swapInt(value));
@@ -567,9 +556,8 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     protected void _setLong(int index, long value) {
-        VarHandle varHandle = PlatformDependent.longBeByteBufferView();
-        if (varHandle != null) {
-            varHandle.set(buffer, index, value);
+        if (PlatformDependent.hasVarHandle()) {
+            VarHandleByteBufferAccess.setLongBE(buffer, index, value);
             return;
         }
         buffer.putLong(index, value);
@@ -577,9 +565,8 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     protected void _setLongLE(int index, long value) {
-        VarHandle varHandle = PlatformDependent.longLeByteBufferView();
-        if (varHandle != null) {
-            varHandle.set(buffer, index, value);
+        if (PlatformDependent.hasVarHandle()) {
+            VarHandleByteBufferAccess.setLongLE(buffer, index, value);
             return;
         }
         buffer.putLong(index, ByteBufUtil.swapLong(value));

--- a/buffer/src/main/java/io/netty/buffer/VarHandleByteBufferAccess.java
+++ b/buffer/src/main/java/io/netty/buffer/VarHandleByteBufferAccess.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import io.netty.util.internal.PlatformDependent;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Centralizes all ByteBuffer VarHandle get/set calls so classes like UnpooledDirectByteBuf
+ * don't directly reference signature-polymorphic methods. This allows avoiding class verification
+ * failures on older Android runtimes by not loading this class when VarHandle is disabled.
+ *
+ * Methods here must only be called when PlatformDependent.hasVarHandle() is true.
+ */
+final class VarHandleByteBufferAccess {
+
+    private VarHandleByteBufferAccess() {
+    }
+
+    // short (big endian)
+    static short getShortBE(ByteBuffer buffer, int index) {
+        //noinspection DataFlowIssue
+        return (short) PlatformDependent.shortBeByteBufferView().get(buffer, index);
+    }
+
+    static void setShortBE(ByteBuffer buffer, int index, int value) {
+        //noinspection DataFlowIssue
+        PlatformDependent.shortBeByteBufferView().set(buffer, index, (short) value);
+    }
+
+    // short (little endian)
+    static short getShortLE(ByteBuffer buffer, int index) {
+        //noinspection DataFlowIssue
+        return (short) PlatformDependent.shortLeByteBufferView().get(buffer, index);
+    }
+
+    static void setShortLE(ByteBuffer buffer, int index, int value) {
+        //noinspection DataFlowIssue
+        PlatformDependent.shortLeByteBufferView().set(buffer, index, (short) value);
+    }
+
+    // int (big endian)
+    static int getIntBE(ByteBuffer buffer, int index) {
+        //noinspection DataFlowIssue
+        return (int) PlatformDependent.intBeByteBufferView().get(buffer, index);
+    }
+
+    static void setIntBE(ByteBuffer buffer, int index, int value) {
+        //noinspection DataFlowIssue
+        PlatformDependent.intBeByteBufferView().set(buffer, index, value);
+    }
+
+    // int (little endian)
+    static int getIntLE(ByteBuffer buffer, int index) {
+        //noinspection DataFlowIssue
+        return (int) PlatformDependent.intLeByteBufferView().get(buffer, index);
+    }
+
+    static void setIntLE(ByteBuffer buffer, int index, int value) {
+        //noinspection DataFlowIssue
+        PlatformDependent.intLeByteBufferView().set(buffer, index, value);
+    }
+
+    // long (big endian)
+    static long getLongBE(ByteBuffer buffer, int index) {
+        //noinspection DataFlowIssue
+        return (long) PlatformDependent.longBeByteBufferView().get(buffer, index);
+    }
+
+    static void setLongBE(ByteBuffer buffer, int index, long value) {
+        //noinspection DataFlowIssue
+        PlatformDependent.longBeByteBufferView().set(buffer, index, value);
+    }
+
+    // long (little endian)
+    static long getLongLE(ByteBuffer buffer, int index) {
+        //noinspection DataFlowIssue
+        return (long) PlatformDependent.longLeByteBufferView().get(buffer, index);
+    }
+
+    static void setLongLE(ByteBuffer buffer, int index, long value) {
+        //noinspection DataFlowIssue
+        PlatformDependent.longLeByteBufferView().set(buffer, index, value);
+    }
+}


### PR DESCRIPTION
…erification error

Motivation:

Android 8–12 ART/Dalvik rejects classes with direct signature-polymorphic VarHandle call sites. After upgrading Netty to 4.2.4+, UnpooledDirectByteBuf triggers a java.lang.VerifyError when its methods reference ByteBuffer VarHandle view operations, even if VarHandles are disabled via -Dio.netty.varHandle.enabled=false. As suggested by yawkat in #15654, the fix is to move VarHandle usage into a separate class and only load it when VarHandles are actually available.

Modification:

- Introduce VarHandleByteBufferAccess to centralize all ByteBuffer VarHandle get/set operations.
- Update UnpooledDirectByteBuf to:
  - Guard VarHandle paths with PlatformDependent.hasVarHandle().
  - Delegate to VarHandleByteBufferAccess for get/set of short/int/long (BE/LE).
  - Fall back to ByteBuffer methods (and byte-order swaps) when VarHandles are unavailable.
  - Remove direct VarHandle import to avoid embedding signature-polymorphic call sites in this class.
- No behavioral changes on platforms with working VarHandles; Android 8–12 avoids verifier failures by not loading the helper class.

Touched methods in UnpooledDirectByteBuf: _getShort, _getShortLE, _getInt, _getIntLE, _getLong, _getLongLE, _setShort, _setShortLE, _setInt, _setIntLE, _setLong, _setLongLE.

Result:

Fixes #15654.

---

I threw AI at the problem and told it to fix the issue according to my comment on the issue thread. @ajith211, please try this fix. You'll have to build netty locally to test it though.