### PR TITLE
Expose the list of supported io_uring features

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
@@ -143,40 +143,7 @@ public final class IoUring {
         } catch (Throwable t) {
             cause = t;
         }
-        if (cause != null) {
-            if (logger.isTraceEnabled()) {
-                logger.debug("IoUring support is not available using kernel {}", kernelVersion, cause);
-            } else if (logger.isDebugEnabled()) {
-                logger.debug("IoUring support is not available using kernel {}: {}", kernelVersion, cause.getMessage());
-            }
-        } else {
-            if (logger.isDebugEnabled()) {
-                logger.debug("IoUring support is available using kernel {} (" +
-                        "CQE_F_SOCK_NONEMPTY_SUPPORTED={}, " +
-                        "SPLICE_SUPPORTED={}, " +
-                        "ACCEPT_NO_WAIT_SUPPORTED={}, " +
-                        "ACCEPT_MULTISHOT_SUPPORTED={}, " +
-                        "POLL_ADD_MULTISHOT_SUPPORTED={} " +
-                        "RECV_MULTISHOT_SUPPORTED={}, " +
-                        "IORING_RECVSEND_BUNDLE_SUPPORTED={}, " +
-                        "REGISTER_IOWQ_MAX_WORKERS_SUPPORTED={}, " +
-                        "SETUP_SUBMIT_ALL_SUPPORTED={}, " +
-                        "SETUP_CQE_MIXED_SUPPORTED={}, " +
-                        "SETUP_SINGLE_ISSUER_SUPPORTED={}, " +
-                        "SETUP_DEFER_TASKRUN_SUPPORTED={}, " +
-                        "REGISTER_BUFFER_RING_SUPPORTED={}, " +
-                        "REGISTER_BUFFER_RING_INC_SUPPORTED={}, " +
-                        "SEND_ZC_SUPPORTED={}, " +
-                        "SENDMSG_ZC_SUPPORTED={}" +
-                        ")", kernelVersion, socketNonEmptySupported, spliceSupported, acceptSupportNoWait,
-                        acceptMultishotSupported, pollAddMultishotSupported, recvMultishotSupported,
-                        recvsendBundleSupported, registerIowqWorkersSupported, submitAllSupported,
-                        cqeMixedSupported, singleIssuerSupported, deferTaskrunSupported,
-                        registerBufferRingSupported, registerBufferRingIncSupported,
-                        sendZcSupported, sendmsgZcSupported
-                );
-            }
-        }
+        // Assign static finals first so printFeatures() (no-arg) can read them.
         UNAVAILABILITY_CAUSE = cause;
         IORING_CQE_F_SOCK_NONEMPTY_SUPPORTED = socketNonEmptySupported;
         IORING_SPLICE_SUPPORTED = spliceSupported;
@@ -217,6 +184,18 @@ public final class IoUring {
                     SystemPropertyUtil.getInt("io.netty.iouring.cqSize", 4096));
         } else {
             DEFAULT_CQ_SIZE = DISABLE_SETUP_CQ_SIZE;
+        }
+        // Now that all static fields are assigned, emit the debug log using the shared printFeatures()
+        if (cause != null) {
+            if (logger.isTraceEnabled()) {
+                logger.debug("IoUring support is not available using kernel {}", kernelVersion, cause);
+            } else if (logger.isDebugEnabled()) {
+                logger.debug("IoUring support is not available using kernel {}: {}", kernelVersion, cause.getMessage());
+            }
+        } else {
+            if (logger.isDebugEnabled()) {
+                logger.debug("IoUring support is available using kernel {}: {}", kernelVersion, supportedFeatures());
+            }
         }
     }
 
@@ -396,6 +375,47 @@ public final class IoUring {
 
     public static Throwable unavailabilityCause() {
         return UNAVAILABILITY_CAUSE;
+    }
+
+    private static String supportedFeatures() {
+        if (!isAvailable()) {
+            return "";
+        }
+        return "CQE_F_SOCK_NONEMPTY_SUPPORTED=" + IORING_CQE_F_SOCK_NONEMPTY_SUPPORTED
+                + ", SPLICE_SUPPORTED=" + IORING_SPLICE_SUPPORTED
+                + ", ACCEPT_NO_WAIT_SUPPORTED=" + IORING_ACCEPT_NO_WAIT_SUPPORTED
+                + ", ACCEPT_MULTISHOT_SUPPORTED=" + IORING_ACCEPT_MULTISHOT_SUPPORTED
+                + ", POLL_ADD_MULTISHOT_SUPPORTED=" + IORING_POLL_ADD_MULTISHOT_SUPPORTED
+                + ", RECV_MULTISHOT_SUPPORTED=" + IORING_RECV_MULTISHOT_SUPPORTED
+                + ", IORING_RECVSEND_BUNDLE_SUPPORTED=" + IORING_RECVSEND_BUNDLE_SUPPORTED
+                + ", REGISTER_IOWQ_MAX_WORKERS_SUPPORTED=" + IORING_REGISTER_IOWQ_MAX_WORKERS_SUPPORTED
+                + ", SETUP_SUBMIT_ALL_SUPPORTED=" + IORING_SETUP_SUBMIT_ALL_SUPPORTED
+                + ", SETUP_CQE_MIXED_SUPPORTED=" + IORING_SETUP_CQE_MIXED_SUPPORTED
+                + ", SETUP_CQ_SIZE_SUPPORTED=" + IORING_SETUP_CQ_SIZE_SUPPORTED
+                + ", SETUP_SINGLE_ISSUER_SUPPORTED=" + IORING_SETUP_SINGLE_ISSUER_SUPPORTED
+                + ", SETUP_DEFER_TASKRUN_SUPPORTED=" + IORING_SETUP_DEFER_TASKRUN_SUPPORTED
+                + ", SETUP_NO_SQARRAY_SUPPORTED=" + IORING_SETUP_NO_SQARRAY_SUPPORTED
+                + ", REGISTER_BUFFER_RING_SUPPORTED=" + IORING_REGISTER_BUFFER_RING_SUPPORTED
+                + ", REGISTER_BUFFER_RING_INC_SUPPORTED=" + IORING_REGISTER_BUFFER_RING_INC_SUPPORTED
+                + ", SEND_ZC_SUPPORTED=" + IORING_SEND_ZC_SUPPORTED
+                + ", SENDMSG_ZC_SUPPORTED=" + IORING_SENDMSG_ZC_SUPPORTED;
+    }
+
+    /**
+     * Returns a string representation of the io_uring support and feature set. This mirrors the
+     * debug logging output that reports each individual feature's availability.
+     */
+    public static String featureString() {
+        if (!isAvailable()) {
+            Throwable t = unavailabilityCause();
+            return "IoUring unavailable: " + (t == null ? "unknown cause" : t.toString());
+        }
+        return "IoUring features: " + supportedFeatures();
+    }
+
+    @Override
+    public String toString() {
+        return featureString();
     }
 
     private IoUring() {


### PR DESCRIPTION
Motivation:
Users have to enable debug logging to be aware of any unsupported feature which affect performance: it would be nice to make it more friendly via IoUring::toString

Modification:
Centralize the formatting of the list of supported features while enabling toString to use it

Result:
More user-friendly detection of unsupported features