### PR TITLE
Devcontainers: Install gh cli in ubuntu devcontainer

### DIFF
--- a/.devcontainer/ubuntu/devcontainer.json
+++ b/.devcontainer/ubuntu/devcontainer.json
@@ -7,7 +7,8 @@
     "dockerfile": "Dockerfile",
   },
   "features": {
-    "ghcr.io/devcontainers/features/rust:1.5.0": {}
+    "ghcr.io/devcontainers/features/rust:1.5.0": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
   },
   "securityOpt": [ "seccomp=unconfined" ],
   "runArgs": [


### PR DESCRIPTION
Motivation:

When using devcontainers it would be nice to be able to use the gh client directly to create PRs etc

Modifications:

Install gh client via feature

Result:

Easier development when using devcontainers