### PR TITLE
Cleanup: Replace usage of deprecated EventLoopGroup implementation

### DIFF
--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/example/QuicClientExample.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/example/QuicClientExample.java
@@ -22,7 +22,9 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.ChannelInputShutdownReadComplete;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
@@ -45,7 +47,7 @@ public final class QuicClientExample {
     public static void main(String[] args) throws Exception {
         QuicSslContext context = QuicSslContextBuilder.forClient().trustManager(InsecureTrustManagerFactory.INSTANCE).
                 applicationProtocols("http/0.9").build();
-        NioEventLoopGroup group = new NioEventLoopGroup(1);
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
         try {
             ChannelHandler codec = new QuicClientCodecBuilder()
                     .sslContext(context)

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/example/QuicClientZeroRTTExample.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/example/QuicClientZeroRTTExample.java
@@ -25,7 +25,9 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.ChannelInputShutdownReadComplete;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
@@ -68,7 +70,7 @@ public final class QuicClientZeroRTTExample {
     }
 
     static void newChannelAndSendData(QuicSslContext context, ChannelHandler earlyDataSendHandler) throws Exception {
-        NioEventLoopGroup group = new NioEventLoopGroup(1);
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
         try {
             ChannelHandler codec = new QuicClientCodecBuilder()
                     .sslEngineProvider(q -> context.newEngine(q.alloc(), "localhost", 9999))

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/example/QuicServerExample.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/example/QuicServerExample.java
@@ -22,7 +22,9 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
-import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.handler.codec.LineBasedFrameDecoder;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
@@ -50,7 +52,7 @@ public final class QuicServerExample {
         QuicSslContext context = QuicSslContextBuilder.forServer(
                 selfSignedCertificate.privateKey(), null, selfSignedCertificate.certificate())
                 .applicationProtocols("http/0.9").build();
-        NioEventLoopGroup group = new NioEventLoopGroup(1);
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
         ChannelHandler codec = new QuicServerCodecBuilder().sslContext(context)
                 .maxIdleTimeout(5000, TimeUnit.MILLISECONDS)
                 // Configure some limits for the maximal number of streams (and the data) that we want to handle.

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/example/QuicServerSoReusePortExample.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/example/QuicServerSoReusePortExample.java
@@ -22,9 +22,11 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.epoll.EpollChannelOption;
 import io.netty.channel.epoll.EpollDatagramChannel;
-import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.epoll.EpollIoHandler;
 import io.netty.handler.codec.LineBasedFrameDecoder;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.handler.codec.quic.InsecureQuicTokenHandler;
@@ -58,7 +60,7 @@ public final class QuicServerSoReusePortExample {
                 .applicationProtocols("http/0.9").build();
         // We will bind one socket to each EventLoopGroup.
         int numCores = NettyRuntime.availableProcessors();
-        EpollEventLoopGroup group = new EpollEventLoopGroup(numCores);
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(numCores, EpollIoHandler.newFactory());
         try {
             Bootstrap bs = new Bootstrap().group(group)
                     .channel(EpollDatagramChannel.class)

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/example/QuicServerZeroRTTExample.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/example/QuicServerZeroRTTExample.java
@@ -25,7 +25,9 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
-import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.handler.codec.LineBasedFrameDecoder;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
@@ -49,7 +51,7 @@ public final class QuicServerZeroRTTExample {
         QuicSslContext context = QuicSslContextBuilder.forServer(
                 selfSignedCertificate.privateKey(), null, selfSignedCertificate.certificate())
                 .applicationProtocols("http/0.9").earlyData(true).build();
-        NioEventLoopGroup group = new NioEventLoopGroup(1);
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
         ChannelHandler codec = new QuicServerCodecBuilder().sslContext(context)
                 .maxIdleTimeout(5000, TimeUnit.MILLISECONDS)
                 // Configure some limits for the maximal number of streams (and the data) that we want to handle.

--- a/handler/src/test/java/io/netty/handler/ssl/JdkDelegatingPrivateKeyMethodTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/JdkDelegatingPrivateKeyMethodTest.java
@@ -28,7 +28,8 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
@@ -83,7 +84,7 @@ public class JdkDelegatingPrivateKeyMethodTest {
 
         mockProvider = new MockAlternativeKeyProvider();
         Security.addProvider(mockProvider);
-        GROUP = new NioEventLoopGroup();
+        GROUP = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
 
         // Create server certificate bundle
         RSA_BUNDLE = new CertificateBuilder()

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramChannelTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramChannelTest.java
@@ -20,6 +20,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.socket.SocketProtocolFamily;
 import io.netty.channel.unix.Socket;
 import org.junit.jupiter.api.BeforeEach;
@@ -70,7 +71,7 @@ public class EpollDatagramChannelTest {
 
     @Test
     public void testLocalAddressBeforeAndAfterBind() {
-        EventLoopGroup group = new EpollEventLoopGroup(1);
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, EpollIoHandler.newFactory());
         try {
             TestHandler handler = new TestHandler();
             InetSocketAddress localAddressBeforeBind = new InetSocketAddress(LOCALHOST, 0);

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDetectPeerCloseWithoutReadTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDetectPeerCloseWithoutReadTest.java
@@ -17,13 +17,14 @@ package io.netty.channel.epoll;
 
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.ServerChannel;
 import io.netty.channel.unix.tests.DetectPeerCloseWithoutReadTest;
 
 public class EpollDetectPeerCloseWithoutReadTest extends DetectPeerCloseWithoutReadTest {
     @Override
     protected EventLoopGroup newGroup() {
-        return new EpollEventLoopGroup(2);
+        return new MultiThreadIoEventLoopGroup(2, EpollIoHandler.newFactory());
     }
 
     @Override

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollServerSocketChannelConfigTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollServerSocketChannelConfigTest.java
@@ -20,6 +20,7 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -40,7 +41,7 @@ public class EpollServerSocketChannelConfigTest {
 
     @BeforeAll
     public static void before() {
-        group = new EpollEventLoopGroup(1);
+        group = new MultiThreadIoEventLoopGroup(1,  EpollIoHandler.newFactory());
         ServerBootstrap bootstrap = new ServerBootstrap();
         ch = (EpollServerSocketChannel) bootstrap.group(group)
                 .channel(EpollServerSocketChannel.class)

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelConfigTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelConfigTest.java
@@ -21,6 +21,7 @@ import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -50,7 +51,7 @@ public class EpollSocketChannelConfigTest {
     @BeforeAll
     public static void beforeClass() {
         rand = new Random();
-        group = new EpollEventLoopGroup(1);
+        group = new MultiThreadIoEventLoopGroup(1, EpollIoHandler.newFactory());
     }
 
     @AfterAll

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelTest.java
@@ -20,6 +20,7 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
@@ -31,7 +32,7 @@ public class EpollSocketChannelTest {
 
     @Test
     public void testTcpInfo() throws Exception {
-        EventLoopGroup group = new EpollEventLoopGroup(1);
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, EpollIoHandler.newFactory());
 
         try {
             Bootstrap bootstrap = new Bootstrap();
@@ -49,7 +50,7 @@ public class EpollSocketChannelTest {
 
     @Test
     public void testTcpInfoReuse() throws Exception {
-        EventLoopGroup group = new EpollEventLoopGroup(1);
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, EpollIoHandler.newFactory());
 
         try {
             Bootstrap bootstrap = new Bootstrap();
@@ -106,7 +107,7 @@ public class EpollSocketChannelTest {
     // See https://github.com/netty/netty/issues/7159
     @Test
     public void testSoLingerNoAssertError() throws Exception {
-        EventLoopGroup group = new EpollEventLoopGroup(1);
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, EpollIoHandler.newFactory());
 
         try {
             Bootstrap bootstrap = new Bootstrap();

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketStringEchoBusyWaitTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketStringEchoBusyWaitTest.java
@@ -18,6 +18,7 @@ package io.netty.channel.epoll;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.SelectStrategy;
 import io.netty.channel.SelectStrategyFactory;
 import io.netty.testsuite.transport.TestsuitePermutation;
@@ -38,8 +39,8 @@ public class EpollSocketStringEchoBusyWaitTest extends SocketStringEchoTest {
 
     @BeforeAll
     public static void setup() throws Exception {
-        EPOLL_LOOP = new EpollEventLoopGroup(2, new DefaultThreadFactory("testsuite-epoll-busy-wait", true),
-                new SelectStrategyFactory() {
+        EPOLL_LOOP = new MultiThreadIoEventLoopGroup(2, new DefaultThreadFactory("testsuite-epoll-busy-wait", true),
+                EpollIoHandler.newFactory(1024, new SelectStrategyFactory() {
                     @Override
                     public SelectStrategy newSelectStrategy() {
                         return new SelectStrategy() {
@@ -49,7 +50,7 @@ public class EpollSocketStringEchoBusyWaitTest extends SocketStringEchoTest {
                             }
                         };
                     }
-                });
+                }));
     }
 
     @AfterAll

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTcpMd5Test.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTcpMd5Test.java
@@ -21,6 +21,7 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ConnectTimeoutException;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
 import org.junit.jupiter.api.AfterAll;
@@ -45,7 +46,7 @@ public class EpollSocketTcpMd5Test {
 
     @BeforeAll
     public static void beforeClass() {
-        GROUP = new EpollEventLoopGroup(1);
+        GROUP = new MultiThreadIoEventLoopGroup(1, EpollIoHandler.newFactory());
     }
 
     @AfterAll

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSpliceTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSpliceTest.java
@@ -25,6 +25,7 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.unix.FileDescriptor;
 import io.netty.util.NetUtil;
@@ -57,7 +58,7 @@ public class EpollSpliceTest {
         final EchoHandler sh = new EchoHandler();
         final EchoHandler ch = new EchoHandler();
 
-        EventLoopGroup group = new EpollEventLoopGroup(1);
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, EpollIoHandler.newFactory());
         ServerBootstrap bs = new ServerBootstrap();
         bs.channel(EpollServerSocketChannel.class);
         bs.group(group).childHandler(sh);
@@ -187,7 +188,7 @@ public class EpollSpliceTest {
     @Test
     @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
     public void spliceToFile() throws Throwable {
-        EventLoopGroup group = new EpollEventLoopGroup(1);
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, EpollIoHandler.newFactory());
         File file = PlatformDependent.createTempFile("netty-splice", null, null);
         file.deleteOnExit();
 

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueChannelConfigTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueChannelConfigTest.java
@@ -21,6 +21,7 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.unix.Buffer;
 import io.netty.channel.unix.IntegerUnixChannelOption;
 import io.netty.channel.unix.RawUnixChannelOption;
@@ -70,7 +71,7 @@ public class KQueueChannelConfigTest {
     // See https://github.com/netty/netty/issues/7159
     @Test
     public void testSoLingerNoAssertError() throws Exception {
-        EventLoopGroup group = new KQueueEventLoopGroup(1);
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, KQueueIoHandler.newFactory());
 
         try {
             Bootstrap bootstrap = new Bootstrap();

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDetectPeerCloseWithoutReadTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDetectPeerCloseWithoutReadTest.java
@@ -17,13 +17,14 @@ package io.netty.channel.kqueue;
 
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.ServerChannel;
 import io.netty.channel.unix.tests.DetectPeerCloseWithoutReadTest;
 
 public class KQueueDetectPeerCloseWithoutReadTest extends DetectPeerCloseWithoutReadTest {
     @Override
     protected EventLoopGroup newGroup() {
-        return new KQueueEventLoopGroup(2);
+        return new MultiThreadIoEventLoopGroup(2, KQueueIoHandler.newFactory());
     }
 
     @Override

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueServerSocketChannelConfigTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueServerSocketChannelConfigTest.java
@@ -19,6 +19,7 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.EventLoopGroup;
 
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -37,7 +38,7 @@ public class KQueueServerSocketChannelConfigTest {
 
     @BeforeAll
     public static void before() {
-        group = new KQueueEventLoopGroup(1);
+        group = new MultiThreadIoEventLoopGroup(1, KQueueIoHandler.newFactory());
         ServerBootstrap bootstrap = new ServerBootstrap();
         ch = (KQueueServerSocketChannel) bootstrap.group(group)
                 .channel(KQueueServerSocketChannel.class)

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketChannelConfigTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketChannelConfigTest.java
@@ -20,6 +20,7 @@ import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.EventLoopGroup;
 
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -46,7 +47,7 @@ public class KQueueSocketChannelConfigTest {
     @BeforeAll
     public static void beforeClass() {
         rand = new Random();
-        group = new KQueueEventLoopGroup(1);
+        group = new MultiThreadIoEventLoopGroup(1, KQueueIoHandler.newFactory());
     }
 
     @AfterAll


### PR DESCRIPTION
Motivation:

We still had some places left where we did use the old deprecated EventLoopGroup implementations

Modifications:

Replace with using MultiThreadIoEventLoopGroup

Result:

Cleanup