### PR TITLE
Use real, instead of synthetic, HTTP/2 stream id (#15842)

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
@@ -185,7 +185,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
 
     private final Http2StreamChannelConfig config = new Http2StreamChannelConfig(this);
     private final Http2ChannelUnsafe unsafe = new Http2ChannelUnsafe();
-    private final ChannelId channelId;
+    private final Http2StreamChannelId channelId;
     private final ChannelPipeline pipeline;
     private final DefaultHttp2FrameStream stream;
     private final ChannelPromise closePromise;
@@ -584,7 +584,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
 
     @Override
     public String toString() {
-        return parent().toString() + "(H2 - " + stream + ')';
+        return parent().toString() + '/' + channelId.getSequenceId() + " (H2 - " + stream + ')';
     }
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelId.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelId.java
@@ -69,6 +69,10 @@ final class Http2StreamChannelId implements ChannelId {
         return id == otherId.id && parentId.equals(otherId.parentId);
     }
 
+    public int getSequenceId() {
+        return id;
+    }
+
     @Override
     public String toString() {
         return asShortText();


### PR DESCRIPTION
Motivation:
The `AbstractHttp2StreamChannel` subclasses use a synthetic id in their `ChannelId`, but include the real stream id in their `toString()` method.
Using two different ids makes it harder to correlate the two in logs. The synthetic ids are necessary because the stream id is assigned at a protocol level at some point after the channel has been created.

Modification:
Include the synthetic id in the `AbstractHttp2StreamChannel.toString()` output.

Result:
Easier to correlate HTTP/2 channel and stream ids, to help with debugging.

(cherry picked from commit d01673aeb2e979ca88495b69a130aee88c951093)