### PR TITLE
Add ChannelOutboundInvoker.register(...) and ChannelOutboundHandler.r…

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientUpgradeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientUpgradeHandler.java
@@ -122,6 +122,11 @@ public class HttpClientUpgradeHandler extends HttpObjectAggregator implements Ch
     }
 
     @Override
+    public void register(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        ctx.register(promise);
+    }
+
+    @Override
     public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) throws Exception {
         ctx.bind(localAddress, promise);
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketProtocolHandler.java
@@ -155,6 +155,11 @@ abstract class WebSocketProtocolHandler extends MessageToMessageDecoder<WebSocke
     }
 
     @Override
+    public void register(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        ctx.register(promise);
+    }
+
+    @Override
     public void bind(ChannelHandlerContext ctx, SocketAddress localAddress,
                      ChannelPromise promise) throws Exception {
         ctx.bind(localAddress, promise);

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameCodec.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameCodec.java
@@ -175,6 +175,11 @@ public class SpdyFrameCodec extends ByteToMessageDecoder
     }
 
     @Override
+    public void register(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        ctx.register(promise);
+    }
+
+    @Override
     public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) throws Exception {
         ctx.bind(localAddress, promise);
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -452,6 +452,11 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
     }
 
     @Override
+    public void register(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        ctx.register(promise);
+    }
+
+    @Override
     public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) throws Exception {
         ctx.bind(localAddress, promise);
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameInboundWriter.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameInboundWriter.java
@@ -226,6 +226,16 @@ final class Http2FrameInboundWriter {
         }
 
         @Override
+        public ChannelFuture register(ChannelPromise promise) {
+            return channel.register(promise);
+        }
+
+        @Override
+        public ChannelFuture register() {
+            return channel.register();
+        }
+
+        @Override
         public ChannelFuture bind(SocketAddress localAddress) {
             return channel.bind(localAddress);
         }

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3FrameCodec.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3FrameCodec.java
@@ -603,6 +603,11 @@ final class Http3FrameCodec extends ByteToMessageDecoder implements ChannelOutbo
     }
 
     @Override
+    public void register(ChannelHandlerContext ctx, ChannelPromise promise) {
+        ctx.register(promise);
+    }
+
+    @Override
     public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) {
         ctx.bind(localAddress, promise);
     }

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3FrameToHttpObjectCodec.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3FrameToHttpObjectCodec.java
@@ -261,6 +261,11 @@ public final class Http3FrameToHttpObjectCodec extends Http3RequestStreamInbound
     }
 
     @Override
+    public void register(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        ctx.register(promise);
+    }
+
+    @Override
     public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) {
         ctx.bind(localAddress, promise);
     }

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3FrameTypeDuplexValidationHandler.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3FrameTypeDuplexValidationHandler.java
@@ -55,6 +55,11 @@ class Http3FrameTypeDuplexValidationHandler<T extends Http3Frame> extends Http3F
     }
 
     @Override
+    public void register(ChannelHandlerContext ctx, ChannelPromise promise) {
+        ctx.register(promise);
+    }
+
+    @Override
     public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) {
         ctx.bind(localAddress, promise);
     }

--- a/handler-proxy/src/main/java/io/netty/handler/proxy/HttpProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/handler/proxy/HttpProxyHandler.java
@@ -300,6 +300,11 @@ public final class HttpProxyHandler extends ProxyHandler {
         }
 
         @Override
+        public void register(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+            codec.register(ctx, promise);
+        }
+
+        @Override
         public void bind(ChannelHandlerContext ctx, SocketAddress localAddress,
                          ChannelPromise promise) throws Exception {
             codec.bind(ctx, localAddress, promise);

--- a/handler/src/main/java/io/netty/handler/ssl/SslClientHelloHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslClientHelloHandler.java
@@ -307,6 +307,11 @@ public abstract class SslClientHelloHandler<T> extends ByteToMessageDecoder impl
     }
 
     @Override
