### PR TITLE
Add a filter when tasks are moved from scheduledTaskQueue to taskQueue.

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
@@ -192,13 +192,16 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
         }
         long nanoTime = getCurrentTimeNanos();
         for (;;) {
-            Runnable scheduledTask = pollScheduledTask(nanoTime);
+            ScheduledFutureTask scheduledTask = (ScheduledFutureTask) pollScheduledTask(nanoTime);
             if (scheduledTask == null) {
                 return true;
             }
+            if (scheduledTask.isCancelled()) {
+                continue;
+            }
             if (!taskQueue.offer(scheduledTask)) {
                 // No space left in the task queue add it back to the scheduledTaskQueue so we pick it up again.
-                scheduledTaskQueue.add((ScheduledFutureTask<?>) scheduledTask);
+                scheduledTaskQueue.add(scheduledTask);
                 return false;
             }
         }

--- a/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
@@ -139,10 +139,12 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor im
 
     private void fetchFromScheduledTaskQueue() {
         long nanoTime = getCurrentTimeNanos();
-        Runnable scheduledTask = pollScheduledTask(nanoTime);
-        while (scheduledTask != null) {
+        ScheduledFutureTask scheduledTask;
+        while ((scheduledTask = (ScheduledFutureTask) pollScheduledTask(nanoTime)) != null) {
+            if (scheduledTask.isCancelled()) {
+                continue;
+            }
             taskQueue.add(scheduledTask);
-            scheduledTask = pollScheduledTask(nanoTime);
         }
     }
 


### PR DESCRIPTION
 

**Motivation:**
Currently, when fetching expired tasks from the delayed queue (scheduledTaskQueue) and moving them to the task queue (taskQueue), there’s no check to see if the tasks have been cancelled. This causes cancelled tasks to be transferred to taskQueue, and the cancellation is only detected when the tasks are actually executed.

**Modification:**
Add a check when fetching expired tasks from scheduledTaskQueue and moving them to taskQueue.
Do not add tasks to taskQueue if they have been cancelled.

**Result:**
Reduced invalid operations such as the transfer of cancelled tasks between queues and subsequent unnecessary processes.
