### PR TITLE
Faster slicing of unpooled direct buffers

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
@@ -767,7 +767,7 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     public ByteBuffer nioBuffer(int index, int length) {
         checkIndex(index, length);
-        return ((ByteBuffer) buffer.duplicate().position(index).limit(index + length)).slice();
+        return PlatformDependent.offsetSlice(buffer, index, length);
     }
 
     @Override

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -1056,6 +1056,14 @@ public final class PlatformDependent {
         return Pow2.align(value, alignment);
     }
 
+    public static ByteBuffer offsetSlice(ByteBuffer buffer, int index, int length) {
+        if (PlatformDependent0.hasOffsetSliceMethod()) {
+            return PlatformDependent0.offsetSlice(buffer, index, length);
+        } else {
+            return ((ByteBuffer) buffer.duplicate().clear().position(index).limit(index + length)).slice();
+        }
+    }
+
     private static void incrementMemoryCounter(int capacity) {
         if (DIRECT_MEMORY_COUNTER != null) {
             long newUsedMemory = DIRECT_MEMORY_COUNTER.addAndGet(capacity);

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -48,6 +48,7 @@ final class PlatformDependent0 {
     private static final MethodHandle DIRECT_BUFFER_CONSTRUCTOR;
     private static final MethodHandle ALLOCATE_ARRAY_METHOD;
     private static final MethodHandle ALIGN_SLICE;
+    private static final MethodHandle OFFSET_SLICE;
     private static final boolean IS_ANDROID = isAndroid0();
     private static final int JAVA_VERSION = javaVersion0();
     private static final Throwable EXPLICIT_NO_UNSAFE_CAUSE = explicitNoUnsafeCause0();
@@ -479,6 +480,22 @@ final class PlatformDependent0 {
             ALIGN_SLICE = null;
         }
 
+        if (javaVersion() >= 13) {
+            OFFSET_SLICE = (MethodHandle) AccessController.doPrivileged(new PrivilegedAction<Object>() {
+                @Override
+                public Object run() {
+                    try {
+                        return MethodHandles.publicLookup().findVirtual(
+                                ByteBuffer.class, "slice", methodType(ByteBuffer.class, int.class, int.class));
+                    } catch (Throwable e) {
+                        return null;
+                    }
+                }
+            });
+        } else {
+            OFFSET_SLICE = null;
+        }
+
         logger.debug("java.nio.DirectByteBuffer.<init>(long, {int,long}): {}",
                 DIRECT_BUFFER_CONSTRUCTOR != null ? "available" : "unavailable");
     }
@@ -627,6 +644,19 @@ final class PlatformDependent0 {
         } catch (Throwable e) {
             rethrowIfPossible(e);
             throw new LinkageError("ByteBuffer.alignedSlice not available", e);
+        }
+    }
+
+    static boolean hasOffsetSliceMethod() {
+        return OFFSET_SLICE != null;
+    }
+
+    static ByteBuffer offsetSlice(ByteBuffer buffer, int index, int length) {
+        try {
+            return (ByteBuffer) OFFSET_SLICE.invokeExact(buffer, index, length);
+        } catch (Throwable e) {
+            rethrowIfPossible(e);
+            throw new LinkageError("ByteBuffer.slice(int, int) not available", e);
         }
     }
 


### PR DESCRIPTION
Motivation:
The UnpooledDirectByteBuf is used as the chunk implementation in the adaptive allocator. As a consequence, its `ByteBuf.nioBuffer(int, int)` method is used to obtain the internal NIO buffers of the allocated adaptive buffers.

Modification:
On Java 13, we can implemenet this in terms of the new `ByteBuffer.slice(int, int)`, which allocates the slice directly and avoids allocating a temporary duplicate buffer.

Result:
AdaptiveByteBuf method that rely on the internal NIO buffer are now faster when they need to allocate the underlying ByteBuffer.

Fixes https://github.com/netty/netty/issues/15723