### PR TITLE
Fix ZstdEncoder not producing data when source is smaller than block …

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/ZstdEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZstdEncoder.java
@@ -141,6 +141,11 @@ public final class ZstdEncoder extends MessageToByteEncoder<ByteBuf> {
                 flushBufferedData(out);
             }
         }
+        // return the remaining data in the buffer
+        // when buffer size is smaller than the block size
+        if (buffer.isReadable()) {
+            flushBufferedData(out);
+        }
     }
 
     private void flushBufferedData(ByteBuf out) {

--- a/codec/src/test/java/io/netty/handler/codec/compression/ZstdEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/ZstdEncoderTest.java
@@ -22,7 +22,9 @@ import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
@@ -30,9 +32,10 @@ import org.mockito.MockitoAnnotations;
 
 import java.io.InputStream;
 
-
 import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ZstdEncoderTest extends AbstractEncoderTest {
@@ -76,6 +79,18 @@ public class ZstdEncoderTest extends AbstractEncoderTest {
     @MethodSource("smallData")
     public void testCompressionOfSmallBatchedFlow(final ByteBuf data) throws Exception {
         testCompressionOfBatchedFlow(data);
+    }
+
+    @Test
+    public void testCompressionOfTinyData() throws Exception {
+        ByteBuf data = Unpooled.copiedBuffer("Hello, World", CharsetUtil.UTF_8);
+        assertTrue(channel.writeOutbound(data));
+        assertTrue(channel.finish());
+
+        ByteBuf out = channel.readOutbound();
+        assertThat(out.readableBytes()).isPositive();
+        out.release();
+        assertNull(channel.readOutbound());
     }
 
     @Override


### PR DESCRIPTION
…size (#15859)

Motivation:
If the size of the input buffer is smaller than the configured block size (64 KB by default), then ZstdEncoder.write only produces an empty buffer. With the default sizes, this makes the encoder unusable for variable size content. This is for fixing the
issue(https://github.com/netty/netty/issues/15340)

Modification:

Return the uncompressed data if for small size data

Result:

Fixes #15340