### PR TITLE
Fix flaky tests in codec-http module (#15862)

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketExtensionUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketExtensionUtil.java
@@ -21,7 +21,7 @@ import io.netty.handler.codec.http.HttpHeaders;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -53,7 +53,7 @@ public final class WebSocketExtensionUtil {
                 String name = extensionParameters[0].trim();
                 Map<String, String> parameters;
                 if (extensionParameters.length > 1) {
-                    parameters = new HashMap<String, String>(extensionParameters.length - 1);
+                    parameters = new LinkedHashMap<String, String>(extensionParameters.length - 1);
                     for (int i = 1; i < extensionParameters.length; i++) {
                         String parameter = extensionParameters[i].trim();
                         Matcher parameterMatcher = PARAMETER.matcher(parameter);
@@ -93,7 +93,7 @@ public final class WebSocketExtensionUtil {
                 extraExtensions.add(userDefined);
             } else {
                 // merge with higher precedence to user defined parameters
-                Map<String, String> mergedParameters = new HashMap<String, String>(matchingExtra.parameters());
+                Map<String, String> mergedParameters = new LinkedHashMap<String, String>(matchingExtra.parameters());
                 mergedParameters.putAll(userDefined.parameters());
                 extraExtensions.set(i, new WebSocketExtensionData(matchingExtra.name(), mergedParameters));
             }


### PR DESCRIPTION
### Motivation

The failure was found with
[NonDex](https://github.com/TestingResearchIllinois/NonDex), which explores non-determinism in tests. These tests can cause test failure under different JVMs, etc.

The non-determinism in the test class
`io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionUtilTest` in `codec-http` module is caused by the `WebSocketExtensionUtil` storing extension parameters in a HashMap, whose iteration order is nondeterministic. When `computeMergeExtensionsHeaderValue` serializes these parameters using `data.parameters().entrySet()`, the output ordering varies depending on the underlying hash iteration order.

#### Modifications

Replacing the parameter hashmaps with `LinkedHashMap` fixes the issue by preserving deterministic insertion/iteration order.

### Result

After the 3-line modification, the tests no longer depend on non-deterministic order of HashMap iteration.

### Failure Reproduction

1. Checkout the 4.2 branch and the recent commit I tested on: 0a3df28b2d8ed7b2f4f5389c81b2306c055e4762
2. Environment: 

> openjdk 17.0.16 2025-07-15
OpenJDK Runtime Environment (build 17.0.16+8-Ubuntu-0ubuntu124.04.1) OpenJDK 64-Bit Server VM (build 17.0.16+8-Ubuntu-0ubuntu124.04.1, mixed mode, sharing)

> Apache Maven 3.9.11
3. Run test with [NonDex](https://github.com/TestingResearchIllinois/NonDex), for example:
```
mvn -pl codec-http edu.illinois:nondex-maven-plugin:2.1.7:nondex \
    -Dtest=io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionUtilTest#computeMergeExtensionsHeaderValueWhenNoConflictingUserDefinedHeader \
    -DnondexRerun=true -DnondexRuns=1 -DnondexSeed=974622 \
    -Djacoco.skip -Drat.skip -Dpmd.skip -Denforcer.skip 
```
4. Observe the test failure