### PR TITLE
HTTP2 duplex examples: update docs

### DIFF
--- a/example/src/main/java/io/netty/example/http2/helloworld/frame/server/Http2Server.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/frame/server/Http2Server.java
@@ -42,9 +42,6 @@ import io.netty.pkitesting.X509Bundle;
 /**
  * An HTTP/2 Server that responds to requests with a Hello World. Once started, you can test the
  * server with the example client.
- *
- * <p>This example is making use of the "multiplexing" http2 API, where streams are mapped to child
- * Channels. This API is very experimental and incomplete.
  */
 public final class Http2Server {
 

--- a/example/src/main/java/io/netty/example/http2/helloworld/multiplex/server/HelloWorldHttp2Handler.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/multiplex/server/HelloWorldHttp2Handler.java
@@ -33,9 +33,6 @@ import io.netty.util.CharsetUtil;
 
 /**
  * A simple handler that responds with the message "Hello World!".
- *
- * <p>This example is making use of the "multiplexing" http2 API, where streams are mapped to child
- * Channels. This API is very experimental and incomplete.
  */
 @Sharable
 public class HelloWorldHttp2Handler extends ChannelDuplexHandler {

--- a/example/src/main/java/io/netty/example/http2/helloworld/multiplex/server/Http2Server.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/multiplex/server/Http2Server.java
@@ -42,9 +42,6 @@ import io.netty.pkitesting.X509Bundle;
 /**
  * An HTTP/2 Server that responds to requests with a Hello World. Once started, you can test the
  * server with the example client.
- *
- * <p>This example is making use of the "multiplexing" http2 API, where streams are mapped to child
- * Channels. This API is very experimental and incomplete.
  */
 public final class Http2Server {
 


### PR DESCRIPTION
Motivation:

The notes about the stability of the "multiplexing" http2 API are outdated. Let's update them so people are not confused.

Modifications:

Update outdated doc.

Result:

Fixes #15717