### PR TITLE
Fix SizeClasses comment

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/SizeClasses.java
+++ b/buffer/src/main/java/io/netty/buffer/SizeClasses.java
@@ -107,7 +107,7 @@ final class SizeClasses implements SizeClassesMetric {
 
     private final int[] pageIdx2sizeTab;
 
-    // lookup table for sizeIdx <= smallMaxSizeIdx
+    // lookup table for sizeIdx < nSizes
     private final int[] sizeIdx2sizeTab;
 
     // lookup table used for size <= lookupMaxClass


### PR DESCRIPTION
Motivation:
Comment on the sizeId2sizeTab table looks like it's referencing wrong field, going by how its created and used.

Modification:
Make it reference the nSizes field, which is used in the computation of the table.

Result:
Clearer comment.
Fixes https://github.com/netty/netty/issues/15333