### PR TITLE
*SocketChannel should not require InetSocketAddress

### DIFF
--- a/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyServer.java
+++ b/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyServer.java
@@ -110,7 +110,7 @@ abstract class ProxyServer {
     }
 
     public final InetSocketAddress address() {
-        return new InetSocketAddress(NetUtil.LOCALHOST, ch.localAddress().getPort());
+        return new InetSocketAddress(NetUtil.LOCALHOST, ((InetSocketAddress) ch.localAddress()).getPort());
     }
 
     protected abstract void configure(SocketChannel ch) throws Exception;

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
@@ -87,16 +87,6 @@ public final class EpollServerSocketChannel extends AbstractEpollServerChannel i
     }
 
     @Override
-    public InetSocketAddress remoteAddress() {
-        return (InetSocketAddress) super.remoteAddress();
-    }
-
-    @Override
-    public InetSocketAddress localAddress() {
-        return (InetSocketAddress) super.localAddress();
-    }
-
-    @Override
     public EpollServerSocketChannelConfig config() {
         return config;
     }

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannel.java
@@ -108,16 +108,6 @@ public final class EpollSocketChannel extends AbstractEpollStreamChannel impleme
     }
 
     @Override
-    public InetSocketAddress remoteAddress() {
-        return (InetSocketAddress) super.remoteAddress();
-    }
-
-    @Override
-    public InetSocketAddress localAddress() {
-        return (InetSocketAddress) super.localAddress();
-    }
-
-    @Override
     public EpollSocketChannelConfig config() {
         return config;
     }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringServerSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringServerSocketChannel.java
@@ -66,16 +66,6 @@ public final class IoUringServerSocketChannel extends AbstractIoUringServerChann
     }
 
     @Override
-    public InetSocketAddress remoteAddress() {
-        return (InetSocketAddress) super.remoteAddress();
-    }
-
-    @Override
-    public InetSocketAddress localAddress() {
-        return (InetSocketAddress) super.localAddress();
-    }
-
-    @Override
     public void doBind(SocketAddress localAddress) throws Exception {
         super.doBind(localAddress);
         if (IoUring.isTcpFastOpenServerSideAvailable()) {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
@@ -23,7 +23,6 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.SocketChannelConfig;
 import io.netty.channel.unix.IovArray;
 
-import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.ArrayDeque;
 import java.util.Queue;
@@ -56,16 +55,6 @@ public final class IoUringSocketChannel extends AbstractIoUringStreamChannel imp
     @Override
     public SocketChannelConfig config() {
         return config;
-    }
-
-    @Override
-    public InetSocketAddress remoteAddress() {
-        return (InetSocketAddress) super.remoteAddress();
-    }
-
-    @Override
-    public InetSocketAddress localAddress() {
-        return (InetSocketAddress) super.localAddress();
     }
 
     @Override

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerSocketChannel.java
@@ -18,7 +18,6 @@ package io.netty.channel.kqueue;
 import io.netty.channel.Channel;
 import io.netty.channel.socket.ServerSocketChannel;
 
-import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
 import static io.netty.channel.kqueue.BsdSocket.newSocketStream;
@@ -56,16 +55,6 @@ public final class KQueueServerSocketChannel extends AbstractKQueueServerChannel
             socket.setTcpFastOpen(true);
         }
         active = true;
-    }
-
-    @Override
-    public InetSocketAddress remoteAddress() {
-        return (InetSocketAddress) super.remoteAddress();
-    }
-
-    @Override
-    public InetSocketAddress localAddress() {
-        return (InetSocketAddress) super.localAddress();
     }
 
     @Override

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannel.java
@@ -62,16 +62,6 @@ public final class KQueueSocketChannel extends AbstractKQueueStreamChannel imple
     }
 
     @Override
-    public InetSocketAddress remoteAddress() {
-        return (InetSocketAddress) super.remoteAddress();
-    }
-
-    @Override
-    public InetSocketAddress localAddress() {
-        return (InetSocketAddress) super.localAddress();
-    }
-
-    @Override
     public KQueueSocketChannelConfig config() {
         return config;
     }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringAutoReadTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringAutoReadTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Timeout;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.util.concurrent.TimeUnit;
 
@@ -62,7 +63,8 @@ public class IoUringAutoReadTest {
                     })
                     .bind(0).sync().channel();
 
