### PR TITLE
Make the ubuntu devcontainer use SDK MAN

### DIFF
--- a/.devcontainer/ubuntu/Dockerfile
+++ b/.devcontainer/ubuntu/Dockerfile
@@ -20,7 +20,7 @@ RUN apt update && apt install -y \
 
 USER vscode
 RUN curl -s "https://get.sdkman.io" | bash
-ARG java_version="25-tem"
+ARG java_version="25-zulu"
 ENV JAVA_VERSION=$java_version
 RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && \
     yes | sdk install java $JAVA_VERSION && \


### PR DESCRIPTION
Motivation:
This makes it easier to install arbitrary Java versions, as oppose to just the ones available through the apt package repository.

Modification:
Install SDK MAN into the ubuntu devcontainer and use it to install Java, instead of relying on apt for that.

Result:
We can now more easily switch to whichever Java version we want in the devcontainer, without being limited to what's available through apt.