### PR TITLE
    AbstractChannel: Move connect logical to AbstractChannel and so remove code-duplication

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicChannel.java
@@ -28,7 +28,6 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
-import io.netty.channel.ConnectTimeoutException;
 import io.netty.channel.DefaultChannelPipeline;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.socket.DatagramPacket;
@@ -143,7 +142,6 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     private ByteBuf finBuffer;
     private ByteBuf outErrorCodeBuffer;
     private ChannelPromise connectPromise;
-    private ScheduledFuture<?> connectTimeoutFuture;
     private QuicConnectionAddress connectAddress;
     private CloseData closeData;
     private QuicConnectionCloseEvent connectionCloseEvent;
@@ -1489,6 +1487,44 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         }
     }
 
+    @Override
+    protected void doConnect(SocketAddress remote, SocketAddress local, ChannelPromise channelPromise) {
+        assert executor().inEventLoop();
+        if (server) {
+            channelPromise.setFailure(new UnsupportedOperationException());
+            return;
+        }
+
+        if (connectPromise != null) {
+            channelPromise.setFailure(new ConnectionPendingException());
+            return;
+        }
+
+        if (remote instanceof QuicConnectionAddress) {
+            if (!sourceConnectionIds.isEmpty()) {
+                // If a key is assigned we know this channel was already connected.
+                channelPromise.setFailure(new AlreadyConnectedException());
+                return;
+            }
+
+            connectAddress = (QuicConnectionAddress) remote;
+            connectPromise = channelPromise;
+
+            parent().connect(new QuicheQuicChannelAddress(QuicheQuicChannel.this))
+                    .addListener(f -> {
+                        ChannelPromise connectPromise = QuicheQuicChannel.this.connectPromise;
+                        if (connectPromise != null && !f.isSuccess()) {
+                            connectPromise.tryFailure(f.cause());
+                            // close everything after notify about failure.
+                            unsafe().close(newPromise());
+                        }
+                    });
+            return;
+        }
+
+        channelPromise.setFailure(new UnsupportedOperationException());
+    }
+
     private final class QuicChannelUnsafe extends AbstractChannel.AbstractUnsafe {
 
         void connectStream(QuicStreamType type, @Nullable ChannelHandler handler,
@@ -1524,70 +1560,6 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                     streams.remove(streamId);
                 }
             });
-        }
-
-        @Override
-        public void connect(SocketAddress remote, SocketAddress local, ChannelPromise channelPromise) {
-            assert executor().inEventLoop();
-            if (!channelPromise.setUncancellable()) {
-                return;
-            }
-            if (server) {
-                channelPromise.setFailure(new UnsupportedOperationException());
-                return;
-            }
-
-            if (connectPromise != null) {
-                channelPromise.setFailure(new ConnectionPendingException());
-                return;
-            }
-
-            if (remote instanceof QuicConnectionAddress) {
-                if (!sourceConnectionIds.isEmpty()) {
-                    // If a key is assigned we know this channel was already connected.
-                    channelPromise.setFailure(new AlreadyConnectedException());
-                    return;
-                }
-
-                connectAddress = (QuicConnectionAddress) remote;
-                connectPromise = channelPromise;
-
-                // Schedule connect timeout.
-                int connectTimeoutMillis = config().getConnectTimeoutMillis();
-                if (connectTimeoutMillis > 0) {
-                    connectTimeoutFuture = executor().schedule(() -> {
-                        ChannelPromise connectPromise = QuicheQuicChannel.this.connectPromise;
-                        if (connectPromise != null && !connectPromise.isDone()
-                                && connectPromise.tryFailure(new ConnectTimeoutException(
-                                "connection timed out: " + remote))) {
-                            close(newPromise());
-                        }
-                    }, connectTimeoutMillis, TimeUnit.MILLISECONDS);
-                }
-
-                connectPromise.addListener((ChannelFuture future) -> {
-                    if (future.isCancelled()) {
-                        if (connectTimeoutFuture != null) {
-                            connectTimeoutFuture.cancel(false);
-                        }
-                        connectPromise = null;
-                        close(newPromise());
-                    }
-                });
-
-                parent().connect(new QuicheQuicChannelAddress(QuicheQuicChannel.this))
-                        .addListener(f -> {
-                            ChannelPromise connectPromise = QuicheQuicChannel.this.connectPromise;
-                            if (connectPromise != null && !f.isSuccess()) {
-                                connectPromise.tryFailure(f.cause());
-                                // close everything after notify about failure.
-                                unsafe().close(newPromise());
-                            }
-                        });
-                return;
-            }
-
-            channelPromise.setFailure(new UnsupportedOperationException());
         }
 
         private void fireConnectCloseEventIfNeeded(QuicheQuicConnection conn) {
@@ -1941,7 +1913,6 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                 state = ChannelState.ACTIVE;
 
                 boolean promiseSet = promise.trySuccess();
-                pipeline().fireChannelActive();
                 notifyAboutHandshakeCompletionIfNeeded(conn, null);
                 fireDatagramExtensionEvent(conn);
                 if (!promiseSet) {

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -23,12 +23,9 @@ import io.netty.channel.AbstractChannel;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelException;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPromise;
-import io.netty.channel.ConnectTimeoutException;
 import io.netty.channel.EventLoop;
 import io.netty.channel.IoEvent;
 import io.netty.channel.IoRegistration;
@@ -41,7 +38,6 @@ import io.netty.channel.unix.IovArray;
 import io.netty.channel.unix.Socket;
 import io.netty.channel.unix.UnixChannel;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.concurrent.Future;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -50,10 +46,8 @@ import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.AlreadyConnectedException;
 import java.nio.channels.ClosedChannelException;
-import java.nio.channels.ConnectionPendingException;
 import java.nio.channels.NotYetConnectedException;
 import java.nio.channels.UnresolvedAddressException;
-import java.util.concurrent.TimeUnit;
 
 import static io.netty.channel.epoll.EpollIoOps.EPOLL_ERR_IN_MASK;
 import static io.netty.channel.epoll.EpollIoOps.EPOLL_ERR_OUT_MASK;
@@ -65,12 +59,7 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
 abstract class AbstractEpollChannel extends AbstractChannel implements UnixChannel {
     private static final ChannelMetadata METADATA = new ChannelMetadata(false);
     protected final LinuxSocket socket;
-    /**
-     * The future of the current connection attempt.  If not null, subsequent
-     * connection attempts will fail.
-     */
     private ChannelPromise connectPromise;
-    private Future<?> connectTimeoutFuture;
     private SocketAddress requestedRemoteAddress;
     private volatile SocketAddress local;
     private volatile SocketAddress remote;
@@ -173,12 +162,6 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
             // Use tryFailure() instead of setFailure() to avoid the race against cancel().
             promise.tryFailure(new ClosedChannelException());
             this.connectPromise = null;
-        }
-
-        Future<?> future = connectTimeoutFuture;
-        if (future != null) {
-            future.cancel(false);
-            connectTimeoutFuture = null;
         }
 
         if (isRegistered()) {
@@ -440,6 +423,24 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
                 remoteAddress.getAddress(), remoteAddress.getPort(), fastOpen);
     }
 
+    @Override
+    protected void doConnect(
+            final SocketAddress remoteAddress, final SocketAddress localAddress, final ChannelPromise promise) {
+        final boolean connected;
+        requestedRemoteAddress = remoteAddress;
+        try {
+            connected = doConnect(remoteAddress, localAddress);
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
+            return;
+        }
+        if (connected) {
+            promise.setSuccess();
+        } else {
+            connectPromise = promise;
+        }
+    }
+
     protected abstract class AbstractEpollUnsafe extends AbstractUnsafe implements EpollIoHandle {
         boolean readPending;
         private EpollRecvByteAllocatorHandle allocHandle;
@@ -642,127 +643,24 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
             }
         }
 
