### PR TITLE
Fix Zstd compression for large data (#15861)

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/StandardCompressionOptions.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/StandardCompressionOptions.java
@@ -71,7 +71,7 @@ public final class StandardCompressionOptions {
     /**
      * Default implementation of {@link ZstdOptions} with{compressionLevel(int)} set to
      * {@link ZstdConstants#DEFAULT_COMPRESSION_LEVEL},{@link ZstdConstants#DEFAULT_BLOCK_SIZE},
-     * {@link ZstdConstants#MAX_BLOCK_SIZE}
+     * {@link ZstdConstants#DEFAULT_MAX_ENCODE_SIZE}
      */
     public static ZstdOptions zstd() {
         return ZstdOptions.DEFAULT;

--- a/codec/src/main/java/io/netty/handler/codec/compression/ZstdConstants.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZstdConstants.java
@@ -35,9 +35,9 @@ final class ZstdConstants {
     static final int MAX_COMPRESSION_LEVEL = Zstd.maxCompressionLevel();
 
     /**
-     * Max block size
+     * Max encode size
      */
-    static final int MAX_BLOCK_SIZE = 1 << (DEFAULT_COMPRESSION_LEVEL + 7) + 0x0F;   //  32 M
+    static final int DEFAULT_MAX_ENCODE_SIZE = Integer.MAX_VALUE;
     /**
      * Default block size
      */

--- a/codec/src/main/java/io/netty/handler/codec/compression/ZstdEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZstdEncoder.java
@@ -28,7 +28,7 @@ import static io.netty.handler.codec.compression.ZstdConstants.DEFAULT_COMPRESSI
 import static io.netty.handler.codec.compression.ZstdConstants.MIN_COMPRESSION_LEVEL;
 import static io.netty.handler.codec.compression.ZstdConstants.MAX_COMPRESSION_LEVEL;
 import static io.netty.handler.codec.compression.ZstdConstants.DEFAULT_BLOCK_SIZE;
-import static io.netty.handler.codec.compression.ZstdConstants.MAX_BLOCK_SIZE;
+import static io.netty.handler.codec.compression.ZstdConstants.DEFAULT_MAX_ENCODE_SIZE;
 
 /**
  *  Compresses a {@link ByteBuf} using the Zstandard algorithm.
@@ -56,7 +56,7 @@ public final class ZstdEncoder extends MessageToByteEncoder<ByteBuf> {
      * please use {@link ZstdEncoder(int,int)} constructor
      */
     public ZstdEncoder() {
-        this(DEFAULT_COMPRESSION_LEVEL, DEFAULT_BLOCK_SIZE, MAX_BLOCK_SIZE);
+        this(DEFAULT_COMPRESSION_LEVEL, DEFAULT_BLOCK_SIZE, DEFAULT_MAX_ENCODE_SIZE);
     }
 
     /**
@@ -65,7 +65,7 @@ public final class ZstdEncoder extends MessageToByteEncoder<ByteBuf> {
      *            specifies the level of the compression
      */
     public ZstdEncoder(int compressionLevel) {
-        this(compressionLevel, DEFAULT_BLOCK_SIZE, MAX_BLOCK_SIZE);
+        this(compressionLevel, DEFAULT_BLOCK_SIZE, DEFAULT_MAX_ENCODE_SIZE);
     }
 
     /**
@@ -113,7 +113,9 @@ public final class ZstdEncoder extends MessageToByteEncoder<ByteBuf> {
         while (remaining > 0) {
             int curSize = Math.min(blockSize, remaining);
             remaining -= curSize;
-            bufferSize += Zstd.compressBound(curSize);
+            // calculate the max compressed size with Zstd.compressBound since
+            // it returns the maximum size of the compressed data
+            bufferSize = Math.max(bufferSize, Zstd.compressBound(curSize));
         }
 
         if (bufferSize > maxEncodeSize || 0 > bufferSize) {

--- a/codec/src/main/java/io/netty/handler/codec/compression/ZstdOptions.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZstdOptions.java
@@ -21,7 +21,7 @@ import static io.netty.handler.codec.compression.ZstdConstants.DEFAULT_COMPRESSI
 import static io.netty.handler.codec.compression.ZstdConstants.MIN_COMPRESSION_LEVEL;
 import static io.netty.handler.codec.compression.ZstdConstants.MAX_COMPRESSION_LEVEL;
 import static io.netty.handler.codec.compression.ZstdConstants.DEFAULT_BLOCK_SIZE;
-import static io.netty.handler.codec.compression.ZstdConstants.MAX_BLOCK_SIZE;
+import static io.netty.handler.codec.compression.ZstdConstants.DEFAULT_MAX_ENCODE_SIZE;
 
 /**
  * {@link ZstdOptions} holds compressionLevel for
@@ -36,9 +36,10 @@ public class ZstdOptions implements CompressionOptions {
     /**
      * Default implementation of {@link ZstdOptions} with{compressionLevel(int)} set to
      * {@link ZstdConstants#DEFAULT_COMPRESSION_LEVEL},{@link ZstdConstants#DEFAULT_BLOCK_SIZE},
-     * {@link ZstdConstants#MAX_BLOCK_SIZE}
+     * {@link ZstdConstants#DEFAULT_MAX_ENCODE_SIZE}
      */
-    static final ZstdOptions DEFAULT = new ZstdOptions(DEFAULT_COMPRESSION_LEVEL, DEFAULT_BLOCK_SIZE, MAX_BLOCK_SIZE);
+    static final ZstdOptions DEFAULT = new ZstdOptions(DEFAULT_COMPRESSION_LEVEL, DEFAULT_BLOCK_SIZE,
+            DEFAULT_MAX_ENCODE_SIZE);
 
     /**
      * Create a new {@link ZstdOptions}

--- a/codec/src/test/java/io/netty/handler/codec/compression/ZstdEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/ZstdEncoderTest.java
@@ -49,6 +49,14 @@ public class ZstdEncoderTest extends AbstractEncoderTest {
         when(ctx.alloc()).thenReturn(ByteBufAllocator.DEFAULT);
     }
 
+    public static ByteBuf[] hugeData() {
+        final byte[] bytesHuge = new byte[36 * 1024 * 1024];
+        ByteBuf heap = Unpooled.wrappedBuffer(bytesHuge);
+        ByteBuf direct = Unpooled.directBuffer(bytesHuge.length);
+        direct.writeBytes(bytesHuge);
+        return new ByteBuf[] {heap, direct};
+    }
+
     @Override
     public EmbeddedChannel createChannel() {
         return new EmbeddedChannel(new ZstdEncoder());
@@ -57,6 +65,16 @@ public class ZstdEncoderTest extends AbstractEncoderTest {
     @ParameterizedTest
     @MethodSource("largeData")
     public void testCompressionOfLargeBatchedFlow(final ByteBuf data) throws Exception {
+        testCompressionOfLargeDataBatchedFlow(data);
+    }
+
+    @ParameterizedTest
+    @MethodSource("hugeData")
+    public void testCompressionOfHugeBatchedFlow(final ByteBuf data) throws Exception {
+        testCompressionOfLargeDataBatchedFlow(data);
+    }
+
+    private void testCompressionOfLargeDataBatchedFlow(final ByteBuf data) throws Exception {
         final int dataLength = data.readableBytes();
         int written = 0;
 

--- a/codec/src/test/java/io/netty/handler/codec/compression/ZstdIntegrationTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/ZstdIntegrationTest.java
@@ -17,7 +17,7 @@ package io.netty.handler.codec.compression;
 
 import io.netty.channel.embedded.EmbeddedChannel;
 
-import static io.netty.handler.codec.compression.ZstdConstants.MAX_BLOCK_SIZE;
+import static io.netty.handler.codec.compression.ZstdConstants.DEFAULT_MAX_ENCODE_SIZE;
 
 public class ZstdIntegrationTest extends AbstractIntegrationTest {
 
@@ -25,7 +25,7 @@ public class ZstdIntegrationTest extends AbstractIntegrationTest {
 
     @Override
     protected EmbeddedChannel createEncoder() {
-        return new EmbeddedChannel(new ZstdEncoder(BLOCK_SIZE, MAX_BLOCK_SIZE));
+        return new EmbeddedChannel(new ZstdEncoder(BLOCK_SIZE, DEFAULT_MAX_ENCODE_SIZE));
     }
 
     @Override


### PR DESCRIPTION
Motivation:

Zstd compression fails for sources larger than 31MB since the default max encode size is 32M. This is PR is to change default max encode size to `Integer.MAX_VALUE` so that `ZstdEncoder` can works for large data

Modification:

Change default max encode size to `Integer.MAX_VALUE` so that `ZstdEncoder` can works for large data


Result:

Fixes #14972

`ZstdEncoder` can works for the large data