### PR TITLE
Tighten contract between Channel and EventLoop by require the EventLo…

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicChannelBootstrap.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicChannelBootstrap.java
@@ -19,7 +19,6 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelOption;
-import io.netty.channel.EventLoop;
 import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
@@ -226,8 +225,7 @@ public final class QuicChannelBootstrap {
                 streamHandler, Quic.toOptionsArray(streamOptions), Quic.toAttributesArray(streamAttrs));
 
         Quic.setupChannel(channel, Quic.toOptionsArray(options), Quic.toAttributesArray(attrs), handler, logger);
-        EventLoop eventLoop = parent.executor();
-        channel.register(eventLoop).addListener((ChannelFuture future) -> {
+        channel.register().addListener((ChannelFuture future) -> {
             Throwable cause = future.cause();
             if (cause != null) {
                 promise.setFailure(cause);

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicChannel.java
@@ -30,7 +30,6 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.ConnectTimeoutException;
 import io.netty.channel.DefaultChannelPipeline;
-import io.netty.channel.EventLoop;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.handler.ssl.SniCompletionEvent;
@@ -188,7 +187,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                               @Nullable Executor sslTaskExecutor,
                               @Nullable QuicConnectionIdGenerator connectionIdAddressGenerator,
                               @Nullable QuicResetTokenGenerator resetTokenGenerator) {
-        super(parent);
+        super(parent.executor(), null, parent);
         config = new QuicheQuicChannelConfig(this);
         this.freeTask = freeTask;
         this.server = server;
@@ -435,7 +434,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                 if (msg instanceof QuicStreamChannel) {
                     QuicStreamChannel channel = (QuicStreamChannel) msg;
                     Quic.setupChannel(channel, streamOptionsArray, streamAttrsArray, streamHandler, logger);
-                    channel.register(ctx.channel().executor());
+                    channel.register();
                 } else {
                     super.onUnhandledInboundMessage(ctx, msg);
                 }
@@ -506,11 +505,6 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     @Override
     protected AbstractUnsafe newUnsafe() {
         return new QuicChannelUnsafe();
-    }
-
-    @Override
-    protected boolean isCompatible(EventLoop eventLoop) {
-        return parent().executor() == eventLoop;
     }
 
     @Override
@@ -1499,7 +1493,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
             if (handler != null) {
                 streamChannel.pipeline().addLast(handler);
             }
-            streamChannel.register(executor()).addListener((ChannelFuture f) -> {
+            streamChannel.register().addListener((ChannelFuture f) -> {
                 if (f.isSuccess()) {
                     promise.setSuccess(streamChannel);
                 } else {

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicServerCodec.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicServerCodec.java
@@ -273,7 +273,7 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
 
         addChannel(channel);
 
-        channel.register(ctx.channel().executor());
+        channel.register();
         return channel;
     }
 

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicStreamChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicStreamChannel.java
@@ -491,17 +491,12 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
         }
 
         @Override
-        public void register(EventLoop eventLoop, ChannelPromise promise) {
-            assert eventLoop.inEventLoop();
+        public void register(ChannelPromise promise) {
             if (!promise.setUncancellable()) {
                 return;
             }
             if (registered) {
                 promise.setFailure(new IllegalStateException());
-                return;
-            }
-            if (eventLoop != parent.executor()) {
-                promise.setFailure(new IllegalArgumentException());
                 return;
             }
             registered = true;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
@@ -663,7 +663,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
         }
 
         @Override
-        public void register(EventLoop eventLoop, ChannelPromise promise) {
+        public void register(ChannelPromise promise) {
             if (!promise.setUncancellable()) {
                 return;
             }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
@@ -179,7 +179,7 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
                 } else {
                     streamChannel = new Http2MultiplexCodecStreamChannel(stream, inboundStreamHandler);
                 }
-                ChannelFuture future = streamChannel.register(ctx.channel().executor());
+                ChannelFuture future = streamChannel.register();
                 if (future.isDone()) {
                     Http2MultiplexHandler.registerDone(future);
                 } else {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexHandler.java
@@ -249,7 +249,7 @@ public final class Http2MultiplexHandler extends Http2ChannelDuplexHandler {
                         } else {
                             ch = new Http2MultiplexHandlerStreamChannel(stream, inboundStreamHandler);
                         }
-                        ChannelFuture future = ch.register(ctx.channel().executor());
+                        ChannelFuture future = ch.register();
                         if (future.isDone()) {
                             registerDone(future);
                         } else {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrap.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrap.java
@@ -186,7 +186,7 @@ public final class Http2StreamChannelBootstrap {
             return;
         }
 
-        ChannelFuture future = streamChannel.register(ctx.channel().executor());
+        ChannelFuture future = streamChannel.register();
         future.addListener(new ChannelFutureListener() {
             @Override
             public void operationComplete(ChannelFuture future) {

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/EmbeddedQuicStreamChannel.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/EmbeddedQuicStreamChannel.java
@@ -231,8 +231,8 @@ final class EmbeddedQuicStreamChannel extends EmbeddedChannel implements QuicStr
                 }
 
                 @Override
-                public void register(EventLoop eventLoop, ChannelPromise promise) {
-                    superUnsafe.register(eventLoop, promise);
+                public void register(ChannelPromise promise) {
+                    superUnsafe.register(promise);
                 }
 
                 @Override

--- a/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/IoTransport.java
+++ b/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/IoTransport.java
@@ -43,14 +43,14 @@ public final class IoTransport {
             new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory()).next(),
             new ChannelFactory<SocketChannel>() {
                 @Override
-                public SocketChannel newChannel() {
-                    return new NioSocketChannel();
+                public SocketChannel newChannel(EventLoop eventLoop) {
+                    return new NioSocketChannel(eventLoop);
                 }
             },
             new ChannelFactory<DatagramChannel>() {
                 @Override
-                public DatagramChannel newChannel() {
-                    return new NioDatagramChannel();
+                public DatagramChannel newChannel(EventLoop eventLoop) {
+                    return new NioDatagramChannel(eventLoop);
                 }
             });
 

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -3363,10 +3363,23 @@ public class DnsNameResolverTest {
         DnsNameResolver resolver = null;
         try {
             DnsNameResolverBuilder builder = newResolver(strategy);
-            final DatagramChannel datagramChannel = new NioDatagramChannel();
             ChannelFactory<DatagramChannel> channelFactory = new ChannelFactory<DatagramChannel>() {
                 @Override
-                public DatagramChannel newChannel() {
+                public DatagramChannel newChannel(EventLoop eventLoop) {
+                    DatagramChannel datagramChannel = new NioDatagramChannel(eventLoop);
+                    if (truncatedBecauseOfMtu) {
+                        datagramChannel.pipeline().addFirst(new ChannelInboundHandlerAdapter() {
+                            @Override
+                            public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                                if (msg instanceof DatagramPacket) {
+                                    // Truncate the packet by 1 byte.
+                                    DatagramPacket packet = (DatagramPacket) msg;
+                                    packet.content().writerIndex(packet.content().writerIndex() - 1);
+                                }
+                                ctx.fireChannelRead(msg);
+                            }
+                        });
+                    }
                     return datagramChannel;
                 }
             };
@@ -3384,19 +3397,7 @@ public class DnsNameResolverTest {
                     .maxQueriesPerResolve(16)
                     .nameServerProvider(new SingletonDnsServerAddressStreamProvider(dnsServer2.localAddress()));
             resolver = builder.build();
-            if (truncatedBecauseOfMtu) {
-                datagramChannel.pipeline().addFirst(new ChannelInboundHandlerAdapter() {
-                    @Override
-                    public void channelRead(ChannelHandlerContext ctx, Object msg) {
-                        if (msg instanceof DatagramPacket) {
-                            // Truncate the packet by 1 byte.
-                            DatagramPacket packet = (DatagramPacket) msg;
-                            packet.content().writerIndex(packet.content().writerIndex() - 1);
-                        }
-                        ctx.fireChannelRead(msg);
-                    }
-                });
-            }
+
             Future<AddressedEnvelope<DnsResponse, InetSocketAddress>> envelopeFuture = resolver.query(
                     new DefaultDnsQuestion(host, DnsRecordType.TXT));
 
@@ -3529,11 +3530,10 @@ public class DnsNameResolverTest {
         ServerSocket serverSocket = null;
         try {
             DnsNameResolverBuilder builder = newResolver(strategy);
-            final DatagramChannel datagramChannel = new NioDatagramChannel();
             ChannelFactory<DatagramChannel> channelFactory = new ChannelFactory<DatagramChannel>() {
                 @Override
-                public DatagramChannel newChannel() {
-                    return datagramChannel;
+                public DatagramChannel newChannel(EventLoop eventLoop) {
+                    return new NioDatagramChannel(eventLoop);
                 }
             };
             builder.datagramChannelFactory(channelFactory);

--- a/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
@@ -78,8 +78,8 @@ public abstract class AbstractSingleThreadEventLoopTest {
         final SingleThreadEventLoop loop = (SingleThreadEventLoop) group.next();
 
         try {
-            final Channel ch1 = newChannel();
-            final Channel ch2 = newChannel();
+            final Channel ch1 = newChannel(loop);
+            final Channel ch2 = newChannel(loop);
 
             int rc = registeredChannels(loop);
             boolean channelCountSupported = rc != -1;
@@ -88,8 +88,8 @@ public abstract class AbstractSingleThreadEventLoopTest {
                 assertEquals(0, registeredChannels(loop));
             }
 
-            assertTrue(ch1.register(loop).syncUninterruptibly().isSuccess());
-            assertTrue(ch2.register(loop).syncUninterruptibly().isSuccess());
+            assertTrue(ch1.register().syncUninterruptibly().isSuccess());
+            assertTrue(ch2.register().syncUninterruptibly().isSuccess());
             if (channelCountSupported) {
                 checkNumRegisteredChannels(loop, 2);
             }
@@ -219,10 +219,10 @@ public abstract class AbstractSingleThreadEventLoopTest {
         EventLoopGroup group = newEventLoopGroup();
         final SingleThreadEventLoop loop = (SingleThreadEventLoop) group.next();
         try {
-            final Channel ch1 = newChannel();
-            final Channel ch2 = newChannel();
-            ch1.register(loop).syncUninterruptibly();
-            ch2.register(loop).syncUninterruptibly();
+            final Channel ch1 = newChannel(loop);
+            final Channel ch2 = newChannel(loop);
+            ch1.register().syncUninterruptibly();
+            ch2.register().syncUninterruptibly();
             assertEquals(2, registeredChannels(loop));
 
             runBlockingOn(loop, new Runnable() {
@@ -267,8 +267,8 @@ public abstract class AbstractSingleThreadEventLoopTest {
         final SingleThreadEventLoop loop = (SingleThreadEventLoop) group.next();
 
         try {
-            final Channel ch = newChannel();
-            ch.register(loop).syncUninterruptibly();
+            final Channel ch = newChannel(loop);
+            ch.register().syncUninterruptibly();
             assertEquals(1, registeredChannels(loop));
 
             runBlockingOn(loop, new Runnable() {
@@ -448,6 +448,6 @@ public abstract class AbstractSingleThreadEventLoopTest {
     }
     protected abstract EventLoopGroup newEventLoopGroup();
     protected abstract EventLoopGroup newAutoScalingEventLoopGroup();
-    protected abstract Channel newChannel();
+    protected abstract Channel newChannel(EventLoop loop);
     protected abstract Class<? extends ServerChannel> serverChannelClass();
 }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/NioEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/NioEventLoopTest.java
@@ -16,6 +16,7 @@
 package io.netty.testsuite.transport;
 
 import io.netty.channel.Channel;
+import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.ServerChannel;
@@ -39,8 +40,8 @@ public class NioEventLoopTest extends AbstractSingleThreadEventLoopTest {
     }
 
     @Override
-    protected Channel newChannel() {
-        return new NioSocketChannel();
+    protected Channel newChannel(EventLoop eventLoop) {
+        return new NioSocketChannel(eventLoop);
     }
 
     @Override

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketTestPermutation.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketTestPermutation.java
@@ -20,6 +20,7 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFactory;
+import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.nio.NioIoHandler;
@@ -121,8 +122,8 @@ public class SocketTestPermutation {
             public Bootstrap newInstance() {
                 return new Bootstrap().group(NIO_GROUP).channelFactory(new ChannelFactory<Channel>() {
                     @Override
-                    public Channel newChannel() {
-                        return new NioDatagramChannel(family);
+                    public Channel newChannel(EventLoop eventLoop) {
+                        return new NioDatagramChannel(eventLoop, family);
                     }
 
                     @Override

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -82,8 +82,8 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
 
     protected volatile boolean active;
 
-    AbstractEpollChannel(Channel parent, LinuxSocket fd, boolean active, EpollIoOps initialOps) {
-        super(parent);
+    AbstractEpollChannel(EventLoop eventLoop, Channel parent, LinuxSocket fd, boolean active, EpollIoOps initialOps) {
+        super(eventLoop, EpollIoHandle.class, parent);
         this.socket = checkNotNull(fd, "fd");
         this.active = active;
         if (active) {
@@ -95,8 +95,9 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
         this.ops = initialOps;
     }
 
-    AbstractEpollChannel(Channel parent, LinuxSocket fd, SocketAddress remote, EpollIoOps initialOps) {
-        super(parent);
+    AbstractEpollChannel(EventLoop eventLoop, Channel parent, LinuxSocket fd,
+                         SocketAddress remote, EpollIoOps initialOps) {
+        super(eventLoop, EpollIoHandle.class, parent);
         this.socket = checkNotNull(fd, "fd");
         this.active = true;
         // Directly cache the remote and local addresses
@@ -233,11 +234,6 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
             ops = inital;
             registration.cancel();
         }
-    }
-
-    @Override
-    protected boolean isCompatible(EventLoop loop) {
-        return loop.isCompatible(AbstractEpollUnsafe.class);
     }
 
     @Override

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
@@ -21,6 +21,8 @@ import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
 
 import java.net.InetSocketAddress;
@@ -29,16 +31,26 @@ import java.net.SocketAddress;
 public abstract class AbstractEpollServerChannel extends AbstractEpollChannel implements ServerChannel {
     private static final ChannelMetadata METADATA = new ChannelMetadata(false, 16);
 
-    protected AbstractEpollServerChannel(int fd) {
-        this(new LinuxSocket(fd), false);
+    private final EventLoopGroup childEventLoopGroup;
+
+    protected AbstractEpollServerChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup, int fd) {
+        this(eventLoop, childEventLoopGroup, new LinuxSocket(fd), false);
     }
 
-    protected AbstractEpollServerChannel(LinuxSocket fd) {
-        this(fd, isSoErrorZero(fd));
+    protected AbstractEpollServerChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup, LinuxSocket fd) {
+        this(eventLoop, childEventLoopGroup, fd, isSoErrorZero(fd));
     }
 
-    protected AbstractEpollServerChannel(LinuxSocket fd, boolean active) {
-        super(null, fd, active, EpollIoOps.valueOf(0));
+    protected AbstractEpollServerChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup,
+                                         LinuxSocket fd, boolean active) {
+        super(eventLoop, null, fd, active, EpollIoOps.valueOf(0));
+        this.childEventLoopGroup =
+                validateEventLoopGroup(childEventLoopGroup, "childEventLoopGroup", EpollIoHandle.class);
+    }
+
+    @Override
+    public EventLoopGroup childEventExecutorGroup() {
+        return childEventLoopGroup;
     }
 
     @Override
@@ -66,7 +78,8 @@ public abstract class AbstractEpollServerChannel extends AbstractEpollChannel im
         throw new UnsupportedOperationException();
     }
 
-    protected abstract Channel newChildChannel(int fd, byte[] remote, int offset, int len) throws Exception;
+    protected abstract Channel newChildChannel(EventLoop eventLoop, int fd, byte[] remote, int offset, int len)
+            throws Exception;
 
     final class EpollServerSocketUnsafe extends AbstractEpollUnsafe {
         // Will hold the remote address after accept(...) was successful.
@@ -108,8 +121,8 @@ public abstract class AbstractEpollServerChannel extends AbstractEpollChannel im
                         allocHandle.incMessagesRead(1);
 
                         readPending = false;
-                        pipeline.fireChannelRead(newChildChannel(allocHandle.lastBytesRead(), acceptedAddress, 1,
-                                                                 acceptedAddress[0]));
+                        pipeline.fireChannelRead(newChildChannel(childEventExecutorGroup().next(),
+                                allocHandle.lastBytesRead(), acceptedAddress, 1, acceptedAddress[0]));
                     } while (allocHandle.continueReading());
                 } catch (Throwable t) {
                     exception = t;

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -67,31 +67,31 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
 
     private WritableByteChannel byteChannel;
 
-    protected AbstractEpollStreamChannel(Channel parent, int fd) {
-        this(parent, new LinuxSocket(fd));
+    protected AbstractEpollStreamChannel(EventLoop eventLoop, Channel parent, int fd) {
+        this(eventLoop, parent, new LinuxSocket(fd));
     }
 
-    protected AbstractEpollStreamChannel(int fd) {
-        this(new LinuxSocket(fd));
+    protected AbstractEpollStreamChannel(EventLoop eventLoop, int fd) {
+        this(eventLoop, new LinuxSocket(fd));
     }
 
-    AbstractEpollStreamChannel(LinuxSocket fd) {
-        this(fd, isSoErrorZero(fd));
+    AbstractEpollStreamChannel(EventLoop eventLoop, LinuxSocket fd) {
+        this(eventLoop, fd, isSoErrorZero(fd));
     }
 
-    AbstractEpollStreamChannel(Channel parent, LinuxSocket fd) {
+    AbstractEpollStreamChannel(EventLoop eventLoop, Channel parent, LinuxSocket fd) {
         // Add EPOLLRDHUP so we are notified once the remote peer close the connection.
-        super(parent, fd, true, EpollIoOps.EPOLLRDHUP);
+        super(eventLoop, parent, fd, true, EpollIoOps.EPOLLRDHUP);
     }
 
-    protected AbstractEpollStreamChannel(Channel parent, LinuxSocket fd, SocketAddress remote) {
+    protected AbstractEpollStreamChannel(EventLoop eventLoop, Channel parent, LinuxSocket fd, SocketAddress remote) {
         // Add EPOLLRDHUP so we are notified once the remote peer close the connection.
-        super(parent, fd, remote, EpollIoOps.EPOLLRDHUP);
+        super(eventLoop, parent, fd, remote, EpollIoOps.EPOLLRDHUP);
     }
 
-    protected AbstractEpollStreamChannel(LinuxSocket fd, boolean active) {
+    protected AbstractEpollStreamChannel(EventLoop eventLoop, LinuxSocket fd, boolean active) {
         // Add EPOLLRDHUP so we are notified once the remote peer close the connection.
-        super(null, fd, active, EpollIoOps.EPOLLRDHUP);
+        super(eventLoop, null, fd, active, EpollIoOps.EPOLLRDHUP);
     }
 
     @Override

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -25,6 +25,7 @@ import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultAddressedEnvelope;
+import io.netty.channel.EventLoop;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.socket.SocketProtocolFamily;
@@ -92,28 +93,28 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
      * Create a new instance which selects the {@link SocketProtocolFamily} to use depending
      * on the Operation Systems default which will be chosen.
      */
-    public EpollDatagramChannel() {
-        this((SocketProtocolFamily) null);
+    public EpollDatagramChannel(EventLoop eventLoop) {
+        this(eventLoop, (SocketProtocolFamily) null);
     }
 
     /**
      * Create a new instance using the given {@link SocketProtocolFamily}. If {@code null} is used it will depend
      * on the Operation Systems default which will be chosen.
      */
-    public EpollDatagramChannel(SocketProtocolFamily family) {
-        this(newSocketDgram(family), false);
+    public EpollDatagramChannel(EventLoop eventLoop, SocketProtocolFamily family) {
+        this(eventLoop, newSocketDgram(family), false);
     }
 
     /**
      * Create a new instance which selects the {@link SocketProtocolFamily} to use depending
      * on the Operation Systems default which will be chosen.
      */
-    public EpollDatagramChannel(int fd) {
-        this(new LinuxSocket(fd), true);
+    public EpollDatagramChannel(EventLoop eventLoop, int fd) {
+        this(eventLoop, new LinuxSocket(fd), true);
     }
 
-    private EpollDatagramChannel(LinuxSocket fd, boolean active) {
-        super(null, fd, active, EpollIoOps.valueOf(0));
+    private EpollDatagramChannel(EventLoop eventLoop, LinuxSocket fd, boolean active) {
+        super(eventLoop, null, fd, active, EpollIoOps.valueOf(0));
 
         // Configure IP_MULTICAST_ALL - disable by default to match the behaviour of NIO.
         try {

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainDatagramChannel.java
@@ -22,6 +22,7 @@ import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.DefaultAddressedEnvelope;
+import io.netty.channel.EventLoop;
 import io.netty.channel.unix.DomainDatagramChannel;
 import io.netty.channel.unix.DomainDatagramChannelConfig;
 import io.netty.channel.unix.DomainDatagramPacket;
@@ -58,16 +59,16 @@ public final class EpollDomainDatagramChannel extends AbstractEpollChannel imple
 
     private final EpollDomainDatagramChannelConfig config;
 
-    public EpollDomainDatagramChannel() {
-        this(newSocketDomainDgram(), false);
+    public EpollDomainDatagramChannel(EventLoop eventLoop) {
+        this(eventLoop, newSocketDomainDgram(), false);
     }
 
-    public EpollDomainDatagramChannel(int fd) {
-        this(new LinuxSocket(fd), true);
+    public EpollDomainDatagramChannel(EventLoop eventLoop, int fd) {
+        this(eventLoop, new LinuxSocket(fd), true);
     }
 
-    private EpollDomainDatagramChannel(LinuxSocket socket, boolean active) {
-        super(null, socket, active, EpollIoOps.valueOf(0));
+    private EpollDomainDatagramChannel(EventLoop eventLoop, LinuxSocket socket, boolean active) {
+        super(eventLoop, null, socket, active, EpollIoOps.valueOf(0));
         config = new EpollDomainDatagramChannelConfig(this);
     }
 

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannel.java
@@ -19,6 +19,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoop;
 import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.channel.unix.DomainSocketChannel;
 import io.netty.channel.unix.FileDescriptor;
@@ -35,26 +36,26 @@ public final class EpollDomainSocketChannel extends AbstractEpollStreamChannel i
     private volatile DomainSocketAddress local;
     private volatile DomainSocketAddress remote;
 
-    public EpollDomainSocketChannel() {
-        super(newSocketDomain(), false);
+    public EpollDomainSocketChannel(EventLoop eventLoop) {
+        super(eventLoop, newSocketDomain(), false);
     }
 
-    EpollDomainSocketChannel(Channel parent, FileDescriptor fd) {
-        this(parent, new LinuxSocket(fd.intValue()));
+    EpollDomainSocketChannel(EventLoop eventLoop, Channel parent, FileDescriptor fd) {
+        this(eventLoop, parent, new LinuxSocket(fd.intValue()));
     }
 
-    public EpollDomainSocketChannel(int fd) {
-        super(fd);
+    public EpollDomainSocketChannel(EventLoop eventLoop, int fd) {
+        super(eventLoop, fd);
     }
 
-    public EpollDomainSocketChannel(Channel parent, LinuxSocket fd) {
-        super(parent, fd);
+    public EpollDomainSocketChannel(EventLoop eventLoop, Channel parent, LinuxSocket fd) {
+        super(eventLoop, parent, fd);
         local = fd.localDomainSocketAddress();
         remote = fd.remoteDomainSocketAddress();
     }
 
-    public EpollDomainSocketChannel(int fd, boolean active) {
-        super(new LinuxSocket(fd), active);
+    public EpollDomainSocketChannel(EventLoop eventLoop, int fd, boolean active) {
+        super(eventLoop, new LinuxSocket(fd), active);
     }
 
     @Override

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerDomainSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerDomainSocketChannel.java
@@ -16,6 +16,8 @@
 package io.netty.channel.epoll;
 
 import io.netty.channel.Channel;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
 import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.channel.unix.ServerDomainSocketChannel;
 import io.netty.channel.unix.Socket;
@@ -35,29 +37,31 @@ public final class EpollServerDomainSocketChannel extends AbstractEpollServerCha
     private final EpollServerChannelConfig config = new EpollServerChannelConfig(this);
     private volatile DomainSocketAddress local;
 
-    public EpollServerDomainSocketChannel() {
-        super(newSocketDomain(), false);
+    public EpollServerDomainSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup) {
+        super(eventLoop, childEventLoopGroup, newSocketDomain(), false);
     }
 
-    public EpollServerDomainSocketChannel(int fd) {
-        super(fd);
+    public EpollServerDomainSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup, int fd) {
+        super(eventLoop, childEventLoopGroup, fd);
     }
 
-    public EpollServerDomainSocketChannel(int fd, boolean active) {
-        super(new LinuxSocket(fd), active);
+    public EpollServerDomainSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup,
+                                          int fd, boolean active) {
+        super(eventLoop, childEventLoopGroup, new LinuxSocket(fd), active);
     }
 
-    EpollServerDomainSocketChannel(LinuxSocket fd) {
-        super(fd);
+    EpollServerDomainSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup, LinuxSocket fd) {
+        super(eventLoop, childEventLoopGroup, fd);
     }
 
-    EpollServerDomainSocketChannel(LinuxSocket fd, boolean active) {
-        super(fd, active);
+    EpollServerDomainSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup,
+                                   LinuxSocket fd, boolean active) {
+        super(eventLoop, childEventLoopGroup, fd, active);
     }
 
     @Override
-    protected Channel newChildChannel(int fd, byte[] addr, int offset, int len) throws Exception {
-        return new EpollDomainSocketChannel(this, new Socket(fd));
+    protected Channel newChildChannel(EventLoop eventLoop, int fd, byte[] addr, int offset, int len) throws Exception {
+        return new EpollDomainSocketChannel(eventLoop, this, new Socket(fd));
     }
 
     @Override

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
@@ -16,6 +16,8 @@
 package io.netty.channel.epoll;
 
 import io.netty.channel.Channel;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.channel.socket.SocketProtocolFamily;
 
@@ -39,28 +41,30 @@ public final class EpollServerSocketChannel extends AbstractEpollServerChannel i
     private final EpollServerSocketChannelConfig config;
     private volatile Collection<InetAddress> tcpMd5SigAddresses = Collections.emptyList();
 
-    public EpollServerSocketChannel() {
-        this((SocketProtocolFamily) null);
+    public EpollServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup) {
+        this(eventLoop, childEventLoopGroup, (SocketProtocolFamily) null);
     }
 
-    public EpollServerSocketChannel(SocketProtocolFamily protocol) {
-        super(newSocketStream(protocol), false);
+    public EpollServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup,
+                                    SocketProtocolFamily protocol) {
+        super(eventLoop, childEventLoopGroup, newSocketStream(protocol), false);
         config = new EpollServerSocketChannelConfig(this);
     }
 
-    public EpollServerSocketChannel(int fd) {
+    public EpollServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup, int fd) {
         // Must call this constructor to ensure this object's local address is configured correctly.
         // The local address can only be obtained from a Socket object.
-        this(new LinuxSocket(fd));
+        this(eventLoop, childEventLoopGroup, new LinuxSocket(fd));
     }
 
-    EpollServerSocketChannel(LinuxSocket fd) {
-        super(fd);
+    EpollServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup, LinuxSocket fd) {
+        super(eventLoop, childEventLoopGroup, fd);
         config = new EpollServerSocketChannelConfig(this);
     }
 
-    EpollServerSocketChannel(LinuxSocket fd, boolean active) {
-        super(fd, active);
+    EpollServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup,
+                             LinuxSocket fd, boolean active) {
+        super(eventLoop, childEventLoopGroup, fd, active);
         config = new EpollServerSocketChannelConfig(this);
     }
 
@@ -81,8 +85,10 @@ public final class EpollServerSocketChannel extends AbstractEpollServerChannel i
     }
 
     @Override
-    protected Channel newChildChannel(int fd, byte[] address, int offset, int len) throws Exception {
-        return new EpollSocketChannel(this, new LinuxSocket(fd), address(address, offset, len));
+    protected Channel newChildChannel(EventLoop eventLoop, int fd, byte[] address, int offset, int len)
+            throws Exception {
+        return new EpollSocketChannel(eventLoop, this,
+                new LinuxSocket(fd), address(address, offset, len));
     }
 
     Collection<InetAddress> tcpMd5SigAddresses() {

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannel.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOutboundBuffer;
+import io.netty.channel.EventLoop;
 import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.SocketProtocolFamily;
@@ -46,28 +47,23 @@ public final class EpollSocketChannel extends AbstractEpollStreamChannel impleme
 
     private volatile Collection<InetAddress> tcpMd5SigAddresses = Collections.emptyList();
 
-    public EpollSocketChannel() {
-        super(newSocketStream(), false);
+    public EpollSocketChannel(EventLoop eventLoop) {
+        super(eventLoop, newSocketStream(), false);
         config = new EpollSocketChannelConfig(this);
     }
 
-    public EpollSocketChannel(SocketProtocolFamily protocol) {
-        super(newSocketStream(protocol), false);
+    public EpollSocketChannel(EventLoop eventLoop, SocketProtocolFamily protocol) {
+        super(eventLoop, newSocketStream(protocol), false);
         config = new EpollSocketChannelConfig(this);
     }
 
-    public EpollSocketChannel(int fd) {
-        super(fd);
+    public EpollSocketChannel(EventLoop eventLoop, int fd) {
+        super(eventLoop, fd);
         config = new EpollSocketChannelConfig(this);
     }
 
-    EpollSocketChannel(LinuxSocket fd, boolean active) {
-        super(fd, active);
-        config = new EpollSocketChannelConfig(this);
-    }
-
-    EpollSocketChannel(Channel parent, LinuxSocket fd, InetSocketAddress remoteAddress) {
-        super(parent, fd, remoteAddress);
+    EpollSocketChannel(EventLoop eventLoop, Channel parent, LinuxSocket fd, InetSocketAddress remoteAddress) {
+        super(eventLoop, parent, fd, remoteAddress);
         config = new EpollSocketChannelConfig(this);
 
         if (parent instanceof EpollServerSocketChannel) {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -132,8 +132,8 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
     private volatile SocketAddress local;
     private volatile SocketAddress remote;
 
-    AbstractIoUringChannel(final Channel parent, LinuxSocket socket, boolean active) {
-        super(parent);
+    AbstractIoUringChannel(EventLoop eventLoop, Channel parent, LinuxSocket socket, boolean active) {
+        super(eventLoop, IoUringIoHandle.class, parent);
         this.socket = checkNotNull(socket, "fd");
 
         if (active) {
@@ -147,8 +147,8 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         logger.trace("Create {} Socket: {}", this instanceof ServerChannel ? "Server" : "Channel", socket.intValue());
     }
 
-    AbstractIoUringChannel(Channel parent, LinuxSocket fd, SocketAddress remote) {
-        super(parent);
+    AbstractIoUringChannel(EventLoop eventLoop, Channel parent, LinuxSocket fd, SocketAddress remote) {
+        super(eventLoop, IoUringIoHandle.class, parent);
         this.socket = checkNotNull(fd, "fd");
         this.active = true;
 
@@ -200,6 +200,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         return id;
     }
 
+    @Override
     public final boolean isOpen() {
         return socket.isOpen();
     }
@@ -216,11 +217,6 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
 
     private AbstractUringUnsafe ioUringUnsafe() {
         return (AbstractUringUnsafe) unsafe();
-    }
-
-    @Override
-    protected boolean isCompatible(final EventLoop loop) {
-        return loop.isCompatible(AbstractUringUnsafe.class);
     }
 
     protected final ByteBuf newDirectBuffer(ByteBuf buf) {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
@@ -21,6 +21,8 @@ import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
 import io.netty.channel.IoRegistration;
 import io.netty.channel.ServerChannel;
 import io.netty.channel.unix.Buffer;
@@ -62,10 +64,14 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
         }
     }
     private final AcceptedAddressMemory acceptedAddressMemory;
+    private final EventLoopGroup childEventLoopGroup;
     private long acceptId;
 
-    protected AbstractIoUringServerChannel(LinuxSocket socket, boolean active) {
-        super(null, socket, active);
+    protected AbstractIoUringServerChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup,
+                                           LinuxSocket socket, boolean active) {
+        super(eventLoop, null, socket, active);
+        this.childEventLoopGroup =
+                validateEventLoopGroup(childEventLoopGroup, "childEventLoopGroup", IoUringIoHandle.class);
 
         // We can only depend on the accepted address if multi-shot is not used.
         // From the manpage:
@@ -87,6 +93,11 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
         } else {
             acceptedAddressMemory = new AcceptedAddressMemory();
         }
+    }
+
+    @Override
+    public EventLoopGroup childEventExecutorGroup() {
+        return childEventLoopGroup;
     }
 
     @Override
@@ -127,7 +138,7 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
     }
 
     abstract Channel newChildChannel(
-            int fd, ByteBuffer acceptedAddressMemory) throws Exception;
+            EventLoop eventLoop, int fd, ByteBuffer acceptedAddressMemory) throws Exception;
 
     private final class UringServerChannelUnsafe extends AbstractIoUringChannel.AbstractUringUnsafe {
 
@@ -234,7 +245,7 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
                     acceptedAddressBuffer = acceptedAddressMemory.acceptedAddressMemory;
                 }
                 try {
-                    Channel channel = newChildChannel(res, acceptedAddressBuffer);
+                    Channel channel = newChildChannel(childEventExecutorGroup().next(), res, acceptedAddressBuffer);
                     pipeline.fireChannelRead(channel);
 
                     if (allocHandle.continueReading() &&

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -50,12 +50,12 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
     // The configured buffer ring if any
     private IoUringBufferRing bufferRing;
 
-    AbstractIoUringStreamChannel(Channel parent, LinuxSocket socket, boolean active) {
-        super(parent, socket, active);
+    AbstractIoUringStreamChannel(EventLoop eventLoop, Channel parent, LinuxSocket socket, boolean active) {
+        super(eventLoop, parent, socket, active);
     }
 
-    AbstractIoUringStreamChannel(Channel parent, LinuxSocket socket, SocketAddress remote) {
-        super(parent, socket, remote);
+    AbstractIoUringStreamChannel(EventLoop eventLoop, Channel parent, LinuxSocket socket, SocketAddress remote) {
+        super(eventLoop, parent, socket, remote);
     }
 
     @Override

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
@@ -23,6 +23,7 @@ import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultAddressedEnvelope;
+import io.netty.channel.EventLoop;
 import io.netty.channel.IoRegistration;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.DatagramChannelConfig;
@@ -85,16 +86,16 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
      * Create a new instance which selects the {@link SocketProtocolFamily} to use depending
      * on the Operation Systems default which will be chosen.
      */
-    public IoUringDatagramChannel() {
-        this(null);
+    public IoUringDatagramChannel(EventLoop eventLoop) {
+        this(eventLoop, null);
     }
 
     /**
      * Create a new instance using the given {@link SocketProtocolFamily}. If {@code null} is used it will depend
      * on the Operation Systems default which will be chosen.
      */
-    public IoUringDatagramChannel(SocketProtocolFamily family) {
-        this(LinuxSocket.newSocketDgram(useIpv6(family)), false);
+    public IoUringDatagramChannel(EventLoop eventLoop, SocketProtocolFamily family) {
+        this(eventLoop, LinuxSocket.newSocketDgram(useIpv6(family)), false);
     }
 
     private static boolean useIpv6(SocketProtocolFamily family) {
@@ -108,13 +109,13 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
      * Create a new instance which selects the {@link SocketProtocolFamily} to use depending
      * on the Operation Systems default which will be chosen.
      */
-    public IoUringDatagramChannel(int fd) {
-        this(new LinuxSocket(fd), true);
+    public IoUringDatagramChannel(EventLoop eventLoop, int fd) {
+        this(eventLoop, new LinuxSocket(fd), true);
     }
 
-    private IoUringDatagramChannel(LinuxSocket fd, boolean active) {
+    private IoUringDatagramChannel(EventLoop eventLoop, LinuxSocket fd, boolean active) {
         // Always use a blocking fd and so make use of fast-poll.
-        super(null, fd, active);
+        super(eventLoop, null, fd, active);
 
         // Configure IP_MULTICAST_ALL - disable by default to match the behaviour of NIO.
         try {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDomainSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDomainSocketChannel.java
@@ -21,6 +21,7 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
+import io.netty.channel.EventLoop;
 import io.netty.channel.IoRegistration;
 import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.channel.unix.DomainSocketChannel;
@@ -43,17 +44,17 @@ public final class IoUringDomainSocketChannel extends AbstractIoUringStreamChann
     private volatile DomainSocketAddress local;
     private volatile DomainSocketAddress remote;
 
-    public IoUringDomainSocketChannel() {
-        super(null, LinuxSocket.newSocketDomain(), false);
+    public IoUringDomainSocketChannel(EventLoop eventLoop) {
+        super(eventLoop, null, LinuxSocket.newSocketDomain(), false);
         config = new IoUringDomainSocketChannelConfig(this);
     }
 
-    IoUringDomainSocketChannel(Channel parent, FileDescriptor fd) {
-        this(parent, new LinuxSocket(fd.intValue()));
+    IoUringDomainSocketChannel(EventLoop eventLoop, Channel parent, FileDescriptor fd) {
+        this(eventLoop, parent, new LinuxSocket(fd.intValue()));
     }
 
-    IoUringDomainSocketChannel(Channel parent, LinuxSocket fd) {
-        super(parent, fd, true);
+    IoUringDomainSocketChannel(EventLoop eventLoop, Channel parent, LinuxSocket fd) {
+        super(eventLoop, parent, fd, true);
         local = fd.localDomainSocketAddress();
         remote = fd.remoteDomainSocketAddress();
         config = new IoUringDomainSocketChannelConfig(this);

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringServerDomainSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringServerDomainSocketChannel.java
@@ -19,6 +19,8 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
 import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.channel.unix.ServerDomainSocketChannel;
 import io.netty.util.internal.logging.InternalLogger;
@@ -38,8 +40,8 @@ public final class IoUringServerDomainSocketChannel extends AbstractIoUringServe
 
     private volatile DomainSocketAddress local;
 
-    public IoUringServerDomainSocketChannel() {
-        super(LinuxSocket.newSocketDomain(), false);
+    public IoUringServerDomainSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup) {
+        super(eventLoop, childEventLoopGroup, LinuxSocket.newSocketDomain(), false);
         this.config = new IoUringServerSocketChannelConfig(this);
         this.closeFuture().addListener(new ChannelFutureListener() {
             @Override
@@ -57,8 +59,8 @@ public final class IoUringServerDomainSocketChannel extends AbstractIoUringServe
     }
 
     @Override
-    Channel newChildChannel(int fd, ByteBuffer acceptedAddressMemory) throws Exception {
-        return new IoUringDomainSocketChannel(this, new LinuxSocket(fd));
+    Channel newChildChannel(EventLoop eventLoop, int fd, ByteBuffer acceptedAddressMemory) throws Exception {
+        return new IoUringDomainSocketChannel(eventLoop, this, new LinuxSocket(fd));
     }
 
     @Override

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringServerSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringServerSocketChannel.java
@@ -17,6 +17,8 @@ package io.netty.channel.uring;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.channel.socket.ServerSocketChannelConfig;
 
@@ -27,7 +29,7 @@ import java.nio.ByteBuffer;
 public final class IoUringServerSocketChannel extends AbstractIoUringServerChannel implements ServerSocketChannel {
     private final IoUringServerSocketChannelConfig config;
 
-    public IoUringServerSocketChannel() {
+    public IoUringServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup) {
         // We don't use a blocking fd for the server channel at the moment as
         // there is no support for IORING_CQE_F_SOCK_NONEMPTY and IORING_ACCEPT_DONTWAIT
         // at the moment. Once these land in the kernel we should check if we can use these and if so make
@@ -36,7 +38,7 @@ public final class IoUringServerSocketChannel extends AbstractIoUringServerChann
         //
         //  - https://lore.kernel.org/netdev/20240509180627.204155-1-axboe@kernel.dk/
         //  - https://lore.kernel.org/io-uring/20240508142725.91273-1-axboe@kernel.dk/
-        super(LinuxSocket.newSocketStream(), false);
+        super(eventLoop, childEventLoopGroup, LinuxSocket.newSocketStream(), false);
         this.config = new IoUringServerSocketChannelConfig(this);
     }
 
@@ -46,7 +48,7 @@ public final class IoUringServerSocketChannel extends AbstractIoUringServerChann
     }
 
     @Override
-    Channel newChildChannel(int fd, ByteBuffer acceptedAddressMemory) {
+    Channel newChildChannel(EventLoop eventLoop, int fd, ByteBuffer acceptedAddressMemory) {
         IoUringIoHandler handler = registration().attachment();
         LinuxSocket socket = new LinuxSocket(fd);
         if (acceptedAddressMemory != null) {
@@ -60,9 +62,9 @@ public final class IoUringServerSocketChannel extends AbstractIoUringServerChann
                 byte[] addressArray = handler.inet4AddressArray();
                 address = SockaddrIn.getIPv4(acceptedAddressMemory, addressArray);
             }
-            return new IoUringSocketChannel(this, new LinuxSocket(fd), address);
+            return new IoUringSocketChannel(eventLoop, this, new LinuxSocket(fd), address);
         }
-        return new IoUringSocketChannel(this, new LinuxSocket(fd));
+        return new IoUringSocketChannel(eventLoop, this, new LinuxSocket(fd));
     }
 
     @Override

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
@@ -18,6 +18,7 @@ package io.netty.channel.uring;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelOutboundBuffer;
+import io.netty.channel.EventLoop;
 import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.SocketChannelConfig;
@@ -32,18 +33,18 @@ import static io.netty.channel.unix.Errors.ioResult;
 public final class IoUringSocketChannel extends AbstractIoUringStreamChannel implements SocketChannel {
     private final IoUringSocketChannelConfig config;
 
-    public IoUringSocketChannel() {
-       super(null, LinuxSocket.newSocketStream(), false);
+    public IoUringSocketChannel(EventLoop eventLoop) {
+       super(eventLoop, null, LinuxSocket.newSocketStream(), false);
        this.config = new IoUringSocketChannelConfig(this);
     }
 
-    IoUringSocketChannel(Channel parent, LinuxSocket fd) {
-        super(parent, fd, true);
+    IoUringSocketChannel(EventLoop eventLoop, Channel parent, LinuxSocket fd) {
+        super(eventLoop, parent, fd, true);
         this.config = new IoUringSocketChannelConfig(this);
     }
 
-    IoUringSocketChannel(Channel parent, LinuxSocket fd, SocketAddress remote) {
-        super(parent, fd, remote);
+    IoUringSocketChannel(EventLoop eventLoop, Channel parent, LinuxSocket fd, SocketAddress remote) {
+        super(eventLoop, parent, fd, remote);
         this.config = new IoUringSocketChannelConfig(this);
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
@@ -79,8 +79,8 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
     private volatile SocketAddress local;
     private volatile SocketAddress remote;
 
-    AbstractKQueueChannel(Channel parent, BsdSocket fd, boolean active) {
-        super(parent);
+    AbstractKQueueChannel(EventLoop eventLoop, Channel parent, BsdSocket fd, boolean active) {
+        super(eventLoop, KQueueIoHandle.class, parent);
         socket = checkNotNull(fd, "fd");
         this.active = active;
         if (active) {
@@ -91,19 +91,14 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
         }
     }
 
-    AbstractKQueueChannel(Channel parent, BsdSocket fd, SocketAddress remote) {
-        super(parent);
+    AbstractKQueueChannel(EventLoop eventLoop, Channel parent, BsdSocket fd, SocketAddress remote) {
+        super(eventLoop, KQueueIoHandle.class, parent);
         socket = checkNotNull(fd, "fd");
         active = true;
         // Directly cache the remote and local addresses
         // See https://github.com/netty/netty/issues/2359
         this.remote = remote;
         local = fd.localAddress();
-    }
-
-    @Override
-    protected boolean isCompatible(EventLoop loop) {
-        return loop.isCompatible(AbstractKQueueUnsafe.class);
     }
 
     static boolean isSoErrorZero(BsdSocket fd) {

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueDatagramChannel.java
@@ -18,6 +18,7 @@ package io.netty.channel.kqueue;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOutboundBuffer;
+import io.netty.channel.EventLoop;
 
 import java.io.IOException;
 
@@ -25,8 +26,8 @@ abstract class AbstractKQueueDatagramChannel extends AbstractKQueueChannel {
 
     private static final ChannelMetadata METADATA = new ChannelMetadata(true, 16);
 
-    AbstractKQueueDatagramChannel(Channel parent, BsdSocket fd, boolean active) {
-        super(parent, fd, active);
+    AbstractKQueueDatagramChannel(EventLoop eventLoop, Channel parent, BsdSocket fd, boolean active) {
+        super(eventLoop, parent, fd, active);
     }
 
     @Override

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueServerChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueServerChannel.java
@@ -20,6 +20,8 @@ import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
 
 import java.net.InetSocketAddress;
@@ -28,12 +30,21 @@ import java.net.SocketAddress;
 public abstract class AbstractKQueueServerChannel extends AbstractKQueueChannel implements ServerChannel {
     private static final ChannelMetadata METADATA = new ChannelMetadata(false, 16);
 
-    AbstractKQueueServerChannel(BsdSocket fd) {
-        this(fd, isSoErrorZero(fd));
+    private final EventLoopGroup childEventLoopGroup;
+
+    AbstractKQueueServerChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup, BsdSocket fd) {
+        this(eventLoop, childEventLoopGroup, fd, isSoErrorZero(fd));
     }
 
-    AbstractKQueueServerChannel(BsdSocket fd, boolean active) {
-        super(null, fd, active);
+    AbstractKQueueServerChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup, BsdSocket fd, boolean active) {
+        super(eventLoop, null, fd, active);
+        this.childEventLoopGroup =
+                validateEventLoopGroup(childEventLoopGroup, "childEventLoopGroup", KQueueIoHandle.class);
+    }
+
+    @Override
+    public EventLoopGroup childEventExecutorGroup() {
+        return childEventLoopGroup;
     }
 
     @Override
@@ -61,7 +72,7 @@ public abstract class AbstractKQueueServerChannel extends AbstractKQueueChannel 
         throw new UnsupportedOperationException();
     }
 
-    abstract Channel newChildChannel(int fd, byte[] remote, int offset, int len) throws Exception;
+    abstract Channel newChildChannel(EventLoop loop, int fd, byte[] remote, int offset, int len) throws Exception;
 
     @Override
     protected boolean doConnect(SocketAddress remoteAddress, SocketAddress localAddress) throws Exception {
@@ -100,8 +111,8 @@ public abstract class AbstractKQueueServerChannel extends AbstractKQueueChannel 
                         allocHandle.incMessagesRead(1);
 
                         readPending = false;
-                        pipeline.fireChannelRead(newChildChannel(acceptFd, acceptedAddress, 1,
-                                                                 acceptedAddress[0]));
+                        pipeline.fireChannelRead(newChildChannel(childEventExecutorGroup().next(),
+                                acceptFd, acceptedAddress, 1, acceptedAddress[0]));
                     } while (allocHandle.continueReading());
                 } catch (Throwable t) {
                     exception = t;

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
@@ -65,16 +65,16 @@ public abstract class AbstractKQueueStreamChannel extends AbstractKQueueChannel 
         }
     };
 
-    AbstractKQueueStreamChannel(Channel parent, BsdSocket fd, boolean active) {
-        super(parent, fd, active);
+    AbstractKQueueStreamChannel(EventLoop eventLoop, Channel parent, BsdSocket fd, boolean active) {
+        super(eventLoop, parent, fd, active);
     }
 
-    AbstractKQueueStreamChannel(Channel parent, BsdSocket fd, SocketAddress remote) {
-        super(parent, fd, remote);
+    AbstractKQueueStreamChannel(EventLoop eventLoop, Channel parent, BsdSocket fd, SocketAddress remote) {
+        super(eventLoop, parent, fd, remote);
     }
 
-    AbstractKQueueStreamChannel(BsdSocket fd) {
-        this(null, fd, isSoErrorZero(fd));
+    AbstractKQueueStreamChannel(EventLoop eventLoop, BsdSocket fd) {
+        this(eventLoop, null, fd, isSoErrorZero(fd));
     }
 
     @Override

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
@@ -22,6 +22,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultAddressedEnvelope;
+import io.netty.channel.EventLoop;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.DatagramChannelConfig;
 import io.netty.channel.socket.DatagramPacket;
@@ -56,22 +57,22 @@ public final class KQueueDatagramChannel extends AbstractKQueueDatagramChannel i
     private volatile boolean connected;
     private final KQueueDatagramChannelConfig config;
 
-    public KQueueDatagramChannel() {
-        super(null, newSocketDgram(), false);
+    public KQueueDatagramChannel(EventLoop eventLoop) {
+        super(eventLoop, null, newSocketDgram(), false);
         config = new KQueueDatagramChannelConfig(this);
     }
 
-    public KQueueDatagramChannel(SocketProtocolFamily protocol) {
-        super(null, newSocketDgram(protocol), false);
+    public KQueueDatagramChannel(EventLoop eventLoop, SocketProtocolFamily protocol) {
+        super(eventLoop, null, newSocketDgram(protocol), false);
         config = new KQueueDatagramChannelConfig(this);
     }
 
-    public KQueueDatagramChannel(int fd) {
-        this(new BsdSocket(fd), true);
+    public KQueueDatagramChannel(EventLoop eventLoop, int fd) {
+        this(eventLoop, new BsdSocket(fd), true);
     }
 
-    KQueueDatagramChannel(BsdSocket socket, boolean active) {
-        super(null, socket, active);
+    KQueueDatagramChannel(EventLoop eventLoop, BsdSocket socket, boolean active) {
+        super(eventLoop, null, socket, active);
         config = new KQueueDatagramChannelConfig(this);
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainDatagramChannel.java
@@ -20,6 +20,7 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.AddressedEnvelope;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.DefaultAddressedEnvelope;
+import io.netty.channel.EventLoop;
 import io.netty.channel.unix.DomainDatagramChannel;
 import io.netty.channel.unix.DomainDatagramChannelConfig;
 import io.netty.channel.unix.DomainDatagramPacket;
@@ -54,16 +55,16 @@ public final class KQueueDomainDatagramChannel extends AbstractKQueueDatagramCha
 
     private final KQueueDomainDatagramChannelConfig config;
 
-    public KQueueDomainDatagramChannel() {
-        this(newSocketDomainDgram(), false);
+    public KQueueDomainDatagramChannel(EventLoop eventLoop) {
+        this(eventLoop, newSocketDomainDgram(), false);
     }
 
-    public KQueueDomainDatagramChannel(int fd) {
-        this(new BsdSocket(fd), true);
+    public KQueueDomainDatagramChannel(EventLoop eventLoop, int fd) {
+        this(eventLoop, new BsdSocket(fd), true);
     }
 
-    private KQueueDomainDatagramChannel(BsdSocket socket, boolean active) {
-        super(null, socket, active);
+    private KQueueDomainDatagramChannel(EventLoop eventLoop, BsdSocket socket, boolean active) {
+        super(eventLoop, null, socket, active);
         config = new KQueueDomainDatagramChannelConfig(this);
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannel.java
@@ -19,6 +19,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoop;
 import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.channel.unix.DomainSocketChannel;
 import io.netty.channel.unix.FileDescriptor;
@@ -36,16 +37,16 @@ public final class KQueueDomainSocketChannel extends AbstractKQueueStreamChannel
     private volatile DomainSocketAddress local;
     private volatile DomainSocketAddress remote;
 
-    public KQueueDomainSocketChannel() {
-        super(null, newSocketDomain(), false);
+    public KQueueDomainSocketChannel(EventLoop eventLoop) {
+        super(eventLoop, null, newSocketDomain(), false);
     }
 
-    public KQueueDomainSocketChannel(int fd) {
-        this(null, new BsdSocket(fd));
+    public KQueueDomainSocketChannel(EventLoop eventLoop, int fd) {
+        this(eventLoop, null, new BsdSocket(fd));
     }
 
-    KQueueDomainSocketChannel(Channel parent, BsdSocket fd) {
-        super(parent, fd, true);
+    KQueueDomainSocketChannel(EventLoop eventLoop, Channel parent, BsdSocket fd) {
+        super(eventLoop, parent, fd, true);
         local = fd.localDomainSocketAddress();
         remote = fd.remoteDomainSocketAddress();
     }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerDomainSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerDomainSocketChannel.java
@@ -16,6 +16,8 @@
 package io.netty.channel.kqueue;
 
 import io.netty.channel.Channel;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
 import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.channel.unix.ServerDomainSocketChannel;
 import io.netty.util.internal.logging.InternalLogger;
@@ -34,21 +36,22 @@ public final class KQueueServerDomainSocketChannel extends AbstractKQueueServerC
     private final KQueueServerChannelConfig config = new KQueueServerChannelConfig(this);
     private volatile DomainSocketAddress local;
 
-    public KQueueServerDomainSocketChannel() {
-        super(newSocketDomain(), false);
+    public KQueueServerDomainSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup) {
+        super(eventLoop, childEventLoopGroup, newSocketDomain(), false);
     }
 
-    public KQueueServerDomainSocketChannel(int fd) {
-        this(new BsdSocket(fd), false);
+    public KQueueServerDomainSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup, int fd) {
+        this(eventLoop, childEventLoopGroup, new BsdSocket(fd), false);
     }
 
-    KQueueServerDomainSocketChannel(BsdSocket socket, boolean active) {
-        super(socket, active);
+    KQueueServerDomainSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup,
+                                    BsdSocket socket, boolean active) {
+        super(eventLoop, childEventLoopGroup, socket, active);
     }
 
     @Override
-    protected Channel newChildChannel(int fd, byte[] addr, int offset, int len) throws Exception {
-        return new KQueueDomainSocketChannel(this, new BsdSocket(fd));
+    protected Channel newChildChannel(EventLoop eventLoop, int fd, byte[] addr, int offset, int len) throws Exception {
+        return new KQueueDomainSocketChannel(eventLoop, this, new BsdSocket(fd));
     }
 
     @Override

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerSocketChannel.java
@@ -16,6 +16,8 @@
 package io.netty.channel.kqueue;
 
 import io.netty.channel.Channel;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.ServerSocketChannel;
 
 import java.net.SocketAddress;
@@ -26,24 +28,24 @@ import static io.netty.channel.unix.NativeInetAddress.address;
 public final class KQueueServerSocketChannel extends AbstractKQueueServerChannel implements ServerSocketChannel {
     private final KQueueServerSocketChannelConfig config;
 
-    public KQueueServerSocketChannel() {
-        super(newSocketStream(), false);
+    public KQueueServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup) {
+        super(eventLoop, childEventLoopGroup, newSocketStream(), false);
         config = new KQueueServerSocketChannelConfig(this);
     }
 
-    public KQueueServerSocketChannel(int fd) {
+    public KQueueServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup, int fd) {
         // Must call this constructor to ensure this object's local address is configured correctly.
         // The local address can only be obtained from a Socket object.
-        this(new BsdSocket(fd));
+        this(eventLoop, childEventLoopGroup, new BsdSocket(fd));
     }
 
-    KQueueServerSocketChannel(BsdSocket fd) {
-        super(fd);
+    KQueueServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup, BsdSocket fd) {
+        super(eventLoop, childEventLoopGroup, fd);
         config = new KQueueServerSocketChannelConfig(this);
     }
 
-    KQueueServerSocketChannel(BsdSocket fd, boolean active) {
-        super(fd, active);
+    KQueueServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup, BsdSocket fd, boolean active) {
+        super(eventLoop, childEventLoopGroup, fd, active);
         config = new KQueueServerSocketChannelConfig(this);
     }
 
@@ -63,7 +65,8 @@ public final class KQueueServerSocketChannel extends AbstractKQueueServerChannel
     }
 
     @Override
-    protected Channel newChildChannel(int fd, byte[] address, int offset, int len) throws Exception {
-        return new KQueueSocketChannel(this, new BsdSocket(fd), address(address, offset, len));
+    protected Channel newChildChannel(EventLoop eventLoop, int fd, byte[] address, int offset, int len)
+            throws Exception {
+        return new KQueueSocketChannel(eventLoop, this, new BsdSocket(fd), address(address, offset, len));
     }
 }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannel.java
@@ -18,6 +18,7 @@ package io.netty.channel.kqueue;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelOutboundBuffer;
+import io.netty.channel.EventLoop;
 import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.SocketProtocolFamily;
@@ -31,23 +32,23 @@ import java.util.concurrent.Executor;
 public final class KQueueSocketChannel extends AbstractKQueueStreamChannel implements SocketChannel {
     private final KQueueSocketChannelConfig config;
 
-    public KQueueSocketChannel() {
-        super(null, BsdSocket.newSocketStream(), false);
+    public KQueueSocketChannel(EventLoop eventLoop) {
+        super(eventLoop, null, BsdSocket.newSocketStream(), false);
         config = new KQueueSocketChannelConfig(this);
     }
 
-    public KQueueSocketChannel(SocketProtocolFamily protocol) {
-        super(null, BsdSocket.newSocketStream(protocol), false);
+    public KQueueSocketChannel(EventLoop eventLoop, SocketProtocolFamily protocol) {
+        super(eventLoop, null, BsdSocket.newSocketStream(protocol), false);
         config = new KQueueSocketChannelConfig(this);
     }
 
-    public KQueueSocketChannel(int fd) {
-        super(new BsdSocket(fd));
+    public KQueueSocketChannel(EventLoop eventLoop, int fd) {
+        super(eventLoop, new BsdSocket(fd));
         config = new KQueueSocketChannelConfig(this);
     }
 
-    KQueueSocketChannel(Channel parent, BsdSocket fd, InetSocketAddress remoteAddress) {
-        super(parent, fd, remoteAddress);
+    KQueueSocketChannel(EventLoop eventLoop, Channel parent, BsdSocket fd, InetSocketAddress remoteAddress) {
+        super(eventLoop, parent, fd, remoteAddress);
         config = new KQueueSocketChannelConfig(this);
     }
 

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollChannelConfigTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollChannelConfigTest.java
@@ -34,7 +34,7 @@ public class EpollChannelConfigTest {
     @Test
     public void testOptionGetThrowsChannelException() throws Exception {
         Epoll.ensureAvailability();
-        EpollSocketChannel channel = new EpollSocketChannel();
+        EpollSocketChannel channel = new EpollSocketChannel(EpollSocketTestPermutation.EPOLL_GROUP.next());
         channel.config().getSoLinger();
         channel.fd().close();
         try {
@@ -48,7 +48,7 @@ public class EpollChannelConfigTest {
     @Test
     public void testOptionSetThrowsChannelException() throws Exception {
         Epoll.ensureAvailability();
-        EpollSocketChannel channel = new EpollSocketChannel();
+        EpollSocketChannel channel = new EpollSocketChannel(EpollSocketTestPermutation.EPOLL_GROUP.next());
         channel.config().setKeepAlive(true);
         channel.fd().close();
         try {
@@ -62,7 +62,7 @@ public class EpollChannelConfigTest {
     @Test
     public void testIntegerOption() throws Exception {
         Epoll.ensureAvailability();
-        EpollSocketChannel channel = new EpollSocketChannel();
+        EpollSocketChannel channel = new EpollSocketChannel(EpollSocketTestPermutation.EPOLL_GROUP.next());
         IntegerUnixChannelOption opt = new IntegerUnixChannelOption("INT_OPT", 1, 2);
         Integer zero = 0;
         assertEquals(zero, channel.config().getOption(opt));
@@ -74,7 +74,7 @@ public class EpollChannelConfigTest {
     @Test
     public void testRawOption() throws Exception {
         Epoll.ensureAvailability();
-        EpollSocketChannel channel = new EpollSocketChannel();
+        EpollSocketChannel channel = new EpollSocketChannel(EpollSocketTestPermutation.EPOLL_GROUP.next());
         // Value for SOL_SOCKET and SO_REUSEADDR
         // See https://github.com/torvalds/linux/blob/v5.17/include/uapi/asm-generic/socket.h
         RawUnixChannelOption opt = new RawUnixChannelOption("RAW_OPT", 1, 2, 4);

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramChannelConfigTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramChannelConfigTest.java
@@ -25,7 +25,7 @@ public class EpollDatagramChannelConfigTest {
     @Test
     public void testIpFreeBind() throws Exception {
         Epoll.ensureAvailability();
-        EpollDatagramChannel channel = new EpollDatagramChannel();
+        EpollDatagramChannel channel = new EpollDatagramChannel(EpollSocketTestPermutation.EPOLL_GROUP.next());
         assertTrue(channel.config().setOption(EpollChannelOption.IP_FREEBIND, true));
         assertTrue(channel.config().getOption(EpollChannelOption.IP_FREEBIND));
         channel.fd().close();

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramChannelTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramChannelTest.java
@@ -46,22 +46,25 @@ public class EpollDatagramChannelTest {
 
     @Test
     public void testDefaultMaxMessagePerRead() {
-        EpollDatagramChannel channel = new EpollDatagramChannel();
+        EpollDatagramChannel channel = new EpollDatagramChannel(EpollSocketTestPermutation.EPOLL_GROUP.next());
         assertEquals(16, channel.config().getMaxMessagesPerRead());
         channel.unsafe().closeForcibly();
     }
 
     @Test
     public void testNotActiveNoLocalRemoteAddress() throws IOException {
-        checkNotActiveNoLocalRemoteAddress(new EpollDatagramChannel());
-        checkNotActiveNoLocalRemoteAddress(new EpollDatagramChannel(SocketProtocolFamily.INET));
-        checkNotActiveNoLocalRemoteAddress(new EpollDatagramChannel(SocketProtocolFamily.INET6));
+        checkNotActiveNoLocalRemoteAddress(new EpollDatagramChannel(EpollSocketTestPermutation.EPOLL_GROUP.next()));
+        checkNotActiveNoLocalRemoteAddress(new EpollDatagramChannel(EpollSocketTestPermutation.EPOLL_GROUP.next(),
+                SocketProtocolFamily.INET));
+        checkNotActiveNoLocalRemoteAddress(new EpollDatagramChannel(EpollSocketTestPermutation.EPOLL_GROUP.next(),
+                SocketProtocolFamily.INET6));
     }
 
     @Test
     public void testActiveHasLocalAddress() throws IOException {
         Socket socket = Socket.newSocketDgram();
-        EpollDatagramChannel channel = new EpollDatagramChannel(socket.intValue());
+        EpollDatagramChannel channel = new EpollDatagramChannel(EpollSocketTestPermutation.EPOLL_GROUP.next(),
+                socket.intValue());
         InetSocketAddress localAddress = channel.localAddress();
         assertTrue(channel.active);
         assertNotNull(localAddress);

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainDatagramChannelTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainDatagramChannelTest.java
@@ -29,7 +29,8 @@ public class EpollDomainDatagramChannelTest {
 
     @Test
     public void testDefaultMaxMessagePerRead() {
-        EpollDomainDatagramChannel channel = new EpollDomainDatagramChannel();
+        EpollDomainDatagramChannel channel = new EpollDomainDatagramChannel(
+                EpollSocketTestPermutation.EPOLL_GROUP.next());
         assertEquals(16, channel.config().getMaxMessagesPerRead());
         channel.unsafe().closeForcibly();
     }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketFdTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketFdTest.java
@@ -68,7 +68,7 @@ public class EpollDomainSocketFdTest extends AbstractSocketTest {
             @Override
             public void channelActive(ChannelHandlerContext ctx) throws Exception {
                 // Create new channel and obtain a file descriptor from it.
-                final EpollDomainSocketChannel ch = new EpollDomainSocketChannel();
+                final EpollDomainSocketChannel ch = new EpollDomainSocketChannel(ctx.channel().executor());
 
                 ctx.writeAndFlush(ch.fd()).addListener(new ChannelFutureListener() {
                     @Override

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollEventLoopTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollEventLoopTest.java
@@ -15,6 +15,7 @@
  */
 package io.netty.channel.epoll;
 
+import io.netty.channel.EventLoop;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.testsuite.transport.AbstractSingleThreadEventLoopTest;
 import io.netty.channel.EventLoopGroup;
@@ -43,8 +44,8 @@ public class EpollEventLoopTest extends AbstractSingleThreadEventLoopTest {
     }
 
     @Override
-    protected ServerSocketChannel newChannel() {
-        return new EpollServerSocketChannel();
+    protected ServerSocketChannel newChannel(EventLoop eventLoop) {
+        return new EpollServerSocketChannel(eventLoop, eventLoop);
     }
 
     @Override

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTcpMd5Test.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTcpMd5Test.java
@@ -16,6 +16,7 @@
 package io.netty.channel.epoll;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOption;
@@ -56,10 +57,10 @@ public class EpollSocketTcpMd5Test {
 
     @BeforeEach
     public void setup() {
-        Bootstrap bootstrap = new Bootstrap();
+        ServerBootstrap bootstrap = new ServerBootstrap();
         server = (EpollServerSocketChannel) bootstrap.group(GROUP)
                 .channel(EpollServerSocketChannel.class)
-                .handler(new ChannelInboundHandlerAdapter())
+                .childHandler(new ChannelInboundHandlerAdapter())
                 .bind(new InetSocketAddress(NetUtil.LOCALHOST4, 0)).syncUninterruptibly().channel();
     }
 
@@ -90,10 +91,10 @@ public class EpollSocketTcpMd5Test {
 
     @Test
     public void testServerOption() throws Exception {
-        Bootstrap bootstrap = new Bootstrap();
+        ServerBootstrap bootstrap = new ServerBootstrap();
         EpollServerSocketChannel ch = (EpollServerSocketChannel) bootstrap.group(GROUP)
                 .channel(EpollServerSocketChannel.class)
-                .handler(new ChannelInboundHandlerAdapter())
+                .childHandler(new ChannelInboundHandlerAdapter())
                 .bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
 
         try {

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTestPermutation.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTestPermutation.java
@@ -20,6 +20,7 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFactory;
 import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.socket.SocketProtocolFamily;
@@ -145,8 +146,8 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
                     public Bootstrap newInstance() {
                         return new Bootstrap().group(NIO_GROUP).channelFactory(new ChannelFactory<Channel>() {
                             @Override
-                            public Channel newChannel() {
-                                return new NioDatagramChannel(family);
+                            public Channel newChannel(EventLoop eventLoop) {
+                                return new NioDatagramChannel(eventLoop, family);
                             }
 
                             @Override
@@ -161,8 +162,8 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
                     public Bootstrap newInstance() {
                         return new Bootstrap().group(EPOLL_GROUP).channelFactory(new ChannelFactory<Channel>() {
                             @Override
-                            public Channel newChannel() {
-                                return new EpollDatagramChannel(family);
+                            public Channel newChannel(EventLoop eventLoop) {
+                                return new EpollDatagramChannel(eventLoop, family);
                             }
 
                             @Override
@@ -188,8 +189,8 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
             public Bootstrap newInstance() {
                 return new Bootstrap().group(EPOLL_GROUP).channelFactory(new ChannelFactory<Channel>() {
                     @Override
-                    public Channel newChannel() {
-                        return new EpollDatagramChannel(family);
+                    public Channel newChannel(EventLoop eventLoop) {
+                        return new EpollDatagramChannel(eventLoop, family);
                     }
 
                     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringChannelConfigTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringChannelConfigTest.java
@@ -36,7 +36,7 @@ public class IoUringChannelConfigTest {
 
     @Test
     public void testIntegerOption() throws Exception {
-        IoUringSocketChannel channel = new IoUringSocketChannel();
+        IoUringSocketChannel channel = new IoUringSocketChannel(IoUringSocketTestPermutation.IO_URING_GROUP.next());
         IntegerUnixChannelOption opt = new IntegerUnixChannelOption("INT_OPT", 1, 2);
         Integer zero = 0;
         assertEquals(zero, channel.config().getOption(opt));
@@ -47,7 +47,7 @@ public class IoUringChannelConfigTest {
 
     @Test
     public void testRawOption() throws Exception {
-        IoUringSocketChannel channel = new IoUringSocketChannel();
+        IoUringSocketChannel channel = new IoUringSocketChannel(IoUringSocketTestPermutation.IO_URING_GROUP.next());
         // Value for SOL_SOCKET and SO_REUSEADDR
         // See https://github.com/torvalds/linux/blob/v5.17/include/uapi/asm-generic/socket.h
         RawUnixChannelOption opt = new RawUnixChannelOption("RAW_OPT", 1, 2, 4);

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketFdTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketFdTest.java
@@ -76,7 +76,7 @@ public class IoUringDomainSocketFdTest extends AbstractSocketTest {
             @Override
             public void channelActive(ChannelHandlerContext ctx) throws Exception {
                 // Create new channel and obtain a file descriptor from it.
-                final IoUringDomainSocketChannel ch = new IoUringDomainSocketChannel();
+                final IoUringDomainSocketChannel ch = new IoUringDomainSocketChannel(ctx.channel().executor());
 
                 ctx.writeAndFlush(ch.fd()).addListener(new ChannelFutureListener() {
                     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringEventLoopTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringEventLoopTest.java
@@ -59,8 +59,8 @@ public class IoUringEventLoopTest extends AbstractSingleThreadEventLoopTest {
     }
 
     @Override
-    protected Channel newChannel() {
-        return new IoUringServerSocketChannel();
+    protected Channel newChannel(EventLoop eventLoop) {
+        return new IoUringServerSocketChannel(eventLoop, eventLoop);
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketTestPermutation.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketTestPermutation.java
@@ -20,6 +20,7 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFactory;
 import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.socket.SocketProtocolFamily;
@@ -217,8 +218,8 @@ public class IoUringSocketTestPermutation extends SocketTestPermutation {
                         return new Bootstrap().group(IO_URING_GROUP)
                                 .channelFactory(new ChannelFactory<Channel>() {
                             @Override
-                            public Channel newChannel() {
-                                return new IoUringDatagramChannel(family);
+                            public Channel newChannel(EventLoop eventLoop) {
+                                return new IoUringDatagramChannel(eventLoop, family);
                             }
 
                             @Override
@@ -233,8 +234,8 @@ public class IoUringSocketTestPermutation extends SocketTestPermutation {
                     public Bootstrap newInstance() {
                         return new Bootstrap().group(NIO_GROUP).channelFactory(new ChannelFactory<Channel>() {
                             @Override
-                            public Channel newChannel() {
-                                return new NioDatagramChannel(family);
+                            public Channel newChannel(EventLoop eventLoop) {
+                                return new NioDatagramChannel(eventLoop, family);
                             }
 
                             @Override

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueChannelConfigTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueChannelConfigTest.java
@@ -44,7 +44,7 @@ public class KQueueChannelConfigTest {
 
     @Test
     public void testOptionGetThrowsChannelException() throws Exception {
-        KQueueSocketChannel channel = new KQueueSocketChannel();
+        KQueueSocketChannel channel = new KQueueSocketChannel(KQueueSocketTestPermutation.KQUEUE_GROUP.next());
         channel.config().getSoLinger();
         channel.fd().close();
         try {
@@ -57,7 +57,7 @@ public class KQueueChannelConfigTest {
 
     @Test
     public void testOptionSetThrowsChannelException() throws Exception {
-        KQueueSocketChannel channel = new KQueueSocketChannel();
+        KQueueSocketChannel channel = new KQueueSocketChannel(KQueueSocketTestPermutation.KQUEUE_GROUP.next());
         channel.config().setKeepAlive(true);
         channel.fd().close();
         try {
@@ -88,7 +88,7 @@ public class KQueueChannelConfigTest {
 
     @Test
     public void testIntegerOption() throws Exception {
-        KQueueSocketChannel channel = new KQueueSocketChannel();
+        KQueueSocketChannel channel = new KQueueSocketChannel(KQueueSocketTestPermutation.KQUEUE_GROUP.next());
         IntegerUnixChannelOption opt = new IntegerUnixChannelOption("INT_OPT", 0xffff, 0x0004);
         Integer zero = 0;
         assertEquals(zero, channel.config().getOption(opt));
@@ -99,7 +99,7 @@ public class KQueueChannelConfigTest {
 
     @Test
     public void testRawOption() throws Exception {
-        KQueueSocketChannel channel = new KQueueSocketChannel();
+        KQueueSocketChannel channel = new KQueueSocketChannel(KQueueSocketTestPermutation.KQUEUE_GROUP.next());
         // Value for SOL_SOCKET and SO_REUSEADDR
         // See https://opensource.apple.com/source/xnu/xnu-201/bsd/sys/socket.h.auto.html
         RawUnixChannelOption opt = new RawUnixChannelOption("RAW_OPT", 0xffff, 0x0004, 4);

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainSocketFdTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainSocketFdTest.java
@@ -68,7 +68,7 @@ public class KQueueDomainSocketFdTest extends AbstractSocketTest {
             @Override
             public void channelActive(ChannelHandlerContext ctx) throws Exception {
                 // Create new channel and obtain a file descriptor from it.
-                final KQueueDomainSocketChannel ch = new KQueueDomainSocketChannel();
+                final KQueueDomainSocketChannel ch = new KQueueDomainSocketChannel(ctx.channel().executor());
 
                 ctx.writeAndFlush(ch.fd()).addListener(new ChannelFutureListener() {
                     @Override

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueEventLoopTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueEventLoopTest.java
@@ -44,8 +44,8 @@ public class KQueueEventLoopTest extends AbstractSingleThreadEventLoopTest {
     }
 
     @Override
-    protected ServerSocketChannel newChannel() {
-        return new KQueueServerSocketChannel();
+    protected ServerSocketChannel newChannel(EventLoop eventLoop) {
+        return new KQueueServerSocketChannel(eventLoop, eventLoop);
     }
 
     @Override

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTestPermutation.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTestPermutation.java
@@ -20,6 +20,7 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFactory;
 import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.socket.SocketProtocolFamily;
@@ -139,8 +140,8 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
                     public Bootstrap newInstance() {
                         return new Bootstrap().group(NIO_GROUP).channelFactory(new ChannelFactory<Channel>() {
                             @Override
-                            public Channel newChannel() {
-                                return new NioDatagramChannel(family);
+                            public Channel newChannel(EventLoop eventLoop) {
+                                return new NioDatagramChannel(eventLoop, family);
                             }
 
                             @Override
@@ -155,8 +156,8 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
                     public Bootstrap newInstance() {
                         return new Bootstrap().group(KQUEUE_GROUP).channelFactory(new ChannelFactory<Channel>() {
                             @Override
-                            public Channel newChannel() {
-                                return new KQueueDatagramChannel(family);
+                            public Channel newChannel(EventLoop eventLoop) {
+                                return new KQueueDatagramChannel(eventLoop, family);
                             }
 
                             @Override

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KqueueDatagramChannelTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KqueueDatagramChannelTest.java
@@ -29,7 +29,7 @@ public class KqueueDatagramChannelTest {
 
     @Test
     public void testDefaultMaxMessagePerRead() {
-        KQueueDatagramChannel channel = new KQueueDatagramChannel();
+        KQueueDatagramChannel channel = new KQueueDatagramChannel(KQueueSocketTestPermutation.KQUEUE_GROUP.next());
         assertEquals(16, channel.config().getMaxMessagesPerRead());
         channel.unsafe().closeForcibly();
     }

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KqueueDomainDatagramChannelTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KqueueDomainDatagramChannelTest.java
@@ -29,7 +29,8 @@ public class KqueueDomainDatagramChannelTest {
 
     @Test
     public void testDefaultMaxMessagePerRead() {
-        KQueueDomainDatagramChannel channel = new KQueueDomainDatagramChannel();
+        KQueueDomainDatagramChannel channel = new KQueueDomainDatagramChannel(
+                KQueueSocketTestPermutation.KQUEUE_GROUP.next());
         assertEquals(16, channel.config().getMaxMessagesPerRead());
         channel.unsafe().closeForcibly();
     }

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
@@ -26,6 +26,8 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPromise;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.nio.AbstractNioMessageChannel;
 import io.netty.channel.nio.NioIoOps;
@@ -81,15 +83,15 @@ public class NioSctpChannel extends AbstractNioMessageChannel implements io.nett
     /**
      * Create a new instance
      */
-    public NioSctpChannel() {
-        this(newSctpChannel());
+    public NioSctpChannel(EventLoop eventLoop) {
+        this(eventLoop, newSctpChannel());
     }
 
     /**
      * Create a new instance using {@link SctpChannel}
      */
-    public NioSctpChannel(SctpChannel sctpChannel) {
-        this(null, sctpChannel);
+    public NioSctpChannel(EventLoop eventLoop, SctpChannel sctpChannel) {
+        this(eventLoop, null, sctpChannel);
     }
 
     /**
@@ -99,8 +101,8 @@ public class NioSctpChannel extends AbstractNioMessageChannel implements io.nett
      *                      or {@code null}.
      * @param sctpChannel   the underlying {@link SctpChannel}
      */
-    public NioSctpChannel(Channel parent, SctpChannel sctpChannel) {
-        super(parent, sctpChannel, SelectionKey.OP_READ);
+    public NioSctpChannel(EventLoop eventLoop, Channel parent, SctpChannel sctpChannel) {
+        super(eventLoop, parent, sctpChannel, SelectionKey.OP_READ);
         try {
             sctpChannel.configureBlocking(false);
             config = new NioSctpChannelConfig(this, sctpChannel);

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpServerChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpServerChannel.java
@@ -22,7 +22,10 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPromise;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.AbstractNioMessageChannel;
+import io.netty.channel.nio.NioIoHandle;
 import io.netty.channel.sctp.DefaultSctpServerChannelConfig;
 import io.netty.channel.sctp.SctpServerChannelConfig;
 
@@ -58,13 +61,20 @@ public class NioSctpServerChannel extends AbstractNioMessageChannel
     }
 
     private final SctpServerChannelConfig config;
-
+    private final EventLoopGroup childEventLoopGroup;
     /**
      * Create a new instance
      */
-    public NioSctpServerChannel() {
-        super(null, newSocket(), SelectionKey.OP_ACCEPT);
+    public NioSctpServerChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup) {
+        super(eventLoop, null, newSocket(), SelectionKey.OP_ACCEPT);
+        this.childEventLoopGroup =
+                validateEventLoopGroup(childEventLoopGroup, "childEventLoopGroup", NioIoHandle.class);
         config = new NioSctpServerChannelConfig(this, javaChannel());
+    }
+
+    @Override
+    public EventLoopGroup childEventExecutorGroup() {
+        return childEventLoopGroup;
     }
 
     @Override
@@ -140,7 +150,7 @@ public class NioSctpServerChannel extends AbstractNioMessageChannel
         if (ch == null) {
             return 0;
         }
-        buf.add(new NioSctpChannel(this, ch));
+        buf.add(new NioSctpChannel(childEventLoopGroup.next(), this, ch));
         return 1;
     }
 

--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -17,7 +17,6 @@
 package io.netty.bootstrap;
 
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFactory;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
@@ -26,7 +25,6 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelPromise;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.ReflectiveChannelFactory;
 import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.GlobalEventExecutor;
@@ -59,7 +57,6 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
     private static final Map.Entry<AttributeKey<?>, Object>[] EMPTY_ATTRIBUTE_ARRAY = new Map.Entry[0];
 
     volatile EventLoopGroup group;
-    private volatile ChannelFactory<? extends C> channelFactory;
     private volatile SocketAddress localAddress;
 
     // The order in which ChannelOptions are applied is important they may depend on each other for validation
@@ -75,7 +72,6 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
 
     AbstractBootstrap(AbstractBootstrap<B, C> bootstrap) {
         group = bootstrap.group;
-        channelFactory = bootstrap.channelFactory;
         handler = bootstrap.handler;
         localAddress = bootstrap.localAddress;
         synchronized (bootstrap.options) {
@@ -101,34 +97,6 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
     @SuppressWarnings("unchecked")
     private B self() {
         return (B) this;
-    }
-
-    /**
-     * The {@link Class} which is used to create {@link Channel} instances from.
-     * You either use this or {@link #channelFactory(io.netty.channel.ChannelFactory)} if your
-     * {@link Channel} implementation has no no-args constructor.
-     */
-    public B channel(Class<? extends C> channelClass) {
-        return channelFactory(new ReflectiveChannelFactory<C>(
-                ObjectUtil.checkNotNull(channelClass, "channelClass")
-        ));
-    }
-
-    /**
-     * {@link io.netty.channel.ChannelFactory} which is used to create {@link Channel} instances from
-     * when calling {@link #bind()}. This method is usually only used if {@link #channel(Class)}
-     * is not working for you because of some more complex needs. If your {@link Channel} implementation
-     * has a no-args constructor, its highly recommend to just use {@link #channel(Class)} to
-     * simplify your code.
-     */
-    public B channelFactory(ChannelFactory<? extends C> channelFactory) {
-        ObjectUtil.checkNotNull(channelFactory, "channelFactory");
-        if (this.channelFactory != null) {
-            throw new IllegalStateException("channelFactory set already");
-        }
-
-        this.channelFactory = channelFactory;
-        return self();
     }
 
     /**
@@ -210,9 +178,6 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
     public B validate() {
         if (group == null) {
             throw new IllegalStateException("group not set");
-        }
-        if (channelFactory == null) {
-            throw new IllegalStateException("channel or channelFactory not set");
         }
         return self();
     }
@@ -311,24 +276,25 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
         }
     }
 
+    protected abstract Channel newChannel(EventLoop loop);
+
     final ChannelFuture initAndRegister() {
         Channel channel = null;
+        EventLoop loop = config().group().next();
+
         try {
-            channel = channelFactory.newChannel();
+            channel = newChannel(loop);
             init(channel);
         } catch (Throwable t) {
             if (channel != null) {
                 // channel can be null if newChannel crashed (eg SocketException("too many open files"))
                 channel.unsafe().closeForcibly();
-                // as the Channel is not registered yet we need to force the usage of the GlobalEventExecutor
-                return new DefaultChannelPromise(channel, GlobalEventExecutor.INSTANCE).setFailure(t);
+                return channel.newPromise().setFailure(t);
             }
-            // as the Channel is not registered yet we need to force the usage of the GlobalEventExecutor
-            return new DefaultChannelPromise(new FailedChannel(), GlobalEventExecutor.INSTANCE).setFailure(t);
+            return new FailedChannel(group.next()).newFailedFuture(t);
         }
 
-        EventLoop loop = config().group().next();
-        ChannelFuture reqFut = channel.register(loop);
+        ChannelFuture reqFut = channel.register();
         if (reqFut.cause() != null) {
             if (channel.isRegistered()) {
                 channel.close();
@@ -429,11 +395,6 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
 
     final SocketAddress localAddress() {
         return localAddress;
-    }
-
-    @SuppressWarnings("deprecation")
-    final ChannelFactory<? extends C> channelFactory() {
-        return channelFactory;
     }
 
     final ChannelHandler handler() {

--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrapConfig.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrapConfig.java
@@ -46,13 +46,6 @@ public abstract class AbstractBootstrapConfig<B extends AbstractBootstrap<B, C>,
     }
 
     /**
-     * Returns the configured {@link ChannelFactory} or {@code null} if non is configured yet.
-     */
-    public final ChannelFactory<? extends C> channelFactory() {
-        return bootstrap.channelFactory();
-    }
-
-    /**
      * Returns the configured {@link ChannelHandler} or {@code null} if non is configured yet.
      */
     public final ChannelHandler handler() {
@@ -92,13 +85,7 @@ public abstract class AbstractBootstrapConfig<B extends AbstractBootstrap<B, C>,
                     .append(StringUtil.simpleClassName(group))
                     .append(", ");
         }
-        @SuppressWarnings("deprecation")
-        ChannelFactory<? extends C> factory = channelFactory();
-        if (factory != null) {
-            buf.append("channelFactory: ")
-                    .append(factory)
-                    .append(", ");
-        }
+
         SocketAddress localAddress = localAddress();
         if (localAddress != null) {
             buf.append("localAddress: ")

--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -16,12 +16,14 @@
 package io.netty.bootstrap;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFactory;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.ReflectiveChannelFactory;
 import io.netty.resolver.AddressResolver;
 import io.netty.resolver.AddressResolverGroup;
 import io.netty.resolver.DefaultAddressResolverGroup;
@@ -53,6 +55,7 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
     private ExternalAddressResolver externalResolver;
     private volatile boolean disableResolver;
     private volatile SocketAddress remoteAddress;
+    volatile ChannelFactory<? extends Channel> channelFactory;
 
     public Bootstrap() { }
 
@@ -61,6 +64,34 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
         externalResolver = bootstrap.externalResolver;
         disableResolver = bootstrap.disableResolver;
         remoteAddress = bootstrap.remoteAddress;
+        channelFactory = bootstrap.channelFactory;
+    }
+
+    /**
+     * The {@link Class} which is used to create {@link Channel} instances from.
+     * You either use this or {@link #channelFactory(io.netty.channel.ChannelFactory)} if your
+     * {@link Channel} implementation has no no-args constructor.
+     */
+    public Bootstrap channel(Class<? extends Channel> channelClass) {
+        ObjectUtil.checkNotNull(channelClass, "channelClass");
+        return channelFactory(new ReflectiveChannelFactory<>(channelClass));
+    }
+
+    /**
+     * {@link io.netty.channel.ChannelFactory} which is used to create {@link Channel} instances from
+     * when calling {@link #bind()}. This method is usually only used if {@link #channel(Class)}
+     * is not working for you because of some more complex needs. If your {@link Channel} implementation
+     * has a no-args constructor, its highly recommend to just use {@link #channel(Class)} to
+     * simplify your code.
+     */
+    public Bootstrap channelFactory(ChannelFactory<? extends Channel> channelFactory) {
+        ObjectUtil.checkNotNull(channelFactory, "channelFactory");
+        if (this.channelFactory != null) {
+            throw new IllegalStateException("channelFactory set already");
+        }
+
+        this.channelFactory = channelFactory;
+        return this;
     }
 
     /**
@@ -290,10 +321,18 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
     }
 
     @Override
+    protected Channel newChannel(EventLoop eventLoop) {
+        return channelFactory.newChannel(eventLoop);
+    }
+
+    @Override
     public Bootstrap validate() {
         super.validate();
         if (config.handler() == null) {
             throw new IllegalStateException("handler not set");
+        }
+        if (channelFactory == null) {
+            throw new IllegalStateException("channel or channelFactory not set");
         }
         return this;
     }
@@ -329,6 +368,10 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
             return null;
         }
         return ExternalAddressResolver.getOrDefault(externalResolver);
+    }
+
+    final ChannelFactory<? extends Channel> channelFactory() {
+        return channelFactory;
     }
 
     /* Holder to avoid NoClassDefFoundError in case netty-resolver dependency is excluded

--- a/transport/src/main/java/io/netty/bootstrap/BootstrapConfig.java
+++ b/transport/src/main/java/io/netty/bootstrap/BootstrapConfig.java
@@ -16,6 +16,7 @@
 package io.netty.bootstrap;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFactory;
 import io.netty.resolver.AddressResolverGroup;
 
 import java.net.SocketAddress;
@@ -44,6 +45,13 @@ public final class BootstrapConfig extends AbstractBootstrapConfig<Bootstrap, Ch
         return bootstrap.resolver();
     }
 
+    /**
+     * Returns the configured {@link ChannelFactory} or {@code null} if non is configured yet.
+     */
+    public ChannelFactory<? extends Channel> channelFactory() {
+        return bootstrap.channelFactory();
+    }
+
     @Override
     public String toString() {
         StringBuilder buf = new StringBuilder(super.toString());
@@ -57,6 +65,12 @@ public final class BootstrapConfig extends AbstractBootstrapConfig<Bootstrap, Ch
         if (remoteAddress != null) {
             buf.append(", remoteAddress: ")
                     .append(remoteAddress);
+        }
+        ChannelFactory<? extends Channel> factory = channelFactory();
+        if (factory != null) {
+            buf.append("channelFactory: ")
+                    .append(factory)
+                    .append(", ");
         }
         return buf.append(')').toString();
     }

--- a/transport/src/main/java/io/netty/bootstrap/FailedChannel.java
+++ b/transport/src/main/java/io/netty/bootstrap/FailedChannel.java
@@ -29,18 +29,13 @@ final class FailedChannel extends AbstractChannel {
     private static final ChannelMetadata METADATA = new ChannelMetadata(false);
     private final ChannelConfig config = new DefaultChannelConfig(this);
 
-    FailedChannel() {
-        super(null);
+    FailedChannel(EventLoop eventLoop) {
+        super(eventLoop, null, null);
     }
 
     @Override
     protected AbstractUnsafe newUnsafe() {
         return new FailedChannelUnsafe();
-    }
-
-    @Override
-    protected boolean isCompatible(EventLoop loop) {
-        return false;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
@@ -27,7 +27,9 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.ReflectiveServerChannelFactory;
 import io.netty.channel.ServerChannel;
+import io.netty.channel.ServerChannelFactory;
 import io.netty.util.AttributeKey;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.logging.InternalLogger;
@@ -55,17 +57,46 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
     private final ServerBootstrapConfig config = new ServerBootstrapConfig(this);
     private volatile EventLoopGroup childGroup;
     private volatile ChannelHandler childHandler;
+    volatile ServerChannelFactory<? extends ServerChannel> channelFactory;
 
     public ServerBootstrap() { }
 
     private ServerBootstrap(ServerBootstrap bootstrap) {
         super(bootstrap);
+        channelFactory = bootstrap.channelFactory;
         childGroup = bootstrap.childGroup;
         childHandler = bootstrap.childHandler;
         synchronized (bootstrap.childOptions) {
             childOptions.putAll(bootstrap.childOptions);
         }
         childAttrs.putAll(bootstrap.childAttrs);
+    }
+
+    /**
+     * The {@link Class} which is used to create {@link Channel} instances from.
+     * You either use this or {@link #channelFactory(io.netty.channel.ServerChannelFactory)} if your
+     * {@link Channel} implementation has no no-args constructor.
+     */
+    public ServerBootstrap channel(Class<? extends ServerChannel> channelClass) {
+        ObjectUtil.checkNotNull(channelClass, "channelClass");
+        return channelFactory(new ReflectiveServerChannelFactory<>(channelClass));
+    }
+
+    /**
+     * {@link io.netty.channel.ServerChannelFactory} which is used to create {@link ServerChannel} instances from
+     * when calling {@link #bind()}. This method is usually only used if {@link #channel(Class)}
+     * is not working for you because of some more complex needs. If your {@link ServerChannel} implementation
+     * has a no-args constructor, its highly recommend to just use {@link #channel(Class)} to
+     * simplify your code.
+     */
+    public ServerBootstrap channelFactory(ServerChannelFactory<? extends ServerChannel> channelFactory) {
+        ObjectUtil.checkNotNull(channelFactory, "channelFactory");
+        if (this.channelFactory != null) {
+            throw new IllegalStateException("channelFactory set already");
+        }
+
+        this.channelFactory = channelFactory;
+        return this;
     }
 
     /**
@@ -133,6 +164,11 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
     }
 
     @Override
+    protected Channel newChannel(EventLoop eventLoop) {
+        return channelFactory.newChannel(eventLoop, childGroup);
+    }
+
+    @Override
     void init(Channel channel) {
         setChannelOptions(channel, newOptionsArray(), logger);
         setAttributes(channel, newAttributesArray());
@@ -185,6 +221,9 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
         if (childGroup == null) {
             logger.warn("childGroup is not set. Using parentGroup instead.");
             childGroup = config.group();
+        }
+        if (channelFactory == null) {
+            throw new IllegalStateException("channel or channelFactory not set");
         }
         return this;
     }
@@ -242,10 +281,7 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
             }
 
             try {
-                // TODO: This is just a hack for now and will be replaced on the follow PR that will change
-                //  Unsafe interface.
-                EventLoop loop = childGroup.next();
-                child.register(loop).addListener(new ChannelFutureListener() {
+                child.register().addListener(new ChannelFutureListener() {
                     @Override
                     public void operationComplete(ChannelFuture future) throws Exception {
                         if (!future.isSuccess()) {
@@ -297,6 +333,10 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
 
     final ChannelHandler childHandler() {
         return childHandler;
+    }
+
+    final ServerChannelFactory<? extends ServerChannel> channelFactory() {
+        return channelFactory;
     }
 
     final Map<ChannelOption<?>, Object> childOptions() {

--- a/transport/src/main/java/io/netty/bootstrap/ServerBootstrapConfig.java
+++ b/transport/src/main/java/io/netty/bootstrap/ServerBootstrapConfig.java
@@ -15,10 +15,13 @@
  */
 package io.netty.bootstrap;
 
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFactory;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
+import io.netty.channel.ServerChannelFactory;
 import io.netty.util.AttributeKey;
 import io.netty.util.internal.StringUtil;
 
@@ -31,6 +34,13 @@ public final class ServerBootstrapConfig extends AbstractBootstrapConfig<ServerB
 
     ServerBootstrapConfig(ServerBootstrap bootstrap) {
         super(bootstrap);
+    }
+
+    /**
+     * Returns the configured {@link ServerChannelFactory} or {@code null} if non is configured yet.
+     */
+    public ServerChannelFactory<? extends ServerChannel> channelFactory() {
+        return bootstrap.channelFactory();
     }
 
     /**
@@ -93,6 +103,14 @@ public final class ServerBootstrapConfig extends AbstractBootstrapConfig<ServerB
             buf.append(childHandler);
             buf.append(", ");
         }
+
+        ServerChannelFactory<? extends ServerChannel> factory = channelFactory();
+        if (factory != null) {
+            buf.append("channelFactory: ")
+                    .append(factory)
+                    .append(", ");
+        }
+
         if (buf.charAt(buf.length() - 1) == '(') {
             buf.append(')');
         } else {

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -21,6 +21,7 @@ import io.netty.util.DefaultAttributeMap;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -35,6 +36,8 @@ import java.nio.channels.NotYetConnectedException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * A skeletal {@link Channel} implementation.
  */
@@ -47,10 +50,10 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
     private final Unsafe unsafe;
     private final DefaultChannelPipeline pipeline;
     private final CloseFuture closeFuture = new CloseFuture(this);
+    private final EventLoop eventLoop;
 
     private volatile SocketAddress localAddress;
     private volatile SocketAddress remoteAddress;
-    private volatile EventLoop eventLoop;
     private volatile boolean registered;
     private boolean closeInitiated;
     private Throwable initialCloseCause;
@@ -65,11 +68,8 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
      * @param parent
      *        the parent of this channel. {@code null} if there's no parent.
      */
-    protected AbstractChannel(Channel parent) {
-        this.parent = parent;
-        id = newId();
-        unsafe = newUnsafe();
-        pipeline = newChannelPipeline();
+    protected AbstractChannel(EventLoop eventLoop, Class<? extends IoHandle> handleType, Channel parent) {
+        this(eventLoop, handleType, parent, null);
     }
 
     /**
@@ -78,11 +78,32 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
      * @param parent
      *        the parent of this channel. {@code null} if there's no parent.
      */
-    protected AbstractChannel(Channel parent, ChannelId id) {
+    protected AbstractChannel(EventLoop eventLoop, Class<? extends IoHandle> handleType, Channel parent, ChannelId id) {
         this.parent = parent;
-        this.id = id;
+        this.eventLoop = validateEventLoopGroup(eventLoop, "eventLoop", handleType);
+        this.id = id == null ? DefaultChannelId.newInstance() : id;
         unsafe = newUnsafe();
         pipeline = newChannelPipeline();
+    }
+
+    /**
+     * Validate that the {@link EventLoopGroup} supports the given {@link Class channel type}.
+     * If validation fails this will throw a runtime exception.
+     *
+     * @param group         the group to check against
+     * @param name          the name of the param that is used when throwing an exception.
+     * @param handleType   the {@link Channel} type.
+     * @return              the group itself
+     * @param <T>           the concreate type of the {@link EventLoopGroup}.
+     */
+    protected static <T extends EventLoopGroup> T validateEventLoopGroup(
+            T group, String name, Class<? extends IoHandle> handleType) {
+        requireNonNull(group, name);
+        if (handleType != null && !group.isCompatible(handleType)) {
+            throw new IllegalArgumentException(group + " does not support IoHandle of type " +
+                    StringUtil.simpleClassName(handleType));
+        }
+        return group;
     }
 
     protected final int maxMessagesPerWrite() {
@@ -100,14 +121,6 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
     @Override
     public final ChannelId id() {
         return id;
-    }
-
-    /**
-     * Returns a new {@link DefaultChannelId} instance. Subclasses may override this method to assign custom
-     * {@link ChannelId}s to {@link Channel}s that use the {@link AbstractChannel#AbstractChannel(Channel)} constructor.
-     */
-    protected ChannelId newId() {
-        return DefaultChannelId.newInstance();
     }
 
     /**
@@ -315,19 +328,11 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         }
 
         @Override
-        public final void register(EventLoop eventLoop, final ChannelPromise promise) {
-            ObjectUtil.checkNotNull(eventLoop, "eventLoop");
+        public final void register(final ChannelPromise promise) {
             if (isRegistered()) {
                 promise.setFailure(new IllegalStateException("registered to an event loop already"));
                 return;
             }
-            if (!isCompatible(eventLoop)) {
-                promise.setFailure(
-                        new IllegalStateException("incompatible event loop type: " + eventLoop.getClass().getName()));
-                return;
-            }
-
-            AbstractChannel.this.eventLoop = eventLoop;
 
             // Clear any cached executors from prior event loop registrations.
             AbstractChannelHandlerContext context = pipeline.tail;
@@ -912,11 +917,6 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             return null;
         }
     }
-
-    /**
-     * Return {@code true} if the given {@link EventLoop} is compatible with this instance.
-     */
-    protected abstract boolean isCompatible(EventLoop loop);
 
     /**
      * Returns the {@link SocketAddress} which is bound locally.

--- a/transport/src/main/java/io/netty/channel/AbstractServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractServerChannel.java
@@ -31,11 +31,20 @@ import java.net.SocketAddress;
 public abstract class AbstractServerChannel extends AbstractChannel implements ServerChannel {
     private static final ChannelMetadata METADATA = new ChannelMetadata(false, 16);
 
+    private final EventLoopGroup childEventLoopGroup;
+
     /**
      * Creates a new instance.
      */
-    protected AbstractServerChannel() {
-        super(null);
+    protected AbstractServerChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup,
+                                    Class<? extends IoHandle> handleType) {
+        super(eventLoop, handleType, null);
+        this.childEventLoopGroup = validateEventLoopGroup(childEventLoopGroup, "childEventLoopGroup", handleType);
+    }
+
+    @Override
+    public EventLoopGroup childEventExecutorGroup() {
+        return childEventLoopGroup;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/Channel.java
+++ b/transport/src/main/java/io/netty/channel/Channel.java
@@ -354,15 +354,15 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparabl
     }
 
     // These are just added for now and will be removed in the followup PR.
-    default ChannelFuture register(EventLoop loop) {
-        DefaultChannelPromise promise = new DefaultChannelPromise(this, loop);
-        register(loop, promise);
+    default ChannelFuture register() {
+        DefaultChannelPromise promise = new DefaultChannelPromise(this, executor());
+        register(promise);
         return promise;
     }
 
     // These are just added for now and will be removed in the followup PR.
-    default ChannelFuture register(EventLoop loop, ChannelPromise promise) {
-        unsafe().register(loop, promise);
+    default ChannelFuture register(ChannelPromise promise) {
+        unsafe().register(promise);
         return promise;
     }
 
@@ -374,7 +374,7 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparabl
      *   <li>{@link #localAddress()}</li>
      *   <li>{@link #remoteAddress()}</li>
      *   <li>{@link #closeForcibly()}</li>
-     *   <li>{@link #register(EventLoop, ChannelPromise)}</li>
+     *   <li>{@link #register(ChannelPromise)}</li>
      *   <li>{@link #deregister(ChannelPromise)}</li>
      * </ul>
      */
@@ -400,9 +400,9 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparabl
 
         /**
          * Register the {@link Channel} of the {@link ChannelPromise} and notify
-         * the {@link ChannelFuture} once the registration was complete.
+         * the {@link ChannelPromise} once the registration was complete.
          */
-        void register(EventLoop eventLoop, ChannelPromise promise);
+        void register(ChannelPromise promise);
 
         /**
          * Bind the {@link SocketAddress} to the {@link Channel} of the {@link ChannelPromise} and notify

--- a/transport/src/main/java/io/netty/channel/ChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/ChannelPipeline.java
@@ -16,7 +16,6 @@
 package io.netty.channel;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.util.concurrent.EventExecutorGroup;
 
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;

--- a/transport/src/main/java/io/netty/channel/ReflectiveServerChannelFactory.java
+++ b/transport/src/main/java/io/netty/channel/ReflectiveServerChannelFactory.java
@@ -24,14 +24,14 @@ import java.lang.reflect.Constructor;
 /**
  * A {@link ChannelFactory} that instantiates a new {@link Channel} by invoking its default constructor reflectively.
  */
-public class ReflectiveChannelFactory<T extends Channel> implements ChannelFactory<T> {
+public class ReflectiveServerChannelFactory<T extends ServerChannel> implements ServerChannelFactory<T> {
 
     private final Constructor<? extends T> constructor;
 
-    public ReflectiveChannelFactory(Class<? extends T> clazz) {
+    public ReflectiveServerChannelFactory(Class<? extends T> clazz) {
         ObjectUtil.checkNotNull(clazz, "clazz");
         try {
-            this.constructor = clazz.getConstructor(EventLoop.class);
+            this.constructor = clazz.getConstructor(EventLoop.class, EventLoopGroup.class);
         } catch (NoSuchMethodException e) {
             throw new IllegalArgumentException("Class " + StringUtil.simpleClassName(clazz) +
                     " does not have a public non-arg constructor", e);
@@ -39,17 +39,18 @@ public class ReflectiveChannelFactory<T extends Channel> implements ChannelFacto
     }
 
     @Override
-    public T newChannel(EventLoop eventLoop) {
+    public T newChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup) {
         try {
-            return constructor.newInstance(eventLoop);
+            return constructor.newInstance(eventLoop, childEventLoopGroup);
         } catch (Throwable t) {
-            throw new ChannelException("Unable to create Channel from class " + constructor.getDeclaringClass(), t);
+            throw new ChannelException(
+                    "Unable to create ServerChannel from class " + constructor.getDeclaringClass(), t);
         }
     }
 
     @Override
     public String toString() {
-        return StringUtil.simpleClassName(ReflectiveChannelFactory.class) +
+        return StringUtil.simpleClassName(ReflectiveServerChannelFactory.class) +
                 '(' + StringUtil.simpleClassName(constructor.getDeclaringClass()) + ".class)";
     }
 }

--- a/transport/src/main/java/io/netty/channel/ServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/ServerChannel.java
@@ -23,5 +23,10 @@ import io.netty.channel.socket.ServerSocketChannel;
  * a good example.
  */
 public interface ServerChannel extends Channel {
-    // This is a tag interface.
+    /**
+     * Returns the {@link EventLoopGroup} that is used for the child {@link Channel}s.
+     *
+     * @return  the used child group.
+     */
+    EventLoopGroup childEventExecutorGroup();
 }

--- a/transport/src/main/java/io/netty/channel/ServerChannelFactory.java
+++ b/transport/src/main/java/io/netty/channel/ServerChannelFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Netty Project
+ * Copyright 2025 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -16,14 +16,15 @@
 package io.netty.channel;
 
 /**
- * Creates a new {@link Channel}.
+ * Creates a new {@link ServerChannel}.
  */
-public interface ChannelFactory<T extends Channel> {
+public interface ServerChannelFactory<T extends ServerChannel> {
     /**
      * Creates a new channel.
      *
-     * @param eventLoop             the {@link EventLoop} to use for the {@link Channel}
-     * @return                      the {@link Channel}.
+     * @param eventLoop             the {@link EventLoop} to use for the {@link ServerChannel}
+     * @param childEventLoopGroup   the {@link EventLoopGroup} that is used for the child {@link Channel}s.
+     * @return                      the {@link ServerChannel}.
      */
-    T newChannel(EventLoop eventLoop);
+    T newChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup);
 }

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
@@ -65,7 +65,6 @@ public class EmbeddedChannel extends AbstractChannel {
     private static final ChannelMetadata METADATA_NO_DISCONNECT = new ChannelMetadata(false);
     private static final ChannelMetadata METADATA_DISCONNECT = new ChannelMetadata(true);
 
-    private final EmbeddedEventLoop loop;
     private final ChannelFutureListener recordExceptionListener = new ChannelFutureListener() {
         @Override
         public void operationComplete(ChannelFuture future) throws Exception {
@@ -216,8 +215,8 @@ public class EmbeddedChannel extends AbstractChannel {
      * @param builder The builder
      */
     protected EmbeddedChannel(Builder builder) {
-        super(builder.parent, builder.channelId);
-        loop = new EmbeddedEventLoop(builder.ticker == null ? new EmbeddedEventLoop.FreezableTicker() : builder.ticker);
+        super(new EmbeddedEventLoop(builder.ticker == null ? new EmbeddedEventLoop.FreezableTicker() : builder.ticker),
+                EmbeddedUnsafe.class, builder.parent, builder.channelId);
         metadata = metadata(builder.hasDisconnect);
         config = builder.config == null ? new DefaultChannelConfig(this) : builder.config;
         if (builder.handler == null) {
@@ -261,15 +260,14 @@ public class EmbeddedChannel extends AbstractChannel {
     /**
      * Register this {@code Channel} on its {@link EventLoop}.
      */
-    public void register() throws Exception {
+    public void registerNow() throws Exception {
         register0();
     }
 
     private void register0() {
         ChannelPromise promise = newPromise();
-        unsafe().register(embeddedEventLoop(), promise);
+        unsafe().register(promise);
         assert promise.isDone();
-
         Throwable cause = promise.cause();
         if (cause != null) {
             PlatformDependent.throwException(cause);
@@ -972,11 +970,7 @@ public class EmbeddedChannel extends AbstractChannel {
     }
 
     private EmbeddedEventLoop embeddedEventLoop() {
-        if (isRegistered()) {
-            return (EmbeddedEventLoop) super.executor();
-        }
-
-        return loop;
+        return (EmbeddedEventLoop) super.executor();
     }
 
     /**
@@ -986,11 +980,6 @@ public class EmbeddedChannel extends AbstractChannel {
         if (!checkOpen(true)) {
             checkException();
         }
-    }
-
-    @Override
-    protected boolean isCompatible(EventLoop loop) {
-        return loop instanceof EmbeddedEventLoop;
     }
 
     @Override
@@ -1214,10 +1203,10 @@ public class EmbeddedChannel extends AbstractChannel {
             }
 
             @Override
-            public void register(EventLoop eventLoop, ChannelPromise promise) {
+            public void register(ChannelPromise promise) {
                 executingStackCnt++;
                 try {
-                    EmbeddedUnsafe.this.register(eventLoop, promise);
+                    EmbeddedUnsafe.this.register(promise);
                 } finally {
                     executingStackCnt--;
                     maybeRunPendingTasks();

--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -90,13 +90,18 @@ public class LocalChannel extends AbstractChannel {
     private volatile boolean writeInProgress;
     private volatile Future<?> finishReadFuture;
 
-    public LocalChannel() {
-        super(null);
+    /**
+     * Create a new instance.
+     *
+     * @param eventLoop             the {@link EventLoop} to use for the {@link LocalChannel}
+     */
+    public LocalChannel(EventLoop eventLoop) {
+        super(eventLoop, LocalIoHandle.class, null);
         config().setAllocator(new PreferHeapByteBufAllocator(config.getAllocator()));
     }
 
-    protected LocalChannel(LocalServerChannel parent, LocalChannel peer) {
-        super(parent);
+    protected LocalChannel(EventLoop eventLoop, LocalServerChannel parent, LocalChannel peer) {
+        super(eventLoop, LocalIoHandle.class, parent);
         config().setAllocator(new PreferHeapByteBufAllocator(config.getAllocator()));
         this.peer = peer;
         localAddress = parent.localAddress();
@@ -143,12 +148,6 @@ public class LocalChannel extends AbstractChannel {
         return new LocalUnsafe();
     }
 
-    @Override
-    protected boolean isCompatible(EventLoop loop) {
-        return loop.isCompatible(LocalUnsafe.class);
-    }
-
-    @Override
     protected SocketAddress localAddress0() {
         return localAddress;
     }

--- a/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
@@ -16,11 +16,13 @@
 package io.netty.channel.local;
 
 import io.netty.channel.AbstractServerChannel;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
 import io.netty.channel.IoEvent;
 import io.netty.channel.IoRegistration;
 import io.netty.channel.PreferHeapByteBufAllocator;
@@ -54,7 +56,14 @@ public class LocalServerChannel extends AbstractServerChannel {
     private volatile LocalAddress localAddress;
     private volatile boolean acceptInProgress;
 
-    public LocalServerChannel() {
+    /**
+     * Create a new instance.
+     *
+     * @param eventLoop             the {@link EventLoop} to use for the {@link ServerChannel}
+     * @param childEventLoopGroup   the {@link EventLoopGroup} that is used for the child {@link Channel}s.
+     */
+    public LocalServerChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup) {
+        super(eventLoop, childEventLoopGroup, LocalIoHandle.class);
         config().setAllocator(new PreferHeapByteBufAllocator(config.getAllocator()));
     }
 
@@ -81,11 +90,6 @@ public class LocalServerChannel extends AbstractServerChannel {
     @Override
     public boolean isActive() {
         return state == 1;
-    }
-
-    @Override
-    protected boolean isCompatible(EventLoop loop) {
-        return loop.isCompatible(LocalServerUnsafe.class);
     }
 
     @Override
@@ -184,7 +188,7 @@ public class LocalServerChannel extends AbstractServerChannel {
      * to create custom instances of {@link LocalChannel}s.
      */
     protected LocalChannel newLocalChannel(LocalChannel peer) {
-        return new LocalChannel(this, peer);
+        return new LocalChannel(childEventExecutorGroup().next(), this, peer);
     }
 
     private void serve0(final LocalChannel child) {

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
@@ -23,6 +23,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoop;
 import io.netty.channel.FileRegion;
 import io.netty.channel.IoRegistration;
 import io.netty.channel.RecvByteBufAllocator;
@@ -62,11 +63,12 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
     /**
      * Create a new instance
      *
+     * @param eventLoop         the {@link EventLoop} to use for the {@link Channel}
      * @param parent            the parent {@link Channel} by which this instance was created. May be {@code null}
      * @param ch                the underlying {@link SelectableChannel} on which it operates
      */
-    protected AbstractNioByteChannel(Channel parent, SelectableChannel ch) {
-        super(parent, ch, SelectionKey.OP_READ);
+    protected AbstractNioByteChannel(EventLoop eventLoop, Channel parent, SelectableChannel ch) {
+        super(eventLoop, parent, ch, SelectionKey.OP_READ);
     }
 
     /**

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
@@ -76,16 +76,17 @@ public abstract class AbstractNioChannel extends AbstractChannel {
     /**
      * Create a new instance
      *
+     * @param eventLoop         the {@link EventLoop} to use for the {@link Channel}
      * @param parent            the parent {@link Channel} by which this instance was created. May be {@code null}
      * @param ch                the underlying {@link SelectableChannel} on which it operates
      * @param readOps           the ops to set to receive data from the {@link SelectableChannel}
      */
-    protected AbstractNioChannel(Channel parent, SelectableChannel ch, int readOps) {
-        this(parent, ch, NioIoOps.valueOf(readOps));
+    protected AbstractNioChannel(EventLoop eventLoop, Channel parent, SelectableChannel ch, int readOps) {
+        this(eventLoop, parent, ch, NioIoOps.valueOf(readOps));
     }
 
-    protected AbstractNioChannel(Channel parent, SelectableChannel ch, NioIoOps readOps) {
-        super(parent);
+    protected AbstractNioChannel(EventLoop eventLoop, Channel parent, SelectableChannel ch, NioIoOps readOps) {
+        super(eventLoop, NioIoHandle.class, parent);
         this.ch = ch;
         this.readInterestOp = ObjectUtil.checkNotNull(readOps, "readOps").value;
         this.readOps = readOps;
@@ -446,11 +447,6 @@ public abstract class AbstractNioChannel extends AbstractChannel {
                 close(newPromise());
             }
         }
-    }
-
-    @Override
-    protected boolean isCompatible(EventLoop loop) {
-        return loop.isCompatible(AbstractNioUnsafe.class);
     }
 
     @SuppressWarnings("unchecked")

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioMessageChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioMessageChannel.java
@@ -19,6 +19,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoop;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.ServerChannel;
 
@@ -34,15 +35,14 @@ import java.util.List;
 public abstract class AbstractNioMessageChannel extends AbstractNioChannel {
     boolean inputShutdown;
 
-    /**
-     * @see AbstractNioChannel#AbstractNioChannel(Channel, SelectableChannel, int)
-     */
-    protected AbstractNioMessageChannel(Channel parent, SelectableChannel ch, int readInterestOp) {
-        super(parent, ch, readInterestOp);
+    protected AbstractNioMessageChannel(EventLoop eventLoop, Channel parent,
+                                        SelectableChannel ch, int readInterestOp) {
+        super(eventLoop, parent, ch, readInterestOp);
     }
 
-    protected AbstractNioMessageChannel(Channel parent, SelectableChannel ch, NioIoOps readOps) {
-        super(parent, ch, readOps);
+    protected AbstractNioMessageChannel(EventLoop eventLoop, Channel parent,
+                                        SelectableChannel ch, NioIoOps readOps) {
+        super(eventLoop, parent, ch, readOps);
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
@@ -27,6 +27,7 @@ import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultAddressedEnvelope;
 import io.netty.channel.DefaultChannelConfig;
+import io.netty.channel.EventLoop;
 import io.netty.channel.FixedRecvByteBufAllocator;
 import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
@@ -126,24 +127,24 @@ public final class NioDatagramChannel
     /**
      * Create a new instance which will use the Operation Systems default {@link SocketProtocolFamily}.
      */
-    public NioDatagramChannel() {
-        this(newSocket(DEFAULT_SELECTOR_PROVIDER));
+    public NioDatagramChannel(EventLoop eventLoop) {
+        this(eventLoop, newSocket(DEFAULT_SELECTOR_PROVIDER));
     }
 
     /**
      * Create a new instance using the given {@link SelectorProvider}
      * which will use the Operation Systems default {@link SocketProtocolFamily}.
      */
-    public NioDatagramChannel(SelectorProvider provider) {
-        this(newSocket(provider));
+    public NioDatagramChannel(EventLoop eventLoop, SelectorProvider provider) {
+        this(eventLoop, newSocket(provider));
     }
 
     /**
      * Create a new instance using the given {@link SocketProtocolFamily}. If {@code null} is used it will depend
      * on the Operation Systems default which will be chosen.
      */
-    public NioDatagramChannel(SocketProtocolFamily protocolFamily) {
-        this(newSocket(DEFAULT_SELECTOR_PROVIDER, protocolFamily));
+    public NioDatagramChannel(EventLoop eventLoop, SocketProtocolFamily protocolFamily) {
+        this(eventLoop, newSocket(DEFAULT_SELECTOR_PROVIDER, protocolFamily));
     }
 
     /**
@@ -151,16 +152,19 @@ public final class NioDatagramChannel
      * If {@link SocketProtocolFamily} is {@code null} it will depend on the Operation Systems default
      * which will be chosen.
      */
-    public NioDatagramChannel(SelectorProvider provider, SocketProtocolFamily protocolFamily) {
-        this(newSocket(provider, protocolFamily));
+    public NioDatagramChannel(EventLoop eventLoop, SelectorProvider provider, SocketProtocolFamily protocolFamily) {
+        this(eventLoop, newSocket(provider, protocolFamily));
     }
 
     /**
      * Create a new instance from the given {@link DatagramChannel}.
+     *
+     * @param eventLoop     the {@link EventLoop} to use for the {@link Channel}
+     * @param channel       the underlying {@link DatagramChannel}.
      */
-    public NioDatagramChannel(DatagramChannel socket) {
-        super(null, socket, SelectionKey.OP_READ);
-        config = new NioDatagramChannelConfig(this, socket);
+    public NioDatagramChannel(EventLoop eventLoop, DatagramChannel channel) {
+        super(eventLoop, null, channel, SelectionKey.OP_READ);
+        config = new NioDatagramChannelConfig(this, channel);
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioServerSocketChannel.java
@@ -21,11 +21,14 @@ import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.DefaultChannelConfig;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.ServerChannelRecvByteBufAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.nio.AbstractNioMessageChannel;
+import io.netty.channel.nio.NioIoHandle;
 import io.netty.channel.socket.ServerSocketChannelConfig;
 import io.netty.channel.socket.SocketProtocolFamily;
 import io.netty.util.NetUtil;
@@ -76,33 +79,39 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel
     }
 
     private final ServerSocketChannelConfig config;
+    private final EventLoopGroup childEventLoopGroup;
 
     /**
      * Create a new instance
      */
-    public NioServerSocketChannel() {
-        this(DEFAULT_SELECTOR_PROVIDER);
+    public NioServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup) {
+        this(eventLoop, childEventLoopGroup, DEFAULT_SELECTOR_PROVIDER);
     }
 
     /**
      * Create a new instance using the given {@link SelectorProvider}.
      */
-    public NioServerSocketChannel(SelectorProvider provider) {
-        this(provider, (SocketProtocolFamily) null);
+    public NioServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup,
+                                  SelectorProvider provider) {
+        this(eventLoop, childEventLoopGroup, provider, (SocketProtocolFamily) null);
     }
 
     /**
      * Create a new instance using the given {@link SelectorProvider} and protocol family (supported only since JDK 15).
      */
-    public NioServerSocketChannel(SelectorProvider provider, SocketProtocolFamily family) {
-        this(newChannel(provider, family));
+    public NioServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup,
+                                  SelectorProvider provider, SocketProtocolFamily family) {
+        this(eventLoop, childEventLoopGroup, newChannel(provider, family));
     }
 
     /**
      * Create a new instance using the given {@link ServerSocketChannel}.
      */
-    public NioServerSocketChannel(ServerSocketChannel channel) {
-        super(null, channel, SelectionKey.OP_ACCEPT);
+    public NioServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup,
+                                  ServerSocketChannel channel) {
+        super(eventLoop, null, channel, SelectionKey.OP_ACCEPT);
+        this.childEventLoopGroup = validateEventLoopGroup(
+                childEventLoopGroup, "childEventLoopGroup", NioIoHandle.class);
         config = new NioServerSocketChannelConfig(this, channel);
     }
 
@@ -112,8 +121,14 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel
      *
      * @param family the {@link SocketProtocolFamily} to use or {@code null} if the default should be used.
      */
-    public NioServerSocketChannel(SocketProtocolFamily family) {
-        this(DEFAULT_SELECTOR_PROVIDER, family);
+    public NioServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup,
+                                  SocketProtocolFamily family) {
+        this(eventLoop, childEventLoopGroup, DEFAULT_SELECTOR_PROVIDER, family);
+    }
+
+    @Override
+    public EventLoopGroup childEventExecutorGroup() {
+        return childEventLoopGroup;
     }
 
     @Override
@@ -175,7 +190,7 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel
 
         try {
             if (ch != null) {
-                buf.add(new NioSocketChannel(this, ch));
+                buf.add(new NioSocketChannel(childEventLoopGroup.next(), this, ch));
                 return 1;
             }
         } catch (Throwable t) {

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
@@ -85,50 +85,54 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
 
     /**
      * Create a new instance
+     *
+     * @param eventLoop the {@link EventLoop} to use for the {@link Channel}
      */
-    public NioSocketChannel() {
-        this(DEFAULT_SELECTOR_PROVIDER);
+    public NioSocketChannel(EventLoop eventLoop) {
+        this(eventLoop, DEFAULT_SELECTOR_PROVIDER);
     }
 
     /**
      * Create a new instance using the given {@link SelectorProvider}.
      */
-    public NioSocketChannel(SelectorProvider provider) {
-        this(provider, (SocketProtocolFamily) null);
+    public NioSocketChannel(EventLoop eventLoop, SelectorProvider provider) {
+        this(eventLoop, provider, (SocketProtocolFamily) null);
     }
 
     /**
      * Create a new instance using the given {@link SelectorProvider} and protocol family (supported only since JDK 15).
      */
-    public NioSocketChannel(SelectorProvider provider, SocketProtocolFamily family) {
-        this(newChannel(provider, family));
+    public NioSocketChannel(EventLoop eventLoop, SelectorProvider provider, SocketProtocolFamily family) {
+        this(eventLoop, newChannel(provider, family));
     }
 
     /**
      * Create a new instance using the given {@link SocketChannel}.
      */
-    public NioSocketChannel(SocketChannel socket) {
-        this(null, socket);
+    public NioSocketChannel(EventLoop eventLoop, SocketChannel socket) {
+        this(eventLoop, null, socket);
     }
 
     /**
      * Create a new instance using the given {@link SocketProtocolFamily}. If {@code null} is used it will depend
      * on the Operation Systems default which will be chosen.
      *
-     * @param family the {@link SocketProtocolFamily} to use or {@code null} if the default should be used.
+     * @param eventLoop the {@link EventLoop} to use for the {@link Channel}
+     * @param family    the {@link SocketProtocolFamily} to use or {@code null} if the default should be used.
      */
-    public NioSocketChannel(SocketProtocolFamily family) {
-        this(newChannel(DEFAULT_SELECTOR_PROVIDER, family));
+    public NioSocketChannel(EventLoop eventLoop, SocketProtocolFamily family) {
+        this(eventLoop, newChannel(DEFAULT_SELECTOR_PROVIDER, family));
     }
     /**
      * Create a new instance
      *
+     * @param eventLoop the {@link EventLoop} to use for the {@link Channel}
      * @param parent    the {@link Channel} which created this instance or {@code null} if it was created by the user
-     * @param socket    the {@link SocketChannel} which will be used
+     * @param channel   the {@link SocketChannel} which will be used
      */
-    public NioSocketChannel(Channel parent, SocketChannel socket) {
-        super(parent, socket);
-        config = new NioSocketChannelConfig(this, socket);
+    protected NioSocketChannel(EventLoop eventLoop, Channel parent, SocketChannel channel) {
+        super(eventLoop, parent, channel);
+        config = new NioSocketChannelConfig(this, channel);
     }
 
     @Override

--- a/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
@@ -26,6 +26,7 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.DefaultChannelConfig;
+import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.IoHandle;
 import io.netty.channel.IoHandler;
@@ -329,7 +330,7 @@ public class BootstrapTest {
                 .group(groupA)
                 .channelFactory(new ChannelFactory<Channel>() {
             @Override
-            public Channel newChannel() {
+            public Channel newChannel(EventLoop eventLoop) {
                 throw exception;
             }
         });
@@ -367,8 +368,8 @@ public class BootstrapTest {
                 .group(groupA)
                 .channelFactory(new ChannelFactory<Channel>() {
                     @Override
-                    public Channel newChannel() {
-                        return new LocalChannel() {
+                    public Channel newChannel(EventLoop eventLoop) {
+                        return new LocalChannel(eventLoop) {
                             private ChannelConfigValidator config;
                             @Override
                             public synchronized ChannelConfig config() {

--- a/transport/src/test/java/io/netty/channel/AbstractChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/AbstractChannelTest.java
@@ -43,11 +43,11 @@ public class AbstractChannelTest {
         // This allows us to have a single-threaded test
         when(eventLoop.inEventLoop()).thenReturn(true);
 
-        TestChannel channel = new TestChannel();
+        TestChannel channel = new TestChannel(eventLoop);
         ChannelInboundHandler handler = mock(ChannelInboundHandler.class);
         channel.pipeline().addLast(handler);
 
-        registerChannel(eventLoop, channel);
+        registerChannel(channel);
 
         verify(handler).handlerAdded(any(ChannelHandlerContext.class));
         verify(handler).channelRegistered(any(ChannelHandlerContext.class));
@@ -68,15 +68,15 @@ public class AbstractChannelTest {
             }
         }).when(eventLoop).execute(any(Runnable.class));
 
-        final TestChannel channel = new TestChannel();
+        final TestChannel channel = new TestChannel(eventLoop);
         ChannelInboundHandler handler = mock(ChannelInboundHandler.class);
 
         channel.pipeline().addLast(handler);
 
-        registerChannel(eventLoop, channel);
+        registerChannel(channel);
         channel.unsafe().deregister(new DefaultChannelPromise(channel));
 
-        registerChannel(eventLoop, channel);
+        registerChannel(channel);
 
         verify(handler).handlerAdded(any(ChannelHandlerContext.class));
 
@@ -88,7 +88,8 @@ public class AbstractChannelTest {
 
     @Test
     public void ensureDefaultChannelId() {
-        TestChannel channel = new TestChannel();
+        final EventLoop eventLoop = mock(EventLoop.class);
+        TestChannel channel = new TestChannel(eventLoop);
         final ChannelId channelId = channel.id();
         assertTrue(channelId instanceof DefaultChannelId);
     }
@@ -114,44 +115,6 @@ public class AbstractChannelTest {
 
     @Test
     public void testClosedChannelExceptionCarryIOException() throws Exception {
-        final IOException ioException = new IOException();
-        final Channel channel = new TestChannel() {
-            private boolean open = true;
-            private boolean active;
-
-            @Override
-            protected AbstractUnsafe newUnsafe() {
-                return new AbstractUnsafe() {
-                    @Override
-                    public void connect(
-                            SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
-                        active = true;
-                        promise.setSuccess();
-                    }
-                };
-            }
-
-            @Override
-            protected void doClose()  {
-                active = false;
-                open = false;
-            }
-
-            @Override
-            protected void doWrite(ChannelOutboundBuffer in) throws Exception {
-                throw ioException;
-            }
-
-            @Override
-            public boolean isOpen() {
-                return open;
-            }
-
-            @Override
-            public boolean isActive() {
-                return active;
-            }
-        };
 
         EventLoop loop = new SingleThreadEventLoop(null, Executors.defaultThreadFactory(), true) {
 
@@ -205,8 +168,47 @@ public class AbstractChannelTest {
                 return true;
             }
         };
+        final IOException ioException = new IOException();
+        final Channel channel = new TestChannel(loop) {
+            private boolean open = true;
+            private boolean active;
+
+            @Override
+            protected AbstractUnsafe newUnsafe() {
+                return new AbstractUnsafe() {
+                    @Override
+                    public void connect(
+                            SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+                        active = true;
+                        promise.setSuccess();
+                    }
+                };
+            }
+
+            @Override
+            protected void doClose()  {
+                active = false;
+                open = false;
+            }
+
+            @Override
+            protected void doWrite(ChannelOutboundBuffer in) throws Exception {
+                throw ioException;
+            }
+
+            @Override
+            public boolean isOpen() {
+                return open;
+            }
+
+            @Override
+            public boolean isActive() {
+                return active;
+            }
+        };
+
         try {
-            registerChannel(loop, channel);
+            registerChannel(channel);
             channel.connect(new InetSocketAddress(NetUtil.LOCALHOST, 8888)).sync();
             assertSame(ioException, channel.writeAndFlush("").await().cause());
 
@@ -226,9 +228,9 @@ public class AbstractChannelTest {
         assertSame(expected, cause.getCause());
     }
 
-    private static void registerChannel(EventLoop eventLoop, Channel channel) throws Exception {
+    private static void registerChannel(Channel channel) throws Exception {
         DefaultChannelPromise future = new DefaultChannelPromise(channel);
-        channel.unsafe().register(eventLoop, future);
+        channel.unsafe().register(future);
         future.sync(); // Cause any exceptions to be thrown
     }
 
@@ -237,8 +239,8 @@ public class AbstractChannelTest {
 
         private final ChannelConfig config = new DefaultChannelConfig(this);
 
-        TestChannel() {
-            super(null);
+        TestChannel(EventLoop eventLoop) {
+            super(eventLoop, null, null);
         }
 
         @Override
@@ -269,11 +271,6 @@ public class AbstractChannelTest {
                     promise.setFailure(new UnsupportedOperationException());
                 }
             };
-        }
-
-        @Override
-        protected boolean isCompatible(EventLoop loop) {
-            return true;
         }
 
         @Override

--- a/transport/src/test/java/io/netty/channel/AbstractEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/AbstractEventLoopTest.java
@@ -15,165 +15,17 @@
  */
 package io.netty.channel;
 
-import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.socket.SocketChannel;
-import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
 
-import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public abstract class AbstractEventLoopTest {
-
-    /**
-     * Test for https://github.com/netty/netty/issues/14923
-     */
-    @ParameterizedTest
-    @EnumSource(DeregisterMethod.class)
-    void testReregisterOnChannelHandlerContext(DeregisterMethod method) throws Exception {
-        EventLoopGroup group = newEventLoopGroup();
-        AtomicReference<Throwable> throwable = new AtomicReference<>();
-        try {
-            ServerBootstrap b = new ServerBootstrap();
-            ReRegisterHandler reRegisterHandler = new ReRegisterHandler(group, method, throwable);
-            b.group(group)
-                    .channel(newChannel())
-                    .childHandler(new ChannelInitializer<SocketChannel>() {
-                        @Override
-                        public void initChannel(SocketChannel ch) {
-                            ChannelPipeline p = ch.pipeline();
-                            p.addLast("logging", new LoggingHandler());
-                            p.addLast(reRegisterHandler);
-                        }
-                    });
-
-            ChannelFuture f = b.bind(0).sync();
-
-            Channel client = new Bootstrap()
-                    .group(group)
-                    .channel(newSocketChannel())
-                    .handler(new ChannelInboundHandlerAdapter() {
-                        @Override
-                        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-                            ReferenceCountUtil.release(msg);
-                        }
-
-                        @Override
-                        public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
-                            super.channelReadComplete(ctx);
-                            ctx.close();
-                        }
-
-                        @Override
-                        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-                            throwable.set(cause);
-                            super.exceptionCaught(ctx, cause);
-                            ctx.close();
-                        }
-                    })
-                    .connect(f.channel().localAddress())
-                    .sync()
-                    .channel();
-            client.closeFuture().addListener(ignore -> f.channel().close());
-            client.writeAndFlush(Unpooled.copiedBuffer("hello", StandardCharsets.US_ASCII));
-
-            f.channel().closeFuture().sync();
-            Throwable caughtThrowable = throwable.get();
-            if (caughtThrowable != null) {
-                fail(caughtThrowable);
-            }
-        } finally {
-            group.shutdownGracefully();
-        }
-    }
-
-    enum DeregisterMethod implements Function<ChannelHandlerContext, ChannelFuture> {
-        CONTEXT {
-            @Override
-            public ChannelFuture apply(ChannelHandlerContext ctx) {
-                return ctx.deregister();
-            }
-        },
-        CONTEXT_PROMISE {
-            @Override
-            public ChannelFuture apply(ChannelHandlerContext ctx) {
-                return ctx.deregister(ctx.newPromise());
-            }
-        },
-        CHANNEL {
-            @Override
-            public ChannelFuture apply(ChannelHandlerContext ctx) {
-                return ctx.channel().deregister();
-            }
-        },
-        CHANNEL_PROMISE {
-            @Override
-            public ChannelFuture apply(ChannelHandlerContext ctx) {
-                return ctx.channel().deregister(ctx.channel().newPromise());
-            }
-        }
-    }
-
-    @ChannelHandler.Sharable
-    static class ReRegisterHandler extends ChannelInboundHandlerAdapter {
-
-        final EventLoopGroup eventLoopGroup;
-        private final DeregisterMethod method;
-        private final AtomicReference<Throwable> throwable;
-
-        ReRegisterHandler(EventLoopGroup eventLoopGroup,
-                                 DeregisterMethod method,
-                                 AtomicReference<Throwable> throwable) {
-            this.eventLoopGroup = eventLoopGroup;
-            this.method = method;
-            this.throwable = throwable;
-        }
-
-        @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-            super.exceptionCaught(ctx, cause);
-            throwable.set(cause);
-            ctx.close();
-        }
-
-        @Override
-        public void channelRead(ChannelHandlerContext outCtx, Object msg) throws Exception {
-            final EventLoop newLoop = anyNotEqual(outCtx.channel().executor());
-            ChannelFutureListener pipelieModifyingListener = register -> {
-                outCtx.pipeline().addLast(new ChannelInboundHandlerAdapter() {
-                    @Override
-                    public void channelRead(ChannelHandlerContext inCtx, Object inMsg) {
-                        outCtx.writeAndFlush(inMsg);
-                    }
-                });
-                outCtx.fireChannelRead(msg);
-            };
-            ChannelFutureListener reregisteringListener = deregister -> {
-                deregister.channel().pipeline().fireUserEventTriggered("Unregistered user event");
-                deregister.channel().register(newLoop).addListener(pipelieModifyingListener);
-            };
-            method.apply(outCtx).addListener(reregisteringListener);
-        }
-
-        private EventLoop anyNotEqual(EventLoop eventLoop) {
-            EventLoop next;
-            do {
-                next = eventLoopGroup.next();
-            } while (eventLoop == next);
-
-            return next;
-        }
-    }
 
     @Test
     @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)

--- a/transport/src/test/java/io/netty/channel/ChannelInitializerTest.java
+++ b/transport/src/test/java/io/netty/channel/ChannelInitializerTest.java
@@ -81,10 +81,10 @@ public class ChannelInitializerTest {
         final Exception exception = new Exception();
         final AtomicReference<Throwable> causeRef = new AtomicReference<Throwable>();
 
-        ChannelPipeline pipeline = new LocalChannel().pipeline();
+        ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
 
         if (registerFirst) {
-            pipeline.channel().register(group.next()).syncUninterruptibly();
+            pipeline.channel().register().syncUninterruptibly();
         }
         pipeline.addFirst(new ChannelInitializer<Channel>() {
             @Override
@@ -100,7 +100,7 @@ public class ChannelInitializerTest {
         });
 
         if (!registerFirst) {
-            pipeline.channel().register(group.next()).syncUninterruptibly();
+            pipeline.channel().register().syncUninterruptibly();
         }
         pipeline.channel().close().syncUninterruptibly();
         pipeline.channel().closeFuture().syncUninterruptibly();

--- a/transport/src/test/java/io/netty/channel/ChannelOutboundBufferTest.java
+++ b/transport/src/test/java/io/netty/channel/ChannelOutboundBufferTest.java
@@ -20,6 +20,7 @@ import io.netty.buffer.CompositeByteBuf;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
@@ -195,17 +196,12 @@ public class ChannelOutboundBufferTest {
         private final ChannelConfig config = new DefaultChannelConfig(this);
 
         TestChannel() {
-            super(null);
+            super(Mockito.mock(EventLoop.class), null, null);
         }
 
         @Override
         protected AbstractUnsafe newUnsafe() {
             return new TestUnsafe();
-        }
-
-        @Override
-        protected boolean isCompatible(EventLoop loop) {
-            return false;
         }
 
         @Override

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTailTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTailTest.java
@@ -49,15 +49,13 @@ public class DefaultChannelPipelineTailTest {
     @Test
     public void testOnUnhandledInboundChannelActive() throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
-        MyChannel myChannel = new MyChannel() {
-            @Override
-            protected void onUnhandledInboundChannelActive() {
-                latch.countDown();
-            }
-        };
-
         Bootstrap bootstrap = new Bootstrap()
-                .channelFactory(new MyChannelFactory(myChannel))
+                .channelFactory(e -> new MyChannel(e) {
+                    @Override
+                    protected void onUnhandledInboundChannelActive() {
+                        latch.countDown();
+                    }
+                })
                 .group(GROUP)
                 .handler(new ChannelInboundHandlerAdapter())
                 .remoteAddress(new InetSocketAddress(0));
@@ -75,15 +73,13 @@ public class DefaultChannelPipelineTailTest {
     @Test
     public void testOnUnhandledInboundChannelInactive() throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
-        MyChannel myChannel = new MyChannel() {
-            @Override
-            protected void onUnhandledInboundChannelInactive() {
-                latch.countDown();
-            }
-        };
-
         Bootstrap bootstrap = new Bootstrap()
-                .channelFactory(new MyChannelFactory(myChannel))
+                .channelFactory(e -> new MyChannel(e) {
+                    @Override
+                    protected void onUnhandledInboundChannelInactive() {
+                        latch.countDown();
+                    }
+                })
                 .group(GROUP)
                 .handler(new ChannelInboundHandlerAdapter())
                 .remoteAddress(new InetSocketAddress(0));
@@ -100,16 +96,14 @@ public class DefaultChannelPipelineTailTest {
     public void testOnUnhandledInboundException() throws Exception {
         final AtomicReference<Throwable> causeRef = new AtomicReference<Throwable>();
         final CountDownLatch latch = new CountDownLatch(1);
-        MyChannel myChannel = new MyChannel() {
-            @Override
-            protected void onUnhandledInboundException(Throwable cause) {
-                causeRef.set(cause);
-                latch.countDown();
-            }
-        };
-
         Bootstrap bootstrap = new Bootstrap()
-                .channelFactory(new MyChannelFactory(myChannel))
+                .channelFactory(e -> new MyChannel(e) {
+                    @Override
+                    protected void onUnhandledInboundException(Throwable cause) {
+                        causeRef.set(cause);
+                        latch.countDown();
+                    }
+                })
                 .group(GROUP)
                 .handler(new ChannelInboundHandlerAdapter())
                 .remoteAddress(new InetSocketAddress(0));
@@ -130,15 +124,13 @@ public class DefaultChannelPipelineTailTest {
     @Test
     public void testOnUnhandledInboundMessage() throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
-        MyChannel myChannel = new MyChannel() {
-            @Override
-            protected void onUnhandledInboundMessage(Object msg) {
-                latch.countDown();
-            }
-        };
-
         Bootstrap bootstrap = new Bootstrap()
-                .channelFactory(new MyChannelFactory(myChannel))
+                .channelFactory(e -> new MyChannel(e) {
+                    @Override
+                    protected void onUnhandledInboundMessage(Object msg) {
+                        latch.countDown();
+                    }
+                })
                 .group(GROUP)
                 .handler(new ChannelInboundHandlerAdapter())
                 .remoteAddress(new InetSocketAddress(0));
@@ -157,15 +149,13 @@ public class DefaultChannelPipelineTailTest {
     @Test
     public void testOnUnhandledInboundReadComplete() throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
-        MyChannel myChannel = new MyChannel() {
-            @Override
-            protected void onUnhandledInboundReadComplete() {
-                latch.countDown();
-            }
-        };
-
         Bootstrap bootstrap = new Bootstrap()
-                .channelFactory(new MyChannelFactory(myChannel))
+                .channelFactory(e -> new MyChannel(e) {
+                    @Override
+                    protected void onUnhandledInboundReadComplete() {
+                        latch.countDown();
+                    }
+                })
                 .group(GROUP)
                 .handler(new ChannelInboundHandlerAdapter())
                 .remoteAddress(new InetSocketAddress(0));
@@ -184,15 +174,13 @@ public class DefaultChannelPipelineTailTest {
     @Test
     public void testOnUnhandledInboundUserEventTriggered() throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
-        MyChannel myChannel = new MyChannel() {
-            @Override
-            protected void onUnhandledInboundUserEventTriggered(Object evt) {
-                latch.countDown();
-            }
-        };
-
         Bootstrap bootstrap = new Bootstrap()
-                .channelFactory(new MyChannelFactory(myChannel))
+                .channelFactory(e -> new MyChannel(e) {
+                    @Override
+                    protected void onUnhandledInboundUserEventTriggered(Object evt) {
+                        latch.countDown();
+                    }
+                })
                 .group(GROUP)
                 .handler(new ChannelInboundHandlerAdapter())
                 .remoteAddress(new InetSocketAddress(0));
@@ -211,15 +199,13 @@ public class DefaultChannelPipelineTailTest {
     @Test
     public void testOnUnhandledInboundWritabilityChanged() throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
-        MyChannel myChannel = new MyChannel() {
-            @Override
-            protected void onUnhandledInboundWritabilityChanged() {
-                latch.countDown();
-            }
-        };
-
         Bootstrap bootstrap = new Bootstrap()
-                .channelFactory(new MyChannelFactory(myChannel))
+                .channelFactory(e -> new MyChannel(e) {
+                    @Override
+                    protected void onUnhandledInboundWritabilityChanged() {
+                        latch.countDown();
+                    }
+                })
                 .group(GROUP)
                 .handler(new ChannelInboundHandlerAdapter())
                 .remoteAddress(new InetSocketAddress(0));
@@ -235,19 +221,6 @@ public class DefaultChannelPipelineTailTest {
         }
     }
 
-    private static class MyChannelFactory implements ChannelFactory<MyChannel> {
-        private final MyChannel channel;
-
-        MyChannelFactory(MyChannel channel) {
-            this.channel = channel;
-        }
-
-        @Override
-        public MyChannel newChannel() {
-            return channel;
-        }
-    }
-
     private abstract static class MyChannel extends AbstractChannel {
         private static final ChannelMetadata METADATA = new ChannelMetadata(false);
 
@@ -256,8 +229,8 @@ public class DefaultChannelPipelineTailTest {
         private boolean active;
         private boolean closed;
 
-        protected MyChannel() {
-            super(null);
+        protected MyChannel(EventLoop eventLoop) {
+            super(eventLoop, null, null);
         }
 
         @Override
@@ -288,11 +261,6 @@ public class DefaultChannelPipelineTailTest {
         @Override
         protected AbstractUnsafe newUnsafe() {
             return new MyUnsafe();
-        }
-
-        @Override
-        protected boolean isCompatible(EventLoop loop) {
-            return true;
         }
 
         @Override

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
@@ -169,7 +169,7 @@ public class DefaultChannelPipelineTest {
 
     @Test
     public void testRemoveChannelHandler() {
-        ChannelPipeline pipeline = new LocalChannel().pipeline();
+        ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
 
         ChannelHandler handler1 = newHandler();
         ChannelHandler handler2 = newHandler();
@@ -192,7 +192,7 @@ public class DefaultChannelPipelineTest {
 
     @Test
     public void testRemoveIfExists() {
-        DefaultChannelPipeline pipeline = new DefaultChannelPipeline(new LocalChannel());
+        DefaultChannelPipeline pipeline = new DefaultChannelPipeline(new LocalChannel(group.next()));
 
         ChannelHandler handler1 = newHandler();
         ChannelHandler handler2 = newHandler();
@@ -214,7 +214,7 @@ public class DefaultChannelPipelineTest {
 
     @Test
     public void testRemoveIfExistsDoesNotThrowException() {
-        DefaultChannelPipeline pipeline = new DefaultChannelPipeline(new LocalChannel());
+        DefaultChannelPipeline pipeline = new DefaultChannelPipeline(new LocalChannel(group.next()));
 
         ChannelHandler handler1 = newHandler();
         ChannelHandler handler2 = newHandler();
@@ -228,7 +228,7 @@ public class DefaultChannelPipelineTest {
 
     @Test
     public void testRemoveThrowNoSuchElementException() {
-        final DefaultChannelPipeline pipeline = new DefaultChannelPipeline(new LocalChannel());
+        final DefaultChannelPipeline pipeline = new DefaultChannelPipeline(new LocalChannel(group.next()));
 
         ChannelHandler handler1 = newHandler();
         pipeline.addLast("handler1", handler1);
@@ -243,7 +243,7 @@ public class DefaultChannelPipelineTest {
 
     @Test
     public void testReplaceChannelHandler() {
-        ChannelPipeline pipeline = new LocalChannel().pipeline();
+        ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
 
         ChannelHandler handler1 = newHandler();
         pipeline.addLast("handler1", handler1);
@@ -268,7 +268,7 @@ public class DefaultChannelPipelineTest {
 
     @Test
     public void testReplaceHandlerChecksDuplicateNames() {
-        final ChannelPipeline pipeline = new LocalChannel().pipeline();
+        final ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
 
         ChannelHandler handler1 = newHandler();
         ChannelHandler handler2 = newHandler();
@@ -286,7 +286,7 @@ public class DefaultChannelPipelineTest {
 
     @Test
     public void testReplaceNameWithGenerated() {
-        ChannelPipeline pipeline = new LocalChannel().pipeline();
+        ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
 
         ChannelHandler handler1 = newHandler();
         pipeline.addLast("handler1", handler1);
@@ -300,7 +300,7 @@ public class DefaultChannelPipelineTest {
 
     @Test
     public void testRenameChannelHandler() {
-        ChannelPipeline pipeline = new LocalChannel().pipeline();
+        ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
 
         ChannelHandler handler1 = newHandler();
         pipeline.addLast("handler1", handler1);
@@ -328,7 +328,7 @@ public class DefaultChannelPipelineTest {
 
     @Test
     public void testChannelHandlerContextNavigation() {
-        ChannelPipeline pipeline = new LocalChannel().pipeline();
+        ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
 
         final int HANDLER_ARRAY_LEN = 5;
         ChannelHandler[] firstHandlers = newHandlers(HANDLER_ARRAY_LEN);
@@ -345,9 +345,9 @@ public class DefaultChannelPipelineTest {
     public void testThrowInExceptionCaught() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicInteger counter = new AtomicInteger();
-        Channel channel = new LocalChannel();
+        Channel channel = new LocalChannel(group.next());
         try {
-            channel.register(group.next()).syncUninterruptibly();
+            channel.register().syncUninterruptibly();
             channel.pipeline().addLast(new ChannelInboundHandlerAdapter() {
                 class TestException extends Exception { }
 
@@ -384,9 +384,9 @@ public class DefaultChannelPipelineTest {
     public void testThrowInOtherHandlerAfterInvokedFromExceptionCaught() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicInteger counter = new AtomicInteger();
-        Channel channel = new LocalChannel();
+        Channel channel = new LocalChannel(group.next());
         try {
-            channel.register(group.next()).syncUninterruptibly();
+            channel.register().syncUninterruptibly();
             channel.pipeline().addLast(new ChannelInboundHandlerAdapter() {
                 @Override
                 public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
@@ -426,7 +426,7 @@ public class DefaultChannelPipelineTest {
     @Test
     public void testFireChannelRegistered() throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
-        ChannelPipeline pipeline = new LocalChannel().pipeline();
+        ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
         pipeline.addLast(new ChannelInitializer<Channel>() {
             @Override
             protected void initChannel(Channel ch) {
@@ -438,13 +438,13 @@ public class DefaultChannelPipelineTest {
                 });
             }
         });
-        pipeline.channel().register(group.next());
+        pipeline.channel().register();
         assertTrue(latch.await(2, TimeUnit.SECONDS));
     }
 
     @Test
     public void testPipelineOperation() {
-        ChannelPipeline pipeline = new LocalChannel().pipeline();
+        ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
 
         final int handlerNum = 5;
         ChannelHandler[] handlers1 = newHandlers(handlerNum);
@@ -472,7 +472,7 @@ public class DefaultChannelPipelineTest {
 
     @Test
     public void testChannelHandlerContextOrder() {
-        ChannelPipeline pipeline = new LocalChannel().pipeline();
+        ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
 
         pipeline.addFirst("1", newHandler());
         pipeline.addLast("10", newHandler());
@@ -675,8 +675,8 @@ public class DefaultChannelPipelineTest {
     // Tests for https://github.com/netty/netty/issues/2349
     @Test
     public void testCancelBind() {
-        ChannelPipeline pipeline = new LocalChannel().pipeline();
-        pipeline.channel().register(group.next());
+        ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
+        pipeline.channel().register();
 
         ChannelPromise promise = pipeline.channel().newPromise();
         assertTrue(promise.cancel(false));
@@ -686,8 +686,8 @@ public class DefaultChannelPipelineTest {
 
     @Test
     public void testCancelConnect() {
-        ChannelPipeline pipeline = new LocalChannel().pipeline();
-        pipeline.channel().register(group.next());
+        ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
+        pipeline.channel().register();
 
         ChannelPromise promise = pipeline.channel().newPromise();
         assertTrue(promise.cancel(false));
@@ -697,8 +697,8 @@ public class DefaultChannelPipelineTest {
 
     @Test
     public void testCancelDisconnect() {
-        ChannelPipeline pipeline = new LocalChannel().pipeline();
-        pipeline.channel().register(group.next());
+        ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
+        pipeline.channel().register();
 
         ChannelPromise promise = pipeline.channel().newPromise();
         assertTrue(promise.cancel(false));
@@ -708,8 +708,8 @@ public class DefaultChannelPipelineTest {
 
     @Test
     public void testCancelClose() {
-        ChannelPipeline pipeline = new LocalChannel().pipeline();
-        pipeline.channel().register(group.next());
+        ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
+        pipeline.channel().register();
 
         ChannelPromise promise = pipeline.channel().newPromise();
         assertTrue(promise.cancel(false));
@@ -719,11 +719,11 @@ public class DefaultChannelPipelineTest {
 
     @Test
     public void testWrongPromiseChannel() throws Exception {
-        final ChannelPipeline pipeline = new LocalChannel().pipeline();
-        pipeline.channel().register(group.next()).sync();
+        final ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
+        pipeline.channel().register().sync();
 
-        ChannelPipeline pipeline2 = new LocalChannel().pipeline();
-        pipeline2.channel().register(group.next()).sync();
+        ChannelPipeline pipeline2 = new LocalChannel(group.next()).pipeline();
+        pipeline2.channel().register().sync();
 
         try {
             final ChannelPromise promise2 = pipeline2.channel().newPromise();
@@ -741,8 +741,8 @@ public class DefaultChannelPipelineTest {
 
     @Test
     public void testUnexpectedVoidChannelPromiseCloseFuture() throws Exception {
-        final ChannelPipeline pipeline = new LocalChannel().pipeline();
-        pipeline.channel().register(group.next()).sync();
+        final ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
+        pipeline.channel().register().sync();
 
         try {
             final ChannelPromise promise = (ChannelPromise) pipeline.channel().closeFuture();
@@ -759,8 +759,8 @@ public class DefaultChannelPipelineTest {
 
     @Test
     public void testCancelDeregister() {
-        ChannelPipeline pipeline = new LocalChannel().pipeline();
-        pipeline.channel().register(group.next());
+        ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
+        pipeline.channel().register();
 
         ChannelPromise promise = pipeline.channel().newPromise();
         assertTrue(promise.cancel(false));
@@ -770,8 +770,8 @@ public class DefaultChannelPipelineTest {
 
     @Test
     public void testCancelWrite() {
-        ChannelPipeline pipeline = new LocalChannel().pipeline();
-        pipeline.channel().register(group.next());
+        ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
+        pipeline.channel().register();
 
         ChannelPromise promise = pipeline.channel().newPromise();
         assertTrue(promise.cancel(false));
@@ -784,8 +784,8 @@ public class DefaultChannelPipelineTest {
 
     @Test
     public void testCancelWriteAndFlush() {
-        ChannelPipeline pipeline = new LocalChannel().pipeline();
-        pipeline.channel().register(group.next());
+        ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
+        pipeline.channel().register();
 
         ChannelPromise promise = pipeline.channel().newPromise();
         assertTrue(promise.cancel(false));
@@ -798,25 +798,25 @@ public class DefaultChannelPipelineTest {
 
     @Test
     public void testFirstContextEmptyPipeline() {
-        ChannelPipeline pipeline = new LocalChannel().pipeline();
+        ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
         assertNull(pipeline.firstContext());
     }
 
     @Test
     public void testLastContextEmptyPipeline() {
-        ChannelPipeline pipeline = new LocalChannel().pipeline();
+        ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
         assertNull(pipeline.lastContext());
     }
 
     @Test
     public void testFirstHandlerEmptyPipeline() {
-        ChannelPipeline pipeline = new LocalChannel().pipeline();
+        ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
         assertNull(pipeline.first());
     }
 
     @Test
     public void testLastHandlerEmptyPipeline() {
-        ChannelPipeline pipeline = new LocalChannel().pipeline();
+        ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
         assertNull(pipeline.last());
     }
 
@@ -850,10 +850,10 @@ public class DefaultChannelPipelineTest {
         final EventLoop loop = group.next();
 
         CheckEventExecutorHandler handler = new CheckEventExecutorHandler(loop);
-        ChannelPipeline pipeline = new LocalChannel().pipeline();
+        ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
         pipeline.addFirst(handler);
         assertFalse(handler.addedPromise.isDone());
-        pipeline.channel().register(group.next());
+        pipeline.channel().register();
         handler.addedPromise.syncUninterruptibly();
         pipeline.remove(handler);
         handler.removedPromise.syncUninterruptibly();
@@ -866,10 +866,10 @@ public class DefaultChannelPipelineTest {
         final CountDownLatch latch = new CountDownLatch(1);
 
         CheckEventExecutorHandler handler = new CheckEventExecutorHandler(loop);
-        ChannelPipeline pipeline = new LocalChannel().pipeline();
+        ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
         pipeline.addFirst(handler);
         assertFalse(handler.addedPromise.isDone());
-        pipeline.channel().register(group.next());
+        pipeline.channel().register();
         handler.addedPromise.syncUninterruptibly();
         pipeline.replace(handler, null, new ChannelHandlerAdapter() {
             @Override
@@ -885,7 +885,7 @@ public class DefaultChannelPipelineTest {
     public void testAddRemoveHandlerNotRegistered() throws Throwable {
         final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
         ChannelHandler handler = new ErrorChannelHandler(error);
-        ChannelPipeline pipeline = new LocalChannel().pipeline();
+        ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
         pipeline.addFirst(handler);
         pipeline.remove(handler);
 
@@ -899,7 +899,7 @@ public class DefaultChannelPipelineTest {
     public void testAddReplaceHandlerNotRegistered() throws Throwable {
         final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
         ChannelHandler handler = new ErrorChannelHandler(error);
-        ChannelPipeline pipeline = new LocalChannel().pipeline();
+        ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
         pipeline.addFirst(handler);
         pipeline.replace(handler, null, new ErrorChannelHandler(error));
 
@@ -912,7 +912,7 @@ public class DefaultChannelPipelineTest {
     @Test
     @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
     public void testAddRemoveHandlerCalledOnceRegistered() throws Throwable {
-        ChannelPipeline pipeline = new LocalChannel().pipeline();
+        ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
         CallbackCheckHandler handler = new CallbackCheckHandler();
 
         pipeline.addFirst(handler);
@@ -921,7 +921,7 @@ public class DefaultChannelPipelineTest {
         assertNull(handler.addedHandler.getNow());
         assertNull(handler.removedHandler.getNow());
 
-        pipeline.channel().register(group.next()).syncUninterruptibly();
+        pipeline.channel().register().syncUninterruptibly();
         Throwable cause = handler.error.get();
         if (cause != null) {
             throw cause;
@@ -934,7 +934,7 @@ public class DefaultChannelPipelineTest {
     @Test
     @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
     public void testAddReplaceHandlerCalledOnceRegistered() throws Throwable {
-        ChannelPipeline pipeline = new LocalChannel().pipeline();
+        ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
         CallbackCheckHandler handler = new CallbackCheckHandler();
         CallbackCheckHandler handler2 = new CallbackCheckHandler();
 
@@ -946,7 +946,7 @@ public class DefaultChannelPipelineTest {
         assertNull(handler2.addedHandler.getNow());
         assertNull(handler2.removedHandler.getNow());
 
-        pipeline.channel().register(group.next()).syncUninterruptibly();
+        pipeline.channel().register().syncUninterruptibly();
         Throwable cause = handler.error.get();
         if (cause != null) {
             throw cause;
@@ -969,16 +969,14 @@ public class DefaultChannelPipelineTest {
     @Test
     @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
     public void testAddBefore() throws Throwable {
-        ChannelPipeline pipeline1 = new LocalChannel().pipeline();
-        ChannelPipeline pipeline2 = new LocalChannel().pipeline();
-
         EventLoopGroup defaultGroup = new MultiThreadIoEventLoopGroup(2, LocalIoHandler.newFactory());
+        EventLoop eventLoop1 = defaultGroup.next();
+        EventLoop eventLoop2 = defaultGroup.next();
         try {
-            EventLoop eventLoop1 = defaultGroup.next();
-            EventLoop eventLoop2 = defaultGroup.next();
-
-            pipeline1.channel().register(eventLoop1).syncUninterruptibly();
-            pipeline2.channel().register(eventLoop2).syncUninterruptibly();
+            ChannelPipeline pipeline1 = new LocalChannel(eventLoop1).pipeline();
+            ChannelPipeline pipeline2 = new LocalChannel(eventLoop2).pipeline();
+            pipeline1.channel().register().syncUninterruptibly();
+            pipeline2.channel().register().syncUninterruptibly();
 
             CountDownLatch latch = new CountDownLatch(2 * 10);
             for (int i = 0; i < 10; i++) {
@@ -994,21 +992,31 @@ public class DefaultChannelPipelineTest {
     @Test
     @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
     public void testAddInListenerNio() {
-        testAddInListener(new NioSocketChannel(), new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory()));
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        try {
+            testAddInListener(new NioSocketChannel(group.next()));
+        } finally {
+            group.shutdownGracefully();
+        }
     }
 
     @Test
     @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
     public void testAddInListenerLocal() {
-        testAddInListener(new LocalChannel(), new MultiThreadIoEventLoopGroup(1, LocalIoHandler.newFactory()));
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, LocalIoHandler.newFactory());
+        try {
+            testAddInListener(new LocalChannel(group.next()));
+        } finally {
+            group.shutdownGracefully();
+        }
     }
 
-    private static void testAddInListener(Channel channel, EventLoopGroup group) {
+    private static void testAddInListener(Channel channel) {
         ChannelPipeline pipeline1 = channel.pipeline();
         try {
             final Object event = new Object();
             final Promise<Object> promise = ImmediateEventExecutor.INSTANCE.newPromise();
-            pipeline1.channel().register(group.next()).addListener(new ChannelFutureListener() {
+            pipeline1.channel().register().addListener(new ChannelFutureListener() {
                 @Override
                 public void operationComplete(ChannelFuture future) {
                     ChannelPipeline pipeline = future.channel().pipeline();
@@ -1040,13 +1048,12 @@ public class DefaultChannelPipelineTest {
             assertSame(event, promise.syncUninterruptibly().getNow());
         } finally {
             pipeline1.channel().close().syncUninterruptibly();
-            group.shutdownGracefully();
         }
     }
 
     @Test
     public void testNullName() {
-        ChannelPipeline pipeline = new LocalChannel().pipeline();
+        ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
         pipeline.addLast(newHandler());
         pipeline.addLast(null, newHandler());
         pipeline.addFirst(newHandler());
@@ -1069,8 +1076,8 @@ public class DefaultChannelPipelineTest {
             // the time.
             for (int i = 0; i < 500; i++) {
 
-                ChannelPipeline pipeline = new LocalChannel().pipeline();
-                pipeline.channel().register(group.next()).sync();
+                ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
+                pipeline.channel().register().sync();
 
                 final CountDownLatch latch = new CountDownLatch(1);
 
@@ -1516,10 +1523,10 @@ public class DefaultChannelPipelineTest {
         };
         assertEquals(1, referenceCounted.refCnt());
 
-        Channel channel = new LocalChannel();
-        Channel channel2 = new LocalChannel();
-        channel.register(group.next()).syncUninterruptibly();
-        channel2.register(group.next()).syncUninterruptibly();
+        Channel channel = new LocalChannel(group.next());
+        Channel channel2 = new LocalChannel(group.next());
+        channel.register().syncUninterruptibly();
+        channel2.register().syncUninterruptibly();
 
         try {
             if (flush) {
@@ -1551,12 +1558,12 @@ public class DefaultChannelPipelineTest {
 
     private static void handlerAddedStateUpdatedBeforeHandlerAddedDone(boolean executeInEventLoop)
             throws InterruptedException {
-        final ChannelPipeline pipeline = new LocalChannel().pipeline();
+        final ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
         final Object userEvent = new Object();
         final Object writeObject = new Object();
         final CountDownLatch doneLatch = new CountDownLatch(1);
 
-        pipeline.channel().register(group.next()).syncUninterruptibly();
+        pipeline.channel().register().syncUninterruptibly();
 
         Runnable r = new Runnable() {
             @Override

--- a/transport/src/test/java/io/netty/channel/SingleThreadEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/SingleThreadEventLoopTest.java
@@ -389,7 +389,7 @@ public class SingleThreadEventLoopTest {
         }
 
         try {
-            ChannelFuture f = new LocalChannel().register(loopA);
+            ChannelFuture f = new LocalChannel(loopA).register();
             f.awaitUninterruptibly();
             assertFalse(f.isSuccess());
             assertInstanceOf(RejectedExecutionException.class, f.cause());
@@ -408,7 +408,7 @@ public class SingleThreadEventLoopTest {
     public void testRegistrationAfterShutdown2() throws Exception {
         loopA.shutdown();
         final CountDownLatch latch = new CountDownLatch(1);
-        Channel ch = new LocalChannel();
+        Channel ch = new LocalChannel(loopA);
         ChannelPromise promise = ch.newPromise();
         promise.addListener(new ChannelFutureListener() {
             @Override
@@ -427,7 +427,7 @@ public class SingleThreadEventLoopTest {
         }
 
         try {
-            ChannelFuture f = promise.channel().register(loopA);
+            ChannelFuture f = promise.channel().register();
             f.awaitUninterruptibly();
             assertFalse(f.isSuccess());
             assertInstanceOf(RejectedExecutionException.class, f.cause());

--- a/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
@@ -72,7 +72,7 @@ public class EmbeddedChannelTest {
     public void testNotRegistered() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(false, false);
         assertFalse(channel.isRegistered());
-        channel.register();
+        channel.register().sync();
         assertTrue(channel.isRegistered());
         assertFalse(channel.finish());
     }
@@ -82,7 +82,7 @@ public class EmbeddedChannelTest {
         EmbeddedChannel channel = new EmbeddedChannel(true, false);
         assertTrue(channel.isRegistered());
         try {
-            channel.register();
+            channel.register().sync();
             fail();
         } catch (IllegalStateException expected) {
             // This is expected the channel is registered already on an EventLoop.
@@ -633,7 +633,7 @@ public class EmbeddedChannelTest {
         channel.deregister().addListener(new ChannelFutureListener() {
             @Override
             public void operationComplete(ChannelFuture future) {
-                channel.register(embeddedEventLoop);
+                channel.register();
             }
         });
 

--- a/transport/src/test/java/io/netty/channel/nio/NioEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/nio/NioEventLoopTest.java
@@ -115,8 +115,8 @@ public class NioEventLoopTest extends AbstractEventLoopTest {
         EventLoop loop = group.next();
 
         try {
-            Channel channel = new NioServerSocketChannel();
-            channel.register(loop).syncUninterruptibly();
+            Channel channel = new NioServerSocketChannel(loop, group);
+            channel.register().syncUninterruptibly();
             channel.bind(new InetSocketAddress(0)).syncUninterruptibly();
 
             SocketChannel selectableChannel = SocketChannel.open();

--- a/transport/src/test/java/io/netty/channel/socket/nio/AbstractNioChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/nio/AbstractNioChannelTest.java
@@ -16,7 +16,10 @@
 package io.netty.channel.socket.nio;
 
 import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.nio.AbstractNioChannel;
+import io.netty.channel.nio.NioIoHandler;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -31,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 public abstract class AbstractNioChannelTest<T extends AbstractNioChannel> {
 
-    protected abstract T newNioChannel();
+    protected abstract T newNioChannel(EventLoopGroup eventLoopGroup);
 
     protected abstract NetworkChannel jdkChannel(T channel);
 
@@ -39,7 +42,8 @@ public abstract class AbstractNioChannelTest<T extends AbstractNioChannel> {
 
     @Test
     public void testNioChannelOption() throws IOException {
-        T channel = newNioChannel();
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        T channel = newNioChannel(group);
         try {
             NetworkChannel jdkChannel = jdkChannel(channel);
             ChannelOption<Boolean> option = NioChannelOption.of(StandardSocketOptions.SO_REUSEADDR);
@@ -55,28 +59,33 @@ public abstract class AbstractNioChannelTest<T extends AbstractNioChannel> {
             assertNotEquals(value1, value4);
         } finally {
             channel.unsafe().closeForcibly();
+            group.shutdownGracefully();
         }
     }
 
     @Test
     public void testInvalidNioChannelOption() {
-        T channel = newNioChannel();
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        T channel = newNioChannel(group);
         try {
             ChannelOption<Object> option = (ChannelOption) NioChannelOption.of(newInvalidOption());
             assertFalse(channel.config().setOption(option, ""));
             assertNull(channel.config().getOption(option));
         } finally {
             channel.unsafe().closeForcibly();
+            group.shutdownGracefully();
         }
     }
 
     @Test
     public void testGetOptions()  {
-        T channel = newNioChannel();
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        T channel = newNioChannel(group);
         try {
             channel.config().getOptions();
         } finally {
             channel.unsafe().closeForcibly();
+            group.shutdownGracefully();
         }
     }
 }

--- a/transport/src/test/java/io/netty/channel/socket/nio/AbstractNioDomainChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/nio/AbstractNioDomainChannelTest.java
@@ -16,7 +16,10 @@
 package io.netty.channel.socket.nio;
 
 import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.nio.AbstractNioChannel;
+import io.netty.channel.nio.NioIoHandler;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -31,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 public abstract class AbstractNioDomainChannelTest<T extends AbstractNioChannel> {
 
-    protected abstract T newNioChannel();
+    protected abstract T newNioChannel(EventLoopGroup group);
 
     protected abstract NetworkChannel jdkChannel(T channel);
 
@@ -39,7 +42,8 @@ public abstract class AbstractNioDomainChannelTest<T extends AbstractNioChannel>
 
     @Test
     public void testNioChannelOption() throws IOException {
-        T channel = newNioChannel();
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        T channel = newNioChannel(group);
         try {
             NetworkChannel jdkChannel = jdkChannel(channel);
             ChannelOption<Integer> option = NioChannelOption.of(StandardSocketOptions.SO_RCVBUF);
@@ -55,28 +59,33 @@ public abstract class AbstractNioDomainChannelTest<T extends AbstractNioChannel>
             assertNotEquals(value1, value4);
         } finally {
             channel.unsafe().closeForcibly();
+            group.shutdownGracefully();
         }
     }
 
     @Test
     public void testInvalidNioChannelOption() {
-        T channel = newNioChannel();
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        T channel = newNioChannel(group);
         try {
             ChannelOption<Object> option = (ChannelOption) NioChannelOption.of(newInvalidOption());
             assertFalse(channel.config().setOption(option, ""));
             assertNull(channel.config().getOption(option));
         } finally {
             channel.unsafe().closeForcibly();
+            group.shutdownGracefully();
         }
     }
 
     @Test
     public void testGetOptions()  {
-        T channel = newNioChannel();
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        T channel = newNioChannel(group);
         try {
             channel.config().getOptions();
         } finally {
             channel.unsafe().closeForcibly();
+            group.shutdownGracefully();
         }
     }
 }

--- a/transport/src/test/java/io/netty/channel/socket/nio/NioDatagramChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/nio/NioDatagramChannelTest.java
@@ -68,8 +68,8 @@ public class NioDatagramChannelTest extends AbstractNioChannelTest<NioDatagramCh
     }
 
     @Override
-    protected NioDatagramChannel newNioChannel() {
-        return new NioDatagramChannel();
+    protected NioDatagramChannel newNioChannel(EventLoopGroup eventLoopGroup) {
+        return new NioDatagramChannel(eventLoopGroup.next());
     }
 
     @Override

--- a/transport/src/test/java/io/netty/channel/socket/nio/NioDomainSocketChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/nio/NioDomainSocketChannelTest.java
@@ -15,6 +15,9 @@
  */
 package io.netty.channel.socket.nio;
 
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -26,10 +29,15 @@ import java.nio.channels.spi.SelectorProvider;
 class NioDomainSocketChannelTest {
     @Test
     void accessParent() throws IOException {
-        NioServerSocketChannel parent = new NioServerSocketChannel();
-        SocketChannel ch = SelectorProvider.provider().openSocketChannel(StandardProtocolFamily.UNIX);
-        NioSocketChannel child = new NioSocketChannel(parent, ch);
-        Assertions.assertSame(parent, child.parent());
-        ch.close();
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        try {
+            NioServerSocketChannel parent = new NioServerSocketChannel(group.next(), group.next());
+            SocketChannel ch = SelectorProvider.provider().openSocketChannel(StandardProtocolFamily.UNIX);
+            NioSocketChannel child = new NioSocketChannel(group.next(), parent, ch);
+            Assertions.assertSame(parent, child.parent());
+            ch.close();
+        } finally {
+            group.shutdownGracefully();
+        }
     }
 }

--- a/transport/src/test/java/io/netty/channel/socket/nio/NioServerDomainSocketChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/nio/NioServerDomainSocketChannelTest.java
@@ -46,11 +46,11 @@ public class NioServerDomainSocketChannelTest extends AbstractNioDomainChannelTe
     public void testCloseOnError() throws Exception {
         ServerSocketChannel jdkChannel = SelectorProvider.provider()
                 .openServerSocketChannel(StandardProtocolFamily.UNIX);
-        NioServerSocketChannel serverSocketChannel = new NioServerSocketChannel(jdkChannel);
         EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        NioServerSocketChannel serverSocketChannel = new NioServerSocketChannel(group.next(), group, jdkChannel);
         File file = newRandomTmpFile();
         try {
-            serverSocketChannel.register(group.next()).syncUninterruptibly();
+            serverSocketChannel.register().syncUninterruptibly();
             serverSocketChannel.bind(UnixDomainSocketAddress.of(file.getAbsolutePath()))
                     .syncUninterruptibly();
             assertFalse(serverSocketChannel.closeOnReadError(new IOException()));
@@ -63,12 +63,13 @@ public class NioServerDomainSocketChannelTest extends AbstractNioDomainChannelTe
 
     @Test
     public void testIsActiveFalseAfterClose() throws Exception {
-        io.netty.channel.socket.ServerSocketChannel serverSocketChannel =
-                new NioServerSocketChannel(SelectorProvider.provider(), SocketProtocolFamily.UNIX);
         EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+
+        io.netty.channel.socket.ServerSocketChannel serverSocketChannel =
+                new NioServerSocketChannel(group.next(), group, SelectorProvider.provider(), SocketProtocolFamily.UNIX);
         File file = newRandomTmpFile();
         try {
-            serverSocketChannel.register(group.next()).syncUninterruptibly();
+            serverSocketChannel.register().syncUninterruptibly();
             Channel channel = serverSocketChannel.bind(
                     UnixDomainSocketAddress.of(file.getAbsolutePath()))
                     .syncUninterruptibly().channel();
@@ -95,8 +96,8 @@ public class NioServerDomainSocketChannelTest extends AbstractNioDomainChannelTe
             if (bindJdkChannel) {
                 jdkChannel.bind(localAddress);
             }
-            NioServerSocketChannel serverSocketChannel = new NioServerSocketChannel(jdkChannel);
-            serverSocketChannel.register(group.next()).syncUninterruptibly();
+            NioServerSocketChannel serverSocketChannel = new NioServerSocketChannel(group.next(), group, jdkChannel);
+            serverSocketChannel.register().syncUninterruptibly();
             assertTrue(serverSocketChannel.isOpen());
 
             assertEquals(bindJdkChannel, serverSocketChannel.isActive());
@@ -111,8 +112,8 @@ public class NioServerDomainSocketChannelTest extends AbstractNioDomainChannelTe
     }
 
     @Override
-    protected NioServerSocketChannel newNioChannel() {
-        return new NioServerSocketChannel();
+    protected NioServerSocketChannel newNioChannel(EventLoopGroup group) {
+        return new NioServerSocketChannel(group.next(), group);
     }
 
     @Override

--- a/transport/src/test/java/io/netty/channel/socket/nio/NioServerSocketChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/nio/NioServerSocketChannelTest.java
@@ -37,10 +37,10 @@ public class NioServerSocketChannelTest extends AbstractNioChannelTest<NioServer
     @Test
     public void testCloseOnError() throws Exception {
         ServerSocketChannel jdkChannel = ServerSocketChannel.open();
-        NioServerSocketChannel serverSocketChannel = new NioServerSocketChannel(jdkChannel);
         EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        NioServerSocketChannel serverSocketChannel = new NioServerSocketChannel(group.next(), group, jdkChannel);
         try {
-            serverSocketChannel.register(group.next()).syncUninterruptibly();
+            serverSocketChannel.register().syncUninterruptibly();
             serverSocketChannel.bind(new InetSocketAddress(0)).syncUninterruptibly();
             assertFalse(serverSocketChannel.closeOnReadError(new IOException()));
             assertTrue(serverSocketChannel.closeOnReadError(new IllegalArgumentException()));
@@ -52,10 +52,10 @@ public class NioServerSocketChannelTest extends AbstractNioChannelTest<NioServer
 
     @Test
     public void testIsActiveFalseAfterClose()  {
-        NioServerSocketChannel serverSocketChannel = new NioServerSocketChannel();
         EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        NioServerSocketChannel serverSocketChannel = new NioServerSocketChannel(group.next(), group);
         try {
-            serverSocketChannel.register(group.next()).syncUninterruptibly();
+            serverSocketChannel.register().syncUninterruptibly();
             Channel channel = serverSocketChannel.bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
             assertTrue(channel.isActive());
             assertTrue(channel.isOpen());
@@ -68,8 +68,8 @@ public class NioServerSocketChannelTest extends AbstractNioChannelTest<NioServer
     }
 
     @Override
-    protected NioServerSocketChannel newNioChannel() {
-        return new NioServerSocketChannel();
+    protected NioServerSocketChannel newNioChannel(EventLoopGroup eventLoopGroup) {
+        return new NioServerSocketChannel(eventLoopGroup.next(), eventLoopGroup);
     }
 
     @Override

--- a/transport/src/test/java/io/netty/channel/socket/nio/NioSocketChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/nio/NioSocketChannelTest.java
@@ -59,7 +59,6 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
@@ -168,16 +167,10 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
     @Test
     @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
     public void testChannelReRegisterReadSameEventLoop() throws Exception {
-        testChannelReRegisterRead(true);
+        testChannelReRegisterRead();
     }
 
-    @Test
-    @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
-    public void testChannelReRegisterReadDifferentEventLoop() throws Exception {
-        testChannelReRegisterRead(false);
-    }
-
-    private static void testChannelReRegisterRead(final boolean sameEventLoop) throws Exception {
+    private static void testChannelReRegisterRead() throws Exception {
         EventLoopGroup group = new MultiThreadIoEventLoopGroup(2, NioIoHandler.newFactory());
         final CountDownLatch latch = new CountDownLatch(1);
 
@@ -205,20 +198,6 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
 
                          @Override
                          public void channelActive(final ChannelHandlerContext ctx) throws Exception {
-                             final EventLoop loop = group.next();
-                             if (sameEventLoop) {
-                                 deregister(ctx, loop);
-                             } else {
-                                 loop.execute(new Runnable() {
-                                     @Override
-                                     public void run() {
-                                         deregister(ctx, loop);
-                                     }
-                                 });
-                             }
-                         }
-
-                         private void deregister(ChannelHandlerContext ctx, final EventLoop loop) {
                              // As soon as the channel becomes active re-register it to another
                              // EventLoop. After this is done we should still receive the data that
                              // was written to the channel.
@@ -226,8 +205,7 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
                                  @Override
                                  public void operationComplete(ChannelFuture cf) {
                                      Channel channel = cf.channel();
-                                     assertNotSame(loop, channel.executor());
-                                     channel.register(group.next());
+                                     channel.register();
                                  }
                              });
                          }
@@ -291,8 +269,8 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
     }
 
     @Override
-    protected NioSocketChannel newNioChannel() {
-        return new NioSocketChannel();
+    protected NioSocketChannel newNioChannel(EventLoopGroup eventLoopGroup) {
+        return new NioSocketChannel(eventLoopGroup.next());
     }
 
     @Override


### PR DESCRIPTION
…op on Channel construction. 

Motivation:

At the moment it’s possible to have a Channel in Netty that is not registered / assigned to an EventLoop until register(...) is called. This is suboptimal as if the Channel is not registered it is also not possible to do anything useful with a ChannelFuture that belongs to the Channel. We should think about if we should have the EventLoop as a constructor argument of a Channel and have the register / deregister method only have the effect of add a Channel to KQueue/Epoll/... It is also currently possible to deregister a Channel from one EventLoop and register it with another EventLoop. This operation defeats the threading model assumptions that are wide spread in Netty, and requires careful user level coordination to pull off without any concurrency issues. It is not a commonly used feature in practice, may be better handled by other means (e.g. client side load balancing), and therefore we propose removing this feature.

Modifications:

- Change all Channel implementations to require an EventLoop for construction ( + an EventLoopGroup for all ServerChannel implementations)
- Remove all register(...) methods from EventLoopGroup
- Change ChannelUnsafe.register(...) to not take an EventLoop as parameter (as the EventLoop is supplied on custruction).
- Change ChannelFactory to take an EventLoop to create new Channels and introduce ServerChannelFactory which takes an EventLoop and one EventLoopGroup to create new ServerChannel instances.
- Add ServerChannel.childEventLoopGroup()
- Ensure all operations on the accepted Channel is done in the EventLoop of the Channel in ServerBootstrap
- Change unit tests for new behaviour

Result:

A Channel always has an EventLoop assigned which will never change during its life-time. This ensures we are always be able to call any operation on the Channel once constructed (unit the EventLoop is shutdown). This also simplifies the logic in DefaultChannelPipeline a lot as we can always call handlerAdded / handlerRemoved directly without the need to wait for register() to happen.

Also note that its still possible to deregister a Channel and register it again. It's just not possible anymore to move from one EventLoop to another (which was not really safe anyway).