### PR TITLE
Allow CertificateBuilder to specify Provider instance to use

### DIFF
--- a/pkitesting/pom.xml
+++ b/pkitesting/pom.xml
@@ -66,6 +66,11 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bctls-jdk18on</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pkitesting/src/main/java/io/netty/pkitesting/Algorithms.java
+++ b/pkitesting/src/main/java/io/netty/pkitesting/Algorithms.java
@@ -59,15 +59,16 @@ final class Algorithms {
         }
     }
 
-    static KeyPairGenerator keyPairGenerator(String keyType, AlgorithmParameterSpec spec, SecureRandom rng)
-            throws GeneralSecurityException {
+    static KeyPairGenerator keyPairGenerator(String keyType, AlgorithmParameterSpec spec,
+            SecureRandom rng, Provider provider) throws GeneralSecurityException {
         try {
             KeyPairGenerator keyGen = KeyPairGenerator.getInstance(keyType);
             keyGen.initialize(spec, rng);
             return keyGen;
         } catch (GeneralSecurityException e) {
             try {
-                KeyPairGenerator keyGen = KeyPairGenerator.getInstance(keyType, bouncyCastle());
+                KeyPairGenerator keyGen = KeyPairGenerator.getInstance(keyType,
+                    provider != null ? provider : bouncyCastle());
                 keyGen.initialize(spec, rng);
                 return keyGen;
             } catch (GeneralSecurityException ex) {
@@ -77,12 +78,12 @@ final class Algorithms {
         }
     }
 
-    static Signature signature(String algorithmIdentifier) throws NoSuchAlgorithmException {
+    static Signature signature(String algorithmIdentifier, Provider provider) throws NoSuchAlgorithmException {
         try {
             return Signature.getInstance(algorithmIdentifier);
         } catch (NoSuchAlgorithmException e) {
             try {
-                return Signature.getInstance(algorithmIdentifier, bouncyCastle());
+                return Signature.getInstance(algorithmIdentifier, provider != null ? provider : bouncyCastle());
             } catch (NoSuchAlgorithmException ex) {
                 e.addSuppressed(ex);
             }

--- a/pkitesting/src/main/java/io/netty/pkitesting/CertificateBuilder.java
+++ b/pkitesting/src/main/java/io/netty/pkitesting/CertificateBuilder.java
@@ -175,7 +175,7 @@ public final class CertificateBuilder {
      * @return This certificate builder.
      */
     public CertificateBuilder provider(Provider provider) {
-        this.provider = requireNonNull(provider);
+        this.provider = provider;
         return this;
     }
 

--- a/pkitesting/src/main/java/io/netty/pkitesting/CertificateBuilder.java
+++ b/pkitesting/src/main/java/io/netty/pkitesting/CertificateBuilder.java
@@ -166,6 +166,7 @@ public final class CertificateBuilder {
         copy.publicKey = publicKey;
         copy.keyUsage = keyUsage;
         copy.extendedKeyUsage = new TreeSet<>(extendedKeyUsage);
+        copy.provider = provider;
         return copy;
     }
 

--- a/pkitesting/src/main/java/io/netty/pkitesting/RevocationServer.java
+++ b/pkitesting/src/main/java/io/netty/pkitesting/RevocationServer.java
@@ -169,7 +169,7 @@ public final class RevocationServer {
         CertificateList list = new CertificateList(issuer, now, now, certs.entrySet());
         try {
             Signed signed = new Signed(list.getEncoded(), issuer);
-            return signed.getEncoded();
+            return signed.getEncoded(null);
         } catch (Exception e) {
             throw new IllegalStateException("Failed to sign CRL", e);
         }

--- a/pkitesting/src/main/java/io/netty/pkitesting/Signed.java
+++ b/pkitesting/src/main/java/io/netty/pkitesting/Signed.java
@@ -29,6 +29,7 @@ import java.io.UncheckedIOException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
+import java.security.Provider;
 import java.security.Signature;
 import java.security.SignatureException;
 import java.util.Objects;
@@ -48,8 +49,8 @@ final class Signed {
         this.privateKey = privateKey;
     }
 
-    byte[] getEncoded() throws NoSuchAlgorithmException, InvalidKeyException, SignatureException {
-        Signature signature = Algorithms.signature(algorithmIdentifier);
+    byte[] getEncoded(Provider provider) throws NoSuchAlgorithmException, InvalidKeyException, SignatureException {
+        Signature signature = Algorithms.signature(algorithmIdentifier, provider);
         signature.initSign(privateKey);
         signature.update(toBeSigned);
         byte[] signatureBytes = signature.sign();
@@ -65,7 +66,8 @@ final class Signed {
         }
     }
 
-    InputStream toInputStream() throws NoSuchAlgorithmException, SignatureException, InvalidKeyException {
-        return new ByteArrayInputStream(getEncoded());
+    InputStream toInputStream(Provider provider)
+            throws NoSuchAlgorithmException, SignatureException, InvalidKeyException {
+        return new ByteArrayInputStream(getEncoded(provider));
     }
 }


### PR DESCRIPTION
Motivation:

The 4.2 release introduced a new module, `netty-pkitesting`, which includes a `CertificateBuilder` class. It greatly simplifies the certificate generation but one particular limitation that we run into is that `CertificateBuilder` implementation only supports `BouncyCastleProvider` (see please https://github.com/netty/netty/blob/4.2/pkitesting/src/main/java/io/netty/pkitesting/Algorithms.java#L93).

In OpenSearch fe we are working towards supporting FIPS mode and use `BouncyCastleFipsProvider` only (which Netty is also aware of, see please https://github.com/netty/netty/blob/4.2/handler/src/main/java/io/netty/handler/ssl/util/BouncyCastleUtil.java#L37). The  `CertificateBuilder` class would greatly simplify the testing efforts but we could not use it with non-default provider.

Modification:

Allow `CertificateBuilder` to specify `Provider` instance to use. 

Result:

```java
      CertificateBuilder builder = new CertificateBuilder()
                .algorithm(algorithm)
                .provider(new BouncyCastleJsseProvider());
```

