### PR TITLE
IoUring: Simplify CompletionCallback.handle(...) method signaure

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionCallback.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionCallback.java
@@ -29,5 +29,5 @@ interface CompletionCallback {
      * @return              {@code true} if we more data (in a loop) can be handled be this callback, {@code false}
      *                      otherwise.
      */
-    boolean handle(int res, int flags, long udata, ByteBuffer extraCqeData);
+    void handle(int res, int flags, long udata, ByteBuffer extraCqeData);
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionQueue.java
@@ -135,10 +135,7 @@ final class CompletionQueue {
                 ringHead++;
 
                 i++;
-                if (!callback.handle(res, flags, udata, extraCqeData(cqeIdx))) {
-                    // Stop processing. as the callback can not handle any more completions for now,
-                    break;
-                }
+                callback.handle(res, flags, udata, extraCqeData(cqeIdx));
                 if (ringHead == tail) {
                     // Let's fetch the tail one more time as it might have changed because a completion might have
                     // triggered a submission (io_uring_enter). This can happen as we automatically submit once we

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/SubmissionQueueTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/SubmissionQueueTest.java
@@ -82,7 +82,6 @@ public class SubmissionQueueTest {
         assertFalse(completionQueue.hasCompletions());
         assertEquals(0, completionQueue.process((res, flags, data, cqeExtraData) -> {
             fail("Should not be called");
-            return false;
         }));
 
         // Ensure both return not null and also not segfault.
@@ -141,12 +140,12 @@ public class SubmissionQueueTest {
             assertNotEquals(0, ringBuffer.ioUringSubmissionQueue().flags() & Native.IORING_SQ_CQ_OVERFLOW);
 
             // The completion queue should have only had space for 2 events
-            int processed = completionQueue.process((res, flags, udata, extraCqeData) -> true);
+            int processed = completionQueue.process((res, flags, udata, extraCqeData) -> { });
             assertEquals(2, processed);
 
             // submit again to ensure we flush the event that did overflow
             submissionQueue.submitAndGetNow();
-            processed = completionQueue.process((res, flags, udata, extraCqeData) -> true);
+            processed = completionQueue.process((res, flags, udata, extraCqeData) -> { });
             assertEquals(1, processed);
 
             // Everything was processed and so the overflow flag should have been cleared
@@ -204,7 +203,6 @@ public class SubmissionQueueTest {
                 } else {
                     assertNull(extraCqeData);
                 }
-                return true;
             });
             assertEquals(1, processed);
             assertFalse(completionQueue.hasCompletions());


### PR DESCRIPTION
Motiviation:

There is is no need to be able to break the processing loop early. Let's just remove the ability by changing the return type of the handle method.

Modification:

- Change boolean to void as return type

Result:

Simplify and cleanup