### PR TITLE
Close Channel and fail bootstrap when setting a ChannelOption causes …

### DIFF
--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -473,31 +473,26 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
         }
     }
 
-    static Throwable setChannelOptions(
-            Channel channel, Map.Entry<ChannelOption<?>, Object>[] options, InternalLogger logger) {
+    static void setChannelOptions(
+            Channel channel, Map.Entry<ChannelOption<?>, Object>[] options, InternalLogger logger) throws Throwable {
         for (Map.Entry<ChannelOption<?>, Object> e: options) {
-            Throwable error = setChannelOption(channel, e.getKey(), e.getValue(), logger);
-            if (error != null) {
-                return error;
-            }
+            setChannelOption(channel, e.getKey(), e.getValue(), logger);
         }
-        return null;
     }
 
     @SuppressWarnings("unchecked")
-    private static Throwable setChannelOption(
-            Channel channel, ChannelOption<?> option, Object value, InternalLogger logger) {
+    private static void setChannelOption(
+            Channel channel, ChannelOption<?> option, Object value, InternalLogger logger) throws Throwable {
         try {
             if (!channel.config().setOption((ChannelOption<Object>) option, value)) {
                 logger.warn("Unknown channel option '{}' for channel '{}' of type '{}'",
                         option, channel, channel.getClass());
             }
-            return null;
         } catch (Throwable t) {
             logger.warn(
                     "Failed to set channel option '{}' with value '{}' for channel '{}' of type '{}'",
                     option, value, channel, channel.getClass(), t);
-            return t;
+            throw t;
         }
     }
 

--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -32,6 +32,7 @@ import io.netty.util.concurrent.GlobalEventExecutor;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.SocketUtils;
 import io.netty.util.internal.StringUtil;
+import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
 
 import java.net.InetAddress;
@@ -52,6 +53,9 @@ import java.util.concurrent.ConcurrentHashMap;
  * transports such as datagram (UDP).</p>
  */
 public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C extends Channel> implements Cloneable {
+
+    private static final boolean CLOSE_ON_SET_OPTION_FAILURE = SystemPropertyUtil.getBoolean(
+            "io.netty.bootstrap.closeOnSetOptionFailure", true);
     @SuppressWarnings("unchecked")
     private static final Map.Entry<ChannelOption<?>, Object>[] EMPTY_OPTION_ARRAY = new Map.Entry[0];
     @SuppressWarnings("unchecked")
@@ -492,7 +496,10 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
             logger.warn(
                     "Failed to set channel option '{}' with value '{}' for channel '{}' of type '{}'",
                     option, value, channel, channel.getClass(), t);
-            throw t;
+            if (CLOSE_ON_SET_OPTION_FAILURE) {
+                // Only rethrow if we want to close the channel in case of a failure.
+                throw t;
+            }
         }
     }
 

--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -357,7 +357,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
         return regFuture;
     }
 
-    abstract void init(Channel channel) throws Exception;
+    abstract void init(Channel channel) throws Throwable;
 
     Collection<ChannelInitializerExtension> getInitializerExtensions() {
         ClassLoader loader = extensionsClassLoader;
@@ -473,25 +473,31 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
         }
     }
 