-        @Override
-        public void connect(
-                final SocketAddress remoteAddress, final SocketAddress localAddress, final ChannelPromise promise) {
-            // Don't mark the connect promise as uncancellable as in fact we can cancel it as it is using
-            // non-blocking io.
-            if (promise.isDone() || !ensureOpen(promise)) {
-                return;
-            }
-
-            try {
-                if (connectPromise != null) {
-                    throw new ConnectionPendingException();
-                }
-
-                boolean wasActive = isActive();
-                if (doConnect(remoteAddress, localAddress)) {
-                    fulfillConnectPromise(promise, wasActive);
-                } else {
-                    connectPromise = promise;
-                    requestedRemoteAddress = remoteAddress;
-
-                    // Schedule connect timeout.
-                    final int connectTimeoutMillis = config().getConnectTimeoutMillis();
-                    if (connectTimeoutMillis > 0) {
-                        connectTimeoutFuture = executor().schedule(new Runnable() {
-                            @Override
-                            public void run() {
-                                ChannelPromise connectPromise = AbstractEpollChannel.this.connectPromise;
-                                if (connectPromise != null && !connectPromise.isDone()
-                                        && connectPromise.tryFailure(new ConnectTimeoutException(
-                                                "connection timed out after " + connectTimeoutMillis + " ms: " +
-                                                        remoteAddress))) {
-                                    close(newPromise());
-                                }
-                            }
-                        }, connectTimeoutMillis, TimeUnit.MILLISECONDS);
-                    }
-
-                    promise.addListener(new ChannelFutureListener() {
-                        @Override
-                        public void operationComplete(ChannelFuture future) {
-                            // If the connect future is cancelled we also cancel the timeout and close the
-                            // underlying socket.
-                            if (future.isCancelled()) {
-                                if (connectTimeoutFuture != null) {
-                                    connectTimeoutFuture.cancel(false);
-                                }
-                                connectPromise = null;
-                                close(newPromise());
-                            }
-                        }
-                    });
-                }
-            } catch (Throwable t) {
-                closeIfClosed();
-                promise.tryFailure(annotateConnectException(t, remoteAddress));
-            }
-        }
-
-        private void fulfillConnectPromise(ChannelPromise promise, boolean wasActive) {
-            if (promise == null) {
-                // Closed via cancellation and the promise has been notified already.
-                return;
-            }
-            active = true;
-
-            // Get the state as trySuccess() may trigger an ChannelFutureListener that will close the Channel.
-            // We still need to ensure we call fireChannelActive() in this case.
-            boolean active = isActive();
-
-            // trySuccess() will return false if a user cancelled the connection attempt.
-            boolean promiseSet = promise.trySuccess();
-
-            // Regardless if the connection attempt was cancelled, channelActive() event should be triggered,
-            // because what happened is what happened.
-            if (!wasActive && active) {
-                pipeline().fireChannelActive();
-            }
-
-            // If a user cancelled the connection attempt, close the channel, which is followed by channelInactive().
-            if (!promiseSet) {
-                close(newPromise());
-            }
-        }
-
-        private void fulfillConnectPromise(ChannelPromise promise, Throwable cause) {
-            if (promise == null) {
-                // Closed via cancellation and the promise has been notified already.
-                return;
-            }
-
-            // Use tryFailure() instead of setFailure() to avoid the race against cancel().
-            promise.tryFailure(cause);
-            closeIfClosed();
-        }
-
         private void finishConnect() {
             // Note this method is invoked by the event loop only if the connection attempt was
             // neither cancelled nor timed out.
 
             assert executor().inEventLoop();
-
-            boolean connectStillInProgress = false;
+            assert connectPromise != null;
+            ChannelPromise promise = connectPromise;
+            final boolean connected;
             try {
-                boolean wasActive = isActive();
-                if (!doFinishConnect()) {
-                    connectStillInProgress = true;
-                    return;
-                }
-                fulfillConnectPromise(connectPromise, wasActive);
-            } catch (Throwable t) {
-                fulfillConnectPromise(connectPromise, annotateConnectException(t, requestedRemoteAddress));
-            } finally {
-                if (!connectStillInProgress) {
-                    // Check for null as the connectTimeoutFuture is only created if a connectTimeoutMillis > 0 is used
-                    // See https://github.com/netty/netty/issues/1770
-                    if (connectTimeoutFuture != null) {
-                        connectTimeoutFuture.cancel(false);
-                    }
-                    connectPromise = null;
-                }
+                connected = doFinishConnect();
+            } catch (Throwable cause) {
+                connectPromise = null;
+                promise.setFailure(cause);
+                return;
+            }
+            if (connected) {
+                connectPromise = null;
+                promise.setSuccess();
             }
         }
 
@@ -776,6 +674,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
                     remote = computeRemoteAddr((InetSocketAddress) requestedRemoteAddress, socket.remoteAddress());
                 }
                 requestedRemoteAddress = null;
+                active = true;
 
                 return true;
             }
@@ -828,6 +727,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
         if (connected) {
             remote = remoteSocketAddr == null ?
                     remoteAddress : computeRemoteAddr(remoteSocketAddr, socket.remoteAddress());
+            active = true;
         }
         // We always need to set the localAddress even if not connected yet as the bind already took place.
         //

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
@@ -81,17 +81,17 @@ public abstract class AbstractEpollServerChannel extends AbstractEpollChannel im
     protected abstract Channel newChildChannel(EventLoop eventLoop, int fd, byte[] remote, int offset, int len)
             throws Exception;
 
+    @Override
+    protected void doConnect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+        // Connect not supported by ServerChannel implementations
+        promise.setFailure(new UnsupportedOperationException());
+    }
+
     final class EpollServerSocketUnsafe extends AbstractEpollUnsafe {
         // Will hold the remote address after accept(...) was successful.
         // We need 24 bytes for the address as maximum + 1 byte for storing the length.
         // So use 26 bytes as it's a power of two.
         private final byte[] acceptedAddress = new byte[26];
-
-        @Override
-        public void connect(SocketAddress socketAddress, SocketAddress socketAddress2, ChannelPromise channelPromise) {
-            // Connect not supported by ServerChannel implementations
-            channelPromise.setFailure(new UnsupportedOperationException());
-        }
 
         @Override
         void epollInReady() {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -23,12 +23,9 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.AbstractChannel;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPromise;
-import io.netty.channel.ConnectTimeoutException;
 import io.netty.channel.EventLoop;
 import io.netty.channel.IoEvent;
 import io.netty.channel.IoRegistration;
@@ -59,8 +56,6 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ConnectionPendingException;
 import java.nio.channels.NotYetConnectedException;
 import java.nio.channels.UnresolvedAddressException;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
 
 import static io.netty.channel.unix.Errors.ERRNO_EINPROGRESS_NEGATIVE;
 import static io.netty.channel.unix.Errors.ERROR_EALREADY_NEGATIVE;
@@ -110,7 +105,6 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
      * The future of the current connection attempt.  If not null, subsequent connection attempts will fail.
      */
     private ChannelPromise connectPromise;
-    private ScheduledFuture<?> connectTimeoutFuture;
     private SocketAddress requestedRemoteAddress;
     private CleanableDirectBuffer cleanable;
     private ByteBuffer remoteAddressMemory;
@@ -308,11 +302,8 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
                 if (connectPromise != null) {
                     // Use tryFailure() instead of setFailure() to avoid the race against cancel().
                     connectPromise.tryFailure(new ClosedChannelException());
-                    AbstractIoUringChannel.this.connectPromise = null;
                     cancelConnect = true;
                 }
-
-                cancelConnectTimeoutFuture();
             } finally {
                 // It's important we cancel all outstanding connect, write and read operations now so
                 // we will be able to process a delayed close if needed.
@@ -611,51 +602,6 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
             }
         }
 
