### PR TITLE
Disable module-info plugin detection of provides declaration (#15868)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1722,6 +1722,7 @@
               <configuration>
                 <moduleName>${javaModuleName}</moduleName>
                 <outputDirectory>${project.build.outputDirectory}/META-INF/versions/11/</outputDirectory>
+                <detectProvides>false</detectProvides>
               </configuration>
               <goals>
                 <goal>generate</goal>


### PR DESCRIPTION
Motivation:

The module-info plugin detects by default provides declaration based on class analysis. The default should rather be to avoid detection and provide explicit declaration when that is needed.

Modification:

Use a more sane default

Result:

Don't risk depending on something that does not support JPM