### PR TITLE
Add support for :protocol pseudo-header in Http3Headers

### DIFF
--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3Headers.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3Headers.java
@@ -51,8 +51,13 @@ public interface Http3Headers extends Headers<CharSequence, CharSequence, Http3H
         /**
          * {@code :status}.
          */
-        STATUS(":status", false, 0x10);
+        STATUS(":status", false, 0x10),
 
+        /**
+         * {@code :protocol}.
+         */
+        PROTOCOL(":protocol", true, 0x20);
+        
         private static final char PSEUDO_HEADER_PREFIX = ':';
         private static final byte PSEUDO_HEADER_PREFIX_BYTE = (byte) PSEUDO_HEADER_PREFIX;
 
@@ -185,6 +190,10 @@ public interface Http3Headers extends Headers<CharSequence, CharSequence, Http3H
     Http3Headers status(CharSequence value);
 
     /**
+     * Sets the {@link PseudoHeaderName#PROTOCOL} header
+     */
+    Http3Headers protocol(CharSequence value);
+    /**
      * Gets the {@link PseudoHeaderName#METHOD} header or {@code null} if there is no such header
      *
      * @return the value of the header.
@@ -223,6 +232,12 @@ public interface Http3Headers extends Headers<CharSequence, CharSequence, Http3H
      */
     @Nullable
     CharSequence status();
+
+    /**
+     * Gets the {@link PseudoHeaderName#PROTOCOL} header or {@code null} if not present
+     */
+    @Nullable
+    CharSequence protocol();
 
     /**
      * Returns {@code true} if a header with the {@code name} and {@code value} exists, {@code false} otherwise.


### PR DESCRIPTION

Introduce :protocol pseudo-header support in Http3Headers

Motivation:
This change introduces support for the :protocol pseudo-header in HTTP/3, which is required for protocols that extend HTTP semantics, such as WebTransport. Handling the :protocol header enables proper negotiation and identification of protocol-level behavior beyond standard HTTP/3 semantics.
Previously, Http3Headers did not provide methods to set or retrieve the :protocol pseudo-header, which limited the ability to implement protocol-specific extensions or future-proof HTTP/3 features that rely on this header.

Modification:
Added a new PROTOCOL pseudo-header constant to Http3Headers.
Ensured compatibility with existing HTTP/3 header handling.
This prepares the codebase for future protocol extensions such as WebTransport, or other application-level protocols requiring header negotiation.

Result:
Http3Headers now supports the :protocol pseudo-header.
Enables proper implementation of protocol-specific extensions on top of HTTP/3.
Future-proofing the HTTP/3 stack for WebTransport and other emerging protocols.

Fixes: #<GitHub issue number> (if applicable) NA