### PR TITLE
Channel: Trim down Channel.Unsafe scope

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicChannel.java
@@ -1569,7 +1569,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                             if (connectPromise != null && !f.isSuccess()) {
                                 connectPromise.tryFailure(f.cause());
                                 // close everything after notify about failure.
-                                unsafe().closeForcibly();
+                                unsafe().close(newPromise());
                             }
                         });
                 return;

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicServerCodec.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicServerCodec.java
@@ -241,12 +241,12 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
         Quic.setupChannel(channel, optionsArray, attrsArray, handler, LOGGER);
         QuicSslEngine engine = sslEngineProvider.apply(channel);
         if (!(engine instanceof QuicheQuicSslEngine)) {
-            channel.unsafe().closeForcibly();
+            channel.unsafe().close(channel.newPromise());
             throw new IllegalArgumentException("QuicSslEngine is not of type "
                     + QuicheQuicSslEngine.class.getSimpleName());
         }
         if (engine.getUseClientMode()) {
-            channel.unsafe().closeForcibly();
+            channel.unsafe().close(channel.newPromise());
             throw new IllegalArgumentException("QuicSslEngine is not created in server mode");
         }
 
@@ -264,7 +264,7 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
                     config.nativeAddress(), ssl, true);
         });
         if (connection  == null) {
-            channel.unsafe().closeForcibly();
+            channel.unsafe().close(channel.newPromise());
             LOGGER.debug("quiche_accept failed");
             return null;
         }

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicStreamChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicStreamChannel.java
@@ -472,22 +472,11 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
         }
 
         @SuppressWarnings("deprecation")
-        @Override
         public RecvByteBufAllocator.Handle recvBufAllocHandle() {
             if (recvHandle == null) {
                 recvHandle = config.getRecvByteBufAllocator().newHandle();
             }
             return recvHandle;
-        }
-
-        @Override
-        public SocketAddress localAddress() {
-            return address;
-        }
-
-        @Override
-        public SocketAddress remoteAddress() {
-            return address;
         }
 
         @Override
@@ -621,12 +610,6 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
             } catch (RejectedExecutionException e) {
                 LOGGER.warn("Can't invoke task later as EventLoop rejected it", e);
             }
-        }
-
-        @Override
-        public void closeForcibly() {
-            assert executor().inEventLoop();
-            close(newPromise());
         }
 
         @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
@@ -643,23 +643,12 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
             promise.setFailure(new UnsupportedOperationException());
         }
 
-        @Override
         public RecvByteBufAllocator.Handle recvBufAllocHandle() {
             if (recvHandle == null) {
                 recvHandle = config().getRecvByteBufAllocator().newHandle();
                 recvHandle.reset(config());
             }
             return recvHandle;
-        }
-
-        @Override
-        public SocketAddress localAddress() {
-            return parent().unsafe().localAddress();
-        }
-
-        @Override
-        public SocketAddress remoteAddress() {
-            return parent().unsafe().remoteAddress();
         }
 
         @Override
@@ -767,11 +756,6 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
         }
 
         @Override
-        public void closeForcibly() {
-            close(newPromise());
-        }
-
-        @Override
         public void deregister(ChannelPromise promise) {
             fireChannelInactiveAndDeregister(promise, false);
         }
@@ -867,7 +851,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
                 if (readEOS && (inboundBuffer == null || inboundBuffer.isEmpty())) {
                     // Double check there is nothing left to flush such as a window update frame.
                     flush();
-                    unsafe.closeForcibly();
+                    unsafe.close(newPromise());
                 }
             } else {
                 do { // Process messages until there are none left (or the user stopped requesting) and also handle EOS.
@@ -876,7 +860,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
                         // Double check there is nothing left to flush such as a window update frame.
                         flush();
                         if (readEOS) {
-                            unsafe.closeForcibly();
+                            unsafe.close(newPromise());
                         }
                         break;
                     }
@@ -950,7 +934,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
             // rely upon flush occurring in channelReadComplete on the parent channel.
             flush();
             if (readEOS) {
-                unsafe.closeForcibly();
+                unsafe.close(newPromise());
             }
         }
 
