### PR TITLE
IoUring: Don't delay close operation if we still wait for the second …

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
@@ -275,9 +275,5 @@ public final class IoUringSocketChannel extends AbstractIoUringStreamChannel imp
                 zcWriteQueue.add(ZC_BATCH_MARKER);
             }
         }
-        @Override
-        protected boolean canCloseNow0() {
-            return (zcWriteQueue == null || zcWriteQueue.isEmpty()) && super.canCloseNow0();
-        }
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketSendSzSendmsgZcTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketSendSzSendmsgZcTest.java
@@ -21,6 +21,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.unix.IntegerUnixChannelOption;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.AbstractClientSocketTest;
 import org.junit.jupiter.api.Test;
@@ -52,7 +53,7 @@ public class IoUringSocketSendSzSendmsgZcTest extends AbstractClientSocketTest {
         run(testInfo, new Runner<Bootstrap>() {
             @Override
             public void run(Bootstrap bootstrap) throws Throwable {
-                testBufferLifecycleCorrectlyHandled(bootstrap, false, false);
+                testBufferLifecycleCorrectlyHandled(bootstrap, false, Close.NONE);
             }
         });
     }
@@ -63,40 +64,77 @@ public class IoUringSocketSendSzSendmsgZcTest extends AbstractClientSocketTest {
         run(testInfo, new Runner<Bootstrap>() {
             @Override
             public void run(Bootstrap bootstrap) throws Throwable {
-                testBufferLifecycleCorrectlyHandled(bootstrap, true, false);
+                testBufferLifecycleCorrectlyHandled(bootstrap, true, Close.NONE);
             }
         });
     }
 
     @Test
     @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
-    public void testBufferLifecycleCorrectlyHandledUsingSendZcWhenRemotePeerCloseSocket(TestInfo testInfo)
+    public void testBufferLifecycleCorrectlyHandledUsingSendZcWhenRemoteClose(TestInfo testInfo)
             throws Throwable {
         run(testInfo, new Runner<Bootstrap>() {
             @Override
             public void run(Bootstrap bootstrap) throws Throwable {
-                testBufferLifecycleCorrectlyHandled(bootstrap, false, true);
+                testBufferLifecycleCorrectlyHandled(bootstrap, false, Close.REMOTE);
             }
         });
     }
 
     @Test
     @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
-    public void testBufferLifecycleCorrectlyHandledUsingSendmsgZcWhenRemotePeerCloseSocket(TestInfo testInfo)
+    public void testBufferLifecycleCorrectlyHandledUsingSendmsgZcWhenRemoteClose(TestInfo testInfo)
             throws Throwable {
         run(testInfo, new Runner<Bootstrap>() {
             @Override
             public void run(Bootstrap bootstrap) throws Throwable {
-                testBufferLifecycleCorrectlyHandled(bootstrap, true, true);
+                testBufferLifecycleCorrectlyHandled(bootstrap, true, Close.REMOTE);
             }
         });
     }
 
