### PR TITLE
Mark EventLoopTaskQueueFactory deprecated

### DIFF
--- a/transport/src/main/java/io/netty/channel/EventLoopTaskQueueFactory.java
+++ b/transport/src/main/java/io/netty/channel/EventLoopTaskQueueFactory.java
@@ -22,7 +22,10 @@ import java.util.Queue;
  *
  * Generally speaking the returned {@link Queue} MUST be thread-safe and depending on the {@link EventLoop}
  * implementation must be of type {@link java.util.concurrent.BlockingQueue}.
+ *
+ * @deprecated Not used anymore by new {@link IoEventLoopGroup} and {@link IoEventLoop} implementations
  */
+@Deprecated
 public interface EventLoopTaskQueueFactory {
 
     /**


### PR DESCRIPTION
Motivation:

We don't use EventLoopTaskQueueFactory anymore, let's deprecate it.

Modifications:

Add deprecation

Result:

Fixes https://github.com/netty/netty/issues/15786