### PR TITLE
Make big endian ASCII hashcode consistent with little endian

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -965,7 +965,7 @@ public final class PlatformDependent {
      * The resulting hash code will be case insensitive.
      */
     public static int hashCodeAscii(byte[] bytes, int startPos, int length) {
-        return !hasUnsafe() || !unalignedAccess() ?
+        return !hasUnsafe() || !unalignedAccess() || BIG_ENDIAN_NATIVE_ORDER ?
                 hashCodeAsciiSafe(bytes, startPos, length) :
                 PlatformDependent0.hashCodeAscii(bytes, startPos, length);
     }


### PR DESCRIPTION
Motivation:
AsciiString should have a consistent hash code regardless of the platform we're running on, because we don't know of the hash code gets exposed or used across platforms.

An optimized version of the hash code was assuming a little-endian platform but could end up being used on big endian platforms.

Modification:
Add a condition that the safe, platform-agnostic hash code implementation should be used on big endian platforms.

Result:
The AsciiString hash code values are now always the same regardless of the platform and JVM configuration we're running on.