### PR TITLE
AbstractChannel: Share code to handle pending writes

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -441,6 +441,11 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
         }
     }
 
+    @Override
+    protected final boolean isWriteFlushedScheduled() {
+        return isFlagSet(Native.EPOLLOUT);
+    }
+
     protected abstract class AbstractEpollUnsafe extends AbstractUnsafe implements EpollIoHandle {
         boolean readPending;
         private EpollRecvByteAllocatorHandle allocHandle;
@@ -602,16 +607,6 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
             return new EpollRecvByteAllocatorHandle(handle);
         }
 
-        @Override
-        protected final void flush0() {
-            // Flush immediately only when there's no pending flush.
-            // If there's a pending flush operation, event loop will call forceFlush() later,
-            // and thus there's no need to call it now.
-            if (!isFlagSet(Native.EPOLLOUT)) {
-                super.flush0();
-            }
-        }
-
         /**
          * Called once a EPOLLOUT event is ready to be processed
          */
@@ -621,7 +616,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
                 finishConnect();
             } else if (!socket.isOutputShutdown()) {
                 // directly call super.flush0() to force a flush now
-                super.flush0();
+                writeFlushedNow();
             }
         }
 

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -59,9 +59,9 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
     private final Runnable flushTask = new Runnable() {
         @Override
         public void run() {
-            // Calling flush0 directly to ensure we not try to flush messages that were added via write(...) in the
-            // meantime.
-            ((AbstractEpollUnsafe) unsafe()).flush0();
+            // Calling writeFlushed() directly to ensure we not try to flush messages that were added via write(...)
+            // in the meantime.
+            writeFlushed();
         }
     };
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -448,6 +448,11 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         remote = socket.remoteAddress();
     }
 
+    @Override
+    protected final boolean isWriteFlushedScheduled() {
+        return (ioState & POLL_OUT_SCHEDULED) != 0;
+    }
+
     protected abstract class AbstractUringUnsafe extends AbstractUnsafe implements IoUringIoHandle {
         private IoUringRecvByteAllocatorHandle allocHandle;
         private boolean closed;
@@ -590,16 +595,6 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
 
         protected boolean canCloseNow0() {
             return true;
-        }
-
-        @Override
-        protected final void flush0() {
-            // Flush immediately only when there's no pending flush.
-            // If there's a pending flush operation, event loop will call forceFlush() later,
-            // and thus there's no need to call it now.
-            if ((ioState & POLL_OUT_SCHEDULED) == 0) {
-                super.flush0();
-            }
         }
 
         @Override
@@ -861,7 +856,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
                 }
             } else if (!socket.isOutputShutdown()) {
                 // Try writing again
-                super.flush0();
+                writeFlushedNow();
             }
         }
 

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
@@ -389,6 +389,11 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
         }
     }
 
+    @Override
+    protected boolean isWriteFlushedScheduled() {
+        return writeFilterEnabled;
+    }
+
     @UnstableApi
     public abstract class AbstractKQueueUnsafe extends AbstractUnsafe implements KQueueIoHandle {
         boolean readPending;
@@ -470,8 +475,8 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
                 // pending connect which is now complete so handle it.
                 finishConnect();
             } else if (!socket.isOutputShutdown()) {
-                // directly call super.flush0() to force a flush now
-                super.flush0();
+                // directly call writeFlushedNow() to force a flush now
+                writeFlushedNow();
             }
         }
 
@@ -541,16 +546,6 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
                         (RecvByteBufAllocator.ExtendedHandle) super.recvBufAllocHandle());
             }
             return allocHandle;
