### PR TITLE
IoUring: Only free resourcees once we are sure no more events are han…

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
@@ -277,8 +277,8 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
         }
 
         @Override
-        protected void freeResourcesNow(IoRegistration reg) {
-            super.freeResourcesNow(reg);
+        public void unregistered() {
+            super.unregistered();
             if (acceptedAddressMemory != null) {
                 acceptedAddressMemory.free();
             }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -612,8 +612,8 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
         }
 
         @Override
-        protected void freeResourcesNow(IoRegistration reg) {
-            super.freeResourcesNow(reg);
+        public void unregistered() {
+            super.unregistered();
             assert readBuffer == null;
         }
     }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
@@ -618,10 +618,10 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
         }
 
         @Override
-        protected void freeResourcesNow(IoRegistration reg) {
+        public void unregistered() {
+            super.unregistered();
             sendmsgHdrs.release();
             recvmsgHdrs.release();
-            super.freeResourcesNow(reg);
         }
     }
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDomainSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDomainSocketChannel.java
@@ -239,8 +239,8 @@ public final class IoUringDomainSocketChannel extends AbstractIoUringStreamChann
         }
 
         @Override
-        protected void freeResourcesNow(IoRegistration reg) {
-            super.freeResourcesNow(reg);
+        public void unregistered() {
+            super.unregistered();
             if (readMsgHdrMemory != null) {
                 readMsgHdrMemory.release();
                 readMsgHdrMemory = null;

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandle.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandle.java
@@ -15,11 +15,20 @@
  */
 package io.netty.channel.uring;
 
+import io.netty.channel.IoEvent;
 import io.netty.channel.IoHandle;
+import io.netty.channel.IoRegistration;
 
 /**
  * {@link IoHandle} implementation for io_uring.
  */
 public interface IoUringIoHandle extends IoHandle {
-    // Marker interface.
+
+    /**
+     * Called once this {@link IoUringIoHandle} was unregistered and so will not receive any more events
+     * via {@link #handle(IoRegistration, IoEvent)}.
+     */
+    default void unregistered() {
+        // Noop by default.
+    }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -587,6 +587,7 @@ public final class IoUringIoHandler implements IoHandler {
         private void remove() {
             DefaultIoUringIoRegistration old = registrations.remove(id);
             assert old == this;
+            handle.unregistered();
         }
 
         void close() {


### PR DESCRIPTION
…dled by the handle

Motivation:

We should better only free up native resources once we can be sure we not will get any more events delivered.

Modifications:

- Add new default method to IoUringIoHandle which will be called once we know for sure no more events are dispatched
- Move code that frees native resource to this method

Result:

Safer cleanup of resources