### PR TITLE
Blockhound should not be listed as a META-INF provided server by netty-common

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -258,6 +258,10 @@
         <executions>
           <execution>
             <id>module-info</id>
+            <configuration>
+              <!-- Otherwise detects blockhound that is not an explicit JPMS module -->
+              <detectProvides>false</detectProvides>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
Motivation:

The latest version of module-info plugin does now lists blockhound as a provided service in the module-info.class it creates. Since blockound is not exported by netty-common (as blockhound is not a proper JPMS module) this creates an issue where netty-common uses a module it does not import.

Changes:

Disable provides detection, to avoid listing blockhound as a provides declaration.
