### PR TITLE
Improve adaptive allocator thread local performance

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -24,7 +24,6 @@ import io.netty.util.Recycler.EnhancedHandle;
 import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.concurrent.FastThreadLocalThread;
 import io.netty.util.concurrent.MpscIntQueue;
-import io.netty.util.internal.ObjectPool;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.RefCnt;
@@ -549,8 +548,8 @@ final class AdaptivePoolingAllocator {
         private static final int MIN_SEGMENTS_PER_CHUNK = 32;
         private final int segmentSize;
         private final int chunkSize;
+        // this is stored from big to small segment offsets
         private final int[] segmentOffsets;
-        private final short[] reversedCompressedOffsets;
 
         private SizeClassChunkControllerFactory(int segmentSize) {
             this.segmentSize = ObjectUtil.checkPositive(segmentSize, "segmentSize");
@@ -558,35 +557,15 @@ final class AdaptivePoolingAllocator {
             final int segmentsCount = chunkSize / segmentSize;
             segmentOffsets = new int[segmentsCount];
             int segmentOffset = 0;
-            for (int i = 0; i < segmentsCount; i++) {
+            for (int i = segmentsCount - 1; i >= 0; i--) {
                 segmentOffsets[i] = segmentOffset;
                 segmentOffset += segmentSize;
             }
-            // chunkSize has a range of [128 KiB, 528 kiB] and segment count [32, 4096]
-            assert (segmentSize & 31) == 0;
-            assert compressSegmentOffset(chunkSize) > 0;
-            final short compressedSegmentSize = compressSegmentOffset(segmentSize);
-            assert compressedSegmentSize > 0;
-            reversedCompressedOffsets = new short[segmentsCount];
-            short compressedOffset = 0;
-            for (int i = 0; i < segmentsCount; i++) {
-                reversedCompressedOffsets[(segmentsCount - i) - 1] = compressedOffset;
-                compressedOffset += compressedSegmentSize;
-            }
-        }
-
-        public static short compressSegmentOffset(int segmentOffset) {
-            return (short) (segmentOffset >> 5);
-        }
-
-        public static int uncompressSegmentOffset(short compressedOffset) {
-            return compressedOffset << 5;
         }
 
         @Override
         public ChunkController create(MagazineGroup group) {
-            return new SizeClassChunkController(group, segmentSize, chunkSize,
-                                                segmentOffsets, reversedCompressedOffsets);
+            return new SizeClassChunkController(group, segmentSize, chunkSize, segmentOffsets);
         }
     }
 
@@ -597,16 +576,13 @@ final class AdaptivePoolingAllocator {
         private final int chunkSize;
         private final ChunkRegistry chunkRegistry;
         private final int[] segmentOffsets;
-        private final short[] reversedCompressedOffsets;
 
-        private SizeClassChunkController(MagazineGroup group, int segmentSize, int chunkSize,
-                                         int[] segmentOffsets, short[] reversedCompressedOffsets) {
+        private SizeClassChunkController(MagazineGroup group, int segmentSize, int chunkSize, int[] segmentOffsets) {
             chunkAllocator = group.chunkAllocator;
             this.segmentSize = segmentSize;
             this.chunkSize = chunkSize;
             chunkRegistry = group.allocator.chunkRegistry;
             this.segmentOffsets = segmentOffsets;
-            this.reversedCompressedOffsets = reversedCompressedOffsets;
         }
 
         @Override
@@ -625,8 +601,7 @@ final class AdaptivePoolingAllocator {
             AbstractByteBuf chunkBuffer = chunkAllocator.allocate(chunkSize, chunkSize);
             assert chunkBuffer.capacity() == chunkSize;
             SizeClassedChunk chunk = new SizeClassedChunk(chunkBuffer, magazine, true,
-                                                          segmentSize, segmentOffsets, reversedCompressedOffsets,
-                                                          size -> false);
+                                                          segmentSize, segmentOffsets, size -> false);
             chunkRegistry.add(chunk);
             return chunk;
         }
@@ -1340,12 +1315,12 @@ final class AdaptivePoolingAllocator {
         }
     }
 
-    private static final class ShortStack {
+    private static final class IntStack {
 
-        private final short[] stack;
+        private final int[] stack;
         private int top;
 
-        ShortStack(short[] initialValues) {
+        IntStack(int[] initialValues) {
             stack = initialValues.clone();
             top = initialValues.length - 1;
         }
@@ -1354,13 +1329,13 @@ final class AdaptivePoolingAllocator {
             return top == -1;
         }
 
-        public short pop() {
-            final short last = stack[top];
+        public int pop() {
+            final int last = stack[top];
             top--;
             return last;
         }
 
-        public void push(short value) {
+        public void push(int value) {
             stack[top + 1] = value;
             top++;
         }
@@ -1374,12 +1349,11 @@ final class AdaptivePoolingAllocator {
         private static final int FREE_LIST_EMPTY = -1;
         private final int segmentSize;
         private final MpscIntQueue externalFreeList;
-        private final ShortStack localFreeList;
+        private final IntStack localFreeList;
         private Thread ownerThread;
 
         SizeClassedChunk(AbstractByteBuf delegate, Magazine magazine, boolean pooled, int segmentSize,
-                         int[] segmentOffsets, short[] reversedCompressedOffsets,
-                         ChunkReleasePredicate shouldReleaseChunk) {
+                         int[] segmentOffsets, ChunkReleasePredicate shouldReleaseChunk) {
             super(delegate, magazine, pooled, shouldReleaseChunk);
             this.segmentSize = segmentSize;
             int segmentCount = segmentOffsets.length;
@@ -1389,16 +1363,16 @@ final class AdaptivePoolingAllocator {
             this.ownerThread = magazine.group.ownerThread;
             if (ownerThread == null) {
                 externalFreeList.fill(segmentCount, new IntSupplier() {
-                    int counter;
+                    int counter = segmentCount - 1;
 
                     @Override
                     public int getAsInt() {
-                        return segmentOffsets[counter++];
+                        return segmentOffsets[counter--];
                     }
                 });
                 localFreeList = null;
             } else {
-                localFreeList = new ShortStack(reversedCompressedOffsets);
+                localFreeList = new IntStack(segmentOffsets);
             }
         }
 
@@ -1424,7 +1398,7 @@ final class AdaptivePoolingAllocator {
 
         private int nextAvailableSegmentOffset() {
             final int startIndex;
-            ShortStack localFreeList = this.localFreeList;
+            IntStack localFreeList = this.localFreeList;
             if (localFreeList != null) {
                 assert Thread.currentThread() == ownerThread;
                 if (localFreeList.isEmpty()) {
@@ -1433,7 +1407,7 @@ final class AdaptivePoolingAllocator {
                         throw new IllegalStateException("Free list is empty");
                     }
                 } else {
-                    startIndex = SizeClassChunkControllerFactory.uncompressSegmentOffset(localFreeList.pop());
+                    startIndex = localFreeList.pop();
                 }
             } else {
                 startIndex = externalFreeList.poll();
@@ -1447,7 +1421,7 @@ final class AdaptivePoolingAllocator {
         private int remainingCapacityOnFreeList() {
             final int segmentSize = this.segmentSize;
             int remainingCapacity = externalFreeList.size() * segmentSize;
-            ShortStack localFreeList = this.localFreeList;
+            IntStack localFreeList = this.localFreeList;
             if (localFreeList != null) {
                 assert Thread.currentThread() == ownerThread;
                 remainingCapacity += localFreeList.size() * segmentSize;
@@ -1483,9 +1457,9 @@ final class AdaptivePoolingAllocator {
         }
 
         private void releaseSegmentOffsetIntoFreeList(int startIndex) {
-            ShortStack localFreeList = this.localFreeList;
+            IntStack localFreeList = this.localFreeList;
             if (localFreeList != null && Thread.currentThread() == ownerThread) {
-                localFreeList.push(SizeClassChunkControllerFactory.compressSegmentOffset(startIndex));
+                localFreeList.push(startIndex);
             } else {
                 boolean segmentReturned = externalFreeList.offer(startIndex);
                 assert segmentReturned : "Unable to return segment " + startIndex + " to free list";

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -365,6 +365,7 @@ final class AdaptivePoolingAllocator {
         private final Queue<Chunk> chunkReuseQueue;
         private final StampedLock magazineExpandLock;
         private final Magazine threadLocalMagazine;
+        private Thread ownerThread;
         private volatile Magazine[] magazines;
         private volatile boolean freed;
 
@@ -377,9 +378,11 @@ final class AdaptivePoolingAllocator {
             this.chunkControllerFactory = chunkControllerFactory;
             chunkReuseQueue = createSharedChunkQueue();
             if (isThreadLocal) {
+                ownerThread = Thread.currentThread();
                 magazineExpandLock = null;
                 threadLocalMagazine = new Magazine(this, false, chunkReuseQueue, chunkControllerFactory.create(this));
             } else {
+                ownerThread = null;
                 magazineExpandLock = new StampedLock();
                 threadLocalMagazine = null;
                 Magazine[] mags = new Magazine[INITIAL_MAGAZINES];
@@ -470,14 +473,16 @@ final class AdaptivePoolingAllocator {
             boolean isAdded = chunkReuseQueue.offer(buffer);
             if (freed && isAdded) {
                 // Help to free the reuse queue.
-                freeChunkReuseQueue();
+                freeChunkReuseQueue(ownerThread);
             }
             return isAdded;
         }
 
         private void free() {
             freed = true;
+            Thread ownerThread = this.ownerThread;
             if (threadLocalMagazine != null) {
+                this.ownerThread = null;
                 threadLocalMagazine.free();
             } else {
                 long stamp = magazineExpandLock.writeLock();
@@ -490,14 +495,22 @@ final class AdaptivePoolingAllocator {
                     magazineExpandLock.unlockWrite(stamp);
                 }
             }
-            freeChunkReuseQueue();
+            freeChunkReuseQueue(ownerThread);
         }
 
-        private void freeChunkReuseQueue() {
+        private void freeChunkReuseQueue(Thread ownerThread) {
             for (;;) {
                 Chunk chunk = chunkReuseQueue.poll();
                 if (chunk == null) {
                     break;
+                }
+                if (ownerThread != null && chunk instanceof SizeClassedChunk) {
+                    SizeClassedChunk threadLocalChunk = (SizeClassedChunk) chunk;
+                    assert ownerThread == threadLocalChunk.ownerThread;
+                    // no release segment can ever happen from the owner Thread since it's not running anymore
+                    // This is required to let the ownerThread to be GC'ed despite there are AdaptiveByteBuf
+                    // that reference some thread local chunk
+                    threadLocalChunk.ownerThread = null;
                 }
                 chunk.release();
             }
@@ -537,20 +550,43 @@ final class AdaptivePoolingAllocator {
         private final int segmentSize;
         private final int chunkSize;
         private final int[] segmentOffsets;
+        private final short[] reversedCompressedOffsets;
 
         private SizeClassChunkControllerFactory(int segmentSize) {
             this.segmentSize = ObjectUtil.checkPositive(segmentSize, "segmentSize");
             chunkSize = Math.max(MIN_CHUNK_SIZE, segmentSize * MIN_SEGMENTS_PER_CHUNK);
-            int segmentsCount = chunkSize / segmentSize;
+            final int segmentsCount = chunkSize / segmentSize;
             segmentOffsets = new int[segmentsCount];
+            int segmentOffset = 0;
             for (int i = 0; i < segmentsCount; i++) {
-                segmentOffsets[i] = i * segmentSize;
+                segmentOffsets[i] = segmentOffset;
+                segmentOffset += segmentSize;
             }
+            // chunkSize has a range of [128 KiB, 528 kiB] and segment count [32, 4096]
+            assert (segmentSize & 31) == 0;
+            assert compressSegmentOffset(chunkSize) > 0;
+            final short compressedSegmentSize = compressSegmentOffset(segmentSize);
+            assert compressedSegmentSize > 0;
+            reversedCompressedOffsets = new short[segmentsCount];
+            short compressedOffset = 0;
+            for (int i = 0; i < segmentsCount; i++) {
+                reversedCompressedOffsets[(segmentsCount - i) - 1] = compressedOffset;
+                compressedOffset += compressedSegmentSize;
+            }
+        }
+
+        public static short compressSegmentOffset(int segmentOffset) {
+            return (short) (segmentOffset >> 5);
+        }
+
+        public static int uncompressSegmentOffset(short compressedOffset) {
+            return compressedOffset << 5;
         }
 
         @Override
         public ChunkController create(MagazineGroup group) {
-            return new SizeClassChunkController(group, segmentSize, chunkSize, segmentOffsets);
+            return new SizeClassChunkController(group, segmentSize, chunkSize,
+                                                segmentOffsets, reversedCompressedOffsets);
         }
     }
 
@@ -561,13 +597,16 @@ final class AdaptivePoolingAllocator {
         private final int chunkSize;
         private final ChunkRegistry chunkRegistry;
         private final int[] segmentOffsets;
+        private final short[] reversedCompressedOffsets;
 
-        private SizeClassChunkController(MagazineGroup group, int segmentSize, int chunkSize, int[] segmentOffsets) {
+        private SizeClassChunkController(MagazineGroup group, int segmentSize, int chunkSize,
+                                         int[] segmentOffsets, short[] reversedCompressedOffsets) {
             chunkAllocator = group.chunkAllocator;
             this.segmentSize = segmentSize;
             this.chunkSize = chunkSize;
             chunkRegistry = group.allocator.chunkRegistry;
             this.segmentOffsets = segmentOffsets;
+            this.reversedCompressedOffsets = reversedCompressedOffsets;
         }
 
         @Override
@@ -586,7 +625,8 @@ final class AdaptivePoolingAllocator {
             AbstractByteBuf chunkBuffer = chunkAllocator.allocate(chunkSize, chunkSize);
             assert chunkBuffer.capacity() == chunkSize;
             SizeClassedChunk chunk = new SizeClassedChunk(chunkBuffer, magazine, true,
-                    segmentSize, segmentOffsets, size -> false);
+                                                          segmentSize, segmentOffsets, reversedCompressedOffsets,
+                                                          size -> false);
             chunkRegistry.add(chunk);
             return chunk;
         }
@@ -1189,8 +1229,8 @@ final class AdaptivePoolingAllocator {
         /**
          * Called when a ByteBuf is done using its allocation in this chunk.
          */
-        boolean releaseSegment(int ignoredSegmentId) {
-            return release();
+        void releaseSegment(int ignoredSegmentId) {
+            release();
         }
 
         private void retain() {
@@ -1300,34 +1340,71 @@ final class AdaptivePoolingAllocator {
         }
     }
 
+    private static final class ShortStack {
+
+        private final short[] stack;
+        private int top;
+
+        ShortStack(short[] initialValues) {
+            stack = initialValues.clone();
+            top = initialValues.length - 1;
+        }
+
+        public boolean isEmpty() {
+            return top == -1;
+        }
+
+        public short pop() {
+            final short last = stack[top];
+            top--;
+            return last;
+        }
+
+        public void push(short value) {
+            stack[top + 1] = value;
+            top++;
+        }
+
+        public int size() {
+            return top + 1;
+        }
+    }
+
     private static final class SizeClassedChunk extends Chunk {
         private static final int FREE_LIST_EMPTY = -1;
         private final int segmentSize;
-        private final MpscIntQueue freeList;
+        private final MpscIntQueue externalFreeList;
+        private final ShortStack localFreeList;
+        private Thread ownerThread;
 
         SizeClassedChunk(AbstractByteBuf delegate, Magazine magazine, boolean pooled, int segmentSize,
-                         int[] segmentOffsets, ChunkReleasePredicate shouldReleaseChunk) {
+                         int[] segmentOffsets, short[] reversedCompressedOffsets,
+                         ChunkReleasePredicate shouldReleaseChunk) {
             super(delegate, magazine, pooled, shouldReleaseChunk);
             this.segmentSize = segmentSize;
             int segmentCount = segmentOffsets.length;
             assert delegate.capacity() / segmentSize == segmentCount;
-            assert segmentCount > 0: "Chunk must have a positive number of segments";
-            freeList = MpscIntQueue.create(segmentCount, FREE_LIST_EMPTY);
-            freeList.fill(segmentCount, new IntSupplier() {
-                int counter;
-                @Override
-                public int getAsInt() {
-                    return segmentOffsets[counter++];
-                }
-            });
+            assert segmentCount > 0 : "Chunk must have a positive number of segments";
+            externalFreeList = MpscIntQueue.create(segmentCount, FREE_LIST_EMPTY);
+            this.ownerThread = magazine.group.ownerThread;
+            if (ownerThread == null) {
+                externalFreeList.fill(segmentCount, new IntSupplier() {
+                    int counter;
+
+                    @Override
+                    public int getAsInt() {
+                        return segmentOffsets[counter++];
+                    }
+                });
+                localFreeList = null;
+            } else {
+                localFreeList = new ShortStack(reversedCompressedOffsets);
+            }
         }
 
         @Override
         public void readInitInto(AdaptiveByteBuf buf, int size, int startingCapacity, int maxCapacity) {
-            int startIndex = freeList.poll();
-            if (startIndex == FREE_LIST_EMPTY) {
-                throw new IllegalStateException("Free list is empty");
-            }
+            final int startIndex = nextAvailableSegmentOffset();
             allocatedBytes += segmentSize;
             Chunk chunk = this;
             chunk.retain();
@@ -1345,13 +1422,46 @@ final class AdaptivePoolingAllocator {
             }
         }
 
+        private int nextAvailableSegmentOffset() {
+            final int startIndex;
+            ShortStack localFreeList = this.localFreeList;
+            if (localFreeList != null) {
+                assert Thread.currentThread() == ownerThread;
+                if (localFreeList.isEmpty()) {
+                    startIndex = externalFreeList.poll();
+                    if (startIndex == FREE_LIST_EMPTY) {
+                        throw new IllegalStateException("Free list is empty");
+                    }
+                } else {
+                    startIndex = SizeClassChunkControllerFactory.uncompressSegmentOffset(localFreeList.pop());
+                }
+            } else {
+                startIndex = externalFreeList.poll();
+                if (startIndex == FREE_LIST_EMPTY) {
+                    throw new IllegalStateException("Free list is empty");
+                }
+            }
+            return startIndex;
+        }
+
+        private int remainingCapacityOnFreeList() {
+            final int segmentSize = this.segmentSize;
+            int remainingCapacity = externalFreeList.size() * segmentSize;
+            ShortStack localFreeList = this.localFreeList;
+            if (localFreeList != null) {
+                assert Thread.currentThread() == ownerThread;
+                remainingCapacity += localFreeList.size() * segmentSize;
+            }
+            return remainingCapacity;
+        }
+
         @Override
         public int remainingCapacity() {
             int remainingCapacity = super.remainingCapacity();
             if (remainingCapacity > segmentSize) {
                 return remainingCapacity;
             }
-            int updatedRemainingCapacity = freeList.size() * segmentSize;
+            int updatedRemainingCapacity = remainingCapacityOnFreeList();
             if (updatedRemainingCapacity == remainingCapacity) {
                 return remainingCapacity;
             }
@@ -1372,12 +1482,20 @@ final class AdaptivePoolingAllocator {
             return false;
         }
 
+        private void releaseSegmentOffsetIntoFreeList(int startIndex) {
+            ShortStack localFreeList = this.localFreeList;
+            if (localFreeList != null && Thread.currentThread() == ownerThread) {
+                localFreeList.push(SizeClassChunkControllerFactory.compressSegmentOffset(startIndex));
+            } else {
+                boolean segmentReturned = externalFreeList.offer(startIndex);
+                assert segmentReturned : "Unable to return segment " + startIndex + " to free list";
+            }
+        }
+
         @Override
-        boolean releaseSegment(int startIndex) {
-            boolean released = release();
-            boolean segmentReturned = freeList.offer(startIndex);
-            assert segmentReturned: "Unable to return segment " + startIndex + " to free list";
-            return released;
+        void releaseSegment(int startIndex) {
+            release();
+            releaseSegmentOffsetIntoFreeList(startIndex);
         }
     }
 

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -548,24 +548,15 @@ final class AdaptivePoolingAllocator {
         private static final int MIN_SEGMENTS_PER_CHUNK = 32;
         private final int segmentSize;
         private final int chunkSize;
-        // this is stored from big to small segment offsets
-        private final int[] segmentOffsets;
 
         private SizeClassChunkControllerFactory(int segmentSize) {
             this.segmentSize = ObjectUtil.checkPositive(segmentSize, "segmentSize");
             chunkSize = Math.max(MIN_CHUNK_SIZE, segmentSize * MIN_SEGMENTS_PER_CHUNK);
-            final int segmentsCount = chunkSize / segmentSize;
-            segmentOffsets = new int[segmentsCount];
-            int segmentOffset = 0;
-            for (int i = segmentsCount - 1; i >= 0; i--) {
-                segmentOffsets[i] = segmentOffset;
-                segmentOffset += segmentSize;
-            }
         }
 
         @Override
         public ChunkController create(MagazineGroup group) {
-            return new SizeClassChunkController(group, segmentSize, chunkSize, segmentOffsets);
+            return new SizeClassChunkController(group, segmentSize, chunkSize);
         }
     }
 
@@ -575,14 +566,38 @@ final class AdaptivePoolingAllocator {
         private final int segmentSize;
         private final int chunkSize;
         private final ChunkRegistry chunkRegistry;
-        private final int[] segmentOffsets;
 
-        private SizeClassChunkController(MagazineGroup group, int segmentSize, int chunkSize, int[] segmentOffsets) {
+        private SizeClassChunkController(MagazineGroup group, int segmentSize, int chunkSize) {
             chunkAllocator = group.chunkAllocator;
             this.segmentSize = segmentSize;
             this.chunkSize = chunkSize;
             chunkRegistry = group.allocator.chunkRegistry;
-            this.segmentOffsets = segmentOffsets;
+        }
+
+        private MpscIntQueue createEmptyFreeList() {
+            return MpscIntQueue.create(chunkSize / segmentSize, SizeClassedChunk.FREE_LIST_EMPTY);
+        }
+
+        private MpscIntQueue createFreeList() {
+            final int segmentsCount = chunkSize / segmentSize;
+            final MpscIntQueue freeList = MpscIntQueue.create(segmentsCount, SizeClassedChunk.FREE_LIST_EMPTY);
+            int segmentOffset = 0;
+            for (int i = 0; i < segmentsCount; i++) {
+                freeList.offer(segmentOffset);
+                segmentOffset += segmentSize;
+            }
+            return freeList;
+        }
+
+        private IntStack createLocalFreeList() {
+            final int segmentsCount = chunkSize / segmentSize;
+            int segmentOffset = chunkSize;
+            int[] offsets = new int[segmentsCount];
+            for (int i = 0; i < segmentsCount; i++) {
+                segmentOffset -= segmentSize;
+                offsets[i] = segmentOffset;
+            }
+            return new IntStack(offsets);
         }
 
         @Override
@@ -600,8 +615,7 @@ final class AdaptivePoolingAllocator {
         public Chunk newChunkAllocation(int promptingSize, Magazine magazine) {
             AbstractByteBuf chunkBuffer = chunkAllocator.allocate(chunkSize, chunkSize);
             assert chunkBuffer.capacity() == chunkSize;
-            SizeClassedChunk chunk = new SizeClassedChunk(chunkBuffer, magazine, true,
-                                                          segmentSize, segmentOffsets, size -> false);
+            SizeClassedChunk chunk = new SizeClassedChunk(chunkBuffer, magazine, this);
             chunkRegistry.add(chunk);
             return chunk;
         }
@@ -1321,7 +1335,7 @@ final class AdaptivePoolingAllocator {
         private int top;
 
         IntStack(int[] initialValues) {
-            stack = initialValues.clone();
+            stack = initialValues;
             top = initialValues.length - 1;
         }
 
@@ -1352,27 +1366,17 @@ final class AdaptivePoolingAllocator {
         private final IntStack localFreeList;
         private Thread ownerThread;
 
-        SizeClassedChunk(AbstractByteBuf delegate, Magazine magazine, boolean pooled, int segmentSize,
-                         int[] segmentOffsets, ChunkReleasePredicate shouldReleaseChunk) {
-            super(delegate, magazine, pooled, shouldReleaseChunk);
-            this.segmentSize = segmentSize;
-            int segmentCount = segmentOffsets.length;
-            assert delegate.capacity() / segmentSize == segmentCount;
-            assert segmentCount > 0 : "Chunk must have a positive number of segments";
-            externalFreeList = MpscIntQueue.create(segmentCount, FREE_LIST_EMPTY);
+        SizeClassedChunk(AbstractByteBuf delegate, Magazine magazine,
+                         SizeClassChunkController controller) {
+            super(delegate, magazine, true, ignoredSize -> false);
+            this.segmentSize = controller.segmentSize;
             this.ownerThread = magazine.group.ownerThread;
             if (ownerThread == null) {
-                externalFreeList.fill(segmentCount, new IntSupplier() {
-                    int counter = segmentCount - 1;
-
-                    @Override
-                    public int getAsInt() {
-                        return segmentOffsets[counter--];
-                    }
-                });
+                externalFreeList = controller.createFreeList();
                 localFreeList = null;
             } else {
-                localFreeList = new IntStack(segmentOffsets);
+                externalFreeList = controller.createEmptyFreeList();
+                localFreeList = controller.createLocalFreeList();
             }
         }
 

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -814,12 +814,33 @@ final class AdaptivePoolingAllocator {
         }
         private static final Chunk MAGAZINE_FREED = new Chunk();
 
-        private static final Recycler<AdaptiveByteBuf> EVENT_LOOP_LOCAL_BUFFER_POOL = new Recycler<AdaptiveByteBuf>() {
-            @Override
-            protected AdaptiveByteBuf newObject(Handle<AdaptiveByteBuf> handle) {
-                return new AdaptiveByteBuf(handle);
+        private static final class AdaptiveRecycler extends Recycler<AdaptiveByteBuf> {
+
+            private AdaptiveRecycler(boolean unguarded) {
+                // uses fast thread local
+                super(unguarded);
             }
-        };
+
+            private AdaptiveRecycler(int maxCapacity, boolean unguarded) {
+                // doesn't use fast thread local, shared
+                super(maxCapacity, unguarded);
+            }
+
+            @Override
+            protected AdaptiveByteBuf newObject(final Handle<AdaptiveByteBuf> handle) {
+                return new AdaptiveByteBuf((EnhancedHandle<AdaptiveByteBuf>) handle);
+            }
+
+            public static AdaptiveRecycler threadLocal() {
+                return new AdaptiveRecycler(true);
+            }
+
+            public static AdaptiveRecycler sharedWith(int maxCapacity) {
+                return new AdaptiveRecycler(maxCapacity, true);
+            }
+        }
+
+        private static final AdaptiveRecycler EVENT_LOOP_LOCAL_BUFFER_POOL = AdaptiveRecycler.threadLocal();
 
         private Chunk current;
         @SuppressWarnings("unused") // updated via NEXT_IN_LINE
@@ -827,8 +848,7 @@ final class AdaptivePoolingAllocator {
         private final MagazineGroup group;
         private final ChunkController chunkController;
         private final StampedLock allocationLock;
-        private final Queue<AdaptiveByteBuf> bufferQueue;
-        private final ObjectPool.Handle<AdaptiveByteBuf> handle;
+        private final AdaptiveRecycler recycler;
         private final Queue<Chunk> sharedChunkQueue;
 
         Magazine(MagazineGroup group, boolean shareable, Queue<Chunk> sharedChunkQueue,
@@ -839,17 +859,10 @@ final class AdaptivePoolingAllocator {
             if (shareable) {
                 // We only need the StampedLock if this Magazine will be shared across threads.
                 allocationLock = new StampedLock();
-                bufferQueue = PlatformDependent.newFixedMpmcQueue(MAGAZINE_BUFFER_QUEUE_CAPACITY);
-                handle = new ObjectPool.Handle<AdaptiveByteBuf>() {
-                    @Override
-                    public void recycle(AdaptiveByteBuf self) {
-                        bufferQueue.offer(self);
-                    }
-                };
+                recycler = AdaptiveRecycler.sharedWith(MAGAZINE_BUFFER_QUEUE_CAPACITY);
             } else {
                 allocationLock = null;
-                bufferQueue = null;
-                handle = null;
+                recycler = null;
             }
             this.sharedChunkQueue = sharedChunkQueue;
         }
@@ -1074,15 +1087,8 @@ final class AdaptivePoolingAllocator {
         }
 
         public AdaptiveByteBuf newBuffer() {
-            AdaptiveByteBuf buf;
-            if (handle == null) {
-                buf = EVENT_LOOP_LOCAL_BUFFER_POOL.get();
-            } else {
-                buf = bufferQueue.poll();
-                if (buf == null) {
-                    buf = new AdaptiveByteBuf(handle);
-                }
-            }
+            AdaptiveRecycler recycler = this.recycler;
+            AdaptiveByteBuf buf = recycler == null? EVENT_LOOP_LOCAL_BUFFER_POOL.get() : recycler.get();
             buf.resetRefCnt();
             buf.discardMarks();
             return buf;
@@ -1377,7 +1383,7 @@ final class AdaptivePoolingAllocator {
 
     static final class AdaptiveByteBuf extends AbstractReferenceCountedByteBuf {
 
-        private final ObjectPool.Handle<AdaptiveByteBuf> handle;
+        private final EnhancedHandle<AdaptiveByteBuf> handle;
 
         // this both act as adjustment and the start index for a free list segment allocation
         private int startIndex;
@@ -1389,7 +1395,7 @@ final class AdaptivePoolingAllocator {
         private boolean hasArray;
         private boolean hasMemoryAddress;
 
-        AdaptiveByteBuf(ObjectPool.Handle<AdaptiveByteBuf> recyclerHandle) {
+        AdaptiveByteBuf(EnhancedHandle<AdaptiveByteBuf> recyclerHandle) {
             super(0);
             handle = ObjectUtil.checkNotNull(recyclerHandle, "recyclerHandle");
         }
@@ -1866,12 +1872,7 @@ final class AdaptivePoolingAllocator {
             tmpNioBuf = null;
             chunk = null;
             rootParent = null;
-            if (handle instanceof EnhancedHandle) {
-                EnhancedHandle<AdaptiveByteBuf>  enhancedHandle = (EnhancedHandle<AdaptiveByteBuf>) handle;
-                enhancedHandle.unguardedRecycle(this);
-            } else {
-                handle.recycle(this);
-            }
+            handle.unguardedRecycle(this);
         }
     }
 

--- a/microbench/src/main/java/io/netty/microbench/buffer/ByteBufAllocatorAllocPatternBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/ByteBufAllocatorAllocPatternBenchmark.java
@@ -1,0 +1,629 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.buffer;
+
+import io.netty.buffer.AdaptiveByteBufAllocator;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import io.netty.util.concurrent.FastThreadLocalThread;
+import io.netty.util.internal.MathUtil;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.BenchmarkParams;
+
+import java.util.ArrayList;
+import java.util.SplittableRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+@Warmup(iterations = 10, time = 1)
+@Measurement(iterations = 10, time = 1)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@Threads(1)
+public class ByteBufAllocatorAllocPatternBenchmark extends AbstractMicrobenchmark {
+
+    public enum AllocatorType {
+        ADAPTIVE(AdaptiveByteBufAllocator::new),
+        POOLED(() -> PooledByteBufAllocator.DEFAULT);
+
+        private final Supplier<ByteBufAllocator> factory;
+
+        AllocatorType(Supplier<ByteBufAllocator> factory) {
+            this.factory = factory;
+        }
+
+        private ByteBufAllocator create() {
+            return factory.get();
+        }
+    }
+
+    @Param({ "ADAPTIVE" })
+    public AllocatorType allocatorType;
+
+    @Param({ "0", "200000" })
+    public int pollutionIterations;
+
+    private ByteBufAllocator allocator;
+
+    @State(Scope.Thread)
+    public static class AllocationPatternState {
+        private int[] releaseIndexes;
+        private int[] sizes;
+        private int nextReleaseIndex;
+        private int nextSizeIndex;
+        private ByteBuf[] buffers;
+        private ByteBufAllocator allocator;
+
+        @Setup
+        public void setup(ByteBufAllocatorAllocPatternBenchmark benchmark) {
+            this.allocator = benchmark.allocator;
+            releaseIndexes = new int[MAX_LIVE_BUFFERS];
+            sizes = new int[MathUtil.findNextPositivePowerOfTwo(FLATTEND_SIZE_ARRAY.length)];
+            SplittableRandom rand = new SplittableRandom(SEED);
+            // Pre-generate the to be released index.
+            for (int i = 0; i < releaseIndexes.length; i++) {
+                releaseIndexes[i] = rand.nextInt(releaseIndexes.length);
+            }
+            // Shuffle the `flattendSizeArray` to `sizes`.
+            for (int i = 0; i < sizes.length; i++) {
+                int sizeIndex = rand.nextInt(FLATTEND_SIZE_ARRAY.length);
+                sizes[i] = FLATTEND_SIZE_ARRAY[sizeIndex];
+            }
+            nextReleaseIndex = 0;
+            nextSizeIndex = 0;
+            buffers = new ByteBuf[MAX_LIVE_BUFFERS];
+        }
+
+        private int getNextReleaseIndex() {
+            int index = nextReleaseIndex;
+            nextReleaseIndex = (nextReleaseIndex + 1) & (releaseIndexes.length - 1);
+            return releaseIndexes[index];
+        }
+
+        private int getNextSizeIndex() {
+            int index = nextSizeIndex;
+            nextSizeIndex = (nextSizeIndex + 1) & (sizes.length - 1);
+            return index;
+        }
+
+        @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+        private static void release(ByteBuf buf) {
+            buf.release();
+        }
+
+        @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+        private static ByteBuf allocateHeap(ByteBufAllocator allocator, int size) {
+            return allocator.heapBuffer(size);
+        }
+
+        @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+        private static ByteBuf allocateDirect(ByteBufAllocator allocator, int size) {
+            return allocator.directBuffer(size);
+        }
+
+        @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+        public void performDirectAllocation() {
+            int size = sizes[getNextSizeIndex()];
+            int releaseIndex = getNextReleaseIndex();
+            ByteBuf[] buffers = this.buffers;
+            ByteBuf oldBuf = buffers[releaseIndex];
+            if (oldBuf != null) {
+                release(oldBuf);
+            }
+            ByteBuf newBuf = allocateDirect(allocator, size);
+            buffers[releaseIndex] = newBuf;
+        }
+
+        @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+        public void performHeapAllocation() {
+            int size = sizes[getNextSizeIndex()];
+            int releaseIndex = getNextReleaseIndex();
+            ByteBuf oldBuf = buffers[releaseIndex];
+            if (oldBuf != null) {
+                release(oldBuf);
+            }
+            ByteBuf newBuf = allocateHeap(allocator, size);
+            buffers[releaseIndex] = newBuf;
+        }
+
+        private static void releaseBufferArray(ByteBuf[] buffers) {
+            if (buffers == null) {
+                return;
+            }
+            for (int i = 0; i < buffers.length; i++) {
+                if (buffers[i] != null && buffers[i].refCnt() > 0) {
+                    buffers[i].release();
+                    buffers[i] = null;
+                }
+            }
+        }
+
+        @TearDown
+        public void tearDown() {
+            releaseBufferArray(buffers);
+        }
+    }
+
+    @Setup
+    public void setupAllocatorAndPollute(BenchmarkParams params) throws InterruptedException {
+        allocator = allocatorType.create();
+        if (pollutionIterations == 0) {
+            return;
+        }
+
+        final boolean directAllocation = params.getBenchmark().contains("Direct");
+
+        int perThreadIterations = pollutionIterations / 2;
+
+        Runnable pollutionTask = () -> {
+            AllocationPatternState state = new AllocationPatternState();
+            state.setup(this);
+            try {
+                if (directAllocation) {
+                    for (int i = 0; i < perThreadIterations; i++) {
+                        state.performDirectAllocation();
+                    }
+                } else {
+                    for (int i = 0; i < perThreadIterations; i++) {
+                        state.performHeapAllocation();
+                    }
+                }
+            } finally {
+                state.tearDown();
+            }
+        };
+
+        Thread normalThread = new Thread(pollutionTask);
+        Thread fastThread = new FastThreadLocalThread(pollutionTask);
+
+        normalThread.start();
+        fastThread.start();
+        normalThread.join();
+        fastThread.join();
+    }
+
+    @Benchmark
+    public void directAllocation(AllocationPatternState state) {
+        state.performDirectAllocation();
+    }
+
+    @Benchmark
+    public void heapAllocation(AllocationPatternState state) {
+        state.performHeapAllocation();
+    }
+
+    private static final int SEED = 42;
+    // Allocation size array.
+    private static final int[] FLATTEND_SIZE_ARRAY;
+
+    private static final int MAX_LIVE_BUFFERS = 8192;
+
+    // Use event-loop threads.
+    public ByteBufAllocatorAllocPatternBenchmark() {
+        super(true, false);
+    }
+
+    /**
+     * Copied from AllocationPatternSimulator.
+     * An allocation pattern derived from a web socket proxy service.
+     */
+    private static final int[] WEB_SOCKET_PROXY_PATTERN = {
+            // Size, Frequency
+            9, 316,
+            13, 3,
+            15, 10344,
+            17, 628,
+            21, 316,
+            36, 338,
+            48, 338,
+            64, 23,
+            128, 17,
+            256, 21272,
+            287, 69,
+            304, 65,
+            331, 11,
+            332, 7,
+            335, 2,
+            343, 2,
+            362, 1,
+            363, 16,
+            365, 17,
+            370, 11,
+            371, 51,
+            392, 11,
+            393, 4,
+            396, 3,
+            401, 1,
+            402, 3,
+            413, 1,
+            414, 2,
+            419, 16,
+            421, 1,
+            423, 16,
+            424, 46,
+            433, 1,
+            435, 1,
+            439, 3,
+            441, 13,
+            444, 3,
+            449, 1,
+            450, 1,
+            453, 2,
+            455, 3,
+            458, 3,
+            462, 7,
+            463, 8,
+            464, 1,
+            466, 59,
+            470, 1,
+            472, 2,
+            475, 1,
+            478, 2,
+            480, 12,
+            481, 16,
+            482, 2,
+            483, 2,
+            486, 1,
+            489, 2,
+            493, 2,
+            494, 1,
+            495, 1,
+            497, 14,
+            498, 1,
+            499, 2,
+            500, 58,
+            503, 1,
+            507, 1,
+            509, 2,
+            510, 2,
+            511, 13,
+            512, 3,
+            513, 4,
+            516, 1,
+            519, 2,
+            520, 1,
+            522, 5,
+            523, 1,
+            525, 15,
+            526, 1,
+            527, 55,
+            528, 2,
+            529, 1,
+            530, 1,
+            531, 3,
+            533, 1,
+            534, 1,
+            535, 1,
+            536, 10,
+            538, 4,
+            539, 3,
+            540, 2,
+            541, 1,
+            542, 3,
+            543, 10,
+            545, 5,
+            546, 1,
+            547, 14,
+            548, 1,
+            549, 53,
+            551, 1,
+            552, 1,
+            553, 1,
+            554, 1,
+            555, 2,
+            556, 11,
+            557, 3,
+            558, 7,
+            559, 4,
+            561, 3,
+            562, 1,
+            563, 6,
+            564, 3,
+            565, 13,
+            566, 31,
+            567, 24,
+            568, 1,
+            569, 1,
+            570, 4,
+            571, 2,
+            572, 9,
+            573, 7,
+            574, 3,
+            575, 2,
+            576, 4,
+            577, 2,
+            578, 7,
+            579, 12,
+            580, 38,
+            581, 22,
+            582, 1,
+            583, 3,
+            584, 5,
+            585, 9,
+            586, 9,
+            587, 6,
+            588, 3,
+            589, 5,
+            590, 8,
+            591, 23,
+            592, 42,
+            593, 3,
+            594, 5,
+            595, 11,
+            596, 10,
+            597, 7,
+            598, 5,
+            599, 13,
+            600, 26,
+            601, 41,
+            602, 8,
+            603, 14,
+            604, 18,
+            605, 14,
+            606, 16,
+            607, 35,
+            608, 57,
+            609, 74,
+            610, 13,
+            611, 24,
+            612, 22,
+            613, 52,
+            614, 88,
+            615, 28,
+            616, 23,
+            617, 37,
+            618, 70,
+            619, 74,
+            620, 31,
+            621, 59,
+            622, 110,
+            623, 37,
+            624, 67,
+            625, 110,
+            626, 55,
+            627, 140,
+            628, 71,
+            629, 141,
+            630, 141,
+            631, 147,
+            632, 190,
+            633, 254,
+            634, 349,
+            635, 635,
+            636, 5443,
+            637, 459,
+            639, 1,
+            640, 2,
+            642, 1,
+            644, 2,
+            645, 1,
+            647, 1,
+            649, 1,
+            650, 1,
+            652, 1,
+            655, 3,
+            656, 1,
+            658, 4,
+            659, 2,
+            660, 1,
+            661, 1,
+            662, 6,
+            663, 8,
+            664, 9,
+            665, 4,
+            666, 5,
+            667, 62,
+            668, 5,
+            693, 1,
+            701, 2,
+            783, 1,
+            941, 1,
+            949, 1,
+            958, 16,
+            988, 1,
+            1024, 29289,
+            1028, 1,
+            1086, 1,
+            1249, 2,
+            1263, 1,
+            1279, 24,
+            1280, 11,
+            1309, 1,
+            1310, 1,
+            1311, 2,
+            1343, 1,
+            1360, 2,
+            1483, 1,
+            1567, 1,
+            1957, 1,
+            2048, 2636,
+            2060, 1,
+            2146, 1,
+            2190, 1,
+            2247, 1,
+            2273, 1,
+            2274, 1,
+            2303, 106,
+            2304, 45,
+            2320, 1,
+            2333, 10,
+            2334, 14,
+            2335, 7,
+            2367, 7,
+            2368, 2,
+            2384, 7,
+            2399, 1,
+            2400, 14,
+            2401, 6,
+            2423, 1,
+            2443, 9,
+            2444, 1,
+            2507, 3,
+            3039, 1,
+            3140, 1,
+            3891, 1,
+            3893, 1,
+            4096, 26,
+            4118, 1,
+            4321, 1,
+            4351, 226,
+            4352, 15,
+            4370, 1,
+            4381, 1,
+            4382, 11,
+            4383, 10,
+            4415, 4,
+            4416, 3,
+            4432, 5,
+            4447, 1,
+            4448, 31,
+            4449, 14,
+            4471, 1,
+            4491, 42,
+            4492, 16,
+            4555, 26,
+            4556, 19,
+            4571, 1,
+            4572, 2,
+            4573, 53,
+            4574, 165,
+            5770, 1,
+            5803, 2,
+            6026, 1,
+            6144, 2,
+            6249, 1,
+            6278, 1,
+            6466, 1,
+            6680, 1,
+            6726, 2,
+            6728, 1,
+            6745, 1,
+            6746, 1,
+            6759, 1,
+            6935, 1,
+            6978, 1,
+            6981, 2,
+            6982, 1,
+            7032, 1,
+            7081, 1,
+            7086, 1,
+            7110, 1,
+            7172, 3,
+            7204, 2,
+            7236, 2,
+            7238, 1,
+            7330, 1,
+            7427, 3,
+            7428, 1,
+            7458, 1,
+            7459, 1,
+            7650, 2,
+            7682, 6,
+            7765, 1,
+            7937, 3,
+            7969, 1,
+            8192, 2,
+            8415, 1,
+            8447, 555,
+            8478, 3,
+            8479, 5,
+            8511, 2,
+            8512, 1,
+            8528, 1,
+            8543, 2,
+            8544, 9,
+            8545, 8,
+            8567, 1,
+            8587, 16,
+            8588, 12,
+            8650, 1,
+            8651, 9,
+            8652, 9,
+            8668, 3,
+            8669, 46,
+            8670, 195,
+            8671, 6,
+            10240, 4,
+            14336, 1,
+            14440, 4,
+            14663, 3,
+            14919, 1,
+            14950, 2,
+            15002, 1,
+            15159, 1,
+            15173, 2,
+            15205, 1,
+            15395, 1,
+            15396, 1,
+            15397, 2,
+            15428, 1,
+            15446, 1,
+            15619, 7,
+            15651, 5,
+            15683, 2,
+            15874, 8,
+            15906, 8,
+            15907, 2,
+            16128, 2,
+            16129, 37,
+            16161, 3,
+            16352, 2,
+            16383, 1,
+            16384, 42,
+            16610, 2,
+            16639, 9269,
+            16704, 2,
+            16736, 3,
+            16737, 2,
+            16779, 2,
+            16780, 7,
+            16843, 2,
+            16844, 5,
+            16860, 6,
+            16861, 67,
+            16862, 281,
+            16863, 13,
+            18432, 6,
+    };
+
+    static {
+        // Flat the WEB_SOCKET_PROXY_PATTERN.
+        ArrayList<Integer> sizeList = new ArrayList<>();
+        for (int i = 0; i < WEB_SOCKET_PROXY_PATTERN.length; i += 2) {
+            int size = WEB_SOCKET_PROXY_PATTERN[i];
+            int frequency = WEB_SOCKET_PROXY_PATTERN[i + 1];
+            for (int j = 0; j < frequency; j++) {
+                sizeList.add(size);
+            }
+        }
+        FLATTEND_SIZE_ARRAY = sizeList.stream().mapToInt(Integer::intValue).toArray();
+    }
+}


### PR DESCRIPTION
Motivation:

Adaptive allocator perform costly atomic operations in the thread local path, which reduce its performance

Modification:

Reduce the amount of atomic operations in the thread local allocation's fast path

Result:

Fixes #15571


These are the different variations I want to test:

- [x] Uses unguarded `Recycler`s
- [x] Implements "compressed" local free list (LIFO) 
- [x] Use a mpsc q for the reuse chunk q in the thread-local case 
**NO VISIBLE IMPROVEMENTS**
- [x] Guards `nextInLine`'s  `getAndSet` with a null check via volatile `get` first, since size classed chunks rarely end up into `nextInLine` (i.e. which is mostly `null`) 
**NO VISIBLE IMPROVEMENTS**
- [x] Implements a var handle based `MpscIntQueue` (done at 1c4e1e47f457b26c11b2795631a447b8056c8917)
**NO VISIBLE IMPROVEMENTS**
- [x] Remove the live/raw ref cnt as mentioned at https://github.com/netty/netty/pull/15736#issuecomment-3369747561
- [ ] Remove the ref count for size classed chunks (see 8953bbe41e502dcd5747fc58f6ce555a57e3ccc6 and 8cb1bf07c9cad4cb31a10576cef6f699bd31337e)
- [x] Use the "pinned" Recycler instead of the `FastThreadLocal`-based one