### PR TITLE
Fix how huge decompression was disabled (#15711)

### DIFF
--- a/codec/src/test/java/io/netty/handler/codec/compression/AbstractIntegrationTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/AbstractIntegrationTest.java
@@ -24,6 +24,7 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
+import io.netty.util.ResourceLeakDetector;
 import io.netty.util.internal.EmptyArrays;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
@@ -185,7 +186,11 @@ public abstract class AbstractIntegrationTest {
         }
     }
 
-    @DisabledIf("io.netty.util.ResourceLeakDetector#isEnabled")
+    static boolean hasLeakDetector() {
+        return ResourceLeakDetector.getLevel().ordinal() > ResourceLeakDetector.Level.SIMPLE.ordinal();
+    }
+
+    @DisabledIf("hasLeakDetector")
     @Test
     public void testHugeDecompress() {
         int chunkSize = 1024 * 1024;


### PR DESCRIPTION
Motivation:
We only meant to disable these tests for ADVANCE and PARANOID leak detection levels. They were accidentally also disabled for the SIMPLE leak detection level that we use by default. This meant we never ran these tests.

Modification:
Allow these tests to run when leak detection is enabled with the SIMPLE level.

Result:
Our builds now run these tests again.