### PR TITLE
DatagramChannel: Don't enforce InetSocketAddress

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicCodec.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicCodec.java
@@ -183,12 +183,13 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
                 ByteBuf direct = ctx.alloc().directBuffer(buffer.readableBytes());
                 try {
                     direct.writeBytes(buffer, buffer.readerIndex(), buffer.readableBytes());
-                    handleQuicPacket(packet.sender(), packet.recipient(), direct);
+                    handleQuicPacket((InetSocketAddress) packet.sender(),
+                            (InetSocketAddress) packet.recipient(), direct);
                 } finally {
                     direct.release();
                 }
             } else {
-                handleQuicPacket(packet.sender(), packet.recipient(), buffer);
+                handleQuicPacket((InetSocketAddress) packet.sender(), (InetSocketAddress) packet.recipient(), buffer);
             }
         } finally {
             packet.release();

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsQueryDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsQueryDecoder.java
@@ -20,6 +20,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.handler.codec.MessageToMessageDecoder;
 
+import java.net.InetSocketAddress;
 import java.util.List;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
@@ -53,7 +54,8 @@ public class DatagramDnsQueryDecoder extends MessageToMessageDecoder<DatagramPac
                 new DnsMessageUtil.DnsQueryFactory() {
             @Override
             public DnsQuery newQuery(int id, DnsOpCode dnsOpCode) {
-                return new DatagramDnsQuery(packet.sender(), packet.recipient(), id, dnsOpCode);
+                return new DatagramDnsQuery((InetSocketAddress) packet.sender(),
+                        (InetSocketAddress) packet.recipient(), id, dnsOpCode);
             }
         });
         out.add(query);

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsResponseDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsResponseDecoder.java
@@ -63,6 +63,7 @@ public class DatagramDnsResponseDecoder extends MessageToMessageDecoder<Datagram
     }
 
     protected DnsResponse decodeResponse(ChannelHandlerContext ctx, DatagramPacket packet) throws Exception {
-        return responseDecoder.decode(packet.sender(), packet.recipient(), packet.content());
+        return responseDecoder.decode((InetSocketAddress) packet.sender(),
+                (InetSocketAddress) packet.recipient(), packet.content());
     }
 }

--- a/handler/src/main/java/io/netty/handler/pcap/PcapWriteHandler.java
+++ b/handler/src/main/java/io/netty/handler/pcap/PcapWriteHandler.java
@@ -485,8 +485,8 @@ public final class PcapWriteHandler extends ChannelDuplexHandler implements Clos
                 }
 
                 DatagramPacket datagramPacket = ((DatagramPacket) msg).duplicate();
-                InetSocketAddress srcAddr = datagramPacket.sender();
-                InetSocketAddress dstAddr = datagramPacket.recipient();
+                InetSocketAddress srcAddr = (InetSocketAddress) datagramPacket.sender();
+                InetSocketAddress dstAddr = (InetSocketAddress) datagramPacket.recipient();
 
                 // If `datagramPacket.sender()` is `null` then DatagramPacket is initialized
                 // `sender` (local) address. In this case, we'll get source address from Channel.

--- a/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
@@ -1368,16 +1368,6 @@ public class PcapWriteHandlerTest {
         }
 
         @Override
-        public InetSocketAddress localAddress() {
-            return (InetSocketAddress) super.localAddress();
-        }
-
-        @Override
-        public InetSocketAddress remoteAddress() {
-            return (InetSocketAddress) super.remoteAddress();
-        }
-
-        @Override
         protected SocketAddress localAddress0() {
             return local;
         }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramMulticastTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramMulticastTest.java
@@ -100,7 +100,7 @@ public class DatagramMulticastTest extends AbstractDatagramTest {
             assertEquals(iface, sc.config().getNetworkInterface());
             assertInterfaceAddress(iface, sc.config().getInterface());
 
-            InetSocketAddress addr = sc.localAddress();
+            InetSocketAddress addr = (InetSocketAddress) sc.localAddress();
             cb.localAddress(addr.getPort());
             clientFuture = cb.bind().await();
         } while (!clientFuture.isSuccess() && --attempts > 0);
