### PR TITLE
Fix [15908] - Ignore unknown Http3Setting Identifier in Http3SettingsFrame

### DIFF
--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ErrorCode.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ErrorCode.java
@@ -16,9 +16,16 @@
 package io.netty.handler.codec.http3;
 
 /**
- * Different <a href="https://tools.ietf.org/html/draft-ietf-quic-http-32#section-8.1">HTTP3 error codes</a>.
+ * Different <a href="https://datatracker.ietf.org/doc/html/rfc9114#name-http-3-error-codes">HTTP3 error codes</a>.
  */
 public enum Http3ErrorCode {
+
+    /**
+     * Datagram or Capsule Protocol parse error
+     * <a href="https://www.rfc-editor.org/rfc/rfc9297.html#name-http-3-error-code">rfc9297</a>
+     * registered in IANA http3 <a href="https://www.iana.org/assignments/http3-parameters/http3-parameters.xhtml#http3-parameters-error-codes">IANA Http3 Error Codes</a>
+     */
+    H3_DATAGRAM_ERROR(0x33),
 
     /**
      *  No error. This is used when the connection or stream needs to be closed, but there is no error to signal.

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ErrorCode.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ErrorCode.java
@@ -24,7 +24,8 @@ public enum Http3ErrorCode {
      * Datagram or Capsule Protocol parse error
      * <a href="https://www.rfc-editor.org/rfc/rfc9297.html#name-http-3-error-code">rfc9297</a>
      * registered in IANA http3
-     * <a href="http://www.iana.org/assignments/http3-parameters/http3-parameters.xhtml#http3-parameters-error-codes">
+     * <a href="https://www.iana.org/assignments/http3-parameters/http3-parameters.xhtml#http3-parameters-error-codes"
+     * >
      *     IANA Http3 Error Codes</a>
      */
     H3_DATAGRAM_ERROR(0x33),

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ErrorCode.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ErrorCode.java
@@ -23,7 +23,9 @@ public enum Http3ErrorCode {
     /**
      * Datagram or Capsule Protocol parse error
      * <a href="https://www.rfc-editor.org/rfc/rfc9297.html#name-http-3-error-code">rfc9297</a>
-     * registered in IANA http3 <a href="https://www.iana.org/assignments/http3-parameters/http3-parameters.xhtml#http3-parameters-error-codes">IANA Http3 Error Codes</a>
+     * registered in IANA http3
+     * <a href="http://www.iana.org/assignments/http3-parameters/http3-parameters.xhtml#http3-parameters-error-codes">
+     *     IANA Http3 Error Codes</a>
      */
     H3_DATAGRAM_ERROR(0x33),
 

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3SettingIdentifier.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3SettingIdentifier.java
@@ -1,0 +1,78 @@
+package io.netty.handler.codec.http3;
+
+import javax.annotation.Nullable;
+
+public enum Http3SettingIdentifier {
+
+    /**
+     * QPACK maximum table capacity setting identifier (<b>0x1</b>).
+     * <p>
+     * Defined in <a href="https://datatracker.ietf.org/doc/html/rfc9204#section-5">
+     * RFC 9204, Section 5 (SETTINGS_QPACK_MAX_TABLE_CAPACITY)</a> and registered in
+     * the <a href="https://www.iana.org/assignments/http3-parameters/http3-parameters.xhtml#settings">
+     * HTTP/3 SETTINGS registry (IANA)</a>.
+     * <br>
+     * Controls the maximum size of the dynamic table used by QPACK.
+     */
+    HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY(0x1),
+
+    /**
+     * Maximum field section size setting identifier (<b>0x6</b>).
+     * <p>
+     * Defined in <a href="https://datatracker.ietf.org/doc/html/rfc9114#section-7.2.4.1">
+     * RFC 9114, Section 7.2.4.1 (SETTINGS_MAX_FIELD_SECTION_SIZE)</a> , also referenced
+     * in the <a href="https://datatracker.ietf.org/doc/html/rfc9114#section-7.2.4.1">
+     * HTTP/3 SETTINGS registry (RFC 9114, Section 7.2.4.1)</a> and registered in
+     * the <a href="https://www.iana.org/assignments/http3-parameters/http3-parameters.xhtml#settings">
+     * HTTP/3 SETTINGS registry (IANA)</a>.
+     * <br>
+     * Specifies the upper bound on the total size of HTTP field sections accepted by a peer.
+     */
+    HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE(0x6),
+
+    /**
+     * QPACK blocked streams setting identifier (<b>0x7</b>).
+     * <p>
+     * Defined in <a href="https://datatracker.ietf.org/doc/html/rfc9204#section-5">
+     * RFC 9204, Section 5 (SETTINGS_QPACK_BLOCKED_STREAMS)</a> and registered in
+     * the <a href="https://www.iana.org/assignments/http3-parameters/http3-parameters.xhtml#settings">
+     * HTTP/3 SETTINGS registry (IANA)</a>.
+     * <br>
+     * Indicates the maximum number of streams that can be blocked waiting for QPACK instructions.
+     */
+    HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS(0x7),
+
+    /**
+     * ENABLE_CONNECT_PROTOCOL setting identifier (<b>0x8</b>).
+     * <p>
+     * Defined and registered in <a href="https://datatracker.ietf.org/doc/html/rfc9220#section-5">
+     * RFC 9220, Section 5 (IANA Considerations)</a> and registered in
+     * the <a href="https://www.iana.org/assignments/http3-parameters/http3-parameters.xhtml#settings">
+     * HTTP/3 SETTINGS registry (IANA)</a>.
+     * <br>
+     * Enables use of the CONNECT protocol in HTTP/3 when set to 1; disabled when 0.
+     */
+    HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL(0x8),
+
+    HTTP3_SETTINGS_H3_DATAGRAM(0x33);
+
+    private final long id;
+
+    Http3SettingIdentifier(long id) {
+        this.id = id;
+    }
+
+    public long id() {
+        return id;
+    }
+
+    @Nullable
+    public static Http3SettingIdentifier fromId(long id) {
+        for (Http3SettingIdentifier s : values()) {
+            if (s.id == id) {
+                return s;
+            }
+        }
+        return null; // unknown setting → ignored when receiving
+    }
+}

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3SettingIdentifier.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3SettingIdentifier.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package io.netty.handler.codec.http3;
 
 import javax.annotation.Nullable;
@@ -54,6 +69,16 @@ public enum Http3SettingIdentifier {
      */
     HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL(0x8),
 
+    /**
+     * ENABLE_H3_DATAGRAM setting identifier (<b>0x8</b>).
+     * <p>
+     * Defined and registered in <a href="https://datatracker.ietf.org/doc/html/rfc9297#name-http-3-setting">
+     * RFC 9220, Section 5 (IANA Considerations)</a> and registered in
+     * the <a href="https://www.iana.org/assignments/http3-parameters/http3-parameters.xhtml#settings">
+     * HTTP/3 SETTINGS registry (IANA)</a>.
+     * <br>
+     * Enables use of the CONNECT protocol in HTTP/3 when set to 1; disabled when 0.
+     */
     HTTP3_SETTINGS_H3_DATAGRAM(0x33);
 
     private final long id;

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3SettingIdentifier.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3SettingIdentifier.java
@@ -87,10 +87,22 @@ public enum Http3SettingIdentifier {
         this.id = id;
     }
 
+    /**
+     * Returns the Identifier of {@link Http3SettingIdentifier}
+     * for example:
+     * SETTINGS_QPACK_MAX_TABLE_CAPACITY = 0x1 = 1 in the settings frame
+     * <br>
+     * @return long(represented as hexadecimal above) value of the Identifier
+     */
     public long id() {
         return id;
     }
 
+    /**
+     * Returns {@link Http3SettingIdentifier}
+     * @param id
+     * @return {@link Http3SettingIdentifier} enum which represents @param id, null otherwise
+     */
     @Nullable
     public static Http3SettingIdentifier fromId(long id) {
         for (Http3SettingIdentifier s : values()) {

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3SettingIdentifier.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3SettingIdentifier.java
@@ -97,7 +97,7 @@ public enum Http3SettingIdentifier {
                             Function.identity()
                     ))
     );
-            
+
     Http3SettingIdentifier(long id) {
         this.id = id;
     }

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3SettingIdentifier.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3SettingIdentifier.java
@@ -15,7 +15,14 @@
  */
 package io.netty.handler.codec.http3;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public enum Http3SettingIdentifier {
 
@@ -83,6 +90,14 @@ public enum Http3SettingIdentifier {
 
     private final long id;
 
+    private static final Map<Long, Http3SettingIdentifier> LOOKUP =
+            Arrays.stream(values())
+                    .collect(Collectors.toMap(
+                            Http3SettingIdentifier::id,
+                            Function.identity()
+                    ));
+
+
     Http3SettingIdentifier(long id) {
         this.id = id;
     }
@@ -105,11 +120,6 @@ public enum Http3SettingIdentifier {
      */
     @Nullable
     public static Http3SettingIdentifier fromId(long id) {
-        for (Http3SettingIdentifier s : values()) {
-            if (s.id == id) {
-                return s;
-            }
-        }
-        return null; // unknown setting → ignored when receiving
+        return LOOKUP.get(id);
     }
 }

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3SettingIdentifier.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3SettingIdentifier.java
@@ -97,7 +97,6 @@ public enum Http3SettingIdentifier {
                             Function.identity()
                     ));
 
-
     Http3SettingIdentifier(long id) {
         this.id = id;
     }

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3SettingIdentifier.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3SettingIdentifier.java
@@ -90,12 +90,14 @@ public enum Http3SettingIdentifier {
 
     private final long id;
 
-    private static final Map<Long, Http3SettingIdentifier> LOOKUP =
-            Arrays.stream(values())
+    private static final Map<Long, Http3SettingIdentifier> LOOKUP = Collections.unmodifiableMap(
+        Arrays.stream(values())
                     .collect(Collectors.toMap(
                             Http3SettingIdentifier::id,
                             Function.identity()
-                    ));
+                    ))
+    );
+            
 
     Http3SettingIdentifier(long id) {
         this.id = id;

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3SettingIdentifier.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3SettingIdentifier.java
@@ -98,7 +98,6 @@ public enum Http3SettingIdentifier {
                     ))
     );
             
-
     Http3SettingIdentifier(long id) {
         this.id = id;
     }

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3Settings.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3Settings.java
@@ -38,63 +38,13 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
  *   <li>{@code ENABLE_CONNECT_PROTOCOL} (0x8)</li>
  * </ul>
  *
- * Non-standard settings are permitted as long as they use positive values.
+ * Non-standard settings are ignored
  * Reserved HTTP/2 setting identifiers are rejected.
  *
  */
 public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
 
     private final LongObjectMap<Long> settings;
-
-    /**
-     * QPACK maximum table capacity setting identifier (<b>0x1</b>).
-     * <p>
-     * Defined in <a href="https://datatracker.ietf.org/doc/html/rfc9204#section-5">
-     * RFC 9204, Section 5 (QPACK-MAX_TABLE_CAPACITY)</a> and registered in
-     * the <a href="https://www.iana.org/assignments/http3-parameters/http3-parameters.xhtml#settings">
-     * HTTP/3 SETTINGS registry (IANA)</a>.
-     * <br>
-     * Controls the maximum size of the dynamic table used by QPACK.
-     */
-    public static final long HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY = 0x1;
-
-    /**
-     * Maximum field section size setting identifier (<b>0x6</b>).
-     * <p>
-     * Defined in <a href="https://datatracker.ietf.org/doc/html/rfc9114#section-7.2.4.1">
-     * RFC 9114, Section 7.2.4.1 (SETTINGS_MAX_FIELD_SECTION_SIZE)</a> , also referenced
-     * in the <a href="https://datatracker.ietf.org/doc/html/rfc9114#section-7.2.4.1">
-     * HTTP/3 SETTINGS registry (RFC 9114, Section 7.2.4.1)</a> and registered in
-     * the <a href="https://www.iana.org/assignments/http3-parameters/http3-parameters.xhtml#settings">
-     * HTTP/3 SETTINGS registry (IANA)</a>.
-     * <br>
-     * Specifies the upper bound on the total size of HTTP field sections accepted by a peer.
-     */
-    public static final long HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE = 0x6;
-
-    /**
-     * QPACK blocked streams setting identifier (<b>0x7</b>).
-     * <p>
-     * Defined in <a href="https://datatracker.ietf.org/doc/html/rfc9204#section-5">
-     * RFC 9204, Section 5 (QPACK_BLOCKED_STREAMS)</a> and registered in
-     * the <a href="https://www.iana.org/assignments/http3-parameters/http3-parameters.xhtml#settings">
-     * HTTP/3 SETTINGS registry (IANA)</a>.
-     * <br>
-     * Indicates the maximum number of streams that can be blocked waiting for QPACK instructions.
-     */
-    public static final long HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS = 0x7;
-
-    /**
-     * ENABLE_CONNECT_PROTOCOL setting identifier (<b>0x8</b>).
-     * <p>
-     * Defined and registered in <a href="https://datatracker.ietf.org/doc/html/rfc9220#section-5">
-     * RFC 9220, Section 5 (IANA Considerations)</a> and registered in
-     * the <a href="https://www.iana.org/assignments/http3-parameters/http3-parameters.xhtml#settings">
-     * HTTP/3 SETTINGS registry (IANA)</a>.
-     * <br>
-     * Enables use of the CONNECT protocol in HTTP/3 when set to 1; disabled when 0.
-     */
-    public static final long HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL = 0x8;
 
     private static final Long TRUE = 1L;
     private static final Long FALSE = 0L;
@@ -130,7 +80,7 @@ public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
      * <p>
      * The key and value are validated according to the HTTP/3 specification.
      * Reserved HTTP/2 setting identifiers and negative values are not allowed.
-     *
+     * Ignore any unknown id/key as per <a href="https://www.rfc-editor.org/rfc/rfc9114.html#section-7.2.4-9>rfc9114</a>
      * @param key   the numeric setting identifier
      * @param value the setting value (non-null)
      * @return the previous value associated with the key, or {@code null} if none
@@ -138,7 +88,20 @@ public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
      */
     @Nullable
     public Long put(long key, Long value) {
+
+        //HTTP2 Settings present - Throw Error
+        if (Http3CodecUtils.isReservedHttp2Setting(key)) {
+            throw new IllegalArgumentException("Setting is reserved for HTTP/2: " + key);
+        }
+
+        //Non-Standard/Unknown setting identifier present - Ignore
+        if (Http3SettingIdentifier.fromId(key) == null) {
+            return value;
+        }
+
+        //Validation
         verifyStandardSetting(key, value);
+
         return settings.put(key, value);
     }
 
@@ -160,7 +123,7 @@ public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
      */
     @Nullable
     public Long qpackMaxTableCapacity() {
-        return get(HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY);
+        return get(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY.id());
     }
 
     /**
@@ -170,7 +133,7 @@ public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
      * @return this instance for method chaining
      */
     public Http3Settings qpackMaxTableCapacity(long value) {
-        put(HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY, value);
+        put(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY.id(), value);
         return this;
     }
 
@@ -181,7 +144,7 @@ public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
      */
     @Nullable
     public Long maxFieldSectionSize() {
-        return get(HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE);
+        return get(Http3SettingIdentifier.HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE.id());
     }
 
     /**
@@ -191,7 +154,7 @@ public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
      * @return this instance for method chaining
      */
     public Http3Settings maxFieldSectionSize(long value) {
-        put(HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE, value);
+        put(Http3SettingIdentifier.HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE.id(), value);
         return this;
     }
 
@@ -202,7 +165,7 @@ public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
      */
     @Nullable
     public Long qpackBlockedStreams() {
-        return get(HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS);
+        return get(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id());
     }
 
     /**
@@ -212,7 +175,7 @@ public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
      * @return this instance for method chaining
      */
     public Http3Settings qpackBlockedStreams(long value) {
-        put(HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS, value);
+        put(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id(), value);
         return this;
     }
 
@@ -223,7 +186,7 @@ public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
      */
     @Nullable
     public Boolean connectProtocolEnabled() {
-        Long value = get(HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL);
+        Long value = get(Http3SettingIdentifier.HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL.id());
         return value == null ? null : TRUE.equals(value);
     }
 
@@ -234,7 +197,7 @@ public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
      * @return this instance for method chaining
      */
     public Http3Settings enableConnectProtocol(boolean enabled) {
-        put(HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL, enabled ? TRUE : FALSE);
+        put(Http3SettingIdentifier.HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL.id(), enabled ? TRUE : FALSE);
         return this;
     }
 
@@ -352,21 +315,20 @@ public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
      */
     private static void verifyStandardSetting(long key, Long value) {
         checkNotNull(value, "value");
-        if (Http3CodecUtils.isReservedHttp2Setting(key)) {
-            throw new IllegalArgumentException("Setting is reserved for HTTP/2: " + key);
-        }
-        switch ((int) key) {
-            case (int) HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY:
-            case (int) HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS:
-            case (int) HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE:
+
+        switch (Http3SettingIdentifier.fromId(key)) {
+            case HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY:
+            case HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS:
+            case HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE:
                 if (value < 0) {
                     throw new IllegalArgumentException("Setting 0x" + toHexString(key)
                             + " invalid: " + value + " (must be >= 0)");
                 }
                 break;
-            case (int) HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL:
+            case HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL:
+            case HTTP3_SETTINGS_H3_DATAGRAM:
                 if (value != 0L && value != 1L) {
-                    throw new IllegalArgumentException("ENABLE_CONNECT_PROTOCOL invalid: " + value
+                    throw new IllegalArgumentException("Invalid: " + value + "for " + Http3SettingIdentifier.valueOf(String.valueOf(key))
                             + " (expected 0 or 1)");
                 }
                 break;

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3Settings.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3Settings.java
@@ -343,10 +343,7 @@ public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
      */
     private static void verifyStandardSetting(Http3SettingIdentifier identifier, Long value) {
         checkNotNull(value, "value");
-
-        if (identifier == null) {
-            return;
-        }
+        checkNotNull(identifier, "identifier");
 
         switch (identifier) {
             case HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY:

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3Settings.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3Settings.java
@@ -95,13 +95,15 @@ public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
             throw new IllegalArgumentException("Setting is reserved for HTTP/2: " + key);
         }
 
+        Http3SettingIdentifier identifier = Http3SettingIdentifier.fromId(key);
+
         // When Non-Standard/Unknown settings identifier identifier present - Ignore
-        if (Http3SettingIdentifier.fromId(key) == null) {
+        if (identifier == null) {
             return value;
         }
 
         //Validation
-        verifyStandardSetting(key, value);
+        verifyStandardSetting(identifier, value);
 
         return settings.put(key, value);
     }
@@ -332,26 +334,26 @@ public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
     }
 
     /**
-     * Validates a setting key and value pair against HTTP/3.
+     * Validates a setting identifier and value pair against HTTP/3.
      * Note that it can only validate the valid HTTP/3 settings
      * Does not validate non-standard settings
-     * @param key the setting identifier
+     * @param identifier the setting identifier
      * @param value the setting value
-     * @throws IllegalArgumentException if the key or value violates the protocol specification
+     * @throws IllegalArgumentException if the identifier or value violates the protocol specification
      */
-    private static void verifyStandardSetting(long key, Long value) {
+    private static void verifyStandardSetting(Http3SettingIdentifier identifier, Long value) {
         checkNotNull(value, "value");
 
-        if (Http3SettingIdentifier.fromId(key) == null) {
+        if (identifier == null) {
             return;
         }
 
-        switch (Http3SettingIdentifier.fromId(key)) {
+        switch (identifier) {
             case HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY:
             case HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS:
             case HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE:
                 if (value < 0) {
-                    throw new IllegalArgumentException("Setting 0x" + toHexString(key)
+                    throw new IllegalArgumentException("Setting 0x" + toHexString(identifier.id())
                             + " invalid: " + value + " (must be >= 0)");
                 }
                 break;
@@ -360,13 +362,13 @@ public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
                 if (value != 0L && value != 1L) {
                     throw new IllegalArgumentException(
                             "Invalid: " + value + "for "
-                                    + Http3SettingIdentifier.valueOf(String.valueOf(key))
+                                    + Http3SettingIdentifier.valueOf(String.valueOf(identifier))
                             + " (expected 0 or 1)");
                 }
                 break;
             default:
                 if (value < 0) {
-                    throw new IllegalArgumentException("Setting 0x" + toHexString(key) + " invalid: " + value);
+                    throw new IllegalArgumentException("Setting 0x" + toHexString(identifier.id()) + " invalid: " + value);
                 }
         }
     }

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3Settings.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3Settings.java
@@ -368,7 +368,8 @@ public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
                 break;
             default:
                 if (value < 0) {
-                    throw new IllegalArgumentException("Setting 0x" + toHexString(identifier.id()) + " invalid: " + value);
+                    throw new IllegalArgumentException("Setting 0x"
+                            + toHexString(identifier.id()) + " invalid: " + value);
                 }
         }
     }

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3Settings.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3Settings.java
@@ -332,14 +332,19 @@ public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
     }
 
     /**
-     * Validates a setting key and value pair against HTTP/3 and HTTP/2 constraints.
-     *
+     * Validates a setting key and value pair against HTTP/3.
+     * Note that it can only validate the valid HTTP/3 settings
+     * Does not validate non-standard settings
      * @param key the setting identifier
      * @param value the setting value
      * @throws IllegalArgumentException if the key or value violates the protocol specification
      */
     private static void verifyStandardSetting(long key, Long value) {
         checkNotNull(value, "value");
+
+        if(Http3SettingIdentifier.fromId(key) == null) {
+            return;
+        }
 
         switch (Http3SettingIdentifier.fromId(key)) {
             case HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY:

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3Settings.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3Settings.java
@@ -36,6 +36,7 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
  *   <li>{@code MAX_FIELD_SECTION_SIZE} (0x6)</li>
  *   <li>{@code QPACK_BLOCKED_STREAMS} (0x7)</li>
  *   <li>{@code ENABLE_CONNECT_PROTOCOL} (0x8)</li>
+ *   <li>{@code H3_DATAGRAM} (0x33)</>
  * </ul>
  *
  * Non-standard settings are ignored
@@ -89,12 +90,12 @@ public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
     @Nullable
     public Long put(long key, Long value) {
 
-        //HTTP2 Settings present - Throw Error
+        // When HTTP2 settings identifier present - Throw Error
         if (Http3CodecUtils.isReservedHttp2Setting(key)) {
             throw new IllegalArgumentException("Setting is reserved for HTTP/2: " + key);
         }
 
-        //Non-Standard/Unknown setting identifier present - Ignore
+        // When Non-Standard/Unknown settings identifier identifier present - Ignore
         if (Http3SettingIdentifier.fromId(key) == null) {
             return value;
         }
@@ -202,6 +203,28 @@ public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
     }
 
     /**
+     * Returns whether the {@code H3_DATAGRAM} setting is enabled.
+     *
+     * @return {@code true} if enabled, {@code false} if disabled, or {@code null} if not set
+     */
+    @Nullable
+    public Boolean h3DatagramEnabled() {
+        Long value = get(Http3SettingIdentifier.HTTP3_SETTINGS_H3_DATAGRAM.id());
+        return value == null ? null : TRUE.equals(value);
+    }
+
+    /**
+     * Sets the {@code H3_DATAGRAM} settings identifier.
+     *
+     * @param enabled whether to enable the H3 Datagram
+     * @return this instance for method chaining
+     */
+    public Http3Settings enableH3Datagram(boolean enabled) {
+        put(Http3SettingIdentifier.HTTP3_SETTINGS_H3_DATAGRAM.id(), enabled ? TRUE : FALSE);
+        return this;
+    }
+
+    /**
      * Replaces all current settings with those from another {@link Http3Settings} instance.
      *
      * @param http3Settings the source settings (non-null)
@@ -220,6 +243,7 @@ public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
      *   <li>{@code QPACK_BLOCKED_STREAMS} = 0</li>
      *   <li>{@code ENABLE_CONNECT_PROTOCOL} = false</li>
      *   <li>{@code MAX_FIELD_SECTION_SIZE} = unlimited</li>
+     *   <li>{@code H3_DATAGRAM} = false </>
      * </ul>
      *
      * @return a default {@link Http3Settings} instance
@@ -229,7 +253,8 @@ public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
                 .qpackMaxTableCapacity(0)
                 .qpackBlockedStreams(0)
                 .maxFieldSectionSize(Long.MAX_VALUE)
-                .enableConnectProtocol(false);
+                .enableConnectProtocol(false)
+                .enableH3Datagram(false);
     }
 
     /**

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3Settings.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3Settings.java
@@ -353,7 +353,9 @@ public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
             case HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL:
             case HTTP3_SETTINGS_H3_DATAGRAM:
                 if (value != 0L && value != 1L) {
-                    throw new IllegalArgumentException("Invalid: " + value + "for " + Http3SettingIdentifier.valueOf(String.valueOf(key))
+                    throw new IllegalArgumentException(
+                            "Invalid: " + value + "for "
+                                    + Http3SettingIdentifier.valueOf(String.valueOf(key))
                             + " (expected 0 or 1)");
                 }
                 break;

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3Settings.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3Settings.java
@@ -342,7 +342,7 @@ public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
     private static void verifyStandardSetting(long key, Long value) {
         checkNotNull(value, "value");
 
-        if(Http3SettingIdentifier.fromId(key) == null) {
+        if (Http3SettingIdentifier.fromId(key) == null) {
             return;
         }
 

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3SettingsFrame.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3SettingsFrame.java
@@ -31,7 +31,6 @@ public interface Http3SettingsFrame extends Http3ControlStreamFrame, Iterable<Ma
      */
     @Deprecated
     long HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY = Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY.id();
-            ;
 
     /**
      * @deprecated Use {@link Http3SettingIdentifier#HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS} instead.

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3SettingsFrame.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3SettingsFrame.java
@@ -25,36 +25,37 @@ import java.util.Map;
 public interface Http3SettingsFrame extends Http3ControlStreamFrame, Iterable<Map.Entry<Long, Long>> {
 
     /**
-     * @deprecated Use {@link Http3Settings#HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY} instead.
+     * @deprecated Use {@link Http3SettingIdentifier#HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY} instead.
      * See <a href="https://tools.ietf.org/html/draft-ietf-quic-qpack-19#section-5">
      * SETTINGS_QPACK_MAX_TABLE_CAPACITY</a>.
      */
     @Deprecated
-    long HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY = Http3Settings.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY;
+    long HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY = Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY.id();
+            ;
 
     /**
-     * @deprecated Use {@link Http3Settings#HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS} instead.
+     * @deprecated Use {@link Http3SettingIdentifier#HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS} instead.
      * See <a href="https://tools.ietf.org/html/draft-ietf-quic-qpack-19#section-5">
      * SETTINGS_QPACK_BLOCKED_STREAMS</a>.
      */
     @Deprecated
-    long HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS = Http3Settings.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS;
+    long HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS = Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id();
 
     /**
-     * @deprecated Use {@link Http3Settings#HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL} instead.
+     * @deprecated Use {@link Http3SettingIdentifier#HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL} instead.
      * See <a href="https://www.rfc-editor.org/rfc/rfc9220.html#section-5">
      * SETTINGS_ENABLE_CONNECT_PROTOCOL</a>.
      */
     @Deprecated
-    long HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL = Http3Settings.HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL;
+    long HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL = Http3SettingIdentifier.HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL.id();
 
     /**
-     * @deprecated Use {@link Http3Settings#HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE} instead.
+     * @deprecated Use {@link Http3SettingIdentifier#HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE} instead.
      * See <a href="https://tools.ietf.org/html/draft-ietf-quic-http-32#section-7.2.4.1">
      * SETTINGS_MAX_FIELD_SECTION_SIZE</a>.
      */
     @Deprecated
-    long HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE = Http3Settings.HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE;
+    long HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE = Http3SettingIdentifier.HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE.id();
 
     default Http3Settings settings() {
         throw new UnsupportedOperationException(

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/DefaultHttp3SettingsFrameTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/DefaultHttp3SettingsFrameTest.java
@@ -41,19 +41,19 @@ class DefaultHttp3SettingsFrameTest {
 
         assertNotNull(frame.settings());
         assertFalse(frame.iterator().hasNext());
-        assertNull(frame.get(Http3Settings.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY));
+        assertNull(frame.get(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY.id()));
     }
 
     @Test
     void testPutAndGetDelegatesToSettings() {
         DefaultHttp3SettingsFrame frame = new DefaultHttp3SettingsFrame();
 
-        frame.put(Http3Settings.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY, 256L);
-        frame.put(Http3Settings.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS, 8L);
+        frame.put(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY.id(), 256L);
+        frame.put(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id(), 8L);
 
         assertEquals(256L, frame.settings().qpackMaxTableCapacity());
         assertEquals(8L, frame.settings().qpackBlockedStreams());
-        assertEquals(8L, frame.get(Http3Settings.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS));
+        assertEquals(8L, frame.get(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id()));
     }
 
     @Test
@@ -72,7 +72,7 @@ class DefaultHttp3SettingsFrameTest {
 
         // Modify settings externally and verify frame sees update
         settings.qpackBlockedStreams(3);
-        assertEquals(3L, frame.get(Http3Settings.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS));
+        assertEquals(3L, frame.get(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id()));
     }
 
     @Test
@@ -130,17 +130,17 @@ class DefaultHttp3SettingsFrameTest {
         assertEquals(original, copy);
 
         // Modify original and ensure copy remains unchanged
-        original.put(Http3Settings.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS, 5L);
+        original.put(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id(), 5L);
         assertNotEquals(original, copy);
     }
 
     @Test
     void testDeprecatedMethodsStillWork() {
         DefaultHttp3SettingsFrame frame = new DefaultHttp3SettingsFrame();
-        frame.put(Http3Settings.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS, 5L);
+        frame.put(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id(), 5L);
 
         // Uses old get() API
-        assertEquals(5L, frame.get(Http3Settings.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS));
+        assertEquals(5L, frame.get(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id()));
 
         // New typed accessor matches
         assertEquals(5L, frame.settings().qpackBlockedStreams());

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3FrameCodecTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3FrameCodecTest.java
@@ -272,7 +272,9 @@ public class Http3FrameCodecTest {
         settingsFrame.put(Http3SettingsFrame.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS, 1L);
         settingsFrame.put(Http3SettingsFrame.HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE, 128L);
         settingsFrame.put(Http3SettingsFrame.HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL, 0L);
+        settingsFrame.put(Http3SettingIdentifier.HTTP3_SETTINGS_H3_DATAGRAM.id(), 1L);
         // Ensure we can encode and decode all sizes correctly.
+        // unknown settings id/key will be ignored
         settingsFrame.put(63, 63L);
         settingsFrame.put(16383, 16383L);
         settingsFrame.put(1073741823, 1073741823L);

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3SettingsTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3SettingsTest.java
@@ -47,6 +47,7 @@ public class Http3SettingsTest {
         assertEquals(0L, settings.qpackBlockedStreams());
         assertEquals(Boolean.FALSE, settings.connectProtocolEnabled());
         assertEquals(Long.MAX_VALUE, settings.maxFieldSectionSize());
+        assertEquals(Boolean.FALSE, settings.h3DatagramEnabled());
     }
 
     @Test
@@ -62,11 +63,13 @@ public class Http3SettingsTest {
         assertEquals(4L, settings.qpackBlockedStreams());
         assertEquals(Boolean.TRUE, settings.connectProtocolEnabled());
         assertEquals(4096L, settings.maxFieldSectionSize());
+        assertNull(settings.h3DatagramEnabled());
     }
 
     @Test
     void testEqualsAndHashCode() {
         Http3Settings s1 = new Http3Settings()
+                .enableH3Datagram(true)
                 .qpackMaxTableCapacity(256)
                 .qpackBlockedStreams(8)
                 .enableConnectProtocol(true);
@@ -74,7 +77,8 @@ public class Http3SettingsTest {
         Http3Settings s2 = new Http3Settings()
                 .qpackMaxTableCapacity(256)
                 .qpackBlockedStreams(8)
-                .enableConnectProtocol(true);
+                .enableConnectProtocol(true)
+                .enableH3Datagram(true);
 
         Http3Settings s3 = new Http3Settings().qpackMaxTableCapacity(999);
 
@@ -97,19 +101,23 @@ public class Http3SettingsTest {
             assertNotNull(e.getValue());
             count.incrementAndGet();
         }
-        assertTrue(count.get() >= 2);
+        assertTrue(count.get() == 2);
     }
 
     @Test
     void testForEachConsumer() {
         Http3Settings settings = new Http3Settings()
                 .qpackMaxTableCapacity(5)
-                .qpackBlockedStreams(7);
+                .qpackBlockedStreams(7)
+                .enableH3Datagram(true)
+                .maxFieldSectionSize(1);
 
         List<Long> keys = new ArrayList<>();
         settings.forEach(entry -> keys.add(entry.getKey()));
         assertTrue(keys.contains(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY.id()));
         assertTrue(keys.contains(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id()));
+        assertTrue(keys.contains(Http3SettingIdentifier.HTTP3_SETTINGS_H3_DATAGRAM.id()));
+        assertTrue(keys.contains(Http3SettingIdentifier.HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE.id()));
     }
 
     @Test
@@ -152,11 +160,14 @@ public class Http3SettingsTest {
         assertThrows(IllegalArgumentException.class,
                 () -> settings.put(Http3SettingIdentifier.HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL.id(), 5L));
 
+        assertThrows(IllegalArgumentException.class,
+                () -> settings.put(Http3SettingIdentifier.HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL.id(), 15L));
     }
 
     @Test
     void testVerifyStandardSettingValidCases() {
         Http3Settings settings = new Http3Settings();
+        settings.put(Http3SettingIdentifier.HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL.id(), 1L);
         settings.put(Http3SettingIdentifier.HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL.id(), 1L);
         settings.put(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY.id(), 0L);
         settings.put(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id(), 5L);

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3SettingsTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3SettingsTest.java
@@ -259,7 +259,6 @@ public class Http3SettingsTest {
         assertThrows(NullPointerException.class, () -> settings.put(1, null));
     }
 
-
     @Test
     void testCopyFromNullThrows() {
         Http3Settings settings = new Http3Settings();

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3SettingsTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3SettingsTest.java
@@ -108,8 +108,8 @@ public class Http3SettingsTest {
 
         List<Long> keys = new ArrayList<>();
         settings.forEach(entry -> keys.add(entry.getKey()));
-        assertTrue(keys.contains(Http3Settings.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY));
-        assertTrue(keys.contains(Http3Settings.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS));
+        assertTrue(keys.contains(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY.id()));
+        assertTrue(keys.contains(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id()));
     }
 
     @Test
@@ -150,31 +150,28 @@ public class Http3SettingsTest {
 
         // Invalid ENABLE_CONNECT_PROTOCOL (must be 0 or 1)
         assertThrows(IllegalArgumentException.class,
-                () -> settings.put(Http3Settings.HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL, 5L));
+                () -> settings.put(Http3SettingIdentifier.HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL.id(), 5L));
 
-        // Non-standard but negative key
-        assertThrows(IllegalArgumentException.class,
-                () -> settings.put(0x9999, -99L));
     }
 
     @Test
     void testVerifyStandardSettingValidCases() {
         Http3Settings settings = new Http3Settings();
-        settings.put(Http3Settings.HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL, 1L);
-        settings.put(Http3Settings.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY, 0L);
-        settings.put(Http3Settings.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS, 5L);
-        settings.put(Http3Settings.HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE, 4096L);
+        settings.put(Http3SettingIdentifier.HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL.id(), 1L);
+        settings.put(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY.id(), 0L);
+        settings.put(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id(), 5L);
+        settings.put(Http3SettingIdentifier.HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE.id(), 4096L);
 
         assertEquals(Boolean.TRUE, settings.connectProtocolEnabled());
         assertEquals(4096L, settings.maxFieldSectionSize());
     }
 
     @Test
-    void testCustomSettingsAllowed() {
+    void testCustomSettingsIgnored() {
         Http3Settings settings = new Http3Settings();
         long customKey = 0xdeadbeefL;
         settings.put(customKey, 123L);
-        assertEquals(123L, settings.get(customKey));
+        assertNull(settings.get(customKey));
     }
 
     @Test
@@ -241,7 +238,7 @@ public class Http3SettingsTest {
     void testPutOverridesExistingKey() {
         Http3Settings settings = new Http3Settings();
         settings.qpackMaxTableCapacity(10);
-        settings.put(Http3Settings.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY, 20L);
+        settings.put(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY.id(), 20L);
         assertEquals(20L, settings.qpackMaxTableCapacity());
     }
 
@@ -251,12 +248,6 @@ public class Http3SettingsTest {
         assertThrows(NullPointerException.class, () -> settings.put(1, null));
     }
 
-    @Test
-    void testUnknownCustomSettingPositiveValueAllowed() {
-        Http3Settings settings = new Http3Settings();
-        assertDoesNotThrow(() -> settings.put(0xABCD, 1L));
-        assertEquals(1L, settings.get(0xABCD));
-    }
 
     @Test
     void testCopyFromNullThrows() {


### PR DESCRIPTION
## Motivation

* According to the spec https://www.rfc-editor.org/rfc/rfc9114.html#section-7.2.4-9 , endpoints **must ignore unknown settings identifiers**. Netty’s previous behavior incorrectly **stored** unknown settings values, which contradicts RFC behaviour.
* A **HTTP/3 error code** was missing - H3_DATAGRAM_ERROR
* The **SETTINGS_H3_DATAGRAM (0x33)** identifier was not added.
* Prior behaviour fixed in [https://github.com/netty/netty/pull/15835](https://github.com/netty/netty/pull/15835) still allowed direct injection of unsupported settings; this PR effectively deprecates that direct-settings behaviour completely.

---

## Modification

* [x] **Ignore unknown HTTP/3 SETTINGS identifiers**

  * Updated parsing logic to skip unknown settings identifiers:

    ```java
    // When Non-Standard/Unknown settings identifier present - Ignore
    if (Http3SettingIdentifier.fromId(key) == null) {
        return value;
    }
    ```

  * Unknown settings are **no longer stored** in `Http3Settings`.

  * Fully aligns with HTTP/3 specification behaviour.

  * Effectively **deprecates the old direct-settings behavior** introduced/fixed in PR #15835.

* [x] **Added missing HTTP/3 error codes**

  * Implemented the remaining H3 error codes defined in the RFC.
  * Ensures accurate error propagation and complete protocol support.

* [x] **Added `SETTINGS_H3_DATAGRAM (0x33)`**

  * Introduced the identifier:

    ```java
    SETTINGS_H3_DATAGRAM(0x33)
    ```

  * Added proper handling in both encoder and decoder paths.

* [x] **Added unit tests**

  * Tests covering:

    * Ignoring unknown setting identifiers
    * Correct handling of `SETTINGS_H3_DATAGRAM`
    * Verification of newly added error codes
    * Ensuring unknown settings do **not** appear in `Http3Settings`

---

## Result

* [x] Netty now **correctly ignores unknown HTTP/3 settings**, as required by the specification.
* [x] `Http3Settings` no longer stores invalid or non-standard identifiers.
* [x] Full support for **`SETTINGS_H3_DATAGRAM (0x33)`**.
* [x] Complete coverage of **HTTP/3 error codes**.
* [x] Added unit tests ensure long-term correctness.
* [x] Behaviour from PR #15835 is effectively superseded and corrected.

Fixes #[15908](https://github.com/netty/netty/issues/15908)
