### PR TITLE
IoUring: Add some details on what to do if ENOMEM is observed when us…

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringChannelOption.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringChannelOption.java
@@ -59,6 +59,11 @@ public final class IoUringChannelOption<T> extends UnixChannelOption<T> {
      * The threshold for zero-copy write (send_zc and sendmsg_zc).
      * If it is set to {@code -1}, then this function will be disabled.
      * <p>
+     * If the locked memory limit is too low you will observe
+     * <a href="https://github.com/axboe/liburing/commit/e951bf0c08c81a2ea0c4b7bca7e4494f2043d367">-ENOMEM</a> and
+     * writes will be failed. This is a clear sign that you should increase the locked memory limit via
+     * {@code ulimit -l}.
+     * <p>
      * Check
      * <a href="https://man.archlinux.org/man/io_uring_enter.2.en#IORING_OP_SEND_ZC"> man io_uring_enter</a>
      * for more details.


### PR DESCRIPTION
…ing zero copy writes.

Motivation:

If zero copy writes are used the user needs to ensure enough locked memory can be used. If this is not the case ENOMEM is reported. Let's clearly document what the user can do in this situation.

Modifications:

Add more detals around ENOMEM handling

Result:

Easier for the user to understand what to do when ENOMEM is received.