### PR TITLE
Bootstrap: Also include Channel type when logging of unsupported Chan…

### DIFF
--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -485,11 +485,13 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
             Channel channel, ChannelOption<?> option, Object value, InternalLogger logger) {
         try {
             if (!channel.config().setOption((ChannelOption<Object>) option, value)) {
-                logger.warn("Unknown channel option '{}' for channel '{}'", option, channel);
+                logger.warn("Unknown channel option '{}' for channel '{}' of type '{}'",
+                        option, channel, channel.getClass());
             }
         } catch (Throwable t) {
             logger.warn(
-                    "Failed to set channel option '{}' with value '{}' for channel '{}'", option, value, channel, t);
+                    "Failed to set channel option '{}' with value '{}' for channel '{}' of type '{}'",
+                    option, value, channel, channel.getClass(), t);
         }
     }
 


### PR DESCRIPTION
…nelOption

Motivation:

At the moment we don't log the Channel type when we can't set a ChannelOption because it is not supported. This makes it hard to debug.

Modifications:

Add Channel type to the log message as well

Result:

Easier to understand why a ChannelOption was not supported