### PR TITLE
Resolver: Use default of 2 attempts to match native resolver defaults

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/UnixResolverOptions.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/UnixResolverOptions.java
@@ -52,7 +52,7 @@ final class UnixResolverOptions {
 
     /**
      * The maximum allowed number of DNS queries to send when resolving a host name.
-     * The default value is {@code 16}.
+     * The default value is {@code 2}.
      */
     int attempts() {
         return attempts;
@@ -71,7 +71,9 @@ final class UnixResolverOptions {
 
         private int ndots = 1;
         private int timeout = 5;
-        private int attempts = 16;
+        // Use 2 as default as this is also what is used by the native resolver:
+        // https://linux.die.net/man/5/resolver
+        private int attempts = 2;
 
         private Builder() {
         }

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/UnixResolverDnsServerAddressStreamProviderTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/UnixResolverDnsServerAddressStreamProviderTest.java
@@ -193,7 +193,7 @@ public class UnixResolverDnsServerAddressStreamProviderTest {
     public void defaultValueReturnedIfAttemptsOptionsIsNotPresent(@TempDir Path tempDir) throws IOException {
         File f = buildFile(tempDir, "search localdomain\n" +
             "nameserver 127.0.0.11\n");
-        assertEquals(16, parseEtcResolverOptions(f).attempts());
+        assertEquals(2, parseEtcResolverOptions(f).attempts());
     }
 
     @Test


### PR DESCRIPTION
Motivation:

We used a default of 16 which is much higher then the default that is used by the native resolver

Modifications:

Change default to 2

Result:

Fixes https://github.com/netty/netty/issues/15316