-        private void fulfillConnectPromise(ChannelPromise promise, Throwable cause) {
-            if (promise == null) {
-                // Closed via cancellation and the promise has been notified already.
-                return;
-            }
-
-            // Use tryFailure() instead of setFailure() to avoid the race against cancel().
-            promise.tryFailure(cause);
-            closeIfClosed();
-        }
-
-        private void fulfillConnectPromise(ChannelPromise promise, boolean wasActive) {
-            if (promise == null) {
-                // Closed via cancellation and the promise has been notified already.
-                return;
-            }
-            active = true;
-
-            if (local == null) {
-                local = socket.localAddress();
-            }
-            computeRemote();
-
-            // Register POLLRDHUP
-            schedulePollRdHup();
-
-            // Get the state as trySuccess() may trigger an ChannelFutureListener that will close the Channel.
-            // We still need to ensure we call fireChannelActive() in this case.
-            boolean active = isActive();
-
-            // trySuccess() will return false if a user cancelled the connection attempt.
-            boolean promiseSet = promise.trySuccess();
-
-            // Regardless if the connection attempt was cancelled, channelActive() event should be triggered,
-            // because what happened is what happened.
-            if (!wasActive && active) {
-                pipeline().fireChannelActive();
-            }
-
-            // If a user cancelled the connection attempt, close the channel, which is followed by channelInactive().
-            if (!promiseSet) {
-                close(newPromise());
-            }
-        }
-
         @Override
         public final IoUringRecvByteAllocatorHandle recvBufAllocHandle() {
             if (allocHandle == null) {
@@ -883,33 +829,35 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
                 return;
             }
             // pending connect
-            if (connectPromise != null) {
+            if (connectPromise != null && !connectPromise.isDone()) {
                 // Note this method is invoked by the event loop only if the connection attempt was
                 // neither cancelled nor timed out.
-
                 assert executor().inEventLoop();
 
-                boolean connectStillInProgress = false;
+                ChannelPromise promise = connectPromise;
+                final boolean connected;
                 try {
-                    boolean wasActive = isActive();
-                    if (!socket.finishConnect()) {
-                        connectStillInProgress = true;
-                        return;
+                    connected = socket.finishConnect();
+                } catch (Throwable cause) {
+                    connectPromise = null;
+                    promise.setFailure(cause);
+                    return;
+                }
+                if (connected) {
+                    connectPromise = null;
+                    active = true;
+                    if (local == null) {
+                        local = socket.localAddress();
                     }
-                    fulfillConnectPromise(connectPromise, wasActive);
-                } catch (Throwable t) {
-                    fulfillConnectPromise(connectPromise, annotateConnectException(t, requestedRemoteAddress));
-                } finally {
-                    if (!connectStillInProgress) {
-                        // Check for null as the connectTimeoutFuture is only created if a connectTimeoutMillis > 0
-                        // is used
-                        // See https://github.com/netty/netty/issues/1770
-                        cancelConnectTimeoutFuture();
-                        connectPromise = null;
-                    } else {
-                        // The connect was not done yet, register for POLLOUT again
-                        schedulePollOut();
-                    }
+                    computeRemote();
+
+                    // Register POLLRDHUP
+                    schedulePollRdHup();
+
+                    promise.setSuccess();
+                } else {
+                    // The connect was not done yet, register for POLLOUT again
+                    schedulePollOut();
                 }
             } else if (!socket.isOutputShutdown()) {
                 // Try writing again
@@ -1004,147 +952,117 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
          */
         void connectComplete(byte op, int res, int flags, short data) {
             ioState &= ~CONNECT_SCHEDULED;
+            assert connectPromise != null;
             freeRemoteAddressMemory();
 
             if (res == ERRNO_EINPROGRESS_NEGATIVE || res == ERROR_EALREADY_NEGATIVE) {
                 // connect not complete yet need to wait for poll_out event
                 schedulePollOut();
             } else {
-                try {
-                    if (res == 0) {
-                        fulfillConnectPromise(connectPromise, active);
-                        if (readPending) {
-                            doBeginReadNow();
-                        }
-                    } else {
-                        try {
-                            Errors.throwConnectException("io_uring connect", res);
-                        } catch (Throwable cause) {
-                            fulfillConnectPromise(connectPromise, cause);
-                        }
+                ChannelPromise promise = connectPromise;
+                connectPromise = null;
+                if (res == 0) {
+                    active = true;
+                    if (local == null) {
+                        local = socket.localAddress();
                     }
-                } finally {
-                    // Check for null as the connectTimeoutFuture is only created if a connectTimeoutMillis > 0 is
-                    // used
-                    // See https://github.com/netty/netty/issues/1770
-                    cancelConnectTimeoutFuture();
-                    connectPromise = null;
-                }
-            }
-        }
+                    computeRemote();
 
-        @Override
-        public void connect(
-                final SocketAddress remoteAddress, final SocketAddress localAddress, final ChannelPromise promise) {
-            // Don't mark the connect promise as uncancellable as in fact we can cancel it as it is using
-            // non-blocking io.
-            if (promise.isDone() || !ensureOpen(promise)) {
-                return;
-            }
+                    // Register POLLRDHUP
+                    schedulePollRdHup();
 
-            if (delayedClose != null) {
-                promise.tryFailure(annotateConnectException(new ClosedChannelException(), remoteAddress));
-                return;
-            }
-            try {
-                if (connectPromise != null) {
-                    throw new ConnectionPendingException();
-                }
-                if (localAddress instanceof InetSocketAddress) {
-                    checkResolvable((InetSocketAddress) localAddress);
-                }
-
-                if (remoteAddress instanceof InetSocketAddress) {
-                    checkResolvable((InetSocketAddress) remoteAddress);
-                }
-
-                if (remote != null) {
-                    // Check if already connected before trying to connect. This is needed as connect(...) will not#
-                    // return -1 and set errno to EISCONN if a previous connect(...) attempt was setting errno to
-                    // EINPROGRESS and finished later.
-                    throw new AlreadyConnectedException();
-                }
-
-                if (localAddress != null) {
-                    socket.bind(localAddress);
-                }
-
-                if (remoteAddress instanceof InetSocketAddress) {
-                    InetSocketAddress inetSocketAddress = (InetSocketAddress) remoteAddress;
-                    ByteBuf initialData = null;
-                    if (IoUring.isTcpFastOpenClientSideAvailable() &&
-                        config().getOption(ChannelOption.TCP_FASTOPEN_CONNECT) == Boolean.TRUE) {
-                        ChannelOutboundBuffer outbound = outboundBuffer();
-                        outbound.addFlush();
-                        Object curr;
-                        if ((curr = outbound.current()) instanceof ByteBuf) {
-                            initialData = (ByteBuf) curr;
-                        }
+                    promise.setSuccess();
+                    if (readPending) {
+                        doBeginReadNow();
                     }
-                    if (initialData != null) {
-                        msgHdrMemoryArray = new MsgHdrMemoryArray((short) 1);
-                        MsgHdrMemory hdr = msgHdrMemoryArray.hdr(0);
-                        hdr.set(socket, inetSocketAddress, IoUring.memoryAddress(initialData),
-                                initialData.readableBytes(), (short) 0);
-
-                        int fd = fd().intValue();
-                        IoRegistration registration = registration();
-                        IoUringIoOps ops = IoUringIoOps.newSendmsg(fd, (byte) 0, Native.MSG_FASTOPEN,
-                                hdr.address(), hdr.idx());
-                        connectId = registration.submit(ops);
-                        if (connectId == 0) {
-                            // Directly release the memory if submitting failed.
-                            freeMsgHdrArray();
-                        }
-                    } else {
-                        submitConnect(inetSocketAddress);
-                    }
-                } else if (remoteAddress instanceof DomainSocketAddress) {
-                    DomainSocketAddress unixDomainSocketAddress = (DomainSocketAddress) remoteAddress;
-                    submitConnect(unixDomainSocketAddress);
-                } else {
-                    throw new Error("Unexpected SocketAddress implementation " + className(remoteAddress));
-                }
-
-                if (connectId != 0) {
-                    ioState |= CONNECT_SCHEDULED;
-                }
-            } catch (Throwable t) {
-                closeIfClosed();
-                promise.tryFailure(annotateConnectException(t, remoteAddress));
-                return;
-            }
-            connectPromise = promise;
-            requestedRemoteAddress = remoteAddress;
-            // Schedule connect timeout.
-            int connectTimeoutMillis = config().getConnectTimeoutMillis();
-            if (connectTimeoutMillis > 0) {
-                connectTimeoutFuture = executor().schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        ChannelPromise connectPromise = AbstractIoUringChannel.this.connectPromise;
-                        if (connectPromise != null && !connectPromise.isDone() &&
-                                connectPromise.tryFailure(new ConnectTimeoutException(
-                                        "connection timed out: " + remoteAddress))) {
-                            close(newPromise());
-                        }
-                    }
-                }, connectTimeoutMillis, TimeUnit.MILLISECONDS);
-            }
-
-            promise.addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) {
-                    // If the connect future is cancelled we also cancel the timeout and close the
-                    // underlying socket.
-                    if (future.isCancelled()) {
-                        cancelConnectTimeoutFuture();
+                } else if (!promise.isDone()) {
+                    try {
+                        Errors.throwConnectException("io_uring connect", res);
+                    } catch (Throwable cause) {
                         connectPromise = null;
-                        close(newPromise());
+                        promise.setFailure(cause);
                     }
                 }
-            });
+            }
         }
+    }
+
+    @Override
+    protected void doConnect(
+            final SocketAddress remoteAddress, final SocketAddress localAddress, final ChannelPromise promise) {
+        if (delayedClose != null) {
+            promise.tryFailure(new ClosedChannelException());
+            return;
+        }
+        try {
+            if (connectPromise != null) {
+                throw new ConnectionPendingException();
+            }
+            if (localAddress instanceof InetSocketAddress) {
+                checkResolvable((InetSocketAddress) localAddress);
+            }
+
+            if (remoteAddress instanceof InetSocketAddress) {
+                checkResolvable((InetSocketAddress) remoteAddress);
+            }
+
+            if (remote != null) {
+                // Check if already connected before trying to connect. This is needed as connect(...) will not#
+                // return -1 and set errno to EISCONN if a previous connect(...) attempt was setting errno to
+                // EINPROGRESS and finished later.
+                throw new AlreadyConnectedException();
+            }
+
+            if (localAddress != null) {
+                socket.bind(localAddress);
+            }
+
+            if (remoteAddress instanceof InetSocketAddress) {
+                InetSocketAddress inetSocketAddress = (InetSocketAddress) remoteAddress;
+                ByteBuf initialData = null;
+                if (IoUring.isTcpFastOpenClientSideAvailable() &&
+                        config().getOption(ChannelOption.TCP_FASTOPEN_CONNECT) == Boolean.TRUE) {
+                    ChannelOutboundBuffer outbound = outboundBuffer();
+                    outbound.addFlush();
+                    Object curr;
+                    if ((curr = outbound.current()) instanceof ByteBuf) {
+                        initialData = (ByteBuf) curr;
+                    }
+                }
+                if (initialData != null) {
+                    msgHdrMemoryArray = new MsgHdrMemoryArray((short) 1);
+                    MsgHdrMemory hdr = msgHdrMemoryArray.hdr(0);
+                    hdr.set(socket, inetSocketAddress, IoUring.memoryAddress(initialData),
+                            initialData.readableBytes(), (short) 0);
+
+                    int fd = fd().intValue();
+                    IoRegistration registration = registration();
+                    IoUringIoOps ops = IoUringIoOps.newSendmsg(fd, (byte) 0, Native.MSG_FASTOPEN,
+                            hdr.address(), hdr.idx());
+                    connectId = registration.submit(ops);
+                    if (connectId == 0) {
+                        // Directly release the memory if submitting failed.
+                        freeMsgHdrArray();
+                    }
+                } else {
+                    submitConnect(inetSocketAddress);
+                }
+            } else if (remoteAddress instanceof DomainSocketAddress) {
+                DomainSocketAddress unixDomainSocketAddress = (DomainSocketAddress) remoteAddress;
+                submitConnect(unixDomainSocketAddress);
+            } else {
+                throw new Error("Unexpected SocketAddress implementation " + className(remoteAddress));
+            }
+
+            if (connectId != 0) {
+                ioState |= CONNECT_SCHEDULED;
+            }
+        } catch (Throwable t) {
+            promise.tryFailure(t);
+            return;
+        }
+        connectPromise = promise;
+        requestedRemoteAddress = remoteAddress;
     }
 
     private void submitConnect(InetSocketAddress inetSocketAddress) {
@@ -1242,13 +1160,6 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
     private static boolean isAllowHalfClosure(ChannelConfig config) {
         return config instanceof SocketChannelConfig &&
                ((SocketChannelConfig) config).isAllowHalfClosure();
-    }
-
-    private void cancelConnectTimeoutFuture() {
-        if (connectTimeoutFuture != null) {
-            connectTimeoutFuture.cancel(false);
-            connectTimeoutFuture = null;
-        }
     }
 
     private void computeRemote() {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
@@ -275,18 +275,17 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
         }
 
         @Override
-        public void connect(final SocketAddress remoteAddress, final SocketAddress localAddress,
-                            final ChannelPromise promise) {
-            promise.setFailure(new UnsupportedOperationException());
-        }
-
-        @Override
         public void unregistered() {
             super.unregistered();
             if (acceptedAddressMemory != null) {
                 acceptedAddressMemory.free();
             }
         }
+    }
+
+    @Override
+    protected void doConnect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+        promise.setFailure(new UnsupportedOperationException());
     }
 
     @Override

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDomainSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDomainSocketChannel.java
@@ -220,26 +220,6 @@ public final class IoUringDomainSocketChannel extends AbstractIoUringStreamChann
         }
 
         @Override
