### PR TITLE
buffer: Fix JFR deadlock during ReturnChunkEvent initialization

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ReturnChunkEvent.java
+++ b/buffer/src/main/java/io/netty/buffer/ReturnChunkEvent.java
@@ -25,7 +25,7 @@ import jdk.jfr.Name;
 @Description("Triggered when a memory chunk is prepared for re-use by an allocator")
 final class ReturnChunkEvent extends AbstractChunkEvent {
     static final String NAME = "io.netty.ReturnChunk";
-    private static final FreeChunkEvent INSTANCE = new FreeChunkEvent();
+    private static final ReturnChunkEvent INSTANCE = new ReturnChunkEvent();
 
     /**
      * Statically check if this event is enabled.


### PR DESCRIPTION
Motivation:

ReturnChunkEvent uses the wrong event type for the isEventEnabled check.

Modification:

Use the right event type.

Result:

Avoids class initialization deadlocks when JFR is enabled on older JDKs, with no changes to event semantics.

Fixes #15742