### PR TITLE
Remove method from Channel.Unsafe to retrieve ChannelOutboundBuffer

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicStreamChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicStreamChannel.java
@@ -22,7 +22,6 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelId;
 import io.netty.channel.ChannelMetadata;
-import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelId;
@@ -75,6 +74,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
     private volatile boolean outputShutdown;
     private volatile QuicStreamPriority priority;
     private volatile long capacity;
+    private volatile boolean hasPending;
 
     QuicheQuicStreamChannel(QuicheQuicChannel parent, long streamId) {
         this.parent = parent;
@@ -92,6 +92,11 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
         if (parent.streamType(streamId) == QuicStreamType.UNIDIRECTIONAL && parent.isStreamLocalCreated(streamId)) {
             inputShutdown = true;
         }
+    }
+
+    @Override
+    public boolean hasPendingBytes() {
+        return hasPending;
     }
 
     @Override
@@ -686,6 +691,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
                 }
                 return written;
             } finally {
+                updateHasPending();
                 closeIfNeeded(wasFinSent);
                 inWriteQueued = false;
             }
@@ -718,7 +724,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
                 // Touch the message to make things easier in terms of debugging buffer leaks.
                 ReferenceCountUtil.touch(msg);
                 queue.add(msg, promise);
-
+                updateHasPending();
                 // Try again to write queued messages.
                 writeQueued();
             } else {
@@ -732,7 +738,13 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
             ReferenceCountUtil.touch(msg);
 
             queue.add(msg, promise);
+            updateHasPending();
             queue.removeAndFailAll(cause);
+            updateHasPending();
+        }
+
+        private void updateHasPending() {
+            hasPending = queue.bytes() > 0;
         }
 
         private Object filterMsg(Object msg) {
@@ -864,12 +876,6 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
         public void flush() {
             assert executor().inEventLoop();
             // NOOP.
-        }
-
-        @Override
-        @Nullable
-        public ChannelOutboundBuffer outboundBuffer() {
-            return null;
         }
 
         private void closeOnRead(ChannelPipeline pipeline, boolean readFrames) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
@@ -334,6 +334,12 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
             pipeline.fireChannelWritabilityChanged();
         }
     }
+
+    @Override
+    public boolean hasPendingBytes() {
+        return false;
+    }
+
     @Override
     public Http2FrameStream stream() {
         return stream;
@@ -1168,12 +1174,6 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
             // that are explicit flushed.
             writeDoneAndNoFlush = false;
             flush0(parentContext());
-        }
-
-        @Override
-        public ChannelOutboundBuffer outboundBuffer() {
-            // Always return null as we not use the ChannelOutboundBuffer and not even support it.
-            return null;
         }
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
@@ -90,7 +90,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
             .method(HttpMethod.GET.asciiName()).scheme(HttpScheme.HTTPS.name())
             .authority(new AsciiString("example.org")).path(new AsciiString("/foo"));
 
-    private EmbeddedChannel parentChannel;
+    private ParentChannel parentChannel;
     private Http2FrameWriter frameWriter;
     private Http2FrameInboundWriter frameInboundWriter;
     private TestChannelInitializer childChannelInitializer;
@@ -104,7 +104,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     @BeforeEach
     public void setUp() {
         childChannelInitializer = new TestChannelInitializer();
-        parentChannel = new EmbeddedChannel();
+        parentChannel = new ParentChannel();
         frameInboundWriter = new Http2FrameInboundWriter(parentChannel);
         parentChannel.connect(new InetSocketAddress(0));
         frameWriter = Http2TestUtil.mockedFrameWriter();
@@ -1136,8 +1136,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
         // Add something to the ChannelOutboundBuffer of the parent to simulate queuing in the parents channel buffer
         // and verify that this only affect the writability of the parent channel while the child stays writable
         // until it used all of its credits.
-        parentChannel.unsafe().outboundBuffer().addMessage(
-                Unpooled.buffer().writeZero(800), 800, parentChannel.newPromise());
+        parentChannel.addBuffer(Unpooled.buffer().writeZero(800));
         assertFalse(parentChannel.isWritable());
 
         assertTrue(childChannel.isWritable());
@@ -1723,5 +1722,12 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
 
     private static int eqStreamId(Http2StreamChannel channel) {
         return eq(channel.stream().id());
+    }
+
+    private static final class ParentChannel extends EmbeddedChannel {
+
+        void addBuffer(ByteBuf buf) {
+            outboundBuffer().addMessage(buf, buf.readableBytes(), newPromise());
+        }
     }
 }

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/EmbeddedQuicStreamChannel.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/EmbeddedQuicStreamChannel.java
@@ -263,11 +263,6 @@ final class EmbeddedQuicStreamChannel extends EmbeddedChannel implements QuicStr
                 public void flush() {
                     superUnsafe.flush();
                 }
-
-                @Override
-                public ChannelOutboundBuffer outboundBuffer() {
-                    return superUnsafe.outboundBuffer();
-                }
             };
         }
         return unsafe;

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -2181,8 +2181,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
             // If we weren't able to include client_hello in the TCP SYN (e.g. no token, disabled at the OS) we have to
             // flush pending data in the outbound buffer later in channelActive().
             final ChannelOutboundBuffer outboundBuffer;
-            if (fastOpen && ((outboundBuffer = channel.unsafe().outboundBuffer()) == null ||
-                    outboundBuffer.totalPendingWriteBytes() > 0)) {
+            if (fastOpen && channel.hasPendingBytes()) {
                 setState(STATE_NEEDS_FLUSH);
             }
         }

--- a/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
+++ b/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
@@ -109,7 +109,6 @@ public class IdleStateHandler extends ChannelDuplexHandler {
         }
     };
 
