### PR TITLE
HTTP2 examples: update docs

### DIFF
--- a/example/src/main/java/io/netty/example/http2/helloworld/frame/server/HelloWorldHttp2Handler.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/frame/server/HelloWorldHttp2Handler.java
@@ -35,9 +35,7 @@ import static io.netty.buffer.Unpooled.unreleasableBuffer;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 
 /**
- * A simple handler that responds with the message "Hello World!".
- *
- * <p>This example is making use of the "frame codec" http2 API. This API is very experimental and incomplete.
+ * A simple handler that responds with the message "Hello World!" using "frame codec" http2 API.
  */
 @Sharable
 public class HelloWorldHttp2Handler extends ChannelDuplexHandler {


### PR DESCRIPTION
Motivation:

The notes about the stability of the codec is outdated. Let's update it so people are not confused.

Modifications:

Update outdated doc.

Result:

Fixes #15717