### PR TITLE
Run the BoringSSL x25519mlkem768 test on all JDKs

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/PkiTestingTlsTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/PkiTestingTlsTest.java
@@ -136,7 +136,6 @@ public class PkiTestingTlsTest {
      * The ephemeral session key is used for the symmetric encryption algorithm.
      * To make that quantum safe, we just need to double the bit-width, from AES-128 to AES-256.
      */
-    @EnabledForJreRange(min = JRE.JAVA_24)
     @EnabledIf("isBoringSSLAvailable")
     @ParameterizedTest
     @ValueSource(booleans = { true, false })


### PR DESCRIPTION
Motivation:
This test does not need to be restricted to JDK 24 or newer, because BoringSSL takes care of the post-quantum crypto. The certificates used are just EC-P256, which is supported everywhere.

Modification:
Remove the JDK 24 restriction from the test.

Result:
Test now runs on every JDK we test with.