### PR TITLE
Fix race condition in NonStickyEventExecutorGroup causing incorrect i…

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/NonStickyEventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/NonStickyEventExecutorGroup.java
@@ -258,6 +258,8 @@ public final class NonStickyEventExecutorGroup implements EventExecutorGroup {
                             executor.execute(this);
                             return; // done
                         } catch (Throwable ignore) {
+                            // Restore executingThread since we're continuing to execute tasks.
+                            executingThread.set(current);
                             // Reset the state back to running as we will keep on executing tasks.
                             state.set(RUNNING);
                             // if an error happened we should just ignore it and let the loop run again as there is not


### PR DESCRIPTION
…nEventLoop() results (#15927)

## Motivation

A race condition exists in
`NonStickyEventExecutorGroup.NonStickyOrderedEventExecutor` that can cause `inEventLoop()` to return incorrect results,
  potentially leading to deadlocks and synchronization issues.

## Modifications

- Restore `executingThread` in the exception handler before setting `state` to `RUNNING` in

`common/src/main/java/io/netty/util/concurrent/NonStickyEventExecutorGroup.java:262`
- Add test `testInEventLoopAfterReschedulingFailure()` to verify `inEventLoop()` returns true after failed reschedule attempt

## Result

The executor correctly maintains `executingThread` even when rescheduling fails, and `inEventLoop()` consistently returns accurate results.

## Details

When the executor processes `maxTaskExecutePerRun` tasks and needs to reschedule itself, if `executor.execute(this)` throws an exception (e.g., queue
full), the catch block previously reset `state` to `RUNNING` but did not restore `executingThread`, leaving it `null`.

This fix ensures `executingThread.set(current)` is called before `state.set(RUNNING)` to maintain the invariant that when `state == RUNNING`, the
  executing thread is properly tracked.


## Testing

The new test `testInEventLoopAfterReschedulingFailure()` has been verified to fail without the fix and pass with the fix applied.
