### PR TITLE
Fix http2 connection stream issue

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowController.java
@@ -263,7 +263,7 @@ public class DefaultHttp2LocalFlowController implements Http2LocalFlowController
 
     @Override
     public void receiveFlowControlledFrame(Http2Stream stream, ByteBuf data, int padding,
-                                           boolean endOfStream) throws Http2Exception {
+            boolean endOfStream) throws Http2Exception {
         assert ctx != null && ctx.executor().inEventLoop();
         int dataLength = data.readableBytes() + padding;
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowController.java
@@ -103,10 +103,11 @@ public class DefaultHttp2LocalFlowController implements Http2LocalFlowController
             public void onStreamClosed(Http2Stream stream) {
                 try {
                     // When a stream is closed, consume any remaining bytes so that they
-                    // are restored to the connection window.
+                    // are restored to the connection window. Do not attempt this for the
+                    // connection stream
                     FlowState state = state(stream);
                     int unconsumedBytes = state.unconsumedBytes();
-                    if (ctx != null && unconsumedBytes > 0) {
+                    if (ctx != null && unconsumedBytes > 0 && stream.id() != CONNECTION_STREAM_ID) {
                         if (consumeAllBytes(state, unconsumedBytes)) {
                             // As the user has no real control on when this callback is used we should better
                             // call flush() if we produced any window update to ensure we not stale.
@@ -262,7 +263,7 @@ public class DefaultHttp2LocalFlowController implements Http2LocalFlowController
 
     @Override
     public void receiveFlowControlledFrame(Http2Stream stream, ByteBuf data, int padding,
-            boolean endOfStream) throws Http2Exception {
+                                           boolean endOfStream) throws Http2Exception {
         assert ctx != null && ctx.executor().inEventLoop();
         int dataLength = data.readableBytes() + padding;
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
@@ -21,6 +21,7 @@ import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_WINDOW_SIZE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -98,6 +99,21 @@ public class DefaultHttp2LocalFlowControllerTest {
             });
         }
         when(ctx.executor()).thenReturn(executor);
+    }
+
+    @Test
+    public void connectionStreamCloseShouldNotThrowWhenUnconsumedBytesPresent() throws Http2Exception {
+        int dataSize = (int) (DEFAULT_WINDOW_SIZE * DEFAULT_WINDOW_UPDATE_RATIO) + 1;
+
+        // Receive data on a child stream so the connection-level state has unconsumed bytes.
+        receiveFlowControlledFrame(STREAM_ID, dataSize, 0, false);
+        assertTrue(controller.unconsumedBytes(connection.connectionStream()) > 0);
+        reset(frameWriter);
+
+        assertDoesNotThrow(() -> connection.listeners.get(0).onStreamClosed(connection.connectionStream()));
+        // No WINDOW_UPDATE should be written for the connection stream as a result of closing it.
+        verifyWindowUpdateNotSent(CONNECTION_STREAM_ID);
+        verifyNoMoreInteractions(frameWriter);
     }
 
     @Test


### PR DESCRIPTION
Motivation:

Http2 connection stream throws the `Http2Exception` for the stream id 0 when the stream is closed in `DefaultHttp2LocalFlowController`

Modification:

Skip the  connection stream for stream id 0 so that it will not throw the `Http2Exception`

Result:

Fixes #15536


