### PR TITLE
Deprecate useless SslContextBuilder methods

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
@@ -441,7 +441,10 @@ public final class SslContextBuilder {
      * @param keyPassword the password of the {@code key}, or {@code null} if it's not
      *     password-protected
      * @param keyCertChain an X.509 certificate chain
+     * @deprecated Use {@link #keyManager(PrivateKey, X509Certificate...)} instead since the private key is given
+     * directly.
      */
+    @Deprecated
     public SslContextBuilder keyManager(PrivateKey key, String keyPassword, X509Certificate... keyCertChain) {
         if (forServer) {
             checkNonEmpty(keyCertChain, "keyCertChain");
@@ -469,7 +472,9 @@ public final class SslContextBuilder {
      * @param keyPassword the password of the {@code key}, or {@code null} if it's not
      *     password-protected
      * @param keyCertChain an X.509 certificate chain
+     * @deprecated Use {@link #keyManager(PrivateKey, Iterable)} instead since the private key is given directly.
      */
+    @Deprecated
     public SslContextBuilder keyManager(PrivateKey key, String keyPassword,
                                         Iterable<? extends X509Certificate> keyCertChain) {
         return keyManager(key, keyPassword, toArray(keyCertChain, EMPTY_X509_CERTIFICATES));


### PR DESCRIPTION
Motivation:
There is no point in passing a private key password if we are directly passing the private key object. The password passed in these methods is only used when creating and reading an in-memory KeyStore, which don't need password protection.

Modification:
Deprecate methods that serve no purpose.

Result:
Less confusing API.

Fixes https://github.com/netty/netty/issues/7998