### PR TITLE
Adjust the execution order of processCancelledTasks

### DIFF
--- a/common/src/main/java/io/netty/util/HashedWheelTimer.java
+++ b/common/src/main/java/io/netty/util/HashedWheelTimer.java
@@ -494,11 +494,11 @@ public class HashedWheelTimer implements Timer {
                 final long deadline = waitForNextTick();
                 if (deadline > 0) {
                     int idx = (int) (tick & mask);
-                    processCancelledTasks();
                     HashedWheelBucket bucket =
                             wheel[idx];
                     transferTimeoutsToBuckets();
                     bucket.expireTimeouts(deadline);
+                    processCancelledTasks();
                     tick++;
                 }
             } while (WORKER_STATE_UPDATER.get(HashedWheelTimer.this) == WORKER_STATE_STARTED);


### PR DESCRIPTION
Motivation:

The current delayed tasks support a cancel function, which is executed in the current work thread. This can lead to uncertain time consumption for the cancellation operation, and this consumption will directly further increase the delay of the currently due tasks.

Modification:

Since due tasks are more sensitive to delay than cancellation operations, I believe the order of cancellation operations should be adjusted: prioritize executing due tasks first, then perform cancellation operations.


Result:

Reduce the delay of due tasks
