### PR TITLE
Native: Include error value when throwing NativeIoException in the me…

### DIFF
--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/Errors.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/Errors.java
@@ -84,7 +84,7 @@ public final class Errors {
         }
 
         public NativeIoException(String method, int expectedErr, boolean fillInStackTrace) {
-            super(method + "(..) failed: " + errnoString(-expectedErr));
+            super(method + "(..) failed with error(" + expectedErr + "): " + errnoString(-expectedErr));
             this.expectedErr = expectedErr;
             this.fillInStackTrace = fillInStackTrace;
         }
@@ -106,7 +106,7 @@ public final class Errors {
         private static final long serialVersionUID = -5532328671712318161L;
         private final int expectedErr;
         NativeConnectException(String method, int expectedErr) {
-            super(method + "(..) failed: " + errnoString(-expectedErr));
+            super(method + "(..) failed with error(" + expectedErr + "):" + errnoString(-expectedErr));
             this.expectedErr = expectedErr;
         }
 
@@ -163,7 +163,7 @@ public final class Errors {
         if (err == ERRNO_ENOENT_NEGATIVE) {
             return new FileNotFoundException();
         }
-        return new ConnectException(method + "(..) failed: " + errnoString(-err));
+        return new ConnectException(method + "(..) failed with error(" + err + "): " + errnoString(-err));
     }
 
     public static NativeIoException newConnectionResetException(String method, int errnoNegative) {


### PR DESCRIPTION
…ssage

Motivation:

We should include the error value (which is a negative errno) in the message of the NativeIoException. This allows easier debugging as it is much easier to lookup the errno value and its cause then the human readable message.

Modification:

Include error in the message of the exception

Result:

Easier to debug failed native ops