### PR TITLE
AbstractChannel: All outbound io operations must support asynchronous…

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicChannel.java
@@ -549,17 +549,27 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     }
 
     @Override
-    protected void doBind(SocketAddress socketAddress) {
-        throw new UnsupportedOperationException();
+    protected void doRegister(ChannelPromise promise) {
+        promise.setSuccess();
     }
 
     @Override
-    protected void doDisconnect() throws Exception {
-        doClose();
+    protected void doDeregister(ChannelPromise promise) {
+        promise.setSuccess();
     }
 
     @Override
-    protected void doClose() throws Exception {
+    protected void doBind(SocketAddress socketAddress, ChannelPromise promise) {
+        promise.setFailure(new UnsupportedOperationException());
+    }
+
+    @Override
+    protected void doDisconnect(ChannelPromise promise) {
+        doClose(promise);
+    }
+
+    @Override
+    protected void doClose(ChannelPromise promise) {
         if (state == ChannelState.CLOSED) {
             return;
         }
@@ -572,6 +582,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                 closeData = null;
             }
             failPendingConnectPromise();
+            promise.setSuccess();
             return;
         }
 
@@ -597,7 +608,8 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
             int res = Quiche.quiche_conn_close(conn.address(), app, err,
                     Quiche.readerMemoryAddress(reason), reason.readableBytes());
             if (res < 0 && res != Quiche.QUICHE_ERR_DONE) {
-                throw Quiche.convertToException(res);
+                promise.setFailure(Quiche.convertToException(res));
+                return;
             }
             // As we called quiche_conn_close(...) we need to ensure we will call quiche_conn_send(...) either
             // now or we will do so once we see the channelReadComplete event.
@@ -607,7 +619,6 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                 sendResult = SendResult.SOME;
             }
         } finally {
-
             // making sure that connection statistics is available
             // even after channel is closed
             statsAtClose = collectStats0(conn, executor().newPromise());
@@ -638,6 +649,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
 
                 local = null;
                 remote = null;
+                promise.setSuccess();
             }
         }
     }

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -167,48 +167,61 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
     }
 
     @Override
