### PR TITLE
update/cleanup codeql workflow (#15683)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,6 +29,7 @@ env:
 
 permissions:
   contents: read
+  security-events: write
 
 # Cancel running jobs when a new push happens to the same branch as otherwise it will
 # tie up too many resources without providing much value.
@@ -38,10 +39,6 @@ concurrency:
 
 jobs:
   analyze:
-    permissions:
-      actions: read  # for github/codeql-action/init to get workflow details
-      contents: read  # for actions/checkout to fetch code
-      security-events: write  # for github/codeql-action/analyze to upload SARIF results
     name: Analyze
     runs-on: ubuntu-latest
 
@@ -50,59 +47,40 @@ jobs:
       matrix:
         # Override automatic language detection by changing the below list
         # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
-        language: ['java', 'cpp' ]
-        # Learn more...
-        # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
+        language: [ 'java', 'cpp' ]
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v5
 
-    # Cache .m2/repository
-    - name: Cache local Maven repository
-      uses: actions/cache@v4
-      continue-on-error: true
-      with:
-        path: ~/.m2/repository
-        key: cache-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          cache-maven-${{ hashFiles('**/pom.xml') }}
-          cache-maven-
+      - name: Cache local Maven repository
+        uses: actions/cache@v4
+        continue-on-error: true
+        with:
+          path: ~/.m2/repository
+          key: cache-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            cache-maven-${{ hashFiles('**/pom.xml') }}
+            cache-maven-
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: '11'
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    # - name: Autobuild
-    #  uses: github/codeql-action/autobuild@v2
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          tools: linked
+          build-mode: manual
+          languages: ${{ matrix.language }}
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
+      - name: Install tools / libraries
+        run: sudo apt-get update && sudo apt-get -y install autoconf automake libtool make tar cmake perl ninja-build git cargo
 
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-    - uses: actions/setup-java@v4
-      with:
-        distribution: 'zulu'
-        java-version: '11' # The JDK version to make available on the path.
+      - name: Compile project
+        run: ./mvnw -B -ntp clean package -DskipTests=true -DskipH3Spec=true
 
-    #- run: |
-    #   make bootstrap
-    #   make release
-    - name: Install tools / libraries
-      run: sudo apt-get update && sudo apt-get -y install autoconf automake libtool make tar cmake perl ninja-build git cargo
-
-    - name: Compile project
-      run: ./mvnw -B -ntp clean package -DskipTests=true -DskipH3Spec=true
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
Motivation:
As stated when executing the workflow, the major version (v2) of codeql that is currently in use has long been deprecated. This PR updates the codeql actions to v3 and also includes bumping the other action version majors (major bump due to a new major nodejs requirement, not relevant on github-hosted runners) as well as a bit of cleanup to the action.

Modification:
Updates the codeql actions to v3, updates actions/checkout and action/setup-java to v5 (codeql action only), cleanup of codeql workflow definition.

Result:
The latest codeql version is in use and the workflow definition is cleaned up.

(cherry picked from commit bcdaf60a6b7971cc48432041fa3f9b640f2d1514)
Backport of https://github.com/netty/netty/pull/15683