### PR TITLE
Update to latest JDK26 EA release

### DIFF
--- a/.github/scripts/check_java_ea_version.sh
+++ b/.github/scripts/check_java_ea_version.sh
@@ -17,7 +17,7 @@
 set -e
 
 # Keep this version in sync with docker-compose.centos-7.26.yaml
-export EXPECTED_VERSION='26.ea.15'
+export EXPECTED_VERSION='26.ea.16'
 
 curl -s "https://get.sdkman.io" | bash
 source "$HOME/.sdkman/bin/sdkman-init.sh"

--- a/docker/docker-compose.centos-7.26.yaml
+++ b/docker/docker-compose.centos-7.26.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-7-26
     build:
       args:
-        java_version : "26.ea.15-open"
+        java_version : "26.ea.16-open"
 
   build:
     image: netty:centos-7-26


### PR DESCRIPTION
Motivation:

We need to update our JDK26 EA version

Modifications:

Update to latest release

Result:

Github action does not fail anymore