### PR TITLE
Implement Quic stream reset frame application protocol error code pro…

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicException.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicException.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Exception produced while processing {@code QUIC}.
  */
-public final class QuicException extends Exception {
+public class QuicException extends Exception {
 
     private final QuicTransportError error;
 

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicStreamResetException.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicStreamResetException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.quic;
+
+/**
+ * Signals a stream reset.
+ */
+public final class QuicStreamResetException extends QuicException {
+
+    private final long applicationProtocolCode;
+
+    public QuicStreamResetException(String message, long applicationProtocolCode) {
+        super(message);
+
+        this.applicationProtocolCode = applicationProtocolCode;
+    }
+
+    /**
+     * Returns the optional application protocol error code set on {@code RESET_STREAM} frames.
+     *
+     * Note: this is not yet implemented for {@code STOP_SENDING} frames.
+     *
+     * @return the optional application protocol error code or {@code -1} when no such code is provided.
+     */
+    public long applicationProtocolCode() {
+        return applicationProtocolCode;
+    }
+}

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/Quiche.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/Quiche.java
@@ -30,6 +30,8 @@ import javax.net.ssl.SSLHandshakeException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+import static io.netty.handler.codec.quic.QuicheError.STREAM_RESET;
+
 final class Quiche {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(Quiche.class);
     private static final boolean TRACE_LOGGING_ENABLED = logger.isTraceEnabled();
@@ -401,9 +403,11 @@ final class Quiche {
     static native byte[] quiche_conn_destination_id(long connAddr);
 
     /**
-     * See <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L258">quiche_conn_stream_recv</a>.
+     * See <a href="https://github.com/cloudflare/quiche/blob/0.24.5/quiche/include/quiche.h#L397">
+     *     quiche_conn_stream_recv</a>.
      */
-    static native int quiche_conn_stream_recv(long connAddr, long streamId, long outAddr, int bufLen, long finAddr);
+    static native int quiche_conn_stream_recv(long connAddr, long streamId, long outAddr, int bufLen, long finAddr,
+                                              long outErrorCodeAddr);
 
     /**
      * See <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L262">quiche_conn_stream_send</a>.
@@ -895,10 +899,19 @@ final class Quiche {
     }
 
     static Exception convertToException(int result) {
+        return convertToException(result, -1);
+    }
+
+    static Exception convertToException(int result, long code) {
         QuicTransportErrorHolder holder = ERROR_MAPPINGS.get(result);
         if (holder == null) {
             // There is no mapping to a transport error, it's something internal so throw it directly.
-            return new QuicException(QuicheError.valueOf(result).message());
+            QuicheError error = QuicheError.valueOf(result);
+            if (error == STREAM_RESET) {
+                return new QuicStreamResetException(error.message(), code);
+            } else {
+                return new QuicException(error.message());
+            }
         }
         Exception exception = new QuicException(holder.error + ": " + holder.quicheErrorName, holder.error);
         if (result == QUICHE_ERR_TLS_FAIL) {

--- a/codec-native-quic/src/main/c/netty_quic_quiche.c
+++ b/codec-native-quic/src/main/c/netty_quic_quiche.c
@@ -490,9 +490,8 @@ static jint netty_quiche_conn_stream_priority(JNIEnv* env, jclass clazz, jlong c
     return (jint) quiche_conn_stream_priority((quiche_conn *) conn, (uint64_t) stream_id,  (uint8_t) urgency, incremental == JNI_TRUE ? true : false);
 }
 
-static jint netty_quiche_conn_stream_recv(JNIEnv* env, jclass clazz, jlong conn, jlong stream_id, jlong out, int buf_len, jlong finAddr) {
-    uint64_t error_code;
-    return (jint) quiche_conn_stream_recv((quiche_conn *) conn, (uint64_t) stream_id,  (uint8_t *) out, (size_t) buf_len, (bool *) finAddr, &error_code);
+static jint netty_quiche_conn_stream_recv(JNIEnv* env, jclass clazz, jlong conn, jlong stream_id, jlong out, int buf_len, jlong finAddr, jlong error_codeAddr) {
+    return (jint) quiche_conn_stream_recv((quiche_conn *) conn, (uint64_t) stream_id,  (uint8_t *) out, (size_t) buf_len, (bool *) finAddr, (uint64_t *) error_codeAddr);
 }
 
 static jint netty_quiche_conn_stream_send(JNIEnv* env, jclass clazz, jlong conn, jlong stream_id, jlong buf, int buf_len, jboolean fin) {
@@ -1181,7 +1180,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "quiche_conn_peer_streams_left_bidi", "(J)J", (void *) netty_quiche_conn_peer_streams_left_bidi },
   { "quiche_conn_peer_streams_left_uni", "(J)J", (void *) netty_quiche_conn_peer_streams_left_uni },
   { "quiche_conn_stream_priority", "(JJBZ)I", (void *) netty_quiche_conn_stream_priority },
-  { "quiche_conn_stream_recv", "(JJJIJ)I", (void *) netty_quiche_conn_stream_recv },
+  { "quiche_conn_stream_recv", "(JJJIJJ)I", (void *) netty_quiche_conn_stream_recv },
   { "quiche_conn_stream_send", "(JJJIZ)I", (void *) netty_quiche_conn_stream_send },
   { "quiche_conn_stream_shutdown", "(JJIJ)I", (void *) netty_quiche_conn_stream_shutdown },
   { "quiche_conn_stream_capacity", "(JJ)J", (void *) netty_quiche_conn_stream_capacity },

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicStreamShutdownTest.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicStreamShutdownTest.java
@@ -31,10 +31,12 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class QuicStreamShutdownTest extends AbstractQuicTest {
 
@@ -97,11 +99,6 @@ public class QuicStreamShutdownTest extends AbstractQuicTest {
             server = QuicTestUtils.newServer(executor, new ChannelInboundHandlerAdapter(),
                     new ChannelInboundHandlerAdapter() {
                         @Override
-                        public void channelRegistered(ChannelHandlerContext ctx) {
-                            ctx.fireChannelRegistered();
-                        }
-
-                        @Override
                         public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
                             QuicStreamChannel streamChannel = (QuicStreamChannel) ctx.channel();
                             streamChannel.shutdownInput().addListener(new ChannelFutureListener() {
@@ -156,6 +153,74 @@ public class QuicStreamShutdownTest extends AbstractQuicTest {
             if (error != null) {
                 fail("Failure during execution", error);
             }
+        } finally {
+            QuicTestUtils.closeIfNotNull(channel);
+            QuicTestUtils.closeIfNotNull(server);
+
+            shutdown(executor);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("newSslTaskExecutors")
+    public void testShutdownOutputClosureByServerCausesStreamReset(Executor executor) throws Throwable {
+        Channel server = null;
+        Channel channel = null;
+        CountDownLatch latch = new CountDownLatch(2);
+        AtomicReference<Throwable> errorRef = new AtomicReference<>();
+        AtomicLong applicationErrorCode = new AtomicLong(-1);
+        try {
+            server = QuicTestUtils.newServer(executor, new ChannelInboundHandlerAdapter(),
+                    new ChannelInboundHandlerAdapter() {
+                        @Override
+                        public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                            QuicStreamChannel streamChannel = (QuicStreamChannel) ctx.channel();
+                            ByteBuf buffer = (ByteBuf) msg;
+                            buffer.release();
+                            streamChannel.shutdownOutput(100).addListener(new ChannelFutureListener() {
+                                @Override
+                                public void operationComplete(ChannelFuture f) {
+                                    if (!f.isSuccess()) {
+                                        errorRef.compareAndSet(null, f.cause());
+                                    }
+                                    latch.countDown();
+                                }
+                            });
+                        }
+                    });
+
+            channel = QuicTestUtils.newClient(executor);
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
+                    .handler(new ChannelInboundHandlerAdapter())
+                    .streamHandler(new ChannelInboundHandlerAdapter())
+                    .remoteAddress(server.localAddress())
+                    .connect()
+                    .get();
+
+            QuicStreamChannel streamChannel = quicChannel.createStream(QuicStreamType.BIDIRECTIONAL,
+                    new ChannelInboundHandlerAdapter() {
+                        @Override
+                        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                            if (cause instanceof QuicStreamResetException) {
+                                QuicStreamResetException reset = (QuicStreamResetException) cause;
+                                applicationErrorCode.set(reset.applicationProtocolCode());
+                            } else {
+                                errorRef.set(cause);
+                            }
+                            latch.countDown();
+                        }
+                    }).sync().getNow();
+
+            streamChannel.writeAndFlush(Unpooled.buffer().writeInt(4)).sync();
+
+            if (!latch.await(5, TimeUnit.SECONDS)) {
+                fail("Timeout while waiting for completion", errorRef.get());
+            }
+            Throwable error = errorRef.get();
+            if (error != null) {
+                fail("Failure during execution", error);
+            }
+            assertEquals(100, applicationErrorCode.get());
         } finally {
             QuicTestUtils.closeIfNotNull(channel);
             QuicTestUtils.closeIfNotNull(server);


### PR DESCRIPTION
…pagation (#15845)

Motivation:

Quic stream support currently does not propagate the optional application protocol error carried by a Quic reset frame. This information matters to properly implement protocols on top of Quic such as HTTP/3 that uses it to signal HTTP/3 errors (such as rejecting or cancelling a request).

Changes:

Modify the `quiche_conn_stream_recv` JNI binding to pass an extra pointer that will receive the applicaiton protocol error code upon stream reset. The `QuicheQuicChannel` now allocates a direct buffer holding the application protocol error code.

`QuicStreamException` and `QuicStreamResetException` sub classes of `QuicException` are introduced to let protocol handlers to handle stream reset with as much information as possible.

Note:

Supporting stop sending frame error code should be implemented sooner or later (which is less trivial because the error code is propagated in the chain call unless stream recv that confines in a single method call).
