### PR TITLE
Remove deprecated EpollMode

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -125,8 +125,6 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
      * <ul>
      *   <li>both channels need to be registered to the same {@link EventLoop}, otherwise an
      *   {@link IllegalArgumentException} is thrown. </li>
-     *   <li>{@link EpollChannelConfig#getEpollMode()} must be {@link EpollMode#LEVEL_TRIGGERED} for this and the
-     *   target {@link AbstractEpollStreamChannel}</li>
      * </ul>
      *
      */
@@ -143,8 +141,6 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
      * <ul>
      *   <li>both channels need to be registered to the same {@link EventLoop}, otherwise an
      *   {@link IllegalArgumentException} is thrown. </li>
-     *   <li>{@link EpollChannelConfig#getEpollMode()} must be {@link EpollMode#LEVEL_TRIGGERED} for this and the
-     *   target {@link AbstractEpollStreamChannel}</li>
      * </ul>
      *
      */
@@ -154,10 +150,6 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
             throw new IllegalArgumentException("EventLoops are not the same.");
         }
         checkPositiveOrZero(len, "len");
-        if (ch.config().getEpollMode() != EpollMode.LEVEL_TRIGGERED
-                || config().getEpollMode() != EpollMode.LEVEL_TRIGGERED) {
-            throw new IllegalStateException("spliceTo() supported only when using " + EpollMode.LEVEL_TRIGGERED);
-        }
         checkNotNull(promise, "promise");
         if (!isOpen()) {
             promise.tryFailure(new ClosedChannelException());
@@ -176,8 +168,6 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
      *
      * Please note:
      * <ul>
-     *   <li>{@link EpollChannelConfig#getEpollMode()} must be {@link EpollMode#LEVEL_TRIGGERED} for this
-     *   {@link AbstractEpollStreamChannel}</li>
      *   <li>the {@link FileDescriptor} will not be closed after the {@link ChannelFuture} is notified</li>
      *   <li>this channel must be registered to an event loop or {@link IllegalStateException} will be thrown.</li>
      * </ul>
@@ -194,8 +184,6 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
      *
      * Please note:
      * <ul>
-     *   <li>{@link EpollChannelConfig#getEpollMode()} must be {@link EpollMode#LEVEL_TRIGGERED} for this
-     *   {@link AbstractEpollStreamChannel}</li>
      *   <li>the {@link FileDescriptor} will not be closed after the {@link ChannelPromise} is notified</li>
      *   <li>this channel must be registered to an event loop or {@link IllegalStateException} will be thrown.</li>
      * </ul>
@@ -204,9 +192,6 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
                                         final ChannelPromise promise) {
         checkPositiveOrZero(len, "len");
         checkPositiveOrZero(offset, "offset");
-        if (config().getEpollMode() != EpollMode.LEVEL_TRIGGERED) {
-            throw new IllegalStateException("spliceTo() supported only when using " + EpollMode.LEVEL_TRIGGERED);
-        }
         checkNotNull(promise, "promise");
         if (!isOpen()) {
             promise.tryFailure(new ClosedChannelException());

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollChannelConfig.java
@@ -25,18 +25,13 @@ import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.unix.IntegerUnixChannelOption;
 import io.netty.channel.unix.RawUnixChannelOption;
-import io.netty.util.internal.logging.InternalLogger;
-import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Map;
 
 import static io.netty.channel.unix.Limits.SSIZE_MAX;
 
 public class EpollChannelConfig extends DefaultChannelConfig {
-
-    private static final InternalLogger LOGGER = InternalLoggerFactory.getInstance(EpollChannelConfig.class);
 
     private volatile long maxBytesPerGatheringWrite = SSIZE_MAX;
 
@@ -59,17 +54,9 @@ public class EpollChannelConfig extends DefaultChannelConfig {
         return channel;
     }
 
-    @Override
-    public Map<ChannelOption<?>, Object> getOptions() {
-        return getOptions(super.getOptions(), EpollChannelOption.EPOLL_MODE);
-    }
-
     @SuppressWarnings("unchecked")
     @Override
     public <T> T getOption(ChannelOption<T> option) {
-        if (option == EpollChannelOption.EPOLL_MODE) {
-            return (T) getEpollMode();
-        }
         try {
             if (option instanceof IntegerUnixChannelOption) {
                 IntegerUnixChannelOption opt = (IntegerUnixChannelOption) option;
@@ -91,25 +78,20 @@ public class EpollChannelConfig extends DefaultChannelConfig {
     @Override
     public <T> boolean setOption(ChannelOption<T> option, T value) {
         validate(option, value);
-        if (option == EpollChannelOption.EPOLL_MODE) {
-            setEpollMode((EpollMode) value);
-        } else {
-            try {
-                if (option instanceof IntegerUnixChannelOption) {
-                    IntegerUnixChannelOption opt = (IntegerUnixChannelOption) option;
-                    ((AbstractEpollChannel) channel).socket.setIntOpt(opt.level(), opt.optname(), (Integer) value);
-                    return true;
-                } else if (option instanceof RawUnixChannelOption) {
-                    RawUnixChannelOption opt = (RawUnixChannelOption) option;
-                    ((AbstractEpollChannel) channel).socket.setRawOpt(opt.level(), opt.optname(), (ByteBuffer) value);
-                    return true;
-                }
-            } catch (IOException e) {
-                throw new ChannelException(e);
+        try {
+            if (option instanceof IntegerUnixChannelOption) {
+                IntegerUnixChannelOption opt = (IntegerUnixChannelOption) option;
+                ((AbstractEpollChannel) channel).socket.setIntOpt(opt.level(), opt.optname(), (Integer) value);
+                return true;
+            } else if (option instanceof RawUnixChannelOption) {
+                RawUnixChannelOption opt = (RawUnixChannelOption) option;
+                ((AbstractEpollChannel) channel).socket.setRawOpt(opt.level(), opt.optname(), (ByteBuffer) value);
+                return true;
             }
-            return super.setOption(option, value);
+        } catch (IOException e) {
+            throw new ChannelException(e);
         }
-        return true;
+        return super.setOption(option, value);
     }
 
     @Override
@@ -176,35 +158,6 @@ public class EpollChannelConfig extends DefaultChannelConfig {
     @Override
     public EpollChannelConfig setMessageSizeEstimator(MessageSizeEstimator estimator) {
         super.setMessageSizeEstimator(estimator);
-        return this;
-    }
-
-    /**
-     * Return the {@link EpollMode} used. Default is
-     * {@link EpollMode#EDGE_TRIGGERED}. If you want to use {@link #isAutoRead()} {@code false} or
-     * {@link #getMaxMessagesPerRead()} and have an accurate behaviour you should use
-     * {@link EpollMode#LEVEL_TRIGGERED}.
-     *
-     * @deprecated Netty always uses level-triggered mode and so this method is just a no-op.
-     */
-    @Deprecated
-    public EpollMode getEpollMode() {
-        return EpollMode.LEVEL_TRIGGERED;
-    }
-
-    /**
-     * Set the {@link EpollMode} used. Default is
-     * {@link EpollMode#EDGE_TRIGGERED}. If you want to use {@link #isAutoRead()} {@code false} or
-     * {@link #getMaxMessagesPerRead()} and have an accurate behaviour you should use
-     * {@link EpollMode#LEVEL_TRIGGERED}.
-     *
-     * <strong>Be aware this config setting can only be adjusted before the channel was registered.</strong>
-     *
-     * @deprecated Netty always uses level-triggered mode and so this method is just a no-op.
-     */
-    @Deprecated
-    public EpollChannelConfig setEpollMode(EpollMode mode) {
-        LOGGER.debug("Changing the EpollMode is not supported anymore, this is just a no-op");
         return this;
     }
 

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollChannelOption.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollChannelOption.java
@@ -50,13 +50,6 @@ public final class EpollChannelOption<T> extends UnixChannelOption<T> {
     public static final ChannelOption<Boolean> TCP_QUICKACK = valueOf(EpollChannelOption.class, "TCP_QUICKACK");
     public static final ChannelOption<Integer> SO_BUSY_POLL = valueOf(EpollChannelOption.class, "SO_BUSY_POLL");
 
-    /**
-     * @deprecated Netty always uses level-triggered mode and so this method is just a no-op.
-     */
-    @Deprecated
-    public static final ChannelOption<EpollMode> EPOLL_MODE =
-            ChannelOption.valueOf(EpollChannelOption.class, "EPOLL_MODE");
-
     public static final ChannelOption<Map<InetAddress, byte[]>> TCP_MD5SIG = valueOf("TCP_MD5SIG");
 
     public static final ChannelOption<Integer> MAX_DATAGRAM_PAYLOAD_SIZE = valueOf("MAX_DATAGRAM_PAYLOAD_SIZE");

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannelConfig.java
@@ -408,12 +408,6 @@ public final class EpollDatagramChannelConfig extends EpollChannelConfig impleme
         }
     }
 
-    @Override
-    public EpollDatagramChannelConfig setEpollMode(EpollMode mode) {
-        super.setEpollMode(mode);
-        return this;
-    }
-
     /**
      * Returns {@code true} if the SO_REUSEPORT option is set.
      */

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainDatagramChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainDatagramChannelConfig.java
@@ -110,12 +110,6 @@ public final class EpollDomainDatagramChannelConfig extends EpollChannelConfig i
     }
 
     @Override
-    public EpollDomainDatagramChannelConfig setEpollMode(EpollMode mode) {
-        super.setEpollMode(mode);
-        return this;
-    }
-
-    @Override
     @Deprecated
     public EpollDomainDatagramChannelConfig setMaxMessagesPerRead(int maxMessagesPerRead) {
         super.setMaxMessagesPerRead(maxMessagesPerRead);

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannelConfig.java
@@ -155,12 +155,6 @@ public final class EpollDomainSocketChannelConfig extends EpollChannelConfig
     }
 
     @Override
-    public EpollDomainSocketChannelConfig setEpollMode(EpollMode mode) {
-        super.setEpollMode(mode);
-        return this;
-    }
-
-    @Override
     public EpollDomainSocketChannelConfig setReadMode(DomainSocketReadMode mode) {
         this.mode = ObjectUtil.checkNotNull(mode, "mode");
         return this;

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerChannelConfig.java
@@ -225,10 +225,4 @@ public class EpollServerChannelConfig extends EpollChannelConfig implements Serv
         super.setMessageSizeEstimator(estimator);
         return this;
     }
-
-    @Override
-    public EpollServerChannelConfig setEpollMode(EpollMode mode) {
-        super.setEpollMode(mode);
-        return this;
-    }
 }

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannelConfig.java
@@ -681,12 +681,6 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
         return this;
     }
 
-    @Override
-    public EpollSocketChannelConfig setEpollMode(EpollMode mode) {
-        super.setEpollMode(mode);
-        return this;
-    }
-
     private void calculateMaxBytesPerGatheringWrite() {
         // Multiply by 2 to give some extra space in case the OS can process write data faster than we can provide.
         int newSendBufferSize = getSendBufferSize() << 1;

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSpliceTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSpliceTest.java
@@ -66,13 +66,11 @@ public class EpollSpliceTest {
 
         ServerBootstrap bs2 = new ServerBootstrap();
         bs2.channel(EpollServerSocketChannel.class);
-        bs2.childOption(EpollChannelOption.EPOLL_MODE, EpollMode.LEVEL_TRIGGERED);
         bs2.group(group).childHandler(new ChannelInboundHandlerAdapter() {
             @Override
             public void channelActive(final ChannelHandlerContext ctx) throws Exception {
                 ctx.channel().config().setAutoRead(false);
                 Bootstrap bs = new Bootstrap();
-                bs.option(EpollChannelOption.EPOLL_MODE, EpollMode.LEVEL_TRIGGERED);
 
                 bs.channel(EpollSocketChannel.class);
                 bs.group(ctx.channel().executor()).handler(new ChannelInboundHandlerAdapter() {
@@ -196,7 +194,6 @@ public class EpollSpliceTest {
         ServerBootstrap bs = new ServerBootstrap();
         bs.channel(EpollServerSocketChannel.class);
         bs.group(group).childHandler(sh);
-        bs.childOption(EpollChannelOption.EPOLL_MODE, EpollMode.LEVEL_TRIGGERED);
         Channel sc = bs.bind(NetUtil.LOCALHOST, 0).syncUninterruptibly().channel();
 
         Bootstrap cb = new Bootstrap();


### PR DESCRIPTION
Motivation:

EpolMode was deprecated and didnt do anything anymore. Let's remove it

Modifications:

Remove deprecated code

Result:

Cleanup