### PR TITLE
Add classname to the error of unsupported msg type for io_uring

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -47,6 +47,7 @@ import io.netty.channel.unix.UnixChannelUtil;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.PromiseNotifier;
 import io.netty.util.internal.CleanableDirectBuffer;
+import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -1203,7 +1204,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
             ByteBuf buf = (ByteBuf) msg;
             return UnixChannelUtil.isBufferCopyNeededForWrite(buf)? newDirectBuffer(buf) : buf;
         }
-        throw new UnsupportedOperationException("unsupported message type");
+        throw new UnsupportedOperationException("unsupported message type" + StringUtil.simpleClassName(msg));
     }
 
     @Override


### PR DESCRIPTION
### Motivation:

When I tried to introduce IO_URING to the Apache Spark project https://github.com/apache/spark/pull/52791, I encountered some unclear errors

```java
25/11/03 08:33:00.843 shuffle-client-4-1 DEBUG NettyLogger: [id: 0xdbb775fa, L:/127.0.0.1:53586 - R:localhost/127.0.0.1:41495] WRITE: MessageWithHeader [headerLength: 21, bodyLength: 64]
25/11/03 08:33:00.844 shuffle-client-4-1 ERROR TransportClient: Failed to send RPC RPC 8484038884338210137 to localhost/127.0.0.1:41495
java.lang.UnsupportedOperationException: unsupported message type
	at io.netty.channel.uring.AbstractIoUringChannel.filterOutboundMessage(AbstractIoUringChannel.java:1206)
	at io.netty.channel.uring.AbstractIoUringStreamChannel.filterOutboundMessage(AbstractIoUringStreamChannel.java:231)
	at io.netty.channel.AbstractChannel$AbstractUnsafe.write(AbstractChannel.java:739)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.write(DefaultChannelPipeline.java:1386)
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:823)
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:752)
	at io.netty.handler.logging.LoggingHandler.write(LoggingHandler.java:288)
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:825)
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:752)
	at io.netty.handler.codec.MessageToMessageEncoder.write(MessageToMessageEncoder.java:113)
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:827)
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:752)
	at io.netty.handler.timeout.IdleStateHandler.write(IdleStateHandler.java:309)
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:825)
	at io.netty.channel.AbstractChannelHandlerContext$WriteTask.run(AbstractChannelHandlerContext.java:1136)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:148)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:141)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:535)
	at io.netty.channel.SingleThreadIoEventLoop.run(SingleThreadIoEventLoop.java:201)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:1193)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:840)
```

It would be beneficial to include a customized message type in the error content.
### Modification:

Add a simple class name to the error content, like other channel implementations

