### PR TITLE
GraalVM: Constructor arguments of NIO channels need to be adjusted

### DIFF
--- a/transport/src/main/resources/META-INF/native-image/io.netty/netty5-transport/reflect-config.json
+++ b/transport/src/main/resources/META-INF/native-image/io.netty/netty5-transport/reflect-config.json
@@ -2,13 +2,13 @@
     {
       "name": "io.netty.channel.socket.nio.NioServerSocketChannel",
       "methods": [
-        { "name": "<init>", "parameterTypes": [] }
+        { "name": "<init>", "parameterTypes": ["io.netty.channel.EventLoop", "io.netty.Channel.EventLoopGroup"] }
       ]
     },
     {
       "name": "io.netty.channel.socket.nio.NioSocketChannel",
       "methods": [
-        { "name": "<init>", "parameterTypes": [] }
+        { "name": "<init>", "parameterTypes": ["io.netty.channel.EventLoop"] }
       ]
     },
     {
@@ -40,7 +40,7 @@
         "name": "io.netty.channel.socket.nio.NioDatagramChannel",
         "methods": [
           {
-            "name": "<init>", "parameterTypes": []
+            "name": "<init>", "parameterTypes": ["io.netty.channel.EventLoop"]
           }
         ]
     }


### PR DESCRIPTION
Motivation:

Our channel implementation don't have a no-arg constructor anymore, we need to adjust the graal config.

Modifications:

Adjust graal config

Result:

Graal build passes again