+    public void register(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        ctx.register(promise);
+    }
+
+    @Override
     public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) throws Exception {
         ctx.bind(localAddress, promise);
     }

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -749,6 +749,11 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
     }
 
     @Override
+    public void register(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        ctx.register(promise);
+    }
+
+    @Override
     public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) throws Exception {
         ctx.bind(localAddress, promise);
     }

--- a/microbench/src/main/java/io/netty/microbench/channel/EmbeddedChannelHandlerContext.java
+++ b/microbench/src/main/java/io/netty/microbench/channel/EmbeddedChannelHandlerContext.java
@@ -168,6 +168,16 @@ public abstract class EmbeddedChannelHandlerContext implements ChannelHandlerCon
     }
 
     @Override
+    public ChannelFuture register(ChannelPromise promise) {
+        return channel.register(promise);
+    }
+
+    @Override
+    public ChannelFuture register() {
+        return channel.register();
+    }
+
+    @Override
     public final ChannelFuture bind(SocketAddress localAddress, ChannelPromise promise) {
         try {
             channel().bind(localAddress, promise);

--- a/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
@@ -265,6 +265,15 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
         public void channelRead(ChannelHandlerContext ctx, Object msg) {
             final Channel child = (Channel) msg;
 
+            EventLoop loop = child.executor();
+            if (loop.inEventLoop()) {
+                initChildChannel(child);
+            } else {
+                loop.execute(() -> initChildChannel(child));
+            }
+        }
+
+        private void initChildChannel(Channel child) {
             child.pipeline().addLast(childHandler);
 
             setChannelOptions(child, childOptions, logger);

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -19,7 +19,6 @@ import io.netty.channel.socket.ChannelOutputShutdownEvent;
 import io.netty.channel.socket.ChannelOutputShutdownException;
 import io.netty.util.DefaultAttributeMap;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.logging.InternalLogger;

--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -51,6 +51,7 @@ import static io.netty.channel.ChannelHandlerMask.MASK_FLUSH;
 import static io.netty.channel.ChannelHandlerMask.MASK_ONLY_INBOUND;
 import static io.netty.channel.ChannelHandlerMask.MASK_ONLY_OUTBOUND;
 import static io.netty.channel.ChannelHandlerMask.MASK_READ;
+import static io.netty.channel.ChannelHandlerMask.MASK_REGISTER;
 import static io.netty.channel.ChannelHandlerMask.MASK_USER_EVENT_TRIGGERED;
 import static io.netty.channel.ChannelHandlerMask.MASK_WRITE;
 import static io.netty.channel.ChannelHandlerMask.mask;
@@ -420,6 +421,11 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
     }
 
     @Override
+    public ChannelFuture register() {
+        return register(newPromise());
+    }
+
+    @Override
     public ChannelFuture bind(SocketAddress localAddress) {
         return bind(localAddress, newPromise());
     }
@@ -447,6 +453,54 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
     @Override
     public ChannelFuture deregister() {
         return deregister(newPromise());
+    }
+
+    @Override
+    public ChannelFuture register(final ChannelPromise promise) {
+        if (isNotValidPromise(promise)) {
+            // cancelled
+            return promise;
+        }
+
+        final AbstractChannelHandlerContext next = findContextOutbound(MASK_REGISTER);
+        EventExecutor executor = next.executor();
+        if (executor.inEventLoop()) {
+            next.invokeRegister(promise);
+        } else {
+            safeExecute(executor, new Runnable() {
+                @Override
+                public void run() {
+                    next.invokeRegister(promise);
+                }
+            }, promise, null, false);
+        }
+
+        return promise;
+    }
+
+    private void invokeRegister(ChannelPromise promise) {
+        if (invokeHandler()) {
+            try {
+                // DON'T CHANGE
+                // Duplex handlers implements both out/in interfaces causing a scalability issue
+                // see https://bugs.openjdk.org/browse/JDK-8180450
+                final ChannelHandler handler = handler();
+                final DefaultChannelPipeline.HeadContext headContext = pipeline.head;
+                if (handler == headContext) {
+                    headContext.register(this, promise);
+                } else if (handler instanceof ChannelDuplexHandler) {
+                    ((ChannelDuplexHandler) handler).register(this, promise);
+                } else if (handler instanceof ChannelOutboundHandlerAdapter) {
+                    ((ChannelOutboundHandlerAdapter) handler).register(this, promise);
+                } else {
+                    ((ChannelOutboundHandler) handler).register(this, promise);
+                }
+            } catch (Throwable t) {
+                notifyOutboundHandlerException(t, promise);
+            }
+        } else {
+            register(promise);
+        }
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -467,12 +467,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         if (executor.inEventLoop()) {
             next.invokeRegister(promise);
         } else {
-            safeExecute(executor, new Runnable() {
-                @Override
-                public void run() {
-                    next.invokeRegister(promise);
-                }
-            }, promise, null, false);
+            safeExecute(executor, () -> next.invokeRegister(promise), promise, null, false);
         }
 
         return promise;

--- a/transport/src/main/java/io/netty/channel/Channel.java
+++ b/transport/src/main/java/io/netty/channel/Channel.java
@@ -353,17 +353,14 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparabl
         return pipeline().newFailedFuture(cause);
     }
 
-    // These are just added for now and will be removed in the followup PR.
+    @Override
     default ChannelFuture register() {
-        DefaultChannelPromise promise = new DefaultChannelPromise(this, executor());
-        register(promise);
-        return promise;
+        return pipeline().register();
     }
 
-    // These are just added for now and will be removed in the followup PR.
+    @Override
     default ChannelFuture register(ChannelPromise promise) {
-        unsafe().register(promise);
-        return promise;
+        return pipeline().register(promise);
     }
 
     /**

--- a/transport/src/main/java/io/netty/channel/ChannelDuplexHandler.java
+++ b/transport/src/main/java/io/netty/channel/ChannelDuplexHandler.java
@@ -29,6 +29,18 @@ import java.net.SocketAddress;
 public class ChannelDuplexHandler extends ChannelInboundHandlerAdapter implements ChannelOutboundHandler {
 
     /**
+     * Calls {@link ChannelHandlerContext#register(ChannelPromise)} to forward
+     * to the next {@link ChannelOutboundHandler} in the {@link ChannelPipeline}.
+     *
+     * Sub-classes may override this method to change behavior.
+     */
+    @Skip
+    @Override
+    public void register(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        ctx.register(promise);
+    }
+
+    /**
      * Calls {@link ChannelHandlerContext#bind(SocketAddress, ChannelPromise)} to forward
      * to the next {@link ChannelOutboundHandler} in the {@link ChannelPipeline}.
      *

--- a/transport/src/main/java/io/netty/channel/ChannelHandlerMask.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandlerMask.java
@@ -53,13 +53,14 @@ final class ChannelHandlerMask {
     static final int MASK_READ = 1 << 14;
     static final int MASK_WRITE = 1 << 15;
     static final int MASK_FLUSH = 1 << 16;
+    static final int MASK_REGISTER = 1 << 17;
 
     static final int MASK_ONLY_INBOUND =  MASK_CHANNEL_REGISTERED |
             MASK_CHANNEL_UNREGISTERED | MASK_CHANNEL_ACTIVE | MASK_CHANNEL_INACTIVE | MASK_CHANNEL_READ |
             MASK_CHANNEL_READ_COMPLETE | MASK_USER_EVENT_TRIGGERED | MASK_CHANNEL_WRITABILITY_CHANGED;
     private static final int MASK_ALL_INBOUND = MASK_EXCEPTION_CAUGHT | MASK_ONLY_INBOUND;
     static final int MASK_ONLY_OUTBOUND =  MASK_BIND | MASK_CONNECT | MASK_DISCONNECT |
-            MASK_CLOSE | MASK_DEREGISTER | MASK_READ | MASK_WRITE | MASK_FLUSH;
+            MASK_CLOSE | MASK_DEREGISTER | MASK_READ | MASK_WRITE | MASK_FLUSH | MASK_REGISTER;
     private static final int MASK_ALL_OUTBOUND = MASK_EXCEPTION_CAUGHT | MASK_ONLY_OUTBOUND;
 
     private static final FastThreadLocal<Map<Class<? extends ChannelHandler>, Integer>> MASKS =
@@ -149,6 +150,9 @@ final class ChannelHandlerMask {
                 }
                 if (isSkippable(handlerType, "flush", ChannelHandlerContext.class)) {
                     mask &= ~MASK_FLUSH;
+                }
+                if (isSkippable(handlerType, "register", ChannelHandlerContext.class, ChannelPromise.class)) {
+                    mask &= ~MASK_REGISTER;
                 }
             }
 

--- a/transport/src/main/java/io/netty/channel/ChannelOutboundHandler.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundHandler.java
@@ -21,6 +21,16 @@ import java.net.SocketAddress;
  * {@link ChannelHandler} which will get notified for IO-outbound-operations.
  */
 public interface ChannelOutboundHandler extends ChannelHandler {
+
+    /**
+     * Called once a register operation is made for an {@link EventLoop}.
+     *
+     * @param ctx               the {@link ChannelHandlerContext} for which the close operation is made
+     * @param promise           the {@link ChannelPromise} to notify once the operation completes
+     * @throws Exception        thrown if an error occurs
+     */
+    void register(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception;
+
     /**
      * Called once a bind operation is made.
      *

--- a/transport/src/main/java/io/netty/channel/ChannelOutboundHandlerAdapter.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundHandlerAdapter.java
@@ -26,6 +26,18 @@ import java.net.SocketAddress;
 public class ChannelOutboundHandlerAdapter extends ChannelHandlerAdapter implements ChannelOutboundHandler {
 
     /**
+     * Calls {@link ChannelHandlerContext#register(ChannelPromise)} to forward
+     * to the next {@link ChannelOutboundHandler} in the {@link ChannelPipeline}.
+     *
+     * Sub-classes may override this method to change behavior.
+     */
+    @Skip
+    @Override
+    public void register(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        ctx.register(promise);
+    }
+
+    /**
      * Calls {@link ChannelHandlerContext#bind(SocketAddress, ChannelPromise)} to forward
      * to the next {@link ChannelOutboundHandler} in the {@link ChannelPipeline}.
      *

--- a/transport/src/main/java/io/netty/channel/ChannelOutboundInvoker.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundInvoker.java
@@ -24,6 +24,20 @@ import java.net.SocketAddress;
 public interface ChannelOutboundInvoker {
 
     /**
+     * Request to register to the {@link EventExecutor} and notify the
+     * {@link ChannelFuture} once the operation completes, either because the operation was successful or because of
+     * an error.
+     *
+     * The given {@link ChannelPromise} will be notified.
+     * <p>
+     * This will result in having the
+     * {@link ChannelOutboundHandler#register(ChannelHandlerContext, ChannelPromise)}
+     * method called of the next {@link ChannelOutboundHandler} contained in the {@link ChannelPipeline} of the
+     * {@link Channel}.
+     */
+    ChannelFuture register(ChannelPromise promise);
+
+    /**
      * Request to bind to the given {@link SocketAddress} and notify the {@link ChannelFuture} once the operation
      * completes, either because the operation was successful or because of an error.
      * <p>
@@ -109,6 +123,22 @@ public interface ChannelOutboundInvoker {
      */
     default ChannelFuture deregister() {
         return deregister(newPromise());
+    }
+
+    /**
+     * Request to register to the {@link EventExecutor} and notify the
+     * {@link ChannelFuture} once the operation completes, either because the operation was successful or because of
+     * an error.
+     *
+     * The given {@link ChannelPromise} will be notified.
+     * <p>
+     * This will result in having the
+     * {@link ChannelOutboundHandler#register(ChannelHandlerContext, ChannelPromise)}
+     * method called of the next {@link ChannelOutboundHandler} contained in the {@link ChannelPipeline} of the
+     * {@link Channel}.
+     */
+    default ChannelFuture register() {
+        return register(newPromise());
     }
 
     /**

--- a/transport/src/main/java/io/netty/channel/CombinedChannelDuplexHandler.java
+++ b/transport/src/main/java/io/netty/channel/CombinedChannelDuplexHandler.java
@@ -448,6 +448,11 @@ public class CombinedChannelDuplexHandler<I extends ChannelInboundHandler, O ext
         }
 
         @Override
+        public ChannelFuture register() {
+            return ctx.register();
+        }
+
+        @Override
         public ChannelFuture bind(SocketAddress localAddress) {
             return ctx.bind(localAddress);
         }
@@ -475,6 +480,11 @@ public class CombinedChannelDuplexHandler<I extends ChannelInboundHandler, O ext
         @Override
         public ChannelFuture deregister() {
             return ctx.deregister();
+        }
+
+        @Override
+        public ChannelFuture register(ChannelPromise promise) {
+            return ctx.register(promise);
         }
 
         @Override

--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -900,6 +900,11 @@ public class DefaultChannelPipeline implements ChannelPipeline {
     }
 
     @Override
+    public final ChannelFuture register() {
+        return tail.register();
+    }
+
+    @Override
     public final ChannelFuture bind(SocketAddress localAddress) {
         return tail.bind(localAddress);
     }
@@ -933,6 +938,11 @@ public class DefaultChannelPipeline implements ChannelPipeline {
     public final ChannelPipeline flush() {
         tail.flush();
         return this;
+    }
+
+    @Override
+    public final ChannelFuture register(ChannelPromise promise) {
+        return tail.register(promise);
     }
 
     @Override
@@ -1286,6 +1296,11 @@ public class DefaultChannelPipeline implements ChannelPipeline {
         @Override
         public void handlerRemoved(ChannelHandlerContext ctx) {
             // NOOP
+        }
+
+        @Override
+        public void register(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+            unsafe.register(promise);
         }
 
         @Override

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
@@ -1144,6 +1144,12 @@ public class DefaultChannelPipelineTest {
                 errorRef = new AssertionError("Method should never been called");
             }
 
+            @Override
+            public void register(ChannelHandlerContext ctx, ChannelPromise promise) {
+                fail();
+                ctx.register(promise);
+            }
+
             @Skip
             @Override
             public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) {

--- a/transport/src/test/java/io/netty/channel/LoggingHandler.java
+++ b/transport/src/test/java/io/netty/channel/LoggingHandler.java
@@ -23,11 +23,17 @@ final class LoggingHandler implements ChannelInboundHandler, ChannelOutboundHand
 
     enum Event { WRITE, FLUSH, BIND, CONNECT, DISCONNECT, CLOSE, DEREGISTER, READ, WRITABILITY,
         HANDLER_ADDED, HANDLER_REMOVED, EXCEPTION, READ_COMPLETE, REGISTERED, UNREGISTERED, ACTIVE, INACTIVE,
-        USER }
+        USER, REGISTER }
 
     private StringBuilder log = new StringBuilder();
 
     private final EnumSet<Event> interest = EnumSet.allOf(Event.class);
+
+    @Override
+    public void register(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        log(Event.REGISTER);
+        ctx.register(promise);
+    }
 
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {


### PR DESCRIPTION
…egister(...) methods

Motivation:

With the recent changes of taking the EventLoop as part of the construction of Channel's we can let the whole register operation flow through the pipeline as any other outbound operation. This will provide more flexibility and is also more consistent with the rest.

Modifications:

- Add ChannelOutboundInvoker.register(...) and ChannelOutboundHandler.register(...) methods
- Let the registration flow throught the ChannelPipeline

Result:

More consistent handling of outbound operations and more flexibility
