### PR TITLE
Add new callbacks to IoHandle implementation to allow better handling…

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
@@ -296,6 +296,7 @@ public class EpollIoHandler implements IoHandler {
                         logger.debug("Unable to remove fd {} from epoll {}", fd, epollFd.intValue());
                     }
                 }
+                handle.unregistered();
             }
         }
 
@@ -333,6 +334,7 @@ public class EpollIoHandler implements IoHandler {
         if (epollHandle instanceof AbstractEpollChannel.AbstractEpollUnsafe) {
             numChannels++;
         }
+        handle.registered();
         return registration;
     }
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandle.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandle.java
@@ -15,20 +15,11 @@
  */
 package io.netty.channel.uring;
 
-import io.netty.channel.IoEvent;
 import io.netty.channel.IoHandle;
-import io.netty.channel.IoRegistration;
 
 /**
  * {@link IoHandle} implementation for io_uring.
  */
 public interface IoUringIoHandle extends IoHandle {
 
-    /**
-     * Called once this {@link IoUringIoHandle} was unregistered and so will not receive any more events
-     * via {@link #handle(IoRegistration, IoEvent)}.
-     */
-    default void unregistered() {
-        // Noop by default.
-    }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -487,6 +487,7 @@ public final class IoUringIoHandler implements IoHandler {
                 registrations.put(id, old);
             } else {
                 registration.setId(id);
+                ioHandle.registered();
                 break;
             }
         }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoHandler.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoHandler.java
@@ -309,6 +309,7 @@ public final class KQueueIoHandler implements IoHandler {
             if (removed.isHandleForChannel()) {
                 numChannels--;
             }
+            removed.handle.unregistered();
         }
     }
 
@@ -394,10 +395,10 @@ public final class KQueueIoHandler implements IoHandler {
             registrations.put(old.id, old);
             throw new IllegalStateException();
         }
-
         if (registration.isHandleForChannel()) {
             numChannels++;
         }
+        handle.registered();
         return registration;
     }
 

--- a/transport/src/main/java/io/netty/channel/IoHandle.java
+++ b/transport/src/main/java/io/netty/channel/IoHandle.java
@@ -31,4 +31,20 @@ public interface IoHandle extends AutoCloseable {
      *                      while this method is executed and so must not escape it.
      */
     void handle(IoRegistration registration, IoEvent ioEvent);
+
+    /**
+     * Called once this {@link IoHandle} was registered and so will start to receive events
+     * via {@link #handle(IoRegistration, IoEvent)}.
+     */
+    default void registered() {
+        // Noop by default.
+    }
+
+    /**
+     * Called once this {@link IoHandle} was unregistered and so will not receive any more events
+     * via {@link #handle(IoRegistration, IoEvent)}.
+     */
+    default void unregistered() {
+        // Noop by default.
+    }
 }

--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -176,7 +176,7 @@ public class LocalChannel extends AbstractChannel {
             });
         } else {
             try {
-                ((LocalUnsafe) unsafe()).registerNow();
+                ((LocalUnsafe) unsafe()).registered();
             } catch (Throwable cause) {
                 promise.setFailure(cause);
             }
@@ -194,7 +194,7 @@ public class LocalChannel extends AbstractChannel {
                 registration.cancel();
             }
         } else {
-            ((LocalUnsafe) unsafe()).deregisterNow();
+            ((LocalUnsafe) unsafe()).unregistered();
         }
     }
 
@@ -484,7 +484,7 @@ public class LocalChannel extends AbstractChannel {
         }
 
         @Override
-        public void registerNow() {
+        public void registered() {
             // Check if both peer and parent are non-null because this channel was created by a LocalServerChannel.
             // This is needed as a peer may not be null also if a LocalChannel was connected before and
             // deregistered / registered later again.
@@ -520,7 +520,7 @@ public class LocalChannel extends AbstractChannel {
         }
 
         @Override
-        public void deregisterNow() {
+        public void unregistered() {
             // Just remove the shutdownHook as this Channel may be closed later or registered to another EventLoop
             ((SingleThreadEventExecutor) eventLoop()).removeShutdownHook(shutdownHook);
         }

--- a/transport/src/main/java/io/netty/channel/local/LocalIoHandle.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalIoHandle.java
@@ -21,7 +21,5 @@ import io.netty.channel.IoHandle;
  * {@link IoHandle} sub-type that is used by the local transport internally.
  */
 interface LocalIoHandle extends IoHandle {
-    void registerNow();
-    void deregisterNow();
     void closeNow();
 }

--- a/transport/src/main/java/io/netty/channel/local/LocalIoHandler.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalIoHandler.java
@@ -97,7 +97,7 @@ public final class LocalIoHandler implements IoHandler {
         LocalIoHandle localHandle = cast(handle);
         if (registeredChannels.add(localHandle)) {
             LocalIoRegistration registration = new LocalIoRegistration(executor, localHandle);
-            localHandle.registerNow();
+            localHandle.registered();
             return registration;
         }
         throw new IllegalStateException();
@@ -148,7 +148,7 @@ public final class LocalIoHandler implements IoHandler {
 
         private void cancel0() {
             if (registeredChannels.remove(handle)) {
-                handle.deregisterNow();
+                handle.unregistered();
             }
         }
     }

--- a/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
@@ -112,7 +112,7 @@ public class LocalServerChannel extends AbstractServerChannel {
             });
         } else {
             try {
-                ((LocalServerUnsafe) unsafe()).registerNow();
+                ((LocalServerUnsafe) unsafe()).registered();
             } catch (Throwable cause) {
                 promise.setFailure(cause);
                 return;
@@ -149,7 +149,7 @@ public class LocalServerChannel extends AbstractServerChannel {
                 registration.cancel();
             }
         } else {
-            ((LocalServerUnsafe) unsafe()).deregisterNow();
+            ((LocalServerUnsafe) unsafe()).unregistered();
         }
     }
 
@@ -237,12 +237,12 @@ public class LocalServerChannel extends AbstractServerChannel {
         }
 
         @Override
-        public void registerNow() {
+        public void registered() {
             ((SingleThreadEventExecutor) eventLoop()).addShutdownHook(shutdownHook);
         }
 
         @Override
-        public void deregisterNow() {
+        public void unregistered() {
             ((SingleThreadEventExecutor) eventLoop()).removeShutdownHook(shutdownHook);
         }
 


### PR DESCRIPTION
… of resources

Motivation:

b7fcf5785dd8fb72019d47565656cd39ae25246b added a new method to IoUringIoHandle which allowed it to better handle native resources. After thinking more about it we should better just move it to IoHandle directly and also add another method that is called when an IoHandle was succesfully registered. This allows to allocate / deallocate resources in a consistent and safe way in any transport.

Modification:

- Move default method from IoUringIoHandle to IoHandle
- Add new default method to IoHandle which is called when a handle is registered successfully.
- Adjust all IoHandler implementations to call these methods correctly.

Result:

Better and more flexible implemention of IoHandle possible