### PR TITLE
Handle invalid content length in continue request

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
@@ -159,14 +159,14 @@ public class HttpObjectAggregator
         }
     }
 
-    private static Object continueResponse(HttpMessage start, int maxContentLength, ChannelPipeline pipeline) {
+    private Object continueResponse(HttpMessage start, int maxContentLength, ChannelPipeline pipeline) {
         if (HttpUtil.isUnsupportedExpectation(start)) {
             // if the request contains an unsupported expectation, we return 417
             pipeline.fireUserEventTriggered(HttpExpectationFailedEvent.INSTANCE);
             return EXPECTATION_FAILED.retainedDuplicate();
         } else if (HttpUtil.is100ContinueExpected(start)) {
             // if the request contains 100-continue but the content-length is too large, we return 413
-            if (getContentLength(start, -1L) <= maxContentLength) {
+            if (!isContentLengthInvalid(start, maxContentLength)) {
                 return CONTINUE.retainedDuplicate();
             }
             pipeline.fireUserEventTriggered(HttpExpectationFailedEvent.INSTANCE);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpObjectAggregatorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpObjectAggregatorTest.java
@@ -26,7 +26,6 @@ import io.netty.handler.codec.PrematureChannelClosureException;
 import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import org.mockito.Mockito;
@@ -757,5 +756,16 @@ public class HttpObjectAggregatorTest {
                 ch.finish();
             }
         });
+    }
+
+    @Test
+    public void invalidContinueLength() {
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpServerCodec(), new HttpObjectAggregator(1024));
+
+        channel.writeInbound(Unpooled.copiedBuffer("POST / HTTP/1.1\r\n" +
+                "Expect: 100-continue\r\n" +
+                "Content-Length:\r\n" +
+                "\r\n\r\n", CharsetUtil.US_ASCII));
+        assertTrue(channel.finishAndReleaseAll());
     }
 }


### PR DESCRIPTION
Motivation:

An invalid content length in a continue request would induce HttpObjectAggregator to throw a NumberFormatException.

Modification:

Use the existing isContentLengthInvalid to guard the getContentLength call in continue request processing.

Result:

No exception thrown.