### PR TITLE
Prevent allocation loops when LeakPresenceDetector ResourceScope is closed

### DIFF
--- a/testsuite-common/src/main/java/io/netty/util/test/LeakPresenceExtension.java
+++ b/testsuite-common/src/main/java/io/netty/util/test/LeakPresenceExtension.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -123,8 +122,12 @@ public final class LeakPresenceExtension
         }
 
         @Override
-        protected ResourceScope currentScope() {
-            return Objects.requireNonNull(SCOPE.get(), "Resource created outside test?");
+        protected ResourceScope currentScope() throws AllocationProhibitedException {
+            ResourceScope scope = SCOPE.get();
+            if (scope == null) {
+                throw new AllocationProhibitedException("Resource created outside test?");
+            }
+            return scope;
         }
     }
 }

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -35,6 +35,7 @@ import io.netty.channel.unix.FileDescriptor;
 import io.netty.channel.unix.IovArray;
 import io.netty.channel.unix.SocketWritableByteChannel;
 import io.netty.channel.unix.UnixChannelUtil;
+import io.netty.util.LeakPresenceDetector;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.logging.InternalLogger;
@@ -726,7 +727,10 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
 
             // If oom will close the read event, release connection.
             // See https://github.com/netty/netty/issues/10434
-            if (allDataRead || cause instanceof OutOfMemoryError || cause instanceof IOException) {
+            if (allDataRead ||
+                    cause instanceof OutOfMemoryError ||
+                    cause instanceof LeakPresenceDetector.AllocationProhibitedException ||
+                    cause instanceof IOException) {
                 shutdownInput(true);
             }
         }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
@@ -33,6 +33,7 @@ import io.netty.channel.socket.DuplexChannel;
 import io.netty.channel.unix.IovArray;
 import io.netty.channel.unix.SocketWritableByteChannel;
 import io.netty.channel.unix.UnixChannelUtil;
+import io.netty.util.LeakPresenceDetector;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
@@ -591,7 +592,10 @@ public abstract class AbstractKQueueStreamChannel extends AbstractKQueueChannel 
 
                 // If oom will close the read event, release connection.
                 // See https://github.com/netty/netty/issues/10434
-                if (close || cause instanceof OutOfMemoryError || cause instanceof IOException) {
+                if (close ||
+                        cause instanceof OutOfMemoryError ||
+                        cause instanceof LeakPresenceDetector.AllocationProhibitedException ||
+                        cause instanceof IOException) {
                     shutdownInput(false);
                 }
             }

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
@@ -30,6 +30,7 @@ import io.netty.channel.internal.ChannelUtils;
 import io.netty.channel.socket.ChannelInputShutdownEvent;
 import io.netty.channel.socket.ChannelInputShutdownReadComplete;
 import io.netty.channel.socket.SocketChannelConfig;
+import io.netty.util.LeakPresenceDetector;
 import io.netty.util.internal.StringUtil;
 
 import java.io.IOException;
@@ -128,7 +129,10 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
 
             // If oom will close the read event, release connection.
             // See https://github.com/netty/netty/issues/10434
-            if (close || cause instanceof OutOfMemoryError || cause instanceof IOException) {
+            if (close ||
+                    cause instanceof OutOfMemoryError ||
+                    cause instanceof LeakPresenceDetector.AllocationProhibitedException ||
+                    cause instanceof IOException) {
                 closeOnRead(pipeline);
             }
         }

--- a/transport/src/main/java/io/netty/channel/oio/AbstractOioByteChannel.java
+++ b/transport/src/main/java/io/netty/channel/oio/AbstractOioByteChannel.java
@@ -28,6 +28,7 @@ import io.netty.channel.FileRegion;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.socket.ChannelInputShutdownEvent;
 import io.netty.channel.socket.ChannelInputShutdownReadComplete;
+import io.netty.util.LeakPresenceDetector;
 import io.netty.util.internal.StringUtil;
 
 import java.io.IOException;
@@ -96,7 +97,10 @@ public abstract class AbstractOioByteChannel extends AbstractOioChannel {
 
         // If oom will close the read event, release connection.
         // See https://github.com/netty/netty/issues/10434
-        if (close || cause instanceof OutOfMemoryError || cause instanceof IOException) {
+        if (close ||
+                cause instanceof OutOfMemoryError ||
+                cause instanceof LeakPresenceDetector.AllocationProhibitedException ||
+                cause instanceof IOException) {
             closeOnRead(pipeline);
         }
     }


### PR DESCRIPTION
Motivation:

When a ResourceScope is closed, attempting to allocate will throw an exception. This can lead to repeated read attempts in byte channels, leading to excessive exceptionCaught events and log messages.

Modification:

Introduce an AllocationProhibitedException that is treated like an OutOfMemoryError by channels.

Result:

No more excessive log output for broken tests.