-        }
-
-        @Override
-        protected final void flush0() {
-            // Flush immediately only when there's no pending flush.
-            // If there's a pending flush operation, event loop will call forceFlush() later,
-            // and thus there's no need to call it now.
-            if (!writeFilterEnabled) {
-                super.flush0();
-            }
         }
 
         protected final void clearReadFilter0() {

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
@@ -59,9 +59,9 @@ public abstract class AbstractKQueueStreamChannel extends AbstractKQueueChannel 
     private final Runnable flushTask = new Runnable() {
         @Override
         public void run() {
-            // Calling flush0 directly to ensure we not try to flush messages that were added via write(...) in the
-            // meantime.
-            ((AbstractKQueueUnsafe) unsafe()).flush0();
+            // Calling writeFlushed() directly to ensure we not try to flush messages that were added via write(...)
+            // in the meantime.
+            writeFlushed();
         }
     };
 

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -50,7 +50,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
 
     private final Channel parent;
     private final ChannelId id;
-    private final Unsafe unsafe;
+    private final AbstractUnsafe unsafe;
     private final ChannelPipeline pipeline;
     private final CloseFuture closeFuture = new CloseFuture(this);
     private final EventLoop eventLoop;
@@ -61,6 +61,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
     private volatile boolean registered;
     private boolean closeInitiated;
     private Throwable initialCloseCause;
+    private boolean inWriteFlushed;
 
     /**
      * The future of the current connection attempt.  If not null, subsequent
@@ -353,13 +354,8 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         private RecvByteBufAllocator.Handle recvHandle;
         private MessageSizeEstimator.Handle estimatorHandle;
 
-        private boolean inFlush0;
         /** true if the channel has never been registered, false otherwise */
         private boolean neverRegistered = true;
-
-        private void assertEventLoop() {
-            assert !registered || eventLoop.inEventLoop();
-        }
 
         MessageSizeEstimator.Handle estimatorHandle() {
             if (estimatorHandle == null) {
@@ -798,8 +794,8 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                     // need to fail the future right away. If it is not null the handling of the rest
                     // will be done in flush0()
                     // See https://github.com/netty/netty/issues/2362
-                    safeSetFailure(promise,
-                            newClosedChannelException(initialCloseCause, "write(Object, ChannelPromise)"));
+                    safeSetFailure(promise, newClosedChannelException(
+                            AbstractUnsafe.class, initialCloseCause, "write(Object, ChannelPromise)"));
                 }
                 return;
             }
@@ -833,48 +829,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             }
 
             outboundBuffer.addFlush();
-            flush0();
-        }
-
-        @SuppressWarnings("deprecation")
-        protected void flush0() {
-            if (inFlush0) {
-                // Avoid re-entrance
-                return;
-            }
-
-            final ChannelOutboundBuffer outboundBuffer = AbstractChannel.this.outboundBuffer;
-            if (outboundBuffer == null || outboundBuffer.isEmpty()) {
-                return;
-            }
-
-            inFlush0 = true;
-
-            // Mark all pending write requests as failure if the channel is inactive.
-            if (!isActive()) {
-                try {
-                    // Check if we need to generate the exception at all.
-                    if (!outboundBuffer.isEmpty()) {
-                        if (isOpen()) {
-                            outboundBuffer.failFlushed(new NotYetConnectedException(), true);
-                        } else {
-                            // Do not trigger channelWritabilityChanged because the channel is closed already.
-                            outboundBuffer.failFlushed(newClosedChannelException(initialCloseCause, "flush0()"), false);
-                        }
-                    }
-                } finally {
-                    inFlush0 = false;
-                }
-                return;
-            }
-
-            try {
-                doWrite(outboundBuffer);
-            } catch (Throwable t) {
-                handleWriteError(t);
-            } finally {
-                inFlush0 = false;
-            }
+            writeFlushed();
         }
 
         protected final void handleWriteError(Throwable t) {
@@ -888,20 +843,20 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                  * may still return {@code true} even if the channel should be closed as result of the exception.
                  */
                 initialCloseCause = t;
-                close(newPromise(), t, newClosedChannelException(t, "flush0()"));
+                close(newPromise(), t, newClosedChannelException(AbstractUnsafe.class, t, "handleWriteError()"));
             } else {
                 try {
                     shutdownOutput(newPromise(), t);
                 } catch (Throwable t2) {
                     initialCloseCause = t;
-                    close(newPromise(), t2, newClosedChannelException(t, "flush0()"));
+                    close(newPromise(), t2, newClosedChannelException(AbstractUnsafe.class, t, "handleWriteError()"));
                 }
             }
         }
 
-        private ClosedChannelException newClosedChannelException(Throwable cause, String method) {
+        private ClosedChannelException newClosedChannelException(Class<?> clazz, Throwable cause, String method) {
             ClosedChannelException exception =
-                    StacklessClosedChannelException.newInstance(AbstractChannel.AbstractUnsafe.class, method);
+                    StacklessClosedChannelException.newInstance(clazz, method);
             if (cause != null) {
                 exception.initCause(cause);
             }
@@ -913,7 +868,8 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                 return true;
             }
 
-            safeSetFailure(promise, newClosedChannelException(initialCloseCause, "ensureOpen(ChannelPromise)"));
+            safeSetFailure(promise, newClosedChannelException(
+                    AbstractUnsafe.class, initialCloseCause, "ensureOpen(ChannelPromise)"));
             return false;
         }
 