-    static void setChannelOptions(
+    static Throwable setChannelOptions(
             Channel channel, Map.Entry<ChannelOption<?>, Object>[] options, InternalLogger logger) {
         for (Map.Entry<ChannelOption<?>, Object> e: options) {
-            setChannelOption(channel, e.getKey(), e.getValue(), logger);
+            Throwable error = setChannelOption(channel, e.getKey(), e.getValue(), logger);
+            if (error != null) {
+                return error;
+            }
         }
+        return null;
     }
 
     @SuppressWarnings("unchecked")
-    private static void setChannelOption(
+    private static Throwable setChannelOption(
             Channel channel, ChannelOption<?> option, Object value, InternalLogger logger) {
         try {
             if (!channel.config().setOption((ChannelOption<Object>) option, value)) {
                 logger.warn("Unknown channel option '{}' for channel '{}' of type '{}'",
                         option, channel, channel.getClass());
             }
+            return null;
         } catch (Throwable t) {
             logger.warn(
                     "Failed to set channel option '{}' with value '{}' for channel '{}' of type '{}'",
                     option, value, channel, channel.getClass(), t);
+            return t;
         }
     }
 

--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -271,11 +271,14 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
     }
 
     @Override
-    void init(Channel channel) {
+    void init(Channel channel) throws Throwable {
         ChannelPipeline p = channel.pipeline();
         p.addLast(config.handler());
 
-        setChannelOptions(channel, newOptionsArray(), logger);
+        Throwable cause = setChannelOptions(channel, newOptionsArray(), logger);
+        if (cause != null) {
+            throw cause;
+        }
         setAttributes(channel, newAttributesArray());
         Collection<ChannelInitializerExtension> extensions = getInitializerExtensions();
         if (!extensions.isEmpty()) {

--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -275,10 +275,8 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
         ChannelPipeline p = channel.pipeline();
         p.addLast(config.handler());
 
-        Throwable cause = setChannelOptions(channel, newOptionsArray(), logger);
-        if (cause != null) {
-            throw cause;
-        }
+        setChannelOptions(channel, newOptionsArray(), logger);
+
         setAttributes(channel, newAttributesArray());
         Collection<ChannelInitializerExtension> extensions = getInitializerExtensions();
         if (!extensions.isEmpty()) {

--- a/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
@@ -132,8 +132,11 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
     }
 
     @Override
-    void init(Channel channel) {
-        setChannelOptions(channel, newOptionsArray(), logger);
+    void init(Channel channel) throws Throwable {
+        Throwable cause = setChannelOptions(channel, newOptionsArray(), logger);
+        if (cause != null) {
+            throw cause;
+        }
         setAttributes(channel, newAttributesArray());
 
         ChannelPipeline p = channel.pipeline();
@@ -227,7 +230,11 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
 
             child.pipeline().addLast(childHandler);
 
-            setChannelOptions(child, childOptions, logger);
+            Throwable cause = setChannelOptions(child, childOptions, logger);
+            if (cause != null) {
+                forceClose(child, cause);
+                return;
+            }
             setAttributes(child, childAttrs);
 
             if (!extensions.isEmpty()) {

--- a/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
@@ -133,10 +133,7 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
 
     @Override
     void init(Channel channel) throws Throwable {
-        Throwable cause = setChannelOptions(channel, newOptionsArray(), logger);
-        if (cause != null) {
-            throw cause;
-        }
+        setChannelOptions(channel, newOptionsArray(), logger);
         setAttributes(channel, newAttributesArray());
 
         ChannelPipeline p = channel.pipeline();
@@ -230,8 +227,9 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
 
             child.pipeline().addLast(childHandler);
 
-            Throwable cause = setChannelOptions(child, childOptions, logger);
-            if (cause != null) {
+            try {
+                setChannelOptions(child, childOptions, logger);
+            } catch (Throwable cause) {
                 forceClose(child, cause);
                 return;
             }

--- a/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
@@ -86,6 +86,29 @@ public class BootstrapTest {
     }
 
     @Test
+    public void testSetOptionsThrow() {
+        final ChannelFuture cf = new Bootstrap()
+                .group(groupA)
+                .channelFactory(new ChannelFactory<Channel>() {
+                    @Override
+                    public Channel newChannel() {
+                        return new TestChannel();
+                    }
+                })
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 4242)
+                .handler(new ChannelInboundHandlerAdapter())
+                .register();
+
+        assertThrows(UnsupportedOperationException.class, new  Executable() {
+            @Override
+            public void execute() throws Throwable {
+                cf.syncUninterruptibly();
+            }
+        });
+        assertFalse(cf.channel().isActive());
+    }
+
+    @Test
     public void testOptionsCopied() {
         final Bootstrap bootstrapA = new Bootstrap();
         bootstrapA.option(ChannelOption.AUTO_READ, true);
@@ -578,4 +601,5 @@ public class BootstrapTest {
             };
         }
     }
+
 }

--- a/transport/src/test/java/io/netty/bootstrap/ServerBootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/ServerBootstrapTest.java
@@ -16,6 +16,8 @@
 package io.netty.bootstrap;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFactory;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelHandlerContext;
@@ -24,6 +26,7 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.ServerChannel;
 import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalChannel;
 import io.netty.channel.local.LocalIoHandler;
@@ -31,6 +34,7 @@ import io.netty.channel.local.LocalServerChannel;
 import io.netty.util.AttributeKey;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.function.Executable;
 
 import java.util.UUID;
 import java.util.concurrent.Callable;
@@ -40,11 +44,42 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ServerBootstrapTest {
+
+    @Test
+    public void testSetOptionsThrow() {
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, LocalIoHandler.newFactory());
+        try {
+            final ChannelFuture cf = new ServerBootstrap()
+                    .group(group)
+                    .channelFactory(new ChannelFactory<ServerChannel>() {
+                        @Override
+                        public ServerChannel newChannel() {
+                            return new TestServerChannel();
+                        }
+                    })
+                    .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 4242)
+                    .handler(new ChannelInboundHandlerAdapter())
+                    .childHandler(new ChannelInboundHandlerAdapter())
+                    .register();
+
+            assertThrows(UnsupportedOperationException.class, new Executable() {
+                @Override
+                public void execute() throws Throwable {
+                    cf.syncUninterruptibly();
+                }
+            });
+            assertFalse(cf.channel().isActive());
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
 
     @Test
     @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
@@ -240,4 +275,6 @@ public class ServerBootstrapTest {
         clientChannel.close().syncUninterruptibly();
         group.shutdownGracefully();
     }
+
+    private static final class TestServerChannel extends TestChannel implements ServerChannel { }
 }

--- a/transport/src/test/java/io/netty/bootstrap/TestChannel.java
+++ b/transport/src/test/java/io/netty/bootstrap/TestChannel.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.bootstrap;
+
+import io.netty.channel.AbstractChannel;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelConfig;
+import io.netty.channel.ChannelMetadata;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelOutboundBuffer;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.DefaultChannelConfig;
+import io.netty.channel.EventLoop;
+
+import java.net.SocketAddress;
+
+class TestChannel extends AbstractChannel {
+    private static final ChannelMetadata METADATA = new ChannelMetadata(false);
+    private final ChannelConfig config;
+    private volatile boolean closed;
+
+    TestChannel() {
+        this(null);
+    }
+
+    TestChannel(Channel parent) {
+        super(parent);
+        config = new TestConfig(this);
+    }
+
+    @Override
+    protected AbstractUnsafe newUnsafe() {
+        return new AbstractUnsafe() {
+            @Override
+            public void connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+                promise.setSuccess();
+            }
+        };
+    }
+
+    @Override
+    protected boolean isCompatible(EventLoop loop) {
+        return true;
+    }
+
+    @Override
+    protected SocketAddress localAddress0() {
+        return null;
+    }
+
+    @Override
+    protected SocketAddress remoteAddress0() {
+        return null;
+    }
+
+    @Override
+    protected void doBind(SocketAddress localAddress) {
+        // NOOP
+    }
+
+    @Override
+    protected void doDisconnect() {
+        closed = true;
+    }
+
+    @Override
+    protected void doClose() {
+        closed = true;
+    }
+
+    @Override
+    protected void doBeginRead() {
+        // NOOP
+    }
+
+    @Override
+    protected void doWrite(ChannelOutboundBuffer in) {
+        // NOOP
+    }
+
+    @Override
+    public ChannelConfig config() {
+        return config;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return !closed;
+    }
+
+    @Override
+    public boolean isActive() {
+        return !closed;
+    }
+
+    @Override
+    public ChannelMetadata metadata() {
+        return METADATA;
+    }
+
+    private static final class TestConfig extends DefaultChannelConfig {
+        TestConfig(Channel channel) {
+            super(channel);
+        }
+
+        @Override
+        public <T> boolean setOption(ChannelOption<T> option, T value) {
+            throw new UnsupportedOperationException("Unsupported channel option: " + option);
+        }
+    }
+}


### PR DESCRIPTION
…an error

Motivation:

We should close the Channel and fail the future of the bootstrap if during setting a ChannelOption we observe an error. At the moment we just log which might make things hard to debug and leave the Channel in an unexpected state.

Modifications:

- Adjust code to also close and faile the future
- Add testcases

Result:

Related to https://github.com/netty/netty/issues/15860#issuecomment-3548588098
