### PR TITLE
Fix concurrent chunk data write bug in adaptive allocator (#15652)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptiveByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptiveByteBufAllocator.java
@@ -125,8 +125,8 @@ public final class AdaptiveByteBufAllocator extends AbstractByteBufAllocator
         @Override
         public AbstractByteBuf allocate(int initialCapacity, int maxCapacity) {
             return PlatformDependent.hasUnsafe() ?
-                    UnsafeByteBufUtil.newUnsafeDirectByteBuf(allocator, initialCapacity, maxCapacity) :
-                    new UnpooledDirectByteBuf(allocator, initialCapacity, maxCapacity);
+                    UnsafeByteBufUtil.newUnsafeDirectByteBuf(allocator, initialCapacity, maxCapacity, false) :
+                    new UnpooledDirectByteBuf(allocator, initialCapacity, maxCapacity, false);
         }
     }
 }

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -543,9 +543,9 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
 
         private SizeClassChunkControllerFactory(int segmentSize) {
             this.segmentSize = ObjectUtil.checkPositive(segmentSize, "segmentSize");
-            this.chunkSize = Math.max(MIN_CHUNK_SIZE, segmentSize * MIN_SEGMENTS_PER_CHUNK);
+            chunkSize = Math.max(MIN_CHUNK_SIZE, segmentSize * MIN_SEGMENTS_PER_CHUNK);
             int segmentsCount = chunkSize / segmentSize;
-            this.segmentOffsets = new int[segmentsCount];
+            segmentOffsets = new int[segmentsCount];
             for (int i = 0; i < segmentsCount; i++) {
                 segmentOffsets[i] = i * segmentSize;
             }
@@ -1770,8 +1770,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                 } else {
                     checkIndex(index, length);
                 }
-                // Directly pass in the rootParent() with the adjusted index
-                return ByteBufUtil.writeUtf8(rootParent(), idx(index), length, sequence, sequence.length());
+                return ByteBufUtil.writeUtf8(this, index, length, sequence, sequence.length());
             }
             if (charset.equals(CharsetUtil.US_ASCII) || charset.equals(CharsetUtil.ISO_8859_1)) {
                 int length = sequence.length();
@@ -1781,8 +1780,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                 } else {
                     checkIndex(index, length);
                 }
-                // Directly pass in the rootParent() with the adjusted index
-                return ByteBufUtil.writeAscii(rootParent(), idx(index), sequence, length);
+                return ByteBufUtil.writeAscii(this, index, sequence, length);
             }
             byte[] bytes = sequence.toString().getBytes(charset);
             if (expand) {

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -403,8 +403,8 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
             buf = directArena.allocate(cache, initialCapacity, maxCapacity);
         } else {
             buf = PlatformDependent.hasUnsafe() ?
-                    UnsafeByteBufUtil.newUnsafeDirectByteBuf(this, initialCapacity, maxCapacity) :
-                    new UnpooledDirectByteBuf(this, initialCapacity, maxCapacity);
+                    UnsafeByteBufUtil.newUnsafeDirectByteBuf(this, initialCapacity, maxCapacity, true) :
+                    new UnpooledDirectByteBuf(this, initialCapacity, maxCapacity, true);
         }
 
         return toLeakAwareBuffer(buf);

