### PR TITLE
IoUring: Compile test with java8 but only run it with Java9 and later

### DIFF
--- a/transport-classes-io_uring/pom.xml
+++ b/transport-classes-io_uring/pom.xml
@@ -127,6 +127,26 @@
               </includes>
             </configuration>
           </execution>
+          <execution>
+            <id>compile-tests-jdk8</id>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+            <configuration>
+              <compilerVersion>1.8</compilerVersion>
+              <fork>true</fork>
+              <source>1.8</source>
+              <target>1.8</target>
+              <release>8</release>
+              <debug>true</debug>
+              <optimize>true</optimize>
+              <showDeprecation>true</showDeprecation>
+              <showWarnings>true</showWarnings>
+              <compilerArgument>-Xlint:-options</compilerArgument>
+              <meminitial>256m</meminitial>
+              <maxmem>1024m</maxmem>
+            </configuration>
+          </execution>
         </executions>
 
       </plugin>

--- a/transport-classes-io_uring/src/test/java/io/netty/channel/uring/LoadClassTest.java
+++ b/transport-classes-io_uring/src/test/java/io/netty/channel/uring/LoadClassTest.java
@@ -15,6 +15,8 @@
  */
 package io.netty.channel.uring;
 
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -39,6 +41,7 @@ public class LoadClassTest {
         return classes.toArray(new Class<?>[0]);
     }
 
+    @EnabledForJreRange(min = JRE.JAVA_9)
     @ParameterizedTest
     @MethodSource("classes")
     public void testLoadClassesWorkWithoutNativeLib(Class<?> clazz) {


### PR DESCRIPTION
Motivation:

a3a7801f28faeabc4e14a025ffc970a7a809b834 added a testcase that ensured we can load classes even if the native lib is not present. Because of how we compile io_uring and how we run tests we need to ensure that test itself is actually compiled via Java8

Modifications:

- Compile the test with Java8
- Only enable on Java9 and later

Result:

CI job passes again when we try to run tests with java8