### PR TITLE
Re-enable reflective field accesses in native images

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -342,7 +342,7 @@ final class PlatformDependent0 {
                         Class<?> bitsClass =
                                 Class.forName("java.nio.Bits", false, getSystemClassLoader());
                         int version = javaVersion();
-                        if (!isNativeImage() && version >= 9) {
+                        if (version >= 9) {
                             // Java9/10 use all lowercase and later versions all uppercase.
                             String fieldName = version >= 11? "MAX_MEMORY" : "maxMemory";
                             // On Java9 and later we try to directly access the field as we can do this without


### PR DESCRIPTION
Motivation:

Reflective field accesses were initially disabled in
https://github.com/netty/netty/pull/10428 because back then native-image
did not support `Unsafe.staticFieldOffset()`.

This is no longer an issue since GraalVM 21.2.0 for JDK 11 (July 2021)
see
https://github.com/oracle/graal/commit/f97bdb527dc2c272b5cb17438f5691e20ac3b012

Modification:

Remove the check for native-image before accessing fields using `Unsafe`.

Result:

Netty can directly access fields necessary for `PlatformDependent0` initialization using `Unsafe`.

@franz1981 please review (PS: I have the "backport" for 4.1 ready as well)