### PR TITLE
Add support for quiche_config_discover_pmtu

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicCodecBuilder.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicCodecBuilder.java
@@ -47,6 +47,7 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
     private Long maxAckDelay;
     private Boolean disableActiveMigration;
     private Boolean enableHystart;
+    private Boolean discoverPmtu;
     private QuicCongestionControlAlgorithm congestionControlAlgorithm;
     private Integer initialCongestionWindowPackets;
     private int localConnIdLength;
@@ -86,6 +87,7 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
         this.maxAckDelay = builder.maxAckDelay;
         this.disableActiveMigration = builder.disableActiveMigration;
         this.enableHystart = builder.enableHystart;
+        this.discoverPmtu = builder.discoverPmtu;
         this.congestionControlAlgorithm = builder.congestionControlAlgorithm;
         this.initialCongestionWindowPackets = builder.initialCongestionWindowPackets;
         this.localConnIdLength = builder.localConnIdLength;
@@ -355,6 +357,23 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
     }
 
     /**
+     * See
+     * <a href="https://docs.rs/quiche/latest/quiche/struct.Config.html#method.discover_pmtu">
+     *     discover_pmtu</a>.
+     *
+     * Configures whether to do path MTU discovery.
+     *
+     * The default value is {@code false}.
+     *
+     * @param enable  {@code true} if path MTU discovery should be enabled.
+     * @return        the instance itself.
+     */
+    public final B discoverPmtu(boolean enable) {
+        this.discoverPmtu = enable;
+        return self();
+    }
+
+    /**
      * Sets the local connection id length that is used.
      *
      * The default is 20, which is also the maximum that is supported.
@@ -467,7 +486,7 @@ public abstract class QuicCodecBuilder<B extends QuicCodecBuilder<B>> {
                 maxIdleTimeout, maxSendUdpPayloadSize, maxRecvUdpPayloadSize, initialMaxData,
                 initialMaxStreamDataBidiLocal, initialMaxStreamDataBidiRemote,
                 initialMaxStreamDataUni, initialMaxStreamsBidi, initialMaxStreamsUni,
-                ackDelayExponent, maxAckDelay, disableActiveMigration, enableHystart,
+                ackDelayExponent, maxAckDelay, disableActiveMigration, enableHystart, discoverPmtu,
                 congestionControlAlgorithm, initialCongestionWindowPackets, recvQueueLen, sendQueueLen,
                 activeConnectionIdLimit, statelessResetToken);
     }

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/Quiche.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/Quiche.java
@@ -708,6 +708,13 @@ final class Quiche {
 
     /**
      * See
+     * <a href="https://docs.rs/quiche/latest/quiche/struct.Config.html#method.discover_pmtu">
+     *     quiche_config_discover_pmtu</a>.
+     */
+    static native void quiche_config_discover_pmtu(long configAddr, boolean value);
+
+    /**
+     * See
      * <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L187">
      *     quiche_config_enable_dgram</a>.
      */

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheConfig.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheConfig.java
@@ -36,6 +36,7 @@ final class QuicheConfig {
                  @Nullable Long maxAckDelay,
                  @Nullable Boolean disableActiveMigration,
                  @Nullable Boolean enableHystart,
+                 @Nullable Boolean discoverPmtu,
                  @Nullable QuicCongestionControlAlgorithm congestionControlAlgorithm,
                  @Nullable Integer initialCongestionWindowPackets,
                  @Nullable Integer recvQueueLen,
@@ -85,6 +86,9 @@ final class QuicheConfig {
             }
             if (enableHystart != null) {
                 Quiche.quiche_config_enable_hystart(config, enableHystart);
+            }
+            if (discoverPmtu != null) {
+                Quiche.quiche_config_discover_pmtu(config, discoverPmtu);
             }
             if (congestionControlAlgorithm != null) {
                 switch (congestionControlAlgorithm) {

--- a/codec-native-quic/src/main/c/netty_quic_quiche.c
+++ b/codec-native-quic/src/main/c/netty_quic_quiche.c
@@ -724,7 +724,7 @@ static jobject netty_new_socket_address(JNIEnv* env, const struct sockaddr_stora
 static jobjectArray netty_quiche_conn_path_stats(JNIEnv* env, jclass clazz, jlong conn, jlong idx) {
     quiche_path_stats stats = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
     if (quiche_conn_path_stats((quiche_conn *) conn, idx, &stats) != 0) {
-        // The idx is not valid. 
+        // The idx is not valid.
         return NULL;
     }
 
@@ -1007,6 +1007,10 @@ static void netty_quiche_config_enable_hystart(JNIEnv* env, jclass clazz, jlong 
     quiche_config_enable_hystart((quiche_config*) config, value == JNI_TRUE ? true : false);
 }
 
+static void netty_quiche_config_discover_pmtu(JNIEnv* env, jclass clazz, jlong config, jboolean value) {
+    quiche_config_discover_pmtu((quiche_config*) config, value == JNI_TRUE ? true : false);
+}
+
 static void netty_quiche_config_set_active_connection_id_limit(JNIEnv* env, jclass clazz, jlong config, jlong value) {
     quiche_config_set_active_connection_id_limit((quiche_config*) config, (uint64_t) value);
 }
@@ -1225,6 +1229,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "quiche_config_set_cc_algorithm", "(JI)V", (void *) netty_quiche_config_set_cc_algorithm },
   { "quiche_config_set_initial_congestion_window_packets", "(JI)V", (void *) netty_quiche_config_set_initial_congestion_window_packets },
   { "quiche_config_enable_hystart", "(JZ)V", (void *) netty_quiche_config_enable_hystart },
+  { "quiche_config_discover_pmtu", "(JZ)V", (void *) netty_quiche_config_discover_pmtu },
   { "quiche_config_set_active_connection_id_limit", "(JJ)V", (void *) netty_quiche_config_set_active_connection_id_limit },
   { "quiche_config_set_stateless_reset_token", "(J[B)V", (void *) netty_quiche_config_set_stateless_reset_token },
   { "quiche_config_free", "(J)V", (void *) netty_quiche_config_free },


### PR DESCRIPTION
**Motivation:**

We have been testing using QUIC in our application but ran into a case where a network path was causing connectivity issues due to the MTU size.
quiche doesn't do MTU discovery by default which means it can't react to these network conditions.
Exposing the setting allows developers to select if they want to enable MTU discovery

**Modification:**

Exposes the discover_pmtu option in the QuicCodecBuilder

**Result:**