-        public void connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
-            // Make sure to assign local/remote first before triggering the callback, to prevent potential NPE issues.
-            ChannelPromise channelPromise = newPromise().addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) throws Exception {
-                    if (future.isSuccess()) {
-                        local = localAddress != null
-                                ? (DomainSocketAddress) localAddress
-                                : socket.localDomainSocketAddress();
-                        remote = (DomainSocketAddress) remoteAddress;
-                        promise.setSuccess();
-                    } else {
-                        promise.setFailure(future.cause());
-                    }
-                }
-            });
-            super.connect(remoteAddress, localAddress, channelPromise);
-        }
-
-        @Override
         public void unregistered() {
             super.unregistered();
             if (readMsgHdrMemory != null) {
@@ -251,6 +231,26 @@ public final class IoUringDomainSocketChannel extends AbstractIoUringStreamChann
                 writeMsgHdrMemory = null;
             }
         }
+    }
+
+    @Override
+    protected void doConnect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+        // Make sure to assign local/remote first before triggering the callback, to prevent potential NPE issues.
+        ChannelPromise channelPromise = newPromise().addListener(new ChannelFutureListener() {
+            @Override
+            public void operationComplete(ChannelFuture future) throws Exception {
+                if (future.isSuccess()) {
+                    local = localAddress != null
+                            ? (DomainSocketAddress) localAddress
+                            : socket.localDomainSocketAddress();
+                    remote = (DomainSocketAddress) remoteAddress;
+                    promise.setSuccess();
+                } else {
+                    promise.setFailure(future.cause());
+                }
+            }
+        });
+        super.doConnect(remoteAddress, localAddress, channelPromise);
     }
 
     @Override

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
@@ -23,12 +23,9 @@ import io.netty.channel.AbstractChannel;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelException;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPromise;
-import io.netty.channel.ConnectTimeoutException;
 import io.netty.channel.EventLoop;
 import io.netty.channel.IoEvent;
 import io.netty.channel.IoRegistration;
