### PR TITLE
Upgrade all macOS Intel workflow runners to macOS 15

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -90,7 +90,7 @@ jobs:
       matrix:
         include:
           - setup: macos-x86_64-java8
-            os: macos-13
+            os: macos-15-intel
           - setup: macos-aarch64-java8
             os: macos-15
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -257,7 +257,7 @@ jobs:
       matrix:
         include:
           - setup: macos-x86_64-java8-boringssl
-            os: macos-13
+            os: macos-15-intel
           - setup: macos-aarch64-java8-boringssl
             os: macos-15
 

--- a/.github/workflows/ci-release-4.2.yml
+++ b/.github/workflows/ci-release-4.2.yml
@@ -185,7 +185,7 @@ jobs:
       matrix:
         include:
           - setup: macos-x86_64-java11
-            os: macos-13
+            os: macos-15-intel
           - setup: macos-aarch64-java11
             os: macos-15
 

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -185,7 +185,7 @@ jobs:
       matrix:
         include:
           - setup: macos-x86_64-java8
-            os: macos-13
+            os: macos-15-intel
           - setup: macos-aarch64-java8
             os: macos-15
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Motivation:
GitHub has deprecated the macOS 13 runners and will be removing them. Details in https://github.com/actions/runner-images/issues/13046

Modification:
Replace the runner OS for all Intel Mac builds with macos-15-intel.

Result:
MacOS builds now run on the latest and last version of MacOS that will have Intel support.
