### PR TITLE
Correct HTTP/2 padding length check (#15793)

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameReader.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameReader.java
@@ -399,7 +399,6 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
     private void readDataFrame(ChannelHandlerContext ctx, ByteBuf payload,
             Http2FrameListener listener) throws Http2Exception {
         int padding = readPadding(payload);
-        verifyPadding(padding);
 
         // Determine how much data there is to read by removing the trailing
         // padding.
@@ -414,7 +413,6 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
         final int headersStreamId = streamId;
         final Http2Flags headersFlags = flags;
         final int padding = readPadding(payload);
-        verifyPadding(padding);
 
         // The callback that is invoked is different depending on whether priority information
         // is present in the headers frame.
@@ -536,7 +534,6 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
             Http2FrameListener listener) throws Http2Exception {
         final int pushPromiseStreamId = streamId;
         final int padding = readPadding(payload);
-        verifyPadding(padding);
         final int promisedStreamId = readUnsignedInt(payload);
 
         // Create a handler that invokes the listener when the header block is complete.
@@ -620,21 +617,19 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
         return payload.readUnsignedByte() + 1;
     }
 
-    private void verifyPadding(int padding) throws Http2Exception {
-        int len = lengthWithoutTrailingPadding(payloadLength, padding);
-        if (len < 0) {
-            throw connectionError(PROTOCOL_ERROR, "Frame payload too small for padding.");
-        }
-    }
-
     /**
      * The padding parameter consists of the 1 byte pad length field and the trailing padding bytes. This method
      * returns the number of readable bytes without the trailing padding.
      */
-    private static int lengthWithoutTrailingPadding(int readableBytes, int padding) {
-        return padding == 0
-                ? readableBytes
-                : readableBytes - (padding - 1);
+    private static int lengthWithoutTrailingPadding(int readableBytes, int padding) throws Http2Exception {
+        if (padding == 0) {
+            return readableBytes;
+        }
+        int n = readableBytes - (padding - 1);
+        if (n < 0) {
+            throw connectionError(PROTOCOL_ERROR, "Frame payload too small for padding.");
+        }
+        return n;
     }
 
     /**

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
@@ -1016,4 +1016,23 @@ public class Http2FrameCodecTest {
     private ChannelHandlerContext eqFrameCodecCtx() {
         return eq(frameCodec.ctx);
     }
+
+    @Test
+    public void invalidPayloadLength() throws Exception {
+        frameInboundWriter.writeInboundSettings(new Http2Settings());
+        channel.writeInbound(Unpooled.wrappedBuffer(new byte[]{
+                0, 0, 4, // length
+                0, // type: DATA
+                9, // flags: PADDED, END_STREAM
+                1, 0, 0, 0, // stream id
+                4, // pad length
+                0, 0, 0 // not enough space for padding
+        }));
+        assertThrows(Http2Exception.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                inboundHandler.checkException();
+            }
+        });
+    }
 }


### PR DESCRIPTION
Motivation:

When the padding of an HTTP/2 DATA frame exceeds the bounds of the frame, an IndexOutOfBoundsException would be thrown instead of the expected Http2Exception:

```
Exception in thread "main" java.lang.IndexOutOfBoundsException: readerIndex: 1, writerIndex: 0 (expected: 0 <= readerIndex <= writerIndex <= capacity(4))
	at io.netty.buffer.AbstractByteBuf.checkIndexBounds(AbstractByteBuf.java:112)
	at io.netty.buffer.AbstractByteBuf.writerIndex(AbstractByteBuf.java:135)
	at io.netty.buffer.WrappedByteBuf.writerIndex(WrappedByteBuf.java:132)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readDataFrame(DefaultHttp2FrameReader.java:408)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.processPayloadState(DefaultHttp2FrameReader.java:244)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readFrame(DefaultHttp2FrameReader.java:164)
```

Modification:

Instead of verifying the padding size against the full payloadLength, which includes the pad length, move the check to
lengthWithoutTrailingPadding where the exact number of remaining bytes is known.

Result:

Proper protocol error.