### PR TITLE
 [io_uring] Fix Unix domain socket support for abstract namespace sockets

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -1186,11 +1186,11 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
     private void submitConnect(DomainSocketAddress unixDomainSocketAddress) {
         cleanable = Buffer.allocateDirectBufferWithNativeOrder(Native.SIZEOF_SOCKADDR_UN);
         remoteAddressMemory = cleanable.buffer();
-        SockaddrIn.setUds(remoteAddressMemory, unixDomainSocketAddress);
+        int addrLen = SockaddrIn.setUds(remoteAddressMemory, unixDomainSocketAddress);
         int fd = fd().intValue();
         IoRegistration registration = registration();
         long addr = Buffer.memoryAddress(remoteAddressMemory);
-        IoUringIoOps ops = IoUringIoOps.newConnect(fd, (byte) 0, addr, Native.SIZEOF_SOCKADDR_UN, nextOpsId());
+        IoUringIoOps ops = IoUringIoOps.newConnect(fd, (byte) 0, addr, addrLen, nextOpsId());
         connectId = registration.submit(ops);
         if (connectId == 0) {
             // Directly release the memory if submitting failed.

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketAbstractAddressesTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketAbstractAddressesTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.unix.DomainSocketAddress;
+import io.netty.testsuite.transport.TestsuitePermutation;
+import io.netty.testsuite.transport.socket.SocketAddressesTest;
+
+import java.net.SocketAddress;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class IoUringDomainSocketAbstractAddressesTest extends SocketAddressesTest {
+    @Override
+    protected SocketAddress newSocketAddress() {
+        return IoUringSocketTestPermutation.newAbstractSocketAddress();
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IoUringSocketTestPermutation.INSTANCE.domainSocket();
+    }
+
+    @Override
+    protected void assertAddress(SocketAddress address) {
+        assertNotNull(((DomainSocketAddress) address).path());
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketAbstractBufferRingEchoTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketAbstractBufferRingEchoTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.testsuite.transport.TestsuitePermutation;
+import io.netty.testsuite.transport.socket.SocketEchoTest;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.net.SocketAddress;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IoUringDomainSocketAbstractBufferRingEchoTest extends SocketEchoTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IoUring.isAvailable());
+        assumeTrue(IoUring.isRegisterBufferRingSupported());
+    }
+
+    @Override
+    protected SocketAddress newSocketAddress() {
+        return IoUringSocketTestPermutation.newAbstractSocketAddress();
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IoUringSocketTestPermutation.INSTANCE.domainSocket();
+    }
+
+    @Override
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.childOption(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
+        cb.option(IoUringChannelOption.IO_URING_BUFFER_GROUP_ID, IoUringSocketTestPermutation.BGID);
+    }
+
+}

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketAbstractEchoTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketAbstractEchoTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.testsuite.transport.TestsuitePermutation;
+
+import java.net.SocketAddress;
+import java.util.List;
+
+public class IoUringDomainSocketAbstractEchoTest extends IoUringSocketEchoTest {
+    @Override
+    protected SocketAddress newSocketAddress() {
+        return IoUringSocketTestPermutation.newAbstractSocketAddress();
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IoUringSocketTestPermutation.INSTANCE.domainSocket();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketAbstractFdTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketAbstractFdTest.java
@@ -23,4 +23,3 @@ public class IoUringDomainSocketAbstractFdTest extends IoUringDomainSocketFdTest
         return IoUringSocketTestPermutation.newAbstractSocketAddress();
     }
 }
-

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketAbstractFdTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketAbstractFdTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import java.net.SocketAddress;
+
+public class IoUringDomainSocketAbstractFdTest extends IoUringDomainSocketFdTest {
+    @Override
+    protected SocketAddress newSocketAddress() {
+        return IoUringSocketTestPermutation.newAbstractSocketAddress();
+    }
+}
+

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketTestPermutation.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketTestPermutation.java
@@ -277,4 +277,9 @@ public class IoUringSocketTestPermutation extends SocketTestPermutation {
         return UnixTestUtils.newDomainSocketAddress();
     }
 
+    public static DomainSocketAddress newAbstractSocketAddress() {
+        // Abstract namespace sockets start with a null byte followed by a unique name
+        return new DomainSocketAddress("\0netty_test_abstract_" + System.nanoTime());
+    }
+
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/SockaddrInTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/SockaddrInTest.java
@@ -15,6 +15,7 @@
  */
 package io.netty.channel.uring;
 
+import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.util.internal.CleanableDirectBuffer;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,7 @@ import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 
 import static io.netty.channel.unix.Buffer.allocateDirectBufferWithNativeOrder;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -94,6 +96,80 @@ public class SockaddrInTest {
                     SockaddrIn.IPV4_MAPPED_IPV6_PREFIX.length);
             assertArrayEquals(ipv4Bytes, ipv4Address.getAddress());
             assertEquals(port, sockAddr.getPort());
+        } finally {
+            cleanableDirectBuffer.clean();
+        }
+    }
+
+    @Test
+    public void testUdsPathname() throws Exception {
+        CleanableDirectBuffer cleanableDirectBuffer = allocateDirectBufferWithNativeOrder(
+                Native.SIZEOF_SOCKADDR_UN);
+        ByteBuffer buffer = cleanableDirectBuffer.buffer();
+        try {
+            String socketPath = "/tmp/test.sock";
+            DomainSocketAddress address = new DomainSocketAddress(socketPath);
+            byte[] pathBytes = socketPath.getBytes(StandardCharsets.UTF_8);
+
+            int expectedLength = Native.SOCKADDR_UN_OFFSETOF_SUN_PATH + pathBytes.length + 1;
+            int actualLength = SockaddrIn.setUds(buffer, address);
+
+            assertEquals(expectedLength, actualLength, "Address length should include null terminator");
+
+            // Verify sun_family is set correctly
+            short family = buffer.getShort(buffer.position() + Native.SOCKADDR_UN_OFFSETOF_SUN_FAMILY);
+            assertEquals(Native.AF_UNIX, family, "sun_family should be AF_UNIX");
+
+            // Verify path is written correctly
+            byte[] writtenPath = new byte[pathBytes.length];
+            buffer.position(buffer.position() + Native.SOCKADDR_UN_OFFSETOF_SUN_PATH);
+            buffer.get(writtenPath);
+            assertArrayEquals(pathBytes, writtenPath, "Path should match");
+
+            // Verify null terminator is present
+            byte nullTerminator = buffer.get();
+            assertEquals(0, nullTerminator, "Pathname socket should have null terminator");
+        } finally {
+            cleanableDirectBuffer.clean();
+        }
+    }
+
+    @Test
+    public void testUdsAbstractNamespace() throws Exception {
+        CleanableDirectBuffer cleanableDirectBuffer = allocateDirectBufferWithNativeOrder(
+                Native.SIZEOF_SOCKADDR_UN);
+        ByteBuffer buffer = cleanableDirectBuffer.buffer();
+        try {
+            // Abstract namespace socket: starts with null byte
+            String abstractName = "\0test-abstract-socket";
+            DomainSocketAddress address = new DomainSocketAddress(abstractName);
+            byte[] nameBytes = abstractName.getBytes(StandardCharsets.UTF_8);
+
+            // For abstract sockets, length should NOT include an extra null terminator
+            int expectedLength = Native.SOCKADDR_UN_OFFSETOF_SUN_PATH + nameBytes.length;
+            int actualLength = SockaddrIn.setUds(buffer, address);
+
+            assertEquals(expectedLength, actualLength,
+                    "Address length should be exact for abstract socket (no extra null terminator)");
+
+            // Verify sun_family is set correctly
+            int position = buffer.position();
+            short family = buffer.getShort(position + Native.SOCKADDR_UN_OFFSETOF_SUN_FAMILY);
+            assertEquals(Native.AF_UNIX, family, "sun_family should be AF_UNIX");
+
+            // Verify name is written correctly (including the leading null byte)
+            byte[] writtenName = new byte[nameBytes.length];
+            buffer.position(position + Native.SOCKADDR_UN_OFFSETOF_SUN_PATH);
+            buffer.get(writtenName);
+            assertArrayEquals(nameBytes, writtenName, "Abstract socket name should match exactly");
+
+            // Verify first byte is null (abstract namespace indicator)
+            assertEquals(0, writtenName[0], "Abstract socket should start with null byte");
+
+            // Verify that the returned length matches exactly what we wrote
+            // (no extra null terminator beyond what's in the name)
+            assertEquals(Native.SOCKADDR_UN_OFFSETOF_SUN_PATH + nameBytes.length, actualLength,
+                    "Returned length should be exact: offsetof(sun_path) + name_length");
         } finally {
             cleanableDirectBuffer.clean();
         }


### PR DESCRIPTION
Motivation:

The current implementation of `SockaddrIn.setUds()` only supports  file path based Unix domain sockets. It incorrectly adds a null  terminator for all sockets and always passes `SIZEOF_SOCKADDR_UN` as the address length to io_uring operations. This breaks abstract namespace sockets, which are distinguished by having a null byte as the first character and must not have an additional null terminator appended and included in the `address_len`. According to unix(7), abstract sockets require a precise address length of `offsetof(sun_path) + actual_name_length`, while pathname sockets require `offsetof(sun_path) + strlen(path) + 1`.

Modifications:

  Modified `SockaddrIn.setUds()` to:
  - Detect abstract namespace sockets by checking if the path starts with '\0'
  - Only append null terminator for pathname sockets, not abstract sockets
  - Calculate and return the correct address length based on socket type

Modified `AbstractIoUringChannel.submitConnect(DomainSocketAddress)` to:
  - Capture the address length returned by `setUds()`
  - Pass the actual address length to `IoUringIoOps.newConnect()` instead of the hardcoded `SIZEOF_SOCKADDR_UN`

Result:

Both pathname-based and abstract namespace Unix domain sockets are now properly supported. Abstract sockets will correctly connect without spurious null bytes, and the kernel will receive the precise address  length required for each socket type.


