### PR TITLE
Add a zero-delay option to AbstractReferenceCountedByteBufBenchmark

### DIFF
--- a/microbench/src/main/java/io/netty/buffer/AbstractReferenceCountedByteBufBenchmark.java
+++ b/microbench/src/main/java/io/netty/buffer/AbstractReferenceCountedByteBufBenchmark.java
@@ -35,6 +35,7 @@ import java.util.concurrent.TimeUnit;
 public class AbstractReferenceCountedByteBufBenchmark extends AbstractMicrobenchmark {
 
     @Param({
+            "0",
             "1",
             "10",
             "100",
@@ -60,8 +61,14 @@ public class AbstractReferenceCountedByteBufBenchmark extends AbstractMicrobench
     @OutputTimeUnit(TimeUnit.NANOSECONDS)
     public boolean retainReleaseUncontended() {
         buf.retain();
-        Blackhole.consumeCPU(delay);
+        delay();
         return buf.release();
+    }
+
+    private void delay() {
+        if (delay > 0) {
+            Blackhole.consumeCPU(delay);
+        }
     }
 
     @Benchmark
@@ -71,7 +78,7 @@ public class AbstractReferenceCountedByteBufBenchmark extends AbstractMicrobench
     public boolean createUseAndRelease(Blackhole useBuffer) {
         ByteBuf unpooled = Unpooled.buffer(1);
         useBuffer.consume(unpooled);
-        Blackhole.consumeCPU(delay);
+        delay();
         return unpooled.release();
     }
 
@@ -81,7 +88,7 @@ public class AbstractReferenceCountedByteBufBenchmark extends AbstractMicrobench
     @GroupThreads(4)
     public boolean retainReleaseContended() {
         buf.retain();
-        Blackhole.consumeCPU(delay);
+        delay();
         return buf.release();
     }
 }


### PR DESCRIPTION
Motivation:
The consumeCPU call can disturb potential optimizations, so its desirable to be able to benchmark the case where it's not present.

Modification:
Add a zero-delay parameter to the benchmark, and make sure the consumeCPU call is skipped in that case.

Result:
More flexible benchmark.