### PR TITLE
Re-enable reflective field accesses in native images

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -393,7 +393,7 @@ final class PlatformDependent0 {
                         Class<?> bitsClass =
                                 Class.forName("java.nio.Bits", false, getSystemClassLoader());
                         int version = javaVersion();
-                        if (unsafeStaticFieldOffsetSupported() && version >= 9) {
+                        if (version >= 9) {
                             // Java9/10 use all lowercase and later versions all uppercase.
                             String fieldName = version >= 11? "MAX_MEMORY" : "maxMemory";
                             // On Java9 and later we try to directly access the field as we can do this without
@@ -605,10 +605,6 @@ final class PlatformDependent0 {
             }
             throw new Error(t);
         }
-    }
-
-    private static boolean unsafeStaticFieldOffsetSupported() {
-        return !RUNNING_IN_NATIVE_IMAGE;
     }
 
     static boolean isExplicitNoUnsafe() {


### PR DESCRIPTION
Backport of https://github.com/netty/netty/pull/15752

Motivation:

Reflective field accesses were initially disabled in
https://github.com/netty/netty/pull/10428 because back then native-image
did not support `Unsafe.staticFieldOffset()`.

This is no longer an issue since GraalVM 21.2.0 for JDK 11 (July 2021)
see
https://github.com/oracle/graal/commit/f97bdb527dc2c272b5cb17438f5691e20ac3b012

Modification:

Remove the check for native-image before accessing fields using `Unsafe`.

Result:

Netty can directly access fields necessary for `PlatformDependent0` initialization using `Unsafe`.

cc @franz1981 