### PR TITLE
Ensure Arena.ofShared() is usable before assuming that we can use Are…

### DIFF
--- a/common/src/main/java/io/netty/util/internal/CleanerJava25.java
+++ b/common/src/main/java/io/netty/util/internal/CleanerJava25.java
@@ -84,6 +84,12 @@ final class CleanerJava25 implements Cleaner {
 
                 // ofShared.type() = ()Arena
                 MethodHandle ofShared = lookup.findStatic(arenaCls, "ofShared", methodType(arenaCls));
+
+                // Try to access shared Arena which might fail on GraalVM 25.0.0 if not enabled
+                // See https://github.com/netty/netty/issues/15762
+                Object shared = ofShared.invoke();
+                ((AutoCloseable) shared).close();
+
                 // allocate.type() = (Arena,long)MemorySegment
                 MethodHandle allocate = lookup.findVirtual(arenaCls, "allocate", methodType(memsegCls, long.class));
                 // asByteBuffer.type() = (MemorySegment)ByteBuffer


### PR DESCRIPTION
…nas on JDK25

Motivation:

Arena.ofShared() is disabled by default on GraalVM 25.0.0 so we can't assume that we can use it by default.

Modifications:

Try to use ofShared() and if it fails don't use Arena's at all

Result:

Fixes https://github.com/netty/netty/issues/15762