### PR TITLE
Make MqttProperties property type constants public (#15386)

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttProperties.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttProperties.java
@@ -28,43 +28,43 @@ import java.util.ArrayList;
 public final class MqttProperties {
 
     // single byte properties
-    static final int PAYLOAD_FORMAT_INDICATOR = 0x01;
-    static final int REQUEST_PROBLEM_INFORMATION = 0x17;
-    static final int REQUEST_RESPONSE_INFORMATION = 0x19;
-    static final int MAXIMUM_QOS = 0x24;
-    static final int RETAIN_AVAILABLE = 0x25;
-    static final int WILDCARD_SUBSCRIPTION_AVAILABLE = 0x28;
-    static final int SUBSCRIPTION_IDENTIFIER_AVAILABLE = 0x29;
-    static final int SHARED_SUBSCRIPTION_AVAILABLE = 0x2A;
+    public static final int PAYLOAD_FORMAT_INDICATOR = 0x01;
+    public static final int REQUEST_PROBLEM_INFORMATION = 0x17;
+    public static final int REQUEST_RESPONSE_INFORMATION = 0x19;
+    public static final int MAXIMUM_QOS = 0x24;
+    public static final int RETAIN_AVAILABLE = 0x25;
+    public static final int WILDCARD_SUBSCRIPTION_AVAILABLE = 0x28;
+    public static final int SUBSCRIPTION_IDENTIFIER_AVAILABLE = 0x29;
+    public static final int SHARED_SUBSCRIPTION_AVAILABLE = 0x2A;
 
     // two bytes properties
-    static final int SERVER_KEEP_ALIVE = 0x13;
-    static final int RECEIVE_MAXIMUM = 0x21;
-    static final int TOPIC_ALIAS_MAXIMUM = 0x22;
-    static final int TOPIC_ALIAS = 0x23;
+    public static final int SERVER_KEEP_ALIVE = 0x13;
+    public static final int RECEIVE_MAXIMUM = 0x21;
+    public static final int TOPIC_ALIAS_MAXIMUM = 0x22;
+    public static final int TOPIC_ALIAS = 0x23;
 
     // four bytes properties
-    static final int PUBLICATION_EXPIRY_INTERVAL = 0x02;
-    static final int SESSION_EXPIRY_INTERVAL = 0x11;
-    static final int WILL_DELAY_INTERVAL = 0x18;
-    static final int MAXIMUM_PACKET_SIZE = 0x27;
+    public static final int PUBLICATION_EXPIRY_INTERVAL = 0x02;
+    public static final int SESSION_EXPIRY_INTERVAL = 0x11;
+    public static final int WILL_DELAY_INTERVAL = 0x18;
+    public static final int MAXIMUM_PACKET_SIZE = 0x27;
 
     // Variable Byte Integer
-    static final int SUBSCRIPTION_IDENTIFIER = 0x0B;
+    public static final int SUBSCRIPTION_IDENTIFIER = 0x0B;
 
     // UTF-8 Encoded String properties
-    static final int CONTENT_TYPE = 0x03;
-    static final int RESPONSE_TOPIC = 0x08;
-    static final int ASSIGNED_CLIENT_IDENTIFIER = 0x12;
-    static final int AUTHENTICATION_METHOD = 0x15;
-    static final int RESPONSE_INFORMATION = 0x1A;
-    static final int SERVER_REFERENCE = 0x1C;
-    static final int REASON_STRING = 0x1F;
-    static final int USER_PROPERTY = 0x26;
+    public static final int CONTENT_TYPE = 0x03;
+    public static final int RESPONSE_TOPIC = 0x08;
+    public static final int ASSIGNED_CLIENT_IDENTIFIER = 0x12;
+    public static final int AUTHENTICATION_METHOD = 0x15;
+    public static final int RESPONSE_INFORMATION = 0x1A;
+    public static final int SERVER_REFERENCE = 0x1C;
+    public static final int REASON_STRING = 0x1F;
+    public static final int USER_PROPERTY = 0x26;
 
     // Binary Data
-    static final int CORRELATION_DATA = 0x09;
-    static final int AUTHENTICATION_DATA = 0x16;
+    public static final int CORRELATION_DATA = 0x09;
+    public static final int AUTHENTICATION_DATA = 0x16;
 
     @Deprecated
     public enum MqttPropertyType {


### PR DESCRIPTION
Motivation:

In #15225 the MqttPropertyType enum was deprecated and a set of static constants was added to MqttProperties as a replacement. The constants are package-private however, so 3rd party code can not actually use them.

Modifications:

Change the access modifiers to public on all static constants.

Result:

3rd party code can now use the constants and avoid using the deprecated MqttPropertyType enum.

Fixes #15386.
