### PR TITLE
Add 32k and 64k size classes to adaptive allocator (#15799)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -149,6 +149,8 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
             8704, // 8192 + 512
             16384,
             16896, // 16384 + 512
+            32768,
+            65536,
     };
     private static final ChunkReleasePredicate CHUNK_RELEASE_ALWAYS = new ChunkReleasePredicate() {
         @Override

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
@@ -20,6 +20,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicReference;
@@ -111,24 +114,29 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
     @Test
     void adaptiveChunkMustDeallocateOrReuseWthBufferRelease() throws Exception {
         AdaptiveByteBufAllocator allocator = newAllocator(false);
-        ByteBuf a = allocator.heapBuffer(28 * 1024);
-        assertEquals(262144, allocator.usedHeapMemory());
-        ByteBuf b = allocator.heapBuffer(100 * 1024);
-        assertEquals(262144, allocator.usedHeapMemory());
-        b.release();
-        a.release();
-        assertEquals(262144, allocator.usedHeapMemory());
-        a = allocator.heapBuffer(28 * 1024);
-        assertEquals(262144, allocator.usedHeapMemory());
-        b = allocator.heapBuffer(100 * 1024);
-        assertEquals(262144, allocator.usedHeapMemory());
-        a.release();
-        ByteBuf c = allocator.heapBuffer(28 * 1024);
-        assertEquals(2 * 262144, allocator.usedHeapMemory());
-        c.release();
-        assertEquals(2 * 262144, allocator.usedHeapMemory());
-        b.release();
-        assertEquals(2 * 262144, allocator.usedHeapMemory());
+        Deque<ByteBuf> bufs = new ArrayDeque<ByteBuf>();
+        assertEquals(0, allocator.usedHeapMemory());
+        assertEquals(0, allocator.usedHeapMemory());
+        bufs.add(allocator.heapBuffer(256));
+        long usedHeapMemory = allocator.usedHeapMemory();
+        int buffersPerChunk = Math.toIntExact(usedHeapMemory / 256);
+        for (int i = 0; i < buffersPerChunk; i++) {
+            bufs.add(allocator.heapBuffer(256));
+        }
+        assertEquals(2 * usedHeapMemory, allocator.usedHeapMemory());
+        bufs.pop().release();
+        assertEquals(2 * usedHeapMemory, allocator.usedHeapMemory());
+        while (!bufs.isEmpty()) {
+            bufs.pop().release();
+        }
+        assertEquals(2 * usedHeapMemory, allocator.usedHeapMemory());
+        for (int i = 0; i < 2 * buffersPerChunk; i++) {
+            bufs.add(allocator.heapBuffer(256));
+        }
+        assertEquals(2 * usedHeapMemory, allocator.usedHeapMemory());
+        while (!bufs.isEmpty()) {
+            bufs.pop().release();
+        }
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Motivation:
I've gotten allocation profile data from "a large e-commerce application", which has sizable allocation volume at 32 KiB and 64 KiB, with very little in between that isn't covered by the existing size classes.

Modification:
Add 32 KiB and 64 KiB size classes to the adaptive allocator. Make the adaptiveChunkMustDeallocateOrReuseWthBufferRelease test more size-class agnostic.

Result:
Nearly 50% memory usage reduction in this e-commerce application use case, according to the allocation pattern simulator for the 1024 live buffers case, which brings adaptive on par with the pooled allocator for this use case.