@@ -39,7 +36,6 @@ import io.netty.channel.socket.SocketChannelConfig;
 import io.netty.channel.unix.FileDescriptor;
 import io.netty.channel.unix.UnixChannel;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.concurrent.Future;
 import io.netty.util.internal.UnstableApi;
 
 import java.io.IOException;
@@ -48,10 +44,8 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.AlreadyConnectedException;
-import java.nio.channels.ConnectionPendingException;
 import java.nio.channels.NotYetConnectedException;
 import java.nio.channels.UnresolvedAddressException;
-import java.util.concurrent.TimeUnit;
 
 import static io.netty.channel.internal.ChannelUtils.WRITE_STATUS_SNDBUF_FULL;
 import static io.netty.channel.unix.UnixChannelUtil.computeRemoteAddr;
@@ -65,7 +59,6 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
      * connection attempts will fail.
      */
     private ChannelPromise connectPromise;
-    private Future<?> connectTimeoutFuture;
     private SocketAddress requestedRemoteAddress;
 
     final BsdSocket socket;
@@ -378,6 +371,24 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
         }
     }
 
+    @Override
+    protected void doConnect(
+            final SocketAddress remoteAddress, final SocketAddress localAddress, final ChannelPromise promise) {
+        final boolean connected;
+        requestedRemoteAddress = remoteAddress;
+        try {
+            connected = doConnect(remoteAddress, localAddress);
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
+            return;
+        }
+        if (connected) {
+            promise.setSuccess();
+        } else {
+            connectPromise = promise;
+        }
+    }
+
     @UnstableApi
     public abstract class AbstractKQueueUnsafe extends AbstractUnsafe implements KQueueIoHandle {
         boolean readPending;
@@ -560,127 +571,25 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
             close(newPromise());
         }
 
-        @Override
-        public void connect(
-                final SocketAddress remoteAddress, final SocketAddress localAddress, final ChannelPromise promise) {
-            // Don't mark the connect promise as uncancellable as in fact we can cancel it as it is using
-            // non-blocking io.
-            if (promise.isDone() || !ensureOpen(promise)) {
-                return;
-            }
-
-            try {
-                if (connectPromise != null) {
-                    throw new ConnectionPendingException();
-                }
-
-                boolean wasActive = isActive();
-                if (doConnect(remoteAddress, localAddress)) {
-                    fulfillConnectPromise(promise, wasActive);
-                } else {
-                    connectPromise = promise;
-                    requestedRemoteAddress = remoteAddress;
-
-                    // Schedule connect timeout.
-                    final int connectTimeoutMillis = config().getConnectTimeoutMillis();
-                    if (connectTimeoutMillis > 0) {
-                        connectTimeoutFuture = executor().schedule(new Runnable() {
-                            @Override
-                            public void run() {
-                                ChannelPromise connectPromise = AbstractKQueueChannel.this.connectPromise;
-                                if (connectPromise != null && !connectPromise.isDone()
-                                        && connectPromise.tryFailure(new ConnectTimeoutException(
-                                                "connection timed out after " + connectTimeoutMillis + " ms: " +
-                                                        remoteAddress))) {
-                                    close(newPromise());
-                                }
-                            }
-                        }, connectTimeoutMillis, TimeUnit.MILLISECONDS);
-                    }
-
-                    promise.addListener(new ChannelFutureListener() {
-                        @Override
-                        public void operationComplete(ChannelFuture future) {
-                            // If the connect future is cancelled we also cancel the timeout and close the
-                            // underlying socket.
-                            if (future.isCancelled()) {
-                                if (connectTimeoutFuture != null) {
-                                    connectTimeoutFuture.cancel(false);
-                                }
-                                connectPromise = null;
-                                close(newPromise());
-                            }
-                        }
-                    });
-                }
-            } catch (Throwable t) {
-                closeIfClosed();
-                promise.tryFailure(annotateConnectException(t, remoteAddress));
-            }
-        }
-
-        private void fulfillConnectPromise(ChannelPromise promise, boolean wasActive) {
-            if (promise == null) {
-                // Closed via cancellation and the promise has been notified already.
-                return;
-            }
-            active = true;
-
-            // Get the state as trySuccess() may trigger an ChannelFutureListener that will close the Channel.
-            // We still need to ensure we call fireChannelActive() in this case.
-            boolean active = isActive();
-
-            // trySuccess() will return false if a user cancelled the connection attempt.
-            boolean promiseSet = promise.trySuccess();
-
-            // Regardless if the connection attempt was cancelled, channelActive() event should be triggered,
-            // because what happened is what happened.
-            if (!wasActive && active) {
-                pipeline().fireChannelActive();
-            }
-
-            // If a user cancelled the connection attempt, close the channel, which is followed by channelInactive().
-            if (!promiseSet) {
-                close(newPromise());
-            }
-        }
-
-        private void fulfillConnectPromise(ChannelPromise promise, Throwable cause) {
-            if (promise == null) {
-                // Closed via cancellation and the promise has been notified already.
-                return;
-            }
-
-            // Use tryFailure() instead of setFailure() to avoid the race against cancel().
-            promise.tryFailure(cause);
-            closeIfClosed();
-        }
-
         private void finishConnect() {
             // Note this method is invoked by the event loop only if the connection attempt was
             // neither cancelled nor timed out.
 
             assert executor().inEventLoop();
-
-            boolean connectStillInProgress = false;
+            assert connectPromise != null;
+            ChannelPromise promise = connectPromise;
+            final boolean connected;
             try {
-                boolean wasActive = isActive();
-                if (!doFinishConnect()) {
-                    connectStillInProgress = true;
-                    return;
-                }
-                fulfillConnectPromise(connectPromise, wasActive);
-            } catch (Throwable t) {
-                fulfillConnectPromise(connectPromise, annotateConnectException(t, requestedRemoteAddress));
-            } finally {
-                if (!connectStillInProgress) {
-                    // Check for null as the connectTimeoutFuture is only created if a connectTimeoutMillis > 0 is used
-                    // See https://github.com/netty/netty/issues/1770
-                    if (connectTimeoutFuture != null) {
-                        connectTimeoutFuture.cancel(false);
-                    }
-                    connectPromise = null;
-                }
+                connected = doFinishConnect();
+            } catch (Throwable cause) {
+                connectPromise = null;
+                promise.setFailure(cause);
+                return;
+            }
+            if (connected) {
+                active = true;
+                connectPromise = null;
+                promise.setSuccess();
             }
         }
 
@@ -742,6 +651,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
         if (connected) {
             remote = remoteSocketAddr == null?
                     remoteAddress : computeRemoteAddr(remoteSocketAddr, socket.remoteAddress());
+            active = true;
         }
         // We always need to set the localAddress even if not connected yet as the bind already took place.
         //

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
@@ -264,7 +264,7 @@ public class NioSctpChannel extends AbstractNioMessageChannel implements io.nett
     }
 
     @Override