--- a/buffer/src/main/java/io/netty/buffer/UnpooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledByteBufAllocator.java
@@ -178,7 +178,7 @@ public final class UnpooledByteBufAllocator extends AbstractByteBufAllocator imp
             extends UnpooledUnsafeNoCleanerDirectByteBuf {
         InstrumentedUnpooledUnsafeNoCleanerDirectByteBuf(
                 UnpooledByteBufAllocator alloc, int initialCapacity, int maxCapacity) {
-            super(alloc, initialCapacity, maxCapacity);
+            super(alloc, initialCapacity, maxCapacity, true);
         }
 
         @Override

--- a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeDirectByteBuf.java
@@ -41,6 +41,11 @@ public class UnpooledUnsafeDirectByteBuf extends UnpooledDirectByteBuf {
         super(alloc, initialCapacity, maxCapacity);
     }
 
+    UnpooledUnsafeDirectByteBuf(ByteBufAllocator alloc, int initialCapacity, int maxCapacity,
+                                boolean allowSectionedInternalNioBufferAccess) {
+        super(alloc, initialCapacity, maxCapacity, allowSectionedInternalNioBufferAccess);
+    }
+
     /**
      * Creates a new direct buffer by wrapping the specified initial buffer.
      *

--- a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeNoCleanerDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeNoCleanerDirectByteBuf.java
@@ -21,8 +21,9 @@ import java.nio.ByteBuffer;
 
 class UnpooledUnsafeNoCleanerDirectByteBuf extends UnpooledUnsafeDirectByteBuf {
 
-    UnpooledUnsafeNoCleanerDirectByteBuf(ByteBufAllocator alloc, int initialCapacity, int maxCapacity) {
-        super(alloc, initialCapacity, maxCapacity);
+    UnpooledUnsafeNoCleanerDirectByteBuf(ByteBufAllocator alloc, int initialCapacity, int maxCapacity,
+                                         boolean allowSectionedInternalNioBufferAccess) {
+        super(alloc, initialCapacity, maxCapacity, allowSectionedInternalNioBufferAccess);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/UnsafeByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/UnsafeByteBufUtil.java
@@ -680,11 +680,14 @@ final class UnsafeByteBufUtil {
     }
 
     static UnpooledUnsafeDirectByteBuf newUnsafeDirectByteBuf(
-            ByteBufAllocator alloc, int initialCapacity, int maxCapacity) {
+            ByteBufAllocator alloc, int initialCapacity, int maxCapacity,
+            boolean allowSectionedInternalNioBufferAccess) {
         if (PlatformDependent.useDirectBufferNoCleaner()) {
-            return new UnpooledUnsafeNoCleanerDirectByteBuf(alloc, initialCapacity, maxCapacity);
+            return new UnpooledUnsafeNoCleanerDirectByteBuf(
+                    alloc, initialCapacity, maxCapacity, allowSectionedInternalNioBufferAccess);
         }
-        return new UnpooledUnsafeDirectByteBuf(alloc, initialCapacity, maxCapacity);
+        return new UnpooledUnsafeDirectByteBuf(
+                alloc, initialCapacity, maxCapacity, allowSectionedInternalNioBufferAccess);
     }
 
     private UnsafeByteBufUtil() { }

--- a/buffer/src/test/java/io/netty/buffer/BigEndianUnsafeNoCleanerDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/BigEndianUnsafeNoCleanerDirectByteBufTest.java
@@ -31,6 +31,6 @@ public class BigEndianUnsafeNoCleanerDirectByteBufTest extends BigEndianDirectBy
 
     @Override
     protected ByteBuf newBuffer(int length, int maxCapacity) {
-        return new UnpooledUnsafeNoCleanerDirectByteBuf(UnpooledByteBufAllocator.DEFAULT, length, maxCapacity);
+        return new UnpooledUnsafeNoCleanerDirectByteBuf(UnpooledByteBufAllocator.DEFAULT, length, maxCapacity, true);
     }
 }

--- a/buffer/src/test/java/io/netty/buffer/LittleEndianUnsafeNoCleanerDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/LittleEndianUnsafeNoCleanerDirectByteBufTest.java
@@ -31,6 +31,6 @@ public class LittleEndianUnsafeNoCleanerDirectByteBufTest extends LittleEndianDi
 
     @Override
     protected ByteBuf newBuffer(int length, int maxCapacity) {
-        return new UnpooledUnsafeNoCleanerDirectByteBuf(UnpooledByteBufAllocator.DEFAULT, length, maxCapacity);
+        return new UnpooledUnsafeNoCleanerDirectByteBuf(UnpooledByteBufAllocator.DEFAULT, length, maxCapacity, true);
     }
 }

--- a/microbench/src/main/java/io/netty/buffer/AbstractByteBufNoCleanerBenchmark.java
+++ b/microbench/src/main/java/io/netty/buffer/AbstractByteBufNoCleanerBenchmark.java
@@ -25,7 +25,7 @@ public abstract class AbstractByteBufNoCleanerBenchmark extends AbstractMicroben
             @Override
             ByteBuf newBuffer(int initialCapacity) {
                 return new UnpooledUnsafeNoCleanerDirectByteBuf(
-                        UnpooledByteBufAllocator.DEFAULT, initialCapacity, Integer.MAX_VALUE);
+                        UnpooledByteBufAllocator.DEFAULT, initialCapacity, Integer.MAX_VALUE, true);
             }
         },
         UNPOOLED {


### PR DESCRIPTION
Motivation:
The adaptive allocator had a few code paths where the internal NIO buffer of the chunk got exposed and mutated directly, through methods like ByteBufUtil.writeUtf8 and .writeAscii. When such methods call internalNioBuffer, they mutate the position and limit of the shared internal buffer, which can lead to exceptions when other threads do the same concurrently.

Modification:
Add a flag to UnpooledDirectByteBuf which will prevent any sharing of the internalNioBuffer by throwing an exception. Use this to find and fix all cases in the AdaptiveByteBuf. Add a test that comprehensively tests this through ByteBuf.setCharSequence. This also proves that none of our other buffer implementations were affected.

Result:
ByteBuf.write/setCharSequence with the adaptive allocator can no longer corrupt data or cause random exceptions to be thrown, but may now be slightly slower as they have to allocate a ByteBuf-specific internal ByteBuffer if they don't already have one.

Fixes https://github.com/netty/netty/issues/15631