### PR TITLE
IoUring: Add missing op code to name mappings

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -303,6 +303,8 @@ final class Native {
             case IORING_OP_MKDIRAT: return "MKDIRAT";
             case IORING_OP_SYMLINKAT: return "SYMLINKAT";
             case IORING_OP_LINKAT: return "LINKAT";
+            case IORING_OP_SEND_ZC: return "SEND_ZC";
+            case IORING_OP_SENDMSG_ZC: return "SENDMSG_ZC";
             default: return "[OP CODE " + op + ']';
         }
     }


### PR DESCRIPTION
Motivation:

We did miss to add the mappings for send_zc and sendmsg_zc and so it's harder to read the log as it should be.

Modifications:

- Add missing mappings for the two op codes

Result:

Easier to read the log