### PR TITLE
Fix ZstdEncoder not producing data when source is smaller than block size

### DIFF
--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/ZstdEncoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/ZstdEncoder.java
@@ -141,6 +141,8 @@ public final class ZstdEncoder extends MessageToByteEncoder<ByteBuf> {
                 flushBufferedData(out);
             }
         }
+        // return the remaining data in the buffer
+        // when buffer size is smaller than the block size
         if (buffer.isReadable()) {
             flushBufferedData(out);
         }

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/ZstdEncoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/ZstdEncoder.java
@@ -141,6 +141,9 @@ public final class ZstdEncoder extends MessageToByteEncoder<ByteBuf> {
                 flushBufferedData(out);
             }
         }
+        if (buffer.isReadable()) {
+            flushBufferedData(out);
+        }
     }
 
     private void flushBufferedData(ByteBuf out) {

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/ZstdEncoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/ZstdEncoderTest.java
@@ -21,7 +21,6 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.VoidChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.BeforeEach;

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/ZstdEncoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/ZstdEncoderTest.java
@@ -88,7 +88,7 @@ public class ZstdEncoderTest extends AbstractEncoderTest {
         ByteBuf out = channel.readOutbound();
         assertThat(out.readableBytes()).isPositive();
         out.release();
-        asssertNull(channel.readOutbound());
+        assertNull(channel.readOutbound());
     }
 
     @Override

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/ZstdEncoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/ZstdEncoderTest.java
@@ -33,7 +33,6 @@ import org.mockito.MockitoAnnotations;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class ZstdEncoderTest extends AbstractEncoderTest {

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/ZstdEncoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/ZstdEncoderTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/ZstdEncoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/ZstdEncoderTest.java
@@ -40,8 +40,6 @@ public class ZstdEncoderTest extends AbstractEncoderTest {
     @Mock
     private ChannelHandlerContext ctx;
 
-    private static String TEST_CONTENT = "Hello, World";
-
     @BeforeEach
     public void setup() {
         MockitoAnnotations.initMocks(this);

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/ZstdEncoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/ZstdEncoderTest.java
@@ -88,7 +88,7 @@ public class ZstdEncoderTest extends AbstractEncoderTest {
         ByteBuf out = channel.readOutbound();
         assertThat(out.readableBytes()).isPositive();
         out.release();
-        asssertNull(out.readOutbound());
+        asssertNull(channel.readOutbound());
     }
 
     @Override

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/ZstdEncoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/ZstdEncoderTest.java
@@ -86,7 +86,6 @@ public class ZstdEncoderTest extends AbstractEncoderTest {
 
         ByteBuf out = channel.readOutbound();
         assertThat(out.readableBytes()).isPositive();
-
         out.release();
         asssertNull(out.readOutbound());
     }

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/ZstdEncoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/ZstdEncoderTest.java
@@ -86,15 +86,15 @@ public class ZstdEncoderTest extends AbstractEncoderTest {
 
     @Test
     public void testCompressionOfTinyData() throws Exception {
-        ByteBuf data = Unpooled.copiedBuffer(TEST_CONTENT, CharsetUtil.UTF_8);
-        assertTrue(channel.writeOutbound(data.retain()));
+        ByteBuf data = Unpooled.copiedBuffer("Hello, World", CharsetUtil.UTF_8);
+        assertTrue(channel.writeOutbound(data));
         assertTrue(channel.finish());
 
         ByteBuf out = channel.readOutbound();
         assertThat(out.readableBytes()).isPositive();
 
         out.release();
-        data.release();
+        asssertNull(out.readOutbound());
     }
 
     @Override

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/ZstdEncoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/ZstdEncoderTest.java
@@ -33,7 +33,6 @@ import org.mockito.MockitoAnnotations;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/ZstdEncoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/ZstdEncoderTest.java
@@ -32,6 +32,7 @@ import org.mockito.MockitoAnnotations;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 


### PR DESCRIPTION
Motivation:
If the size of the input buffer is smaller than the configured block size (64 KB by default), then ZstdEncoder.write only produces an empty buffer. With the default sizes, this makes the encoder unusable for variable size content. This is for fixing the issue(https://github.com/netty/netty/issues/15340)

Modification:

Return the uncompressed data if for small size data

Result:

Fixes #15340 


