### PR TITLE
IoUring: Add support for IORING_SETUP_CQE_MIXED

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionCallback.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionCallback.java
@@ -25,7 +25,8 @@ interface CompletionCallback {
      * @param flags         the flags
      * @param udata         the user data that was provided as part of the submission
      * @param extraCqeData  the extra data for the CQE. This will only be non-null of the ring was setup with
-     *                      {@code IORING_SETUP_CQE32}.
+     *                      {@code IORING_SETUP_CQE32} or {@code IORING_SETUP_CQE_MIXED} and {@code IORING_CQE_F_32} is
+     *                      set in {@code flags}.
      * @return              {@code true} if we more data (in a loop) can be handled be this callback, {@code false}
      *                      otherwise.
      */

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionQueue.java
@@ -55,7 +55,7 @@ final class CompletionQueue {
 
     CompletionQueue(ByteBuffer kHead, ByteBuffer kTail, int ringMask, int ringEntries, ByteBuffer kflags,
                     ByteBuffer completionQueueArray, int ringSize, long ringAddress,
-                    int ringFd, int ringCapacity, int cqeLength) {
+                    int ringFd, int ringCapacity, int cqeLength, boolean extraCqeDataNeeded) {
         this.khead = kHead;
         this.ktail = kTail;
         this.completionQueueArray = completionQueueArray;
@@ -69,19 +69,18 @@ final class CompletionQueue {
         this.ringMask = ringMask;
         ringHead = (int) INT_HANDLE.getVolatile(kHead, 0);
 
-        if (cqeLength == Native.CQE32_SIZE) {
+        if (extraCqeDataNeeded) {
             // Let's create the slices up front to reduce GC-pressure and also ensure that the user
             // can not escape the memory range.
+            // We slice every Native.CQE_SIZE to support IORING_SETUP_CQE32 and IORING_SETUP_CQE_MIXED.
             this.extraCqeData = new ByteBuffer[ringEntries];
             for (int i = 0; i < ringEntries; i++) {
-                int position = i * cqeLength + Native.CQE_SIZE;
+                int position = i * cqeLength;
                 completionQueueArray.position(position).limit(position + Native.CQE_SIZE);
                 extraCqeData[i] = completionQueueArray.slice();
                 completionQueueArray.clear();
             }
-            completionQueueArray.clear();
         } else {
-            assert cqeLength == Native.CQE_SIZE;
             this.extraCqeData = null;
         }
     }
@@ -126,16 +125,30 @@ final class CompletionQueue {
             int i = 0;
             while (ringHead != tail) {
                 int cqeIdx = cqeIdx(ringHead, ringMask);
-                int cqePosition = cqeIdx *  cqeLength;
+                int cqePosition = cqeIdx * cqeLength;
 
                 long udata = completionQueueArray.getLong(cqePosition + CQE_USER_DATA_FIELD);
                 int res = completionQueueArray.getInt(cqePosition + CQE_RES_FIELD);
                 int flags = completionQueueArray.getInt(cqePosition + CQE_FLAGS_FIELD);
 
                 ringHead++;
+                final ByteBuffer extraCqeData;
+                if ((flags & Native.IORING_CQE_F_32) != 0) {
+                    extraCqeData = extraCqeData(cqeIdx + 1);
+                    // We used mixed mode and this was a 32 byte CQE, let's increment the head once more.
+                    ringHead++;
+                } else if (cqeLength == Native.CQE32_SIZE) {
+                    extraCqeData = extraCqeData(cqeIdx + 1);
+                } else {
+                    extraCqeData = null;
+                }
+                // Check if we should just skip it.
+                if ((flags & Native.IORING_CQE_F_SKIP) == 0) {
+                    i++;
 
-                i++;
-                callback.handle(res, flags, udata, extraCqeData(cqeIdx));
+                    callback.handle(res, flags, udata, extraCqeData);
+                }
+
                 if (ringHead == tail) {
                     // Let's fetch the tail one more time as it might have changed because a completion might have
                     // triggered a submission (io_uring_enter). This can happen as we automatically submit once we
@@ -172,7 +185,10 @@ final class CompletionQueue {
                 long udata = completionQueueArray.getLong(cqePosition + CQE_USER_DATA_FIELD);
                 int res = completionQueueArray.getInt(cqePosition + CQE_RES_FIELD);
                 int flags = completionQueueArray.getInt(cqePosition + CQE_FLAGS_FIELD);
-
+                if ((flags & Native.IORING_CQE_F_32) != 0) {
+                    // We used mixed mode and this was a 32 byte CQE, let's increment the head once more.
+                    head++;
+                }
                 sb.add("(res=" + res).add(", flags=" + flags).add(", udata=" + udata).add(")");
             }
         }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -214,12 +214,13 @@ final class Native {
     static final byte IORING_OP_FIXED_FD_INSTALL = 54;
     static final byte IORING_OP_FTRUNCATE = 55;
     static final byte IORING_OP_BIND = 56;
-    static final byte IORING_CQE_F_BUFFER = 1 << 0;
-    static final byte IORING_CQE_F_MORE = 1 << 1;
-    static final byte IORING_CQE_F_SOCK_NONEMPTY = 1 << 2;
-    static final byte IORING_CQE_F_NOTIF = 1 << 3;
-    static final byte IORING_CQE_F_BUF_MORE = 1 << 4;
-
+    static final int IORING_CQE_F_BUFFER = 1 << 0;
+    static final int IORING_CQE_F_MORE = 1 << 1;
+    static final int IORING_CQE_F_SOCK_NONEMPTY = 1 << 2;
+    static final int IORING_CQE_F_NOTIF = 1 << 3;
+    static final int IORING_CQE_F_BUF_MORE = 1 << 4;
+    static final int IORING_CQE_F_SKIP = 1 << 5;
+    static final int IORING_CQE_F_32 = 1 << 15;
     static final int IORING_SETUP_CQSIZE = 1 << 3;
     static final int IORING_SETUP_CLAMP = 1 << 4;
 
@@ -230,6 +231,7 @@ final class Native {
     static final int IORING_SETUP_SINGLE_ISSUER = 1 << 12;
     static final int IORING_SETUP_DEFER_TASKRUN = 1 << 13;
     static final int IORING_SETUP_NO_SQARRAY = 1 << 16;
+    static final int IORING_SETUP_CQE_MIXED = 1 << 18;
     static final int IORING_CQE_BUFFER_SHIFT = 16;
 
     static final short IORING_POLL_ADD_MULTI = 1 << 0;
@@ -244,6 +246,8 @@ final class Native {
     static final short IORING_ACCEPT_MULTISHOT = 1 << 0;
     static final short IORING_ACCEPT_DONTWAIT = 1 << 1;
     static final short IORING_ACCEPT_POLL_FIRST = 1 << 2;
+
+    static final short IORING_NOP_CQE32 = 1 << 5;
 
     static final int IORING_FEAT_NODROP = 1 << 1;
     static final int IORING_FEAT_SUBMIT_STABLE = 1 << 2;
@@ -401,6 +405,7 @@ final class Native {
         int cqringFd = (int) values[8];
         int cqringCapacity = (int) values[9];
         int cqeLength = (setupFlags & IORING_SETUP_CQE32) == 0 ? CQE_SIZE : CQE32_SIZE;
+        boolean extraCqeDataNeeded = (setupFlags & (IORING_SETUP_CQE32 | IORING_SETUP_CQE_MIXED)) != 0;
         CompletionQueue completionQueue = new CompletionQueue(
                 Buffer.wrapMemoryAddressWithNativeOrder(cqkhead, Integer.BYTES),
                 Buffer.wrapMemoryAddressWithNativeOrder(cqktail, Integer.BYTES),
@@ -411,7 +416,7 @@ final class Native {
                 cqringSize,
                 cqringAddress,
                 cqringFd,
-                cqringCapacity, cqeLength);
+                cqringCapacity, cqeLength, extraCqeDataNeeded);
 
         long sqkhead = values[10];
         long sqktail = values[11];
@@ -588,7 +593,7 @@ final class Native {
         return true;
     }
 
-    static native boolean ioUringSetupSupportsFlags(int setupFlags);;
+    static native boolean ioUringSetupSupportsFlags(int setupFlags);
     private static native long[] ioUringSetup(int entries, int cqeSize, int setupFlags);
 
     static IoUringProbe ioUringProbe(int ringfd) {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/SubmissionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/SubmissionQueue.java
@@ -190,9 +190,13 @@ final class SubmissionQueue {
     }
 
     long addNop(byte flags, long udata) {
+        return addNop(flags, 0, udata);
+    }
+
+    long addNop(byte flags, int nopFlags, long udata) {
         // Mimic what liburing does:
         // https://github.com/axboe/liburing/blob/liburing-2.8/src/include/liburing.h#L592
-        return enqueueSqe(Native.IORING_OP_NOP, flags, (short) 0, -1, 0, 0, 0, 0, udata,
+        return enqueueSqe(Native.IORING_OP_NOP, flags, (short) 0, -1, 0, 0, 0, nopFlags, udata,
                 (short) 0, (short) 0, 0, 0);
     }
 


### PR DESCRIPTION
Motivation:

We should add support for IORING_SETUP_CQE_MIXED so the user can setup the ring with it later on. This is also the best way how to support IORING_OP_RECV_ZC in the future.

Modification:

- Add support for IORING_SETUP_CQE_MIXED by correctly handling completions.
- Add unit tests for it

Result:

Support IORING_SETUP_CQE_MIXED