-    protected void doClose0(ChannelPromise promise) {
+    protected void doClose(ChannelPromise promise) {
         try {
             javaChannel().close();
         } catch (Throwable cause) {

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpServerChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpServerChannel.java
@@ -146,7 +146,7 @@ public class NioSctpServerChannel extends AbstractNioMessageChannel
     }
 
     @Override
-    protected void doClose0(ChannelPromise promise) {
+    protected void doClose(ChannelPromise promise) {
         try {
             javaChannel().close();
         } catch (Throwable cause) {

--- a/transport/src/main/java/io/netty/bootstrap/FailedChannel.java
+++ b/transport/src/main/java/io/netty/bootstrap/FailedChannel.java
@@ -35,7 +35,7 @@ final class FailedChannel extends AbstractChannel {
 
     @Override
     protected AbstractUnsafe newUnsafe() {
-        return new FailedChannelUnsafe();
+        return new AbstractUnsafe() { };
     }
 
     @Override
@@ -60,6 +60,11 @@ final class FailedChannel extends AbstractChannel {
 
     @Override
     protected void doBind(SocketAddress localAddress, ChannelPromise promise) {
+        promise.setFailure(new UnsupportedOperationException());
+    }
+
+    @Override
+    protected void doConnect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
         promise.setFailure(new UnsupportedOperationException());
     }
 
@@ -101,12 +106,5 @@ final class FailedChannel extends AbstractChannel {
     @Override
     public ChannelMetadata metadata() {
         return METADATA;
-    }
-
-    private final class FailedChannelUnsafe extends AbstractUnsafe {
-        @Override
-        public void connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
-            promise.setFailure(new UnsupportedOperationException());
-        }
     }
 }

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -31,10 +31,13 @@ import java.net.InetSocketAddress;
 import java.net.NoRouteToHostException;
 import java.net.SocketAddress;
 import java.net.SocketException;
+import java.nio.channels.AlreadyConnectedException;
 import java.nio.channels.ClosedChannelException;
+import java.nio.channels.ConnectionPendingException;
 import java.nio.channels.NotYetConnectedException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import static java.util.Objects.requireNonNull;
 
@@ -58,6 +61,13 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
     private volatile boolean registered;
     private boolean closeInitiated;
     private Throwable initialCloseCause;
+
+    /**
+     * The future of the current connection attempt.  If not null, subsequent
+     * connection attempts will fail.
+     */
+    private ChannelPromise connectPromise;
+    private Future<?> connectTimeoutFuture;
 
     /** Cache for the string representation of this channel */
     private boolean strValActive;
@@ -85,6 +95,19 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         this.id = id == null ? DefaultChannelId.newInstance() : id;
         unsafe = newUnsafe();
         pipeline = newChannelPipeline();
+        closeFuture.addListener(f -> {
+            ChannelPromise connectPromise = this.connectPromise;
+            if (connectPromise != null) {
+                // Use tryFailure() instead of setFailure() to avoid the race against cancel().
+                connectPromise.tryFailure(new ClosedChannelException());
+            }
+
+            Future<?> future = connectTimeoutFuture;
+            if (future != null) {
+                future.cancel(false);
+                connectTimeoutFuture = null;
+            }
+        });
     }
 
     /**
@@ -325,7 +348,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
     /**
      * {@link Unsafe} implementation which sub-classes must extend and use.
      */
-    protected abstract class AbstractUnsafe implements Unsafe {
+    protected class AbstractUnsafe implements Unsafe {
 
         private RecvByteBufAllocator.Handle recvHandle;
         private MessageSizeEstimator.Handle estimatorHandle;
@@ -438,6 +461,94 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                 safeCascade(f, promise);
             });
             doBind(localAddress, bindPromise);
+        }
+
+        @Override
+        public final void connect(
+                final SocketAddress remoteAddress, final SocketAddress localAddress, final ChannelPromise promise) {
+            // Don't mark the connect promise as uncancellable as in fact we can cancel it as it is using
+            // non-blocking io.
+            if (promise.isDone() || !ensureOpen(promise)) {
+                return;
+            }
+            if (connectPromise != null) {
+                if (!connectPromise.isDone()) {
+                    // Already a connect in process.
+                    promise.setFailure(new ConnectionPendingException());
+                } else if (connectPromise.isSuccess()) {
+                    promise.setFailure(new AlreadyConnectedException());
+                } else {
+                    promise.setFailure(connectPromise.cause());
+                }
+                return;
+            }
+
+            boolean wasActive = isActive();
+            connectPromise = promise;
+
+            ChannelPromise p = newPromise();
+            p.addListener(f -> {
+                if  (f.isSuccess()) {
+                    fulfillConnectPromise(connectPromise, wasActive);
+                } else {
+                    fulfillConnectPromise(promise, f.cause(), remoteAddress);
+                }
+            });
+            doConnect(remoteAddress, localAddress, p);
+            if (!p.isDone()) {
+                // Schedule connect timeout.
+                final int connectTimeoutMillis = config().getConnectTimeoutMillis();
+                if (connectTimeoutMillis > 0) {
+                    connectTimeoutFuture = executor().schedule(new Runnable() {
+                        @Override
+                        public void run() {
+                            ChannelPromise connectPromise = AbstractChannel.this.connectPromise;
+                            if (connectPromise != null && !connectPromise.isDone()
+                                    && connectPromise.tryFailure(new ConnectTimeoutException(
+                                    "connection timed out after " + connectTimeoutMillis + " ms: " +
+                                            remoteAddress))) {
+                                close(newPromise());
+                            }
+                        }
+                    }, connectTimeoutMillis, TimeUnit.MILLISECONDS);
+                }
+            }
+        }
+
+        private void fulfillConnectPromise(ChannelPromise promise, boolean wasActive) {
+            if (promise == null) {
+                // Closed via cancellation and the promise has been notified already.
+                return;
+            }
+
+            // Get the state as trySuccess() may trigger an ChannelFutureListener that will close the Channel.
+            // We still need to ensure we call fireChannelActive() in this case.
+            boolean active = isActive();
+
+            // trySuccess() will return false if a user cancelled the connection attempt.
+            boolean promiseSet = promise.trySuccess();
+
+            // Regardless if the connection attempt was cancelled, channelActive() event should be triggered,
+            // because what happened is what happened.
+            if (!wasActive && active) {
+                pipeline().fireChannelActive();
+            }
+
+            // If a user cancelled the connection attempt, close the channel, which is followed by channelInactive().
+            if (!promiseSet) {
+                close(newPromise());
+            }
+        }
+
+        private void fulfillConnectPromise(ChannelPromise promise, Throwable cause, SocketAddress remoteAddress) {
+            if (promise == null) {
+                // Closed via cancellation and the promise has been notified already.
+                return;
+            }
+
+            // Use tryFailure() instead of setFailure() to avoid the race against cancel().
+            promise.tryFailure(annotateConnectException(cause, remoteAddress));
+            closeIfClosed();
         }
 
         @Override
@@ -908,6 +1019,11 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
      * Bind the {@link Channel} to the {@link SocketAddress}
      */
     protected abstract void doBind(SocketAddress localAddress, ChannelPromise promise);
+
+    /**
+     * Connect this {@link Channel} to its remote peer
+     */
+    protected abstract void doConnect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise);
 
     /**
      * Disconnect this {@link Channel} from its remote peer

--- a/transport/src/main/java/io/netty/channel/AbstractServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractServerChannel.java
@@ -68,8 +68,13 @@ public abstract class AbstractServerChannel extends AbstractChannel implements S
     }
 
     @Override
+    protected void doConnect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+        promise.setFailure(new UnsupportedOperationException());
+    }
+
+    @Override
     protected AbstractUnsafe newUnsafe() {
-        return new DefaultServerUnsafe();
+        return new AbstractUnsafe();
     }
 
     @Override
@@ -80,12 +85,5 @@ public abstract class AbstractServerChannel extends AbstractChannel implements S
     @Override
     protected final Object filterOutboundMessage(Object msg) {
         throw new UnsupportedOperationException();
-    }
-
-    private final class DefaultServerUnsafe extends AbstractUnsafe {
-        @Override
-        public void connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
-            safeSetFailure(promise, new UnsupportedOperationException());
-        }
     }
 }

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
@@ -1190,6 +1190,11 @@ public class EmbeddedChannel extends AbstractChannel {
         }
     }
 
+    @Override
+    protected void doConnect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+        promise.setSuccess();
+    }
+
     final class EmbeddedUnsafe extends AbstractUnsafe implements IoHandle {
 
         // Delegates to the EmbeddedUnsafe instance but ensures runPendingTasks() is called after each operation
@@ -1297,11 +1302,6 @@ public class EmbeddedChannel extends AbstractChannel {
                 }
             }
         };
-
-        @Override
-        public void connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
-            safeSetSuccess(promise);
-        }
 
         @Override
         public void handle(IoRegistration registration, IoEvent ioEvent) {

--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -504,11 +504,8 @@ public class LocalChannel extends AbstractChannel {
                     @Override
                     public void run() {
                         ChannelPromise promise = peer.connectPromise;
-
-                        // Only trigger fireChannelActive() if the promise was not null and was not completed yet.
-                        // connectPromise may be set to null if doClose() was called in the meantime.
-                        if (promise != null && promise.trySuccess()) {
-                            peer.pipeline().fireChannelActive();
+                        if (promise != null) {
+                            promise.trySuccess();
                         }
                     }
                 });
@@ -526,54 +523,47 @@ public class LocalChannel extends AbstractChannel {
         public void closeNow() {
             close(newPromise());
         }
+    }
 
-        @Override
-        public void connect(final SocketAddress remoteAddress,
-                SocketAddress localAddress, final ChannelPromise promise) {
-            if (!promise.setUncancellable() || !ensureOpen(promise)) {
-                return;
-            }
-
-            if (state == State.CONNECTED) {
-                Exception cause = new AlreadyConnectedException();
-                safeSetFailure(promise, cause);
-                pipeline().fireExceptionCaught(cause);
-                return;
-            }
-
-            if (connectPromise != null) {
-                throw new ConnectionPendingException();
-            }
-
-            connectPromise = promise;
-
-            if (state != State.BOUND) {
-                // Not bound yet and no localAddress specified - get one.
-                if (localAddress == null) {
-                    localAddress = new LocalAddress(LocalChannel.this);
-                }
-            }
-
-            if (localAddress != null) {
-                try {
-                    doBind0(localAddress);
-                } catch (Throwable t) {
-                    safeSetFailure(promise, t);
-                    close(newPromise());
-                    return;
-                }
-            }
-
-            Channel boundChannel = LocalChannelRegistry.get(remoteAddress);
-            if (!(boundChannel instanceof LocalServerChannel)) {
-                Exception cause = new ConnectException("connection refused: " + remoteAddress);
-                safeSetFailure(promise, cause);
-                close(newPromise());
-                return;
-            }
-
-            LocalServerChannel serverChannel = (LocalServerChannel) boundChannel;
-            peer = serverChannel.serve(LocalChannel.this);
+    @Override
+    protected void doConnect(final SocketAddress remoteAddress,
+                        SocketAddress localAddress, final ChannelPromise promise) {
+        if (state == State.CONNECTED) {
+            Exception cause = new AlreadyConnectedException();
+            promise.setFailure(cause);
+            return;
         }
+
+        if (connectPromise != null) {
+            promise.setFailure(new ConnectionPendingException());
+            return;
+        }
+
+        if (state != State.BOUND) {
+            // Not bound yet and no localAddress specified - get one.
+            if (localAddress == null) {
+                localAddress = new LocalAddress(LocalChannel.this);
+            }
+        }
+
+        if (localAddress != null) {
+            try {
+                doBind0(localAddress);
+            } catch (Throwable t) {
+                promise.setFailure(t);
+                return;
+            }
+        }
+
+        Channel boundChannel = LocalChannelRegistry.get(remoteAddress);
+        if (!(boundChannel instanceof LocalServerChannel)) {
+            Exception cause = new ConnectException("connection refused: " + remoteAddress);
+            promise.setFailure(cause);
+            return;
+        }
+
+        LocalServerChannel serverChannel = (LocalServerChannel) boundChannel;
+        peer = serverChannel.serve(LocalChannel.this);
+        connectPromise = promise;
     }
 }

--- a/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
@@ -225,11 +225,6 @@ public class LocalServerChannel extends AbstractServerChannel {
         }
 
         @Override
-        public void connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
-            safeSetFailure(promise, new UnsupportedOperationException());
-        }
-
-        @Override
         public void registered() {
             ((SingleThreadEventExecutor) executor()).addShutdownHook(shutdownHook);
         }

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
@@ -22,16 +22,12 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.AbstractChannel;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelException;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelPromise;
-import io.netty.channel.ConnectTimeoutException;
 import io.netty.channel.EventLoop;
 import io.netty.channel.IoEvent;
 import io.netty.channel.IoRegistration;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ReferenceCounted;
-import io.netty.util.concurrent.Future;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -39,11 +35,8 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.nio.channels.CancelledKeyException;
-import java.nio.channels.ClosedChannelException;
-import java.nio.channels.ConnectionPendingException;
 import java.nio.channels.SelectableChannel;
 import java.nio.channels.SelectionKey;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Abstract base class for {@link Channel} implementations which use a Selector based approach.
@@ -65,13 +58,7 @@ public abstract class AbstractNioChannel extends AbstractChannel {
         }
     };
 
-    /**
-     * The future of the current connection attempt.  If not null, subsequent
-     * connection attempts will fail.
-     */
-    private ChannelPromise connectPromise;
-    private Future<?> connectTimeoutFuture;
-    private SocketAddress requestedRemoteAddress;
+    private ChannelPromise pendingConnectPromise;
 
     /**
      * Create a new instance
@@ -244,6 +231,22 @@ public abstract class AbstractNioChannel extends AbstractChannel {
         void forceFlush();
     }
 
+    @Override
+    protected void doConnect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+        final boolean connected;
+        try {
+            connected = doConnect(remoteAddress, localAddress);
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
+            return;
+        }
+        if (connected) {
+            promise.setSuccess();
+        } else {
+            pendingConnectPromise = promise;
+        }
+    }
+
     protected abstract class AbstractNioUnsafe extends AbstractUnsafe implements NioUnsafe, NioIoHandle {
         @Override
         public void close() {
@@ -276,122 +279,21 @@ public abstract class AbstractNioChannel extends AbstractChannel {
         }
 
         @Override
-        public final void connect(
-                final SocketAddress remoteAddress, final SocketAddress localAddress, final ChannelPromise promise) {
-            // Don't mark the connect promise as uncancellable as in fact we can cancel it as it is using
-            // non-blocking io.
-            if (promise.isDone() || !ensureOpen(promise)) {
-                return;
-            }
-
-            try {
-                if (connectPromise != null) {
-                    // Already a connect in process.
-                    throw new ConnectionPendingException();
-                }
-
-                boolean wasActive = isActive();
-                if (doConnect(remoteAddress, localAddress)) {
-                    fulfillConnectPromise(promise, wasActive);
-                } else {
-                    connectPromise = promise;
-                    requestedRemoteAddress = remoteAddress;
-
-                    // Schedule connect timeout.
-                    final int connectTimeoutMillis = config().getConnectTimeoutMillis();
-                    if (connectTimeoutMillis > 0) {
-                        connectTimeoutFuture = executor().schedule(new Runnable() {
-                            @Override
-                            public void run() {
-                                ChannelPromise connectPromise = AbstractNioChannel.this.connectPromise;
-                                if (connectPromise != null && !connectPromise.isDone()
-                                        && connectPromise.tryFailure(new ConnectTimeoutException(
-                                                "connection timed out after " + connectTimeoutMillis + " ms: " +
-                                                        remoteAddress))) {
-                                    close(newPromise());
-                                }
-                            }
-                        }, connectTimeoutMillis, TimeUnit.MILLISECONDS);
-                    }
-
-                    promise.addListener(new ChannelFutureListener() {
-                        @Override
-                        public void operationComplete(ChannelFuture future) {
-                            // If the connect future is cancelled we also cancel the timeout and close the
-                            // underlying socket.
-                            if (future.isCancelled()) {
-                                if (connectTimeoutFuture != null) {
-                                    connectTimeoutFuture.cancel(false);
-                                }
-                                connectPromise = null;
-                                close(newPromise());
-                            }
-                        }
-                    });
-                }
-            } catch (Throwable t) {
-                promise.tryFailure(annotateConnectException(t, remoteAddress));
-                closeIfClosed();
-            }
-        }
-
-        private void fulfillConnectPromise(ChannelPromise promise, boolean wasActive) {
-            if (promise == null) {
-                // Closed via cancellation and the promise has been notified already.
-                return;
-            }
-
-            // Get the state as trySuccess() may trigger an ChannelFutureListener that will close the Channel.
-            // We still need to ensure we call fireChannelActive() in this case.
-            boolean active = isActive();
-
-            // trySuccess() will return false if a user cancelled the connection attempt.
-            boolean promiseSet = promise.trySuccess();
-
-            // Regardless if the connection attempt was cancelled, channelActive() event should be triggered,
-            // because what happened is what happened.
-            if (!wasActive && active) {
-                pipeline().fireChannelActive();
-            }
-
-            // If a user cancelled the connection attempt, close the channel, which is followed by channelInactive().
-            if (!promiseSet) {
-                close(newPromise());
-            }
-        }
-
-        private void fulfillConnectPromise(ChannelPromise promise, Throwable cause) {
-            if (promise == null) {
-                // Closed via cancellation and the promise has been notified already.
-                return;
-            }
-
-            // Use tryFailure() instead of setFailure() to avoid the race against cancel().
-            promise.tryFailure(cause);
-            closeIfClosed();
-        }
-
-        @Override
         public final void finishConnect() {
             // Note this method is invoked by the event loop only if the connection attempt was
             // neither cancelled nor timed out.
 
             assert executor().inEventLoop();
-
+            assert pendingConnectPromise != null;
+            ChannelPromise promise = pendingConnectPromise;
+            pendingConnectPromise = null;
             try {
-                boolean wasActive = isActive();
                 doFinishConnect();
-                fulfillConnectPromise(connectPromise, wasActive);
-            } catch (Throwable t) {
-                fulfillConnectPromise(connectPromise, annotateConnectException(t, requestedRemoteAddress));
-            } finally {
-                // Check for null as the connectTimeoutFuture is only created if a connectTimeoutMillis > 0 is used
-                // See https://github.com/netty/netty/issues/1770
-                if (connectTimeoutFuture != null) {
-                    connectTimeoutFuture.cancel(false);
-                }
-                connectPromise = null;
+            } catch (Throwable cause) {
+                promise.setFailure(cause);
+                return;
             }
+            promise.setSuccess();
         }
 
         @Override
@@ -564,23 +466,4 @@ public abstract class AbstractNioChannel extends AbstractChannel {
 
         return buf;
     }
-
-    @Override
-    protected final void doClose(ChannelPromise promise) {
-        ChannelPromise connectPromise = this.connectPromise;
-        if (connectPromise != null) {
-            // Use tryFailure() instead of setFailure() to avoid the race against cancel().
-            connectPromise.tryFailure(new ClosedChannelException());
-            this.connectPromise = null;
-        }
-
-        Future<?> future = connectTimeoutFuture;
-        if (future != null) {
-            future.cancel(false);
-            connectTimeoutFuture = null;
-        }
-        doClose0(promise);
-    }
-
-    protected abstract void doClose0(ChannelPromise promise);
 }

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
@@ -265,7 +265,7 @@ public final class NioDatagramChannel
     }
 
     @Override
-    protected void doClose0(ChannelPromise promise) {
+    protected void doClose(ChannelPromise promise) {
         try {
             javaChannel().close();
         } catch (Throwable cause) {

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioServerSocketChannel.java
@@ -180,7 +180,7 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel
     }
 
     @Override
-    protected void doClose0(ChannelPromise promise) {
+    protected void doClose(ChannelPromise promise) {
         SocketAddress localAddress = localAddress0();
         try {
             try {

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
@@ -354,7 +354,7 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
     }
 
     @Override
-    protected void doClose0(ChannelPromise promise) {
+    protected void doClose(ChannelPromise promise) {
         try {
             javaChannel().close();
         } catch (Throwable cause) {

--- a/transport/src/test/java/io/netty/channel/AbstractChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/AbstractChannelTest.java
@@ -175,14 +175,13 @@ public class AbstractChannelTest {
 
             @Override
             protected AbstractUnsafe newUnsafe() {
-                return new AbstractUnsafe() {
-                    @Override
-                    public void connect(
-                            SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
-                        active = true;
-                        promise.setSuccess();
-                    }
-                };
+                return new AbstractUnsafe() { };
+            }
+
+            @Override
+            protected void doConnect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+                active = true;
+                promise.setSuccess();
             }
 
             @Override
@@ -266,12 +265,7 @@ public class AbstractChannelTest {
 
         @Override
         protected AbstractUnsafe newUnsafe() {
-            return new AbstractUnsafe() {
-                @Override
-                public void connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
-                    promise.setFailure(new UnsupportedOperationException());
-                }
-            };
+            return new AbstractUnsafe() { };
         }
 
         @Override
@@ -297,6 +291,11 @@ public class AbstractChannelTest {
         @Override
         protected void doBind(SocketAddress localAddress, ChannelPromise promise) {
             promise.setSuccess();
+        }
+
+        @Override
+        protected void doConnect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+            promise.setFailure(new UnsupportedOperationException());
         }
 
         @Override

--- a/transport/src/test/java/io/netty/channel/ChannelOutboundBufferTest.java
+++ b/transport/src/test/java/io/netty/channel/ChannelOutboundBufferTest.java
@@ -230,6 +230,11 @@ public class ChannelOutboundBufferTest {
         }
 
         @Override
+        protected void doConnect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+            promise.setFailure(new UnsupportedOperationException());
+        }
+
+        @Override
         protected void doDisconnect(ChannelPromise promise) {
             promise.setFailure(new UnsupportedOperationException());
         }
@@ -270,10 +275,6 @@ public class ChannelOutboundBufferTest {
         }
 
         final class TestUnsafe extends AbstractUnsafe {
-            @Override
-            public void connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
-                throw new UnsupportedOperationException();
-            }
         }
     }
 

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTailTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTailTest.java
@@ -289,6 +289,15 @@ public class DefaultChannelPipelineTailTest {
         }
 
         @Override
+        protected void doConnect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+            if (!active) {
+                active = true;
+            }
+
+            promise.setSuccess();
+        }
+
+        @Override
         protected void doDisconnect(ChannelPromise promise) {
             promise.setSuccess();
         }
@@ -330,19 +339,6 @@ public class DefaultChannelPipelineTailTest {
         }
 
         private class MyUnsafe extends AbstractUnsafe {
-            @Override
-            public void connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
-                if (!ensureOpen(promise)) {
-                    return;
-                }
-
-                if (!active) {
-                    active = true;
-                    pipeline().fireChannelActive();
-                }
-
-                promise.setSuccess();
-            }
         }
 
         private class MyChannelPipeline extends DefaultChannelPipeline {


### PR DESCRIPTION

  Motivation:
  
  We had a lot of duplication related to connecting Channels. We can reduce the duplication by sharing the code via AbstractChannel.
  
  Modification:
  
  - Move shared code to AbstractChannel
  - Add new abstract doConnect(...) method that sub-classes need to override
  
  Result:
  
  Less code-duplication