-    protected void doClose() throws Exception {
-        active = false;
-        // Even if we allow half closed sockets we should give up on reading. Otherwise we may allow a read attempt on a
-        // socket which has not even been connected yet. This has been observed to block during unit tests.
-        inputClosedSeenErrorOnRead = true;
-        try {
-            ChannelPromise promise = connectPromise;
-            if (promise != null) {
-                // Use tryFailure() instead of setFailure() to avoid the race against cancel().
-                promise.tryFailure(new ClosedChannelException());
-                connectPromise = null;
-            }
+    protected void doClose(ChannelPromise promise) {
+        ChannelPromise connectPromise = this.connectPromise;
+        if (connectPromise != null) {
+            // Use tryFailure() instead of setFailure() to avoid the race against cancel().
+            promise.tryFailure(new ClosedChannelException());
+            this.connectPromise = null;
+        }
 
-            Future<?> future = connectTimeoutFuture;
-            if (future != null) {
-                future.cancel(false);
-                connectTimeoutFuture = null;
-            }
+        Future<?> future = connectTimeoutFuture;
+        if (future != null) {
+            future.cancel(false);
+            connectTimeoutFuture = null;
+        }
 
-            if (isRegistered()) {
-                // Need to check if we are on the EventLoop as doClose() may be triggered by the GlobalEventExecutor
-                // if SO_LINGER is used.
-                //
-                // See https://github.com/netty/netty/issues/7159
-                EventLoop loop = executor();
-                if (loop.inEventLoop()) {
-                    doDeregister();
-                } else {
-                    loop.execute(new Runnable() {
-                        @Override
-                        public void run() {
-                            try {
-                                doDeregister();
-                            } catch (Throwable cause) {
-                                pipeline().fireExceptionCaught(cause);
-                            }
-                        }
-                    });
+        if (isRegistered()) {
+            // Need to check if we are on the EventLoop as doClose() may be triggered by the GlobalEventExecutor
+            // if SO_LINGER is used.
+            //
+            // See https://github.com/netty/netty/issues/7159
+            EventLoop loop = executor();
+            ChannelPromise deregisterPromise = newPromise();
+            deregisterPromise.addListener(f -> {
+                active = false;
+                // Even if we allow half closed sockets we should give up on reading. Otherwise we may allow a read
+                // attempt on a socket which has not even been connected yet. This has been observed to block during
+                // unit tests.
+                inputClosedSeenErrorOnRead = true;
+                try {
+                    socket.close();
+                } catch (Throwable cause) {
+                    promise.setFailure(cause);
                 }
+                promise.setSuccess();
+            });
+            if (loop.inEventLoop()) {
+                doDeregister(deregisterPromise);
+            } else {
+                loop.execute(new Runnable() {
+                    @Override
+                    public void run() {
+                        doDeregister(deregisterPromise);
+                    }
+                });
             }
-        } finally {
-            socket.close();
+        } else {
+            active = false;
+            // Even if we allow half closed sockets we should give up on reading. Otherwise we may allow a read attempt
+            // on a socket which has not even been connected yet. This has been observed to block during unit tests.
+            inputClosedSeenErrorOnRead = true;
+            try {
+                socket.close();
+            } catch (Throwable cause) {
+                promise.setFailure(cause);
+            }
+            promise.setSuccess();
         }
     }
 
@@ -218,8 +231,8 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
     }
 
     @Override
-    protected void doDisconnect() throws Exception {
-        doClose();
+    protected void doDisconnect(ChannelPromise promise) {
+        doClose(promise);
     }
 
     @Override
@@ -228,12 +241,13 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
     }
 
     @Override
-    protected void doDeregister() throws Exception {
+    protected void doDeregister(ChannelPromise promise) {
         IoRegistration registration = this.registration;
         if (registration != null) {
             ops = inital;
             registration.cancel();
         }
+        promise.setSuccess();
     }
 
     @Override
@@ -771,12 +785,18 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
     }
 
     @Override
-    protected void doBind(SocketAddress local) throws Exception {
-        if (local instanceof InetSocketAddress) {
-            checkResolvable((InetSocketAddress) local);
+    protected void doBind(SocketAddress local, ChannelPromise promise) {
+        try {
+            if (local instanceof InetSocketAddress) {
+                checkResolvable((InetSocketAddress) local);
+            }
+            socket.bind(local);
+            this.local = socket.localAddress();
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
+            return;
         }
-        socket.bind(local);
-        this.local = socket.localAddress();
+        promise.setSuccess();
     }
 
     /**
@@ -827,7 +847,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
             return connected;
         } finally {
             if (!success) {
-                doClose();
+                doClose(newPromise());
             }
         }
     }

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -393,8 +393,14 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
     }
 
     @Override
-    protected final void doShutdownOutput() throws Exception {
-        socket.shutdown(false, true);
+    protected final void doShutdownOutput(ChannelPromise promise) {
+        try {
+            socket.shutdown(false, true);
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
+            return;
+        }
+        promise.setSuccess();
     }
 
     private void shutdownInput0(final ChannelPromise promise) {

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -335,7 +335,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
     }
 
     @Override
-    protected void doBind(SocketAddress localAddress) throws Exception {
+    protected void doBind(SocketAddress localAddress, ChannelPromise promise) {
         if (localAddress instanceof InetSocketAddress) {
             InetSocketAddress socketAddress = (InetSocketAddress) localAddress;
             if (socketAddress.getAddress().isAnyLocalAddress() &&
@@ -345,8 +345,14 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
                 }
             }
         }
-        super.doBind(localAddress);
-        active = true;
+        super.doBind(localAddress, newPromise().addListener(f -> {
+            if (f.isSuccess()) {
+                active = true;
+                promise.setSuccess();
+            } else {
+                promise.setFailure(f.cause());
+            }
+        }));
     }
 
     @Override
@@ -499,10 +505,16 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
     }
 
     @Override
-    protected void doDisconnect() throws Exception {
-        socket.disconnect();
-        connected = active = false;
-        resetCachedAddresses();
+    protected void doDisconnect(ChannelPromise promise) {
+        try {
+            socket.disconnect();
+            connected = active = false;
+            resetCachedAddresses();
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
+            return;
+        }
+        promise.setSuccess();
     }
 
     @Override
@@ -515,9 +527,15 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
     }
 
     @Override
-    protected void doClose() throws Exception {
-        super.doClose();
-        connected = false;
+    protected void doClose(ChannelPromise promise) {
+        super.doClose(newPromise().addListener(f -> {
+            if (f.isSuccess()) {
+                connected = false;
+                promise.setSuccess();
+            } else {
+                promise.setFailure(f.cause());
+            }
+        }));
     }
 
     final class EpollDatagramChannelUnsafe extends AbstractEpollUnsafe {

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainDatagramChannel.java
@@ -21,6 +21,7 @@ import io.netty.channel.AddressedEnvelope;
 import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultAddressedEnvelope;
 import io.netty.channel.EventLoop;
 import io.netty.channel.unix.DomainDatagramChannel;
@@ -78,18 +79,30 @@ public final class EpollDomainDatagramChannel extends AbstractEpollChannel imple
     }
 
     @Override
-    protected void doBind(SocketAddress localAddress) throws Exception {
-        super.doBind(localAddress);
-        local = (DomainSocketAddress) localAddress;
-        active = true;
+    protected void doBind(SocketAddress localAddress, ChannelPromise promise) {
+        super.doBind(localAddress, newPromise().addListener(f -> {
+            if (f.isSuccess()) {
+                local = (DomainSocketAddress) localAddress;
+                active = true;
+                promise.setSuccess();
+            } else {
+                promise.setFailure(f.cause());
+            }
+        }));
     }
 
     @Override
-    protected void doClose() throws Exception {
-        super.doClose();
-        connected = active = false;
-        local = null;
-        remote = null;
+    protected void doClose(ChannelPromise promise) {
+        super.doClose(newPromise().addListener(f -> {
+            if (f.isSuccess()) {
+                connected = active = false;
+                local = null;
+                remote = null;
+                promise.setSuccess();
+            } else {
+                promise.setSuccess();
+            }
+        }));
     }
 
     @Override
@@ -106,8 +119,8 @@ public final class EpollDomainDatagramChannel extends AbstractEpollChannel imple
     }
 
     @Override
-    protected void doDisconnect() throws Exception {
-        doClose();
+    protected void doDisconnect(ChannelPromise promise) {
+        doClose(promise);
     }
 
     @Override

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannel.java
@@ -19,6 +19,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoop;
 import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.channel.unix.DomainSocketChannel;
@@ -74,9 +75,15 @@ public final class EpollDomainSocketChannel extends AbstractEpollStreamChannel i
     }
 
     @Override
-    protected void doBind(SocketAddress localAddress) throws Exception {
-        socket.bind(localAddress);
-        local = (DomainSocketAddress) localAddress;
+    protected void doBind(SocketAddress localAddress, ChannelPromise promise) {
+        try {
+            socket.bind(localAddress);
+            local = (DomainSocketAddress) localAddress;
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
+            return;
+        }
+        promise.setSuccess();
     }
 
     @Override

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerDomainSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerDomainSocketChannel.java
@@ -16,6 +16,7 @@
 package io.netty.channel.epoll;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.unix.DomainSocketAddress;
@@ -70,18 +71,22 @@ public final class EpollServerDomainSocketChannel extends AbstractEpollServerCha
     }
 
     @Override
-    protected void doBind(SocketAddress localAddress) throws Exception {
-        socket.bind(localAddress);
-        socket.listen(config.getBacklog());
-        local = (DomainSocketAddress) localAddress;
-        active = true;
+    protected void doBind(SocketAddress localAddress, ChannelPromise promise) {
+        try {
+            socket.bind(localAddress);
+            socket.listen(config.getBacklog());
+            local = (DomainSocketAddress) localAddress;
+            active = true;
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
+            return;
+        }
+        promise.setSuccess();
     }
 
     @Override
-    protected void doClose() throws Exception {
-        try {
-            super.doClose();
-        } finally {
+    protected void doClose(ChannelPromise promise) {
+        super.doClose(promise.addListener(f -> {
             DomainSocketAddress local = this.local;
             if (local != null) {
                 // Delete the socket file if possible.
@@ -91,7 +96,7 @@ public final class EpollServerDomainSocketChannel extends AbstractEpollServerCha
                     logger.debug("Failed to delete a domain socket file: {}", local.path());
                 }
             }
-        }
+        }));
     }
 
     @Override

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
@@ -16,6 +16,7 @@
 package io.netty.channel.epoll;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.ServerSocketChannel;
@@ -69,14 +70,25 @@ public final class EpollServerSocketChannel extends AbstractEpollServerChannel i
     }
 
     @Override
-    protected void doBind(SocketAddress localAddress) throws Exception {
-        super.doBind(localAddress);
-        final int tcpFastopen;
-        if (IS_SUPPORTING_TCP_FASTOPEN_SERVER && (tcpFastopen = config.getTcpFastopen()) > 0) {
-            socket.setTcpFastOpen(tcpFastopen);
-        }
-        socket.listen(config.getBacklog());
-        active = true;
+    protected void doBind(SocketAddress localAddress, ChannelPromise promise) {
+        super.doBind(localAddress, newPromise().addListener(f -> {
+            if (f.isSuccess()) {
+                try {
+                    final int tcpFastopen;
+                    if (IS_SUPPORTING_TCP_FASTOPEN_SERVER && (tcpFastopen = config.getTcpFastopen()) > 0) {
+                        socket.setTcpFastOpen(tcpFastopen);
+                    }
+                    socket.listen(config.getBacklog());
+                    active = true;
+                } catch (Throwable cause) {
+                    promise.setFailure(cause);
+                    return;
+                }
+                promise.setSuccess();
+            } else {
+                promise.setFailure(f.cause());
+            }
+        }));
     }
 
     @Override

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -103,18 +103,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
     private boolean inReadComplete;
     private boolean socketHasMoreData;
 
-    private static final class DelayedClose {
-        private final ChannelPromise promise;
-        private final Throwable cause;
-        private final ClosedChannelException closeCause;
-
-        DelayedClose(ChannelPromise promise, Throwable cause, ClosedChannelException closeCause) {
-            this.promise = promise;
-            this.cause = cause;
-            this.closeCause = closeCause;
-        }
-    }
-    private DelayedClose delayedClose;
+    private ChannelPromise delayedClose;
     private boolean inputClosedSeenErrorOnRead;
 
     /**
@@ -273,7 +262,8 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
     protected abstract void cancelOutstandingWrites(IoRegistration registration, int numOutstandingWrites);
 
     @Override
-    protected void doDisconnect() throws Exception {
+    protected void doDisconnect(ChannelPromise promise) {
+        doClose(promise);
     }
 
     private void freeRemoteAddressMemory() {
@@ -292,19 +282,62 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
     }
 
     @Override
-    protected void doClose() throws Exception {
-        active = false;
-
+    protected void doClose(ChannelPromise promise) {
         if (registration != null) {
+            if (delayedClose == null) {
+                // We have a write operation pending that should be completed asap.
+                // We will do the actual close operation one this write result is returned as otherwise
+                // we may get into trouble as we may close the fd while we did not process the write yet.
+                delayedClose = newPromise();
+                delayedClose.addListener(f -> {
+                    if (delayedClose.isSuccess()) {
+                        active = false;
+                        promise.setSuccess();
+                    } else {
+                        promise.setFailure(f.cause());
+                    }
+                });
+            } else {
+                delayedClose.addListener(new PromiseNotifier<>(false, promise));
+                return;
+            }
+
+            boolean cancelConnect = false;
+            try {
+                ChannelPromise connectPromise = AbstractIoUringChannel.this.connectPromise;
+                if (connectPromise != null) {
+                    // Use tryFailure() instead of setFailure() to avoid the race against cancel().
+                    connectPromise.tryFailure(new ClosedChannelException());
+                    AbstractIoUringChannel.this.connectPromise = null;
+                    cancelConnect = true;
+                }
+
+                cancelConnectTimeoutFuture();
+            } finally {
+                // It's important we cancel all outstanding connect, write and read operations now so
+                // we will be able to process a delayed close if needed.
+                ioUringUnsafe().cancelOps(cancelConnect);
+            }
+
             if (socket.markClosed()) {
                 int fd = fd().intValue();
                 IoUringIoOps ops = IoUringIoOps.newClose(fd, (byte) 0, nextOpsId());
-                registration.submit(ops);
+                if (registration.submit(ops) != 0) {
+                    return;
+                }
             }
+            delayedClose.setFailure(new ClosedChannelException());
         } else {
-            // This one was never registered just use a syscall to close.
-            socket.close();
-            ioUringUnsafe().unregistered();
+            try {
+                // This one was never registered just use a syscall to close.
+                socket.close();
+                ioUringUnsafe().unregistered();
+            } catch (Throwable cause) {
+                promise.setFailure(cause);
+                return;
+            }
+            active = false;
+            promise.setSuccess();
         }
     }
 
@@ -479,9 +512,6 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
                     break;
                 case Native.IORING_OP_CLOSE:
                     if (res != Native.ERRNO_ECANCELED_NEGATIVE) {
-                        if (delayedClose != null) {
-                            delayedClose.promise.setSuccess();
-                        }
                         closed = true;
                     }
                     break;
@@ -507,7 +537,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
 
         private void handleDelayedClosed() {
             if (delayedClose != null && canCloseNow()) {
-                closeNow();
+                delayedClose.trySuccess();
             }
         }
 
@@ -526,46 +556,6 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         @Override
         public final void close() throws Exception {
             close(newPromise());
-        }
-
-        @Override
-        protected void close(ChannelPromise promise, Throwable cause, ClosedChannelException closeCause) {
-            if (closeFuture().isDone()) {
-                // Closed already before.
-                safeSetSuccess(promise);
-                return;
-            }
-            if (delayedClose == null) {
-                // We have a write operation pending that should be completed asap.
-                // We will do the actual close operation one this write result is returned as otherwise
-                // we may get into trouble as we may close the fd while we did not process the write yet.
-                delayedClose = new DelayedClose(promise, cause, closeCause);
-            } else {
-                delayedClose.promise.addListener(new PromiseNotifier<>(false, promise));
-                return;
-            }
-
-            boolean cancelConnect = false;
-            try {
-                ChannelPromise connectPromise = AbstractIoUringChannel.this.connectPromise;
-                if (connectPromise != null) {
-                    // Use tryFailure() instead of setFailure() to avoid the race against cancel().
-                    connectPromise.tryFailure(new ClosedChannelException());
-                    AbstractIoUringChannel.this.connectPromise = null;
-                    cancelConnect = true;
-                }
-
-                cancelConnectTimeoutFuture();
-            } finally {
-                // It's important we cancel all outstanding connect, write and read operations now so
-                // we will be able to process a delayed close if needed.
-                cancelOps(cancelConnect);
-            }
-
-            if (canCloseNow()) {
-                // Currently there are is no WRITE and READ scheduled so we can start to teardown the channel.
-                closeNow();
-            }
         }
 
         private void cancelOps(boolean cancelConnect) {
@@ -609,10 +599,6 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
 
         protected boolean canCloseNow0() {
             return true;
-        }
-
-        private void closeNow() {
-            super.close(newPromise(), delayedClose.cause, delayedClose.closeCause);
         }
 
         @Override
@@ -1216,18 +1202,25 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
     }
 
     @Override
-    protected final void doDeregister() {
+    protected final void doDeregister(ChannelPromise promise) {
         // Cancel all previous submitted ops.
         ioUringUnsafe().cancelOps(connectPromise != null);
+        promise.setSuccess();
     }
 
     @Override
-    protected void doBind(final SocketAddress local) throws Exception {
-        if (local instanceof InetSocketAddress) {
-            checkResolvable((InetSocketAddress) local);
+    protected void doBind(final SocketAddress local, ChannelPromise promise) {
+        try {
+            if (local instanceof InetSocketAddress) {
+                checkResolvable((InetSocketAddress) local);
+            }
+            socket.bind(local);
+            this.local = socket.localAddress();
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
+            return;
         }
-        socket.bind(local);
-        this.local = socket.localAddress();
+        promise.setSuccess();
     }
 
     protected static void checkResolvable(InetSocketAddress addr) {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
@@ -106,11 +106,6 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
     }
 
     @Override
-    protected final void doClose() throws Exception {
-        super.doClose();
-    }
-
-    @Override
     protected final AbstractUringUnsafe newUnsafe() {
         return new UringServerChannelUnsafe();
     }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -90,8 +90,14 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
     }
 
     @Override
-    protected final void doShutdownOutput() throws Exception {
-        socket.shutdown(false, true);
+    protected final void doShutdownOutput(ChannelPromise promise) {
+        try {
+            socket.shutdown(false, true);
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
+            return;
+        }
+        promise.setSuccess();
     }
 
     private void shutdownInput0(final ChannelPromise promise) {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
@@ -300,7 +300,7 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
     }
 
     @Override
-    protected void doBind(SocketAddress localAddress) throws Exception {
+    protected void doBind(SocketAddress localAddress, ChannelPromise promise) {
         if (localAddress instanceof InetSocketAddress) {
             InetSocketAddress socketAddress = (InetSocketAddress) localAddress;
             if (socketAddress.getAddress().isAnyLocalAddress() &&
@@ -310,8 +310,14 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
                 }
             }
         }
-        super.doBind(localAddress);
-        active = true;
+        super.doBind(localAddress, newPromise().addListener(f -> {
+            if (f.isSuccess()) {
+                active = true;
+                promise.setSuccess();
+            } else {
+                promise.setFailure(f.cause());
+            }
+        }));
     }
 
     private static void checkUnresolved(AddressedEnvelope<?, ?> envelope) {
@@ -360,18 +366,30 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
     }
 
     @Override
-    protected void doDisconnect() throws Exception {
-        // TODO: use io_uring for this too...
-        socket.disconnect();
-        connected = active = false;
+    protected void doDisconnect(ChannelPromise promise) {
+        try {
+            // TODO: use io_uring for this too...
+            socket.disconnect();
+            connected = active = false;
 
-        resetCachedAddresses();
+            resetCachedAddresses();
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
+            return;
+        }
+        promise.setSuccess();
     }
 
     @Override
-    protected void doClose() throws Exception {
-        super.doClose();
-        connected = false;
+    protected void doClose(ChannelPromise promise) {
+        super.doClose(newPromise().addListener(f -> {
+            if (f.isSuccess()) {
+                connected = false;
+                promise.setSuccess();
+            } else {
+                promise.setFailure(f.cause());
+            }
+        }));
     }
 
     private final class IoUringDatagramChannelUnsafe extends AbstractUringUnsafe {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringServerDomainSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringServerDomainSocketChannel.java
@@ -19,6 +19,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.unix.DomainSocketAddress;
@@ -79,11 +80,16 @@ public final class IoUringServerDomainSocketChannel extends AbstractIoUringServe
     }
 
     @Override
-    protected void doBind(SocketAddress localAddress) throws Exception {
-        socket.bind(localAddress);
-        socket.listen(config.getBacklog());
-        local = (DomainSocketAddress) localAddress;
-        active = true;
+    protected void doBind(SocketAddress localAddress, ChannelPromise promise) {
+        try {
+            socket.bind(localAddress);
+            socket.listen(config.getBacklog());
+            local = (DomainSocketAddress) localAddress;
+            active = true;
+        } catch (Throwable cause) {
+           promise.setFailure(cause);
+           return;
+        }
+        promise.setSuccess();
     }
-
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringServerSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringServerSocketChannel.java
@@ -17,6 +17,7 @@ package io.netty.channel.uring;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.ServerSocketChannel;
@@ -68,15 +69,26 @@ public final class IoUringServerSocketChannel extends AbstractIoUringServerChann
     }
 
     @Override
-    public void doBind(SocketAddress localAddress) throws Exception {
-        super.doBind(localAddress);
-        if (IoUring.isTcpFastOpenServerSideAvailable()) {
-            Integer fastOpen = config().getOption(ChannelOption.TCP_FASTOPEN);
-            if (fastOpen != null && fastOpen > 0) {
-                socket.setTcpFastOpen(fastOpen);
+    public void doBind(SocketAddress localAddress, ChannelPromise promise) {
+        super.doBind(localAddress, newPromise().addListener(f -> {
+            if (f.isSuccess()) {
+                try {
+                    if (IoUring.isTcpFastOpenServerSideAvailable()) {
+                        Integer fastOpen = config().getOption(ChannelOption.TCP_FASTOPEN);
+                        if (fastOpen != null && fastOpen > 0) {
+                            socket.setTcpFastOpen(fastOpen);
+                        }
+                    }
+                    socket.listen(config.getBacklog());
+                    active = true;
+                } catch (Throwable cause) {
+                    promise.setFailure(cause);
+                    return;
+                }
+                promise.setSuccess();
+            } else {
+                promise.setFailure(f.cause());
             }
-        }
-        socket.listen(config.getBacklog());
-        active = true;
+        }));
     }
 }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
@@ -130,17 +130,23 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
     }
 
     @Override
-    protected void doClose() throws Exception {
+    protected void doClose(ChannelPromise promise) {
         active = false;
         // Even if we allow half closed sockets we should give up on reading. Otherwise we may allow a read attempt on a
         // socket which has not even been connected yet. This has been observed to block during unit tests.
         inputClosedSeenErrorOnRead = true;
-        socket.close();
+        try {
+            socket.close();
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
+            return;
+        }
+        promise.setSuccess();
     }
 
     @Override
-    protected void doDisconnect() throws Exception {
-        doClose();
+    protected void doDisconnect(ChannelPromise promise)  {
+        doClose(promise);
     }
 
     void resetCachedAddresses() {
@@ -154,18 +160,27 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
     }
 
     @Override
-    protected void doDeregister() throws Exception {
+    protected void doDeregister(ChannelPromise promise) {
         // As unregisteredFilters() may have not been called because isOpen() returned false we just set both filters
         // to false to ensure a consistent state in all cases.
         // Make sure we unregister our filters from kqueue!
-        readFilter(false);
-        writeFilter(false);
+        try {
+            readFilter(false);
+        } catch (IOException ignore) {
+            // ignore
+        }
+        try {
+            writeFilter(false);
+        } catch (IOException ignore) {
+            // ignore
+        }
         clearRdHup0();
 
         IoRegistration registration = this.registration;
         if (registration != null) {
             registration.cancel();
         }
+        promise.setSuccess();
     }
 
     private void clearRdHup0() {
@@ -684,12 +699,18 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
     }
 
     @Override
-    protected void doBind(SocketAddress local) throws Exception {
-        if (local instanceof InetSocketAddress) {
-            checkResolvable((InetSocketAddress) local);
+    protected void doBind(SocketAddress local, ChannelPromise promise) {
+        try {
+            if (local instanceof InetSocketAddress) {
+                checkResolvable((InetSocketAddress) local);
+            }
+            socket.bind(local);
+            this.local = socket.localAddress();
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
+            return;
         }
-        socket.bind(local);
-        this.local = socket.localAddress();
+        promise.setSuccess();
     }
 
     /**
@@ -740,7 +761,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
             return connected;
         } finally {
             if (!success) {
-                doClose();
+                doClose(newPromise());
             }
         }
     }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
@@ -378,8 +378,14 @@ public abstract class AbstractKQueueStreamChannel extends AbstractKQueueChannel 
 
     @UnstableApi
     @Override
-    protected final void doShutdownOutput() throws Exception {
-        socket.shutdown(false, true);
+    protected final void doShutdownOutput(ChannelPromise promise) {
+        try {
+            socket.shutdown(false, true);
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
+            return;
+        }
+        promise.setSuccess();
     }
 
     @Override

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
@@ -237,9 +237,15 @@ public final class KQueueDatagramChannel extends AbstractKQueueDatagramChannel i
     }
 
     @Override
-    protected void doBind(SocketAddress localAddress) throws Exception {
-        super.doBind(localAddress);
-        active = true;
+    protected void doBind(SocketAddress localAddress, ChannelPromise promise) {
+        super.doBind(localAddress, newPromise().addListener(f -> {
+            if (f.isSuccess()) {
+                active = true;
+                promise.setSuccess();
+            } else {
+                promise.setFailure(f.cause());
+            }
+        }));
     }
 
     @Override
@@ -343,10 +349,16 @@ public final class KQueueDatagramChannel extends AbstractKQueueDatagramChannel i
     }
 
     @Override
-    protected void doDisconnect() throws Exception {
-        socket.disconnect();
+    protected void doDisconnect(ChannelPromise promise) {
+        try {
+            socket.disconnect();
+        } catch (Throwable t) {
+            promise.setFailure(t);
+            return;
+        }
         connected = active = false;
         resetCachedAddresses();
+        promise.setSuccess();
     }
 
     @Override
@@ -359,8 +371,8 @@ public final class KQueueDatagramChannel extends AbstractKQueueDatagramChannel i
     }
 
     @Override
-    protected void doClose() throws Exception {
-        super.doClose();
+    protected void doClose(ChannelPromise promise) {
+        super.doClose(promise);
         connected = false;
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainDatagramChannel.java
@@ -18,7 +18,9 @@ package io.netty.channel.kqueue;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.AddressedEnvelope;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultAddressedEnvelope;
 import io.netty.channel.EventLoop;
 import io.netty.channel.unix.DomainDatagramChannel;
@@ -74,18 +76,30 @@ public final class KQueueDomainDatagramChannel extends AbstractKQueueDatagramCha
     }
 
     @Override
-    protected void doBind(SocketAddress localAddress) throws Exception {
-        super.doBind(localAddress);
-        local = (DomainSocketAddress) localAddress;
-        active = true;
+    protected void doBind(SocketAddress localAddress, ChannelPromise promise) {
+        super.doBind(localAddress, newPromise().addListener(f -> {
+          if (f.isSuccess()) {
+              local = (DomainSocketAddress) localAddress;
+              active = true;
+              promise.setSuccess();
+          } else {
+              promise.setFailure(f.cause());
+          }
+        }));
     }
 
     @Override
-    protected void doClose() throws Exception {
-        super.doClose();
-        connected = active = false;
-        local = null;
-        remote = null;
+    protected void doClose(ChannelPromise promise) {
+        super.doClose(newPromise().addListener(f -> {
+            if (f.isSuccess()) {
+                connected = active = false;
+                local = null;
+                remote = null;
+                promise.setSuccess();
+            } else {
+                promise.setFailure(f.cause());
+            }
+        }));
     }
 
     @Override
@@ -102,8 +116,8 @@ public final class KQueueDomainDatagramChannel extends AbstractKQueueDatagramCha
     }
 
     @Override
-    protected void doDisconnect() throws Exception {
-        doClose();
+    protected void doDisconnect(ChannelPromise promise) {
+        doClose(promise);
     }
 
     @Override

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannel.java
@@ -19,6 +19,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoop;
 import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.channel.unix.DomainSocketChannel;
@@ -67,9 +68,15 @@ public final class KQueueDomainSocketChannel extends AbstractKQueueStreamChannel
     }
 
     @Override
-    protected void doBind(SocketAddress localAddress) throws Exception {
-        socket.bind(localAddress);
-        local = (DomainSocketAddress) localAddress;
+    protected void doBind(SocketAddress localAddress, ChannelPromise promise) {
+        try {
+            socket.bind(localAddress);
+            local = (DomainSocketAddress) localAddress;
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
+            return;
+        }
+        promise.setSuccess();
     }
 
     @Override

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerDomainSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerDomainSocketChannel.java
@@ -16,6 +16,7 @@
 package io.netty.channel.kqueue;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.unix.DomainSocketAddress;
@@ -60,18 +61,22 @@ public final class KQueueServerDomainSocketChannel extends AbstractKQueueServerC
     }
 
     @Override
-    protected void doBind(SocketAddress localAddress) throws Exception {
-        socket.bind(localAddress);
-        socket.listen(config.getBacklog());
-        local = (DomainSocketAddress) localAddress;
-        active = true;
+    protected void doBind(SocketAddress localAddress, ChannelPromise promise) {
+        try {
+            socket.bind(localAddress);
+            socket.listen(config.getBacklog());
+            local = (DomainSocketAddress) localAddress;
+            active = true;
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
+            return;
+        }
+        promise.setSuccess();
     }
 
     @Override
-    protected void doClose() throws Exception {
-        try {
-            super.doClose();
-        } finally {
+    protected void doClose(ChannelPromise promise) {
+        super.doClose(promise.addListener(f -> {
             DomainSocketAddress local = this.local;
             if (local != null) {
                 // Delete the socket file if possible.
@@ -81,7 +86,7 @@ public final class KQueueServerDomainSocketChannel extends AbstractKQueueServerC
                     logger.debug("Failed to delete a domain socket file: {}", local.path());
                 }
             }
-        }
+        }));
     }
 
     @Override

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerSocketChannel.java
@@ -16,6 +16,7 @@
 package io.netty.channel.kqueue;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.ServerSocketChannel;
@@ -50,13 +51,22 @@ public final class KQueueServerSocketChannel extends AbstractKQueueServerChannel
     }
 
     @Override
-    protected void doBind(SocketAddress localAddress) throws Exception {
-        super.doBind(localAddress);
-        socket.listen(config.getBacklog());
-        if (config.isTcpFastOpen()) {
-            socket.setTcpFastOpen(true);
-        }
-        active = true;
+    protected void doBind(SocketAddress localAddress, ChannelPromise promise) {
+        super.doBind(localAddress, newPromise().addListener(f -> {
+            if (f.isSuccess()) {
+                try {
+                    socket.listen(config.getBacklog());
+                    if (config.isTcpFastOpen()) {
+                        socket.setTcpFastOpen(true);
+                    }
+                    active = true;
+                } catch (Throwable cause) {
+                    promise.setFailure(cause);
+                    return;
+                }
+                promise.setSuccess();
+            }
+        }));
     }
 
     @Override

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannel.java
@@ -107,7 +107,7 @@ public final class KQueueSocketChannel extends AbstractKQueueStreamChannel imple
                     // because we try to read or write until the actual close happens which may be later due
                     // SO_LINGER handling.
                     // See https://github.com/netty/netty/issues/4449
-                    doDeregister();
+                    doDeregister(newPromise());
                     return GlobalEventExecutor.INSTANCE;
                 }
             } catch (Throwable ignore) {

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
@@ -220,8 +220,14 @@ public class NioSctpChannel extends AbstractNioMessageChannel implements io.nett
     }
 
     @Override
-    protected void doBind(SocketAddress localAddress) throws Exception {
-        javaChannel().bind(localAddress);
+    protected void doBind(SocketAddress localAddress, ChannelPromise promise) {
+        try {
+            javaChannel().bind(localAddress);
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
+            return;
+        }
+        promise.setSuccess();
     }
 
     @Override
@@ -240,7 +246,7 @@ public class NioSctpChannel extends AbstractNioMessageChannel implements io.nett
             return connected;
         } finally {
             if (!success) {
-                doClose();
+                doClose(newPromise());
             }
         }
     }
@@ -253,13 +259,19 @@ public class NioSctpChannel extends AbstractNioMessageChannel implements io.nett
     }
 
     @Override
-    protected void doDisconnect() throws Exception {
-        doClose();
+    protected void doDisconnect(ChannelPromise promise)  {
+        doClose(promise);
     }
 
     @Override
-    protected void doClose() throws Exception {
-        javaChannel().close();
+    protected void doClose0(ChannelPromise promise) {
+        try {
+            javaChannel().close();
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
+            return;
+        }
+        promise.setSuccess();
     }
 
     @Override

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpServerChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpServerChannel.java
@@ -135,13 +135,25 @@ public class NioSctpServerChannel extends AbstractNioMessageChannel
     }
 
     @Override
-    protected void doBind(SocketAddress localAddress) throws Exception {
-        javaChannel().bind(localAddress, config.getBacklog());
+    protected void doBind(SocketAddress localAddress, ChannelPromise promise) {
+        try {
+            javaChannel().bind(localAddress, config.getBacklog());
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
+            return;
+        }
+        promise.setSuccess();
     }
 
     @Override
-    protected void doClose() throws Exception {
-        javaChannel().close();
+    protected void doClose0(ChannelPromise promise) {
+        try {
+            javaChannel().close();
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
+            return;
+        }
+        promise.setSuccess();
     }
 
     @Override
@@ -222,8 +234,8 @@ public class NioSctpServerChannel extends AbstractNioMessageChannel
     }
 
     @Override
-    protected void doDisconnect() throws Exception {
-        throw new UnsupportedOperationException();
+    protected void doDisconnect(ChannelPromise promise) {
+        promise.setFailure(new UnsupportedOperationException());
     }
 
     @Override

--- a/transport/src/main/java/io/netty/bootstrap/FailedChannel.java
+++ b/transport/src/main/java/io/netty/bootstrap/FailedChannel.java
@@ -49,18 +49,28 @@ final class FailedChannel extends AbstractChannel {
     }
 
     @Override
-    protected void doBind(SocketAddress localAddress) {
-        throw new UnsupportedOperationException();
+    protected void doDeregister(ChannelPromise promise) {
+        promise.setSuccess();
     }
 
     @Override
-    protected void doDisconnect() {
-        throw new UnsupportedOperationException();
+    protected void doRegister(ChannelPromise promise) {
+        promise.setFailure(new UnsupportedOperationException());
     }
 
     @Override
-    protected void doClose() {
-        throw new UnsupportedOperationException();
+    protected void doBind(SocketAddress localAddress, ChannelPromise promise) {
+        promise.setFailure(new UnsupportedOperationException());
+    }
+
+    @Override
+    protected void doDisconnect(ChannelPromise promise) {
+        promise.setFailure(new UnsupportedOperationException());
+    }
+
+    @Override
+    protected void doClose(ChannelPromise promise) {
+        promise.setFailure(new UnsupportedOperationException());
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -19,6 +19,7 @@ import io.netty.channel.socket.ChannelOutputShutdownEvent;
 import io.netty.channel.socket.ChannelOutputShutdownException;
 import io.netty.util.DefaultAttributeMap;
 import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.Future;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.logging.InternalLogger;
@@ -51,6 +52,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
     private final CloseFuture closeFuture = new CloseFuture(this);
     private final EventLoop eventLoop;
 
+    private volatile ChannelOutboundBuffer outboundBuffer = new ChannelOutboundBuffer(AbstractChannel.this);
     private volatile SocketAddress localAddress;
     private volatile SocketAddress remoteAddress;
     private volatile boolean registered;
@@ -316,8 +318,6 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         return strVal;
     }
 
-    private volatile ChannelOutboundBuffer outboundBuffer = new ChannelOutboundBuffer(AbstractChannel.this);
-
     protected final ChannelOutboundBuffer outboundBuffer() {
         return outboundBuffer;
     }
@@ -354,38 +354,16 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
 
         @Override
         public final void register(final ChannelPromise promise) {
-            if (isRegistered()) {
-                promise.setFailure(new IllegalStateException("registered to an event loop already"));
-                return;
-            }
-
-            if (eventLoop.inEventLoop()) {
-                register0(promise);
-            } else {
-                try {
-                    eventLoop.execute(new Runnable() {
-                        @Override
-                        public void run() {
-                            register0(promise);
-                        }
-                    });
-                } catch (Throwable t) {
-                    logger.warn(
-                            "Force-closing a channel whose registration task was not accepted by an event loop: {}",
-                            AbstractChannel.this, t);
-                    close(newPromise());
-                    closeFuture.setClosed();
-                    safeSetFailure(promise, t);
-                }
-            }
-        }
-
-        private void register0(ChannelPromise promise) {
             // check if the channel is still open as it could be closed in the mean time when the register
             // call was outside of the eventLoop
             if (!promise.setUncancellable() || !ensureOpen(promise)) {
                 return;
             }
+            if (isRegistered()) {
+                promise.setFailure(new IllegalStateException("registered to an event loop already"));
+                return;
+            }
+
             ChannelPromise registerPromise = newPromise();
             boolean firstRegistration = neverRegistered;
             registerPromise.addListener(new ChannelFutureListener() {
@@ -443,24 +421,23 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             }
 
             boolean wasActive = isActive();
-            try {
-                doBind(localAddress);
-            } catch (Throwable t) {
-                safeSetFailure(promise, t);
-                closeIfClosed();
-                return;
-            }
-
-            if (!wasActive && isActive()) {
-                invokeLater(new Runnable() {
-                    @Override
-                    public void run() {
-                        pipeline.fireChannelActive();
+            ChannelPromise bindPromise = newPromise();
+            bindPromise.addListener(f -> {
+                if (f.isSuccess()) {
+                    if (!wasActive && isActive()) {
+                        invokeLater(new Runnable() {
+                            @Override
+                            public void run() {
+                                pipeline.fireChannelActive();
+                            }
+                        });
                     }
-                });
-            }
-
-            safeSetSuccess(promise);
+                } else {
+                    closeIfClosed();
+                }
+                safeCascade(f, promise);
+            });
+            doBind(localAddress, bindPromise);
         }
 
         @Override
@@ -472,32 +449,28 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             }
 
             boolean wasActive = isActive();
-            try {
-                doDisconnect();
+            ChannelPromise disconnectPromise = newPromise();
+            disconnectPromise.addListener(f -> {
                 // Reset remoteAddress and localAddress
                 remoteAddress = null;
                 localAddress = null;
-            } catch (Throwable t) {
-                safeSetFailure(promise, t);
-                closeIfClosed();
-                return;
-            }
+                if (wasActive && !isActive()) {
+                    invokeLater(new Runnable() {
+                        @Override
+                        public void run() {
+                            pipeline.fireChannelInactive();
+                        }
+                    });
+                }
 
-            if (wasActive && !isActive()) {
-                invokeLater(new Runnable() {
-                    @Override
-                    public void run() {
-                        pipeline.fireChannelInactive();
-                    }
-                });
-            }
-
-            safeSetSuccess(promise);
-            closeIfClosed(); // doDisconnect() might have closed the channel
+                safeCascade(f, promise);
+                closeIfClosed(); // doDisconnect() might have closed the channel
+            });
+            doDisconnect(disconnectPromise);
         }
 
         @Override
-        public void close(final ChannelPromise promise) {
+        public final void close(final ChannelPromise promise) {
             assertEventLoop();
 
             ClosedChannelException closedChannelException =
@@ -529,7 +502,6 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                 promise.setFailure(new ClosedChannelException());
                 return;
             }
-            AbstractChannel.this.outboundBuffer = null; // Disallow adding any messages and flushes to outboundBuffer.
 
             final Throwable shutdownCause = cause == null ?
                     new ChannelOutputShutdownException("Channel output shutdown") :
@@ -539,16 +511,17 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             // we can not call doDeregister here because we should ensure this side in fin_wait2 state
             // can still receive and process the data which is send by another side in the close_wait state。
             // See https://github.com/netty/netty/issues/11981
-            try {
-                // The shutdown function does not block regardless of the SO_LINGER setting on the socket
-                // so we don't need to use GlobalEventExecutor to execute the shutdown
-                doShutdownOutput();
-                promise.setSuccess();
-            } catch (Throwable err) {
-                promise.setFailure(err);
-            } finally {
+
+            // The shutdown function does not block regardless of the SO_LINGER setting on the socket
+            // so we don't need to use GlobalEventExecutor to execute the shutdown
+            ChannelPromise shutdownPromise = newPromise().addListener(f -> {
+                // Disallow adding any messages and flushes to outboundBuffer.
+                AbstractChannel.this.outboundBuffer = null;
+
+                safeCascade(f, promise);
                 closeOutboundBufferForShutdown(pipeline, outboundBuffer, shutdownCause);
-            }
+            });
+            doShutdownOutput(shutdownPromise);
         }
 
         private void closeOutboundBufferForShutdown(
@@ -558,7 +531,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             pipeline.fireUserEventTriggered(ChannelOutputShutdownEvent.INSTANCE);
         }
 
-        protected void close(final ChannelPromise promise, final Throwable cause,
+        private void close(final ChannelPromise promise, final Throwable cause,
                            final ClosedChannelException closeCause) {
             if (!promise.setUncancellable()) {
                 return;
@@ -583,65 +556,49 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             closeInitiated = true;
 
             final boolean wasActive = isActive();
-            final ChannelOutboundBuffer outboundBuffer = AbstractChannel.this.outboundBuffer;
-            AbstractChannel.this.outboundBuffer = null; // Disallow adding any messages and flushes to outboundBuffer.
+
+            ChannelPromise closePromise = newPromise();
+            closePromise.addListener(f -> {
+                final ChannelOutboundBuffer outboundBuffer = AbstractChannel.this.outboundBuffer;
+                // Disallow adding any messages and flushes to outboundBuffer.
+                AbstractChannel.this.outboundBuffer = null;
+                // Call invokeLater so closeAndDeregister is executed in the EventLoop again!
+                invokeLater(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (outboundBuffer != null) {
+                            // Fail all the queued messages
+                            outboundBuffer.failFlushed(cause, false);
+                            outboundBuffer.close(closeCause);
+                        }
+                        fireChannelInactiveAndDeregister(wasActive);
+                    }
+                });
+                safeCascade(f, promise);
+            });
+
             Executor closeExecutor = prepareToClose();
             if (closeExecutor != null) {
                 closeExecutor.execute(new Runnable() {
                     @Override
                     public void run() {
-                        try {
                             // Execute the close.
-                            doClose0(promise);
-                        } finally {
-                            // Call invokeLater so closeAndDeregister is executed in the EventLoop again!
-                            invokeLater(new Runnable() {
-                                @Override
-                                public void run() {
-                                    if (outboundBuffer != null) {
-                                        // Fail all the queued messages
-                                        outboundBuffer.failFlushed(cause, false);
-                                        outboundBuffer.close(closeCause);
-                                    }
-                                    fireChannelInactiveAndDeregister(wasActive);
-                                }
-                            });
-                        }
+                        doClose0(closePromise);
                     }
                 });
             } else {
-                try {
-                    // Close the channel and fail the queued messages in all cases.
-                    doClose0(promise);
-                } finally {
-                    if (outboundBuffer != null) {
-                        // Fail all the queued messages.
-                        outboundBuffer.failFlushed(cause, false);
-                        outboundBuffer.close(closeCause);
-                    }
-                }
-                if (inFlush0) {
-                    invokeLater(new Runnable() {
-                        @Override
-                        public void run() {
-                            fireChannelInactiveAndDeregister(wasActive);
-                        }
-                    });
-                } else {
-                    fireChannelInactiveAndDeregister(wasActive);
-                }
+                // Close the channel and fail the queued messages in all cases.
+                doClose0(closePromise);
             }
         }
 
         private void doClose0(ChannelPromise promise) {
-            try {
-                doClose();
+            ChannelPromise closePromise = newPromise();
+            closePromise.addListener(f -> {
                 closeFuture.setClosed();
-                safeSetSuccess(promise);
-            } catch (Throwable t) {
-                closeFuture.setClosed();
-                safeSetFailure(promise, t);
-            }
+                safeCascade(f, promise);
+            });
+            doClose(closePromise);
         }
 
         private void fireChannelInactiveAndDeregister(final boolean wasActive) {
@@ -677,24 +634,24 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             invokeLater(new Runnable() {
                 @Override
                 public void run() {
-                    try {
-                        doDeregister();
-                    } catch (Throwable t) {
-                        logger.warn("Unexpected exception occurred while deregistering a channel.", t);
-                    } finally {
-                        if (fireChannelInactive) {
-                            pipeline.fireChannelInactive();
+                    ChannelPromise deregisterPromise = newPromise();
+                    deregisterPromise.addListener(f -> {
+                        if (f.isSuccess()) {
+                            if (fireChannelInactive) {
+                                pipeline.fireChannelInactive();
+                            }
+                            // Some transports like local and AIO does not allow the deregistration of
+                            // an open channel.  Their doDeregister() calls close(). Consequently,
+                            // close() calls deregister() again - no need to fire channelUnregistered, so check
+                            // if it was registered.
+                            if (registered) {
+                                registered = false;
+                                pipeline.fireChannelUnregistered();
+                            }
                         }
-                        // Some transports like local and AIO does not allow the deregistration of
-                        // an open channel.  Their doDeregister() calls close(). Consequently,
-                        // close() calls deregister() again - no need to fire channelUnregistered, so check
-                        // if it was registered.
-                        if (registered) {
-                            registered = false;
-                            pipeline.fireChannelUnregistered();
-                        }
-                        safeSetSuccess(promise);
-                    }
+                        safeCascade(f, promise);
+                    });
+                    doDeregister(deregisterPromise);
                 }
             });
         }
@@ -849,6 +806,14 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             return false;
         }
 
+        protected final void safeCascade(Future<?> future, ChannelPromise promise) {
+            if (future.isSuccess()) {
+                safeSetSuccess(promise);
+            } else {
+                safeSetFailure(promise, future.cause());
+            }
+        }
+
         /**
          * Marks the specified {@code promise} as success.  If the {@code promise} is done already, log a message.
          */
@@ -913,8 +878,8 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         /**
          * Prepares to close the {@link Channel}. If this method returns an {@link Executor}, the
          * caller must call the {@link Executor#execute(Runnable)} method with a task that calls
-         * {@link #doClose()} on the returned {@link Executor}. If this method returns {@code null},
-         * {@link #doClose()} must be called from the caller thread. (i.e. {@link EventLoop})
+         * {@link #doClose(ChannelPromise)} on the returned {@link Executor}. If this method returns {@code null},
+         * {@link #doClose(ChannelPromise)} must be called from the caller thread. (i.e. {@link EventLoop})
          */
         protected Executor prepareToClose() {
             return null;
@@ -935,50 +900,31 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
      * Is called after the {@link Channel} is registered with its {@link EventLoop} as part of the register process.
      * Subclasses may override this method
      *
-     * @deprecated use {@link #doRegister(ChannelPromise)}
-     */
-    @Deprecated
-    protected void doRegister() throws Exception {
-        // NOOP
-    }
-
-    /**
-     * Is called after the {@link Channel} is registered with its {@link EventLoop} as part of the register process.
-     * Subclasses may override this method
-     *
      * @param promise {@link ChannelPromise} that must be notified once done to continue the registration.
      */
-    protected void doRegister(ChannelPromise promise) {
-        try {
-            doRegister();
-        } catch (Throwable cause) {
-            promise.setFailure(cause);
-            return;
-        }
-        promise.setSuccess();
-    }
+    protected abstract void doRegister(ChannelPromise promise);
 
     /**
      * Bind the {@link Channel} to the {@link SocketAddress}
      */
-    protected abstract void doBind(SocketAddress localAddress) throws Exception;
+    protected abstract void doBind(SocketAddress localAddress, ChannelPromise promise);
 
     /**
      * Disconnect this {@link Channel} from its remote peer
      */
-    protected abstract void doDisconnect() throws Exception;
+    protected abstract void doDisconnect(ChannelPromise promise);
 
     /**
      * Close the {@link Channel}
      */
-    protected abstract void doClose() throws Exception;
+    protected abstract void doClose(ChannelPromise promise);
 
     /**
      * Called when conditions justify shutting down the output portion of the channel. This may happen if a write
      * operation throws an exception.
      */
-    protected void doShutdownOutput() throws Exception {
-        doClose();
+    protected void doShutdownOutput(ChannelPromise promise) {
+        doClose(promise);
     }
 
     /**
@@ -986,9 +932,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
      *
      * Sub-classes may override this method
      */
-    protected void doDeregister() throws Exception {
-        // NOOP
-    }
+    protected abstract void doDeregister(ChannelPromise promise);
 
     /**
      * Schedule a read operation.

--- a/transport/src/main/java/io/netty/channel/AbstractServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractServerChannel.java
@@ -63,8 +63,8 @@ public abstract class AbstractServerChannel extends AbstractChannel implements S
     }
 
     @Override
-    protected void doDisconnect() throws Exception {
-        throw new UnsupportedOperationException();
+    protected void doDisconnect(ChannelPromise promise)  {
+        promise.setFailure(new UnsupportedOperationException());
     }
 
     @Override
@@ -73,7 +73,7 @@ public abstract class AbstractServerChannel extends AbstractChannel implements S
     }
 
     @Override
-    protected void doWrite(ChannelOutboundBuffer in) throws Exception {
+    protected void doWrite(ChannelOutboundBuffer in)  {
         throw new UnsupportedOperationException();
     }
 

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
@@ -992,25 +992,34 @@ public class EmbeddedChannel extends AbstractChannel {
     }
 
     @Override
-    protected void doRegister() throws Exception {
+    protected void doDeregister(ChannelPromise promise) {
+        promise.setSuccess();
+    }
+
+    @Override
+    protected void doRegister(ChannelPromise promise) {
         state = State.ACTIVE;
+        promise.setSuccess();
     }
 
     @Override
-    protected void doBind(SocketAddress localAddress) throws Exception {
-        // NOOP
+    protected void doBind(SocketAddress localAddress, ChannelPromise promise) {
+        promise.setSuccess();
     }
 
     @Override
-    protected void doDisconnect() throws Exception {
+    protected void doDisconnect(ChannelPromise promise) {
         if (!metadata.hasDisconnect()) {
-            doClose();
+            doClose(promise);
+        } else {
+            promise.setSuccess();
         }
     }
 
     @Override
-    protected void doClose() throws Exception {
+    protected void doClose(ChannelPromise promise)  {
         state = State.CLOSED;
+        promise.setSuccess();
     }
 
     @Override
@@ -1029,7 +1038,7 @@ public class EmbeddedChannel extends AbstractChannel {
     }
 
     @Override
-    protected void doWrite(ChannelOutboundBuffer in) throws Exception {
+    protected void doWrite(ChannelOutboundBuffer in) {
         for (;;) {
             Object msg = in.current();
             if (msg == null) {
@@ -1187,11 +1196,13 @@ public class EmbeddedChannel extends AbstractChannel {
         // that may change the state of the Channel and may schedule tasks for later execution.
         final Unsafe wrapped = new Unsafe() {
 
+            private final ChannelFutureListener futureListener = f ->  maybeRunPendingTasks();
+
             @Override
             public void register(ChannelPromise promise) {
                 executingStackCnt++;
                 try {
-                    EmbeddedUnsafe.this.register(promise);
+                    EmbeddedUnsafe.this.register(promise.addListener(futureListener));
                 } finally {
                     executingStackCnt--;
                     maybeRunPendingTasks();
@@ -1202,7 +1213,7 @@ public class EmbeddedChannel extends AbstractChannel {
             public void bind(SocketAddress localAddress, ChannelPromise promise) {
                 executingStackCnt++;
                 try {
-                    EmbeddedUnsafe.this.bind(localAddress, promise);
+                    EmbeddedUnsafe.this.bind(localAddress, promise.addListener(futureListener));
                 } finally {
                     executingStackCnt--;
                     maybeRunPendingTasks();
@@ -1213,7 +1224,7 @@ public class EmbeddedChannel extends AbstractChannel {
             public void connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
                 executingStackCnt++;
                 try {
-                    EmbeddedUnsafe.this.connect(remoteAddress, localAddress, promise);
+                    EmbeddedUnsafe.this.connect(remoteAddress, localAddress, promise.addListener(futureListener));
                 } finally {
                     executingStackCnt--;
                     maybeRunPendingTasks();
@@ -1224,7 +1235,7 @@ public class EmbeddedChannel extends AbstractChannel {
             public void disconnect(ChannelPromise promise) {
                 executingStackCnt++;
                 try {
-                    EmbeddedUnsafe.this.disconnect(promise);
+                    EmbeddedUnsafe.this.disconnect(promise.addListener(futureListener));
                 } finally {
                     executingStackCnt--;
                     maybeRunPendingTasks();
@@ -1235,7 +1246,7 @@ public class EmbeddedChannel extends AbstractChannel {
             public void close(ChannelPromise promise) {
                 executingStackCnt++;
                 try {
-                    EmbeddedUnsafe.this.close(promise);
+                    EmbeddedUnsafe.this.close(promise.addListener(futureListener));
                 } finally {
                     executingStackCnt--;
                     maybeRunPendingTasks();
@@ -1246,7 +1257,7 @@ public class EmbeddedChannel extends AbstractChannel {
             public void deregister(ChannelPromise promise) {
                 executingStackCnt++;
                 try {
-                    EmbeddedUnsafe.this.deregister(promise);
+                    EmbeddedUnsafe.this.deregister(promise.addListener(futureListener));
                 } finally {
                     executingStackCnt--;
                     maybeRunPendingTasks();
@@ -1268,7 +1279,7 @@ public class EmbeddedChannel extends AbstractChannel {
             public void write(Object msg, ChannelPromise promise) {
                 executingStackCnt++;
                 try {
-                    EmbeddedUnsafe.this.write(msg, promise);
+                    EmbeddedUnsafe.this.write(msg, promise.addListener(futureListener));
                 } finally {
                     executingStackCnt--;
                     maybeRunPendingTasks();

--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -29,6 +29,7 @@ import io.netty.channel.IoEvent;
 import io.netty.channel.IoRegistration;
 import io.netty.channel.PreferHeapByteBufAllocator;
 import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.group.ChannelGroup;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.SingleThreadEventExecutor;
@@ -39,6 +40,7 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.net.ConnectException;
 import java.net.SocketAddress;
+import java.nio.channels.AlreadyBoundException;
 import java.nio.channels.AlreadyConnectedException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ConnectionPendingException;
@@ -172,17 +174,27 @@ public class LocalChannel extends AbstractChannel {
     }
 
     @Override
-    protected void doDeregister() throws Exception {
-        EventLoop loop = executor();
+    protected void doDeregister(ChannelPromise promise) {
         IoRegistration registration = this.registration;
         if (registration != null) {
             this.registration = null;
             registration.cancel();
         }
+        promise.setSuccess();
     }
 
     @Override
-    protected void doBind(SocketAddress localAddress) throws Exception {
+    protected void doBind(SocketAddress localAddress, ChannelPromise promise) {
+        try {
+            doBind0(localAddress);
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
+            return;
+        }
+        promise.setSuccess();
+    }
+
+    private void doBind0(SocketAddress localAddress) throws Exception {
         this.localAddress =
                 LocalChannelRegistry.register(this, this.localAddress,
                         localAddress);
@@ -190,12 +202,12 @@ public class LocalChannel extends AbstractChannel {
     }
 
     @Override
-    protected void doDisconnect() throws Exception {
-        doClose();
+    protected void doDisconnect(ChannelPromise promise) {
+        doClose(promise);
     }
 
     @Override
-    protected void doClose() throws Exception {
+    protected void doClose(ChannelPromise promise) {
         final LocalChannel peer = this.peer;
         State oldState = state;
         try {
@@ -217,11 +229,11 @@ public class LocalChannel extends AbstractChannel {
                     finishPeerRead(peer);
                 }
 
-                ChannelPromise promise = connectPromise;
-                if (promise != null) {
+                ChannelPromise connectPromise = this.connectPromise;
+                if (connectPromise != null) {
                     // Use tryFailure() instead of setFailure() to avoid the race against cancel().
-                    promise.tryFailure(new ClosedChannelException());
-                    connectPromise = null;
+                    connectPromise.tryFailure(new ClosedChannelException());
+                    this.connectPromise = null;
                 }
             }
 
@@ -249,9 +261,11 @@ public class LocalChannel extends AbstractChannel {
                         // rejects the close Runnable but give a best effort.
                         peer.close();
                     }
-                    PlatformDependent.throwException(cause);
+                    promise.setFailure(cause);
+                    return;
                 }
             }
+            promise.setSuccess();
         } finally {
             // Release all buffers if the Channel was already registered in the past and if it was not closed before.
             if (oldState != null && oldState != State.CLOSED) {
@@ -542,7 +556,7 @@ public class LocalChannel extends AbstractChannel {
 
             if (localAddress != null) {
                 try {
-                    doBind(localAddress);
+                    doBind0(localAddress);
                 } catch (Throwable t) {
                     safeSetFailure(promise, t);
                     close(newPromise());

--- a/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
@@ -112,13 +112,19 @@ public class LocalServerChannel extends AbstractServerChannel {
     }
 
     @Override
-    protected void doBind(SocketAddress localAddress) throws Exception {
-        this.localAddress = LocalChannelRegistry.register(this, this.localAddress, localAddress);
+    protected void doBind(SocketAddress localAddress, ChannelPromise promise) {
+        try {
+            this.localAddress = LocalChannelRegistry.register(this, this.localAddress, localAddress);
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
+            return;
+        }
         state = 1;
+        promise.setSuccess();
     }
 
     @Override
-    protected void doClose() throws Exception {
+    protected void doClose(ChannelPromise promise) {
         if (state <= 1) {
             // Update all internal state before the closeFuture is notified.
             if (localAddress != null) {
@@ -127,15 +133,17 @@ public class LocalServerChannel extends AbstractServerChannel {
             }
             state = 2;
         }
+        promise.setSuccess();
     }
 
     @Override
-    protected void doDeregister() throws Exception {
+    protected void doDeregister(ChannelPromise promise) {
         IoRegistration registration = this.registration;
         if (registration != null) {
             this.registration = null;
             registration.cancel();
         }
+        promise.setSuccess();
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
@@ -464,12 +464,13 @@ public abstract class AbstractNioChannel extends AbstractChannel {
     }
 
     @Override
-    protected void doDeregister() throws Exception {
+    protected void doDeregister(ChannelPromise promise) {
         IoRegistration registration = this.registration;
         if (registration != null) {
             this.registration = null;
             registration.cancel();
         }
+        promise.setSuccess();
     }
 
     @Override
@@ -565,12 +566,12 @@ public abstract class AbstractNioChannel extends AbstractChannel {
     }
 
     @Override
-    protected void doClose() throws Exception {
-        ChannelPromise promise = connectPromise;
-        if (promise != null) {
+    protected final void doClose(ChannelPromise promise) {
+        ChannelPromise connectPromise = this.connectPromise;
+        if (connectPromise != null) {
             // Use tryFailure() instead of setFailure() to avoid the race against cancel().
-            promise.tryFailure(new ClosedChannelException());
-            connectPromise = null;
+            connectPromise.tryFailure(new ClosedChannelException());
+            this.connectPromise = null;
         }
 
         Future<?> future = connectTimeoutFuture;
@@ -578,5 +579,8 @@ public abstract class AbstractNioChannel extends AbstractChannel {
             future.cancel(false);
             connectTimeoutFuture = null;
         }
+        doClose0(promise);
     }
+
+    protected abstract void doClose0(ChannelPromise promise);
 }

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
@@ -215,8 +215,14 @@ public final class NioDatagramChannel
     }
 
     @Override
-    protected void doBind(SocketAddress localAddress) throws Exception {
-        doBind0(localAddress);
+    protected void doBind(SocketAddress localAddress, ChannelPromise promise) {
+        try {
+            doBind0(localAddress);
+        } catch (Throwable t) {
+            promise.setFailure(t);
+            return;
+        }
+        promise.setSuccess();
     }
 
     private void doBind0(SocketAddress localAddress) throws Exception {
@@ -237,7 +243,7 @@ public final class NioDatagramChannel
             return true;
         } finally {
             if (!success) {
-                doClose();
+                doClose(newPromise());
             }
         }
     }
@@ -248,13 +254,25 @@ public final class NioDatagramChannel
     }
 
     @Override
-    protected void doDisconnect() throws Exception {
-        javaChannel().disconnect();
+    protected void doDisconnect(ChannelPromise promise) {
+        try {
+            javaChannel().disconnect();
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
+            return;
+        }
+        promise.setSuccess();
     }
 
     @Override
-    protected void doClose() throws Exception {
-        javaChannel().close();
+    protected void doClose0(ChannelPromise promise) {
+        try {
+            javaChannel().close();
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
+            return;
+        }
+        promise.setSuccess();
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioServerSocketChannel.java
@@ -20,6 +20,7 @@ import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelOutboundBuffer;
+import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
@@ -168,18 +169,33 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel
     }
 
     @Override
-    protected void doBind(SocketAddress localAddress) throws Exception {
-        javaChannel().bind(localAddress, config.getBacklog());
+    protected void doBind(SocketAddress localAddress, ChannelPromise promise) {
+        try {
+            javaChannel().bind(localAddress, config.getBacklog());
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
+            return;
+        }
+        promise.setSuccess();
     }
 
     @Override
-    protected void doClose() throws Exception {
+    protected void doClose0(ChannelPromise promise) {
         SocketAddress localAddress = localAddress0();
-        javaChannel().close();
-        if (localAddress instanceof UnixDomainSocketAddress) {
-            Path path = ((UnixDomainSocketAddress) localAddress).getPath();
-            if (path != null) {
-                path.toFile().delete();
+        try {
+            try {
+                javaChannel().close();
+            } catch (Throwable cause) {
+                promise.setFailure(cause);
+                return;
+            }
+            promise.setSuccess();
+        } finally {
+            if (localAddress instanceof UnixDomainSocketAddress) {
+                Path path = ((UnixDomainSocketAddress) localAddress).getPath();
+                if (path != null) {
+                    path.toFile().delete();
+                }
             }
         }
     }
@@ -224,8 +240,8 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel
     }
 
     @Override
-    protected void doDisconnect() throws Exception {
-        throw new UnsupportedOperationException();
+    protected void doDisconnect(ChannelPromise promise) {
+        promise.setFailure(new UnsupportedOperationException());
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
@@ -173,8 +173,14 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
     }
 
     @Override
-    protected final void doShutdownOutput() throws Exception {
-        javaChannel().shutdownOutput();
+    protected final void doShutdownOutput(ChannelPromise promise) {
+        try {
+            javaChannel().shutdownOutput();
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
+            return;
+        }
+        promise.setSuccess();
     }
 
     @Override
@@ -300,8 +306,14 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
     }
 
     @Override
-    protected void doBind(SocketAddress localAddress) throws Exception {
-        doBind0(localAddress);
+    protected void doBind(SocketAddress localAddress, ChannelPromise promise) {
+        try {
+            doBind0(localAddress);
+        } catch (Throwable t) {
+            promise.setFailure(t);
+            return;
+        }
+        promise.setSuccess();
     }
 
     private void doBind0(SocketAddress localAddress) throws Exception {
@@ -324,7 +336,7 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
             return connected;
         } finally {
             if (!success) {
-                doClose();
+                doClose(newPromise());
             }
         }
     }
@@ -337,14 +349,19 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
     }
 
     @Override
-    protected void doDisconnect() throws Exception {
-        doClose();
+    protected void doDisconnect(ChannelPromise promise) {
+        doClose(promise);
     }
 
     @Override
-    protected void doClose() throws Exception {
-        super.doClose();
-        javaChannel().close();
+    protected void doClose0(ChannelPromise promise) {
+        try {
+            javaChannel().close();
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
+            return;
+        }
+        promise.setSuccess();
     }
 
     @Override
@@ -456,7 +473,7 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
                     // because we try to read or write until the actual close happens which may be later due
                     // SO_LINGER handling.
                     // See https://github.com/netty/netty/issues/4449
-                    doDeregister();
+                    doDeregister(newPromise());
                     return GlobalEventExecutor.INSTANCE;
                 }
             } catch (Throwable ignore) {

--- a/transport/src/test/java/io/netty/channel/AbstractChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/AbstractChannelTest.java
@@ -186,9 +186,10 @@ public class AbstractChannelTest {
             }
 
             @Override
-            protected void doClose()  {
+            protected void doClose(ChannelPromise promise)  {
                 active = false;
                 open = false;
+                promise.setSuccess();
             }
 
             @Override
@@ -284,13 +285,29 @@ public class AbstractChannelTest {
         }
 
         @Override
-        protected void doBind(SocketAddress localAddress) { }
+        protected void doDeregister(ChannelPromise promise) {
+            promise.setSuccess();
+        }
 
         @Override
-        protected void doDisconnect() { }
+        protected void doRegister(ChannelPromise promise) {
+            promise.setSuccess();
+        }
 
         @Override
-        protected void doClose() { }
+        protected void doBind(SocketAddress localAddress, ChannelPromise promise) {
+            promise.setSuccess();
+        }
+
+        @Override
+        protected void doDisconnect(ChannelPromise promise) {
+            promise.setSuccess();
+        }
+
+        @Override
+        protected void doClose(ChannelPromise promise) {
+            promise.setSuccess();
+        }
 
         @Override
         protected void doBeginRead() { }

--- a/transport/src/test/java/io/netty/channel/ChannelOutboundBufferTest.java
+++ b/transport/src/test/java/io/netty/channel/ChannelOutboundBufferTest.java
@@ -215,18 +215,28 @@ public class ChannelOutboundBufferTest {
         }
 
         @Override
-        protected void doBind(SocketAddress localAddress) {
-            throw new UnsupportedOperationException();
+        protected void doDeregister(ChannelPromise promise) {
+            promise.setSuccess();
         }
 
         @Override
-        protected void doDisconnect() {
-            throw new UnsupportedOperationException();
+        protected void doRegister(ChannelPromise promise) {
+            promise.setFailure(new UnsupportedOperationException());
         }
 
         @Override
-        protected void doClose() {
-            throw new UnsupportedOperationException();
+        protected void doBind(SocketAddress localAddress, ChannelPromise promise) {
+            promise.setFailure(new UnsupportedOperationException());
+        }
+
+        @Override
+        protected void doDisconnect(ChannelPromise promise) {
+            promise.setFailure(new UnsupportedOperationException());
+        }
+
+        @Override
+        protected void doClose(ChannelPromise promise) {
+            promise.setFailure(new UnsupportedOperationException());
         }
 
         @Override

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTailTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTailTest.java
@@ -274,16 +274,29 @@ public class DefaultChannelPipelineTailTest {
         }
 
         @Override
-        protected void doBind(SocketAddress localAddress) {
+        protected void doDeregister(ChannelPromise promise) {
+            promise.setSuccess();
         }
 
         @Override
-        protected void doDisconnect() {
+        protected void doRegister(ChannelPromise promise) {
+            promise.setSuccess();
         }
 
         @Override
-        protected void doClose() {
+        protected void doBind(SocketAddress localAddress, ChannelPromise promise) {
+            promise.setSuccess();
+        }
+
+        @Override
+        protected void doDisconnect(ChannelPromise promise) {
+            promise.setSuccess();
+        }
+
+        @Override
+        protected void doClose(ChannelPromise promise) {
             closed = true;
+            promise.setSuccess();
         }
 
         @Override


### PR DESCRIPTION
… execution

Motivation:

AbstractChannel had various do* methods that sub-classes did override to implement outbound io operations. As these methods did not take any promise it was required for them to be non-async. This is quite limiting and not really works for io_uring and so as a result we were not able to replace all syscalls with io_uring ops. We should change this to make our abstract base class more future proof and flexible.

Modifications:

- All do* methods for io outbound operations now take a promise that needs to be notified once the operation is considered to be done.
- Adjust sub-classes for new method signature
- Remove hacks from io_uring impl as these are not needed anymore

Result:

Cleanup of API