### PR TITLE
Fix Snappy compression bug (#15712)

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/Snappy.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Snappy.java
@@ -25,7 +25,7 @@ import java.util.Arrays;
 /**
  * Uncompresses an input {@link ByteBuf} encoded with Snappy compression into an
  * output {@link ByteBuf}.
- *
+ * <p>
  * See <a href="https://github.com/google/snappy/blob/master/format_description.txt">snappy format</a>.
  */
 public final class Snappy {
@@ -123,7 +123,7 @@ public final class Snappy {
 
                     // equivalent to Short.toUnsignedInt
                     // use unsigned short cast to avoid loss precision when 32767 <= length <= 65355
-                    candidate = baseIndex + ((int) table[hash]) & 0xffff;
+                    candidate = baseIndex + (table[hash] & 0xffff);
 
                     table[hash] = (short) (inIndex - baseIndex);
                 }
@@ -148,7 +148,7 @@ public final class Snappy {
                     int prevHash = hash(in, insertTail, shift);
                     table[prevHash] = (short) (inIndex - baseIndex - 1);
                     int currentHash = hash(in, insertTail + 1, shift);
-                    candidate = baseIndex + table[currentHash];
+                    candidate = baseIndex + (table[currentHash] & 0xFFFF);
                     table[currentHash] = (short) (inIndex - baseIndex);
                 }
                 while (in.getInt(insertTail + 1) == in.getInt(candidate));
@@ -708,7 +708,7 @@ public final class Snappy {
 
     /**
      * From the spec:
-     *
+     * <p>
      * "Checksums are not stored directly, but masked, as checksumming data and
      * then its own checksum can be problematic. The masking is the same as used
      * in Apache Hadoop: Rotate the checksum by 15 bits, then add the constant


### PR DESCRIPTION
Motivation:
Certain inputs to the Snappy compression routine can cause an IndexOutOfBoundsException to be thrown.

Modification:
Fix conversion of signed-short to unsigned 16-bit ints. These numbers were used as indices, and negative values caused the exception to be thrown. Add a data pattern to the inputs of the `testHugeDecompress` test (this input pattern catches the bug) and check that the decompressed outputs match the inputs, using a SHA-256 checksum.

Result:
The `testHugeDecompress` test now verifies round-trip data integrity, and we've fixed a bug in Snappy that this found.

