### PR TITLE
Use exact byte length in `Unpooled#copiedBufferUtf8`

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/Unpooled.java
+++ b/buffer/src/main/java/io/netty/buffer/Unpooled.java
@@ -595,9 +595,10 @@ public final class Unpooled {
     private static ByteBuf copiedBufferUtf8(CharSequence string) {
         boolean release = true;
         // Mimic the same behavior as other copiedBuffer implementations.
-        ByteBuf buffer = ALLOC.heapBuffer(ByteBufUtil.utf8Bytes(string));
+        int byteLength = ByteBufUtil.utf8Bytes(string);
+        ByteBuf buffer = ALLOC.heapBuffer(byteLength);
         try {
-            ByteBufUtil.writeUtf8(buffer, string);
+            ByteBufUtil.reserveAndWriteUtf8(buffer, string, byteLength);
             release = false;
             return buffer;
         } finally {


### PR DESCRIPTION
Motivation:

The writeUtf8 method reserves the max number of bytes per char in the underlying buffer. However we have the exact byte length of the utf char sequence calculated already.

Modifications:

Use that exact byte length so the buffer does not need to grow.

Result:

The buffer will not need a grow on each operation.

Fixes #15751.

If there is no issue then describe the changes introduced by this PR.
