### PR TITLE
fix build ci step in main

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -67,7 +67,7 @@ services:
 
   build-boringssl-snapshot:
     <<: *common
-    command: /bin/bash -cl "./mvnw -B -ntp -pl handler -Pboringssl-snapshot clean package -Dxml.skip=true -Dtcnative.classifier=linux-x86_64"
+    command: /bin/bash -cl "./mvnw -B -ntp -am -pl handler -Pboringssl-snapshot clean package -Dxml.skip=true -Dtcnative.classifier=linux-x86_64"
 
   shell:
     <<: *common


### PR DESCRIPTION
Motivation:
The CI build step `linux-x86_64-java25-boringssl-snapshot` is failing to due unresolved project dependencies.

Modification:
Add `-am` flag to maven command to also build projects required by the handler module.

Result:
The CI build step should no longer fail in main.