-            try (Socket sock = new Socket(server.localAddress().getAddress(), server.localAddress().getPort())) {
+            InetSocketAddress localAddress = (InetSocketAddress) server.localAddress();
+            try (Socket sock = new Socket(localAddress.getAddress(), localAddress.getPort())) {
                 OutputStream out = sock.getOutputStream();
                 InputStream in = sock.getInputStream();
 

--- a/transport/src/main/java/io/netty/channel/socket/ServerSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/ServerSocketChannel.java
@@ -25,8 +25,4 @@ import java.net.InetSocketAddress;
 public interface ServerSocketChannel extends ServerChannel {
     @Override
     ServerSocketChannelConfig config();
-    @Override
-    InetSocketAddress localAddress();
-    @Override
-    InetSocketAddress remoteAddress();
 }

--- a/transport/src/main/java/io/netty/channel/socket/SocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/SocketChannel.java
@@ -17,8 +17,6 @@ package io.netty.channel.socket;
 
 import io.netty.channel.Channel;
 
-import java.net.InetSocketAddress;
-
 /**
  * A TCP/IP socket {@link Channel}.
  */
@@ -28,8 +26,4 @@ public interface SocketChannel extends DuplexChannel {
 
     @Override
     SocketChannelConfig config();
-    @Override
-    InetSocketAddress localAddress();
-    @Override
-    InetSocketAddress remoteAddress();
 }

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioServerSocketChannel.java
@@ -30,7 +30,6 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
-import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.SocketAddress;
 import java.nio.channels.SelectionKey;
@@ -107,11 +106,6 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel
     }
 
     @Override
-    public InetSocketAddress localAddress() {
-        return (InetSocketAddress) super.localAddress();
-    }
-
-    @Override
     public ChannelMetadata metadata() {
         return METADATA;
     }
@@ -129,7 +123,7 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel
     }
 
     @Override
-    public InetSocketAddress remoteAddress() {
+    public SocketAddress remoteAddress() {
         return null;
     }
 

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
@@ -159,16 +159,6 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
     }
 
     @Override
-    public InetSocketAddress localAddress() {
-        return (InetSocketAddress) super.localAddress();
-    }
-
-    @Override
-    public InetSocketAddress remoteAddress() {
-        return (InetSocketAddress) super.remoteAddress();
-    }
-
-    @Override
     protected final void doShutdownOutput() throws Exception {
         javaChannel().shutdownOutput();
     }

--- a/transport/src/main/java/io/netty/channel/socket/oio/OioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/OioServerSocketChannel.java
@@ -26,7 +26,6 @@ import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketAddress;
@@ -100,11 +99,6 @@ public class OioServerSocketChannel extends AbstractOioMessageChannel
     }
 
     @Override
-    public InetSocketAddress localAddress() {
-        return (InetSocketAddress) super.localAddress();
-    }
-
-    @Override
     public ChannelMetadata metadata() {
         return METADATA;
     }
@@ -115,7 +109,7 @@ public class OioServerSocketChannel extends AbstractOioMessageChannel
     }
 
     @Override
-    public InetSocketAddress remoteAddress() {
+    public SocketAddress remoteAddress() {
         return null;
     }
 

--- a/transport/src/main/java/io/netty/channel/socket/oio/OioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/OioSocketChannel.java
@@ -267,16 +267,6 @@ public class OioSocketChannel extends OioByteStreamChannel implements SocketChan
     }
 
     @Override
-    public InetSocketAddress localAddress() {
-        return (InetSocketAddress) super.localAddress();
-    }
-
-    @Override
-    public InetSocketAddress remoteAddress() {
-        return (InetSocketAddress) super.remoteAddress();
-    }
-
-    @Override
     protected SocketAddress localAddress0() {
         return socket.getLocalSocketAddress();
     }


### PR DESCRIPTION
Motivation:

We should not require the return type of remote and local addresses to be InetSocketAddress as this limits our ability in terms of flexibility. For example because of this we were not able to wrap java.nio.SocketChannel implementations for UDS.

Modifications:

- Remove overrides and so just return SocketAddress

Result:

Much more flexiblity and be able to remove some code-duplication later on that we introduced in 4.2 to support UDS with NIO