### PR TITLE
DnsNameResolver: Use inflight handling for all DnsQuestions

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DatagramDnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DatagramDnsQueryContext.java
@@ -34,12 +34,13 @@ final class DatagramDnsQueryContext extends DnsQueryContext {
     DatagramDnsQueryContext(Channel channel,
                             InetSocketAddress nameServerAddr,
                             DnsQueryContextManager queryContextManager,
+                            DnsQueryLifecycleObserver queryLifecycleObserver,
                             int maxPayLoadSize, boolean recursionDesired,
                             long queryTimeoutMillis,
                             DnsQuestion question, DnsRecord[] additionals,
                             Promise<AddressedEnvelope<DnsResponse, InetSocketAddress>> promise,
                             Bootstrap socketBootstrap, boolean retryWithTcpOnTimeout) {
-        super(channel, nameServerAddr, queryContextManager, maxPayLoadSize, recursionDesired,
+        super(channel, nameServerAddr, queryContextManager, queryLifecycleObserver, maxPayLoadSize, recursionDesired,
                 queryTimeoutMillis, question, additionals, promise, socketBootstrap, retryWithTcpOnTimeout);
     }
 

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/TcpDnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/TcpDnsQueryContext.java
@@ -33,11 +33,12 @@ final class TcpDnsQueryContext extends DnsQueryContext {
     TcpDnsQueryContext(Channel channel,
                        InetSocketAddress nameServerAddr,
                        DnsQueryContextManager queryContextManager,
+                       DnsQueryLifecycleObserver lifecycleObserver,
                        int maxPayLoadSize, boolean recursionDesired,
                        long queryTimeoutMillis,
                        DnsQuestion question, DnsRecord[] additionals,
                        Promise<AddressedEnvelope<DnsResponse, InetSocketAddress>> promise) {
-        super(channel, nameServerAddr, queryContextManager, maxPayLoadSize, recursionDesired,
+        super(channel, nameServerAddr, queryContextManager, lifecycleObserver, maxPayLoadSize, recursionDesired,
                 // No retry via TCP.
                 queryTimeoutMillis, question, additionals, promise, null, false);
     }


### PR DESCRIPTION
Motivation:

At the moment we only did the inflight handling / merging for resolve(hostname...) calls. We can do it for all DnsQuestion's and so also use the optimization for others. This also fixes a bug where we did not ignore the case of the hostname while doing so

Modifications:

Rewrite to make use of inflight handling / merging for all DnsQuestion's

Result:

More consistent handling
