### PR TITLE
Fix git 2.x download URL for the maven scm plugin

### DIFF
--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -14,7 +14,7 @@ ENV PROJECT_DIR=/root/workspace/project
 RUN sed -i -e 's/^mirrorlist/#mirrorlist/g' -e 's/^#baseurl=http:\/\/mirror.centos.org\/centos\/$releasever\//baseurl=https:\/\/linuxsoft.cern.ch\/centos-vault\/\/7.9.2009\//g' /etc/yum.repos.d/CentOS-Base.repo
 
 # We want to have git 2.x for the maven scm plugin and also for boringssl
-RUN yum install -y https://opensource.wandisco.com/centos/6/git/x86_64/wandisco-git-release-6-1.noarch.rpm
+RUN yum install -y https://opensource.blueoptima.com/centos/6/git/x86_64/wandisco-git-release-6-1.noarch.rpm
 
 RUN yum -y install epel-release
 


### PR DESCRIPTION
Motivation:

The git 2.x download URL  for the maven scm plugin  are no longer accessible.

Modification:

Switch to URL used by the opensource.blueoptima.com website.

Result:

Builds should no longer fail to download git 2.x  for the maven scm plugin.