-    private final boolean observeOutput;
     private final long readerIdleTimeNanos;
     private final long writerIdleTimeNanos;
     private final long allIdleTimeNanos;
@@ -132,11 +131,6 @@ public class IdleStateHandler extends ChannelDuplexHandler {
     private static final byte ST_DESTROYED = 2;
 
     private boolean reading;
-
-    private long lastChangeCheckTimeStamp;
-    private int lastMessageHashCode;
-    private long lastPendingWriteBytes;
-    private long lastFlushProgress;
 
     /**
      * Creates a new instance firing {@link IdleStateEvent}s.
@@ -164,20 +158,8 @@ public class IdleStateHandler extends ChannelDuplexHandler {
     }
 
     /**
-     * @see #IdleStateHandler(boolean, long, long, long, TimeUnit)
-     */
-    public IdleStateHandler(
-            long readerIdleTime, long writerIdleTime, long allIdleTime,
-            TimeUnit unit) {
-        this(false, readerIdleTime, writerIdleTime, allIdleTime, unit);
-    }
-
-    /**
      * Creates a new instance firing {@link IdleStateEvent}s.
-     *
-     * @param observeOutput
-     *        whether or not the consumption of {@code bytes} should be taken into
-     *        consideration when assessing write idleness. The default is {@code false}.
+
      * @param readerIdleTime
      *        an {@link IdleStateEvent} whose state is {@link IdleState#READER_IDLE}
      *        will be triggered when no read was performed for the specified
@@ -194,12 +176,9 @@ public class IdleStateHandler extends ChannelDuplexHandler {
      *        the {@link TimeUnit} of {@code readerIdleTime},
      *        {@code writeIdleTime}, and {@code allIdleTime}
      */
-    public IdleStateHandler(boolean observeOutput,
-            long readerIdleTime, long writerIdleTime, long allIdleTime,
+    public IdleStateHandler(long readerIdleTime, long writerIdleTime, long allIdleTime,
             TimeUnit unit) {
         ObjectUtil.checkNotNull(unit, "unit");
-
-        this.observeOutput = observeOutput;
 
         if (readerIdleTime <= 0) {
             readerIdleTimeNanos = 0;
@@ -343,7 +322,6 @@ public class IdleStateHandler extends ChannelDuplexHandler {
         }
 
         state = ST_INITIALIZED;
-        initOutputChanged(ctx);
 
         lastReadTime = lastWriteTime = ticker.nanoTime();
         if (readerIdleTimeNanos > 0) {
@@ -406,75 +384,6 @@ public class IdleStateHandler extends ChannelDuplexHandler {
             default:
                 throw new IllegalArgumentException("Unhandled: state=" + state + ", first=" + first);
         }
-    }
-
-    /**
-     * @see #hasOutputChanged(ChannelHandlerContext, boolean)
-     */
-    private void initOutputChanged(ChannelHandlerContext ctx) {
-        if (observeOutput) {
-            Channel channel = ctx.channel();
-            Unsafe unsafe = channel.unsafe();
-            ChannelOutboundBuffer buf = unsafe.outboundBuffer();
-
-            if (buf != null) {
-                lastMessageHashCode = System.identityHashCode(buf.current());
-                lastPendingWriteBytes = buf.totalPendingWriteBytes();
-                lastFlushProgress = buf.currentProgress();
-            }
-        }
-    }
-
-    /**
-     * Returns {@code true} if and only if the {@link IdleStateHandler} was constructed
-     * with {@link #observeOutput} enabled and there has been an observed change in the
-     * {@link ChannelOutboundBuffer} between two consecutive calls of this method.
-     *
-     * https://github.com/netty/netty/issues/6150
-     */
-    private boolean hasOutputChanged(ChannelHandlerContext ctx, boolean first) {
-        if (observeOutput) {
-
-            // We can take this shortcut if the ChannelPromises that got passed into write()
-            // appear to complete. It indicates "change" on message level and we simply assume
-            // that there's change happening on byte level. If the user doesn't observe channel
-            // writability events then they'll eventually OOME and there's clearly a different
-            // problem and idleness is least of their concerns.
-            if (lastChangeCheckTimeStamp != lastWriteTime) {
-                lastChangeCheckTimeStamp = lastWriteTime;
-
-                // But this applies only if it's the non-first call.
-                if (!first) {
-                    return true;
-                }
-            }
-
-            Channel channel = ctx.channel();
-            Unsafe unsafe = channel.unsafe();
-            ChannelOutboundBuffer buf = unsafe.outboundBuffer();
-
-            if (buf != null) {
-                int messageHashCode = System.identityHashCode(buf.current());
-                long pendingWriteBytes = buf.totalPendingWriteBytes();
-
-                if (messageHashCode != lastMessageHashCode || pendingWriteBytes != lastPendingWriteBytes) {
-                    lastMessageHashCode = messageHashCode;
-                    lastPendingWriteBytes = pendingWriteBytes;
-
-                    if (!first) {
-                        return true;
-                    }
-                }
-
-                long flushProgress = buf.currentProgress();
-                if (flushProgress != lastFlushProgress) {
-                    lastFlushProgress = flushProgress;
-                    return !first;
-                }
-            }
-        }
-
-        return false;
     }
 
     private abstract static class AbstractIdleTask implements Runnable {
@@ -549,10 +458,6 @@ public class IdleStateHandler extends ChannelDuplexHandler {
                 firstWriterIdleEvent = false;
 
                 try {
-                    if (hasOutputChanged(ctx, first)) {
-                        return;
-                    }
-
                     IdleStateEvent event = newIdleStateEvent(IdleState.WRITER_IDLE, first);
                     channelIdle(ctx, event);
                 } catch (Throwable t) {
@@ -587,10 +492,6 @@ public class IdleStateHandler extends ChannelDuplexHandler {
                 firstAllIdleEvent = false;
 
                 try {
-                    if (hasOutputChanged(ctx, first)) {
-                        return;
-                    }
-
                     IdleStateEvent event = newIdleStateEvent(IdleState.ALL_IDLE, first);
                     channelIdle(ctx, event);
                 } catch (Throwable t) {

--- a/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
@@ -23,7 +23,6 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.FileRegion;
 import io.netty.util.Attribute;
@@ -586,10 +585,11 @@ public abstract class AbstractTrafficShapingHandler extends ChannelDuplexHandler
     }
 
     void setUserDefinedWritability(ChannelHandlerContext ctx, boolean writable) {
-        ChannelOutboundBuffer cob = ctx.channel().unsafe().outboundBuffer();
+        // TODO: Come up with a way to support this without leaking implementation details.
+        /*ChannelOutboundBuffer cob = ctx.channel().unsafe().outboundBuffer();
         if (cob != null) {
             cob.setUserDefinedWritability(userDefinedWritabilityIndex, writable);
-        }
+        }*/
     }
 
     /**

--- a/handler/src/test/java/io/netty/handler/timeout/IdleStateHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/timeout/IdleStateHandlerTest.java
@@ -15,13 +15,9 @@
  */
 package io.netty.handler.timeout;
 
-import io.netty.buffer.Unpooled;
-import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.util.ReferenceCountUtil;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -30,16 +26,13 @@ import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class IdleStateHandlerTest {
 
     @Test
     public void testReaderIdle() throws Exception {
-        IdleStateHandler idleStateHandler = new IdleStateHandler(
-                false, 1L, 0L, 0L, TimeUnit.SECONDS);
+        IdleStateHandler idleStateHandler = new IdleStateHandler(1L, 0L, 0L, TimeUnit.SECONDS);
 
         // We start with one FIRST_READER_IDLE_STATE_EVENT, followed by an infinite number of READER_IDLE_STATE_EVENTs
         anyIdle(idleStateHandler, IdleStateEvent.FIRST_READER_IDLE_STATE_EVENT,
@@ -48,8 +41,7 @@ public class IdleStateHandlerTest {
 
     @Test
     public void testWriterIdle() throws Exception {
-        IdleStateHandler idleStateHandler = new IdleStateHandler(
-                false, 0L, 1L, 0L, TimeUnit.SECONDS);
+        IdleStateHandler idleStateHandler = new IdleStateHandler(0L, 1L, 0L, TimeUnit.SECONDS);
 
         anyIdle(idleStateHandler, IdleStateEvent.FIRST_WRITER_IDLE_STATE_EVENT,
                 IdleStateEvent.WRITER_IDLE_STATE_EVENT, IdleStateEvent.WRITER_IDLE_STATE_EVENT);
@@ -57,8 +49,7 @@ public class IdleStateHandlerTest {
 
     @Test
     public void testAllIdle() throws Exception {
-        IdleStateHandler idleStateHandler = new IdleStateHandler(
-                false, 0L, 0L, 1L, TimeUnit.SECONDS);
+        IdleStateHandler idleStateHandler = new IdleStateHandler(0L, 0L, 1L, TimeUnit.SECONDS);
 
         anyIdle(idleStateHandler, IdleStateEvent.FIRST_ALL_IDLE_STATE_EVENT,
                 IdleStateEvent.ALL_IDLE_STATE_EVENT, IdleStateEvent.ALL_IDLE_STATE_EVENT);
@@ -100,8 +91,7 @@ public class IdleStateHandlerTest {
 
     @Test
     public void testResetReader() throws Exception {
-        final IdleStateHandler idleStateHandler = new IdleStateHandler(
-                false, 1L, 0L, 0L, TimeUnit.SECONDS);
+        final IdleStateHandler idleStateHandler = new IdleStateHandler(1L, 0L, 0L, TimeUnit.SECONDS);
 
         Action action = new Action() {
             @Override
@@ -115,8 +105,7 @@ public class IdleStateHandlerTest {
 
     @Test
     public void testResetWriter() throws Exception {
-        final IdleStateHandler idleStateHandler = new IdleStateHandler(
-                false, 0L, 1L, 0L, TimeUnit.SECONDS);
+        final IdleStateHandler idleStateHandler = new IdleStateHandler(0L, 1L, 0L, TimeUnit.SECONDS);
 
         Action action = new Action() {
             @Override
@@ -130,8 +119,7 @@ public class IdleStateHandlerTest {
 
     @Test
     public void testReaderNotIdle() throws Exception {
-        IdleStateHandler idleStateHandler = new IdleStateHandler(
-                false, 1L, 0L, 0L, TimeUnit.SECONDS);
+        IdleStateHandler idleStateHandler = new IdleStateHandler(1L, 0L, 0L, TimeUnit.SECONDS);
 
         Action action = new Action() {
             @Override
@@ -145,8 +133,7 @@ public class IdleStateHandlerTest {
 
     @Test
     public void testWriterNotIdle() throws Exception {
-        IdleStateHandler idleStateHandler = new IdleStateHandler(
-                false, 0L, 1L, 0L, TimeUnit.SECONDS);
+        IdleStateHandler idleStateHandler = new IdleStateHandler(0L, 1L, 0L, TimeUnit.SECONDS);
 
         Action action = new Action() {
             @Override
@@ -161,8 +148,7 @@ public class IdleStateHandlerTest {
     @Test
     public void testAllNotIdle() throws Exception {
         // Reader...
-        IdleStateHandler idleStateHandler = new IdleStateHandler(
-                false, 0L, 0L, 1L, TimeUnit.SECONDS);
+        IdleStateHandler idleStateHandler = new IdleStateHandler(0L, 0L, 1L, TimeUnit.SECONDS);
 
         Action reader = new Action() {
             @Override
@@ -174,8 +160,7 @@ public class IdleStateHandlerTest {
         anyNotIdle(idleStateHandler, reader, IdleStateEvent.FIRST_ALL_IDLE_STATE_EVENT);
 
         // Writer...
-        idleStateHandler = new IdleStateHandler(
-                false, 0L, 0L, 1L, TimeUnit.SECONDS);
+        idleStateHandler = new IdleStateHandler(0L, 0L, 1L, TimeUnit.SECONDS);
 
         Action writer = new Action() {
             @Override
@@ -225,195 +210,7 @@ public class IdleStateHandlerTest {
         }
     }
 
-    @Test
-    public void testObserveWriterIdle() throws Exception {
-        observeOutputIdle(true);
-    }
-
-    @Test
-    public void testObserveAllIdle() throws Exception {
-        observeOutputIdle(false);
-    }
-
-    private static void observeOutputIdle(boolean writer) throws Exception {
-
-        long writerIdleTime = 0L;
-        long allIdleTime = 0L;
-        IdleStateEvent expected;
-
-        if (writer) {
-            writerIdleTime = 5L;
-            expected = IdleStateEvent.FIRST_WRITER_IDLE_STATE_EVENT;
-        } else {
-            allIdleTime = 5L;
-            expected = IdleStateEvent.FIRST_ALL_IDLE_STATE_EVENT;
-        }
-
-        IdleStateHandler idleStateHandler = new IdleStateHandler(
-                true, 0L, writerIdleTime, allIdleTime, TimeUnit.SECONDS);
-
-        final List<Object> events = new ArrayList<Object>();
-        ChannelInboundHandlerAdapter handler = new ChannelInboundHandlerAdapter() {
-            @Override
-            public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
-                events.add(evt);
-            }
-        };
-
-        ObservableChannel channel = new ObservableChannel(idleStateHandler, handler);
-        channel.freezeTime();
-        try {
-            // We're writing 3 messages that will be consumed at different rates!
-            channel.writeAndFlush(Unpooled.wrappedBuffer(new byte[] { 1 }));
-            channel.writeAndFlush(Unpooled.wrappedBuffer(new byte[] { 2 }));
-            channel.writeAndFlush(Unpooled.wrappedBuffer(new byte[] { 3 }));
-            channel.writeAndFlush(Unpooled.wrappedBuffer(new byte[5 * 1024]));
-
-            // Establish a baseline. We're not consuming anything and let it idle once.
-            channel.advanceTimeBy(5, TimeUnit.SECONDS);
-            channel.runPendingTasks();
-            assertEquals(1, events.size());
-            assertSame(expected, events.get(0));
-            events.clear();
-
-            // Consume one message in 4 seconds, then be idle for 2 seconds,
-            // then run the task and we shouldn't get an IdleStateEvent because
-            // we haven't been idle for long enough!
-            channel.advanceTimeBy(4, TimeUnit.SECONDS);
-            channel.runPendingTasks();
-            assertNotNullAndRelease(channel.consume());
-
-            channel.advanceTimeBy(2, TimeUnit.SECONDS);
-            channel.runPendingTasks();
-            assertEquals(0, events.size());
-
-            // Consume one message in 3 seconds, then be idle for 4 seconds,
-            // then run the task and we shouldn't get an IdleStateEvent because
-            // we haven't been idle for long enough!
-            channel.advanceTimeBy(2, TimeUnit.SECONDS);
-            channel.runPendingTasks();
-            assertNotNullAndRelease(channel.consume());
-
-            channel.advanceTimeBy(4, TimeUnit.SECONDS);
-            channel.runPendingTasks();
-            assertEquals(0, events.size());
-
-            // Don't consume a message and be idle for 5 seconds.
-            // We should get an IdleStateEvent!
-            channel.advanceTimeBy(5, TimeUnit.SECONDS);
-            channel.runPendingTasks();
-            assertEquals(1, events.size());
-            events.clear();
-
-            // Consume one message in 2 seconds, then be idle for 1 seconds,
-            // then run the task and we shouldn't get an IdleStateEvent because
-            // we haven't been idle for long enough!
-            channel.advanceTimeBy(2, TimeUnit.SECONDS);
-            channel.runPendingTasks();
-            assertNotNullAndRelease(channel.consume());
-
-            channel.advanceTimeBy(1, TimeUnit.SECONDS);
-            channel.runPendingTasks();
-            assertEquals(0, events.size());
-
-            // Consume part of the message every 2 seconds, then be idle for 1 seconds,
-            // then run the task and we should get an IdleStateEvent because the first trigger
-            channel.advanceTimeBy(2, TimeUnit.SECONDS);
-            channel.runPendingTasks();
-            assertNotNullAndRelease(channel.consumePart(1024));
-            channel.advanceTimeBy(2, TimeUnit.SECONDS);
-            channel.runPendingTasks();
-            assertNotNullAndRelease(channel.consumePart(1024));
-            channel.advanceTimeBy(1, TimeUnit.SECONDS);
-            channel.runPendingTasks();
-            assertEquals(1, events.size());
-            events.clear();
-
-            // Consume part of the message every 2 seconds, then be idle for 1 seconds,
-            // then consume all the rest of the message, then run the task and we shouldn't
-            // get an IdleStateEvent because the data is flowing and we haven't been idle for long enough!
-            channel.advanceTimeBy(2, TimeUnit.SECONDS);
-            channel.runPendingTasks();
-            assertNotNullAndRelease(channel.consumePart(1024));
-            channel.advanceTimeBy(2, TimeUnit.SECONDS);
-            channel.runPendingTasks();
-            assertNotNullAndRelease(channel.consumePart(1024));
-            channel.advanceTimeBy(1, TimeUnit.SECONDS);
-            channel.runPendingTasks();
-            assertEquals(0, events.size());
-            channel.advanceTimeBy(2, TimeUnit.SECONDS);
-            channel.runPendingTasks();
-            assertNotNullAndRelease(channel.consumePart(1024));
-
-            // There are no messages left! Advance the ticker by 3 seconds,
-            // attempt a consume() but it will be null, then advance the
-            // ticker by an another 2 seconds and we should get an IdleStateEvent
-            // because we've been idle for 5 seconds.
-            channel.advanceTimeBy(3, TimeUnit.SECONDS);
-            channel.runPendingTasks();
-            assertNull(channel.consume());
-
-            channel.advanceTimeBy(2, TimeUnit.SECONDS);
-            channel.runPendingTasks();
-            assertEquals(1, events.size());
-
-            // q.e.d.
-        } finally {
-            channel.finishAndReleaseAll();
-        }
-    }
-
-    private static void assertNotNullAndRelease(Object msg) {
-        assertNotNull(msg);
-        ReferenceCountUtil.release(msg);
-    }
-
     private interface Action {
         void run(EmbeddedChannel channel) throws Exception;
-    }
-
-    private static class ObservableChannel extends EmbeddedChannel {
-
-        ObservableChannel(ChannelHandler... handlers) {
-            super(handlers);
-        }
-
-        @Override
-        protected void doWrite(ChannelOutboundBuffer in) throws Exception {
-            // Overridden to change EmbeddedChannel's default behavior. We went to keep
-            // the messages in the ChannelOutboundBuffer.
-        }
-
-        private Object consume() {
-            ChannelOutboundBuffer buf = unsafe().outboundBuffer();
-            if (buf != null) {
-                Object msg = buf.current();
-                if (msg != null) {
-                    ReferenceCountUtil.retain(msg);
-                    buf.remove();
-                    return msg;
-                }
-            }
-            return null;
-        }
-
-        /**
-         * Consume the part of a message.
-         *
-         * @param byteCount count of byte to be consumed
-         * @return the message currently being consumed
-         */
-        private Object consumePart(int byteCount) {
-            ChannelOutboundBuffer buf = unsafe().outboundBuffer();
-            if (buf != null) {
-                Object msg = buf.current();
-                if (msg != null) {
-                    ReferenceCountUtil.retain(msg);
-                    buf.removeBytes(byteCount);
-                    return msg;
-                }
-            }
-            return null;
-        }
     }
 }

--- a/handler/src/test/java/io/netty/handler/traffic/TrafficShapingHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/traffic/TrafficShapingHandlerTest.java
@@ -35,11 +35,13 @@ import io.netty.channel.local.LocalServerChannel;
 import io.netty.util.Attribute;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+@Disabled("FIX implementation")
 public class TrafficShapingHandlerTest {
 
     private static final long READ_LIMIT_BYTES_PER_SECOND = 1;

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/TrafficShapingHandlerTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/TrafficShapingHandlerTest.java
@@ -32,6 +32,7 @@ import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
@@ -46,6 +47,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Disabled("TODO: Fix implementation")
 public class TrafficShapingHandlerTest extends AbstractSocketTest {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(TrafficShapingHandlerTest.class);
     private static final InternalLogger loggerServer = InternalLoggerFactory.getInstance("ServerTSH");

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannel.java
@@ -110,7 +110,7 @@ public final class EpollSocketChannel extends AbstractEpollStreamChannel impleme
     @Override
     boolean doConnect0(SocketAddress remote) throws Exception {
         if (IS_SUPPORTING_TCP_FASTOPEN_CLIENT && config.isTcpFastOpenConnect()) {
-            ChannelOutboundBuffer outbound = unsafe().outboundBuffer();
+            ChannelOutboundBuffer outbound = outboundBuffer();
             outbound.addFlush();
             Object curr;
             if ((curr = outbound.current()) instanceof ByteBuf) {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -982,7 +982,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
 
                 // If we could write all and we did not schedule a pollout yet let us try to write again
                 if (writtenAll && (ioState & POLL_OUT_SCHEDULED) == 0) {
-                    scheduleWriteIfNeeded(unsafe().outboundBuffer(), false);
+                    scheduleWriteIfNeeded(outboundBuffer(), false);
                 }
             }
         }
@@ -1088,7 +1088,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
                     ByteBuf initialData = null;
                     if (IoUring.isTcpFastOpenClientSideAvailable() &&
                         config().getOption(ChannelOption.TCP_FASTOPEN_CONNECT) == Boolean.TRUE) {
-                        ChannelOutboundBuffer outbound = unsafe().outboundBuffer();
+                        ChannelOutboundBuffer outbound = outboundBuffer();
                         outbound.addFlush();
                         Object curr;
                         if ((curr = outbound.current()) instanceof ByteBuf) {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -588,7 +588,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                 writeId = 0;
                 writeOpCode = 0;
             }
-            ChannelOutboundBuffer channelOutboundBuffer = unsafe().outboundBuffer();
+            ChannelOutboundBuffer channelOutboundBuffer = outboundBuffer();
             Object current = channelOutboundBuffer.current();
             if (current instanceof IoUringFileRegion) {
                 IoUringFileRegion fileRegion = (IoUringFileRegion) current;

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDomainSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDomainSocketChannel.java
@@ -142,7 +142,7 @@ public final class IoUringDomainSocketChannel extends AbstractIoUringStreamChann
                 try {
                     int nativeCallResult = res >= 0 ? res : Errors.ioResult("io_uring sendmsg", res);
                     if (nativeCallResult >= 0) {
-                        ChannelOutboundBuffer channelOutboundBuffer = unsafe().outboundBuffer();
+                        ChannelOutboundBuffer channelOutboundBuffer = outboundBuffer();
                         channelOutboundBuffer.remove();
                     }
                 } catch (Throwable throwable) {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
@@ -136,7 +136,7 @@ public final class IoUringSocketChannel extends AbstractIoUringStreamChannel imp
 
         @Override
         boolean writeComplete0(byte op, int res, int flags, short data, int outstanding) {
-            ChannelOutboundBuffer channelOutboundBuffer = unsafe().outboundBuffer();
+            ChannelOutboundBuffer channelOutboundBuffer = outboundBuffer();
             if (op == Native.IORING_OP_SEND_ZC || op == Native.IORING_OP_SENDMSG_ZC) {
                 return handleWriteCompleteZeroCopy(op, channelOutboundBuffer, res, flags);
             }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannel.java
@@ -65,7 +65,7 @@ public final class KQueueSocketChannel extends AbstractKQueueStreamChannel imple
     @Override
     protected boolean doConnect0(SocketAddress remoteAddress, SocketAddress localAddress) throws Exception {
         if (config.isTcpFastOpenConnect()) {
-            ChannelOutboundBuffer outbound = unsafe().outboundBuffer();
+            ChannelOutboundBuffer outbound = outboundBuffer();
             outbound.addFlush();
             Object curr;
             if ((curr = outbound.current()) instanceof ByteBuf) {

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -118,6 +118,34 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
     }
 
     @Override
+    public boolean hasPendingBytes() {
+        ChannelOutboundBuffer buf = outboundBuffer();
+        return buf != null && buf.totalPendingWriteBytes() > 0;
+    }
+
+    @Override
+    public boolean isWritable() {
+        ChannelOutboundBuffer buf = outboundBuffer();
+        return buf != null && buf.isWritable();
+    }
+
+    @Override
+    public long bytesBeforeUnwritable() {
+        ChannelOutboundBuffer buf = outboundBuffer();
+        // isWritable() is currently assuming if there is no outboundBuffer then the channel is not writable.
+        // We should be consistent with that here.
+        return buf != null ? buf.bytesBeforeUnwritable() : 0;
+    }
+
+    @Override
+    public long bytesBeforeWritable() {
+        ChannelOutboundBuffer buf = outboundBuffer();
+        // isWritable() is currently assuming if there is no outboundBuffer then the channel is not writable.
+        // We should be consistent with that here.
+        return buf != null ? buf.bytesBeforeWritable() : Long.MAX_VALUE;
+    }
+
+    @Override
     public final ChannelId id() {
         return id;
     }
@@ -126,7 +154,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
      * Returns a new {@link ChannelPipeline} instance.
      */
     protected ChannelPipeline newChannelPipeline() {
-        return new DefaultChannelPipeline(this);
+        return new DefaultAbstractChannelPipeline(this);
     }
 
     @Override
@@ -288,12 +316,17 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         return strVal;
     }
 
+    private volatile ChannelOutboundBuffer outboundBuffer = new ChannelOutboundBuffer(AbstractChannel.this);
+
+    protected final ChannelOutboundBuffer outboundBuffer() {
+        return outboundBuffer;
+    }
+
     /**
      * {@link Unsafe} implementation which sub-classes must extend and use.
      */
     protected abstract class AbstractUnsafe implements Unsafe {
 
-        private volatile ChannelOutboundBuffer outboundBuffer = new ChannelOutboundBuffer(AbstractChannel.this);
         private RecvByteBufAllocator.Handle recvHandle;
         private MessageSizeEstimator.Handle estimatorHandle;
 
@@ -317,11 +350,6 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                 recvHandle = config().getRecvByteBufAllocator().newHandle();
             }
             return recvHandle;
-        }
-
-        @Override
-        public final ChannelOutboundBuffer outboundBuffer() {
-            return outboundBuffer;
         }
 
         @Override
@@ -496,12 +524,12 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                 return;
             }
 
-            final ChannelOutboundBuffer outboundBuffer = this.outboundBuffer;
+            final ChannelOutboundBuffer outboundBuffer = AbstractChannel.this.outboundBuffer;
             if (outboundBuffer == null) {
                 promise.setFailure(new ClosedChannelException());
                 return;
             }
-            this.outboundBuffer = null; // Disallow adding any messages and flushes to outboundBuffer.
+            AbstractChannel.this.outboundBuffer = null; // Disallow adding any messages and flushes to outboundBuffer.
 
             final Throwable shutdownCause = cause == null ?
                     new ChannelOutputShutdownException("Channel output shutdown") :
@@ -555,8 +583,8 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             closeInitiated = true;
 
             final boolean wasActive = isActive();
-            final ChannelOutboundBuffer outboundBuffer = this.outboundBuffer;
-            this.outboundBuffer = null; // Disallow adding any messages and flushes to outboundBuffer.
+            final ChannelOutboundBuffer outboundBuffer = AbstractChannel.this.outboundBuffer;
+            AbstractChannel.this.outboundBuffer = null; // Disallow adding any messages and flushes to outboundBuffer.
             Executor closeExecutor = prepareToClose();
             if (closeExecutor != null) {
                 closeExecutor.execute(new Runnable() {
@@ -692,7 +720,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         public final void write(Object msg, ChannelPromise promise) {
             assertEventLoop();
 
-            ChannelOutboundBuffer outboundBuffer = this.outboundBuffer;
+            ChannelOutboundBuffer outboundBuffer = AbstractChannel.this.outboundBuffer;
             if (outboundBuffer == null) {
                 try {
                     // release message now to prevent resource-leak
@@ -731,7 +759,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         public final void flush() {
             assertEventLoop();
 
-            ChannelOutboundBuffer outboundBuffer = this.outboundBuffer;
+            ChannelOutboundBuffer outboundBuffer = AbstractChannel.this.outboundBuffer;
             if (outboundBuffer == null) {
                 return;
             }
@@ -747,7 +775,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                 return;
             }
 
-            final ChannelOutboundBuffer outboundBuffer = this.outboundBuffer;
+            final ChannelOutboundBuffer outboundBuffer = AbstractChannel.this.outboundBuffer;
             if (outboundBuffer == null || outboundBuffer.isEmpty()) {
                 return;
             }
@@ -1060,6 +1088,29 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         @Override
         public Throwable fillInStackTrace() {
             return this;
+        }
+    }
+
+    protected class DefaultAbstractChannelPipeline extends DefaultChannelPipeline {
+
+        protected DefaultAbstractChannelPipeline(AbstractChannel channel) {
+            super(channel);
+        }
+
+        @Override
+        protected final void incrementPendingOutboundBytes(long size) {
+            ChannelOutboundBuffer buffer = outboundBuffer();
+            if (buffer != null) {
+                buffer.incrementPendingOutboundBytes(size);
+            }
+        }
+
+        @Override
+        protected final void decrementPendingOutboundBytes(long size) {
+            ChannelOutboundBuffer buffer = outboundBuffer();
+            if (buffer != null) {
+                buffer.decrementPendingOutboundBytes(size);
+            }
         }
     }
 }

--- a/transport/src/main/java/io/netty/channel/Channel.java
+++ b/transport/src/main/java/io/netty/channel/Channel.java
@@ -154,6 +154,14 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparabl
     ChannelFuture closeFuture();
 
     /**
+     * Returns {@code true} if this {@link Channel} has any pending bytes stored that were not written
+     * to the underlying transport yet, {@code false} otherwise.
+     *
+     * @return  if there are any pending bytes.
+     */
+    boolean hasPendingBytes();
+
+    /**
      * Returns {@code true} if and only if the I/O thread will perform the
      * requested write operation immediately.  Any write requests made when
      * this method returns {@code false} are queued until the I/O thread is
@@ -162,10 +170,7 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparabl
      * {@link WriteBufferWaterMark} can be used to configure on which condition
      * the write buffer would cause this channel to change writability.
      */
-    default boolean isWritable() {
-        ChannelOutboundBuffer buf = unsafe().outboundBuffer();
-        return buf != null && buf.isWritable();
-    }
+    boolean isWritable();
 
     /**
      * Get how many bytes can be written until {@link #isWritable()} returns {@code false}.
@@ -173,12 +178,7 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparabl
      *
      * {@link WriteBufferWaterMark} can be used to define writability settings.
      */
-    default long bytesBeforeUnwritable() {
-        ChannelOutboundBuffer buf = unsafe().outboundBuffer();
-        // isWritable() is currently assuming if there is no outboundBuffer then the channel is not writable.
-        // We should be consistent with that here.
-        return buf != null ? buf.bytesBeforeUnwritable() : 0;
-    }
+    long bytesBeforeUnwritable();
 
     /**
      * Get how many bytes must be drained from underlying buffers until {@link #isWritable()} returns {@code true}.
@@ -186,12 +186,7 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparabl
      *
      * {@link WriteBufferWaterMark} can be used to define writability settings.
      */
-    default long bytesBeforeWritable() {
-        ChannelOutboundBuffer buf = unsafe().outboundBuffer();
-        // isWritable() is currently assuming if there is no outboundBuffer then the channel is not writable.
-        // We should be consistent with that here.
-        return buf != null ? buf.bytesBeforeWritable() : Long.MAX_VALUE;
-    }
+    long bytesBeforeWritable();
 
     /**
      * Returns an <em>internal-use-only</em> object that provides unsafe operations.
@@ -428,10 +423,5 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparabl
          * Flush out all write operations scheduled via {@link #write(Object, ChannelPromise)}.
          */
         void flush();
-
-        /**
-         * Returns the {@link ChannelOutboundBuffer} of the {@link Channel} where the pending write requests are stored.
-         */
-        ChannelOutboundBuffer outboundBuffer();
     }
 }

--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -1198,17 +1198,11 @@ public class DefaultChannelPipeline implements ChannelPipeline {
     }
 
     protected void incrementPendingOutboundBytes(long size) {
-        ChannelOutboundBuffer buffer = channel.unsafe().outboundBuffer();
-        if (buffer != null) {
-            buffer.incrementPendingOutboundBytes(size);
-        }
+       // NOOP
     }
 
     protected void decrementPendingOutboundBytes(long size) {
-        ChannelOutboundBuffer buffer = channel.unsafe().outboundBuffer();
-        if (buffer != null) {
-            buffer.decrementPendingOutboundBytes(size);
-        }
+        // NOOP
     }
 
     // A special catch-all handler that handles both bytes and messages.

--- a/transport/src/main/java/io/netty/channel/PendingBytesTracker.java
+++ b/transport/src/main/java/io/netty/channel/PendingBytesTracker.java
@@ -33,10 +33,8 @@ abstract class PendingBytesTracker implements MessageSizeEstimator.Handle {
     public abstract void decrementPendingOutboundBytes(long bytes);
 
     static PendingBytesTracker newTracker(Channel channel) {
-        if (channel.pipeline() instanceof DefaultChannelPipeline) {
-            return new DefaultChannelPipelinePendingBytesTracker((DefaultChannelPipeline) channel.pipeline());
-        } else {
-            ChannelOutboundBuffer buffer = channel.unsafe().outboundBuffer();
+        if (channel instanceof AbstractChannel) {
+            ChannelOutboundBuffer buffer = ((AbstractChannel) channel).outboundBuffer();
             MessageSizeEstimator.Handle handle = channel.config().getMessageSizeEstimator().newHandle();
             // We need to guard against null as channel.unsafe().outboundBuffer() may returned null
             // if the channel was already closed when constructing the PendingBytesTracker.
@@ -44,6 +42,11 @@ abstract class PendingBytesTracker implements MessageSizeEstimator.Handle {
             return buffer == null ?
                     new NoopPendingBytesTracker(handle) : new ChannelOutboundBufferPendingBytesTracker(buffer, handle);
         }
+        if (channel.pipeline() instanceof DefaultChannelPipeline) {
+            return new DefaultChannelPipelinePendingBytesTracker((DefaultChannelPipeline) channel.pipeline());
+        }
+        MessageSizeEstimator.Handle handle = channel.config().getMessageSizeEstimator().newHandle();
+        return new NoopPendingBytesTracker(handle);
     }
 
     private static final class DefaultChannelPipelinePendingBytesTracker extends PendingBytesTracker {

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
@@ -1285,11 +1285,6 @@ public class EmbeddedChannel extends AbstractChannel {
                     maybeRunPendingTasks();
                 }
             }
-
-            @Override
-            public ChannelOutboundBuffer outboundBuffer() {
-                return EmbeddedUnsafe.this.outboundBuffer();
-            }
         };
 
         @Override
@@ -1308,7 +1303,7 @@ public class EmbeddedChannel extends AbstractChannel {
         }
     }
 
-    private final class EmbeddedChannelPipeline extends DefaultChannelPipeline {
+    private final class EmbeddedChannelPipeline extends DefaultAbstractChannelPipeline {
         EmbeddedChannelPipeline(EmbeddedChannel channel) {
             super(channel);
         }

--- a/transport/src/test/java/io/netty/channel/ChannelOutboundBufferTest.java
+++ b/transport/src/test/java/io/netty/channel/ChannelOutboundBufferTest.java
@@ -286,17 +286,17 @@ public class ChannelOutboundBufferTest {
         ch.write(buffer().writeZero(2));
         assertEquals("", buf.toString());
 
-        ch.unsafe().outboundBuffer().addFlush();
+        ch.outboundBuffer().addFlush();
 
         // Ensure exceeding the high watermark makes channel unwritable.
         ch.write(buffer().writeZero(127));
         assertEquals("false ", buf.toString());
 
         // Ensure going down to the low watermark makes channel writable again by flushing the first write.
-        assertTrue(ch.unsafe().outboundBuffer().remove());
-        assertTrue(ch.unsafe().outboundBuffer().remove());
+        assertTrue(ch.outboundBuffer().remove());
+        assertTrue(ch.outboundBuffer().remove());
         assertEquals(127L + ChannelOutboundBuffer.CHANNEL_OUTBOUND_BUFFER_ENTRY_OVERHEAD,
-                ch.unsafe().outboundBuffer().totalPendingWriteBytes());
+                ch.outboundBuffer().totalPendingWriteBytes());
         assertEquals("false true ", buf.toString());
 
         safeClose(ch);
@@ -316,7 +316,7 @@ public class ChannelOutboundBufferTest {
         ch.config().setWriteBufferLowWaterMark(128);
         ch.config().setWriteBufferHighWaterMark(256);
 
-        ChannelOutboundBuffer cob = ch.unsafe().outboundBuffer();
+        ChannelOutboundBuffer cob = ch.outboundBuffer();
 
         // Ensure that the default value of a user-defined writability flag is true.
         for (int i = 1; i <= 30; i ++) {
@@ -350,7 +350,7 @@ public class ChannelOutboundBufferTest {
         ch.config().setWriteBufferLowWaterMark(128);
         ch.config().setWriteBufferHighWaterMark(256);
 
-        ChannelOutboundBuffer cob = ch.unsafe().outboundBuffer();
+        ChannelOutboundBuffer cob = ch.outboundBuffer();
 
         // Ensure that setting a user-defined writability flag to false affects channel.isWritable()
         cob.setUserDefinedWritability(1, false);
@@ -390,7 +390,7 @@ public class ChannelOutboundBufferTest {
         ch.config().setWriteBufferLowWaterMark(128);
         ch.config().setWriteBufferHighWaterMark(256);
 
-        ChannelOutboundBuffer cob = ch.unsafe().outboundBuffer();
+        ChannelOutboundBuffer cob = ch.outboundBuffer();
 
         // Trigger channelWritabilityChanged() by writing a lot.
         ch.write(buffer().writeZero(257));


### PR DESCRIPTION
Motivation:

ChannelOutboundBuffer is an implementation detail of AbstractChannel and so should not leak into the public API. Let's remove it, this is a followup of 8a5c3de402e3137005b8e5ce39164f303be91571.

Modifications:

- Remove method to retrieve ChannelOutboundBuffer from Unsafe.
- Add new Channel.hasPendingBytes() method and use it in SslHandler as replacement of using ChannelOutboundBuffer
- Remove abilitiy to monitor output changes in IdleStateHandler as how this was implemented was hacky and depended on ChannelOutboundBuffer.
- Disable traffic shapping handler for now as we need to find a better way to support this.

Result:

Don't leak implementation details and also ensure people not mess with internals