### PR TITLE
Update lz4-java dependency with new group ID (#15940)

### DIFF
--- a/codec/pom.xml
+++ b/codec/pom.xml
@@ -74,7 +74,7 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>org.lz4</groupId>
+      <groupId>at.yawk.lz4</groupId>
       <artifactId>lz4-java</artifactId>
       <optional>true</optional>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1057,9 +1057,9 @@
         <version>1.0.3</version>
       </dependency>
       <dependency>
-        <groupId>org.lz4</groupId>
+        <groupId>at.yawk.lz4</groupId>
         <artifactId>lz4-java</artifactId>
-        <version>1.8.0</version>
+        <version>1.9.0</version>
       </dependency>
       <dependency>
         <groupId>com.github.jponge</groupId>


### PR DESCRIPTION
Motivation:

lz4-java has been discontinued (see
[README](https://github.com/lz4/lz4-java)) and I've forked it to fix [CVE-2025-12183](https://sites.google.com/sonatype.com/vulnerabilities/cve-2025-12183). org.lz4:lz4-java:1.8.1 contains a redirect, but the latest version needs new coordinates.

Modification:

Update to latest version, with the forked group ID.

Result:

No more CVE-2025-12183.
