### PR TITLE
Fix Snappy compression bug

### DIFF
--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/Snappy.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/Snappy.java
@@ -25,7 +25,7 @@ import java.util.Arrays;
 /**
  * Uncompresses an input {@link ByteBuf} encoded with Snappy compression into an
  * output {@link ByteBuf}.
- *
+ * <p>
  * See <a href="https://github.com/google/snappy/blob/master/format_description.txt">snappy format</a>.
  */
 public final class Snappy {
@@ -123,7 +123,7 @@ public final class Snappy {
 
                     // equivalent to Short.toUnsignedInt
                     // use unsigned short cast to avoid loss precision when 32767 <= length <= 65355
-                    candidate = baseIndex + ((int) table[hash]) & 0xffff;
+                    candidate = baseIndex + (table[hash] & 0xffff);
 
                     table[hash] = (short) (inIndex - baseIndex);
                 }
@@ -148,7 +148,7 @@ public final class Snappy {
                     int prevHash = hash(in, insertTail, shift);
                     table[prevHash] = (short) (inIndex - baseIndex - 1);
                     int currentHash = hash(in, insertTail + 1, shift);
-                    candidate = baseIndex + table[currentHash];
+                    candidate = baseIndex + (table[currentHash] & 0xFFFF);
                     table[currentHash] = (short) (inIndex - baseIndex);
                 }
                 while (in.getInt(insertTail + 1) == in.getInt(candidate));
@@ -708,7 +708,7 @@ public final class Snappy {
 
     /**
      * From the spec:
-     *
+     * <p>
      * "Checksums are not stored directly, but masked, as checksumming data and
      * then its own checksum can be problematic. The masking is the same as used
      * in Apache Hadoop: Rotate the checksum by 15 bits, then add the constant

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/AbstractIntegrationTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/AbstractIntegrationTest.java
@@ -22,16 +22,19 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.ByteProcessor;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.EmptyArrays;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 
+import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -187,17 +190,22 @@ public abstract class AbstractIntegrationTest {
 
     @DisabledIf("io.netty.util.ResourceLeakDetector#isEnabled")
     @Test
-    public void testHugeDecompress() {
+    public void testHugeDecompress() throws Exception {
         int chunkSize = 1024 * 1024;
         int numberOfChunks = 256;
         int memoryLimit = chunkSize * 128;
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
 
         EmbeddedChannel compressChannel = createEncoder();
         ByteBuf compressed = compressChannel.alloc().buffer();
         for (int i = 0; i <= numberOfChunks; i++) {
             if (i < numberOfChunks) {
                 ByteBuf in = compressChannel.alloc().buffer(chunkSize);
-                in.writeZero(chunkSize);
+                for (int j = 0; j < chunkSize; j++) {
+                    byte byteValue = (byte) (i + (j & 0xA0));
+                    in.writeByte(byteValue);
+                    digest.update(byteValue);
+                }
                 compressChannel.writeOutbound(in);
             } else {
                 compressChannel.close();
@@ -211,24 +219,28 @@ public abstract class AbstractIntegrationTest {
                 buf.release();
             }
         }
+        byte[] expectedData = digest.digest();
 
         PooledByteBufAllocator allocator = new PooledByteBufAllocator(false);
 
-        HugeDecompressIncomingHandler endHandler = new HugeDecompressIncomingHandler(memoryLimit);
+        HugeDecompressIncomingHandler endHandler = new HugeDecompressIncomingHandler(memoryLimit, digest);
         EmbeddedChannel decompressChannel = createDecoder();
         decompressChannel.pipeline().addLast(endHandler);
         decompressChannel.config().setAllocator(allocator);
         decompressChannel.writeInbound(compressed);
         decompressChannel.finishAndReleaseAll();
         assertEquals((long) chunkSize * numberOfChunks, endHandler.total);
+        assertArrayEquals(expectedData, digest.digest());
     }
 
-    private static final class HugeDecompressIncomingHandler extends ChannelInboundHandlerAdapter {
+    private static final class HugeDecompressIncomingHandler extends ChannelInboundHandlerAdapter implements ByteProcessor {
         final int memoryLimit;
+        final MessageDigest digest;
         long total;
 
-        HugeDecompressIncomingHandler(int memoryLimit) {
+        HugeDecompressIncomingHandler(int memoryLimit, MessageDigest digest) {
             this.memoryLimit = memoryLimit;
+            this.digest = digest;
         }
 
         @Override
@@ -236,12 +248,19 @@ public abstract class AbstractIntegrationTest {
             ByteBuf buf = (ByteBuf) msg;
             total += buf.readableBytes();
             try {
+                buf.forEachByte(this);
                 PooledByteBufAllocator allocator = (PooledByteBufAllocator) ctx.alloc();
                 assertThat(allocator.metric().usedHeapMemory()).isLessThan(memoryLimit);
                 assertThat(allocator.metric().usedDirectMemory()).isLessThan(memoryLimit);
             } finally {
                 buf.release();
             }
+        }
+
+        @Override
+        public boolean process(byte value) throws Exception {
+            digest.update(value);
+            return true;
         }
     }
 }

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/AbstractIntegrationTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/AbstractIntegrationTest.java
@@ -233,7 +233,8 @@ public abstract class AbstractIntegrationTest {
         assertArrayEquals(expectedData, digest.digest());
     }
 
-    private static final class HugeDecompressIncomingHandler extends ChannelInboundHandlerAdapter implements ByteProcessor {
+    private static final class HugeDecompressIncomingHandler
+            extends ChannelInboundHandlerAdapter implements ByteProcessor {
         final int memoryLimit;
         final MessageDigest digest;
         long total;


### PR DESCRIPTION
Motivation:
Certain inputs to the Snappy compression routine can cause an IndexOutOfBoundsException to be thrown.

Modification:
Fix conversion of signed-short to unsigned 16-bit ints. These numbers were used as indices, and negative values caused the exception to be thrown. Add a data pattern to the inputs of the `testHugeDecompress` test (this input pattern catches the bug) and check that the decompressed outputs match the inputs, using a SHA-256 checksum.

Result:
The `testHugeDecompress` test now verifies round-trip data integrity, and we've fixed a bug in Snappy that this found.