### PR TITLE
Update jni-util version to clarify licensing (#15687)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -516,7 +516,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>netty-jni-util</artifactId>
-        <version>0.0.9.Final</version>
+        <version>0.0.10.Final</version>
         <classifier>sources</classifier>
         <optional>true</optional>
       </dependency>


### PR DESCRIPTION
Motivation:

A new jni-util version was released which replaced some code which had no clear licensing.

Modifications:

Upgrade to latest version

Result:

Clear licensing of jni-util dependency