### PR TITLE
Avoid buffer duplication in AdaptiveByteBuf.setBytes

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -1821,7 +1821,7 @@ final class AdaptivePoolingAllocator {
         public int setBytes(int index, ScatteringByteChannel in, int length)
                 throws IOException {
             try {
-                return in.read(internalNioBuffer(index, length).duplicate());
+                return in.read(internalNioBuffer(index, length));
             } catch (ClosedChannelException ignored) {
                 return -1;
             }
@@ -1831,7 +1831,7 @@ final class AdaptivePoolingAllocator {
         public int setBytes(int index, FileChannel in, long position, int length)
                 throws IOException {
             try {
-                return in.read(internalNioBuffer(index, length).duplicate(), position);
+                return in.read(internalNioBuffer(index, length), position);
             } catch (ClosedChannelException ignored) {
                 return -1;
             }


### PR DESCRIPTION
Motivation:
The setBytes methods are mutating methods, and therefor not thread-safe. The pooling allocator do not protect the position of its internal NIO buffer in these methods, which means it does not call duplicate on the buffer before using it. The adaptive allocator can make the same optimization.

Modification:
Remove ByteBuffer.duplicate calls from the setBytes methods of the AdaptiveByteBuf.

Result:
No more unnecessary ByteBuffer allocation when calling these methods, so the performance should now be on par with the pooling allocator.

Fixes https://github.com/netty/netty/issues/15723