@@ -994,6 +950,80 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
          */
         protected Executor prepareToClose() {
             return null;
+        }
+    }
+
+    private void assertEventLoop() {
+        assert !registered || eventLoop.inEventLoop();
+    }
+
+    /**
+     * Returns {@code true} if flushed messages should not be tried to write when calling {@link #flush()}. Instead
+     * these will be written once {@link #writeFlushedNow()} is called, which is typically done once the underlying
+     * transport becomes writable again.
+     *
+     * @return {@code true} if write will be done later on by calling {@link #writeFlushedNow()},
+     * {@code false} otherwise.
+     */
+    protected boolean isWriteFlushedScheduled() {
+        return false;
+    }
+
+    /**
+     * Writing previous flushed messages if {@link #isWriteFlushedScheduled()} returns {@code false}, otherwise
+     * do nothing.
+     */
+    protected final void writeFlushed() {
+        assertEventLoop();
+
+        if (isWriteFlushedScheduled()) {
+            return;
+        }
+        writeFlushedNow();
+    }
+
+    /**
+     * Writing previous flushed messages now.
+     */
+    protected final void writeFlushedNow() {
+        assertEventLoop();
+        if (inWriteFlushed) {
+            // Avoid re-entrance
+            return;
+        }
+
+        final ChannelOutboundBuffer outboundBuffer = AbstractChannel.this.outboundBuffer;
+        if (outboundBuffer == null || outboundBuffer.isEmpty()) {
+            return;
+        }
+
+        inWriteFlushed = true;
+
+        // Mark all pending write requests as failure if the channel is inactive.
+        if (!isActive()) {
+            try {
+                // Check if we need to generate the exception at all.
+                if (!outboundBuffer.isEmpty()) {
+                    if (isOpen()) {
+                        outboundBuffer.failFlushed(new NotYetConnectedException(), true);
+                    } else {
+                        // Do not trigger channelWritabilityChanged because the channel is closed already.
+                        outboundBuffer.failFlushed(unsafe.newClosedChannelException(
+                                AbstractChannel.class, initialCloseCause, "writeFlushedNow()"), false);
+                    }
+                }
+            } finally {
+                inWriteFlushed = false;
+            }
+            return;
+        }
+
+        try {
+            doWrite(outboundBuffer);
+        } catch (Throwable t) {
+            unsafe.handleWriteError(t);
+        } finally {
+            inWriteFlushed = false;
         }
     }
 

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
@@ -53,9 +53,9 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
     private final Runnable flushTask = new Runnable() {
         @Override
         public void run() {
-            // Calling flush0 directly to ensure we not try to flush messages that were added via write(...) in the
-            // meantime.
-            ((AbstractNioUnsafe) unsafe()).flush0();
+            // Calling writeFlushed() directly to ensure we not try to flush messages that were added via write(...)
+            // in the meantime.
+            writeFlushed();
         }
     };
     private boolean inputClosedSeenErrorOnRead;

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
@@ -247,6 +247,13 @@ public abstract class AbstractNioChannel extends AbstractChannel {
         }
     }
 
+    @Override
+    protected final boolean isWriteFlushedScheduled() {
+        IoRegistration registration = registration();
+        return registration.isValid() && NioIoOps.WRITE.isIncludedIn((
+                (SelectionKey) registration.attachment()).interestOps());
+    }
+
     protected abstract class AbstractNioUnsafe extends AbstractUnsafe implements NioUnsafe, NioIoHandle {
         @Override
         public void close() {
@@ -297,25 +304,9 @@ public abstract class AbstractNioChannel extends AbstractChannel {
         }
 
         @Override
-        protected final void flush0() {
-            // Flush immediately only when there's no pending flush.
-            // If there's a pending flush operation, event loop will call forceFlush() later,
-            // and thus there's no need to call it now.
-            if (!isFlushPending()) {
-                super.flush0();
-            }
-        }
-
-        @Override
         public final void forceFlush() {
             // directly call super.flush0() to force a flush now
-            super.flush0();
-        }
-
-        private boolean isFlushPending() {
-            IoRegistration registration = registration();
-            return registration.isValid() && NioIoOps.WRITE.isIncludedIn((
-                    (SelectionKey) registration.attachment()).interestOps());
+            writeFlushedNow();
         }
 
         @Override


### PR DESCRIPTION
Motivation:

We can move the logic to handle pending writes to AbstractChannel and so reduce code-duplication

Modifications:

Move shared code

Result:

Reduce code-duplication