### PR TITLE
Kqueue: Ensure classes can be loaded even if native lib is not on the…

### DIFF
--- a/transport-classes-kqueue/pom.xml
+++ b/transport-classes-kqueue/pom.xml
@@ -51,6 +51,22 @@
       <artifactId>netty-transport-native-unix-common</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
@@ -59,6 +59,7 @@ import static io.netty.channel.unix.UnixChannelUtil.computeRemoteAddr;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChannel {
+
     private static final ChannelMetadata METADATA = new ChannelMetadata(false);
     /**
      * The future of the current connection attempt.  If not null, subsequent
@@ -72,15 +73,6 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
     private IoRegistration registration;
     private boolean readFilterEnabled;
     private boolean writeFilterEnabled;
-
-    private static final KQueueIoOps READ_ENABLED_OPS =
-            KQueueIoOps.newOps(Native.EVFILT_READ, Native.EV_ADD_ENABLE, 0);
-    private static final KQueueIoOps WRITE_ENABLED_OPS =
-            KQueueIoOps.newOps(Native.EVFILT_WRITE, Native.EV_ADD_ENABLE, 0);
-    private static final KQueueIoOps READ_DISABLED_OPS =
-            KQueueIoOps.newOps(Native.EVFILT_READ, Native.EV_DELETE_DISABLE, 0);
-    private static final KQueueIoOps WRITE_DISABLED_OPS =
-            KQueueIoOps.newOps(Native.EVFILT_WRITE, Native.EV_DELETE_DISABLE, 0);
 
     boolean readReadyRunnablePending;
     boolean inputClosedSeenErrorOnRead;
@@ -220,10 +212,10 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
 
                 // Add the write event first so we get notified of connection refused on the client side!
                 if (writeFilterEnabled) {
-                    submit(WRITE_ENABLED_OPS);
+                    submit(Native.WRITE_ENABLED_OPS);
                 }
                 if (readFilterEnabled) {
-                    submit(READ_ENABLED_OPS);
+                    submit(Native.READ_ENABLED_OPS);
                 }
                 promise.setSuccess();
             } else {
@@ -366,14 +358,14 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
     void readFilter(boolean readFilterEnabled) throws IOException {
         if (this.readFilterEnabled != readFilterEnabled) {
             this.readFilterEnabled = readFilterEnabled;
-            submit(readFilterEnabled ? READ_ENABLED_OPS : READ_DISABLED_OPS);
+            submit(readFilterEnabled ? Native.READ_ENABLED_OPS : Native.READ_DISABLED_OPS);
         }
     }
 
     void writeFilter(boolean writeFilterEnabled) throws IOException {
         if (this.writeFilterEnabled != writeFilterEnabled) {
             this.writeFilterEnabled = writeFilterEnabled;
-            submit(writeFilterEnabled ? WRITE_ENABLED_OPS : WRITE_DISABLED_OPS);
+            submit(writeFilterEnabled ? Native.WRITE_ENABLED_OPS : Native.WRITE_DISABLED_OPS);
         }
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoHandler.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoHandler.java
@@ -59,9 +59,7 @@ public final class KQueueIoHandler implements IoHandler {
     // https://man.freebsd.org/cgi/man.cgi?query=kevent&apropos=0&sektion=0&manpath=FreeBSD+6.1-RELEASE&format=html#end
     private static final int KQUEUE_MAX_TIMEOUT_SECONDS = 86399; // 24 hours - 1 second
 
-    static {
-        // Ensure JNI is initialized by the time this class is loaded by this time!
-        // We use unix-common methods in this class which are backed by JNI methods.
+    {
         KQueue.ensureAvailability();
     }
 
@@ -116,6 +114,7 @@ public final class KQueueIoHandler implements IoHandler {
      */
     public static IoHandlerFactory newFactory(final int maxEvents,
                                               final SelectStrategyFactory selectStrategyFactory) {
+        KQueue.ensureAvailability();
         ObjectUtil.checkPositiveOrZero(maxEvents, "maxEvents");
         ObjectUtil.checkNotNull(selectStrategyFactory, "selectStrategyFactory");
         return new IoHandlerFactory() {

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/Native.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/Native.java
@@ -115,6 +115,15 @@ final class Native {
     static final boolean IS_SUPPORTING_TCP_FASTOPEN_CLIENT = isSupportingFastOpenClient();
     static final boolean IS_SUPPORTING_TCP_FASTOPEN_SERVER = isSupportingFastOpenServer();
 
+    static final KQueueIoOps READ_ENABLED_OPS =
+            KQueueIoOps.newOps(Native.EVFILT_READ, Native.EV_ADD_ENABLE, 0);
+    static final KQueueIoOps WRITE_ENABLED_OPS =
+            KQueueIoOps.newOps(Native.EVFILT_WRITE, Native.EV_ADD_ENABLE, 0);
+    static final KQueueIoOps READ_DISABLED_OPS =
+            KQueueIoOps.newOps(Native.EVFILT_READ, Native.EV_DELETE_DISABLE, 0);
+    static final KQueueIoOps WRITE_DISABLED_OPS =
+            KQueueIoOps.newOps(Native.EVFILT_WRITE, Native.EV_DELETE_DISABLE, 0);
+
     static FileDescriptor newKQueue() {
         return new FileDescriptor(kqueueCreate());
     }

--- a/transport-classes-kqueue/src/test/java/io/netty/channel/kqueue/LoadClassTest.java
+++ b/transport-classes-kqueue/src/test/java/io/netty/channel/kqueue/LoadClassTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.kqueue;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public class LoadClassTest {
+
+    static Class<?>[] classes() {
+        List<Class<?>> classes = new ArrayList<>();
+        classes.add(KQueueSocketChannel.class);
+        classes.add(KQueueServerSocketChannel.class);
+        classes.add(KQueueDatagramChannel.class);
+
+        classes.add(KQueueDomainSocketChannel.class);
+        classes.add(KQueueServerDomainSocketChannel.class);
+        classes.add(KQueueDomainDatagramChannel.class);
+
+        classes.add(KQueueIoHandler.class);
+        classes.add(KQueueEventLoopGroup.class);
+
+        return classes.toArray(new Class<?>[0]);
+    }
+
+    @ParameterizedTest
+    @MethodSource("classes")
+    public void testLoadClassesWorkWithoutNativeLib(Class<?> clazz) {
+        // Force loading of class.
+        assertDoesNotThrow(() -> Class.forName(clazz.getName()));
+    }
+}


### PR DESCRIPTION
… classpath or platform not supported

Motivation:

We should ensure we can at least load the class even if we don't suppt the platform as people might reference the classes.

Modifications:

- Move static fields into Native class
- Remove check in static block
- Add checks in constructor
- Add test

Result:

Fixes https://github.com/netty/netty/issues/15392