### PR TITLE
Update JDK versions to latest release (#15789)

### DIFF
--- a/docker/docker-compose.centos-6.111.yaml
+++ b/docker/docker-compose.centos-6.111.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-6-1.11
     build:
       args:
-        java_version : "11.0.28-zulu"
+        java_version : "11.0.29-zulu"
 
   build:
     image: netty:centos-6-1.11

--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-6-1.8
     build:
       args:
-        java_version : "8.0.462-zulu"
+        java_version : "8.0.472-zulu"
 
   build:
     image: netty:centos-6-1.8

--- a/docker/docker-compose.centos-6.21.yaml
+++ b/docker/docker-compose.centos-6.21.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-6-21
     build:
       args:
-        java_version : "21.0.8-zulu"
+        java_version : "21.0.9-zulu"
 
   build:
     image: netty:centos-6-21

--- a/docker/docker-compose.centos-6.25.yaml
+++ b/docker/docker-compose.centos-6.25.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-6-25
     build:
       args:
-        java_version : "25-zulu"
+        java_version : "25.0.1-zulu"
 
   build:
     image: netty:centos-6-25

--- a/docker/docker-compose.centos-7.117.yaml
+++ b/docker/docker-compose.centos-7.117.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-7-1.17
     build:
       args:
-        java_version : "17.0.16-zulu"
+        java_version : "17.0.17-zulu"
 
   build:
     image: netty:centos-7-1.17

--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -9,7 +9,7 @@ services:
       dockerfile: docker/Dockerfile.cross_compile_aarch64
       args:
         gcc_version: "10.2-2020.11"
-        java_version: "8.0.462-zulu"
+        java_version: "8.0.472-zulu"
 
   cross-compile-aarch64-common: &cross-compile-aarch64-common
     depends_on: [ cross-compile-aarch64-runtime-setup ]


### PR DESCRIPTION
Motivation:

There are JDK updates we should use them

Modifications:

- Update JDK versions

Result:

Use latest JDK versions
