### PR TITLE
Update JDK versions to latest release

### DIFF
--- a/.github/scripts/check_java_ea_version.sh
+++ b/.github/scripts/check_java_ea_version.sh
@@ -17,7 +17,7 @@
 set -e
 
 # Keep this version in sync with docker-compose.centos-7.26.yaml
-export EXPECTED_VERSION='26.ea.19'
+export EXPECTED_VERSION='26.ea.20'
 
 curl -s "https://get.sdkman.io" | bash
 source "$HOME/.sdkman/bin/sdkman-init.sh"

--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -8,7 +8,7 @@ services:
       context: ../
       dockerfile: docker/Dockerfile.centos6
       args:
-        java_version : "8.0.462-zulu"
+        java_version : "8.0.472-zulu"
 
   build:
     image: netty:centos-6-1.8

--- a/docker/docker-compose.centos-7.111.yaml
+++ b/docker/docker-compose.centos-7.111.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-7-1.11
     build:
       args:
-        java_version : "11.0.28-zulu"
+        java_version : "11.0.29-zulu"
 
   build:
     image: netty:centos-7-1.11

--- a/docker/docker-compose.centos-7.117.yaml
+++ b/docker/docker-compose.centos-7.117.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-7-1.17
     build:
       args:
-        java_version : "17.0.16-zulu"
+        java_version : "17.0.17-zulu"
 
   build:
     image: netty:centos-7-1.17

--- a/docker/docker-compose.centos-7.18.yaml
+++ b/docker/docker-compose.centos-7.18.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-7-1.8
     build:
       args:
-        java_version : "8.0.462-zulu"
+        java_version : "8.0.472-zulu"
 
   build:
     image: netty:centos-7-1.8

--- a/docker/docker-compose.centos-7.21.yaml
+++ b/docker/docker-compose.centos-7.21.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-7-21
     build:
       args:
-        java_version : "21.0.8-zulu"
+        java_version : "21.0.9-zulu"
 
   build:
     image: netty:centos-7-21

--- a/docker/docker-compose.centos-7.25.yaml
+++ b/docker/docker-compose.centos-7.25.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-7-25
     build:
       args:
-        java_version : "25-zulu"
+        java_version : "25.0.1-zulu"
 
   build:
     image: netty:centos-7-25

--- a/docker/docker-compose.centos-7.26.yaml
+++ b/docker/docker-compose.centos-7.26.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-7-26
     build:
       args:
-        java_version : "26.ea.19-open"
+        java_version : "26.ea.20-open"
 
   build:
     image: netty:centos-7-26


### PR DESCRIPTION
Motivation:

There are JDK updates we should use them

Modifications:

- Update JDK versions

Result:

Use latest JDK versions