### PR TITLE
IoUring: Always correctly handle IORING_CQE_F_MORE flag when using ze…

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
@@ -155,9 +155,6 @@ public final class IoUringSocketChannel extends AbstractIoUringStreamChannel imp
 
         private boolean handleWriteCompleteZeroCopy(byte op, ChannelOutboundBuffer channelOutboundBuffer,
                                                     int res, int flags) {
-            if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
-                return true;
-            }
             if ((flags & Native.IORING_CQE_F_NOTIF) == 0) {
                 // We only want to reset these if IORING_CQE_F_NOTIF is not set.
                 // If it's set we know this is only an extra notification for a write but we already handled
@@ -204,6 +201,15 @@ public final class IoUringSocketChannel extends AbstractIoUringStreamChannel imp
                     }
                     return true;
                 } else {
+                    if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
+                        if (more) {
+                            // The send was cancelled but we expect another notification. Just add the marker to the
+                            // queue so we don't get into trouble once the final notification for this operation is
+                            // received.
+                            zcWriteQueue.add(ZC_BATCH_MARKER);
+                        }
+                        return true;
+                    }
                     try {
                         String msg = op == Native.IORING_OP_SEND_ZC ? "io_uring sendzc" : "io_uring sendmsg_zc";
                         int result = ioResult(msg, res);


### PR DESCRIPTION
…ro copy send

Motivation:

We should always respect the IORING_CQE_F_MORE flag if set, even if the write is cancelled as otherwise we might run into issues when trying to process the write queue later on.

Modifications:

Correctly handle ERRNO_ECANCELED_NEGATIVE in all cases.

Result:

Fixes https://github.com/netty/netty/issues/15599
