### PR TITLE
HTTP2: Remove outdated docs

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
@@ -42,9 +42,6 @@ import static io.netty.handler.codec.http2.Http2Error.NO_ERROR;
 import static io.netty.util.internal.logging.InternalLogLevel.DEBUG;
 
 /**
- * <p><em>This API is very immature.</em> The Http2Connection-based API is currently preferred over this API.
- * This API is targeted to eventually replace or reduce the need for the {@link Http2ConnectionHandler} API.
- *
  * <p>An HTTP/2 handler that maps HTTP/2 frames to {@link Http2Frame} objects and vice versa. For every incoming HTTP/2
  * frame, an {@link Http2Frame} object is created and propagated via {@link #channelRead}. Outbound {@link Http2Frame}
  * objects received via {@link #write} are converted to the HTTP/2 wire format. HTTP/2 frames specific to a stream


### PR DESCRIPTION
Motivation:

The notes about the stability of the codec is outdated. Let's remove it so people are not confused.

Modifications:

Remove outdated doc

Result:

Fixes https://github.com/netty/netty/issues/15717
