### PR TITLE
Update to latest module-info plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2006,7 +2006,7 @@
         <plugin>
           <groupId>io.github.dmlloyd.module-info</groupId>
           <artifactId>module-info</artifactId>
-          <version>2.1</version>
+          <version>2.2</version>
           <executions>
             <execution>
               <id>module-info</id>


### PR DESCRIPTION
Motivation:

The old version of the plugin did not work with all JDK target versions

Modifications:

Update to latest release

Result:

Support all versions