### PR TITLE
chore: Update javadoc of CompositeByteBuf#releaes method (#15864)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -2384,4 +2384,17 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
         }
         componentCount = newSize;
     }
+
+    /**
+     * Decreases the reference count by the specified {@code decrement} and deallocates this object if the reference
+     * count reaches at {@code 0}. At this point it will also decrement the reference count of each internal
+     * component by {@code 1}.
+     *
+     * @param decrement the number by which the reference count should be decreased
+     * @return {@code true} if and only if the reference count became {@code 0} and this object has been deallocated
+     */
+    @Override
+    public boolean release(final int decrement) {
+        return super.release(decrement);
+    }
 }


### PR DESCRIPTION
Motivation:

Better javadoc for `CompositeByteBuf#release` method


Modification:

Add javadoc

Result:

Fixes https://github.com/netty/netty/issues/15863
