### PR TITLE
Use unpooled allocator by default on small heap sizes

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -76,8 +76,17 @@ public final class ByteBufUtil {
     static final ByteBufAllocator DEFAULT_ALLOCATOR;
 
     static {
-        String allocType = SystemPropertyUtil.get(
-                "io.netty.allocator.type", "adaptive");
+        String allocType = SystemPropertyUtil.get("io.netty.allocator.type");
+
+        if (allocType == null) {
+            long adaptivePoolThreshold = 512 * 1024 * 1024;
+            if (PlatformDependent.maxDirectMemory() >= adaptivePoolThreshold ||
+                    Runtime.getRuntime().maxMemory() >= adaptivePoolThreshold) {
+                allocType = "adaptive";
+            } else {
+                allocType = "unpooled";
+            }
+        }
 
         ByteBufAllocator alloc;
         if ("unpooled".equals(allocType)) {


### PR DESCRIPTION
Motivation:

With small heap sizes, the overhead of maintaining multiple memory pools can quickly lead to out of memory issues. The adaptive allocator in particular has this problem.

See #15726

Modification:

When both the Xmx and the estimated max direct memory do not exceed 512M, use the unpooled allocator by default instead.

Result:

Fewer memory problems by default on small JVMs.

WDYT?