### PR TITLE
Add close tracing to retain calls

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/SimpleLeakAwareByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SimpleLeakAwareByteBuf.java
@@ -20,6 +20,7 @@ import io.netty.util.IllegalReferenceCountException;
 import io.netty.util.ResourceLeakDetector;
 import io.netty.util.ResourceLeakTracker;
 import io.netty.util.internal.ObjectUtil;
+import io.netty.util.internal.ThrowableUtil;
 
 import java.nio.ByteOrder;
 
@@ -50,22 +51,42 @@ class SimpleLeakAwareByteBuf extends WrappedByteBuf {
 
     @Override
     public ByteBuf retainedSlice() {
-        return unwrappedDerived(super.retainedSlice());
+        try {
+            return unwrappedDerived(super.retainedSlice());
+        } catch (IllegalReferenceCountException irce) {
+            ThrowableUtil.addSuppressed(irce, leak.getCloseStackTraceIfAny());
+            throw irce;
+        }
     }
 
     @Override
     public ByteBuf retainedSlice(int index, int length) {
-        return unwrappedDerived(super.retainedSlice(index, length));
+        try {
+            return unwrappedDerived(super.retainedSlice(index, length));
+        } catch (IllegalReferenceCountException irce) {
+            ThrowableUtil.addSuppressed(irce, leak.getCloseStackTraceIfAny());
+            throw irce;
+        }
     }
 
     @Override
     public ByteBuf retainedDuplicate() {
-        return unwrappedDerived(super.retainedDuplicate());
+        try {
+            return unwrappedDerived(super.retainedDuplicate());
+        } catch (IllegalReferenceCountException irce) {
+            ThrowableUtil.addSuppressed(irce, leak.getCloseStackTraceIfAny());
+            throw irce;
+        }
     }
 
     @Override
     public ByteBuf readRetainedSlice(int length) {
-        return unwrappedDerived(super.readRetainedSlice(length));
+        try {
+            return unwrappedDerived(super.readRetainedSlice(length));
+        } catch (IllegalReferenceCountException irce) {
+            ThrowableUtil.addSuppressed(irce, leak.getCloseStackTraceIfAny());
+            throw irce;
+        }
     }
 
     @Override
@@ -99,6 +120,26 @@ class SimpleLeakAwareByteBuf extends WrappedByteBuf {
     }
 
     @Override
+    public ByteBuf retain() {
+        try {
+            return super.retain();
+        } catch (IllegalReferenceCountException irce) {
+            ThrowableUtil.addSuppressed(irce, leak.getCloseStackTraceIfAny());
+            throw irce;
+        }
+    }
+
+    @Override
+    public ByteBuf retain(int increment) {
+        try {
+            return super.retain(increment);
+        } catch (IllegalReferenceCountException irce) {
+            ThrowableUtil.addSuppressed(irce, leak.getCloseStackTraceIfAny());
+            throw irce;
+        }
+    }
+
+    @Override
     public boolean release() {
         try {
             if (super.release()) {
@@ -107,10 +148,7 @@ class SimpleLeakAwareByteBuf extends WrappedByteBuf {
             }
             return false;
         } catch (IllegalReferenceCountException irce) {
-            Throwable trace = leak.getCloseStackTraceIfAny();
-            if (trace != null) {
-                irce.addSuppressed(trace);
-            }
+            ThrowableUtil.addSuppressed(irce, leak.getCloseStackTraceIfAny());
             throw irce;
         }
     }
@@ -124,10 +162,7 @@ class SimpleLeakAwareByteBuf extends WrappedByteBuf {
             }
             return false;
         } catch (IllegalReferenceCountException irce) {
-            Throwable trace = leak.getCloseStackTraceIfAny();
-            if (trace != null) {
-                irce.addSuppressed(trace);
-            }
+            ThrowableUtil.addSuppressed(irce, leak.getCloseStackTraceIfAny());
             throw irce;
         }
     }

--- a/common/src/main/java/io/netty/util/internal/ThrowableUtil.java
+++ b/common/src/main/java/io/netty/util/internal/ThrowableUtil.java
@@ -45,7 +45,7 @@ public final class ThrowableUtil {
         cause.printStackTrace(pout);
         pout.flush();
         try {
-            return new String(out.toByteArray());
+            return out.toString();
         } finally {
             try {
                 out.close();
@@ -61,7 +61,9 @@ public final class ThrowableUtil {
     }
 
     public static void addSuppressed(Throwable target, Throwable suppressed) {
-        target.addSuppressed(suppressed);
+        if (suppressed != null) {
+            target.addSuppressed(suppressed);
+        }
     }
 
     public static void addSuppressedAndClear(Throwable target, List<Throwable> suppressed) {


### PR DESCRIPTION
Motivation:
We attach close traces to release calls.
It is also possible that retain will be called on a released object, so we should trace those as well.

Modification:
Attach close traces, if any, to any retaining methods that throw IllegalReferenceCountException in SimpleLeakAwareByteBuf.

Result:
We now get close traces from various retain methods as well.