### PR TITLE
Update jni-util version to clarify licensing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -841,7 +841,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-jni-util</artifactId>
-        <version>0.0.9.Final</version>
+        <version>0.0.10.Final</version>
         <classifier>sources</classifier>
         <optional>true</optional>
       </dependency>


### PR DESCRIPTION
Motivation:

A new jni-util version was released which replaced some code which had no clear licensing.

Modifications:

Upgrade to latest version

Result:

Clear licensing of jni-util dependency
