### PR TITLE
Make org.bouncycastle.jce.provider.BouncyCastleProvider optional by deferring initialization (#15756)

### DIFF
--- a/pkitesting/src/main/java/io/netty/pkitesting/Algorithms.java
+++ b/pkitesting/src/main/java/io/netty/pkitesting/Algorithms.java
@@ -91,9 +91,13 @@ final class Algorithms {
         }
     }
 
+    private static final class DefaultProvider {
+        private static final Provider INSTANCE = new BouncyCastleProvider();
+    }
+
     private static synchronized Provider bouncyCastle() {
         if (bouncyCastle == null) {
-            bouncyCastle = new BouncyCastleProvider();
+            bouncyCastle = DefaultProvider.INSTANCE;
         }
         return bouncyCastle;
     }


### PR DESCRIPTION
Motivation:

Initialization of the `Algorithms` class causes
`java.lang.ClassNotFoundException` if
`org.bouncycastle.jce.provider.BouncyCastleProvider` is not present on the classpath.

```
       Caused by:
        java.lang.ClassNotFoundException: org.bouncycastle.jce.provider.BouncyCastleProvider
            at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:580)
            at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:490)
            ... 6 more
```

Follow up to https://github.com/netty/netty/pull/15734

Modification:

Make `org.bouncycastle.jce.provider.BouncyCastleProvider` optional by deferring initialization.

Result:

In case the `CertificateBuilder` is configured with custom `provider` instance, `org.bouncycastle.jce.provider.BouncyCastleProvider` will never be initialized.

If there is no issue then describe the changes introduced by this PR.


(cherry picked from commit 81ac843258d210b77066492ec0227eff96eb0140)
