### PR TITLE
Add executor() to ChannelOutboundInvoker and let it replace eventLoop…

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicChannel.java
@@ -235,7 +235,7 @@ public interface QuicChannel extends Channel {
      * @return          the {@link Future} that will be notified once the operation completes.
      */
     default Future<QuicStreamChannel> createStream(QuicStreamType type, @Nullable ChannelHandler handler) {
-        return createStream(type, handler, eventLoop().newPromise());
+        return createStream(type, handler, executor().newPromise());
     }
 
     /**
@@ -295,7 +295,7 @@ public interface QuicChannel extends Channel {
      * @return the {@link Future} that is notified once the stats were collected.
      */
     default Future<QuicConnectionStats> collectStats() {
-        return collectStats(eventLoop().newPromise());
+        return collectStats(executor().newPromise());
     }
 
     /**
@@ -312,7 +312,7 @@ public interface QuicChannel extends Channel {
      * @return the {@link Future} that is notified once the stats were collected.
      */
     default Future<QuicConnectionPathStats> collectPathStats(int pathIdx) {
-        return collectPathStats(pathIdx, eventLoop().newPromise());
+        return collectPathStats(pathIdx, executor().newPromise());
     }
 
     /**

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicChannelBootstrap.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicChannelBootstrap.java
@@ -190,7 +190,7 @@ public final class QuicChannelBootstrap {
      * @return {@link Future} which is notified once the operation completes.
      */
     public Future<QuicChannel> connect() {
-        return connect(parent.eventLoop().newPromise());
+        return connect(parent.executor().newPromise());
     }
 
     /**
@@ -226,7 +226,7 @@ public final class QuicChannelBootstrap {
                 streamHandler, Quic.toOptionsArray(streamOptions), Quic.toAttributesArray(streamAttrs));
 
         Quic.setupChannel(channel, Quic.toOptionsArray(options), Quic.toAttributesArray(attrs), handler, logger);
-        EventLoop eventLoop = parent.eventLoop();
+        EventLoop eventLoop = parent.executor();
         eventLoop.register(channel).addListener((ChannelFuture future) -> {
             Throwable cause = future.cause();
             if (cause != null) {

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicStreamChannelBootstrap.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicStreamChannelBootstrap.java
@@ -111,7 +111,7 @@ public final class QuicStreamChannelBootstrap {
      * @return  the {@link Future} that is notified once the operation completes.
      */
     public Future<QuicStreamChannel> create() {
-        return create(parent.eventLoop().newPromise());
+        return create(parent.executor().newPromise());
     }
 
     /**

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicChannel.java
@@ -435,7 +435,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                 if (msg instanceof QuicStreamChannel) {
                     QuicStreamChannel channel = (QuicStreamChannel) msg;
                     Quic.setupChannel(channel, streamOptionsArray, streamAttrsArray, streamHandler, logger);
-                    ctx.channel().eventLoop().register(channel);
+                    ctx.channel().executor().register(channel);
                 } else {
                     super.onUnhandledInboundMessage(ctx, msg);
                 }
@@ -458,20 +458,20 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     @Override
     public Future<QuicStreamChannel> createStream(QuicStreamType type, @Nullable ChannelHandler handler,
                                                   Promise<QuicStreamChannel> promise) {
-        if (eventLoop().inEventLoop()) {
+        if (executor().inEventLoop()) {
             ((QuicChannelUnsafe) unsafe()).connectStream(type, handler, promise);
         } else {
-            eventLoop().execute(() -> ((QuicChannelUnsafe) unsafe()).connectStream(type, handler, promise));
+            executor().execute(() -> ((QuicChannelUnsafe) unsafe()).connectStream(type, handler, promise));
         }
         return promise;
     }
 
     @Override
     public ChannelFuture close(boolean applicationClose, int error, ByteBuf reason, ChannelPromise promise) {
-        if (eventLoop().inEventLoop()) {
+        if (executor().inEventLoop()) {
             close0(applicationClose, error, reason, promise);
         } else {
-            eventLoop().execute(() -> close0(applicationClose, error, reason, promise));
+            executor().execute(() -> close0(applicationClose, error, reason, promise));
         }
         return promise;
     }
@@ -510,7 +510,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
 
     @Override
     protected boolean isCompatible(EventLoop eventLoop) {
-        return parent().eventLoop() == eventLoop;
+        return parent().executor() == eventLoop;
     }
 
     @Override
@@ -615,7 +615,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
 
             // making sure that connection statistics is available
             // even after channel is closed
-            statsAtClose = collectStats0(conn, eventLoop().newPromise());
+            statsAtClose = collectStats0(conn, executor().newPromise());
             try {
                 timedOut = Quiche.quiche_conn_is_timed_out(conn.address());
 
@@ -1174,7 +1174,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                 runAll(conn, task);
             } finally {
                 // Move back to the EventLoop.
-                eventLoop().execute(() -> {
+                executor().execute(() -> {
                     // Call connection send to continue handshake if needed.
                     if (connectionSend(conn) != SendResult.NONE) {
                         forceFlushParent();
@@ -1446,7 +1446,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
 
                     // Let's try again sending after we did process all tasks.
                     // We schedule this on the EventLoop as otherwise we will get into trouble with re-entrance.
-                    eventLoop().execute(new Runnable() {
+                    executor().execute(new Runnable() {
                         @Override
                         public void run() {
                             // Call connection send to continue handshake if needed.
@@ -1499,7 +1499,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
             if (handler != null) {
                 streamChannel.pipeline().addLast(handler);
             }
-            eventLoop().register(streamChannel).addListener((ChannelFuture f) -> {
+            executor().register(streamChannel).addListener((ChannelFuture f) -> {
                 if (f.isSuccess()) {
                     promise.setSuccess(streamChannel);
                 } else {
@@ -1511,7 +1511,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
 
         @Override
         public void connect(SocketAddress remote, SocketAddress local, ChannelPromise channelPromise) {
-            assert eventLoop().inEventLoop();
+            assert executor().inEventLoop();
             if (!channelPromise.setUncancellable()) {
                 return;
             }
@@ -1538,7 +1538,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                 // Schedule connect timeout.
                 int connectTimeoutMillis = config().getConnectTimeoutMillis();
                 if (connectTimeoutMillis > 0) {
-                    connectTimeoutFuture = eventLoop().schedule(() -> {
+                    connectTimeoutFuture = executor().schedule(() -> {
                         ChannelPromise connectPromise = QuicheQuicChannel.this.connectPromise;
                         if (connectPromise != null && !connectPromise.isDone()
                                 && connectPromise.tryFailure(new ConnectTimeoutException(
@@ -1771,7 +1771,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                     runAll(conn, task);
                 } finally {
                     // Move back to the EventLoop.
-                    eventLoop().execute(() -> {
+                    executor().execute(() -> {
                         if (!conn.isFreed()) {
                             processReceived(conn);
 
@@ -2026,7 +2026,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                 return;
             }
             if (timeoutFuture == null) {
-                timeoutFuture = eventLoop().schedule(this,
+                timeoutFuture = executor().schedule(this,
                         nanos, TimeUnit.NANOSECONDS);
             } else {
                 long remaining = timeoutFuture.getDelay(TimeUnit.NANOSECONDS);
@@ -2039,7 +2039,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                     // The new timeout is smaller then what was scheduled before. Let's cancel the old timeout
                     // and schedule a new one.
                     cancel();
-                    timeoutFuture = eventLoop().schedule(this, nanos, TimeUnit.NANOSECONDS);
+                    timeoutFuture = executor().schedule(this, nanos, TimeUnit.NANOSECONDS);
                 }
             }
         }
@@ -2054,10 +2054,10 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
 
     @Override
     public Future<QuicConnectionStats> collectStats(Promise<QuicConnectionStats> promise) {
-        if (eventLoop().inEventLoop()) {
+        if (executor().inEventLoop()) {
             collectStats0(promise);
         } else {
-            eventLoop().execute(() -> collectStats0(promise));
+            executor().execute(() -> collectStats0(promise));
         }
         return promise;
     }
@@ -2088,10 +2088,10 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
 
     @Override
     public Future<QuicConnectionPathStats> collectPathStats(int pathIdx, Promise<QuicConnectionPathStats> promise) {
-        if (eventLoop().inEventLoop()) {
+        if (executor().inEventLoop()) {
             collectPathStats0(pathIdx, promise);
         } else {
-            eventLoop().execute(() -> collectPathStats0(pathIdx, promise));
+            executor().execute(() -> collectPathStats0(pathIdx, promise));
         }
         return promise;
     }

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicServerCodec.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicServerCodec.java
@@ -273,7 +273,7 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
 
         addChannel(channel);
 
-        ctx.channel().eventLoop().register(channel);
+        ctx.channel().executor().register(channel);
         return channel;
     }
 

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicStreamChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicStreamChannel.java
@@ -127,16 +127,16 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
 
     @Override
     public ChannelFuture updatePriority(QuicStreamPriority priority, ChannelPromise promise) {
-        if (eventLoop().inEventLoop()) {
+        if (executor().inEventLoop()) {
             updatePriority0(priority, promise);
         } else {
-            eventLoop().execute(() -> updatePriority0(priority, promise));
+            executor().execute(() -> updatePriority0(priority, promise));
         }
         return promise;
     }
 
     private void updatePriority0(QuicStreamPriority priority, ChannelPromise promise) {
-        assert eventLoop().inEventLoop();
+        assert executor().inEventLoop();
         if (!promise.setUncancellable()) {
             return;
         }
@@ -157,16 +157,16 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
 
     @Override
     public ChannelFuture shutdownOutput(ChannelPromise promise) {
-        if (eventLoop().inEventLoop()) {
+        if (executor().inEventLoop()) {
             shutdownOutput0(promise);
         } else {
-            eventLoop().execute(() -> shutdownOutput0(promise));
+            executor().execute(() -> shutdownOutput0(promise));
         }
         return promise;
     }
 
     private void shutdownOutput0(ChannelPromise promise) {
-        assert eventLoop().inEventLoop();
+        assert executor().inEventLoop();
         if (!promise.setUncancellable()) {
             return;
         }
@@ -177,20 +177,20 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
 
     @Override
     public ChannelFuture shutdownInput(int error, ChannelPromise promise) {
-        if (eventLoop().inEventLoop()) {
+        if (executor().inEventLoop()) {
             shutdownInput0(error, promise);
         } else {
-            eventLoop().execute(() -> shutdownInput0(error, promise));
+            executor().execute(() -> shutdownInput0(error, promise));
         }
         return promise;
     }
 
     @Override
     public ChannelFuture shutdownOutput(int error, ChannelPromise promise) {
-        if (eventLoop().inEventLoop()) {
+        if (executor().inEventLoop()) {
             shutdownOutput0(error, promise);
         } else {
-            eventLoop().execute(() -> shutdownOutput0(error, promise));
+            executor().execute(() -> shutdownOutput0(error, promise));
         }
         return promise;
     }
@@ -201,7 +201,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
     }
 
     private void shutdownInput0(int err, ChannelPromise channelPromise) {
-        assert eventLoop().inEventLoop();
+        assert executor().inEventLoop();
         if (!channelPromise.setUncancellable()) {
             return;
         }
@@ -216,7 +216,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
     }
 
     private void shutdownOutput0(int error, ChannelPromise channelPromise) {
-        assert eventLoop().inEventLoop();
+        assert executor().inEventLoop();
         if (!channelPromise.setUncancellable()) {
             return;
         }
@@ -232,16 +232,16 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
 
     @Override
     public ChannelFuture shutdown(ChannelPromise channelPromise) {
-        if (eventLoop().inEventLoop()) {
+        if (executor().inEventLoop()) {
             shutdown0(channelPromise);
         } else {
-            eventLoop().execute(() -> shutdown0(channelPromise));
+            executor().execute(() -> shutdown0(channelPromise));
         }
         return channelPromise;
     }
 
     private void shutdown0(ChannelPromise promise) {
-        assert eventLoop().inEventLoop();
+        assert executor().inEventLoop();
         if (!promise.setUncancellable()) {
             return;
         }
@@ -255,16 +255,16 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
 
     @Override
     public ChannelFuture shutdown(int error, ChannelPromise promise) {
-        if (eventLoop().inEventLoop()) {
+        if (executor().inEventLoop()) {
             shutdown0(error, promise);
         } else {
-            eventLoop().execute(() -> shutdown0(error, promise));
+            executor().execute(() -> shutdown0(error, promise));
         }
         return promise;
     }
 
     private void shutdown0(int error, ChannelPromise channelPromise) {
-        assert eventLoop().inEventLoop();
+        assert executor().inEventLoop();
         if (!channelPromise.setUncancellable()) {
             return;
         }
@@ -333,8 +333,8 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
     }
 
     @Override
-    public EventLoop eventLoop() {
-        return parent.eventLoop();
+    public EventLoop executor() {
+        return parent.executor();
     }
 
     @Override
@@ -413,7 +413,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
      * Stream writability changed.
      */
     boolean writable(long capacity) {
-        assert eventLoop().inEventLoop();
+        assert executor().inEventLoop();
         if (capacity < 0) {
             // If the value is negative its a quiche error.
             if (capacity != Quiche.QUICHE_ERR_DONE) {
@@ -453,7 +453,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
      * Stream is readable.
      */
     void readable() {
-        assert eventLoop().inEventLoop();
+        assert executor().inEventLoop();
         // Mark as readable and if a read is pending execute it.
         readable = true;
         if (readPending) {
@@ -470,7 +470,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
                 QuicheQuicStreamChannel.this, false);
         @Override
         public void connect(SocketAddress remote, SocketAddress local, ChannelPromise promise) {
-            assert eventLoop().inEventLoop();
+            assert executor().inEventLoop();
             promise.setFailure(new UnsupportedOperationException());
         }
 
@@ -503,7 +503,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
                 promise.setFailure(new IllegalStateException());
                 return;
             }
-            if (eventLoop != parent.eventLoop()) {
+            if (eventLoop != parent.executor()) {
                 promise.setFailure(new IllegalArgumentException());
                 return;
             }
@@ -515,7 +515,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
 
         @Override
         public void bind(SocketAddress localAddress, ChannelPromise promise) {
-            assert eventLoop().inEventLoop();
+            assert executor().inEventLoop();
             if (!promise.setUncancellable()) {
                 return;
             }
@@ -524,7 +524,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
 
         @Override
         public void disconnect(ChannelPromise promise) {
-            assert eventLoop().inEventLoop();
+            assert executor().inEventLoop();
             close(promise);
         }
 
@@ -534,7 +534,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
         }
 
         void close(@Nullable ClosedChannelException writeFailCause, ChannelPromise promise) {
-            assert eventLoop().inEventLoop();
+            assert executor().inEventLoop();
             if (!promise.setUncancellable()) {
                 return;
             }
@@ -580,7 +580,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
         }
 
         private void deregister(final ChannelPromise promise, final boolean fireChannelInactive) {
-            assert eventLoop().inEventLoop();
+            assert executor().inEventLoop();
             if (!promise.setUncancellable()) {
                 return;
             }
@@ -628,7 +628,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
                 //         -> handlerA.channelInactive() - (2) another inbound handler method called while in (1) yet
                 //
                 // which means the execution of two inbound handler methods of the same handler overlap undesirably.
-                eventLoop().execute(task);
+                executor().execute(task);
             } catch (RejectedExecutionException e) {
                 LOGGER.warn("Can't invoke task later as EventLoop rejected it", e);
             }
@@ -636,19 +636,19 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
 
         @Override
         public void closeForcibly() {
-            assert eventLoop().inEventLoop();
+            assert executor().inEventLoop();
             close(unsafe().voidPromise());
         }
 
         @Override
         public void deregister(ChannelPromise promise) {
-            assert eventLoop().inEventLoop();
+            assert executor().inEventLoop();
             deregister(promise, false);
         }
 
         @Override
         public void beginRead() {
-            assert eventLoop().inEventLoop();
+            assert executor().inEventLoop();
             readPending = true;
             if (readable) {
                 unsafe().recv();
@@ -675,7 +675,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
         }
 
         boolean writeQueued() {
-            assert eventLoop().inEventLoop();
+            assert executor().inEventLoop();
             boolean wasFinSent = QuicheQuicStreamChannel.this.finSent;
             inWriteQueued = true;
             try {
@@ -721,7 +721,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
 
         @Override
         public void write(Object msg, ChannelPromise promise) {
-            assert eventLoop().inEventLoop();
+            assert executor().inEventLoop();
             if (!promise.setUncancellable()) {
                 ReferenceCountUtil.release(msg);
                 return;
@@ -890,13 +890,13 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
 
         @Override
         public void flush() {
-            assert eventLoop().inEventLoop();
+            assert executor().inEventLoop();
             // NOOP.
         }
 
         @Override
         public ChannelPromise voidPromise() {
-            assert eventLoop().inEventLoop();
+            assert executor().inEventLoop();
             return voidPromise;
         }
 
@@ -947,7 +947,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
         }
 
         void recv() {
-            assert eventLoop().inEventLoop();
+            assert executor().inEventLoop();
             if (inRecv) {
                 // As the use may call read() we need to guard against reentrancy here as otherwise it could
                 // be possible that we re-enter this method while still processing it.

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/Lz4FrameEncoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/Lz4FrameEncoderTest.java
@@ -273,7 +273,7 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
             clientChannel = bs.connect(serverChannel.localAddress()).syncUninterruptibly().channel();
 
             final Channel finalClientChannel = clientChannel;
-            clientChannel.eventLoop().execute(new Runnable() {
+            clientChannel.executor().execute(new Runnable() {
                 @Override
                 public void run() {
                     finalClientChannel.close();

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker.java
@@ -422,7 +422,7 @@ public abstract class WebSocketClientHandshaker {
             // Delay the removal of the decoder so the user can setup the pipeline if needed to handle
             // WebSocketFrame messages.
             // See https://github.com/netty/netty/issues/4533
-            channel.eventLoop().execute(new Runnable() {
+            channel.executor().execute(new Runnable() {
                 @Override
                 public void run() {
                     p.remove(codec);
@@ -439,7 +439,7 @@ public abstract class WebSocketClientHandshaker {
             // Delay the removal of the decoder so the user can setup the pipeline if needed to handle
             // WebSocketFrame messages.
             // See https://github.com/netty/netty/issues/4533
-            channel.eventLoop().execute(new Runnable() {
+            channel.executor().execute(new Runnable() {
                 @Override
                 public void run() {
                     p.remove(context.handler());
@@ -696,7 +696,7 @@ public abstract class WebSocketClientHandshaker {
                 // Also, close might be called twice from different threads.
                 if (future.isSuccess() && channel.isActive() &&
                         FORCE_CLOSE_INIT_UPDATER.compareAndSet(handshaker, 0, 1)) {
-                    final Future<?> forceCloseFuture = channel.eventLoop().schedule(new Runnable() {
+                    final Future<?> forceCloseFuture = channel.executor().schedule(new Runnable() {
                         @Override
                         public void run() {
                             if (channel.isActive()) {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerUpgradeHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerUpgradeHandlerTest.java
@@ -110,7 +110,7 @@ public class HttpServerUpgradeHandlerTest {
                 // make sure the pipeline was reformed irrespective of the flush completing.
                 assertTrue(inReadCall);
                 writeUpgradeMessage = true;
-                ctx.channel().eventLoop().execute(new Runnable() {
+                ctx.channel().executor().execute(new Runnable() {
                     @Override
                     public void run() {
                         ctx.write(msg, promise);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
@@ -330,7 +330,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
                     }
                 };
             }
-            eventLoop().execute(task);
+            executor().execute(task);
         } else {
             pipeline.fireChannelWritabilityChanged();
         }
@@ -382,8 +382,8 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
     }
 
     @Override
-    public EventLoop eventLoop() {
-        return parent().eventLoop();
+    public EventLoop executor() {
+        return parent().executor();
     }
 
     @Override
@@ -592,7 +592,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
      * channel.
      */
     void fireChildRead(Http2Frame frame) {
-        assert eventLoop().inEventLoop();
+        assert executor().inEventLoop();
         if (!isActive()) {
             ReferenceCountUtil.release(frame);
         } else if (readStatus != ReadStatus.IDLE) {
@@ -620,13 +620,13 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
     }
 
     void fireChildReadComplete() {
-        assert eventLoop().inEventLoop();
+        assert executor().inEventLoop();
         assert readStatus != ReadStatus.IDLE || !readCompletePending;
         unsafe.notifyReadComplete(unsafe.recvBufAllocHandle(), false, false);
     }
 
     final void closeWithError(Http2Error error) {
-        assert eventLoop().inEventLoop();
+        assert executor().inEventLoop();
         unsafe.close(unsafe.voidPromise(), error);
     }
 
@@ -839,7 +839,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
                 //       -> handlerA.channelInactive() - (2) another inbound handler method called while in (1) yet
                 //
                 // which means the execution of two inbound handler methods of the same handler overlap undesirably.
-                eventLoop().execute(task);
+                executor().execute(task);
             } catch (RejectedExecutionException e) {
                 logger.warn("{} Can't invoke task later as EventLoop rejected it", channel, e);
             }
@@ -1264,10 +1264,10 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
                 if (changed) {
                     if (channel.isRegistered()) {
                         final Http2ChannelUnsafe unsafe = (Http2ChannelUnsafe) channel.unsafe();
-                        if (channel.eventLoop().inEventLoop()) {
+                        if (channel.executor().inEventLoop()) {
                             unsafe.updateLocalWindowIfNeededAndFlush();
                         } else {
-                            channel.eventLoop().execute(new Runnable() {
+                            channel.executor().execute(new Runnable() {
                                 @Override
                                 public void run() {
                                     unsafe.updateLocalWindowIfNeededAndFlush();

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
@@ -123,7 +123,7 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
 
     @Override
     public final void handlerAdded0(ChannelHandlerContext ctx) throws Exception {
-        if (ctx.executor() != ctx.channel().eventLoop()) {
+        if (ctx.executor() != ctx.channel().executor()) {
             throw new IllegalStateException("EventExecutor must be EventLoop of Channel");
         }
         this.ctx = ctx;
@@ -179,7 +179,7 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
                 } else {
                     streamChannel = new Http2MultiplexCodecStreamChannel(stream, inboundStreamHandler);
                 }
-                ChannelFuture future = ctx.channel().eventLoop().register(streamChannel);
+                ChannelFuture future = ctx.channel().executor().register(streamChannel);
                 if (future.isDone()) {
                     Http2MultiplexHandler.registerDone(future);
                 } else {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexHandler.java
@@ -158,7 +158,7 @@ public final class Http2MultiplexHandler extends Http2ChannelDuplexHandler {
 
     @Override
     protected void handlerAdded0(ChannelHandlerContext ctx) {
-        if (ctx.executor() != ctx.channel().eventLoop()) {
+        if (ctx.executor() != ctx.channel().executor()) {
             throw new IllegalStateException("EventExecutor must be EventLoop of Channel");
         }
         this.ctx = ctx;
@@ -249,7 +249,7 @@ public final class Http2MultiplexHandler extends Http2ChannelDuplexHandler {
                         } else {
                             ch = new Http2MultiplexHandlerStreamChannel(stream, inboundStreamHandler);
                         }
-                        ChannelFuture future = ctx.channel().eventLoop().register(ch);
+                        ChannelFuture future = ctx.channel().executor().register(ch);
                         if (future.isDone()) {
                             registerDone(future);
                         } else {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrap.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrap.java
@@ -101,7 +101,7 @@ public final class Http2StreamChannelBootstrap {
      * @return the {@link Future} that will be notified once the channel was opened successfully or it failed.
      */
     public Future<Http2StreamChannel> open() {
-        return open(channel.eventLoop().<Http2StreamChannel>newPromise());
+        return open(channel.executor().<Http2StreamChannel>newPromise());
     }
 
     /**
@@ -186,7 +186,7 @@ public final class Http2StreamChannelBootstrap {
             return;
         }
 
-        ChannelFuture future = ctx.channel().eventLoop().register(streamChannel);
+        ChannelFuture future = ctx.channel().executor().register(streamChannel);
         future.addListener(new ChannelFutureListener() {
             @Override
             public void operationComplete(ChannelFuture future) {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameInboundWriter.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameInboundWriter.java
@@ -121,7 +121,7 @@ final class Http2FrameInboundWriter {
 
         @Override
         public EventExecutor executor() {
-            return channel.eventLoop();
+            return channel.executor();
         }
 
         @Override

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTransportTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTransportTest.java
@@ -301,7 +301,7 @@ public class Http2MultiplexTransportTest {
                                                 ctx.write(new DefaultHttp2DataFrame(
                                                         Unpooled.copiedBuffer("Hello World", CharsetUtil.US_ASCII),
                                                         true));
-                                                ctx.channel().eventLoop().execute(new Runnable() {
+                                                ctx.channel().executor().execute(new Runnable() {
                                                     @Override
                                                     public void run() {
                                                         ctx.flush();

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrapTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrapTest.java
@@ -104,7 +104,7 @@ public class Http2StreamChannelBootstrapTest {
             });
 
             Http2StreamChannelBootstrap bootstrap = new Http2StreamChannelBootstrap(clientChannel);
-            final Promise<Http2StreamChannel> promise = clientChannel.eventLoop().newPromise();
+            final Promise<Http2StreamChannel> promise = clientChannel.executor().newPromise();
             bootstrap.open(promise);
             assertFalse(promise.isDone());
             closeLatch.countDown();

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
@@ -68,7 +68,7 @@ public final class Http2TestUtil {
      * Runs the given operation within the event loop thread of the given {@link Channel}.
      */
     static void runInChannel(Channel channel, final Http2Runnable runnable) {
-        channel.eventLoop().execute(new Runnable() {
+        channel.executor().execute(new Runnable() {
             @Override
             public void run() {
                 try {

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3FrameCodec.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3FrameCodec.java
@@ -752,19 +752,19 @@ final class Http3FrameCodec extends ByteToMessageDecoder implements ChannelOutbo
         }
 
         void enqueue(Object msg, ChannelPromise promise) {
-            assert ctx.channel().eventLoop().inEventLoop();
+            assert ctx.channel().executor().inEventLoop();
             // Touch the message to allow easier debugging of memory leaks
             ReferenceCountUtil.touch(msg);
             queue.add(msg, promise);
         }
 
         void enqueueFlush() {
-            assert ctx.channel().eventLoop().inEventLoop();
+            assert ctx.channel().executor().inEventLoop();
             queue.add(FLUSH, ctx.voidPromise());
         }
 
         void drain() {
-            assert ctx.channel().eventLoop().inEventLoop();
+            assert ctx.channel().executor().inEventLoop();
             boolean flushSeen = false;
             try {
                 for (;;) {

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ServerPushStreamManager.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ServerPushStreamManager.java
@@ -141,7 +141,7 @@ public final class Http3ServerPushStreamManager {
      * @return the {@link Future} that will be notified once the push-stream was opened.
      */
     public Future<QuicStreamChannel> newPushStream(long pushId, @Nullable ChannelHandler handler) {
-        final Promise<QuicStreamChannel> promise = channel.eventLoop().newPromise();
+        final Promise<QuicStreamChannel> promise = channel.executor().newPromise();
         newPushStream(pushId, handler, promise);
         return promise;
     }

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/QpackAttributes.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/QpackAttributes.java
@@ -36,8 +36,8 @@ final class QpackAttributes {
     QpackAttributes(QuicChannel channel, boolean disableDynamicTable) {
         this.channel = channel;
         dynamicTableDisabled = disableDynamicTable;
-        encoderStreamPromise = dynamicTableDisabled ? null : channel.eventLoop().newPromise();
-        decoderStreamPromise = dynamicTableDisabled ? null : channel.eventLoop().newPromise();
+        encoderStreamPromise = dynamicTableDisabled ? null : channel.executor().newPromise();
+        decoderStreamPromise = dynamicTableDisabled ? null : channel.executor().newPromise();
     }
 
     boolean dynamicTableDisabled() {
@@ -75,7 +75,7 @@ final class QpackAttributes {
     }
 
     void decoderStream(QuicStreamChannel decoderStream) {
-        assert channel.eventLoop().inEventLoop();
+        assert channel.executor().inEventLoop();
         assert !dynamicTableDisabled;
         assert decoderStreamPromise != null;
         assert this.decoderStream == null;
@@ -84,7 +84,7 @@ final class QpackAttributes {
     }
 
     void encoderStream(QuicStreamChannel encoderStream) {
-        assert channel.eventLoop().inEventLoop();
+        assert channel.executor().inEventLoop();
         assert !dynamicTableDisabled;
         assert encoderStreamPromise != null;
         assert this.encoderStream == null;
@@ -93,14 +93,14 @@ final class QpackAttributes {
     }
 
     void encoderStreamInactive(Throwable cause) {
-        assert channel.eventLoop().inEventLoop();
+        assert channel.executor().inEventLoop();
         assert !dynamicTableDisabled;
         assert encoderStreamPromise != null;
         encoderStreamPromise.tryFailure(cause);
     }
 
     void decoderStreamInactive(Throwable cause) {
-        assert channel.eventLoop().inEventLoop();
+        assert channel.executor().inEventLoop();
         assert !dynamicTableDisabled;
         assert decoderStreamPromise != null;
         decoderStreamPromise.tryFailure(cause);

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3ServerPushStreamManagerTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3ServerPushStreamManagerTest.java
@@ -170,7 +170,7 @@ public class Http3ServerPushStreamManagerTest {
                                                                  long pushId)
             throws Exception {
         return newPushStream(() -> {
-            final Promise<QuicStreamChannel> promise = channel.eventLoop().newPromise();
+            final Promise<QuicStreamChannel> promise = channel.executor().newPromise();
             manager.newPushStream(pushId, pushStreamHandler, identity(), promise);
             return (EmbeddedQuicStreamChannel) promise.get();
         });

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3SpecTestServer.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3SpecTestServer.java
@@ -109,7 +109,7 @@ public final class Http3SpecTestServer {
                     .channel(NioDatagramChannel.class)
                     .handler(codec)
                     .bind(new InetSocketAddress(port)).sync().channel();
-            channel.eventLoop().submit(() -> System.out.println("H3SPEC_SERVER_READY"));
+            channel.executor().submit(() -> System.out.println("H3SPEC_SERVER_READY"));
             channel.closeFuture().sync();
         } finally {
             group.shutdownGracefully();

--- a/example/src/main/java/io/netty/example/proxy/HexDumpProxyFrontendHandler.java
+++ b/example/src/main/java/io/netty/example/proxy/HexDumpProxyFrontendHandler.java
@@ -44,7 +44,7 @@ public class HexDumpProxyFrontendHandler extends ChannelInboundHandlerAdapter {
 
         // Start the connection attempt.
         Bootstrap b = new Bootstrap();
-        b.group(inboundChannel.eventLoop())
+        b.group(inboundChannel.executor())
          .channel(ctx.channel().getClass())
          .handler(new HexDumpProxyBackendHandler(inboundChannel))
          .option(ChannelOption.AUTO_READ, false);

--- a/example/src/main/java/io/netty/example/socksproxy/SocksServerConnectHandler.java
+++ b/example/src/main/java/io/netty/example/socksproxy/SocksServerConnectHandler.java
@@ -71,7 +71,7 @@ public final class SocksServerConnectHandler extends SimpleChannelInboundHandler
                     });
 
             final Channel inboundChannel = ctx.channel();
-            b.group(inboundChannel.eventLoop())
+            b.group(inboundChannel.executor())
                     .channel(NioSocketChannel.class)
                     .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10000)
                     .option(ChannelOption.SO_KEEPALIVE, true)
@@ -124,7 +124,7 @@ public final class SocksServerConnectHandler extends SimpleChannelInboundHandler
                     });
 
             final Channel inboundChannel = ctx.channel();
-            b.group(inboundChannel.eventLoop())
+            b.group(inboundChannel.executor())
                     .channel(NioSocketChannel.class)
                     .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10000)
                     .option(ChannelOption.SO_KEEPALIVE, true)

--- a/example/src/main/java/io/netty/example/uptime/UptimeClientHandler.java
+++ b/example/src/main/java/io/netty/example/uptime/UptimeClientHandler.java
@@ -68,7 +68,7 @@ public class UptimeClientHandler extends SimpleChannelInboundHandler<Object> {
     public void channelUnregistered(final ChannelHandlerContext ctx) throws Exception {
         println("Sleeping for: " + UptimeClient.RECONNECT_DELAY + 's');
 
-        ctx.channel().eventLoop().schedule(new Runnable() {
+        ctx.channel().executor().schedule(new Runnable() {
             @Override
             public void run() {
                 println("Reconnecting to: " + UptimeClient.HOST + ':' + UptimeClient.PORT);

--- a/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyServer.java
+++ b/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyServer.java
@@ -168,7 +168,7 @@ abstract class ProxyServer {
             boolean finished = handleProxyProtocol(ctx, msg);
             if (finished) {
                 this.finished = true;
-                ChannelFuture f = connectToDestination(ctx.channel().eventLoop(), new BackendHandler(ctx));
+                ChannelFuture f = connectToDestination(ctx.channel().executor(), new BackendHandler(ctx));
                 f.addListener(new ChannelFutureListener() {
                     @Override
                     public void operationComplete(ChannelFuture future) throws Exception {

--- a/handler/src/main/java/io/netty/handler/flush/FlushConsolidationHandler.java
+++ b/handler/src/main/java/io/netty/handler/flush/FlushConsolidationHandler.java
@@ -207,7 +207,7 @@ public class FlushConsolidationHandler extends ChannelDuplexHandler {
     private void scheduleFlush(final ChannelHandlerContext ctx) {
         if (nextScheduledFlush == null) {
             // Run as soon as possible, but still yield to give a chance for additional writes to enqueue.
-            nextScheduledFlush = ctx.channel().eventLoop().submit(flushTask);
+            nextScheduledFlush = ctx.channel().executor().submit(flushTask);
         }
     }
 

--- a/handler/src/test/java/io/netty/handler/flow/FlowControlHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/flow/FlowControlHandlerTest.java
@@ -248,7 +248,7 @@ public class FlowControlHandlerTest {
             // We should receive 3 messages
             assertTrue(latch.await(1L, SECONDS));
 
-            assertTrue(peer.eventLoop().submit(new Callable<Boolean>() {
+            assertTrue(peer.executor().submit(new Callable<Boolean>() {
                 @Override
                 public Boolean call() {
                     return flow.isQueueEmpty();
@@ -335,7 +335,7 @@ public class FlowControlHandlerTest {
             setAutoReadLatch2.countDown();
             assertTrue(msgRcvLatch3.await(1L, SECONDS));
 
-            assertTrue(peer.eventLoop().submit(new Callable<Boolean>() {
+            assertTrue(peer.executor().submit(new Callable<Boolean>() {
                 @Override
                 public Boolean call() {
                     return flow.isQueueEmpty();
@@ -397,7 +397,7 @@ public class FlowControlHandlerTest {
             peer.read();
             assertTrue(msgRcvLatch3.await(1L, SECONDS));
 
-            assertTrue(peer.eventLoop().submit(new Callable<Boolean>() {
+            assertTrue(peer.executor().submit(new Callable<Boolean>() {
                 @Override
                 public Boolean call() {
                     return flow.isQueueEmpty();
@@ -450,7 +450,7 @@ public class FlowControlHandlerTest {
             // channelRead(1)
             peer.read();
             assertTrue(msgRcvLatch1.await(1L, SECONDS));
-            assertFalse(peer.eventLoop().submit(new Callable<Boolean>() {
+            assertFalse(peer.executor().submit(new Callable<Boolean>() {
                 @Override
                 public Boolean call() {
                     return flow.isQueueEmpty();
@@ -469,7 +469,7 @@ public class FlowControlHandlerTest {
             peer.read();
             assertTrue(msgRcvLatch3.await(1L, SECONDS));
 
-            assertTrue(peer.eventLoop().submit(new Callable<Boolean>() {
+            assertTrue(peer.executor().submit(new Callable<Boolean>() {
                 @Override
                 public Boolean call() {
                     return flow.isQueueEmpty();
@@ -520,7 +520,7 @@ public class FlowControlHandlerTest {
             peer.read();
             assertTrue(latch.await(1L, SECONDS));
 
-            assertTrue(peer.eventLoop().submit(new Callable<Boolean>() {
+            assertTrue(peer.executor().submit(new Callable<Boolean>() {
                 @Override
                 public Boolean call() {
                     return flow.isQueueEmpty();
@@ -623,7 +623,7 @@ public class FlowControlHandlerTest {
                 if (num >= 3) {
                     //We have received 3 messages. Remove myself later
                     final ChannelHandler handler = this;
-                    ctx.channel().eventLoop().execute(new Runnable() {
+                    ctx.channel().executor().execute(new Runnable() {
                         @Override
                         public void run() {
                             ctx.pipeline().remove(handler);
@@ -651,7 +651,7 @@ public class FlowControlHandlerTest {
 
             // We should receive 3 messages
             assertTrue(latch.await(1L, SECONDS));
-            assertTrue(peer.eventLoop().submit(new Callable<Boolean>() {
+            assertTrue(peer.executor().submit(new Callable<Boolean>() {
                 @Override
                 public Boolean call() {
                     return flow.isQueueEmpty();

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -65,11 +65,9 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.opentest4j.AssertionFailedError;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -1533,7 +1531,7 @@ public abstract class SSLEngineTest {
                                 // The server then attempts to trigger a flush operation once the application data is
                                 // received from the client. The flush will encrypt all data and should not result in
                                 // deadlock.
-                                ctx.channel().eventLoop().schedule(new Runnable() {
+                                ctx.channel().executor().schedule(new Runnable() {
                                     @Override
                                     public void run() {
                                         ctx.writeAndFlush(ctx.alloc().buffer(1).writeByte(101));
@@ -4004,7 +4002,7 @@ public abstract class SSLEngineTest {
         int checkServerTrustedCalls = checkServerTrustedCount.get();
         if (checkServerTrustedCalls == 1) {
             do {
-                clientChannel.eventLoop().submit(NOOP).await(); // Wait for exception to propagate.
+                clientChannel.executor().submit(NOOP).await(); // Wait for exception to propagate.
             } while (clientException == null);
             assertEquals("Test exception", clientException.getMessage());
             assertNotNull(handshakeFuture);
@@ -4070,7 +4068,7 @@ public abstract class SSLEngineTest {
         int checkClientTrustedCalls = checkClientTrustedCount.get();
         if (checkClientTrustedCalls == 1) {
             do {
-                serverChannel.eventLoop().submit(NOOP).await(); // Wait for exception to propagate.
+                serverChannel.executor().submit(NOOP).await(); // Wait for exception to propagate.
             } while (serverException == null);
             assertEquals("Test exception", serverException.getMessage());
             assertNotNull(handshakeFuture);

--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -521,7 +521,7 @@ public class SslHandlerTest {
                         ch.pipeline().remove(sslHandler);
 
                         // Schedule the close so removal has time to propagate exception if any.
-                        ch.eventLoop().execute(new Runnable() {
+                        ch.executor().execute(new Runnable() {
                             @Override
                             public void run() {
                                 ch.close();

--- a/handler/src/test/java/io/netty/handler/traffic/TrafficShapingHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/traffic/TrafficShapingHandlerTest.java
@@ -106,7 +106,7 @@ public class TrafficShapingHandlerTest {
             ch.writeAndFlush(Unpooled.wrappedBuffer("bar".getBytes(CharsetUtil.UTF_8))).await();
             assertNotNull(attr.get());
             final Channel clientChannel = ch;
-            ch.eventLoop().submit(new Runnable() {
+            ch.executor().submit(new Runnable() {
                 @Override
                 public void run() {
                     clientChannel.pipeline().remove("traffic-shaping");

--- a/microbench/src/main/java/io/netty/microbench/channel/EmbeddedChannelHandlerContext.java
+++ b/microbench/src/main/java/io/netty/microbench/channel/EmbeddedChannelHandlerContext.java
@@ -45,7 +45,7 @@ public abstract class EmbeddedChannelHandlerContext implements ChannelHandlerCon
         this.alloc = checkNotNull(alloc, "alloc");
         this.channel = checkNotNull(channel, "channel");
         this.handler = checkNotNull(handler, "handler");
-        this.eventLoop = checkNotNull(channel.eventLoop(), "eventLoop");
+        this.eventLoop = checkNotNull(channel.executor(), "eventLoop");
     }
 
     protected abstract void handleException(Throwable t);

--- a/microbench/src/main/java/io/netty/microbench/channel/epoll/EpollSocketChannelBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/channel/epoll/EpollSocketChannelBenchmark.java
@@ -147,12 +147,12 @@ public class EpollSocketChannelBenchmark extends AbstractMicrobenchmark {
 
     @Benchmark
     public Object executeSingle() throws Exception {
-        return chan.eventLoop().submit(runnable).get();
+        return chan.executor().submit(runnable).get();
     }
 
     @Benchmark
     @GroupThreads(3)
     public Object executeMulti() throws Exception {
-        return chan.eventLoop().submit(runnable).get();
+        return chan.executor().submit(runnable).get();
     }
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolveContext.java
@@ -84,12 +84,12 @@ final class DnsAddressResolveContext extends DnsResolveContext<InetAddress> {
     void cache(String hostname, DnsRecord[] additionals,
                DnsRecord result, InetAddress convertedResult) {
         resolveCache.cache(hostname, additionals, convertedResult, result.timeToLive(),
-                channel().eventLoop());
+                channel().executor());
     }
 
     @Override
     void cache(String hostname, DnsRecord[] additionals, UnknownHostException cause) {
-        resolveCache.cache(hostname, additionals, cause, channel().eventLoop());
+        resolveCache.cache(hostname, additionals, cause, channel().executor());
     }
 
     @Override

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
@@ -196,7 +196,7 @@ abstract class DnsQueryContext {
                     // This query was failed due a timeout or cancellation. Let's delay the removal of the id to reduce
                     // the risk of reusing the same id again while the remote nameserver might send the response after
                     // the timeout.
-                    channel.eventLoop().schedule(new Runnable() {
+                    channel.executor().schedule(new Runnable() {
                         @Override
                         public void run() {
                             removeFromContextManager(nameServerAddr);
@@ -270,7 +270,7 @@ abstract class DnsQueryContext {
 
         // Schedule a query timeout task if necessary.
         if (queryTimeoutMillis > 0) {
-            timeoutFuture = channel.eventLoop().schedule(new Runnable() {
+            timeoutFuture = channel.executor().schedule(new Runnable() {
                 @Override
                 public void run() {
                     if (promise.isDone()) {
@@ -371,7 +371,7 @@ abstract class DnsQueryContext {
                 }
                 final Channel tcpCh = future.channel();
                 Promise<AddressedEnvelope<DnsResponse, InetSocketAddress>> promise =
-                        tcpCh.eventLoop().newPromise();
+                        tcpCh.executor().newPromise();
                 final TcpDnsQueryContext tcpCtx = new TcpDnsQueryContext(tcpCh,
                         (InetSocketAddress) tcpCh.remoteAddress(), queryContextManager, queryLifecycleObserver, 0,
                         recursionDesired, queryTimeoutMillis, question(), additionals, promise);

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -20,7 +20,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.channel.AddressedEnvelope;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
 import io.netty.channel.EventLoop;
 import io.netty.handler.codec.CorruptedFrameException;
 import io.netty.handler.codec.dns.DefaultDnsQuestion;
@@ -454,7 +453,7 @@ abstract class DnsResolveContext<T> {
             return;
         }
         final Promise<AddressedEnvelope<? extends DnsResponse, InetSocketAddress>> queryPromise =
-                channel.eventLoop().newPromise();
+                channel.executor().newPromise();
 
         final long queryStartTimeNanos;
         final boolean isFeedbackAddressStream;

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsResolveContextTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsResolveContextTest.java
@@ -42,15 +42,15 @@ public class DnsResolveContextTest {
         EmbeddedChannel channel = new EmbeddedChannel();
         DnsCnameCache cache = new DefaultDnsCnameCache();
         if (chainLength == 1) {
-            cache.cache(HOSTNAME, HOSTNAME, Long.MAX_VALUE, channel.eventLoop());
+            cache.cache(HOSTNAME, HOSTNAME, Long.MAX_VALUE, channel.executor());
         } else {
             String lastName = HOSTNAME;
             for (int i = 1; i < chainLength; i++) {
                 String nextName = i + "." + lastName;
-                cache.cache(lastName, nextName, Long.MAX_VALUE, channel.eventLoop());
+                cache.cache(lastName, nextName, Long.MAX_VALUE, channel.executor());
                 lastName = nextName;
             }
-            cache.cache(lastName, HOSTNAME, Long.MAX_VALUE, channel.eventLoop());
+            cache.cache(lastName, HOSTNAME, Long.MAX_VALUE, channel.executor());
         }
         return cache;
     }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -154,7 +154,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                             if (bytesRead == totalServerBytesWritten) {
                                 // Bounce this through the event loop to make sure it happens after we're done
                                 // with the read operation.
-                                ch.eventLoop().execute(new Runnable() {
+                                ch.executor().execute(new Runnable() {
                                     @Override
                                     public void run() {
                                         clientReadAllDataLatch.countDown();
@@ -588,7 +588,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                                 // but the close will be done after the Selector did process all events. Because of
                                 // this we will need to give it a bit time to ensure the FD is actual closed before we
                                 // count down the latch and try to write.
-                                future.channel().eventLoop().schedule(new Runnable() {
+                                future.channel().executor().schedule(new Runnable() {
                                     @Override
                                     public void run() {
                                         followerCloseLatch.countDown();

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -191,7 +191,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
                 // if SO_LINGER is used.
                 //
                 // See https://github.com/netty/netty/issues/7159
-                EventLoop loop = eventLoop();
+                EventLoop loop = executor();
                 if (loop.inEventLoop()) {
                     doDeregister();
                 } else {
@@ -268,7 +268,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
     final void clearEpollIn() {
         // Only clear if registered with an EventLoop as otherwise
         if (isRegistered()) {
-            final EventLoop loop = eventLoop();
+            final EventLoop loop = executor();
             final AbstractEpollUnsafe unsafe = (AbstractEpollUnsafe) unsafe();
             if (loop.inEventLoop()) {
                 unsafe.clearEpollIn0();
@@ -293,7 +293,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
 
     @Override
     protected void doRegister(ChannelPromise promise) {
-        ((IoEventLoop) eventLoop()).register((AbstractEpollUnsafe) unsafe()).addListener(f -> {
+        ((IoEventLoop) executor()).register((AbstractEpollUnsafe) unsafe()).addListener(f -> {
             if (f.isSuccess()) {
                 registration = (IoRegistration) f.getNow();
                 registration.submit(ops);
@@ -616,7 +616,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
         }
 
         protected final void clearEpollIn0() {
-            assert eventLoop().inEventLoop();
+            assert executor().inEventLoop();
             try {
                 readPending = false;
                 if (!ops.contains(EpollIoOps.EPOLLIN)) {
@@ -657,7 +657,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
                     // Schedule connect timeout.
                     final int connectTimeoutMillis = config().getConnectTimeoutMillis();
                     if (connectTimeoutMillis > 0) {
-                        connectTimeoutFuture = eventLoop().schedule(new Runnable() {
+                        connectTimeoutFuture = executor().schedule(new Runnable() {
                             @Override
                             public void run() {
                                 ChannelPromise connectPromise = AbstractEpollChannel.this.connectPromise;
@@ -733,7 +733,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
             // Note this method is invoked by the event loop only if the connection attempt was
             // neither cancelled nor timed out.
 
-            assert eventLoop().inEventLoop();
+            assert executor().inEventLoop();
 
             boolean connectStillInProgress = false;
             try {

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
@@ -82,7 +82,7 @@ public abstract class AbstractEpollServerChannel extends AbstractEpollChannel im
 
         @Override
         void epollInReady() {
-            assert eventLoop().inEventLoop();
+            assert executor().inEventLoop();
             final ChannelConfig config = config();
             if (shouldBreakEpollInReady(config)) {
                 clearEpollIn0();

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -150,7 +150,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
      */
     public final ChannelFuture spliceTo(final AbstractEpollStreamChannel ch, final int len,
                                         final ChannelPromise promise) {
-        if (ch.eventLoop() != eventLoop()) {
+        if (ch.executor() != executor()) {
             throw new IllegalArgumentException("EventLoops are not the same.");
         }
         checkPositiveOrZero(len, "len");
@@ -224,7 +224,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
             if (!promise.isDone()) {
                 final ClosedChannelException ex = new ClosedChannelException();
                 if (promise.tryFailure(ex)) {
-                    eventLoop().execute(new Runnable() {
+                    executor().execute(new Runnable() {
                         @Override
                         public void run() {
                             // Call this via the EventLoop as it is a MPSC queue.
@@ -443,7 +443,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
             clearFlag(Native.EPOLLOUT);
 
             // We used our writeSpin quantum, and should try to write again later.
-            eventLoop().execute(flushTask);
+            executor().execute(flushTask);
         } else {
             // Underlying descriptor can not accept all data currently, so set the EPOLLOUT flag to be woken up
             // when it can accept more data.
@@ -566,7 +566,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
 
     @Override
     public ChannelFuture shutdownOutput(final ChannelPromise promise) {
-        EventLoop loop = eventLoop();
+        EventLoop loop = executor();
         if (loop.inEventLoop()) {
             ((AbstractUnsafe) unsafe()).shutdownOutput(promise);
         } else {
@@ -597,7 +597,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
                 }
             });
         } else {
-            EventLoop loop = eventLoop();
+            EventLoop loop = executor();
             if (loop.inEventLoop()) {
                 shutdownInput0(promise);
             } else {
@@ -898,7 +898,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
 
         @Override
         public boolean spliceIn(RecvByteBufAllocator.Handle handle) {
-            assert ch.eventLoop().inEventLoop();
+            assert ch.executor().inEventLoop();
             if (len == 0) {
                 // Use trySuccess() as the promise might already be closed by spliceTo(...)
                 promise.trySuccess();
@@ -968,7 +968,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
         }
 
         public boolean spliceOut() throws Exception {
-            assert ch.eventLoop().inEventLoop();
+            assert ch.executor().inEventLoop();
             try {
                 int splicedOut = Native.splice(ch.pipeIn.intValue(), -1, ch.socket.intValue(), -1, len);
                 len -= splicedOut;
@@ -1004,7 +1004,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
 
         @Override
         public boolean spliceIn(RecvByteBufAllocator.Handle handle) {
-            assert eventLoop().inEventLoop();
+            assert executor().inEventLoop();
             if (len == 0) {
                 // Use trySuccess() as the promise might already be failed by spliceTo(...)
                 promise.trySuccess();

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -196,10 +196,10 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
         ObjectUtil.checkNotNull(multicastAddress, "multicastAddress");
         ObjectUtil.checkNotNull(networkInterface, "networkInterface");
 
-        if (eventLoop().inEventLoop()) {
+        if (executor().inEventLoop()) {
             joinGroup0(multicastAddress, networkInterface, source, promise);
         } else {
-            eventLoop().execute(new Runnable() {
+            executor().execute(new Runnable() {
                 @Override
                 public void run() {
                     joinGroup0(multicastAddress, networkInterface, source, promise);
@@ -212,7 +212,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
     private void joinGroup0(
             final InetAddress multicastAddress, final NetworkInterface networkInterface,
             final InetAddress source, final ChannelPromise promise) {
-        assert eventLoop().inEventLoop();
+        assert executor().inEventLoop();
 
         try {
             socket.joinGroup(multicastAddress, networkInterface, source);
@@ -264,10 +264,10 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
         ObjectUtil.checkNotNull(multicastAddress, "multicastAddress");
         ObjectUtil.checkNotNull(networkInterface, "networkInterface");
 
-        if (eventLoop().inEventLoop()) {
+        if (executor().inEventLoop()) {
             leaveGroup0(multicastAddress, networkInterface, source, promise);
         } else {
-            eventLoop().execute(new Runnable() {
+            executor().execute(new Runnable() {
                 @Override
                 public void run() {
                     leaveGroup0(multicastAddress, networkInterface, source, promise);
@@ -280,7 +280,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
     private void leaveGroup0(
             final InetAddress multicastAddress, final NetworkInterface networkInterface, final InetAddress source,
             final ChannelPromise promise) {
-        assert eventLoop().inEventLoop();
+        assert executor().inEventLoop();
 
         try {
             socket.leaveGroup(multicastAddress, networkInterface, source);
@@ -523,7 +523,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
 
         @Override
         void epollInReady() {
-            assert eventLoop().inEventLoop();
+            assert executor().inEventLoop();
             EpollDatagramChannelConfig config = config();
             if (shouldBreakEpollInReady(config)) {
                 clearEpollIn0();

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainDatagramChannel.java
@@ -288,7 +288,7 @@ public final class EpollDomainDatagramChannel extends AbstractEpollChannel imple
 
         @Override
         void epollInReady() {
-            assert eventLoop().inEventLoop();
+            assert executor().inEventLoop();
             final DomainDatagramChannelConfig config = config();
             if (shouldBreakEpollInReady(config)) {
                 clearEpollIn0();

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -168,15 +168,15 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         if (registration == null || !registration.isValid()) {
             return;
         }
-        if (eventLoop().inEventLoop()) {
+        if (executor().inEventLoop()) {
             clearRead();
         } else {
-            eventLoop().execute(this::clearRead);
+            executor().execute(this::clearRead);
         }
     }
 
     private void clearRead() {
-        assert eventLoop().inEventLoop();
+        assert executor().inEventLoop();
         readPending = false;
         IoRegistration registration = this.registration;
         if (registration == null || !registration.isValid()) {
@@ -906,7 +906,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
                 // Note this method is invoked by the event loop only if the connection attempt was
                 // neither cancelled nor timed out.
 
-                assert eventLoop().inEventLoop();
+                assert executor().inEventLoop();
 
                 boolean connectStillInProgress = false;
                 try {
@@ -1138,7 +1138,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
             // Schedule connect timeout.
             int connectTimeoutMillis = config().getConnectTimeoutMillis();
             if (connectTimeoutMillis > 0) {
-                connectTimeoutFuture = eventLoop().schedule(new Runnable() {
+                connectTimeoutFuture = executor().schedule(new Runnable() {
                     @Override
                     public void run() {
                         ChannelPromise connectPromise = AbstractIoUringChannel.this.connectPromise;
@@ -1209,7 +1209,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
 
     @Override
     protected void doRegister(ChannelPromise promise) {
-        IoEventLoop eventLoop = (IoEventLoop) eventLoop();
+        IoEventLoop eventLoop = (IoEventLoop) executor();
         eventLoop.register(ioUringUnsafe()).addListener(f -> {
             if (f.isSuccess()) {
                 registration = (IoRegistration) f.getNow();

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -125,7 +125,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
 
     @Override
     public final ChannelFuture shutdownOutput(final ChannelPromise promise) {
-        EventLoop loop = eventLoop();
+        EventLoop loop = executor();
         if (loop.inEventLoop()) {
             ((AbstractUnsafe) unsafe()).shutdownOutput(promise);
         } else {
@@ -147,7 +147,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
 
     @Override
     public final ChannelFuture shutdownInput(final ChannelPromise promise) {
-        EventLoop loop = eventLoop();
+        EventLoop loop = executor();
         if (loop.inEventLoop()) {
             shutdownInput0(promise);
         } else {

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
@@ -200,7 +200,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
 
     @Override
     protected void doRegister(ChannelPromise promise) {
-        ((IoEventLoop) eventLoop()).register((AbstractKQueueUnsafe) unsafe()).addListener(f -> {
+        ((IoEventLoop) executor()).register((AbstractKQueueUnsafe) unsafe()).addListener(f -> {
             if (f.isSuccess()) {
                 this.registration = (IoRegistration) f.getNow();
                 // Just in case the previous EventLoop was shutdown abruptly, or an event is still pending on the old
@@ -332,7 +332,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
     final void clearReadFilter() {
         // Only clear if registered with an EventLoop as otherwise
         if (isRegistered()) {
-            final EventLoop loop = eventLoop();
+            final EventLoop loop = executor();
             final AbstractKQueueUnsafe unsafe = (AbstractKQueueUnsafe) unsafe();
             if (loop.inEventLoop()) {
                 unsafe.clearReadFilter0();
@@ -534,7 +534,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
         }
 
         protected final void clearReadFilter0() {
-            assert eventLoop().inEventLoop();
+            assert executor().inEventLoop();
             try {
                 readPending = false;
                 readFilter(false);
@@ -575,7 +575,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
                     // Schedule connect timeout.
                     final int connectTimeoutMillis = config().getConnectTimeoutMillis();
                     if (connectTimeoutMillis > 0) {
-                        connectTimeoutFuture = eventLoop().schedule(new Runnable() {
+                        connectTimeoutFuture = executor().schedule(new Runnable() {
                             @Override
                             public void run() {
                                 ChannelPromise connectPromise = AbstractKQueueChannel.this.connectPromise;
@@ -651,7 +651,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
             // Note this method is invoked by the event loop only if the connection attempt was
             // neither cancelled nor timed out.
 
-            assert eventLoop().inEventLoop();
+            assert executor().inEventLoop();
 
             boolean connectStillInProgress = false;
             try {

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueServerChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueServerChannel.java
@@ -76,7 +76,7 @@ public abstract class AbstractKQueueServerChannel extends AbstractKQueueChannel 
 
         @Override
         void readReady(KQueueRecvByteAllocatorHandle allocHandle) {
-            assert eventLoop().inEventLoop();
+            assert executor().inEventLoop();
             final ChannelConfig config = config();
             if (shouldBreakReadReady(config)) {
                 clearReadFilter0();

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
@@ -295,7 +295,7 @@ public abstract class AbstractKQueueStreamChannel extends AbstractKQueueChannel 
             writeFilter(false);
 
             // We used our writeSpin quantum, and should try to write again later.
-            eventLoop().execute(flushTask);
+            executor().execute(flushTask);
         } else {
             // Underlying descriptor can not accept all data currently, so set the WRITE flag to be woken up
             // when it can accept more data.
@@ -404,7 +404,7 @@ public abstract class AbstractKQueueStreamChannel extends AbstractKQueueChannel 
 
     @Override
     public ChannelFuture shutdownOutput(final ChannelPromise promise) {
-        EventLoop loop = eventLoop();
+        EventLoop loop = executor();
         if (loop.inEventLoop()) {
             ((AbstractUnsafe) unsafe()).shutdownOutput(promise);
         } else {
@@ -425,7 +425,7 @@ public abstract class AbstractKQueueStreamChannel extends AbstractKQueueChannel 
 
     @Override
     public ChannelFuture shutdownInput(final ChannelPromise promise) {
-        EventLoop loop = eventLoop();
+        EventLoop loop = executor();
         if (loop.inEventLoop()) {
             shutdownInput0(promise);
         } else {

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
@@ -367,7 +367,7 @@ public final class KQueueDatagramChannel extends AbstractKQueueDatagramChannel i
 
         @Override
         void readReady(KQueueRecvByteAllocatorHandle allocHandle) {
-            assert eventLoop().inEventLoop();
+            assert executor().inEventLoop();
             final DatagramChannelConfig config = config();
             if (shouldBreakReadReady(config)) {
                 clearReadFilter0();

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainDatagramChannel.java
@@ -237,7 +237,7 @@ public final class KQueueDomainDatagramChannel extends AbstractKQueueDatagramCha
 
         @Override
         void readReady(KQueueRecvByteAllocatorHandle allocHandle) {
-            assert eventLoop().inEventLoop();
+            assert executor().inEventLoop();
             final DomainDatagramChannelConfig config = config();
             if (shouldBreakReadReady(config)) {
                 clearReadFilter0();

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSpliceTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSpliceTest.java
@@ -75,7 +75,7 @@ public class EpollSpliceTest {
                 bs.option(EpollChannelOption.EPOLL_MODE, EpollMode.LEVEL_TRIGGERED);
 
                 bs.channel(EpollSocketChannel.class);
-                bs.group(ctx.channel().eventLoop()).handler(new ChannelInboundHandlerAdapter() {
+                bs.group(ctx.channel().executor()).handler(new ChannelInboundHandlerAdapter() {
                     @Override
                     public void channelActive(ChannelHandlerContext context) throws Exception {
                         final EpollSocketChannel ch = (EpollSocketChannel) ctx.channel();

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
@@ -371,7 +371,7 @@ public class NioSctpChannel extends AbstractNioMessageChannel implements io.nett
 
     @Override
     public ChannelFuture bindAddress(final InetAddress localAddress, final ChannelPromise promise) {
-        if (eventLoop().inEventLoop()) {
+        if (executor().inEventLoop()) {
             try {
                 javaChannel().bindAddress(localAddress);
                 promise.setSuccess();
@@ -379,7 +379,7 @@ public class NioSctpChannel extends AbstractNioMessageChannel implements io.nett
                 promise.setFailure(t);
             }
         } else {
-            eventLoop().execute(new Runnable() {
+            executor().execute(new Runnable() {
                 @Override
                 public void run() {
                     bindAddress(localAddress, promise);
@@ -396,7 +396,7 @@ public class NioSctpChannel extends AbstractNioMessageChannel implements io.nett
 
     @Override
     public ChannelFuture unbindAddress(final InetAddress localAddress, final ChannelPromise promise) {
-        if (eventLoop().inEventLoop()) {
+        if (executor().inEventLoop()) {
             try {
                 javaChannel().unbindAddress(localAddress);
                 promise.setSuccess();
@@ -404,7 +404,7 @@ public class NioSctpChannel extends AbstractNioMessageChannel implements io.nett
                 promise.setFailure(t);
             }
         } else {
-            eventLoop().execute(new Runnable() {
+            executor().execute(new Runnable() {
                 @Override
                 public void run() {
                     unbindAddress(localAddress, promise);

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpServerChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpServerChannel.java
@@ -151,7 +151,7 @@ public class NioSctpServerChannel extends AbstractNioMessageChannel
 
     @Override
     public ChannelFuture bindAddress(final InetAddress localAddress, final ChannelPromise promise) {
-        if (eventLoop().inEventLoop()) {
+        if (executor().inEventLoop()) {
             try {
                 javaChannel().bindAddress(localAddress);
                 promise.setSuccess();
@@ -159,7 +159,7 @@ public class NioSctpServerChannel extends AbstractNioMessageChannel
                 promise.setFailure(t);
             }
         } else {
-            eventLoop().execute(new Runnable() {
+            executor().execute(new Runnable() {
                 @Override
                 public void run() {
                     bindAddress(localAddress, promise);
@@ -176,7 +176,7 @@ public class NioSctpServerChannel extends AbstractNioMessageChannel
 
     @Override
     public ChannelFuture unbindAddress(final InetAddress localAddress, final ChannelPromise promise) {
-        if (eventLoop().inEventLoop()) {
+        if (executor().inEventLoop()) {
             try {
                 javaChannel().unbindAddress(localAddress);
                 promise.setSuccess();
@@ -184,7 +184,7 @@ public class NioSctpServerChannel extends AbstractNioMessageChannel
                 promise.setFailure(t);
             }
         } else {
-            eventLoop().execute(new Runnable() {
+            executor().execute(new Runnable() {
                 @Override
                 public void run() {
                     unbindAddress(localAddress, promise);

--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -373,7 +373,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
 
         // This method is invoked before channelRegistered() is triggered.  Give user handlers a chance to set up
         // the pipeline in its channelRegistered() implementation.
-        channel.eventLoop().execute(new Runnable() {
+        channel.executor().execute(new Runnable() {
             @Override
             public void run() {
                 if (regFuture.isSuccess()) {

--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -202,7 +202,7 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
                 return promise;
             }
 
-            final EventLoop eventLoop = channel.eventLoop();
+            final EventLoop eventLoop = channel.executor();
             AddressResolver<SocketAddress> resolver;
             try {
                 resolver = ExternalAddressResolver.getOrDefault(externalResolver).getResolver(eventLoop);
@@ -257,7 +257,7 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
         // This method is invoked before channelRegistered() is triggered.  Give user handlers a chance to set up
         // the pipeline in its channelRegistered() implementation.
         final Channel channel = connectPromise.channel();
-        channel.eventLoop().execute(new Runnable() {
+        channel.executor().execute(new Runnable() {
             @Override
             public void run() {
                 if (localAddress == null) {

--- a/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
@@ -153,7 +153,7 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
                     pipeline.addLast(handler);
                 }
 
-                ch.eventLoop().execute(new Runnable() {
+                ch.executor().execute(new Runnable() {
                     @Override
                     public void run() {
                         pipeline.addLast(new ServerBootstrapAcceptor(
@@ -266,7 +266,7 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
                 // stop accept new connections for 1 second to allow the channel to recover
                 // See https://github.com/netty/netty/issues/1328
                 config.setAutoRead(false);
-                ctx.channel().eventLoop().schedule(enableAutoReadTask, 1, TimeUnit.SECONDS);
+                ctx.channel().executor().schedule(enableAutoReadTask, 1, TimeUnit.SECONDS);
             }
             // still let the exceptionCaught event flow through the pipeline to give the user
             // a chance to do something with it

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -129,7 +129,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
     }
 
     @Override
-    public EventLoop eventLoop() {
+    public EventLoop executor() {
         EventLoop eventLoop = this.eventLoop;
         if (eventLoop == null) {
             throw new IllegalStateException("channel not registered to an event loop");
@@ -892,7 +892,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                 //         -> handlerA.channelInactive() - (2) another inbound handler method called while in (1) yet
                 //
                 // which means the execution of two inbound handler methods of the same handler overlap undesirably.
-                eventLoop().execute(task);
+                executor().execute(task);
             } catch (RejectedExecutionException e) {
                 logger.warn("Can't invoke task later as EventLoop rejected it", e);
             }

--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -133,7 +133,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
     public EventExecutor executor() {
         EventExecutor ex = contextExecutor;
         if (ex == null) {
-            contextExecutor = ex = childExecutor != null ? childExecutor : channel().eventLoop();
+            contextExecutor = ex = childExecutor != null ? childExecutor : channel().executor();
         }
         return ex;
     }

--- a/transport/src/main/java/io/netty/channel/Channel.java
+++ b/transport/src/main/java/io/netty/channel/Channel.java
@@ -84,7 +84,8 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparabl
     /**
      * Return the {@link EventLoop} this {@link Channel} was registered to.
      */
-    EventLoop eventLoop();
+    @Override
+    EventLoop executor();
 
     /**
      * Returns the parent of this channel.

--- a/transport/src/main/java/io/netty/channel/ChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandlerContext.java
@@ -92,11 +92,6 @@ public interface ChannelHandlerContext extends AttributeMap, ChannelInboundInvok
     Channel channel();
 
     /**
-     * Returns the {@link EventExecutor} which is used to execute an arbitrary task.
-     */
-    EventExecutor executor();
-
-    /**
      * The unique name of the {@link ChannelHandlerContext}.The name was used when then {@link ChannelHandler}
      * was added to the {@link ChannelPipeline}. This name can also be used to access the registered
      * {@link ChannelHandler} from the {@link ChannelPipeline}.

--- a/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
@@ -653,7 +653,7 @@ public final class ChannelOutboundBuffer {
                     }
                 };
             }
-            channel.eventLoop().execute(task);
+            channel.executor().execute(task);
         } else {
             pipeline.fireChannelWritabilityChanged();
         }
@@ -698,7 +698,7 @@ public final class ChannelOutboundBuffer {
 
     void close(final Throwable cause, final boolean allowChannelOpen) {
         if (inFail) {
-            channel.eventLoop().execute(new Runnable() {
+            channel.executor().execute(new Runnable() {
                 @Override
                 public void run() {
                     close(cause, allowChannelOpen);

--- a/transport/src/main/java/io/netty/channel/ChannelOutboundInvoker.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundInvoker.java
@@ -284,4 +284,11 @@ public interface ChannelOutboundInvoker {
      * <strong>Be aware this is an expert feature and should be used with care!</strong>
      */
     ChannelPromise voidPromise();
+
+    /**
+     * Returns the {@link EventExecutor} that is used to execute the operations of this {@link ChannelOutboundInvoker}.
+     *
+     * @return  the executor.
+     */
+    EventExecutor executor();
 }

--- a/transport/src/main/java/io/netty/channel/CompleteChannelFuture.java
+++ b/transport/src/main/java/io/netty/channel/CompleteChannelFuture.java
@@ -43,7 +43,7 @@ abstract class CompleteChannelFuture extends CompleteFuture<Void> implements Cha
     protected EventExecutor executor() {
         EventExecutor e = super.executor();
         if (e == null) {
-            return channel().eventLoop();
+            return channel().executor();
         } else {
             return e;
         }

--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -141,6 +141,12 @@ public class DefaultChannelPipeline implements ChannelPipeline {
         }
         return childExecutor;
     }
+
+    @Override
+    public EventExecutor executor() {
+        return channel().executor();
+    }
+
     @Override
     public final Channel channel() {
         return channel;
@@ -591,7 +597,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
     }
 
     final void invokeHandlerAddedIfNeeded() {
-        assert channel.eventLoop().inEventLoop();
+        assert channel.executor().inEventLoop();
         if (firstRegistration) {
             firstRegistration = false;
             // We are now registered to the EventLoop. It's time to call the callbacks for the ChannelHandlers,

--- a/transport/src/main/java/io/netty/channel/DefaultChannelProgressivePromise.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelProgressivePromise.java
@@ -57,7 +57,7 @@ public class DefaultChannelProgressivePromise
     protected EventExecutor executor() {
         EventExecutor e = super.executor();
         if (e == null) {
-            return channel().eventLoop();
+            return channel().executor();
         } else {
             return e;
         }

--- a/transport/src/main/java/io/netty/channel/DefaultChannelPromise.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPromise.java
@@ -57,7 +57,7 @@ public class DefaultChannelPromise extends DefaultPromise<Void> implements Chann
     protected EventExecutor executor() {
         EventExecutor e = super.executor();
         if (e == null) {
-            return channel().eventLoop();
+            return channel().executor();
         } else {
             return e;
         }

--- a/transport/src/main/java/io/netty/channel/PendingWriteQueue.java
+++ b/transport/src/main/java/io/netty/channel/PendingWriteQueue.java
@@ -59,7 +59,7 @@ public final class PendingWriteQueue {
     public PendingWriteQueue(Channel channel) {
         tracker = PendingBytesTracker.newTracker(channel);
         this.invoker = channel;
-        this.executor = channel.eventLoop();
+        this.executor = channel.executor();
     }
 
     /**

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
@@ -892,7 +892,7 @@ public class EmbeddedChannel extends AbstractChannel {
     }
 
     private EmbeddedEventLoop.FreezableTicker freezableTicker() {
-        Ticker ticker = eventLoop().ticker();
+        Ticker ticker = executor().ticker();
         if (ticker instanceof EmbeddedEventLoop.FreezableTicker) {
             return (EmbeddedEventLoop.FreezableTicker) ticker;
         } else {
@@ -971,7 +971,7 @@ public class EmbeddedChannel extends AbstractChannel {
 
     private EmbeddedEventLoop embeddedEventLoop() {
         if (isRegistered()) {
-            return (EmbeddedEventLoop) super.eventLoop();
+            return (EmbeddedEventLoop) super.executor();
         }
 
         return loop;

--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -163,7 +163,7 @@ public class LocalChannel extends AbstractChannel {
 
     @Override
     protected void doRegister(ChannelPromise promise) {
-        EventLoop loop = eventLoop();
+        EventLoop loop = executor();
         if (loop instanceof IoEventLoop) {
             assert registration == null;
             ((IoEventLoop) loop).register((LocalUnsafe) unsafe()).addListener(f -> {
@@ -186,7 +186,7 @@ public class LocalChannel extends AbstractChannel {
 
     @Override
     protected void doDeregister() throws Exception {
-        EventLoop loop = eventLoop();
+        EventLoop loop = executor();
         if (loop instanceof IoEventLoop) {
             IoRegistration registration = this.registration;
             if (registration != null) {
@@ -247,7 +247,7 @@ public class LocalChannel extends AbstractChannel {
                 // Always call peer.eventLoop().execute() even if peer.eventLoop().inEventLoop() is true.
                 // This ensures that if both channels are on the same event loop, the peer's channelInActive
                 // event is triggered *after* this peer's channelInActive event
-                EventLoop peerEventLoop = peer.eventLoop();
+                EventLoop peerEventLoop = peer.executor();
                 final boolean peerIsActive = peer.isActive();
                 try {
                     peerEventLoop.execute(new Runnable() {
@@ -350,7 +350,7 @@ public class LocalChannel extends AbstractChannel {
             }
         } else {
             try {
-                eventLoop().execute(readTask);
+                executor().execute(readTask);
             } catch (Throwable cause) {
                 logger.warn("Closing Local channels {}-{} because exception occurred!", this, peer, cause);
                 close();
@@ -412,7 +412,7 @@ public class LocalChannel extends AbstractChannel {
 
     private void finishPeerRead(final LocalChannel peer) {
         // If the peer is also writing, then we must schedule the event on the event loop to preserve read order.
-        if (peer.eventLoop() == eventLoop() && !peer.writeInProgress) {
+        if (peer.executor() == executor() && !peer.writeInProgress) {
             finishPeerRead0(peer);
         } else {
             runFinishPeerReadTask(peer);
@@ -430,9 +430,9 @@ public class LocalChannel extends AbstractChannel {
         };
         try {
             if (peer.writeInProgress) {
-                peer.finishReadFuture = peer.eventLoop().submit(finishPeerReadTask);
+                peer.finishReadFuture = peer.executor().submit(finishPeerReadTask);
             } else {
-                peer.eventLoop().execute(finishPeerReadTask);
+                peer.executor().execute(finishPeerReadTask);
             }
         } catch (Throwable cause) {
             logger.warn("Closing Local channels {}-{} because exception occurred!", this, peer, cause);
@@ -443,7 +443,7 @@ public class LocalChannel extends AbstractChannel {
     }
 
     private void releaseInboundBuffers() {
-        assert eventLoop() == null || eventLoop().inEventLoop();
+        assert executor() == null || executor().inEventLoop();
         readInProgress = false;
         Queue<Object> inboundBuffer = this.inboundBuffer;
         Object msg;
@@ -503,7 +503,7 @@ public class LocalChannel extends AbstractChannel {
                 // This ensures that if both channels are on the same event loop, the peer's channelActive
                 // event is triggered *after* this channel's channelRegistered event, so that this channel's
                 // pipeline is fully initialized by ChannelInitializer before any channelRead events.
-                peer.eventLoop().execute(new Runnable() {
+                peer.executor().execute(new Runnable() {
                     @Override
                     public void run() {
                         ChannelPromise promise = peer.connectPromise;
@@ -516,13 +516,13 @@ public class LocalChannel extends AbstractChannel {
                     }
                 });
             }
-            ((SingleThreadEventExecutor) eventLoop()).addShutdownHook(shutdownHook);
+            ((SingleThreadEventExecutor) executor()).addShutdownHook(shutdownHook);
         }
 
         @Override
         public void unregistered() {
             // Just remove the shutdownHook as this Channel may be closed later or registered to another EventLoop
-            ((SingleThreadEventExecutor) eventLoop()).removeShutdownHook(shutdownHook);
+            ((SingleThreadEventExecutor) executor()).removeShutdownHook(shutdownHook);
         }
 
         @Override

--- a/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
@@ -99,7 +99,7 @@ public class LocalServerChannel extends AbstractServerChannel {
 
     @Override
     protected void doRegister(ChannelPromise promise) {
-        EventLoop loop = eventLoop();
+        EventLoop loop = executor();
         if (loop instanceof IoEventLoop) {
             assert registration == null;
             ((IoEventLoop) loop).register((LocalServerUnsafe) unsafe()).addListener(f -> {
@@ -141,7 +141,7 @@ public class LocalServerChannel extends AbstractServerChannel {
 
     @Override
     protected void doDeregister() throws Exception {
-        EventLoop loop = eventLoop();
+        EventLoop loop = executor();
         if (loop instanceof IoEventLoop) {
             IoRegistration registration = this.registration;
             if (registration != null) {
@@ -170,10 +170,10 @@ public class LocalServerChannel extends AbstractServerChannel {
 
     LocalChannel serve(final LocalChannel peer) {
         final LocalChannel child = newLocalChannel(peer);
-        if (eventLoop().inEventLoop()) {
+        if (executor().inEventLoop()) {
             serve0(child);
         } else {
-            eventLoop().execute(new Runnable() {
+            executor().execute(new Runnable() {
                 @Override
                 public void run() {
                     serve0(child);
@@ -238,12 +238,12 @@ public class LocalServerChannel extends AbstractServerChannel {
 
         @Override
         public void registered() {
-            ((SingleThreadEventExecutor) eventLoop()).addShutdownHook(shutdownHook);
+            ((SingleThreadEventExecutor) executor()).addShutdownHook(shutdownHook);
         }
 
         @Override
         public void unregistered() {
-            ((SingleThreadEventExecutor) eventLoop()).removeShutdownHook(shutdownHook);
+            ((SingleThreadEventExecutor) executor()).removeShutdownHook(shutdownHook);
         }
 
         @Override

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
@@ -304,7 +304,7 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
             clearOpWrite();
 
             // Schedule flush again later so other tasks can be picked up in the meantime
-            eventLoop().execute(flushTask);
+            executor().execute(flushTask);
         }
     }
 

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
@@ -173,7 +173,7 @@ public abstract class AbstractNioChannel extends AbstractChannel {
     @Deprecated
     protected void setReadPending(final boolean readPending) {
         if (isRegistered()) {
-            EventLoop eventLoop = eventLoop();
+            EventLoop eventLoop = executor();
             if (eventLoop.inEventLoop()) {
                 setReadPending0(readPending);
             } else {
@@ -197,7 +197,7 @@ public abstract class AbstractNioChannel extends AbstractChannel {
      */
     protected final void clearReadPending() {
         if (isRegistered()) {
-            EventLoop eventLoop = eventLoop();
+            EventLoop eventLoop = executor();
             if (eventLoop.inEventLoop()) {
                 clearReadPending0();
             } else {
@@ -301,7 +301,7 @@ public abstract class AbstractNioChannel extends AbstractChannel {
                     // Schedule connect timeout.
                     final int connectTimeoutMillis = config().getConnectTimeoutMillis();
                     if (connectTimeoutMillis > 0) {
-                        connectTimeoutFuture = eventLoop().schedule(new Runnable() {
+                        connectTimeoutFuture = executor().schedule(new Runnable() {
                             @Override
                             public void run() {
                                 ChannelPromise connectPromise = AbstractNioChannel.this.connectPromise;
@@ -377,7 +377,7 @@ public abstract class AbstractNioChannel extends AbstractChannel {
             // Note this method is invoked by the event loop only if the connection attempt was
             // neither cancelled nor timed out.
 
-            assert eventLoop().inEventLoop();
+            assert executor().inEventLoop();
 
             try {
                 boolean wasActive = isActive();
@@ -459,7 +459,7 @@ public abstract class AbstractNioChannel extends AbstractChannel {
     @Override
     protected void doRegister(ChannelPromise promise) {
         assert registration == null;
-        ((IoEventLoop) eventLoop()).register((AbstractNioUnsafe) unsafe()).addListener(f -> {
+        ((IoEventLoop) executor()).register((AbstractNioUnsafe) unsafe()).addListener(f -> {
             if (f.isSuccess()) {
                 registration = (IoRegistration) f.getNow();
                 promise.setSuccess();

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioMessageChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioMessageChannel.java
@@ -68,7 +68,7 @@ public abstract class AbstractNioMessageChannel extends AbstractNioChannel {
 
         @Override
         public void read() {
-            assert eventLoop().inEventLoop();
+            assert executor().inEventLoop();
             final ChannelConfig config = config();
             final ChannelPipeline pipeline = pipeline();
             final RecvByteBufAllocator.Handle allocHandle = unsafe().recvBufAllocHandle();

--- a/transport/src/main/java/io/netty/channel/pool/ChannelHealthChecker.java
+++ b/transport/src/main/java/io/netty/channel/pool/ChannelHealthChecker.java
@@ -32,7 +32,7 @@ public interface ChannelHealthChecker {
     ChannelHealthChecker ACTIVE = new ChannelHealthChecker() {
         @Override
         public Future<Boolean> isHealthy(Channel channel) {
-            EventLoop loop = channel.eventLoop();
+            EventLoop loop = channel.executor();
             return channel.isActive()? loop.newSucceededFuture(Boolean.TRUE) : loop.newSucceededFuture(Boolean.FALSE);
         }
     };

--- a/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
@@ -108,7 +108,7 @@ public class SimpleChannelPool implements ChannelPool {
         this.bootstrap.handler(new ChannelInitializer<Channel>() {
             @Override
             protected void initChannel(Channel ch) throws Exception {
-                assert ch.eventLoop().inEventLoop();
+                assert ch.executor().inEventLoop();
                 handler.channelCreated(ch);
             }
         });
@@ -186,7 +186,7 @@ public class SimpleChannelPool implements ChannelPool {
                     });
                 }
             } else {
-                EventLoop loop = ch.eventLoop();
+                EventLoop loop = ch.executor();
                 if (loop.inEventLoop()) {
                     doHealthCheck(ch, promise);
                 } else {
@@ -224,7 +224,7 @@ public class SimpleChannelPool implements ChannelPool {
 
     private void doHealthCheck(final Channel channel, final Promise<Channel> promise) {
         try {
-            assert channel.eventLoop().inEventLoop();
+            assert channel.executor().inEventLoop();
             Future<Boolean> f = healthCheck.isHealthy(channel);
             if (f.isDone()) {
                 notifyHealthCheck(f, channel, promise);
@@ -243,7 +243,7 @@ public class SimpleChannelPool implements ChannelPool {
 
     private void notifyHealthCheck(Future<Boolean> future, Channel channel, Promise<Channel> promise) {
         try {
-            assert channel.eventLoop().inEventLoop();
+            assert channel.executor().inEventLoop();
             if (future.isSuccess() && future.getNow()) {
                 channel.attr(POOL_KEY).set(this);
                 handler.channelAcquired(channel);
@@ -269,7 +269,7 @@ public class SimpleChannelPool implements ChannelPool {
 
     @Override
     public final Future<Void> release(Channel channel) {
-        return release(channel, channel.eventLoop().<Void>newPromise());
+        return release(channel, channel.executor().<Void>newPromise());
     }
 
     @Override
@@ -277,7 +277,7 @@ public class SimpleChannelPool implements ChannelPool {
         try {
             checkNotNull(channel, "channel");
             checkNotNull(promise, "promise");
-            EventLoop loop = channel.eventLoop();
+            EventLoop loop = channel.executor();
             if (loop.inEventLoop()) {
                 doReleaseChannel(channel, promise);
             } else {
@@ -296,7 +296,7 @@ public class SimpleChannelPool implements ChannelPool {
 
     private void doReleaseChannel(Channel channel, Promise<Void> promise) {
         try {
-            assert channel.eventLoop().inEventLoop();
+            assert channel.executor().inEventLoop();
             // Remove the POOL_KEY attribute from the Channel and check if it was acquired from this pool, if not fail.
             if (channel.attr(POOL_KEY).getAndSet(null) != this) {
                 closeAndFail(channel,

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
@@ -180,7 +180,7 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
 
     @Override
     public ChannelFuture shutdownOutput(final ChannelPromise promise) {
-        final EventLoop loop = eventLoop();
+        final EventLoop loop = executor();
         if (loop.inEventLoop()) {
             ((AbstractUnsafe) unsafe()).shutdownOutput(promise);
         } else {
@@ -206,7 +206,7 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
 
     @Override
     public ChannelFuture shutdownInput(final ChannelPromise promise) {
-        EventLoop loop = eventLoop();
+        EventLoop loop = executor();
         if (loop.inEventLoop()) {
             shutdownInput0(promise);
         } else {

--- a/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
@@ -216,7 +216,7 @@ public class BootstrapTest {
             future.addListener(new ChannelFutureListener() {
                 @Override
                 public void operationComplete(ChannelFuture future) throws Exception {
-                    queue.add(future.channel().eventLoop().inEventLoop(Thread.currentThread()));
+                    queue.add(future.channel().executor().inEventLoop(Thread.currentThread()));
                     queue.add(future.isSuccess());
                 }
             });
@@ -265,7 +265,7 @@ public class BootstrapTest {
             future.addListener(new ChannelFutureListener() {
                 @Override
                 public void operationComplete(ChannelFuture future) throws Exception {
-                    queue.add(future.channel().eventLoop().inEventLoop(Thread.currentThread()));
+                    queue.add(future.channel().executor().inEventLoop(Thread.currentThread()));
                     queue.add(future.isSuccess());
                 }
             });

--- a/transport/src/test/java/io/netty/channel/AbstractEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/AbstractEventLoopTest.java
@@ -185,7 +185,7 @@ public abstract class AbstractEventLoopTest {
 
         @Override
         public void channelRead(ChannelHandlerContext outCtx, Object msg) throws Exception {
-            final EventLoop newLoop = anyNotEqual(outCtx.channel().eventLoop());
+            final EventLoop newLoop = anyNotEqual(outCtx.channel().executor());
             ChannelFutureListener pipelieModifyingListener = register -> {
                 outCtx.pipeline().addLast(new ChannelInboundHandlerAdapter() {
                     @Override

--- a/transport/src/test/java/io/netty/channel/ChannelInitializerTest.java
+++ b/transport/src/test/java/io/netty/channel/ChannelInitializerTest.java
@@ -139,7 +139,7 @@ public class ChannelInitializerTest {
         try {
             // Execute some task on the EventLoop and wait until its done to be sure all handlers are added to the
             // pipeline.
-            channel.eventLoop().submit(new Runnable() {
+            channel.executor().submit(new Runnable() {
                 @Override
                 public void run() {
                     // NOOP
@@ -179,7 +179,7 @@ public class ChannelInitializerTest {
         try {
             // Execute some task on the EventLoop and wait until its done to be sure all handlers are added to the
             // pipeline.
-            channel.eventLoop().submit(new Runnable() {
+            channel.executor().submit(new Runnable() {
                 @Override
                 public void run() {
                     // NOOP

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
@@ -56,7 +56,6 @@ import java.util.NoSuchElementException;
 import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -523,7 +522,7 @@ public class DefaultChannelPipelineTest {
 
             // Add handler.
             p.addFirst(handler.name, handler);
-            self.eventLoop().execute(new Runnable() {
+            self.executor().execute(new Runnable() {
                 @Override
                 public void run() {
                     // Validate handler life-cycle methods called.
@@ -546,7 +545,7 @@ public class DefaultChannelPipelineTest {
         for (final LifeCycleAwareTestHandler handler : handlers) {
             assertSame(handler, p.remove(handler.name));
 
-            self.eventLoop().execute(new Runnable() {
+            self.executor().execute(new Runnable() {
                 @Override
                 public void run() {
                     // Validate handler life-cycle methods called.
@@ -566,7 +565,7 @@ public class DefaultChannelPipelineTest {
 
         setUp(handler1, handler2);
 
-        self.eventLoop().submit(new Runnable() {
+        self.executor().submit(new Runnable() {
             @Override
             public void run() {
                 ChannelPipeline p = self.pipeline();
@@ -588,7 +587,7 @@ public class DefaultChannelPipelineTest {
 
         setUp(handler1, handler2);
 
-        self.eventLoop().submit(new Runnable() {
+        self.executor().submit(new Runnable() {
             @Override
             public void run() {
                 ChannelPipeline p = self.pipeline();
@@ -610,7 +609,7 @@ public class DefaultChannelPipelineTest {
 
         setUp(handler1);
 
-        self.eventLoop().submit(new Runnable() {
+        self.executor().submit(new Runnable() {
             @Override
             public void run() {
                 ChannelPipeline p = self.pipeline();
@@ -631,7 +630,7 @@ public class DefaultChannelPipelineTest {
 
         setUp(handler1);
 
-        self.eventLoop().submit(new Runnable() {
+        self.executor().submit(new Runnable() {
             @Override
             public void run() {
                 ChannelPipeline p = self.pipeline();
@@ -659,7 +658,7 @@ public class DefaultChannelPipelineTest {
 
         setUp(handler1, handler2, handler3);
 
-        self.eventLoop().submit(new Runnable() {
+        self.executor().submit(new Runnable() {
             @Override
             public void run() {
                 ChannelPipeline p = self.pipeline();
@@ -1396,7 +1395,7 @@ public class DefaultChannelPipelineTest {
                 pipeline.channel().closeFuture().syncUninterruptibly();
 
                 // Schedule something on the EventLoop to ensure all other scheduled tasks had a chance to complete.
-                pipeline.channel().eventLoop().submit(new Runnable() {
+                pipeline.channel().executor().submit(new Runnable() {
                     @Override
                     public void run() {
                         // NOOP
@@ -1939,7 +1938,7 @@ public class DefaultChannelPipelineTest {
         };
 
         if (executeInEventLoop) {
-            pipeline.channel().eventLoop().execute(r);
+            pipeline.channel().executor().execute(r);
         } else {
             r.run();
         }

--- a/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
@@ -136,7 +136,7 @@ public class EmbeddedChannelTest {
     public void testScheduling() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new ChannelInboundHandlerAdapter());
         final CountDownLatch latch = new CountDownLatch(2);
-        Future future = ch.eventLoop().schedule(new Runnable() {
+        Future future = ch.executor().schedule(new Runnable() {
             @Override
             public void run() {
                 latch.countDown();
@@ -160,7 +160,7 @@ public class EmbeddedChannelTest {
     @Test
     public void testScheduledCancelled() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new ChannelInboundHandlerAdapter());
-        Future<?> future = ch.eventLoop().schedule(new Runnable() {
+        Future<?> future = ch.executor().schedule(new Runnable() {
             @Override
             public void run() { }
         }, 1, TimeUnit.DAYS);
@@ -646,7 +646,7 @@ public class EmbeddedChannelTest {
         }
 
         final CountDownLatch taskLatch = new CountDownLatch(1);
-        channel.eventLoop().execute(new Runnable() {
+        channel.executor().execute(new Runnable() {
             @Override
             public void run() {
                 taskLatch.countDown();
@@ -689,8 +689,8 @@ public class EmbeddedChannelTest {
             public void run() {
             }
         };
-        ScheduledFuture<?> future10 = channel.eventLoop().schedule(runnable, 10, TimeUnit.MINUTES);
-        ScheduledFuture<?> future20 = channel.eventLoop().schedule(runnable, 20, TimeUnit.MINUTES);
+        ScheduledFuture<?> future10 = channel.executor().schedule(runnable, 10, TimeUnit.MINUTES);
+        ScheduledFuture<?> future20 = channel.executor().schedule(runnable, 20, TimeUnit.MINUTES);
 
         channel.runPendingTasks();
         assertFalse(future10.isDone());
@@ -714,12 +714,12 @@ public class EmbeddedChannelTest {
 
         channel.freezeTime();
         // this future will complete after 10min
-        ScheduledFuture<?> future10 = channel.eventLoop().schedule(runnable, 10, TimeUnit.MINUTES);
+        ScheduledFuture<?> future10 = channel.executor().schedule(runnable, 10, TimeUnit.MINUTES);
         // this future will complete after 10min + 1ns
-        ScheduledFuture<?> future101 = channel.eventLoop().schedule(runnable,
+        ScheduledFuture<?> future101 = channel.executor().schedule(runnable,
                 TimeUnit.MINUTES.toNanos(10) + 1, TimeUnit.NANOSECONDS);
         // this future will complete after 20min
-        ScheduledFuture<?> future20 = channel.eventLoop().schedule(runnable, 20, TimeUnit.MINUTES);
+        ScheduledFuture<?> future20 = channel.executor().schedule(runnable, 20, TimeUnit.MINUTES);
 
         channel.runPendingTasks();
         assertFalse(future10.isDone());
@@ -750,12 +750,12 @@ public class EmbeddedChannelTest {
         };
 
         // this future will complete after 10min
-        ScheduledFuture<?> future10 = channel.eventLoop().schedule(runnable, 10, TimeUnit.MINUTES);
+        ScheduledFuture<?> future10 = channel.executor().schedule(runnable, 10, TimeUnit.MINUTES);
         // this future will complete after 10min + 1ns
-        ScheduledFuture<?> future101 = channel.eventLoop().schedule(runnable,
+        ScheduledFuture<?> future101 = channel.executor().schedule(runnable,
                 TimeUnit.MINUTES.toNanos(10) + 1, TimeUnit.NANOSECONDS);
         // this future will complete after 20min
-        ScheduledFuture<?> future20 = channel.eventLoop().schedule(runnable, 20, TimeUnit.MINUTES);
+        ScheduledFuture<?> future20 = channel.executor().schedule(runnable, 20, TimeUnit.MINUTES);
 
         channel.runPendingTasks();
         assertFalse(future10.isDone());
@@ -776,7 +776,7 @@ public class EmbeddedChannelTest {
 
     @Test
     void testDefaultTickerCannotSleep() {
-        Ticker ticker = new EmbeddedChannel().eventLoop().ticker();
+        Ticker ticker = new EmbeddedChannel().executor().ticker();
         Assertions.assertThrows(UnsupportedOperationException.class, () -> ticker.sleep(1, TimeUnit.SECONDS));
     }
 
@@ -792,13 +792,13 @@ public class EmbeddedChannelTest {
 
         // simple execute
         assertFalse(channel.hasPendingTasks());
-        channel.eventLoop().execute(runnable);
+        channel.executor().execute(runnable);
         assertTrue(channel.hasPendingTasks());
         channel.runPendingTasks();
         assertFalse(channel.hasPendingTasks());
 
         // schedule in the future (note: time is frozen above)
-        channel.eventLoop().schedule(runnable, 1, TimeUnit.SECONDS);
+        channel.executor().schedule(runnable, 1, TimeUnit.SECONDS);
         assertFalse(channel.hasPendingTasks());
         channel.runPendingTasks();
         assertFalse(channel.hasPendingTasks());

--- a/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
@@ -117,7 +117,7 @@ public class LocalChannelTest {
                 // Connect to the server
                 cc = cb.connect(sc.localAddress()).sync().channel();
                 final Channel ccCpy = cc;
-                cc.eventLoop().execute(new Runnable() {
+                cc.executor().execute(new Runnable() {
                     @Override
                     public void run() {
                         // Send a message event up the pipeline.
@@ -764,7 +764,7 @@ public class LocalChannelTest {
                         .addListener(new ChannelFutureListener() {
                             @Override
                             public void operationComplete(ChannelFuture future) throws Exception {
-                                serverChannelCpy.eventLoop().execute(new Runnable() {
+                                serverChannelCpy.executor().execute(new Runnable() {
                                     @Override
                                     public void run() {
                                         // The point of this test is to write while the peer is closed, so we should
@@ -843,7 +843,7 @@ public class LocalChannelTest {
             cc = cb.register().sync().channel();
 
             final ChannelPromise promise = cc.newPromise();
-            final Promise<Void> assertPromise = cc.eventLoop().newPromise();
+            final Promise<Void> assertPromise = cc.executor().newPromise();
 
             cc.pipeline().addLast(new TestHandler() {
                 @Override

--- a/transport/src/test/java/io/netty/channel/local/LocalTransportThreadModelTest.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalTransportThreadModelTest.java
@@ -273,7 +273,7 @@ public class LocalTransportThreadModelTest {
                 final int end = i + ELEMS_PER_ROUNDS;
                 i = end;
 
-                ch.eventLoop().execute(new Runnable() {
+                ch.executor().execute(new Runnable() {
                     @Override
                     public void run() {
                         for (int j = start; j < end; j ++) {

--- a/transport/src/test/java/io/netty/channel/local/LocalTransportThreadModelTest2.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalTransportThreadModelTest2.java
@@ -77,7 +77,7 @@ public class LocalTransportThreadModelTest2 {
 
     public void close(final Channel localChannel, final LocalHandler localRegistrationHandler) {
         // we want to make sure we actually shutdown IN the event loop
-        if (localChannel.eventLoop().inEventLoop()) {
+        if (localChannel.executor().inEventLoop()) {
             // Wait until all messages are flushed before closing the channel.
             if (localRegistrationHandler.lastWriteFuture != null) {
                 localRegistrationHandler.lastWriteFuture.awaitUninterruptibly();
@@ -87,7 +87,7 @@ public class LocalTransportThreadModelTest2 {
             return;
         }
 
-        localChannel.eventLoop().execute(new Runnable() {
+        localChannel.executor().execute(new Runnable() {
             @Override
             public void run() {
                 close(localChannel, localRegistrationHandler);

--- a/transport/src/test/java/io/netty/channel/pool/SimpleChannelPoolTest.java
+++ b/transport/src/test/java/io/netty/channel/pool/SimpleChannelPoolTest.java
@@ -231,7 +231,7 @@ public class SimpleChannelPoolTest {
         Channel channel1 = pool.acquire().syncUninterruptibly().getNow();
         channel1.close().syncUninterruptibly();
         Future<Void> releaseFuture =
-                pool.release(channel1, channel1.eventLoop().<Void>newPromise()).syncUninterruptibly();
+                pool.release(channel1, channel1.executor().<Void>newPromise()).syncUninterruptibly();
         assertTrue(releaseFuture.isSuccess());
 
         Channel channel2 = pool.acquire().syncUninterruptibly().getNow();

--- a/transport/src/test/java/io/netty/channel/socket/nio/NioSocketChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/nio/NioSocketChannelTest.java
@@ -226,7 +226,7 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
                                  @Override
                                  public void operationComplete(ChannelFuture cf) {
                                      Channel channel = cf.channel();
-                                     assertNotSame(loop, channel.eventLoop());
+                                     assertNotSame(loop, channel.executor());
                                      group.next().register(channel);
                                  }
                              });


### PR DESCRIPTION
…() (#11617)

Motivation:

We should just add `executor()` to the `ChannelOutboundInvoker` interface and override this method in `Channel` to return `EventLoop`.

Modifications:

- Add `executor()` method to `ChannelOutboundInvoker`
- Let `Channel` override this method and return `EventLoop`.
- Adjust all usages of `eventLoop()`

Result:

API cleanup