### PR TITLE
IoUring: Use IORING_SETUP_CQE_MIXED by default if possible

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
@@ -40,6 +40,7 @@ public final class IoUring {
     private static final boolean IORING_POLL_ADD_MULTISHOT_SUPPORTED;
     private static final boolean IORING_REGISTER_IOWQ_MAX_WORKERS_SUPPORTED;
     private static final boolean IORING_SETUP_SUBMIT_ALL_SUPPORTED;
+    private static final boolean IORING_SETUP_CQE_MIXED_SUPPORTED;
     private static final boolean IORING_SETUP_CQ_SIZE_SUPPORTED;
     private static final boolean IORING_SETUP_SINGLE_ISSUER_SUPPORTED;
     private static final boolean IORING_SETUP_DEFER_TASKRUN_SUPPORTED;
@@ -71,6 +72,7 @@ public final class IoUring {
         boolean pollAddMultishotSupported = false;
         boolean registerIowqWorkersSupported = false;
         boolean submitAllSupported = false;
+        boolean cqeMixedSupported = false;
         boolean setUpCqSizeSupported = false;
         boolean singleIssuerSupported = false;
         boolean deferTaskrunSupported = false;
@@ -114,6 +116,7 @@ public final class IoUring {
                         pollAddMultishotSupported = Native.isPollAddMultiShotSupported(ioUringProbe);
                         registerIowqWorkersSupported = Native.isRegisterIoWqWorkerSupported(ringBuffer.fd());
                         submitAllSupported = Native.ioUringSetupSupportsFlags(Native.IORING_SETUP_SUBMIT_ALL);
+                        cqeMixedSupported = Native.ioUringSetupSupportsFlags(Native.IORING_SETUP_CQE_MIXED);
                         setUpCqSizeSupported = Native.ioUringSetupSupportsFlags(Native.IORING_SETUP_CQSIZE);
                         singleIssuerSupported = Native.ioUringSetupSupportsFlags(Native.IORING_SETUP_SINGLE_ISSUER);
                         // IORING_SETUP_DEFER_TASKRUN requires to also set IORING_SETUP_SINGLE_ISSUER.
@@ -158,6 +161,7 @@ public final class IoUring {
                         "IORING_RECVSEND_BUNDLE_SUPPORTED={}, " +
                         "REGISTER_IOWQ_MAX_WORKERS_SUPPORTED={}, " +
                         "SETUP_SUBMIT_ALL_SUPPORTED={}, " +
+                        "SETUP_CQE_MIXED_SUPPORTED={}, " +
                         "SETUP_SINGLE_ISSUER_SUPPORTED={}, " +
                         "SETUP_DEFER_TASKRUN_SUPPORTED={}, " +
                         "REGISTER_BUFFER_RING_SUPPORTED={}, " +
@@ -167,7 +171,7 @@ public final class IoUring {
                         ")", kernelVersion, socketNonEmptySupported, spliceSupported, acceptSupportNoWait,
                         acceptMultishotSupported, pollAddMultishotSupported, recvMultishotSupported,
                         recvsendBundleSupported, registerIowqWorkersSupported, submitAllSupported,
-                        singleIssuerSupported, deferTaskrunSupported,
+                        cqeMixedSupported, singleIssuerSupported, deferTaskrunSupported,
                         registerBufferRingSupported, registerBufferRingIncSupported,
                         sendZcSupported, sendmsgZcSupported
                 );
@@ -185,6 +189,7 @@ public final class IoUring {
         IORING_POLL_ADD_MULTISHOT_SUPPORTED = pollAddMultishotSupported;
         IORING_REGISTER_IOWQ_MAX_WORKERS_SUPPORTED = registerIowqWorkersSupported;
         IORING_SETUP_SUBMIT_ALL_SUPPORTED = submitAllSupported;
+        IORING_SETUP_CQE_MIXED_SUPPORTED = cqeMixedSupported;
         IORING_SETUP_CQ_SIZE_SUPPORTED = setUpCqSizeSupported;
         IORING_SETUP_SINGLE_ISSUER_SUPPORTED = singleIssuerSupported;
         IORING_SETUP_DEFER_TASKRUN_SUPPORTED = deferTaskrunSupported;
@@ -300,6 +305,10 @@ public final class IoUring {
 
     static boolean isSetupSubmitAllSupported() {
         return IORING_SETUP_SUBMIT_ALL_SUPPORTED;
+    }
+
+    static boolean isSetupCqeMixedSupported() {
+        return IORING_SETUP_CQE_MIXED_SUPPORTED;
     }
 
     static boolean isSetupSingleIssuerSupported() {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -382,6 +382,11 @@ final class Native {
         if (IoUring.isIoringSetupNoSqarraySupported()) {
             flags  |= Native.IORING_SETUP_NO_SQARRAY;
         }
+
+        // Use IORING_SETUP_CQE_MIXED by default if supported so we can support any OP in the future.
+        if (IoUring.isSetupCqeMixedSupported()) {
+            flags |= Native.IORING_SETUP_CQE_MIXED;
+        }
         return flags;
     }
 


### PR DESCRIPTION
Motivation:

We need to support large CQE for some IO and we can do this easily by using IORING_SETUP_CQE_MIXED by default.

Modification:

Use IORING_SETUP_CQE_MIXED by default if supported

Result:

Be able to support more IO ops and be more future proof.