-    private static void testBufferLifecycleCorrectlyHandled(Bootstrap cb, boolean multiple, boolean remoteClose)
+    @Test
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testBufferLifecycleCorrectlyHandledUsingSendZcWhenLocalClose(TestInfo testInfo)
+            throws Throwable {
+        run(testInfo, new Runner<Bootstrap>() {
+            @Override
+            public void run(Bootstrap bootstrap) throws Throwable {
+                testBufferLifecycleCorrectlyHandled(bootstrap, false, Close.LOCAL);
+            }
+        });
+    }
+
+    @Test
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testBufferLifecycleCorrectlyHandledUsingSendmsgZcWhenLocalClose(TestInfo testInfo)
+            throws Throwable {
+        run(testInfo, new Runner<Bootstrap>() {
+            @Override
+            public void run(Bootstrap bootstrap) throws Throwable {
+                testBufferLifecycleCorrectlyHandled(bootstrap, true, Close.LOCAL);
+            }
+        });
+    }
+
+    private enum Close {
+        REMOTE,
+        LOCAL,
+        NONE
+    }
+
+    private static void testBufferLifecycleCorrectlyHandled(Bootstrap cb, boolean multiple, Close remoteClose)
             throws Throwable {
         cb.handler(new ChannelInboundHandlerAdapter());
         // Force to use send_zc / sendmsg_zc if supported.
         cb.option(IoUringChannelOption.IO_URING_WRITE_ZERO_COPY_THRESHOLD, 0);
+        if (remoteClose == Close.LOCAL) {
+            // Configure TCP_USER_TIMEOUT to a small number so the buffers can be returned quickly.
+            // See:
+            // - https://man7.org/linux/man-pages/man7/tcp.7.html
+            // - https://github.com/torvalds/linux/blob/v6.16/include/uapi/linux/tcp.h#L111
+            cb.option(new IntegerUnixChannelOption("TCP_USER_TIMEOUT", 6, 18), 1000);
+        }
 
         try (ServerSocket serverSocket = new ServerSocket()) {
             serverSocket.bind(new InetSocketAddress(0));
@@ -131,7 +169,10 @@ public class IoUringSocketSendSzSendmsgZcTest extends AbstractClientSocketTest {
                         } else {
                             buffer.release();
                             causeRef.set(f.cause());
-                            latch.countDown();
+
+                            for (int i = 0;i  < numBuffers;i++) {
+                                latch.countDown();
+                            }
                         }
                     });
                     latch.await();
@@ -147,20 +188,28 @@ public class IoUringSocketSendSzSendmsgZcTest extends AbstractClientSocketTest {
                         assertEquals(numBuffers, buffer.refCnt());
                     }
 
-                    if (remoteClose) {
-                        // Don't read any data but just close the socket. This should trigger the required notifications
-                        // to release the buffers.
-                        socket.close();
-                    } else {
-                        // Let's read the bytes now so the buffer can be released again from the NIC.
-                        try (InputStream stream = socket.getInputStream()) {
-                            byte[] bytes = new byte[64 * 1024];
-                            int r;
-                            while (bufferSize != 0 &&
-                                    (r = stream.read(bytes, 0, Math.min(bufferSize, bytes.length))) != -1) {
-                                bufferSize -= r;
+                    switch (remoteClose) {
+                        case REMOTE:
+                            // Don't read any data but just close the socket. This should trigger the required
+                            // notifications to release the buffers.
+                            socket.close();
+                            break;
+                        case LOCAL:
+                            // Don't read any data but just close the channel. Once we did not see an ack for the
+                            // configured TCP_USER_TIMEOUT we will get the required notifications to release the buffers
+                            channel.close().sync();
+                            break;
+                        case NONE:
+                            // Let's read the bytes now so the buffer can be released again from the NIC.
+                            try (InputStream stream = socket.getInputStream()) {
+                                byte[] bytes = new byte[64 * 1024];
+                                int r;
+                                while (bufferSize != 0 &&
+                                        (r = stream.read(bytes, 0, Math.min(bufferSize, bytes.length))) != -1) {
+                                    bufferSize -= r;
+                                }
                             }
-                        }
+                            break;
                     }
 
                     // Wait till the buffer was finally released, which should be done in a timely fashion.

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketSendSzSendmsgZcTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketSendSzSendmsgZcTest.java
@@ -170,7 +170,7 @@ public class IoUringSocketSendSzSendmsgZcTest extends AbstractClientSocketTest {
                             buffer.release();
                             causeRef.set(f.cause());
 
-                            for (int i = 0;i  < numBuffers;i++) {
+                            for (int i = 0; i < numBuffers; i++) {
                                 latch.countDown();
                             }
                         }


### PR DESCRIPTION
…notification when using zero copy

Motivation:

There is really no need to wait with the actual close even if the second notification is still outstanding.

Modifications:

- Don't delay
- Add testcases that the buffer management is correct when we close the channel

Result:

Fix delay when closing channel and zero copy writes are used and also increase test coverage