@@ -108,7 +108,8 @@ public class DatagramMulticastTest extends AbstractDatagramTest {
         assertEquals(iface, cc.config().getNetworkInterface());
         assertInterfaceAddress(iface, cc.config().getInterface());
 
-        InetSocketAddress groupAddress = SocketUtils.socketAddress(groupAddress(), sc.localAddress().getPort());
+        InetSocketAddress groupAddress = SocketUtils.socketAddress(groupAddress(),
+                ((InetSocketAddress) sc.localAddress()).getPort());
 
         cc.joinGroup(groupAddress, iface).sync();
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastInetTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastInetTest.java
@@ -79,7 +79,7 @@ public class DatagramUnicastInetTest extends DatagramUnicastTest {
 
                     InetSocketAddress localAddress = (InetSocketAddress) ctx.channel().localAddress();
                     if (localAddress.getAddress().isAnyLocalAddress()) {
-                        assertEquals(localAddress.getPort(), msg.recipient().getPort());
+                        assertEquals(localAddress.getPort(), ((InetSocketAddress) msg.recipient()).getPort());
                     } else {
                         // Test that the channel's localAddress is equal to the message's recipient
                         assertEquals(localAddress, msg.recipient());
@@ -114,7 +114,7 @@ public class DatagramUnicastInetTest extends DatagramUnicastTest {
                             } else {
                                 InetSocketAddress senderAddress = (InetSocketAddress) sender;
                                 if (senderAddress.getAddress().isAnyLocalAddress()) {
-                                    assertEquals(senderAddress.getPort(), msg.sender().getPort());
+                                    assertEquals(senderAddress.getPort(), ((InetSocketAddress) msg.sender()).getPort());
                                 } else {
                                     assertEquals(sender, msg.sender());
                                 }

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -127,16 +127,6 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
     }
 
     @Override
-    public InetSocketAddress remoteAddress() {
-        return (InetSocketAddress) super.remoteAddress();
-    }
-
-    @Override
-    public InetSocketAddress localAddress() {
-        return (InetSocketAddress) super.localAddress();
-    }
-
-    @Override
     public ChannelMetadata metadata() {
         return METADATA;
     }
@@ -161,7 +151,8 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
         try {
             NetworkInterface iface = config().getNetworkInterface();
             if (iface == null) {
-                iface = NetworkInterface.getByInetAddress(localAddress().getAddress());
+                iface = NetworkInterface.getByInetAddress(
+                        ((InetSocketAddress) localAddress()).getAddress());
             }
             return joinGroup(multicastAddress, iface, null, promise);
         } catch (IOException e) {
@@ -232,7 +223,8 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
     public ChannelFuture leaveGroup(InetAddress multicastAddress, ChannelPromise promise) {
         try {
             return leaveGroup(
-                    multicastAddress, NetworkInterface.getByInetAddress(localAddress().getAddress()), null, promise);
+                    multicastAddress, NetworkInterface.getByInetAddress(
+                            ((InetSocketAddress) localAddress()).getAddress()), null, promise);
         } catch (IOException e) {
             promise.setFailure(e);
         }
@@ -321,7 +313,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
         try {
             return block(
                     multicastAddress,
-                    NetworkInterface.getByInetAddress(localAddress().getAddress()),
+                    NetworkInterface.getByInetAddress(((InetSocketAddress) localAddress()).getAddress()),
                     sourceToBlock, promise);
         } catch (Throwable e) {
             promise.setFailure(e);
@@ -649,8 +641,8 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
             io.netty.channel.unix.SegmentedDatagramPacket segmentedDatagramPacket =
                     (io.netty.channel.unix.SegmentedDatagramPacket) packet;
             ByteBuf content = segmentedDatagramPacket.content();
-            InetSocketAddress recipient = segmentedDatagramPacket.recipient();
-            InetSocketAddress sender = segmentedDatagramPacket.sender();
+            InetSocketAddress recipient = (InetSocketAddress) segmentedDatagramPacket.recipient();
+            InetSocketAddress sender = (InetSocketAddress) segmentedDatagramPacket.sender();
             int segmentSize = segmentedDatagramPacket.segmentSize();
             do {
                 out.add(new DatagramPacket(content.readRetainedSlice(Math.min(content.readableBytes(),
@@ -711,7 +703,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
                 return false;
             }
             byteBuf.writerIndex(bytesReceived);
-            InetSocketAddress local = localAddress();
+            InetSocketAddress local = (InetSocketAddress) localAddress();
             DatagramPacket packet = msg.newDatagramPacket(byteBuf, local);
             if (!(packet instanceof io.netty.channel.unix.SegmentedDatagramPacket)) {
                 processPacket(pipeline(), allocHandle, bytesReceived, packet);
@@ -754,7 +746,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
                 return false;
             }
 
-            InetSocketAddress local = localAddress();
+            InetSocketAddress local = (InetSocketAddress) localAddress();
 
             // Set the writerIndex too the maximum number of bytes we might have read.
             int bytesReceived = received * datagramSize;

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/NativeDatagramPacketArray.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/NativeDatagramPacketArray.java
@@ -129,7 +129,8 @@ final class NativeDatagramPacketArray {
                         segmentSize = seg;
                     }
                 }
-                added = add0(buf, buf.readerIndex(), buf.readableBytes(), segmentSize, packet.recipient());
+                added = add0(buf, buf.readerIndex(), buf.readableBytes(), segmentSize,
+                        (InetSocketAddress) packet.recipient());
             } else if (msg instanceof ByteBuf && connected) {
                 ByteBuf buf = (ByteBuf) msg;
                 added = add0(buf, buf.readerIndex(), buf.readableBytes(), 0, null);

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/SegmentedDatagramPacket.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/SegmentedDatagramPacket.java
@@ -17,7 +17,7 @@ package io.netty.channel.epoll;
 
 import io.netty.buffer.ByteBuf;
 
-import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 
 /**
  * @deprecated use {@link io.netty.channel.unix.SegmentedDatagramPacket}.
@@ -32,7 +32,7 @@ public final class SegmentedDatagramPacket extends io.netty.channel.unix.Segment
      * @param segmentSize   the segment size.
      * @param recipient     the recipient.
      */
-    public SegmentedDatagramPacket(ByteBuf data, int segmentSize, InetSocketAddress recipient) {
+    public SegmentedDatagramPacket(ByteBuf data, int segmentSize, SocketAddress recipient) {
         super(data, segmentSize, recipient);
         checkIsSupported();
     }
@@ -45,7 +45,7 @@ public final class SegmentedDatagramPacket extends io.netty.channel.unix.Segment
      * @param recipient     the recipient.
      */
     public SegmentedDatagramPacket(ByteBuf data, int segmentSize,
-                                   InetSocketAddress recipient, InetSocketAddress sender) {
+                                   SocketAddress recipient, SocketAddress sender) {
         super(data, segmentSize, recipient, sender);
         checkIsSupported();
     }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
@@ -128,16 +128,6 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
     }
 
     @Override
-    public InetSocketAddress remoteAddress() {
-        return (InetSocketAddress) super.remoteAddress();
-    }
-
-    @Override
-    public InetSocketAddress localAddress() {
-        return (InetSocketAddress) super.localAddress();
-    }
-
-    @Override
     public ChannelMetadata metadata() {
         return METADATA;
     }
@@ -162,7 +152,8 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
         try {
             return joinGroup(
                     multicastAddress,
-                    NetworkInterface.getByInetAddress(localAddress().getAddress()), null, promise);
+                    NetworkInterface.getByInetAddress(
+                            ((InetSocketAddress) localAddress()).getAddress()), null, promise);
         } catch (IOException e) {
             promise.setFailure(e);
         }
@@ -214,7 +205,8 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
     public ChannelFuture leaveGroup(InetAddress multicastAddress, ChannelPromise promise) {
         try {
             return leaveGroup(
-                    multicastAddress, NetworkInterface.getByInetAddress(localAddress().getAddress()), null, promise);
+                    multicastAddress, NetworkInterface.getByInetAddress(
+                            ((InetSocketAddress) localAddress()).getAddress()), null, promise);
         } catch (IOException e) {
             promise.setFailure(e);
         }
@@ -286,7 +278,7 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
         try {
             return block(
                     multicastAddress,
-                    NetworkInterface.getByInetAddress(localAddress().getAddress()),
+                    NetworkInterface.getByInetAddress(((InetSocketAddress) localAddress()).getAddress()),
                     sourceToBlock, promise);
         } catch (Throwable e) {
             promise.setFailure(e);

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
@@ -77,16 +77,6 @@ public final class KQueueDatagramChannel extends AbstractKQueueDatagramChannel i
     }
 
     @Override
-    public InetSocketAddress remoteAddress() {
-        return (InetSocketAddress) super.remoteAddress();
-    }
-
-    @Override
-    public InetSocketAddress localAddress() {
-        return (InetSocketAddress) super.localAddress();
-    }
-
-    @Override
     @SuppressWarnings("deprecation")
     public boolean isActive() {
         return socket.isOpen() && (config.getActiveOnOpen() && isRegistered() || active);
@@ -107,7 +97,7 @@ public final class KQueueDatagramChannel extends AbstractKQueueDatagramChannel i
         try {
             NetworkInterface iface = config().getNetworkInterface();
             if (iface == null) {
-                iface = NetworkInterface.getByInetAddress(localAddress().getAddress());
+                iface = NetworkInterface.getByInetAddress(((InetSocketAddress) localAddress()).getAddress());
             }
             return joinGroup(multicastAddress, iface, null, promise);
         } catch (SocketException e) {
@@ -156,7 +146,8 @@ public final class KQueueDatagramChannel extends AbstractKQueueDatagramChannel i
     public ChannelFuture leaveGroup(InetAddress multicastAddress, ChannelPromise promise) {
         try {
             return leaveGroup(
-                    multicastAddress, NetworkInterface.getByInetAddress(localAddress().getAddress()), null, promise);
+                    multicastAddress, NetworkInterface.getByInetAddress(
+                            ((InetSocketAddress) localAddress()).getAddress()), null, promise);
         } catch (SocketException e) {
             promise.setFailure(e);
         }
@@ -223,7 +214,7 @@ public final class KQueueDatagramChannel extends AbstractKQueueDatagramChannel i
         try {
             return block(
                     multicastAddress,
-                    NetworkInterface.getByInetAddress(localAddress().getAddress()),
+                    NetworkInterface.getByInetAddress(((InetSocketAddress) localAddress()).getAddress()),
                     sourceToBlock, promise);
         } catch (Throwable e) {
             promise.setFailure(e);

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramChannelTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramChannelTest.java
@@ -65,7 +65,7 @@ public class EpollDatagramChannelTest {
         Socket socket = Socket.newSocketDgram();
         EpollDatagramChannel channel = new EpollDatagramChannel(EpollSocketTestPermutation.EPOLL_GROUP.next(),
                 socket.intValue());
-        InetSocketAddress localAddress = channel.localAddress();
+        InetSocketAddress localAddress = (InetSocketAddress) channel.localAddress();
         assertTrue(channel.active);
         assertNotNull(localAddress);
         assertEquals(socket.localAddress(), localAddress);

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/SegmentedDatagramPacket.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/SegmentedDatagramPacket.java
@@ -20,6 +20,7 @@ import io.netty.channel.socket.DatagramPacket;
 import io.netty.util.internal.ObjectUtil;
 
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 
 /**
  * Allows to use <a href="https://blog.cloudflare.com/accelerating-udp-packet-transmission-for-quic/">GSO</a>
@@ -36,7 +37,7 @@ public class SegmentedDatagramPacket extends DatagramPacket {
      * @param segmentSize   the segment size.
      * @param recipient     the recipient.
      */
-    public SegmentedDatagramPacket(ByteBuf data, int segmentSize, InetSocketAddress recipient) {
+    public SegmentedDatagramPacket(ByteBuf data, int segmentSize, SocketAddress recipient) {
         super(data, recipient);
         this.segmentSize = ObjectUtil.checkPositive(segmentSize, "segmentSize");
     }
@@ -49,7 +50,7 @@ public class SegmentedDatagramPacket extends DatagramPacket {
      * @param recipient     the recipient.
      */
     public SegmentedDatagramPacket(ByteBuf data, int segmentSize,
-                                   InetSocketAddress recipient, InetSocketAddress sender) {
+                                   SocketAddress recipient, SocketAddress sender) {
         super(data, recipient, sender);
         this.segmentSize = ObjectUtil.checkPositive(segmentSize, "segmentSize");
     }

--- a/transport/src/main/java/io/netty/channel/socket/DatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/DatagramChannel.java
@@ -29,10 +29,6 @@ import java.net.NetworkInterface;
 public interface DatagramChannel extends Channel {
     @Override
     DatagramChannelConfig config();
-    @Override
-    InetSocketAddress localAddress();
-    @Override
-    InetSocketAddress remoteAddress();
 
     /**
      * Return {@code true} if the {@link DatagramChannel} is connected to the remote peer.

--- a/transport/src/main/java/io/netty/channel/socket/DatagramPacket.java
+++ b/transport/src/main/java/io/netty/channel/socket/DatagramPacket.java
@@ -19,18 +19,18 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.channel.DefaultAddressedEnvelope;
 
-import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 
 /**
  * The message container that is used for {@link DatagramChannel} to communicate with the remote peer.
  */
 public class DatagramPacket
-        extends DefaultAddressedEnvelope<ByteBuf, InetSocketAddress> implements ByteBufHolder {
+        extends DefaultAddressedEnvelope<ByteBuf, SocketAddress> implements ByteBufHolder {
 
     /**
      * Create a new instance with the specified packet {@code data} and {@code recipient} address.
      */
-    public DatagramPacket(ByteBuf data, InetSocketAddress recipient) {
+    public DatagramPacket(ByteBuf data, SocketAddress recipient) {
         super(data, recipient);
     }
 
@@ -38,7 +38,7 @@ public class DatagramPacket
      * Create a new instance with the specified packet {@code data}, {@code recipient} address, and {@code sender}
      * address.
      */
-    public DatagramPacket(ByteBuf data, InetSocketAddress recipient, InetSocketAddress sender) {
+    public DatagramPacket(ByteBuf data, SocketAddress recipient, SocketAddress sender) {
         super(data, recipient, sender);
     }
 

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
@@ -380,16 +380,6 @@ public final class NioDatagramChannel
     }
 
     @Override
-    public InetSocketAddress localAddress() {
-        return (InetSocketAddress) super.localAddress();
-    }
-
-    @Override
-    public InetSocketAddress remoteAddress() {
-        return (InetSocketAddress) super.remoteAddress();
-    }
-
-    @Override
     public ChannelFuture joinGroup(InetAddress multicastAddress) {
         return joinGroup(multicastAddress, newPromise());
     }
@@ -399,7 +389,7 @@ public final class NioDatagramChannel
         try {
             NetworkInterface iface = config.getNetworkInterface();
             if (iface == null) {
-                iface = NetworkInterface.getByInetAddress(localAddress().getAddress());
+                iface = NetworkInterface.getByInetAddress(((InetSocketAddress) localAddress()).getAddress());
             }
             return joinGroup(
                     multicastAddress, iface, null, promise);
@@ -475,7 +465,8 @@ public final class NioDatagramChannel
     public ChannelFuture leaveGroup(InetAddress multicastAddress, ChannelPromise promise) {
         try {
             return leaveGroup(
-                    multicastAddress, NetworkInterface.getByInetAddress(localAddress().getAddress()), null, promise);
+                    multicastAddress, NetworkInterface.getByInetAddress(
+                            ((InetSocketAddress) localAddress()).getAddress()), null, promise);
         } catch (SocketException e) {
             promise.setFailure(e);
         }
@@ -595,7 +586,7 @@ public final class NioDatagramChannel
         try {
             return block(
                     multicastAddress,
-                    NetworkInterface.getByInetAddress(localAddress().getAddress()),
+                    NetworkInterface.getByInetAddress(((InetSocketAddress) localAddress()).getAddress()),
                     sourceToBlock, promise);
         } catch (SocketException e) {
             promise.setFailure(e);


### PR DESCRIPTION
Motivation:

We shouldn't enforce InetSocketAddress for DatagramChannel as this will make it impossible to use the same interface / implementation for UDS

Modifications:

Remove overrides

Result:

More flexibility and possible code sharing in the future