@@ -1126,7 +1110,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
                 promise.setSuccess();
             } else {
                 // If the first write fails there is not much we can do, just close
-                closeForcibly();
+                unsafe.close(newPromise());
                 promise.setFailure(wrapStreamClosedError(cause));
             }
         }
@@ -1141,7 +1125,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
                 if (error instanceof IOException) {
                     if (config.isAutoClose()) {
                         // Close channel if needed.
-                        closeForcibly();
+                        unsafe.close(newPromise());
                     } else {
                         // TODO: Once Http2StreamChannel extends DuplexChannel we should call shutdownOutput(...)
                         outboundClosed = true;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexHandler.java
@@ -148,11 +148,7 @@ public final class Http2MultiplexHandler extends Http2ChannelDuplexHandler {
         // childChannel.
         if (!future.isSuccess()) {
             Channel childChannel = future.channel();
-            if (childChannel.isRegistered()) {
-                childChannel.close();
-            } else {
-                childChannel.unsafe().closeForcibly();
-            }
+            childChannel.close();
         }
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrap.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrap.java
@@ -181,7 +181,7 @@ public final class Http2StreamChannelBootstrap {
         try {
             init(streamChannel);
         } catch (Exception e) {
-            streamChannel.unsafe().closeForcibly();
+            streamChannel.unsafe().close(streamChannel.newPromise());
             promise.setFailure(e);
             return;
         }
@@ -195,12 +195,7 @@ public final class Http2StreamChannelBootstrap {
                 } else if (future.isCancelled()) {
                     promise.cancel(false);
                 } else {
-                    if (streamChannel.isRegistered()) {
-                        streamChannel.close();
-                    } else {
-                        streamChannel.unsafe().closeForcibly();
-                    }
-
+                    streamChannel.close();
                     promise.setFailure(future.cause());
                 }
             }

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/EmbeddedQuicStreamChannel.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/EmbeddedQuicStreamChannel.java
@@ -23,7 +23,6 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelId;
-import io.netty.channel.EventLoop;
 import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.WriteBufferWaterMark;
@@ -215,20 +214,6 @@ final class EmbeddedQuicStreamChannel extends EmbeddedChannel implements QuicStr
         if (unsafe == null) {
             Unsafe superUnsafe = super.unsafe();
             unsafe = new Unsafe() {
-                @Override
-                public RecvByteBufAllocator.Handle recvBufAllocHandle() {
-                    return superUnsafe.recvBufAllocHandle();
-                }
-
-                @Override
-                public SocketAddress localAddress() {
-                    return superUnsafe.localAddress();
-                }
-
-                @Override
-                public SocketAddress remoteAddress() {
-                    return superUnsafe.remoteAddress();
-                }
 
                 @Override
                 public void register(ChannelPromise promise) {
@@ -253,11 +238,6 @@ final class EmbeddedQuicStreamChannel extends EmbeddedChannel implements QuicStr
                 @Override
                 public void close(ChannelPromise promise) {
                     superUnsafe.close(promise);
-                }
-
-                @Override
-                public void closeForcibly() {
-                    superUnsafe.closeForcibly();
                 }
 
                 @Override

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketCloseForciblyTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketCloseForciblyTest.java
@@ -42,7 +42,7 @@ public class SocketCloseForciblyTest extends AbstractSocketTest {
             public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
                 SocketChannel childChannel = (SocketChannel) msg;
                 childChannel.config().setSoLinger(0);
-                childChannel.unsafe().closeForcibly();
+                childChannel.unsafe().close(childChannel.newPromise());
             }
         }).childHandler(new ChannelInboundHandlerAdapter());
 

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -356,7 +356,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
     protected final int doReadBytes(ByteBuf byteBuf) throws Exception {
         int writerIndex = byteBuf.writerIndex();
         int localReadAmount;
-        unsafe().recvBufAllocHandle().attemptedBytesRead(byteBuf.writableBytes());
+        ((AbstractUnsafe) unsafe()).recvBufAllocHandle().attemptedBytesRead(byteBuf.writableBytes());
         if (byteBuf.hasMemoryAddress()) {
             localReadAmount = socket.recvAddress(byteBuf.memoryAddress(), writerIndex, byteBuf.capacity());
         } else {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
@@ -229,9 +229,7 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
                 // Only reset if we don't use multi-shot or we need to re-arm because the multi-shot was cancelled.
                 acceptId = 0;
             }
-            final IoUringRecvByteAllocatorHandle allocHandle =
-                    (IoUringRecvByteAllocatorHandle) unsafe()
-                            .recvBufAllocHandle();
+            final IoUringRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
             final ChannelPipeline pipeline = pipeline();
             allocHandle.lastBytesRead(res);
 

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
@@ -277,7 +277,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
     protected final int doReadBytes(ByteBuf byteBuf) throws Exception {
         int writerIndex = byteBuf.writerIndex();
         int localReadAmount;
-        unsafe().recvBufAllocHandle().attemptedBytesRead(byteBuf.writableBytes());
+        ((AbstractUnsafe) unsafe()).recvBufAllocHandle().attemptedBytesRead(byteBuf.writableBytes());
         if (byteBuf.hasMemoryAddress()) {
             localReadAmount = socket.readAddress(byteBuf.memoryAddress(), writerIndex, byteBuf.capacity());
         } else {

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramChannelTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramChannelTest.java
@@ -48,7 +48,7 @@ public class EpollDatagramChannelTest {
     public void testDefaultMaxMessagePerRead() {
         EpollDatagramChannel channel = new EpollDatagramChannel(EpollSocketTestPermutation.EPOLL_GROUP.next());
         assertEquals(16, channel.config().getMaxMessagesPerRead());
-        channel.unsafe().closeForcibly();
+        channel.close();
     }
 
     @Test

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainDatagramChannelTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainDatagramChannelTest.java
@@ -32,6 +32,6 @@ public class EpollDomainDatagramChannelTest {
         EpollDomainDatagramChannel channel = new EpollDomainDatagramChannel(
                 EpollSocketTestPermutation.EPOLL_GROUP.next());
         assertEquals(16, channel.config().getMaxMessagesPerRead());
-        channel.unsafe().closeForcibly();
+        channel.close();
     }
 }

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KqueueDatagramChannelTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KqueueDatagramChannelTest.java
@@ -31,6 +31,6 @@ public class KqueueDatagramChannelTest {
     public void testDefaultMaxMessagePerRead() {
         KQueueDatagramChannel channel = new KQueueDatagramChannel(KQueueSocketTestPermutation.KQUEUE_GROUP.next());
         assertEquals(16, channel.config().getMaxMessagesPerRead());
-        channel.unsafe().closeForcibly();
+        channel.close();
     }
 }

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KqueueDomainDatagramChannelTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KqueueDomainDatagramChannelTest.java
@@ -32,6 +32,6 @@ public class KqueueDomainDatagramChannelTest {
         KQueueDomainDatagramChannel channel = new KQueueDomainDatagramChannel(
                 KQueueSocketTestPermutation.KQUEUE_GROUP.next());
         assertEquals(16, channel.config().getMaxMessagesPerRead());
-        channel.unsafe().closeForcibly();
+        channel.close();
     }
 }

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
@@ -27,7 +27,6 @@ import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoop;
-import io.netty.channel.EventLoopGroup;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.nio.AbstractNioMessageChannel;
 import io.netty.channel.nio.NioIoOps;
@@ -267,7 +266,7 @@ public class NioSctpChannel extends AbstractNioMessageChannel implements io.nett
     protected int doReadMessages(List<Object> buf) throws Exception {
         SctpChannel ch = javaChannel();
 
-        RecvByteBufAllocator.Handle allocHandle = unsafe().recvBufAllocHandle();
+        RecvByteBufAllocator.Handle allocHandle = ((AbstractUnsafe) unsafe()).recvBufAllocHandle();
         ByteBuf buffer = allocHandle.allocate(config().getAllocator());
         boolean free = true;
         try {

--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -288,7 +288,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
         } catch (Throwable t) {
             if (channel != null) {
                 // channel can be null if newChannel crashed (eg SocketException("too many open files"))
-                channel.unsafe().closeForcibly();
+                channel.close();
                 return channel.newPromise().setFailure(t);
             }
             return new FailedChannel(group.next()).newFailedFuture(t);
@@ -296,11 +296,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
 
         ChannelFuture reqFut = channel.register();
         if (reqFut.cause() != null) {
-            if (channel.isRegistered()) {
-                channel.close();
-            } else {
-                channel.unsafe().closeForcibly();
-            }
+            channel.close();
         }
 
         // If we are here and the promise is not failed, it's one of the following cases:

--- a/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
@@ -304,7 +304,7 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
         }
 
         private static void forceClose(Channel child, Throwable t) {
-            child.unsafe().closeForcibly();
+            child.close();
             logger.warn("Failed to register an accepted channel: {}", child, t);
         }
 

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -153,7 +153,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         SocketAddress localAddress = this.localAddress;
         if (localAddress == null) {
             try {
-                this.localAddress = localAddress = unsafe().localAddress();
+                this.localAddress = localAddress = localAddress0();
             } catch (Error e) {
                 throw e;
             } catch (Throwable t) {
@@ -177,7 +177,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         SocketAddress remoteAddress = this.remoteAddress;
         if (remoteAddress == null) {
             try {
-                this.remoteAddress = remoteAddress = unsafe().remoteAddress();
+                this.remoteAddress = remoteAddress = remoteAddress0();
             } catch (Error e) {
                 throw e;
             } catch (Throwable t) {
@@ -312,7 +312,6 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             return estimatorHandle;
         }
 
-        @Override
         public RecvByteBufAllocator.Handle recvBufAllocHandle() {
             if (recvHandle == null) {
                 recvHandle = config().getRecvByteBufAllocator().newHandle();
@@ -323,16 +322,6 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         @Override
         public final ChannelOutboundBuffer outboundBuffer() {
             return outboundBuffer;
-        }
-
-        @Override
-        public final SocketAddress localAddress() {
-            return localAddress0();
-        }
-
-        @Override
-        public final SocketAddress remoteAddress() {
-            return remoteAddress0();
         }
 
         @Override
@@ -356,7 +345,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                     logger.warn(
                             "Force-closing a channel whose registration task was not accepted by an event loop: {}",
                             AbstractChannel.this, t);
-                    closeForcibly();
+                    close(newPromise());
                     closeFuture.setClosed();
                     safeSetFailure(promise, t);
                 }
@@ -395,7 +384,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                         }
                     } else {
                         // Close the channel directly to avoid FD leak.
-                        closeForcibly();
+                        close(newPromise());
                         closeFuture.setClosed();
                         safeSetFailure(promise, future.cause());
                     }
@@ -629,17 +618,6 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
 
         private void fireChannelInactiveAndDeregister(final boolean wasActive) {
             deregister(newPromise(), wasActive && !isActive());
-        }
-
-        @Override
-        public final void closeForcibly() {
-            assertEventLoop();
-
-            try {
-                doClose();
-            } catch (Exception e) {
-                logger.warn("Failed to close a channel.", e);
-            }
         }
 
         @Override

--- a/transport/src/main/java/io/netty/channel/Channel.java
+++ b/transport/src/main/java/io/netty/channel/Channel.java
@@ -368,32 +368,11 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparabl
      * are only provided to implement the actual transport, and must be invoked from an I/O thread except for the
      * following methods:
      * <ul>
-     *   <li>{@link #localAddress()}</li>
-     *   <li>{@link #remoteAddress()}</li>
-     *   <li>{@link #closeForcibly()}</li>
      *   <li>{@link #register(ChannelPromise)}</li>
      *   <li>{@link #deregister(ChannelPromise)}</li>
      * </ul>
      */
     interface Unsafe {
-
-        /**
-         * Return the assigned {@link RecvByteBufAllocator.Handle} which will be used to allocate {@link ByteBuf}'s when
-         * receiving data.
-         */
-        RecvByteBufAllocator.Handle recvBufAllocHandle();
-
-        /**
-         * Return the {@link SocketAddress} to which is bound local or
-         * {@code null} if none.
-         */
-        SocketAddress localAddress();
-
-        /**
-         * Return the {@link SocketAddress} to which is bound remote or
-         * {@code null} if none is bound yet.
-         */
-        SocketAddress remoteAddress();
 
         /**
          * Register the {@link Channel} of the {@link ChannelPromise} and notify
@@ -427,12 +406,6 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparabl
          * operation was complete.
          */
         void close(ChannelPromise promise);
-
-        /**
-         * Closes the {@link Channel} immediately without firing any events.  Probably only useful
-         * when registration attempt failed.
-         */
-        void closeForcibly();
 
         /**
          * Deregister the {@link Channel} of the {@link ChannelPromise} from {@link EventLoop} and notify the

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
@@ -34,7 +34,6 @@ import io.netty.channel.EventLoop;
 import io.netty.channel.IoEvent;
 import io.netty.channel.IoHandle;
 import io.netty.channel.IoRegistration;
-import io.netty.channel.RecvByteBufAllocator;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Ticker;
 import io.netty.util.internal.PlatformDependent;
@@ -1187,20 +1186,6 @@ public class EmbeddedChannel extends AbstractChannel {
         // Delegates to the EmbeddedUnsafe instance but ensures runPendingTasks() is called after each operation
         // that may change the state of the Channel and may schedule tasks for later execution.
         final Unsafe wrapped = new Unsafe() {
-            @Override
-            public RecvByteBufAllocator.Handle recvBufAllocHandle() {
-                return EmbeddedUnsafe.this.recvBufAllocHandle();
-            }
-
-            @Override
-            public SocketAddress localAddress() {
-                return EmbeddedUnsafe.this.localAddress();
-            }
-
-            @Override
-            public SocketAddress remoteAddress() {
-                return EmbeddedUnsafe.this.remoteAddress();
-            }
 
             @Override
             public void register(ChannelPromise promise) {
@@ -1251,17 +1236,6 @@ public class EmbeddedChannel extends AbstractChannel {
                 executingStackCnt++;
                 try {
                     EmbeddedUnsafe.this.close(promise);
-                } finally {
-                    executingStackCnt--;
-                    maybeRunPendingTasks();
-                }
-            }
-
-            @Override
-            public void closeForcibly() {
-                executingStackCnt++;
-                try {
-                    EmbeddedUnsafe.this.closeForcibly();
                 } finally {
                     executingStackCnt--;
                     maybeRunPendingTasks();

--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -273,7 +273,7 @@ public class LocalChannel extends AbstractChannel {
     }
 
     private void readInbound() {
-        RecvByteBufAllocator.Handle handle = unsafe().recvBufAllocHandle();
+        RecvByteBufAllocator.Handle handle = ((AbstractUnsafe) unsafe()).recvBufAllocHandle();
         handle.reset(config());
         ChannelPipeline pipeline = pipeline();
         do {

--- a/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
@@ -169,7 +169,7 @@ public class LocalServerChannel extends AbstractServerChannel {
     }
 
     private void readInbound() {
-        RecvByteBufAllocator.Handle handle = unsafe().recvBufAllocHandle();
+        RecvByteBufAllocator.Handle handle = ((AbstractUnsafe) unsafe()).recvBufAllocHandle();
         handle.reset(config());
         ChannelPipeline pipeline = pipeline();
         do {

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioMessageChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioMessageChannel.java
@@ -71,7 +71,7 @@ public abstract class AbstractNioMessageChannel extends AbstractNioChannel {
             assert executor().inEventLoop();
             final ChannelConfig config = config();
             final ChannelPipeline pipeline = pipeline();
-            final RecvByteBufAllocator.Handle allocHandle = unsafe().recvBufAllocHandle();
+            final RecvByteBufAllocator.Handle allocHandle = recvBufAllocHandle();
             allocHandle.reset(config);
 
             boolean closed = false;

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
@@ -261,7 +261,7 @@ public final class NioDatagramChannel
     protected int doReadMessages(List<Object> buf) throws Exception {
         DatagramChannel ch = javaChannel();
         DatagramChannelConfig config = config();
-        RecvByteBufAllocator.Handle allocHandle = unsafe().recvBufAllocHandle();
+        RecvByteBufAllocator.Handle allocHandle = ((AbstractUnsafe) unsafe()).recvBufAllocHandle();
 
         ByteBuf data = allocHandle.allocate(config.getAllocator());
         allocHandle.attemptedBytesRead(data.writableBytes());

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
@@ -349,7 +349,7 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
 
     @Override
     protected int doReadBytes(ByteBuf byteBuf) throws Exception {
-        final RecvByteBufAllocator.Handle allocHandle = unsafe().recvBufAllocHandle();
+        final RecvByteBufAllocator.Handle allocHandle = ((AbstractUnsafe) unsafe()).recvBufAllocHandle();
         allocHandle.attemptedBytesRead(byteBuf.writableBytes());
         return byteBuf.writeBytes(javaChannel(), allocHandle.attemptedBytesRead());
     }

--- a/transport/src/test/java/io/netty/channel/socket/nio/AbstractNioChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/nio/AbstractNioChannelTest.java
@@ -58,7 +58,7 @@ public abstract class AbstractNioChannelTest<T extends AbstractNioChannel> {
             assertEquals(value3, value4);
             assertNotEquals(value1, value4);
         } finally {
-            channel.unsafe().closeForcibly();
+            channel.close();
             group.shutdownGracefully();
         }
     }
@@ -72,7 +72,7 @@ public abstract class AbstractNioChannelTest<T extends AbstractNioChannel> {
             assertFalse(channel.config().setOption(option, ""));
             assertNull(channel.config().getOption(option));
         } finally {
-            channel.unsafe().closeForcibly();
+            channel.close();
             group.shutdownGracefully();
         }
     }
@@ -84,7 +84,7 @@ public abstract class AbstractNioChannelTest<T extends AbstractNioChannel> {
         try {
             channel.config().getOptions();
         } finally {
-            channel.unsafe().closeForcibly();
+            channel.close();
             group.shutdownGracefully();
         }
     }

--- a/transport/src/test/java/io/netty/channel/socket/nio/AbstractNioDomainChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/nio/AbstractNioDomainChannelTest.java
@@ -58,7 +58,7 @@ public abstract class AbstractNioDomainChannelTest<T extends AbstractNioChannel>
             assertEquals(value3, value4);
             assertNotEquals(value1, value4);
         } finally {
-            channel.unsafe().closeForcibly();
+            channel.close();
             group.shutdownGracefully();
         }
     }
@@ -72,7 +72,7 @@ public abstract class AbstractNioDomainChannelTest<T extends AbstractNioChannel>
             assertFalse(channel.config().setOption(option, ""));
             assertNull(channel.config().getOption(option));
         } finally {
-            channel.unsafe().closeForcibly();
+            channel.close();
             group.shutdownGracefully();
         }
     }
@@ -84,7 +84,7 @@ public abstract class AbstractNioDomainChannelTest<T extends AbstractNioChannel>
         try {
             channel.config().getOptions();
         } finally {
-            channel.unsafe().closeForcibly();
+            channel.close();
             group.shutdownGracefully();
         }
     }


### PR DESCRIPTION
Motivation:

Channel.Unsafe interface contains a lot of methods that are really not needed anymore. Let's remove these with the end-goal of removing the whole interface at some point.

Modifications:

Remove various methods

Result:

Cleanup API
