### PR TITLE
Re-enable JPMS testsuite

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -531,8 +531,8 @@
     <module>testsuite-autobahn</module>
     <module>testsuite-common</module>
     <module>testsuite-http2</module>
-    <!-- Disable modules as these need work for JDK25 requirement
     <module>testsuite-jpms</module>
+    <!-- Disable modules as these need work for JDK25 requirement
     <module>testsuite-karaf</module>
     <module>testsuite-osgi</module>
     <module>testsuite-shading</module>


### PR DESCRIPTION
Motivation:

After recent updates we should be able to use JPMS again... Re-enable the testsuite

Modifications:

Reenable the build of the testsuite-jpms module

Result:

JPMS validated during build of netty 5