### PR TITLE
Changes for Auto Scaling Netty threads

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactory.java
+++ b/common/src/main/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactory.java
@@ -202,9 +202,7 @@ public final class AutoScalingEventExecutorChooserFactory implements EventExecut
                 // chooser that contains all executors as a safe temporary choice.
                 tryScaleUpBy(1);
                 EventExecutor executor = allExecutorsChooser.next();
-                if (this.state.get().pausedExecutors.contains(executor)) {
-                    this.state.get().pausedExecutors.remove(executor);
-                }
+                this.state.get().pausedExecutors.remove(executor);
                 if (executor instanceof SingleThreadEventExecutor) {
                     SingleThreadEventExecutor stee = (SingleThreadEventExecutor) executor;
                     stee.resetIdleCycles();

--- a/common/src/main/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactory.java
+++ b/common/src/main/java/io/netty/util/concurrent/AutoScalingEventExecutorChooserFactory.java
@@ -245,10 +245,9 @@ public final class AutoScalingEventExecutorChooserFactory implements EventExecut
                         if (stee.isSuspended()) {
                             stee.execute(NO_OOP_TASK);
                             wokenUp.add(stee);
-                        } else if (oldState.pausedExecutors.contains(stee)) {
+                        } else if (oldState.pausedExecutors.remove(stee)) {
                             // Remove from the paused list so that it can accept connections once again
                             wokenUp.add(stee);
-                            oldState.pausedExecutors.remove(stee);
                         }
                     }
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -1409,6 +1409,18 @@
                   <new>interface org.jboss.marshalling.UnmarshallingObjectInputFilter</new>
                   <justification>We need to build with upgraded JBoss Marshalling version. Otherwise, testsuite-jpms won't compile.</justification>
                 </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.externalClassExposedInAPI</code>
+                  <new>class java.lang.invoke.MethodHandle</new>
+                  <justification>Exposed supplementary class used in a public capacity for varhandle-stub.</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.externalClassExposedInAPI</code>
+                  <new>class java.lang.invoke.VarHandle</new>
+                  <justification>Exposed supplementary class used in a public capacity for varhandle-stub.</justification>
+                </item>
               </differences>
             </revapi.differences>
           </analysisConfiguration>


### PR DESCRIPTION
### Changes
- Added changes for pausing executors that are idle to finish up active connections before being suspended
- Updated pom.xml for issues compiling changes due to revapi

### Motivation:

Idle executors still handling connections are not properly suspended and would remain active even if under the down scale threshold for as long as at least one connection remains active. 

### Modification:

Added a set of paused executors to the AutoScaling state and appropriate logic to manage idle executors which are still handling connections. Also updated pom.xml for issues compiling changes due to revapi

### Result:

Fixes #15777
