### PR TITLE
Fix codec-native-quic maven warning

### DIFF
--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -1050,12 +1050,6 @@
               </instructions>
             </configuration>
           </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <executions>
           <execution>
             <id>native-manifest</id>
             <phase>process-classes</phase>


### PR DESCRIPTION
Motivation:

Previous patch introduced duplicate declaration of maven-bundle-plugin,
causing Maven to comply.

Modification:

Merge the two declarations into a single one with two executions.

Result:

No warning issued anymore.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>
