### PR TITLE
Allow CertificateBuilder to specify Provider instance to use (#15722)

### DIFF
--- a/pkitesting/pom.xml
+++ b/pkitesting/pom.xml
@@ -71,6 +71,11 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bctls-jdk18on</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pkitesting/src/main/java/io/netty5/pkitesting/Algorithms.java
+++ b/pkitesting/src/main/java/io/netty5/pkitesting/Algorithms.java
@@ -59,15 +59,16 @@ final class Algorithms {
         }
     }
 
-    static KeyPairGenerator keyPairGenerator(String keyType, AlgorithmParameterSpec spec, SecureRandom rng)
-            throws GeneralSecurityException {
+    static KeyPairGenerator keyPairGenerator(String keyType, AlgorithmParameterSpec spec,
+            SecureRandom rng, Provider provider) throws GeneralSecurityException {
         try {
             KeyPairGenerator keyGen = KeyPairGenerator.getInstance(keyType);
             keyGen.initialize(spec, rng);
             return keyGen;
         } catch (GeneralSecurityException e) {
             try {
-                KeyPairGenerator keyGen = KeyPairGenerator.getInstance(keyType, bouncyCastle());
+                KeyPairGenerator keyGen = KeyPairGenerator.getInstance(keyType,
+                    provider != null ? provider : bouncyCastle());
                 keyGen.initialize(spec, rng);
                 return keyGen;
             } catch (GeneralSecurityException ex) {
@@ -77,12 +78,12 @@ final class Algorithms {
         }
     }
 
-    static Signature signature(String algorithmIdentifier) throws NoSuchAlgorithmException {
+    static Signature signature(String algorithmIdentifier, Provider provider) throws NoSuchAlgorithmException {
         try {
             return Signature.getInstance(algorithmIdentifier);
         } catch (NoSuchAlgorithmException e) {
             try {
-                return Signature.getInstance(algorithmIdentifier, bouncyCastle());
+                return Signature.getInstance(algorithmIdentifier, provider != null ? provider : bouncyCastle());
             } catch (NoSuchAlgorithmException ex) {
                 e.addSuppressed(ex);
             }

--- a/pkitesting/src/main/java/io/netty5/pkitesting/CertificateBuilder.java
+++ b/pkitesting/src/main/java/io/netty5/pkitesting/CertificateBuilder.java
@@ -48,6 +48,7 @@ import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
+import java.security.Provider;
 import java.security.PublicKey;
 import java.security.SecureRandom;
 import java.security.cert.CertificateFactory;
@@ -120,6 +121,7 @@ public final class CertificateBuilder {
     };
     private static final String UNSUPPORTED_SIGN = "UNSUPPORTED_SIGN";
 
+    Provider provider;
     SecureRandom random;
     Algorithm algorithm = Algorithm.ecp256;
     Instant notBefore = Instant.now().minus(1, ChronoUnit.DAYS);
@@ -164,7 +166,18 @@ public final class CertificateBuilder {
         copy.publicKey = publicKey;
         copy.keyUsage = keyUsage;
         copy.extendedKeyUsage = new TreeSet<>(extendedKeyUsage);
+        copy.provider = provider;
         return copy;
+    }
+
+    /**
+     * Set the {@link Provider} instance to use when generating keys.
+     * @param provider The provider instance to use.
+     * @return This certificate builder.
+     */
+    public CertificateBuilder provider(Provider provider) {
+        this.provider = provider;
+        return this;
     }
 
     /**
@@ -665,7 +678,7 @@ public final class CertificateBuilder {
             throw new IllegalStateException("Cannot create a self-signed certificate with a " +
                     "key algorithm that does not support signing: " + algorithm);
         }
-        KeyPair keyPair = generateKeyPair();
+        KeyPair keyPair = generateKeyPair(provider);
 
         V3TBSCertificateGenerator generator = createCertBuilder(subject, subject, keyPair, algorithm.signatureType);
 
@@ -673,7 +686,7 @@ public final class CertificateBuilder {
 
         Signed signed = new Signed(tbsCertToBytes(generator), algorithm.signatureType, keyPair.getPrivate());
         CertificateFactory factory = CertificateFactory.getInstance("X.509");
-        X509Certificate cert = (X509Certificate) factory.generateCertificate(signed.toInputStream());
+        X509Certificate cert = (X509Certificate) factory.generateCertificate(signed.toInputStream(provider));
         return X509Bundle.fromRootCertificateAuthority(cert, keyPair);
     }
 
@@ -697,7 +710,7 @@ public final class CertificateBuilder {
     public X509Bundle buildIssuedBy(X509Bundle issuerBundle, String signAlg) throws Exception {
         final KeyPair keyPair;
         if (publicKey == null) {
-            keyPair = generateKeyPair();
+            keyPair = generateKeyPair(provider);
         } else {
             keyPair = new KeyPair(publicKey, null);
         }
@@ -714,7 +727,7 @@ public final class CertificateBuilder {
         }
         Signed signed = new Signed(tbsCertToBytes(generator), signAlg, issuerPrivateKey);
         CertificateFactory factory = CertificateFactory.getInstance("X.509");
-        X509Certificate cert = (X509Certificate) factory.generateCertificate(signed.toInputStream());
+        X509Certificate cert = (X509Certificate) factory.generateCertificate(signed.toInputStream(provider));
         X509Certificate[] issuerPath = issuerBundle.getCertificatePath();
         X509Certificate[] path = new X509Certificate[issuerPath.length + 1];
         path[0] = cert;
@@ -776,8 +789,8 @@ public final class CertificateBuilder {
         throw new IllegalArgumentException("Don't know what signature algorithm is best for " + key);
     }
 
-    private KeyPair generateKeyPair() throws GeneralSecurityException {
-        return algorithm.generateKeyPair(getSecureRandom());
+    private KeyPair generateKeyPair(Provider provider) throws GeneralSecurityException {
+        return algorithm.generateKeyPair(getSecureRandom(), provider);
     }
 
     private V3TBSCertificateGenerator createCertBuilder(
@@ -1014,13 +1027,26 @@ public final class CertificateBuilder {
          */
         public KeyPair generateKeyPair(SecureRandom secureRandom)
                 throws GeneralSecurityException {
+            return generateKeyPair(secureRandom, null);
+        }
+
+        /**
+         * Generate a new {@link KeyPair} using this algorithm, and the given {@link SecureRandom} generator.
+         * @param secureRandom The {@link SecureRandom} generator to use, not {@code null}.
+         * @param provider The {@link Provider} to use, when {@code null}, the default will be used.
+         * @return The generated {@link KeyPair}.
+         * @throws GeneralSecurityException if the key pair cannot be generated using this algorithm for some reason.
+         * @throws UnsupportedOperationException if this algorithm is not support in the current JVM.
+         */
+        public KeyPair generateKeyPair(SecureRandom secureRandom, Provider provider)
+                throws GeneralSecurityException {
             requireNonNull(secureRandom, "secureRandom");
 
             if (parameterSpec == UNSUPPORTED_SPEC) {
                 throw new UnsupportedOperationException("This algorithm is not supported: " + this);
             }
 
-            KeyPairGenerator keyGen = Algorithms.keyPairGenerator(keyType, parameterSpec, secureRandom);
+            KeyPairGenerator keyGen = Algorithms.keyPairGenerator(keyType, parameterSpec, secureRandom, provider);
             return keyGen.generateKeyPair();
         }
 

--- a/pkitesting/src/main/java/io/netty5/pkitesting/RevocationServer.java
+++ b/pkitesting/src/main/java/io/netty5/pkitesting/RevocationServer.java
@@ -22,6 +22,7 @@ import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.security.Provider;
 import java.security.cert.X509Certificate;
 import java.time.Instant;
 import java.util.Collections;
@@ -120,10 +121,20 @@ public final class RevocationServer {
      * @param issuer The issuer to register.
      */
     public void register(X509Bundle issuer) {
+        register(issuer, null);
+    }
+
+    /**
+     * Register an issuer with the revocation server.
+     * This must be done before CRLs can be served for that issuer, and before any of its certificates can be revoked.
+     * @param issuer The issuer to register.
+     * @param provider The {@code Provider} to use (or {@code null} to fallback to default)
+     */
+    public void register(X509Bundle issuer, Provider provider) {
         issuers.computeIfAbsent(issuer.getCertificate(), bundle -> {
             String path = "/crl/" + issuerCounter.incrementAndGet() + ".crl";
             URI uri = URI.create(crlBaseAddress + path);
-            CrlInfo info = new CrlInfo(issuer, uri);
+            CrlInfo info = new CrlInfo(issuer, uri, provider);
             paths.put(path, info);
             return info;
         });
@@ -169,7 +180,7 @@ public final class RevocationServer {
         CertificateList list = new CertificateList(issuer, now, now, certs.entrySet());
         try {
             Signed signed = new Signed(list.getEncoded(), issuer);
-            return signed.getEncoded();
+            return signed.getEncoded(info.provider);
         } catch (Exception e) {
             throw new IllegalStateException("Failed to sign CRL", e);
         }
@@ -179,10 +190,12 @@ public final class RevocationServer {
         private final X509Bundle issuer;
         private final URI uri;
         private final Map<BigInteger, Instant> revokedCerts;
+        private final Provider provider;
 
-        CrlInfo(X509Bundle issuer, URI uri) {
+        CrlInfo(X509Bundle issuer, URI uri, Provider provider) {
             this.issuer = issuer;
             this.uri = uri;
+            this.provider = provider;
             revokedCerts = new ConcurrentHashMap<>();
         }
     }

--- a/pkitesting/src/main/java/io/netty5/pkitesting/Signed.java
+++ b/pkitesting/src/main/java/io/netty5/pkitesting/Signed.java
@@ -29,6 +29,7 @@ import java.io.UncheckedIOException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
+import java.security.Provider;
 import java.security.Signature;
 import java.security.SignatureException;
 import java.util.Objects;
@@ -48,8 +49,8 @@ final class Signed {
         this.privateKey = privateKey;
     }
 
-    byte[] getEncoded() throws NoSuchAlgorithmException, InvalidKeyException, SignatureException {
-        Signature signature = Algorithms.signature(algorithmIdentifier);
+    byte[] getEncoded(Provider provider) throws NoSuchAlgorithmException, InvalidKeyException, SignatureException {
+        Signature signature = Algorithms.signature(algorithmIdentifier, provider);
         signature.initSign(privateKey);
         signature.update(toBeSigned);
         byte[] signatureBytes = signature.sign();
@@ -65,7 +66,8 @@ final class Signed {
         }
     }
 
-    InputStream toInputStream() throws NoSuchAlgorithmException, SignatureException, InvalidKeyException {
-        return new ByteArrayInputStream(getEncoded());
+    InputStream toInputStream(Provider provider)
+            throws NoSuchAlgorithmException, SignatureException, InvalidKeyException {
+        return new ByteArrayInputStream(getEncoded(provider));
     }
 }

--- a/pkitesting/src/test/java/io/netty5/pkitesting/CertificateBuilderTest.java
+++ b/pkitesting/src/test/java/io/netty5/pkitesting/CertificateBuilderTest.java
@@ -18,14 +18,19 @@ package io.netty5.pkitesting;
 import io.netty5.pkitesting.CertificateBuilder.Algorithm;
 import io.netty5.pkitesting.CertificateBuilder.KeyUsage;
 import io.netty5.util.internal.PlatformDependent;
+
+import org.bouncycastle.jsse.provider.BouncyCastleJsseProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.math.BigInteger;
 import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
 import java.security.SecureRandom;
 import java.security.Signature;
 import java.security.cert.CertPathBuilder;
@@ -92,7 +97,18 @@ class CertificateBuilderTest {
         assumeTrue(algorithm != Algorithm.rsa4096 && algorithm != Algorithm.rsa8192);
         assumeTrue(algorithm.isSupported());
 
-        KeyPair keyPair = algorithm.generateKeyPair(RNG);
+        KeyPair keyPair = algorithm.generateKeyPair(RNG, null);
+        assertNotNull(keyPair);
+        assertNotNull(keyPair.getPrivate());
+        assertNotNull(keyPair.getPublic());
+    }
+
+    @ParameterizedTest
+    @EnumSource(names = {"ecp256", "ecp384", "rsa2048", "rsa3072"})
+    void createKeyPairWithProvider(Algorithm algorithm) throws Exception {
+        assumeTrue(algorithm.isSupported());
+
+        KeyPair keyPair = algorithm.generateKeyPair(RNG, new BouncyCastleJsseProvider());
         assertNotNull(keyPair);
         assertNotNull(keyPair.getPrivate());
         assertNotNull(keyPair.getPublic());
@@ -132,6 +148,28 @@ class CertificateBuilderTest {
             mlDsaBuilder.buildIssuedBy(mlKemBundle);
         });
         assertThat(e).hasMessageContaining("cannot be used for signing");
+    }
+
+    @ParameterizedTest
+    @EnabledForJreRange(
+            max = JRE.JAVA_11,
+            disabledReason = "EdXxx are supported in recent Java version")
+    @EnumSource(names = {"ed25519", "ed448"})
+    void createEdCertsWithProvider(Algorithm algorithm) throws Exception {
+        CertificateBuilder builder = BASE.copy()
+                .algorithm(algorithm)
+                .provider(new BouncyCastleJsseProvider());
+
+        CertificateBuilder mlDsaBuilder = BASE.copy()
+                .algorithm(Algorithm.rsa2048);
+        X509Bundle issuer = mlDsaBuilder
+                .subject("CN=issuer.netty.io, O=Netty")
+                .setIsCertificateAuthority(true)
+                .buildSelfSigned();
+
+        // edXxx are not supported by BouncyCastleJsseProvider
+        assertThrows(NoSuchAlgorithmException.class,
+            () -> builder.buildIssuedBy(issuer));
     }
 
     @Test
@@ -215,7 +253,7 @@ class CertificateBuilderTest {
         assertThat(leaf.getCertificate().getIssuerX500Principal()).isEqualTo(
                 new X500Principal(SUBJECT));
 
-        Signature signature = Algorithms.signature(leaf.getCertificate().getSigAlgName());
+        Signature signature = Algorithms.signature(leaf.getCertificate().getSigAlgName(), null);
         signature.initVerify(root.getCertificate());
         signature.update(leaf.getCertificate().getTBSCertificate());
         assertTrue(signature.verify(leaf.getCertificate().getSignature()));
@@ -237,7 +275,7 @@ class CertificateBuilderTest {
         assertThat(leaf.getCertificate().getIssuerX500Principal()).isEqualTo(
                 new X500Principal(SUBJECT));
 
-        Signature signature = Algorithms.signature(leaf.getCertificate().getSigAlgName());
+        Signature signature = Algorithms.signature(leaf.getCertificate().getSigAlgName(), null);
         signature.initVerify(root.getCertificate());
         signature.update(leaf.getCertificate().getTBSCertificate());
         assertTrue(signature.verify(leaf.getCertificate().getSignature()));
@@ -320,14 +358,15 @@ class CertificateBuilderTest {
         assertThat(NOW.plus(1, DAYS).truncatedTo(SECONDS).toEpochMilli()).isEqualTo(cert.getNotAfter().getTime());
     }
 
-    @Test
-    void validCertificatesWithCrlMustPassValidation() throws Exception {
+    @ParameterizedTest
+    @MethodSource("providers")
+    void validCertificatesWithCrlMustPassValidation(Provider provider) throws Exception {
         X509Bundle root = BASE.copy()
                 .setIsCertificateAuthority(true)
                 .setKeyUsage(true, KeyUsage.digitalSignature, KeyUsage.keyCertSign, KeyUsage.cRLSign)
                 .buildSelfSigned();
         RevocationServer server = RevocationServer.getInstance();
-        server.register(root);
+        server.register(root, provider);
         X509Bundle cert = BASE.copy()
                 .subject("CN=leaf.netty.io")
                 .addCrlDistributionPoint(server.getCrlUri(root))
@@ -340,14 +379,15 @@ class CertificateBuilderTest {
         tm.checkClientTrusted(cert.getCertificatePath(), "EC");
     }
 
-    @Test
-    void revokedCertificatesWithCrlMustFailValidation() throws Exception {
+    @ParameterizedTest
+    @MethodSource("providers")
+    void revokedCertificatesWithCrlMustFailValidation(Provider provider) throws Exception {
         X509Bundle root = BASE.copy()
                 .setIsCertificateAuthority(true)
                 .setKeyUsage(true, KeyUsage.digitalSignature, KeyUsage.keyCertSign, KeyUsage.cRLSign)
                 .buildSelfSigned();
         RevocationServer server = RevocationServer.getInstance();
-        server.register(root);
+        server.register(root, provider);
         X509Bundle cert = BASE.copy()
                 .subject("CN=leaf.netty.io")
                 .addCrlDistributionPoint(server.getCrlUri(root))
@@ -369,7 +409,7 @@ class CertificateBuilderTest {
                 .setIsCertificateAuthority(true)
                 .setKeyUsage(true, KeyUsage.digitalSignature, KeyUsage.keyCertSign, KeyUsage.cRLSign)
                 .buildSelfSigned();
-        KeyPair keyPair = Algorithm.ecp256.generateKeyPair(new SecureRandom());
+        KeyPair keyPair = Algorithm.ecp256.generateKeyPair(new SecureRandom(), null);
         X509Bundle bundle = BASE.copy()
                 .subject("CN=leaf.netty.io")
                 .publicKey(keyPair.getPublic())
@@ -392,5 +432,12 @@ class CertificateBuilderTest {
 
         tmf.init(new CertPathTrustManagerParameters(params));
         return (X509TrustManager) tmf.getTrustManagers()[0];
+    }
+
+    private static Provider[] providers() {
+        return new Provider[] {
+            null /* default */,
+            new BouncyCastleJsseProvider()
+        };
     }
 }


### PR DESCRIPTION
Forwardport of https://github.com/netty/netty/pull/15722 

Motivation:

The 4.2 release introduced a new module, `netty-pkitesting`, which includes a `CertificateBuilder` class. It greatly simplifies the certificate generation but one particular limitation that we run into is that `CertificateBuilder` implementation only supports `BouncyCastleProvider` (see please
https://github.com/netty/netty/blob/4.2/pkitesting/src/main/java/io/netty/pkitesting/Algorithms.java#L93).

In OpenSearch fe we are working towards supporting FIPS mode and use `BouncyCastleFipsProvider` only (which Netty is also aware of, see please
https://github.com/netty/netty/blob/4.2/handler/src/main/java/io/netty/handler/ssl/util/BouncyCastleUtil.java#L37). The `CertificateBuilder` class would greatly simplify the testing efforts but we could not use it with non-default provider.

Modification:

Allow `CertificateBuilder` to specify `Provider` instance to use.

Result:

```java
      CertificateBuilder builder = new CertificateBuilder()
                .algorithm(algorithm)
                .provider(new BouncyCastleJsseProvider());
```

---------

