### PR TITLE
Don't fail build if we could not delete directory to free up space

### DIFF
--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -763,7 +763,7 @@
                     </copy>
 
                     <!-- Delete boringssl source directory after build to free up space -->
-                    <delete dir="${boringsslSourceDir}" />
+                    <delete dir="${boringsslSourceDir}" failonerror="false"/>
                   </else>
                 </if>
               </target>
@@ -886,7 +886,7 @@
                     </copy>
 
                     <!-- Delete quiche source directory after build to free up space -->
-                    <delete dir="${quicheSourceDir}" />
+                    <delete dir="${quicheSourceDir}" failonerror="false" />
                   </else>
                 </if>
               </target>


### PR DESCRIPTION
Motivation:

We sometimes observe errors when trying to delete the directory on windows. Deleting the directory is not a requirement and just is done to free up some space during the build process, so just ignore failures and continue the build

Modifications:

More stable builds on windows

Result:

Fix flaky builds on windows
