### PR TITLE
Channel: Remove Channel.Unsafe access from public API and rename Chan…

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicChannel.java
@@ -28,7 +28,6 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
-import io.netty.channel.DefaultChannelPipeline;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.handler.ssl.SniCompletionEvent;
@@ -422,12 +421,12 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     }
 
     void forceClose() {
-        unsafe().close(newPromise());
+        ioTransport().close(newPromise());
     }
 
     @Override
-    protected DefaultChannelPipeline newChannelPipeline() {
-        return new DefaultChannelPipeline(this) {
+    protected ChannelPipeline newChannelPipeline() {
+        return new DefaultAbstractChannelPipeline(this) {
             @Override
             protected void onUnhandledInboundMessage(ChannelHandlerContext ctx, Object msg) {
                 if (msg instanceof QuicStreamChannel) {
@@ -457,9 +456,9 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     public Future<QuicStreamChannel> createStream(QuicStreamType type, @Nullable ChannelHandler handler,
                                                   Promise<QuicStreamChannel> promise) {
         if (executor().inEventLoop()) {
-            ((QuicChannelUnsafe) unsafe()).connectStream(type, handler, promise);
+            connectStream(type, handler, promise);
         } else {
-            executor().execute(() -> ((QuicChannelUnsafe) unsafe()).connectStream(type, handler, promise));
+            executor().execute(() -> connectStream(type, handler, promise));
         }
         return promise;
     }
@@ -499,11 +498,6 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         } else {
             return '(' + traceId + ')' + super.toString();
         }
-    }
-
-    @Override
-    protected AbstractUnsafe newUnsafe() {
-        return new QuicChannelUnsafe();
     }
 
     @Override
@@ -658,7 +652,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         recvDatagramPending = true;
         recvStreamPending = true;
         if (datagramReadable || streamReadable) {
-            ((QuicChannelUnsafe) unsafe()).recv();
+            recv();
         }
     }
 
@@ -800,7 +794,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
             return true;
         }
         if (conn.isClosed()) {
-            unsafe().close(newPromise());
+            ioTransport().close(newPromise());
             return true;
         }
         return false;
@@ -820,7 +814,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         // Make a copy to ensure we not run into a situation when we change the underlying iterator from
         // another method and so run in an assert error.
         for (QuicheQuicStreamChannel stream: streams.values().toArray(new QuicheQuicStreamChannel[0])) {
-            stream.unsafe().close(closedChannelException, newPromise());
+            stream.ioTransport().close(closedChannelException, newPromise());
         }
         streams.clear();
     }
@@ -972,7 +966,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
      * Receive some data on a QUIC connection.
      */
     void recv(InetSocketAddress sender, InetSocketAddress recipient, ByteBuf buffer) {
-        ((QuicChannelUnsafe) unsafe()).connectionRecv(sender, recipient, buffer);
+        connectionRecv(sender, recipient, buffer);
     }
 
     /**
@@ -1517,7 +1511,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                         if (connectPromise != null && !f.isSuccess()) {
                             connectPromise.tryFailure(f.cause());
                             // close everything after notify about failure.
-                            unsafe().close(newPromise());
+                            ioTransport().close(newPromise());
                         }
                     });
             return;
@@ -1526,425 +1520,422 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         channelPromise.setFailure(new UnsupportedOperationException());
     }
 
-    private final class QuicChannelUnsafe extends AbstractChannel.AbstractUnsafe {
+    void connectStream(QuicStreamType type, @Nullable ChannelHandler handler,
+                       Promise<QuicStreamChannel> promise) {
+        if (!promise.setUncancellable()) {
+            return;
+        }
+        long streamId = idGenerator.nextStreamId(type == QuicStreamType.BIDIRECTIONAL);
 
-        void connectStream(QuicStreamType type, @Nullable ChannelHandler handler,
-                           Promise<QuicStreamChannel> promise) {
-            if (!promise.setUncancellable()) {
-                return;
+        try {
+            int res = streamSend0(connection, streamId, Unpooled.EMPTY_BUFFER, false);
+            if (res < 0 && res != Quiche.QUICHE_ERR_DONE) {
+                throw Quiche.convertToException(res);
             }
-            long streamId = idGenerator.nextStreamId(type == QuicStreamType.BIDIRECTIONAL);
-
-            try {
-                int res = streamSend0(connection, streamId, Unpooled.EMPTY_BUFFER, false);
-                if (res < 0 && res != Quiche.QUICHE_ERR_DONE) {
-                    throw Quiche.convertToException(res);
-                }
-            } catch (Exception e) {
-                promise.setFailure(e);
-                return;
-            }
-            if (type == QuicStreamType.UNIDIRECTIONAL) {
-                UNI_STREAMS_LEFT_UPDATER.decrementAndGet(QuicheQuicChannel.this);
+        } catch (Exception e) {
+            promise.setFailure(e);
+            return;
+        }
+        if (type == QuicStreamType.UNIDIRECTIONAL) {
+            UNI_STREAMS_LEFT_UPDATER.decrementAndGet(QuicheQuicChannel.this);
+        } else {
+            BIDI_STREAMS_LEFT_UPDATER.decrementAndGet(QuicheQuicChannel.this);
+        }
+        QuicheQuicStreamChannel streamChannel = addNewStreamChannel(streamId);
+        if (handler != null) {
+            streamChannel.pipeline().addLast(handler);
+        }
+        streamChannel.register().addListener((ChannelFuture f) -> {
+            if (f.isSuccess()) {
+                promise.setSuccess(streamChannel);
             } else {
-                BIDI_STREAMS_LEFT_UPDATER.decrementAndGet(QuicheQuicChannel.this);
+                promise.setFailure(f.cause());
+                streams.remove(streamId);
             }
-            QuicheQuicStreamChannel streamChannel = addNewStreamChannel(streamId);
-            if (handler != null) {
-                streamChannel.pipeline().addLast(handler);
-            }
-            streamChannel.register().addListener((ChannelFuture f) -> {
-                if (f.isSuccess()) {
-                    promise.setSuccess(streamChannel);
-                } else {
-                    promise.setFailure(f.cause());
-                    streams.remove(streamId);
-                }
-            });
-        }
+        });
+    }
 
-        private void fireConnectCloseEventIfNeeded(QuicheQuicConnection conn) {
-            if (connectionCloseEvent == null && !conn.isFreed()) {
-                connectionCloseEvent = Quiche.quiche_conn_peer_error(conn.address());
-                if (connectionCloseEvent != null) {
-                    pipeline().fireUserEventTriggered(connectionCloseEvent);
-                }
+    private void fireConnectCloseEventIfNeeded(QuicheQuicConnection conn) {
+        if (connectionCloseEvent == null && !conn.isFreed()) {
+            connectionCloseEvent = Quiche.quiche_conn_peer_error(conn.address());
+            if (connectionCloseEvent != null) {
+                pipeline().fireUserEventTriggered(connectionCloseEvent);
             }
         }
+    }
 
-        void connectionRecv(InetSocketAddress sender, InetSocketAddress recipient, ByteBuf buffer) {
-            QuicheQuicConnection conn = QuicheQuicChannel.this.connection;
-            if (conn.isFreed()) {
-                return;
-            }
-            int bufferReadable = buffer.readableBytes();
-            if (bufferReadable == 0) {
-                // Nothing to do here. Just return...
-                // See also https://github.com/cloudflare/quiche/issues/817
-                return;
-            }
+    void connectionRecv(InetSocketAddress sender, InetSocketAddress recipient, ByteBuf buffer) {
+        QuicheQuicConnection conn = QuicheQuicChannel.this.connection;
+        if (conn.isFreed()) {
+            return;
+        }
+        int bufferReadable = buffer.readableBytes();
+        if (bufferReadable == 0) {
+            // Nothing to do here. Just return...
+            // See also https://github.com/cloudflare/quiche/issues/817
+            return;
+        }
 
-            reantranceGuard |= IN_RECV;
-            boolean close = false;
+        reantranceGuard |= IN_RECV;
+        boolean close = false;
+        try {
+            ByteBuf tmpBuffer = null;
+            // We need to make a copy if the buffer is read only as recv(...) may modify the input buffer as well.
+            // See https://docs.rs/quiche/0.6.0/quiche/struct.Connection.html#method.recv
+            if (buffer.isReadOnly()) {
+                tmpBuffer = alloc().directBuffer(buffer.readableBytes());
+                tmpBuffer.writeBytes(buffer);
+                buffer = tmpBuffer;
+            }
+            long memoryAddress = Quiche.readerMemoryAddress(buffer);
+
+            ByteBuffer recvInfo = conn.nextRecvInfo();
+            QuicheRecvInfo.setRecvInfo(recvInfo, sender, recipient);
+
+            remote = sender;
+            local = recipient;
+
             try {
-                ByteBuf tmpBuffer = null;
-                // We need to make a copy if the buffer is read only as recv(...) may modify the input buffer as well.
-                // See https://docs.rs/quiche/0.6.0/quiche/struct.Connection.html#method.recv
-                if (buffer.isReadOnly()) {
-                    tmpBuffer = alloc().directBuffer(buffer.readableBytes());
-                    tmpBuffer.writeBytes(buffer);
-                    buffer = tmpBuffer;
-                }
-                long memoryAddress = Quiche.readerMemoryAddress(buffer);
-
-                ByteBuffer recvInfo = conn.nextRecvInfo();
-                QuicheRecvInfo.setRecvInfo(recvInfo, sender, recipient);
-
-                remote = sender;
-                local = recipient;
-
-                try {
-                    do  {
-                        // Call quiche_conn_recv(...) until we consumed all bytes or we did receive some error.
-                        int res = Quiche.quiche_conn_recv(conn.address(), memoryAddress, bufferReadable,
-                                Quiche.memoryAddressWithPosition(recvInfo));
-                        final boolean done;
-                        if (res < 0) {
-                            done = true;
-                            if (res != Quiche.QUICHE_ERR_DONE) {
-                                close = Quiche.shouldClose(res);
-                                Exception e = Quiche.convertToException(res);
-                                if (tryFailConnectPromise(e)) {
-                                    break;
-                                }
-                                fireExceptionEvents(conn, e);
-                            }
-                        } else {
-                            done = false;
-                        }
-                        // Process / schedule all tasks that were created.
-                        Runnable task = conn.sslTask();
-                        if (task != null) {
-                            if (runTasksDirectly()) {
-                                // Consume all tasks
-                                do {
-                                    task.run();
-                                } while ((task = conn.sslTask()) != null);
-                                processReceived(conn);
-                            } else {
-                                runAllTaskRecv(conn, task);
-                            }
-                        } else {
-                            processReceived(conn);
-                        }
-
-                        if (done) {
-                            break;
-                        }
-                        memoryAddress += res;
-                        bufferReadable -= res;
-                    } while (bufferReadable > 0 && !conn.isFreed());
-                } finally {
-                    buffer.skipBytes((int) (memoryAddress - Quiche.readerMemoryAddress(buffer)));
-                    if (tmpBuffer != null) {
-                        tmpBuffer.release();
-                    }
-                }
-                if (close) {
-                    // Let's close now as there is no way to recover
-                    unsafe().close(newPromise());
-                }
-            } finally {
-                reantranceGuard &= ~IN_RECV;
-            }
-        }
-
-        private void processReceived(QuicheQuicConnection conn) {
-            // Handle pending channelActive if needed.
-            if (handlePendingChannelActive(conn)) {
-                // Connection was closed right away.
-                return;
-            }
-
-            notifyAboutHandshakeCompletionIfNeeded(conn, null);
-            fireConnectCloseEventIfNeeded(conn);
-
-            if (conn.isFreed()) {
-                return;
-            }
-
-            long connAddr = conn.address();
-            if (Quiche.quiche_conn_is_established(connAddr) ||
-                    Quiche.quiche_conn_is_in_early_data(connAddr)) {
-                long uniLeftOld = uniStreamsLeft;
-                long bidiLeftOld = bidiStreamsLeft;
-                // Only fetch new stream info when we used all our credits
-                if (uniLeftOld == 0 || bidiLeftOld == 0) {
-                    long uniLeft = Quiche.quiche_conn_peer_streams_left_uni(connAddr);
-                    long bidiLeft = Quiche.quiche_conn_peer_streams_left_bidi(connAddr);
-                    uniStreamsLeft = uniLeft;
-                    bidiStreamsLeft = bidiLeft;
-                    if (uniLeftOld != uniLeft || bidiLeftOld != bidiLeft) {
-                        pipeline().fireUserEventTriggered(QuicStreamLimitChangedEvent.INSTANCE);
-                    }
-                }
-
-                handlePathEvents(conn);
-
-                if (handleWritableStreams(conn)) {
-                    // Some data was produced, let's flush.
-                    flushParent();
-                }
-
-                datagramReadable = true;
-                streamReadable = true;
-
-                recvDatagram(conn);
-                recvStream(conn);
-            }
-        }
-
-        private void handlePathEvents(QuicheQuicConnection conn) {
-            long event;
-            while (!conn.isFreed() && (event = Quiche.quiche_conn_path_event_next(conn.address())) > 0) {
-                try {
-                    int type = Quiche.quiche_path_event_type(event);
-
-                    if (type == Quiche.QUICHE_PATH_EVENT_NEW) {
-                        Object[] ret = Quiche.quiche_path_event_new(event);
-                        InetSocketAddress local = (InetSocketAddress) ret[0];
-                        InetSocketAddress peer = (InetSocketAddress) ret[1];
-                        pipeline().fireUserEventTriggered(new QuicPathEvent.New(local, peer));
-                    } else if (type == Quiche.QUICHE_PATH_EVENT_VALIDATED) {
-                        Object[] ret = Quiche.quiche_path_event_validated(event);
-                        InetSocketAddress local = (InetSocketAddress) ret[0];
-                        InetSocketAddress peer = (InetSocketAddress) ret[1];
-                        pipeline().fireUserEventTriggered(new QuicPathEvent.Validated(local, peer));
-                    } else if (type == Quiche.QUICHE_PATH_EVENT_FAILED_VALIDATION) {
-                        Object[] ret = Quiche.quiche_path_event_failed_validation(event);
-                        InetSocketAddress local = (InetSocketAddress) ret[0];
-                        InetSocketAddress peer = (InetSocketAddress) ret[1];
-                        pipeline().fireUserEventTriggered(new QuicPathEvent.FailedValidation(local, peer));
-                    } else if (type == Quiche.QUICHE_PATH_EVENT_CLOSED) {
-                        Object[] ret = Quiche.quiche_path_event_closed(event);
-                        InetSocketAddress local = (InetSocketAddress) ret[0];
-                        InetSocketAddress peer = (InetSocketAddress) ret[1];
-                        pipeline().fireUserEventTriggered(new QuicPathEvent.Closed(local, peer));
-                    } else if (type == Quiche.QUICHE_PATH_EVENT_REUSED_SOURCE_CONNECTION_ID) {
-                        Object[] ret = Quiche.quiche_path_event_reused_source_connection_id(event);
-                        Long seq = (Long) ret[0];
-                        InetSocketAddress localOld = (InetSocketAddress) ret[1];
-                        InetSocketAddress peerOld = (InetSocketAddress) ret[2];
-                        InetSocketAddress local = (InetSocketAddress) ret[3];
-                        InetSocketAddress peer = (InetSocketAddress) ret[4];
-                        pipeline().fireUserEventTriggered(
-                                new QuicPathEvent.ReusedSourceConnectionId(seq, localOld, peerOld, local, peer));
-                    } else if (type == Quiche.QUICHE_PATH_EVENT_PEER_MIGRATED) {
-                        Object[] ret = Quiche.quiche_path_event_peer_migrated(event);
-                        InetSocketAddress local = (InetSocketAddress) ret[0];
-                        InetSocketAddress peer = (InetSocketAddress) ret[1];
-                        pipeline().fireUserEventTriggered(new QuicPathEvent.PeerMigrated(local, peer));
-                    }
-                } finally {
-                    Quiche.quiche_path_event_free(event);
-                }
-            }
-        }
-
-        private void runAllTaskRecv(QuicheQuicConnection conn, Runnable task) {
-            sslTaskExecutor.execute(decorateTaskRecv(conn, task));
-        }
-
-        private Runnable decorateTaskRecv(QuicheQuicConnection conn, Runnable task) {
-            return () -> {
-                try {
-                    runAll(conn, task);
-                } finally {
-                    // Move back to the EventLoop.
-                    executor().execute(() -> {
-                        if (!conn.isFreed()) {
-                            processReceived(conn);
-
-                            // Call connection send to continue handshake if needed.
-                            if (connectionSend(conn) != SendResult.NONE) {
-                                forceFlushParent();
-                            }
-
-                            freeIfClosed();
-                        }
-                    });
-                }
-            };
-        }
-        void recv() {
-            QuicheQuicConnection conn = connection;
-            if ((reantranceGuard & IN_RECV) != 0 || conn.isFreed()) {
-                return;
-            }
-
-            long connAddr = conn.address();
-            // Check if we can read anything yet.
-            if (!Quiche.quiche_conn_is_established(connAddr) &&
-                    !Quiche.quiche_conn_is_in_early_data(connAddr)) {
-                return;
-            }
-
-            reantranceGuard |= IN_RECV;
-            try {
-                recvDatagram(conn);
-                recvStream(conn);
-            } finally {
-                fireChannelReadCompleteIfNeeded();
-                reantranceGuard &= ~IN_RECV;
-            }
-        }
-
-        private void recvStream(QuicheQuicConnection conn) {
-            if (conn.isFreed()) {
-                return;
-            }
-            long connAddr = conn.address();
-            long readableIterator = Quiche.quiche_conn_readable(connAddr);
-            int totalReadable = 0;
-            if (readableIterator != -1) {
-                try {
-                    // For streams we always process all streams when at least on read was requested.
-                    if (recvStreamPending && streamReadable) {
-                        for (;;) {
-                            int readable = Quiche.quiche_stream_iter_next(
-                                    readableIterator, readableStreams);
-                            for (int i = 0; i < readable; i++) {
-                                long streamId = readableStreams[i];
-                                QuicheQuicStreamChannel streamChannel = streams.get(streamId);
-                                if (streamChannel == null) {
-                                    recvStreamPending = false;
-                                    fireChannelReadCompletePending = true;
-                                    streamChannel = addNewStreamChannel(streamId);
-                                    streamChannel.readable();
-                                    pipeline().fireChannelRead(streamChannel);
-                                } else {
-                                    streamChannel.readable();
-                                }
-                            }
-                            if (readable < readableStreams.length) {
-                                // We did consume all readable streams.
-                                streamReadable = false;
+                do  {
+                    // Call quiche_conn_recv(...) until we consumed all bytes or we did receive some error.
+                    int res = Quiche.quiche_conn_recv(conn.address(), memoryAddress, bufferReadable,
+                            Quiche.memoryAddressWithPosition(recvInfo));
+                    final boolean done;
+                    if (res < 0) {
+                        done = true;
+                        if (res != Quiche.QUICHE_ERR_DONE) {
+                            close = Quiche.shouldClose(res);
+                            Exception e = Quiche.convertToException(res);
+                            if (tryFailConnectPromise(e)) {
                                 break;
                             }
-                            if (readable > 0) {
-                                totalReadable += readable;
+                            fireExceptionEvents(conn, e);
+                        }
+                    } else {
+                        done = false;
+                    }
+                    // Process / schedule all tasks that were created.
+                    Runnable task = conn.sslTask();
+                    if (task != null) {
+                        if (runTasksDirectly()) {
+                            // Consume all tasks
+                            do {
+                                task.run();
+                            } while ((task = conn.sslTask()) != null);
+                            processReceived(conn);
+                        } else {
+                            runAllTaskRecv(conn, task);
+                        }
+                    } else {
+                        processReceived(conn);
+                    }
+
+                    if (done) {
+                        break;
+                    }
+                    memoryAddress += res;
+                    bufferReadable -= res;
+                } while (bufferReadable > 0 && !conn.isFreed());
+            } finally {
+                buffer.skipBytes((int) (memoryAddress - Quiche.readerMemoryAddress(buffer)));
+                if (tmpBuffer != null) {
+                    tmpBuffer.release();
+                }
+            }
+            if (close) {
+                // Let's close now as there is no way to recover
+                ioTransport().close(newPromise());
+            }
+        } finally {
+            reantranceGuard &= ~IN_RECV;
+        }
+    }
+
+    private void processReceived(QuicheQuicConnection conn) {
+        // Handle pending channelActive if needed.
+        if (handlePendingChannelActive(conn)) {
+            // Connection was closed right away.
+            return;
+        }
+
+        notifyAboutHandshakeCompletionIfNeeded(conn, null);
+        fireConnectCloseEventIfNeeded(conn);
+
+        if (conn.isFreed()) {
+            return;
+        }
+
+        long connAddr = conn.address();
+        if (Quiche.quiche_conn_is_established(connAddr) ||
+                Quiche.quiche_conn_is_in_early_data(connAddr)) {
+            long uniLeftOld = uniStreamsLeft;
+            long bidiLeftOld = bidiStreamsLeft;
+            // Only fetch new stream info when we used all our credits
+            if (uniLeftOld == 0 || bidiLeftOld == 0) {
+                long uniLeft = Quiche.quiche_conn_peer_streams_left_uni(connAddr);
+                long bidiLeft = Quiche.quiche_conn_peer_streams_left_bidi(connAddr);
+                uniStreamsLeft = uniLeft;
+                bidiStreamsLeft = bidiLeft;
+                if (uniLeftOld != uniLeft || bidiLeftOld != bidiLeft) {
+                    pipeline().fireUserEventTriggered(QuicStreamLimitChangedEvent.INSTANCE);
+                }
+            }
+
+            handlePathEvents(conn);
+
+            if (handleWritableStreams(conn)) {
+                // Some data was produced, let's flush.
+                flushParent();
+            }
+
+            datagramReadable = true;
+            streamReadable = true;
+
+            recvDatagram(conn);
+            recvStream(conn);
+        }
+    }
+
+    private void handlePathEvents(QuicheQuicConnection conn) {
+        long event;
+        while (!conn.isFreed() && (event = Quiche.quiche_conn_path_event_next(conn.address())) > 0) {
+            try {
+                int type = Quiche.quiche_path_event_type(event);
+
+                if (type == Quiche.QUICHE_PATH_EVENT_NEW) {
+                    Object[] ret = Quiche.quiche_path_event_new(event);
+                    InetSocketAddress local = (InetSocketAddress) ret[0];
+                    InetSocketAddress peer = (InetSocketAddress) ret[1];
+                    pipeline().fireUserEventTriggered(new QuicPathEvent.New(local, peer));
+                } else if (type == Quiche.QUICHE_PATH_EVENT_VALIDATED) {
+                    Object[] ret = Quiche.quiche_path_event_validated(event);
+                    InetSocketAddress local = (InetSocketAddress) ret[0];
+                    InetSocketAddress peer = (InetSocketAddress) ret[1];
+                    pipeline().fireUserEventTriggered(new QuicPathEvent.Validated(local, peer));
+                } else if (type == Quiche.QUICHE_PATH_EVENT_FAILED_VALIDATION) {
+                    Object[] ret = Quiche.quiche_path_event_failed_validation(event);
+                    InetSocketAddress local = (InetSocketAddress) ret[0];
+                    InetSocketAddress peer = (InetSocketAddress) ret[1];
+                    pipeline().fireUserEventTriggered(new QuicPathEvent.FailedValidation(local, peer));
+                } else if (type == Quiche.QUICHE_PATH_EVENT_CLOSED) {
+                    Object[] ret = Quiche.quiche_path_event_closed(event);
+                    InetSocketAddress local = (InetSocketAddress) ret[0];
+                    InetSocketAddress peer = (InetSocketAddress) ret[1];
+                    pipeline().fireUserEventTriggered(new QuicPathEvent.Closed(local, peer));
+                } else if (type == Quiche.QUICHE_PATH_EVENT_REUSED_SOURCE_CONNECTION_ID) {
+                    Object[] ret = Quiche.quiche_path_event_reused_source_connection_id(event);
+                    Long seq = (Long) ret[0];
+                    InetSocketAddress localOld = (InetSocketAddress) ret[1];
+                    InetSocketAddress peerOld = (InetSocketAddress) ret[2];
+                    InetSocketAddress local = (InetSocketAddress) ret[3];
+                    InetSocketAddress peer = (InetSocketAddress) ret[4];
+                    pipeline().fireUserEventTriggered(
+                            new QuicPathEvent.ReusedSourceConnectionId(seq, localOld, peerOld, local, peer));
+                } else if (type == Quiche.QUICHE_PATH_EVENT_PEER_MIGRATED) {
+                    Object[] ret = Quiche.quiche_path_event_peer_migrated(event);
+                    InetSocketAddress local = (InetSocketAddress) ret[0];
+                    InetSocketAddress peer = (InetSocketAddress) ret[1];
+                    pipeline().fireUserEventTriggered(new QuicPathEvent.PeerMigrated(local, peer));
+                }
+            } finally {
+                Quiche.quiche_path_event_free(event);
+            }
+        }
+    }
+
+    private void runAllTaskRecv(QuicheQuicConnection conn, Runnable task) {
+        sslTaskExecutor.execute(decorateTaskRecv(conn, task));
+    }
+
+    private Runnable decorateTaskRecv(QuicheQuicConnection conn, Runnable task) {
+        return () -> {
+            try {
+                runAll(conn, task);
+            } finally {
+                // Move back to the EventLoop.
+                executor().execute(() -> {
+                    if (!conn.isFreed()) {
+                        processReceived(conn);
+
+                        // Call connection send to continue handshake if needed.
+                        if (connectionSend(conn) != SendResult.NONE) {
+                            forceFlushParent();
+                        }
+
+                        freeIfClosed();
+                    }
+                });
+            }
+        };
+    }
+    void recv() {
+        QuicheQuicConnection conn = connection;
+        if ((reantranceGuard & IN_RECV) != 0 || conn.isFreed()) {
+            return;
+        }
+
+        long connAddr = conn.address();
+        // Check if we can read anything yet.
+        if (!Quiche.quiche_conn_is_established(connAddr) &&
+                !Quiche.quiche_conn_is_in_early_data(connAddr)) {
+            return;
+        }
+
+        reantranceGuard |= IN_RECV;
+        try {
+            recvDatagram(conn);
+            recvStream(conn);
+        } finally {
+            fireChannelReadCompleteIfNeeded();
+            reantranceGuard &= ~IN_RECV;
+        }
+    }
+
+    private void recvStream(QuicheQuicConnection conn) {
+        if (conn.isFreed()) {
+            return;
+        }
+        long connAddr = conn.address();
+        long readableIterator = Quiche.quiche_conn_readable(connAddr);
+        int totalReadable = 0;
+        if (readableIterator != -1) {
+            try {
+                // For streams we always process all streams when at least on read was requested.
+                if (recvStreamPending && streamReadable) {
+                    for (;;) {
+                        int readable = Quiche.quiche_stream_iter_next(
+                                readableIterator, readableStreams);
+                        for (int i = 0; i < readable; i++) {
+                            long streamId = readableStreams[i];
+                            QuicheQuicStreamChannel streamChannel = streams.get(streamId);
+                            if (streamChannel == null) {
+                                recvStreamPending = false;
+                                fireChannelReadCompletePending = true;
+                                streamChannel = addNewStreamChannel(streamId);
+                                streamChannel.readable();
+                                pipeline().fireChannelRead(streamChannel);
+                            } else {
+                                streamChannel.readable();
                             }
                         }
-                    }
-                } finally {
-                    Quiche.quiche_stream_iter_free(readableIterator);
-                }
-                readableStreams = growIfNeeded(readableStreams, totalReadable);
-            }
-        }
-
-        private void recvDatagram(QuicheQuicConnection conn) {
-            if (!supportsDatagram) {
-                return;
-            }
-            while (recvDatagramPending && datagramReadable && !conn.isFreed()) {
-                @SuppressWarnings("deprecation")
-                RecvByteBufAllocator.Handle recvHandle = recvBufAllocHandle();
-                recvHandle.reset(config());
-
-                int numMessagesRead = 0;
-                do {
-                    long connAddr = conn.address();
-                    int len = Quiche.quiche_conn_dgram_recv_front_len(connAddr);
-                    if (len == Quiche.QUICHE_ERR_DONE) {
-                        datagramReadable = false;
-                        return;
-                    }
-
-                    ByteBuf datagramBuffer = alloc().directBuffer(len);
-                    recvHandle.attemptedBytesRead(datagramBuffer.writableBytes());
-                    int writerIndex = datagramBuffer.writerIndex();
-                    long memoryAddress = Quiche.writerMemoryAddress(datagramBuffer);
-
-                    int written = Quiche.quiche_conn_dgram_recv(connAddr,
-                            memoryAddress, datagramBuffer.writableBytes());
-                    if (written < 0) {
-                        datagramBuffer.release();
-                        if (written == Quiche.QUICHE_ERR_DONE) {
-                            // We did consume all datagram packets.
-                            datagramReadable = false;
+                        if (readable < readableStreams.length) {
+                            // We did consume all readable streams.
+                            streamReadable = false;
                             break;
                         }
-                        pipeline().fireExceptionCaught(Quiche.convertToException(written));
+                        if (readable > 0) {
+                            totalReadable += readable;
+                        }
                     }
-                    recvHandle.lastBytesRead(written);
-                    recvHandle.incMessagesRead(1);
-                    numMessagesRead++;
-                    datagramBuffer.writerIndex(writerIndex + written);
-                    recvDatagramPending = false;
-                    fireChannelReadCompletePending = true;
-
-                    pipeline().fireChannelRead(datagramBuffer);
-                } while (recvHandle.continueReading() && !conn.isFreed());
-                recvHandle.readComplete();
-
-                // Check if we produced any messages.
-                if (numMessagesRead > 0) {
-                    fireChannelReadCompleteIfNeeded();
                 }
+            } finally {
+                Quiche.quiche_stream_iter_free(readableIterator);
+            }
+            readableStreams = growIfNeeded(readableStreams, totalReadable);
+        }
+    }
+
+    private void recvDatagram(QuicheQuicConnection conn) {
+        if (!supportsDatagram) {
+            return;
+        }
+        while (recvDatagramPending && datagramReadable && !conn.isFreed()) {
+            @SuppressWarnings("deprecation")
+            RecvByteBufAllocator.Handle recvHandle = recvBufAllocHandle();
+            recvHandle.reset(config());
+
+            int numMessagesRead = 0;
+            do {
+                long connAddr = conn.address();
+                int len = Quiche.quiche_conn_dgram_recv_front_len(connAddr);
+                if (len == Quiche.QUICHE_ERR_DONE) {
+                    datagramReadable = false;
+                    return;
+                }
+
+                ByteBuf datagramBuffer = alloc().directBuffer(len);
+                recvHandle.attemptedBytesRead(datagramBuffer.writableBytes());
+                int writerIndex = datagramBuffer.writerIndex();
+                long memoryAddress = Quiche.writerMemoryAddress(datagramBuffer);
+
+                int written = Quiche.quiche_conn_dgram_recv(connAddr,
+                        memoryAddress, datagramBuffer.writableBytes());
+                if (written < 0) {
+                    datagramBuffer.release();
+                    if (written == Quiche.QUICHE_ERR_DONE) {
+                        // We did consume all datagram packets.
+                        datagramReadable = false;
+                        break;
+                    }
+                    pipeline().fireExceptionCaught(Quiche.convertToException(written));
+                }
+                recvHandle.lastBytesRead(written);
+                recvHandle.incMessagesRead(1);
+                numMessagesRead++;
+                datagramBuffer.writerIndex(writerIndex + written);
+                recvDatagramPending = false;
+                fireChannelReadCompletePending = true;
+
+                pipeline().fireChannelRead(datagramBuffer);
+            } while (recvHandle.continueReading() && !conn.isFreed());
+            recvHandle.readComplete();
+
+            // Check if we produced any messages.
+            if (numMessagesRead > 0) {
+                fireChannelReadCompleteIfNeeded();
             }
         }
+    }
 
-        private boolean handlePendingChannelActive(QuicheQuicConnection conn) {
-            if (conn.isFreed() || state == ChannelState.CLOSED) {
-                return true;
-            }
-            if (server) {
-                if (state == ChannelState.OPEN && Quiche.quiche_conn_is_established(conn.address())) {
-                    // We didn't notify before about channelActive... Update state and fire the event.
-                    state = ChannelState.ACTIVE;
-
-                    pipeline().fireChannelActive();
-                    notifyAboutHandshakeCompletionIfNeeded(conn, null);
-                    fireDatagramExtensionEvent(conn);
-                }
-            } else if (connectPromise != null && Quiche.quiche_conn_is_established(conn.address())) {
-                ChannelPromise promise = connectPromise;
-                connectPromise = null;
+    private boolean handlePendingChannelActive(QuicheQuicConnection conn) {
+        if (conn.isFreed() || state == ChannelState.CLOSED) {
+            return true;
+        }
+        if (server) {
+            if (state == ChannelState.OPEN && Quiche.quiche_conn_is_established(conn.address())) {
+                // We didn't notify before about channelActive... Update state and fire the event.
                 state = ChannelState.ACTIVE;
 
-                boolean promiseSet = promise.trySuccess();
+                pipeline().fireChannelActive();
                 notifyAboutHandshakeCompletionIfNeeded(conn, null);
                 fireDatagramExtensionEvent(conn);
-                if (!promiseSet) {
-                    fireConnectCloseEventIfNeeded(conn);
-                    this.close(newPromise());
-                    return true;
-                }
             }
-            return false;
-        }
+        } else if (connectPromise != null && Quiche.quiche_conn_is_established(conn.address())) {
+            ChannelPromise promise = connectPromise;
+            connectPromise = null;
+            state = ChannelState.ACTIVE;
 
-        private void fireDatagramExtensionEvent(QuicheQuicConnection conn) {
-            if (conn.isClosed()) {
-                return;
-            }
-            long connAddr = conn.address();
-            int len = Quiche.quiche_conn_dgram_max_writable_len(connAddr);
-            // QUICHE_ERR_DONE means the remote peer does not support the extension.
-            if (len != Quiche.QUICHE_ERR_DONE) {
-                pipeline().fireUserEventTriggered(new QuicDatagramExtensionEvent(len));
+            boolean promiseSet = promise.trySuccess();
+            notifyAboutHandshakeCompletionIfNeeded(conn, null);
+            fireDatagramExtensionEvent(conn);
+            if (!promiseSet) {
+                fireConnectCloseEventIfNeeded(conn);
+                this.close(newPromise());
+                return true;
             }
         }
+        return false;
+    }
 
-        private QuicheQuicStreamChannel addNewStreamChannel(long streamId) {
-            QuicheQuicStreamChannel streamChannel = new QuicheQuicStreamChannel(
-                    QuicheQuicChannel.this, streamId);
-            QuicheQuicStreamChannel old = streams.put(streamId, streamChannel);
-            assert old == null;
-            streamChannel.writable(streamCapacity(streamId));
-            return streamChannel;
+    private void fireDatagramExtensionEvent(QuicheQuicConnection conn) {
+        if (conn.isClosed()) {
+            return;
         }
+        long connAddr = conn.address();
+        int len = Quiche.quiche_conn_dgram_max_writable_len(connAddr);
+        // QUICHE_ERR_DONE means the remote peer does not support the extension.
+        if (len != Quiche.QUICHE_ERR_DONE) {
+            pipeline().fireUserEventTriggered(new QuicDatagramExtensionEvent(len));
+        }
+    }
+
+    private QuicheQuicStreamChannel addNewStreamChannel(long streamId) {
+        QuicheQuicStreamChannel streamChannel = new QuicheQuicStreamChannel(
+                QuicheQuicChannel.this, streamId);
+        QuicheQuicStreamChannel old = streams.put(streamId, streamChannel);
+        assert old == null;
+        streamChannel.writable(streamCapacity(streamId));
+        return streamChannel;
     }
 
     /**
@@ -2005,7 +1996,7 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
             }
             if (conn.isClosed()) {
                 cancel();
-                unsafe().close(newPromise());
+                ioTransport().close(newPromise());
                 return;
             }
             long nanos = Quiche.quiche_conn_timeout_as_nanos(conn.address());

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicServerCodec.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicServerCodec.java
@@ -241,12 +241,12 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
         Quic.setupChannel(channel, optionsArray, attrsArray, handler, LOGGER);
         QuicSslEngine engine = sslEngineProvider.apply(channel);
         if (!(engine instanceof QuicheQuicSslEngine)) {
-            channel.unsafe().close(channel.newPromise());
+            channel.close(channel.newPromise());
             throw new IllegalArgumentException("QuicSslEngine is not of type "
                     + QuicheQuicSslEngine.class.getSimpleName());
         }
         if (engine.getUseClientMode()) {
-            channel.unsafe().close(channel.newPromise());
+            channel.close(channel.newPromise());
             throw new IllegalArgumentException("QuicSslEngine is not created in server mode");
         }
 
@@ -264,7 +264,7 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
                     config.nativeAddress(), ssl, true);
         });
         if (connection  == null) {
-            channel.unsafe().close(channel.newPromise());
+            channel.close(channel.newPromise());
             LOGGER.debug("quiche_accept failed");
             return null;
         }

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicStreamChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicStreamChannel.java
@@ -27,6 +27,7 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelId;
 import io.netty.channel.DefaultChannelPipeline;
 import io.netty.channel.EventLoop;
+import io.netty.channel.IoTransport;
 import io.netty.channel.PendingWriteQueue;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.socket.ChannelInputShutdownEvent;
@@ -53,7 +54,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
     private final QuicheQuicChannel parent;
     private final ChannelId id;
     private final ChannelPipeline pipeline;
-    private final QuicStreamChannelUnsafe unsafe;
+    private final QuicStreamIoTransport ioTransport;
     private final ChannelPromise closePromise;
     private final PendingWriteQueue queue;
 
@@ -79,8 +80,8 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
     QuicheQuicStreamChannel(QuicheQuicChannel parent, long streamId) {
         this.parent = parent;
         this.id = DefaultChannelId.newInstance();
-        unsafe = new QuicStreamChannelUnsafe();
-        this.pipeline = new DefaultChannelPipeline(this) {
+        ioTransport = new QuicStreamIoTransport();
+        this.pipeline = new DefaultChannelPipeline(this, ioTransport) {
             // TODO: add some overrides maybe ?
         };
         config = new QuicheQuicStreamChannelConfig(this);
@@ -175,8 +176,8 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
             return;
         }
         outputShutdown = true;
-        unsafe.writeWithoutCheckChannelState(QuicStreamFrame.EMPTY_FIN, promise);
-        unsafe.flush();
+        ioTransport.writeWithoutCheckChannelState(QuicStreamFrame.EMPTY_FIN, promise);
+        ioTransport.flush();
     }
 
     @Override
@@ -251,8 +252,8 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
         }
         inputShutdown = true;
         outputShutdown = true;
-        unsafe.writeWithoutCheckChannelState(QuicStreamFrame.EMPTY_FIN, newPromise());
-        unsafe.flush();
+        ioTransport.writeWithoutCheckChannelState(QuicStreamFrame.EMPTY_FIN, newPromise());
+        ioTransport.flush();
         parent().streamShutdown(streamId(), true, false, 0, promise);
         closeIfDone();
     }
@@ -287,7 +288,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
 
     private void closeIfDone() {
         if (finSent && (finReceived || type() == QuicStreamType.UNIDIRECTIONAL && isLocalCreated())) {
-            unsafe().close(newPromise());
+            ioTransport().close(newPromise());
         }
     }
 
@@ -371,9 +372,8 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
         return 8;
     }
 
-    @Override
-    public QuicStreamChannelUnsafe unsafe() {
-        return unsafe;
+    QuicStreamIoTransport ioTransport() {
+        return ioTransport;
     }
 
     @Override
@@ -435,12 +435,12 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
                 }
                 // IF this error was not QUICHE_ERR_STREAM_STOPPED we should close the channel.
                 finSent = true;
-                unsafe().close(newPromise());
+                ioTransport().close(newPromise());
             }
             return false;
         }
         this.capacity = capacity;
-        boolean mayNeedWrite = unsafe().writeQueued();
+        boolean mayNeedWrite = ioTransport().writeQueued();
         // we need to re-read this.capacity as writeQueued() may update the capacity.
         updateWritabilityIfNeeded(this.capacity > 0);
         return mayNeedWrite;
@@ -461,11 +461,11 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
         // Mark as readable and if a read is pending execute it.
         readable = true;
         if (readPending) {
-            unsafe().recv();
+            ioTransport().recv();
         }
     }
 
-    final class QuicStreamChannelUnsafe implements Unsafe {
+    final class QuicStreamIoTransport implements IoTransport {
 
         @SuppressWarnings("deprecation")
         private RecvByteBufAllocator.Handle recvHandle;
@@ -624,11 +624,11 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
         }
 
         @Override
-        public void beginRead() {
+        public void read() {
             assert executor().inEventLoop();
             readPending = true;
             if (readable) {
-                unsafe().recv();
+                ioTransport().recv();
 
                 // As the stream was readable, and we called recv() ourselves we also need to call
                 // connectionSendAndFlush(). This is needed as recv() might consume data and so a window update

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
@@ -25,13 +25,13 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelId;
 import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOption;
-import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelProgressivePromise;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.DefaultChannelPipeline;
 import io.netty.channel.EventLoop;
+import io.netty.channel.IoTransport;
 import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.WriteBufferWaterMark;
@@ -151,7 +151,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
 
             // Notify the child-channel and close it.
             streamChannel.pipeline().fireExceptionCaught(cause);
-            streamChannel.unsafe().close(streamChannel.newPromise());
+            streamChannel.close(streamChannel.newPromise());
         }
     }
 
@@ -203,7 +203,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
     /**
      * This variable represents if a read is in progress for the current channel or was requested.
      * Note that depending upon the {@link RecvByteBufAllocator} behavior a read may extend beyond the
-     * {@link Http2ChannelUnsafe#beginRead()} method scope. The {@link Http2ChannelUnsafe#beginRead()} loop may
+     * {@link Http2ChannelUnsafe#read()} method scope. The {@link Http2ChannelUnsafe#read()} loop may
      * drain all pending data, and then if the parent channel is reading this channel may still accept frames.
      */
     private ReadStatus readStatus = ReadStatus.IDLE;
@@ -217,7 +217,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
     AbstractHttp2StreamChannel(DefaultHttp2FrameStream stream, int id, ChannelHandler inboundHandler) {
         this.stream = stream;
         stream.attachment = this;
-        pipeline = new DefaultChannelPipeline(this) {
+        pipeline = new DefaultChannelPipeline(this, unsafe) {
             @Override
             protected void incrementPendingOutboundBytes(long size) {
                 AbstractHttp2StreamChannel.this.incrementPendingOutboundBytes(size, true);
@@ -436,8 +436,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
         return bytes <= 0 || isWritable() ? 0 : bytes;
     }
 
-    @Override
-    public Unsafe unsafe() {
+    IoTransport unsafe() {
         return unsafe;
     }
 
@@ -630,7 +629,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
         unsafe.close(newPromise(), error);
     }
 
-    private final class Http2ChannelUnsafe implements Unsafe {
+    private final class Http2ChannelUnsafe implements IoTransport {
         @SuppressWarnings("deprecation")
         private RecvByteBufAllocator.Handle recvHandle;
         private boolean writeDoneAndNoFlush;
@@ -828,7 +827,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
         }
 
         @Override
-        public void beginRead() {
+        public void read() {
             if (!isActive()) {
                 return;
             }
@@ -1234,7 +1233,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
                 autoStreamFlowControl = (Boolean) value;
                 if (changed) {
                     if (channel.isRegistered()) {
-                        final Http2ChannelUnsafe unsafe = (Http2ChannelUnsafe) channel.unsafe();
+                        final Http2ChannelUnsafe unsafe = ((AbstractHttp2StreamChannel) channel).unsafe;
                         if (channel.executor().inEventLoop()) {
                             unsafe.updateLocalWindowIfNeededAndFlush();
                         } else {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrap.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrap.java
@@ -181,7 +181,7 @@ public final class Http2StreamChannelBootstrap {
         try {
             init(streamChannel);
         } catch (Exception e) {
-            streamChannel.unsafe().close(streamChannel.newPromise());
+            streamChannel.close(streamChannel.newPromise());
             promise.setFailure(e);
             return;
         }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
@@ -89,9 +89,6 @@ public class DefaultHttp2ConnectionEncoderTest {
     private Channel channel;
 
     @Mock
-    private Channel.Unsafe unsafe;
-
-    @Mock
     private ChannelPipeline pipeline;
 
     @Mock
@@ -121,7 +118,6 @@ public class DefaultHttp2ConnectionEncoderTest {
         when(channel.isActive()).thenReturn(true);
         when(channel.pipeline()).thenReturn(pipeline);
         when(channel.metadata()).thenReturn(metadata);
-        when(channel.unsafe()).thenReturn(unsafe);
         ChannelConfig config = new DefaultChannelConfig(channel);
         when(channel.config()).thenReturn(config);
         doAnswer(new Answer<ChannelFuture>() {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ControlFrameLimitEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ControlFrameLimitEncoderTest.java
@@ -64,9 +64,6 @@ public class Http2ControlFrameLimitEncoderTest {
     private Channel channel;
 
     @Mock
-    private Channel.Unsafe unsafe;
-
-    @Mock
     private ChannelConfig config;
 
     @Mock
@@ -159,7 +156,6 @@ public class Http2ControlFrameLimitEncoderTest {
         when(config.getMessageSizeEstimator()).thenReturn(DefaultMessageSizeEstimator.DEFAULT);
         ChannelMetadata metadata = new ChannelMetadata(false, 16);
         when(channel.metadata()).thenReturn(metadata);
-        when(channel.unsafe()).thenReturn(unsafe);
         handler.handlerAdded(ctx);
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MaxRstFrameLimitEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MaxRstFrameLimitEncoderTest.java
@@ -76,9 +76,6 @@ public class Http2MaxRstFrameLimitEncoderTest {
     private Channel channel;
 
     @Mock
-    private Channel.Unsafe unsafe;
-
-    @Mock
     private ChannelConfig config;
 
     @Mock
@@ -150,7 +147,6 @@ public class Http2MaxRstFrameLimitEncoderTest {
         when(config.getMessageSizeEstimator()).thenReturn(DefaultMessageSizeEstimator.DEFAULT);
         ChannelMetadata metadata = new ChannelMetadata(false, 16);
         when(channel.metadata()).thenReturn(metadata);
-        when(channel.unsafe()).thenReturn(unsafe);
         handler.handlerAdded(ctx);
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
@@ -1240,10 +1240,10 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     public void callUnsafeCloseMultipleTimes() {
         LastInboundHandler inboundHandler = new LastInboundHandler();
         Http2StreamChannel childChannel = newInboundStream(3, false, inboundHandler);
-        childChannel.unsafe().close(childChannel.newPromise());
+        childChannel.close(childChannel.newPromise());
 
         ChannelPromise promise = childChannel.newPromise();
-        childChannel.unsafe().close(promise);
+        childChannel.close(promise);
         promise.syncUninterruptibly();
         childChannel.closeFuture().syncUninterruptibly();
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
@@ -90,9 +90,6 @@ public class StreamBufferingEncoderTest {
     private Channel channel;
 
     @Mock
-    private Channel.Unsafe unsafe;
-
-    @Mock
     private ChannelConfig config;
 
     @Mock
@@ -156,7 +153,6 @@ public class StreamBufferingEncoderTest {
         when(config.getMessageSizeEstimator()).thenReturn(DefaultMessageSizeEstimator.DEFAULT);
         ChannelMetadata metadata = new ChannelMetadata(false, 16);
         when(channel.metadata()).thenReturn(metadata);
-        when(channel.unsafe()).thenReturn(unsafe);
         handler.handlerAdded(ctx);
     }
 

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/EmbeddedQuicStreamChannel.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/EmbeddedQuicStreamChannel.java
@@ -19,8 +19,9 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOption;
-import io.netty.channel.ChannelOutboundBuffer;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelId;
 import io.netty.channel.MessageSizeEstimator;
@@ -39,7 +40,6 @@ import io.netty.handler.codec.quic.QuicStreamType;
 import io.netty.util.AttributeKey;
 import org.jetbrains.annotations.Nullable;
 
-import java.net.SocketAddress;
 import java.util.Map;
 
 import static io.netty.handler.codec.http3.EmbeddedQuicChannel.prependChannelConsumer;
@@ -65,6 +65,16 @@ final class EmbeddedQuicStreamChannel extends EmbeddedChannel implements QuicStr
                     channel.attr(streamTypeKey).set(type);
                     channel.attr(localCreatedKey).set(localCreated);
                 }, handlers));
+        pipeline().addFirst(new ChannelOutboundHandlerAdapter() {
+            @Override
+            public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+                if (msg instanceof QuicStreamFrame && ((QuicStreamFrame) msg).hasFin()) {
+                    // Mimic the API.
+                    promise.addListener(f -> outputShutdown = 0);
+                }
+                super.write(ctx, msg, promise);
+            }
+        });
     }
 
     boolean writeInboundWithFin(Object... msgs) {
@@ -205,67 +215,6 @@ final class EmbeddedQuicStreamChannel extends EmbeddedChannel implements QuicStr
 
     Integer inputShutdownError() {
         return inputShutdown;
-    }
-
-    private Unsafe unsafe;
-
-    @Override
-    public Unsafe unsafe() {
-        if (unsafe == null) {
-            Unsafe superUnsafe = super.unsafe();
-            unsafe = new Unsafe() {
-
-                @Override
-                public void register(ChannelPromise promise) {
-                    superUnsafe.register(promise);
-                }
-
-                @Override
-                public void bind(SocketAddress localAddress, ChannelPromise promise) {
-                    superUnsafe.bind(localAddress, promise);
-                }
-
-                @Override
-                public void connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
-                    superUnsafe.connect(remoteAddress, localAddress, promise);
-                }
-
-                @Override
-                public void disconnect(ChannelPromise promise) {
-                    superUnsafe.disconnect(promise);
-                }
-
-                @Override
-                public void close(ChannelPromise promise) {
-                    superUnsafe.close(promise);
-                }
-
-                @Override
-                public void deregister(ChannelPromise promise) {
-                    superUnsafe.deregister(promise);
-                }
-
-                @Override
-                public void beginRead() {
-                    superUnsafe.beginRead();
-                }
-
-                @Override
-                public void write(Object msg, ChannelPromise promise) {
-                    if (msg instanceof QuicStreamFrame && ((QuicStreamFrame) msg).hasFin()) {
-                        // Mimic the API.
-                        promise.addListener(f -> outputShutdown = 0);
-                    }
-                    superUnsafe.write(msg, promise);
-                }
-
-                @Override
-                public void flush() {
-                    superUnsafe.flush();
-                }
-            };
-        }
-        return unsafe;
     }
 
     private static final class EmbeddedQuicStreamChannelConfig implements QuicStreamChannelConfig {

--- a/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
+++ b/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
@@ -17,13 +17,11 @@ package io.netty.handler.timeout;
 
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
-import io.netty.channel.Channel.Unsafe;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
-import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPromise;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Ticker;

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketCloseForciblyTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketCloseForciblyTest.java
@@ -42,7 +42,7 @@ public class SocketCloseForciblyTest extends AbstractSocketTest {
             public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
                 SocketChannel childChannel = (SocketChannel) msg;
                 childChannel.config().setSoLinger(0);
-                childChannel.unsafe().close(childChannel.newPromise());
+                childChannel.close(childChannel.newPromise());
             }
         }).childHandler(new ChannelInboundHandlerAdapter());
 

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -59,6 +59,7 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
 abstract class AbstractEpollChannel extends AbstractChannel implements UnixChannel {
     private static final ChannelMetadata METADATA = new ChannelMetadata(false);
     protected final LinuxSocket socket;
+    private final EpollIoHandleImpl ioHandle = new  EpollIoHandleImpl();
     private ChannelPromise connectPromise;
     private SocketAddress requestedRemoteAddress;
     private volatile SocketAddress local;
@@ -238,8 +239,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
     @Override
     protected void doBeginRead() throws Exception {
         // Channel.read() or ChannelHandlerContext.read() was called
-        final AbstractEpollUnsafe unsafe = (AbstractEpollUnsafe) unsafe();
-        unsafe.readPending = true;
+        readPending = true;
 
         // We must set the read flag here as it is possible the user didn't read in the last read loop, the
         // executeEpollInReadyRunnable could read nothing, and if the user doesn't explicitly call read they will
@@ -263,17 +263,16 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
         // Only clear if registered with an EventLoop as otherwise
         if (isRegistered()) {
             final EventLoop loop = executor();
-            final AbstractEpollUnsafe unsafe = (AbstractEpollUnsafe) unsafe();
             if (loop.inEventLoop()) {
-                unsafe.clearEpollIn0();
+                clearEpollIn0();
             } else {
                 // schedule a task to clear the EPOLLIN as it is not safe to modify it directly
                 loop.execute(new Runnable() {
                     @Override
                     public void run() {
-                        if (!unsafe.readPending && !config().isAutoRead()) {
+                        if (!readPending && !config().isAutoRead()) {
                             // Still no read triggered so clear it now
-                            unsafe.clearEpollIn0();
+                            clearEpollIn0();
                         }
                     }
                 });
@@ -287,7 +286,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
 
     @Override
     protected void doRegister(ChannelPromise promise) {
-        executor().register((AbstractEpollUnsafe) unsafe()).addListener(f -> {
+        executor().register(ioHandle).addListener(f -> {
             if (f.isSuccess()) {
                 registration = (IoRegistration) f.getNow();
                 registration.submit(ops);
@@ -298,9 +297,6 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
             }
         });
     }
-
-    @Override
-    protected abstract AbstractEpollUnsafe newUnsafe();
 
     /**
      * Returns an off-heap copy of the specified {@link ByteBuf}, and releases the original one.
@@ -355,7 +351,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
     protected final int doReadBytes(ByteBuf byteBuf) throws Exception {
         int writerIndex = byteBuf.writerIndex();
         int localReadAmount;
-        ((AbstractUnsafe) unsafe()).recvBufAllocHandle().attemptedBytesRead(byteBuf.writableBytes());
+        recvBufAllocHandle().attemptedBytesRead(byteBuf.writableBytes());
         if (byteBuf.hasMemoryAddress()) {
             localReadAmount = socket.recvAddress(byteBuf.memoryAddress(), writerIndex, byteBuf.capacity());
         } else {
@@ -448,13 +444,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
         return isFlagSet(Native.EPOLLOUT);
     }
 
-    protected abstract class AbstractEpollUnsafe extends AbstractUnsafe implements EpollIoHandle {
-        boolean readPending;
-        private EpollRecvByteAllocatorHandle allocHandle;
-
-        Channel channel() {
-            return AbstractEpollChannel.this;
-        }
+    private final class EpollIoHandleImpl implements EpollIoHandle {
 
         @Override
         public FileDescriptor fd() {
@@ -463,7 +453,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
 
         @Override
         public void close() {
-            close(newPromise());
+            ioTransport().close(newPromise());
         }
 
         @Override
@@ -506,178 +496,177 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
                 epollRdHupReady();
             }
         }
+    }
 
-        /**
-         * Called once EPOLLIN event is ready to be processed
-         */
-        abstract void epollInReady();
+    boolean readPending;
 
-        final boolean shouldStopReading(ChannelConfig config) {
-            // Check if there is a readPending which was not processed yet.
-            // This could be for two reasons:
-            // * The user called Channel.read() or ChannelHandlerContext.read() in channelRead(...) method
-            // * The user called Channel.read() or ChannelHandlerContext.read() in channelReadComplete(...) method
-            //
-            // See https://github.com/netty/netty/issues/2254
-            return !readPending && !config.isAutoRead();
+    /**
+     * Called once EPOLLIN event is ready to be processed
+     */
+    abstract void epollInReady();
+
+    final boolean shouldStopReading(ChannelConfig config) {
+        // Check if there is a readPending which was not processed yet.
+        // This could be for two reasons:
+        // * The user called Channel.read() or ChannelHandlerContext.read() in channelRead(...) method
+        // * The user called Channel.read() or ChannelHandlerContext.read() in channelReadComplete(...) method
+        //
+        // See https://github.com/netty/netty/issues/2254
+        return !readPending && !config.isAutoRead();
+    }
+
+    /**
+     * Called once EPOLLRDHUP event is ready to be processed
+     */
+    final void epollRdHupReady() {
+        // This must happen before we attempt to read. This will ensure reading continues until an error occurs.
+        ((EpollRecvByteAllocatorHandle) recvBufAllocHandle()).receivedRdHup();
+
+        if (isActive()) {
+            // If it is still active, we need to call epollInReady as otherwise we may miss to
+            // read pending data from the underlying file descriptor.
+            // See https://github.com/netty/netty/issues/3709
+            epollInReady();
+        } else {
+            // Just to be safe make sure the input marked as closed.
+            shutdownInput(false);
         }
 
-        /**
-         * Called once EPOLLRDHUP event is ready to be processed
-         */
-        final void epollRdHupReady() {
-            // This must happen before we attempt to read. This will ensure reading continues until an error occurs.
-            recvBufAllocHandle().receivedRdHup();
+        // Clear the EPOLLRDHUP flag to prevent continuously getting woken up on this event.
+        clearEpollRdHup();
+    }
 
-            if (isActive()) {
-                // If it is still active, we need to call epollInReady as otherwise we may miss to
-                // read pending data from the underlying file descriptor.
-                // See https://github.com/netty/netty/issues/3709
-                epollInReady();
-            } else {
-                // Just to be safe make sure the input marked as closed.
-                shutdownInput(false);
-            }
-
-            // Clear the EPOLLRDHUP flag to prevent continuously getting woken up on this event.
-            clearEpollRdHup();
-        }
-
-        /**
-         * Clear the {@link Native#EPOLLRDHUP} flag from EPOLL, and close on failure.
-         */
-        private void clearEpollRdHup() {
-            try {
-                clearFlag(Native.EPOLLRDHUP);
-            } catch (IOException e) {
-                pipeline().fireExceptionCaught(e);
-                close(newPromise());
-            }
-        }
-
-        /**
-         * Shutdown the input side of the channel.
-         */
-        void shutdownInput(boolean allDataRead) {
-            if (!socket.isInputShutdown()) {
-                if (isAllowHalfClosure(config())) {
-                    try {
-                        socket.shutdown(true, false);
-                    } catch (IOException ignored) {
-                        // We attempted to shutdown and failed, which means the input has already effectively been
-                        // shutdown.
-                        fireEventAndClose(ChannelInputShutdownEvent.INSTANCE);
-                        return;
-                    } catch (NotYetConnectedException ignore) {
-                        // We attempted to shutdown and failed, which means the input has already effectively been
-                        // shutdown.
-                    }
-                    if (shouldStopReading(config())) {
-                        clearEpollIn0();
-                    }
-                    pipeline().fireUserEventTriggered(ChannelInputShutdownEvent.INSTANCE);
-                } else {
-                    close(newPromise());
-                    return;
-                }
-            }
-
-            if (allDataRead && !inputClosedSeenErrorOnRead) {
-                inputClosedSeenErrorOnRead = true;
-                pipeline().fireUserEventTriggered(ChannelInputShutdownReadComplete.INSTANCE);
-            }
-        }
-
-        private void fireEventAndClose(Object evt) {
-            pipeline().fireUserEventTriggered(evt);
+    /**
+     * Clear the {@link Native#EPOLLRDHUP} flag from EPOLL, and close on failure.
+     */
+    private void clearEpollRdHup() {
+        try {
+            clearFlag(Native.EPOLLRDHUP);
+        } catch (IOException e) {
+            pipeline().fireExceptionCaught(e);
             close(newPromise());
         }
+    }
 
-        @Override
-        public EpollRecvByteAllocatorHandle recvBufAllocHandle() {
-            if (allocHandle == null) {
-                allocHandle = newEpollHandle((RecvByteBufAllocator.ExtendedHandle) super.recvBufAllocHandle());
-            }
-            return allocHandle;
-        }
-
-        /**
-         * Create a new {@link EpollRecvByteAllocatorHandle} instance.
-         * @param handle The handle to wrap with EPOLL specific logic.
-         */
-        EpollRecvByteAllocatorHandle newEpollHandle(RecvByteBufAllocator.ExtendedHandle handle) {
-            return new EpollRecvByteAllocatorHandle(handle);
-        }
-
-        /**
-         * Called once a EPOLLOUT event is ready to be processed
-         */
-        final void epollOutReady() {
-            if (connectPromise != null) {
-                // pending connect which is now complete so handle it.
-                finishConnect();
-            } else if (!socket.isOutputShutdown()) {
-                // directly call super.flush0() to force a flush now
-                writeFlushedNow();
-            }
-        }
-
-        protected final void clearEpollIn0() {
-            assert executor().inEventLoop();
-            try {
-                readPending = false;
-                if (!ops.contains(EpollIoOps.EPOLLIN)) {
+    /**
+     * Shutdown the input side of the channel.
+     */
+    void shutdownInput(boolean allDataRead) {
+        if (!socket.isInputShutdown()) {
+            if (isAllowHalfClosure(config())) {
+                try {
+                    socket.shutdown(true, false);
+                } catch (IOException ignored) {
+                    // We attempted to shutdown and failed, which means the input has already effectively been
+                    // shutdown.
+                    fireEventAndClose(ChannelInputShutdownEvent.INSTANCE);
                     return;
+                } catch (NotYetConnectedException ignore) {
+                    // We attempted to shutdown and failed, which means the input has already effectively been
+                    // shutdown.
                 }
-                ops = ops.without(EpollIoOps.EPOLLIN);
-                IoRegistration registration = registration();
-                registration.submit(ops);
-            } catch (UncheckedIOException e) {
-                // When this happens there is something completely wrong with either the filedescriptor or epoll,
-                // so fire the exception through the pipeline and close the Channel.
-                pipeline().fireExceptionCaught(e);
-                unsafe().close(newPromise());
-            }
-        }
-
-        private void finishConnect() {
-            // Note this method is invoked by the event loop only if the connection attempt was
-            // neither cancelled nor timed out.
-
-            assert executor().inEventLoop();
-            assert connectPromise != null;
-            ChannelPromise promise = connectPromise;
-            final boolean connected;
-            try {
-                connected = doFinishConnect();
-            } catch (Throwable cause) {
-                connectPromise = null;
-                promise.setFailure(cause);
+                if (shouldStopReading(config())) {
+                    clearEpollIn0();
+                }
+                pipeline().fireUserEventTriggered(ChannelInputShutdownEvent.INSTANCE);
+            } else {
+                close(newPromise());
                 return;
             }
-            if (connected) {
-                connectPromise = null;
-                promise.setSuccess();
-            }
         }
 
-        /**
-         * Finish the connect
-         */
-        private boolean doFinishConnect() throws Exception {
-            if (socket.finishConnect()) {
-                clearFlag(Native.EPOLLOUT);
-                if (requestedRemoteAddress instanceof InetSocketAddress) {
-                    remote = computeRemoteAddr((InetSocketAddress) requestedRemoteAddress, socket.remoteAddress());
-                }
-                requestedRemoteAddress = null;
-                active = true;
-
-                return true;
-            }
-            setFlag(Native.EPOLLOUT);
-            return false;
+        if (allDataRead && !inputClosedSeenErrorOnRead) {
+            inputClosedSeenErrorOnRead = true;
+            pipeline().fireUserEventTriggered(ChannelInputShutdownReadComplete.INSTANCE);
         }
+    }
+
+    private void fireEventAndClose(Object evt) {
+        pipeline().fireUserEventTriggered(evt);
+        close(newPromise());
+    }
+
+    @Override
+    protected EpollRecvByteAllocatorHandle newRecvBufAllocHandle() {
+        return newEpollHandle((RecvByteBufAllocator.ExtendedHandle) super.newRecvBufAllocHandle());
+    }
+
+    /**
+     * Create a new {@link EpollRecvByteAllocatorHandle} instance.
+     * @param handle The handle to wrap with EPOLL specific logic.
+     */
+    EpollRecvByteAllocatorHandle newEpollHandle(RecvByteBufAllocator.ExtendedHandle handle) {
+        return new EpollRecvByteAllocatorHandle(handle);
+    }
+
+    /**
+     * Called once a EPOLLOUT event is ready to be processed
+     */
+    final void epollOutReady() {
+        if (connectPromise != null) {
+            // pending connect which is now complete so handle it.
+            finishConnect();
+        } else if (!socket.isOutputShutdown()) {
+            // directly call super.flush0() to force a flush now
+            writeFlushedNow();
+        }
+    }
+
+    protected final void clearEpollIn0() {
+        assert executor().inEventLoop();
+        try {
+            readPending = false;
+            if (!ops.contains(EpollIoOps.EPOLLIN)) {
+                return;
+            }
+            ops = ops.without(EpollIoOps.EPOLLIN);
+            IoRegistration registration = registration();
+            registration.submit(ops);
+        } catch (UncheckedIOException e) {
+            // When this happens there is something completely wrong with either the filedescriptor or epoll,
+            // so fire the exception through the pipeline and close the Channel.
+            pipeline().fireExceptionCaught(e);
+            ioTransport().close(newPromise());
+        }
+    }
+
+    private void finishConnect() {
+        // Note this method is invoked by the event loop only if the connection attempt was
+        // neither cancelled nor timed out.
+
+        assert executor().inEventLoop();
+        assert connectPromise != null;
+        ChannelPromise promise = connectPromise;
+        final boolean connected;
+        try {
+            connected = doFinishConnect();
+        } catch (Throwable cause) {
+            connectPromise = null;
+            promise.setFailure(cause);
+            return;
+        }
+        if (connected) {
+            connectPromise = null;
+            promise.setSuccess();
+        }
+    }
+
+    /**
+     * Finish the connect
+     */
+    private boolean doFinishConnect() throws Exception {
+        if (socket.finishConnect()) {
+            clearFlag(Native.EPOLLOUT);
+            if (requestedRemoteAddress instanceof InetSocketAddress) {
+                remote = computeRemoteAddr((InetSocketAddress) requestedRemoteAddress, socket.remoteAddress());
+            }
+            requestedRemoteAddress = null;
+            active = true;
+
+            return true;
+        }
+        setFlag(Native.EPOLLOUT);
+        return false;
     }
 
     @Override

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
@@ -23,6 +23,7 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.ServerChannel;
 
 import java.net.InetSocketAddress;
@@ -32,6 +33,11 @@ public abstract class AbstractEpollServerChannel extends AbstractEpollChannel im
     private static final ChannelMetadata METADATA = new ChannelMetadata(false, 16);
 
     private final EventLoopGroup childEventLoopGroup;
+
+    // Will hold the remote address after accept(...) was successful.
+    // We need 24 bytes for the address as maximum + 1 byte for storing the length.
+    // So use 26 bytes as it's a power of two.
+    private final byte[] acceptedAddress = new byte[26];
 
     protected AbstractEpollServerChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup, int fd) {
         this(eventLoop, childEventLoopGroup, new LinuxSocket(fd), false);
@@ -64,11 +70,6 @@ public abstract class AbstractEpollServerChannel extends AbstractEpollChannel im
     }
 
     @Override
-    protected AbstractEpollUnsafe newUnsafe() {
-        return new EpollServerSocketUnsafe();
-    }
-
-    @Override
     protected void doWrite(ChannelOutboundBuffer in) throws Exception {
         throw new UnsupportedOperationException();
     }
@@ -87,56 +88,49 @@ public abstract class AbstractEpollServerChannel extends AbstractEpollChannel im
         promise.setFailure(new UnsupportedOperationException());
     }
 
-    final class EpollServerSocketUnsafe extends AbstractEpollUnsafe {
-        // Will hold the remote address after accept(...) was successful.
-        // We need 24 bytes for the address as maximum + 1 byte for storing the length.
-        // So use 26 bytes as it's a power of two.
-        private final byte[] acceptedAddress = new byte[26];
+    @Override
+    void epollInReady() {
+        assert executor().inEventLoop();
+        final ChannelConfig config = config();
+        if (shouldBreakEpollInReady(config)) {
+            clearEpollIn0();
+            return;
+        }
+        final RecvByteBufAllocator.Handle allocHandle = recvBufAllocHandle();
+        final ChannelPipeline pipeline = pipeline();
+        allocHandle.reset(config);
+        allocHandle.attemptedBytesRead(1);
 
-        @Override
-        void epollInReady() {
-            assert executor().inEventLoop();
-            final ChannelConfig config = config();
-            if (shouldBreakEpollInReady(config)) {
-                clearEpollIn0();
-                return;
-            }
-            final EpollRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
-            final ChannelPipeline pipeline = pipeline();
-            allocHandle.reset(config);
-            allocHandle.attemptedBytesRead(1);
-
-            Throwable exception = null;
+        Throwable exception = null;
+        try {
             try {
-                try {
-                    do {
-                        // lastBytesRead represents the fd. We use lastBytesRead because it must be set so that the
-                        // EpollRecvByteAllocatorHandle knows if it should try to read again or not when autoRead is
-                        // enabled.
-                        allocHandle.lastBytesRead(socket.accept(acceptedAddress));
-                        if (allocHandle.lastBytesRead() == -1) {
-                            // this means everything was handled for now
-                            break;
-                        }
-                        allocHandle.incMessagesRead(1);
+                do {
+                    // lastBytesRead represents the fd. We use lastBytesRead because it must be set so that the
+                    // EpollRecvByteAllocatorHandle knows if it should try to read again or not when autoRead is
+                    // enabled.
+                    allocHandle.lastBytesRead(socket.accept(acceptedAddress));
+                    if (allocHandle.lastBytesRead() == -1) {
+                        // this means everything was handled for now
+                        break;
+                    }
+                    allocHandle.incMessagesRead(1);
 
-                        readPending = false;
-                        pipeline.fireChannelRead(newChildChannel(childEventExecutorGroup().next(),
-                                allocHandle.lastBytesRead(), acceptedAddress, 1, acceptedAddress[0]));
-                    } while (allocHandle.continueReading());
-                } catch (Throwable t) {
-                    exception = t;
-                }
-                allocHandle.readComplete();
-                pipeline.fireChannelReadComplete();
+                    readPending = false;
+                    pipeline.fireChannelRead(newChildChannel(childEventExecutorGroup().next(),
+                            allocHandle.lastBytesRead(), acceptedAddress, 1, acceptedAddress[0]));
+                } while (allocHandle.continueReading());
+            } catch (Throwable t) {
+                exception = t;
+            }
+            allocHandle.readComplete();
+            pipeline.fireChannelReadComplete();
 
-                if (exception != null) {
-                    pipeline.fireExceptionCaught(exception);
-                }
-            } finally {
-                if (shouldStopReading(config)) {
-                    clearEpollIn();
-                }
+            if (exception != null) {
+                pipeline.fireExceptionCaught(exception);
+            }
+        } finally {
+            if (shouldStopReading(config)) {
+                clearEpollIn();
             }
         }
     }

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -95,11 +95,6 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
     }
 
     @Override
-    protected AbstractEpollUnsafe newUnsafe() {
-        return new EpollStreamUnsafe();
-    }
-
-    @Override
     public ChannelMetadata metadata() {
         return METADATA;
     }
@@ -436,12 +431,12 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
     public ChannelFuture shutdownOutput(final ChannelPromise promise) {
         EventLoop loop = executor();
         if (loop.inEventLoop()) {
-            ((AbstractUnsafe) unsafe()).shutdownOutput(promise);
+            shutdownOutput0(promise);
         } else {
             loop.execute(new Runnable() {
                 @Override
                 public void run() {
-                    ((AbstractUnsafe) unsafe()).shutdownOutput(promise);
+                    shutdownOutput0(promise);
                 }
             });
         }
@@ -456,7 +451,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
 
     @Override
     public ChannelFuture shutdownInput(final ChannelPromise promise) {
-        Executor closeExecutor = ((EpollStreamUnsafe) unsafe()).prepareToClose();
+        Executor closeExecutor = prepareToClose();
         if (closeExecutor != null) {
             closeExecutor.execute(new Runnable() {
                 @Override
@@ -533,106 +528,98 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
         }
     }
 
-    class EpollStreamUnsafe extends AbstractEpollUnsafe {
-        // Overridden here just to be able to access this method from AbstractEpollStreamChannel
-        @Override
-        protected Executor prepareToClose() {
-            return super.prepareToClose();
-        }
-
-        private void handleReadException(ChannelPipeline pipeline, ByteBuf byteBuf, Throwable cause,
-                                         boolean allDataRead, EpollRecvByteAllocatorHandle allocHandle) {
-            if (byteBuf != null) {
-                if (byteBuf.isReadable()) {
-                    readPending = false;
-                    pipeline.fireChannelRead(byteBuf);
-                } else {
-                    byteBuf.release();
-                }
+    private void handleReadException(ChannelPipeline pipeline, ByteBuf byteBuf, Throwable cause,
+                                     boolean allDataRead, EpollRecvByteAllocatorHandle allocHandle) {
+        if (byteBuf != null) {
+            if (byteBuf.isReadable()) {
+                readPending = false;
+                pipeline.fireChannelRead(byteBuf);
+            } else {
+                byteBuf.release();
             }
+        }
+        allocHandle.readComplete();
+        pipeline.fireChannelReadComplete();
+        pipeline.fireExceptionCaught(cause);
+
+        // If oom will close the read event, release connection.
+        // See https://github.com/netty/netty/issues/10434
+        if (allDataRead ||
+                cause instanceof OutOfMemoryError ||
+                cause instanceof LeakPresenceDetector.AllocationProhibitedException ||
+                cause instanceof IOException) {
+            shutdownInput(true);
+        }
+    }
+
+    @Override
+    EpollRecvByteAllocatorHandle newEpollHandle(RecvByteBufAllocator.ExtendedHandle handle) {
+        return new EpollRecvByteAllocatorStreamingHandle(handle);
+    }
+
+    @Override
+    void epollInReady() {
+        final ChannelConfig config = config();
+        if (shouldBreakEpollInReady(config)) {
+            clearEpollIn0();
+            return;
+        }
+        final EpollRecvByteAllocatorHandle allocHandle = (EpollRecvByteAllocatorHandle) recvBufAllocHandle();
+        final ChannelPipeline pipeline = pipeline();
+        final ByteBufAllocator allocator = config.getAllocator();
+        allocHandle.reset(config);
+
+        ByteBuf byteBuf = null;
+        boolean allDataRead = false;
+        try {
+            do {
+                // we use a direct buffer here as the native implementations only be able
+                // to handle direct buffers.
+                byteBuf = allocHandle.allocate(allocator);
+                allocHandle.lastBytesRead(doReadBytes(byteBuf));
+                if (allocHandle.lastBytesRead() <= 0) {
+                    // nothing was read, release the buffer.
+                    byteBuf.release();
+                    byteBuf = null;
+                    allDataRead = allocHandle.lastBytesRead() < 0;
+                    if (allDataRead) {
+                        // There is nothing left to read as we received an EOF.
+                        readPending = false;
+                    }
+                    break;
+                }
+                allocHandle.incMessagesRead(1);
+                readPending = false;
+                pipeline.fireChannelRead(byteBuf);
+                byteBuf = null;
+
+                if (shouldBreakEpollInReady(config)) {
+                    // We need to do this for two reasons:
+                    //
+                    // - If the input was shutdown in between (which may be the case when the user did it in the
+                    //   fireChannelRead(...) method we should not try to read again to not produce any
+                    //   miss-leading exceptions.
+                    //
+                    // - If the user closes the channel we need to ensure we not try to read from it again as
+                    //   the filedescriptor may be re-used already by the OS if the system is handling a lot of
+                    //   concurrent connections and so needs a lot of filedescriptors. If not do this we risk
+                    //   reading data from a filedescriptor that belongs to another socket then the socket that
+                    //   was "wrapped" by this Channel implementation.
+                    break;
+                }
+            } while (allocHandle.continueReading());
+
             allocHandle.readComplete();
             pipeline.fireChannelReadComplete();
-            pipeline.fireExceptionCaught(cause);
 
-            // If oom will close the read event, release connection.
-            // See https://github.com/netty/netty/issues/10434
-            if (allDataRead ||
-                    cause instanceof OutOfMemoryError ||
-                    cause instanceof LeakPresenceDetector.AllocationProhibitedException ||
-                    cause instanceof IOException) {
+            if (allDataRead) {
                 shutdownInput(true);
             }
-        }
-
-        @Override
-        EpollRecvByteAllocatorHandle newEpollHandle(RecvByteBufAllocator.ExtendedHandle handle) {
-            return new EpollRecvByteAllocatorStreamingHandle(handle);
-        }
-
-        @Override
-        void epollInReady() {
-            final ChannelConfig config = config();
-            if (shouldBreakEpollInReady(config)) {
-                clearEpollIn0();
-                return;
-            }
-            final EpollRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
-            final ChannelPipeline pipeline = pipeline();
-            final ByteBufAllocator allocator = config.getAllocator();
-            allocHandle.reset(config);
-
-            ByteBuf byteBuf = null;
-            boolean allDataRead = false;
-            try {
-                do {
-                    // we use a direct buffer here as the native implementations only be able
-                    // to handle direct buffers.
-                    byteBuf = allocHandle.allocate(allocator);
-                    allocHandle.lastBytesRead(doReadBytes(byteBuf));
-                    if (allocHandle.lastBytesRead() <= 0) {
-                        // nothing was read, release the buffer.
-                        byteBuf.release();
-                        byteBuf = null;
-                        allDataRead = allocHandle.lastBytesRead() < 0;
-                        if (allDataRead) {
-                            // There is nothing left to read as we received an EOF.
-                            readPending = false;
-                        }
-                        break;
-                    }
-                    allocHandle.incMessagesRead(1);
-                    readPending = false;
-                    pipeline.fireChannelRead(byteBuf);
-                    byteBuf = null;
-
-                    if (shouldBreakEpollInReady(config)) {
-                        // We need to do this for two reasons:
-                        //
-                        // - If the input was shutdown in between (which may be the case when the user did it in the
-                        //   fireChannelRead(...) method we should not try to read again to not produce any
-                        //   miss-leading exceptions.
-                        //
-                        // - If the user closes the channel we need to ensure we not try to read from it again as
-                        //   the filedescriptor may be re-used already by the OS if the system is handling a lot of
-                        //   concurrent connections and so needs a lot of filedescriptors. If not do this we risk
-                        //   reading data from a filedescriptor that belongs to another socket then the socket that
-                        //   was "wrapped" by this Channel implementation.
-                        break;
-                    }
-                } while (allocHandle.continueReading());
-
-                allocHandle.readComplete();
-                pipeline.fireChannelReadComplete();
-
-                if (allDataRead) {
-                    shutdownInput(true);
-                }
-            } catch (Throwable t) {
-                handleReadException(pipeline, byteBuf, t, allDataRead, allocHandle);
-            } finally {
-                if (shouldStopReading(config)) {
-                    clearEpollIn();
-                }
+        } catch (Throwable t) {
+            handleReadException(pipeline, byteBuf, t, allDataRead, allocHandle);
+        } finally {
+            if (shouldStopReading(config)) {
+                clearEpollIn();
             }
         }
     }

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -322,11 +322,6 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
     }
 
     @Override
-    protected AbstractEpollUnsafe newUnsafe() {
-        return new EpollDatagramChannelUnsafe();
-    }
-
-    @Override
     protected void doBind(SocketAddress localAddress, ChannelPromise promise) {
         if (localAddress instanceof InetSocketAddress) {
             InetSocketAddress socketAddress = (InetSocketAddress) localAddress;
@@ -530,75 +525,72 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
         }));
     }
 
-    final class EpollDatagramChannelUnsafe extends AbstractEpollUnsafe {
+    @Override
+    void epollInReady() {
+        assert executor().inEventLoop();
+        EpollDatagramChannelConfig config = config();
+        if (shouldBreakEpollInReady(config)) {
+            clearEpollIn0();
+            return;
+        }
+        final EpollRecvByteAllocatorHandle allocHandle = (EpollRecvByteAllocatorHandle) recvBufAllocHandle();
+        final ChannelPipeline pipeline = pipeline();
+        final ByteBufAllocator allocator = config.getAllocator();
+        allocHandle.reset(config);
 
-        @Override
-        void epollInReady() {
-            assert executor().inEventLoop();
-            EpollDatagramChannelConfig config = config();
-            if (shouldBreakEpollInReady(config)) {
-                clearEpollIn0();
-                return;
-            }
-            final EpollRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
-            final ChannelPipeline pipeline = pipeline();
-            final ByteBufAllocator allocator = config.getAllocator();
-            allocHandle.reset(config);
-
-            Throwable exception = null;
+        Throwable exception = null;
+        try {
             try {
-                try {
-                    boolean connected = isConnected();
-                    do {
-                        final boolean read;
-                        int datagramSize = config().getMaxDatagramPayloadSize();
+                boolean connected = isConnected();
+                do {
+                    final boolean read;
+                    int datagramSize = config().getMaxDatagramPayloadSize();
 
-                        ByteBuf byteBuf = allocHandle.allocate(allocator);
-                        // Only try to use recvmmsg if its really supported by the running system.
-                        int numDatagram = Native.IS_SUPPORTING_RECVMMSG ?
-                                datagramSize == 0 ? 1 : byteBuf.writableBytes() / datagramSize :
-                                0;
-                        try {
-                            if (numDatagram <= 1) {
-                                if (!connected || config.isUdpGro()) {
-                                    read = recvmsg(allocHandle, cleanDatagramPacketArray(), byteBuf);
-                                } else {
-                                    read = connectedRead(allocHandle, byteBuf, datagramSize);
-                                }
+                    ByteBuf byteBuf = allocHandle.allocate(allocator);
+                    // Only try to use recvmmsg if its really supported by the running system.
+                    int numDatagram = Native.IS_SUPPORTING_RECVMMSG ?
+                            datagramSize == 0 ? 1 : byteBuf.writableBytes() / datagramSize :
+                            0;
+                    try {
+                        if (numDatagram <= 1) {
+                            if (!connected || config.isUdpGro()) {
+                                read = recvmsg(allocHandle, cleanDatagramPacketArray(), byteBuf);
                             } else {
-                                // Try to use scattering reads via recvmmsg(...) syscall.
-                                read = scatteringRead(allocHandle, cleanDatagramPacketArray(),
-                                        byteBuf, datagramSize, numDatagram);
+                                read = connectedRead(allocHandle, byteBuf, datagramSize);
                             }
-                        } catch (NativeIoException e) {
-                            if (connected) {
-                                throw translateForConnected(e);
-                            }
-                            throw e;
-                        }
-
-                        if (read) {
-                            readPending = false;
                         } else {
-                            break;
+                            // Try to use scattering reads via recvmmsg(...) syscall.
+                            read = scatteringRead(allocHandle, cleanDatagramPacketArray(),
+                                    byteBuf, datagramSize, numDatagram);
                         }
-                    // We use the TRUE_SUPPLIER as it is also ok to read less then what we did try to read (as long
-                    // as we read anything).
-                    } while (allocHandle.continueReading(UncheckedBooleanSupplier.TRUE_SUPPLIER));
-                } catch (Throwable t) {
-                    exception = t;
-                }
+                    } catch (NativeIoException e) {
+                        if (connected) {
+                            throw translateForConnected(e);
+                        }
+                        throw e;
+                    }
 
-                allocHandle.readComplete();
-                pipeline.fireChannelReadComplete();
+                    if (read) {
+                        readPending = false;
+                    } else {
+                        break;
+                    }
+                // We use the TRUE_SUPPLIER as it is also ok to read less then what we did try to read (as long
+                // as we read anything).
+                } while (allocHandle.continueReading(UncheckedBooleanSupplier.TRUE_SUPPLIER));
+            } catch (Throwable t) {
+                exception = t;
+            }
 
-                if (exception != null) {
-                    pipeline.fireExceptionCaught(exception);
-                }
-            } finally {
-                if (shouldStopReading(config)) {
-                    clearEpollIn();
-                }
+            allocHandle.readComplete();
+            pipeline.fireChannelReadComplete();
+
+            if (exception != null) {
+                pipeline.fireExceptionCaught(exception);
+            }
+        } finally {
+            if (shouldStopReading(config)) {
+                clearEpollIn();
             }
         }
     }

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainDatagramChannel.java
@@ -275,11 +275,6 @@ public final class EpollDomainDatagramChannel extends AbstractEpollChannel imple
         return METADATA;
     }
 
-    @Override
-    protected AbstractEpollUnsafe newUnsafe() {
-        return new EpollDomainDatagramChannelUnsafe();
-    }
-
     /**
      * Returns the unix credentials (uid, gid, pid) of the peer
      * <a href=https://man7.org/linux/man-pages/man7/socket.7.html>SO_PEERCRED</a>
@@ -298,95 +293,92 @@ public final class EpollDomainDatagramChannel extends AbstractEpollChannel imple
         return remote;
     }
 
-    final class EpollDomainDatagramChannelUnsafe extends AbstractEpollUnsafe {
+    @Override
+    void epollInReady() {
+        assert executor().inEventLoop();
+        final DomainDatagramChannelConfig config = config();
+        if (shouldBreakEpollInReady(config)) {
+            clearEpollIn0();
+            return;
+        }
+        final EpollRecvByteAllocatorHandle allocHandle = (EpollRecvByteAllocatorHandle) recvBufAllocHandle();
+        final ChannelPipeline pipeline = pipeline();
+        final ByteBufAllocator allocator = config.getAllocator();
+        allocHandle.reset(config);
 
-        @Override
-        void epollInReady() {
-            assert executor().inEventLoop();
-            final DomainDatagramChannelConfig config = config();
-            if (shouldBreakEpollInReady(config)) {
-                clearEpollIn0();
-                return;
-            }
-            final EpollRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
-            final ChannelPipeline pipeline = pipeline();
-            final ByteBufAllocator allocator = config.getAllocator();
-            allocHandle.reset(config);
-
-            Throwable exception = null;
+        Throwable exception = null;
+        try {
+            ByteBuf byteBuf = null;
             try {
-                ByteBuf byteBuf = null;
-                try {
-                    boolean connected = isConnected();
-                    do {
-                        byteBuf = allocHandle.allocate(allocator);
-                        allocHandle.attemptedBytesRead(byteBuf.writableBytes());
+                boolean connected = isConnected();
+                do {
+                    byteBuf = allocHandle.allocate(allocator);
+                    allocHandle.attemptedBytesRead(byteBuf.writableBytes());
 
-                        final DomainDatagramPacket packet;
-                        if (connected) {
-                            allocHandle.lastBytesRead(doReadBytes(byteBuf));
-                            if (allocHandle.lastBytesRead() <= 0) {
-                                // nothing was read, release the buffer.
-                                byteBuf.release();
-                                break;
-                            }
-                            packet = new DomainDatagramPacket(byteBuf, (DomainSocketAddress) localAddress(),
-                                    (DomainSocketAddress) remoteAddress());
+                    final DomainDatagramPacket packet;
+                    if (connected) {
+                        allocHandle.lastBytesRead(doReadBytes(byteBuf));
+                        if (allocHandle.lastBytesRead() <= 0) {
+                            // nothing was read, release the buffer.
+                            byteBuf.release();
+                            break;
+                        }
+                        packet = new DomainDatagramPacket(byteBuf, (DomainSocketAddress) localAddress(),
+                                (DomainSocketAddress) remoteAddress());
+                    } else {
+                        final DomainDatagramSocketAddress remoteAddress;
+                        if (byteBuf.hasMemoryAddress()) {
+                            // has a memory address so use optimized call
+                            remoteAddress = socket.recvFromAddressDomainSocket(byteBuf.memoryAddress(),
+                                    byteBuf.writerIndex(), byteBuf.capacity());
                         } else {
-                            final DomainDatagramSocketAddress remoteAddress;
-                            if (byteBuf.hasMemoryAddress()) {
-                                // has a memory address so use optimized call
-                                remoteAddress = socket.recvFromAddressDomainSocket(byteBuf.memoryAddress(),
-                                        byteBuf.writerIndex(), byteBuf.capacity());
-                            } else {
-                                ByteBuffer nioData = byteBuf.internalNioBuffer(
-                                        byteBuf.writerIndex(), byteBuf.writableBytes());
-                                remoteAddress =
-                                        socket.recvFromDomainSocket(nioData, nioData.position(), nioData.limit());
-                            }
-
-                            if (remoteAddress == null) {
-                                allocHandle.lastBytesRead(-1);
-                                byteBuf.release();
-                                break;
-                            }
-                            DomainSocketAddress localAddress = remoteAddress.localAddress();
-                            if (localAddress == null) {
-                                localAddress = (DomainSocketAddress) localAddress();
-                            }
-                            allocHandle.lastBytesRead(remoteAddress.receivedAmount());
-                            byteBuf.writerIndex(byteBuf.writerIndex() + allocHandle.lastBytesRead());
-
-                            packet = new DomainDatagramPacket(byteBuf, localAddress, remoteAddress);
+                            ByteBuffer nioData = byteBuf.internalNioBuffer(
+                                    byteBuf.writerIndex(), byteBuf.writableBytes());
+                            remoteAddress =
+                                    socket.recvFromDomainSocket(nioData, nioData.position(), nioData.limit());
                         }
 
-                        allocHandle.incMessagesRead(1);
+                        if (remoteAddress == null) {
+                            allocHandle.lastBytesRead(-1);
+                            byteBuf.release();
+                            break;
+                        }
+                        DomainSocketAddress localAddress = remoteAddress.localAddress();
+                        if (localAddress == null) {
+                            localAddress = (DomainSocketAddress) localAddress();
+                        }
+                        allocHandle.lastBytesRead(remoteAddress.receivedAmount());
+                        byteBuf.writerIndex(byteBuf.writerIndex() + allocHandle.lastBytesRead());
 
-                        readPending = false;
-                        pipeline.fireChannelRead(packet);
-
-                        byteBuf = null;
-
-                        // We use the TRUE_SUPPLIER as it is also ok to read less then what we did try to read (as long
-                        // as we read anything).
-                    } while (allocHandle.continueReading(UncheckedBooleanSupplier.TRUE_SUPPLIER));
-                } catch (Throwable t) {
-                    if (byteBuf != null) {
-                        byteBuf.release();
+                        packet = new DomainDatagramPacket(byteBuf, localAddress, remoteAddress);
                     }
-                    exception = t;
-                }
 
-                allocHandle.readComplete();
-                pipeline.fireChannelReadComplete();
+                    allocHandle.incMessagesRead(1);
 
-                if (exception != null) {
-                    pipeline.fireExceptionCaught(exception);
+                    readPending = false;
+                    pipeline.fireChannelRead(packet);
+
+                    byteBuf = null;
+
+                    // We use the TRUE_SUPPLIER as it is also ok to read less then what we did try to read (as long
+                    // as we read anything).
+                } while (allocHandle.continueReading(UncheckedBooleanSupplier.TRUE_SUPPLIER));
+            } catch (Throwable t) {
+                if (byteBuf != null) {
+                    byteBuf.release();
                 }
-            } finally {
-                if (shouldStopReading(config)) {
-                    clearEpollIn();
-                }
+                exception = t;
+            }
+
+            allocHandle.readComplete();
+            pipeline.fireChannelReadComplete();
+
+            if (exception != null) {
+                pipeline.fireExceptionCaught(exception);
+            }
+        } finally {
+            if (shouldStopReading(config)) {
+                clearEpollIn();
             }
         }
     }

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannel.java
@@ -60,11 +60,6 @@ public final class EpollDomainSocketChannel extends AbstractEpollStreamChannel i
     }
 
     @Override
-    protected AbstractEpollUnsafe newUnsafe() {
-        return new EpollDomainUnsafe();
-    }
-
-    @Override
     protected DomainSocketAddress localAddress0() {
         return local;
     }
@@ -138,62 +133,60 @@ public final class EpollDomainSocketChannel extends AbstractEpollStreamChannel i
         return socket.getPeerCredentials();
     }
 
-    private final class EpollDomainUnsafe extends EpollStreamUnsafe {
-        @Override
-        void epollInReady() {
-            switch (config().getReadMode()) {
-                case BYTES:
-                    super.epollInReady();
-                    break;
-                case FILE_DESCRIPTORS:
-                    epollInReadFd();
-                    break;
-                default:
-                    throw new Error("Unexpected read mode: " + config().getReadMode());
-            }
+    @Override
+    void epollInReady() {
+        switch (config().getReadMode()) {
+            case BYTES:
+                super.epollInReady();
+                break;
+            case FILE_DESCRIPTORS:
+                epollInReadFd();
+                break;
+            default:
+                throw new Error("Unexpected read mode: " + config().getReadMode());
         }
+    }
 
-        private void epollInReadFd() {
-            if (socket.isInputShutdown()) {
-                clearEpollIn0();
-                return;
-            }
-            final ChannelConfig config = config();
-            final EpollRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
+    private void epollInReadFd() {
+        if (socket.isInputShutdown()) {
+            clearEpollIn0();
+            return;
+        }
+        final ChannelConfig config = config();
+        final EpollRecvByteAllocatorHandle allocHandle = (EpollRecvByteAllocatorHandle) recvBufAllocHandle();
 
-            final ChannelPipeline pipeline = pipeline();
-            allocHandle.reset(config);
+        final ChannelPipeline pipeline = pipeline();
+        allocHandle.reset(config);
 
-            try {
-                readLoop: do {
-                    // lastBytesRead represents the fd. We use lastBytesRead because it must be set so that the
-                    // EpollRecvByteAllocatorHandle knows if it should try to read again or not when autoRead is
-                    // enabled.
-                    allocHandle.lastBytesRead(socket.recvFd());
-                    switch(allocHandle.lastBytesRead()) {
-                    case 0:
-                        break readLoop;
-                    case -1:
-                        close(newPromise());
-                        return;
-                    default:
-                        allocHandle.incMessagesRead(1);
-                        readPending = false;
-                        pipeline.fireChannelRead(new FileDescriptor(allocHandle.lastBytesRead()));
-                        break;
-                    }
-                } while (allocHandle.continueReading());
-
-                allocHandle.readComplete();
-                pipeline.fireChannelReadComplete();
-            } catch (Throwable t) {
-                allocHandle.readComplete();
-                pipeline.fireChannelReadComplete();
-                pipeline.fireExceptionCaught(t);
-            } finally {
-                if (shouldStopReading(config)) {
-                    clearEpollIn();
+        try {
+            readLoop: do {
+                // lastBytesRead represents the fd. We use lastBytesRead because it must be set so that the
+                // EpollRecvByteAllocatorHandle knows if it should try to read again or not when autoRead is
+                // enabled.
+                allocHandle.lastBytesRead(socket.recvFd());
+                switch(allocHandle.lastBytesRead()) {
+                case 0:
+                    break readLoop;
+                case -1:
+                    close(newPromise());
+                    return;
+                default:
+                    allocHandle.incMessagesRead(1);
+                    readPending = false;
+                    pipeline.fireChannelRead(new FileDescriptor(allocHandle.lastBytesRead()));
+                    break;
                 }
+            } while (allocHandle.continueReading());
+
+            allocHandle.readComplete();
+            pipeline.fireChannelReadComplete();
+        } catch (Throwable t) {
+            allocHandle.readComplete();
+            pipeline.fireChannelReadComplete();
+            pipeline.fireExceptionCaught(t);
+        } finally {
+            if (shouldStopReading(config)) {
+                clearEpollIn();
             }
         }
     }

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
@@ -15,7 +15,6 @@
  */
 package io.netty.channel.epoll;
 
-import io.netty.channel.Channel;
 import io.netty.channel.DefaultSelectStrategyFactory;
 import io.netty.channel.IoHandlerContext;
 import io.netty.channel.IoHandle;
@@ -39,9 +38,6 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -88,8 +84,6 @@ public class EpollIoHandler implements IoHandler {
     //    other value T    when EL is waiting with wakeup scheduled at time T
     private final AtomicLong nextWakeupNanos = new AtomicLong(AWAKE);
     private boolean pendingWakeup;
-
-    private int numChannels;
 
     // See https://man7.org/linux/man-pages/man2/timerfd_create.2.html.
     private static final long MAX_SCHEDULED_TIMERFD_NS = 999999999;
@@ -284,8 +278,6 @@ public class EpollIoHandler implements IoHandler {
                     // The Channel mapping was already replaced due FD reuse, put back the stored Channel.
                     registrations.put(fd, old);
                     return;
-                } else if (old.handle instanceof AbstractEpollChannel.AbstractEpollUnsafe) {
-                    numChannels--;
                 }
                 if (handle.fd().isOpen()) {
                     try {
@@ -330,10 +322,6 @@ public class EpollIoHandler implements IoHandler {
         // We either expect to have no registration in the map with the same FD or that the FD of the old registration
         // is already closed.
         assert old == null || !old.isValid();
-
-        if (epollHandle instanceof AbstractEpollChannel.AbstractEpollUnsafe) {
-            numChannels++;
-        }
         handle.registered();
         return registration;
     }
@@ -341,25 +329,6 @@ public class EpollIoHandler implements IoHandler {
     @Override
     public boolean isCompatible(Class<? extends IoHandle> handleType) {
         return EpollIoHandle.class.isAssignableFrom(handleType);
-    }
-
-    int numRegisteredChannels() {
-        return numChannels;
-    }
-
-    List<Channel> registeredChannelsList() {
-        IntObjectMap<DefaultEpollIoRegistration> ch = registrations;
-        if (ch.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        List<Channel> channels = new ArrayList<>(ch.size());
-        for (DefaultEpollIoRegistration registration : ch.values()) {
-            if (registration.handle instanceof AbstractEpollChannel.AbstractEpollUnsafe) {
-                channels.add(((AbstractEpollChannel.AbstractEpollUnsafe) registration.handle).channel());
-            }
-        }
-        return Collections.unmodifiableList(channels);
     }
 
     private long epollWait(IoHandlerContext context, long deadlineNanos) throws IOException {

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannel.java
@@ -103,11 +103,6 @@ public final class EpollSocketChannel extends AbstractEpollStreamChannel impleme
     }
 
     @Override
-    protected AbstractEpollUnsafe newUnsafe() {
-        return new EpollSocketChannelUnsafe();
-    }
-
-    @Override
     boolean doConnect0(SocketAddress remote) throws Exception {
         if (IS_SUPPORTING_TCP_FASTOPEN_CLIENT && config.isTcpFastOpenConnect()) {
             ChannelOutboundBuffer outbound = outboundBuffer();
@@ -130,27 +125,25 @@ public final class EpollSocketChannel extends AbstractEpollStreamChannel impleme
         return super.doConnect0(remote);
     }
 
-    private final class EpollSocketChannelUnsafe extends EpollStreamUnsafe {
-        @Override
-        protected Executor prepareToClose() {
-            try {
-                // Check isOpen() first as otherwise it will throw a RuntimeException
-                // when call getSoLinger() as the fd is not valid anymore.
-                if (isOpen() && config().getSoLinger() > 0) {
-                    // We need to cancel this key of the channel so we may not end up in a eventloop spin
-                    // because we try to read or write until the actual close happens which may be later due
-                    // SO_LINGER handling.
-                    // See https://github.com/netty/netty/issues/4449
-                    registration().cancel();
-                    return GlobalEventExecutor.INSTANCE;
-                }
-            } catch (Throwable ignore) {
-                // Ignore the error as the underlying channel may be closed in the meantime and so
-                // getSoLinger() may produce an exception. In this case we just return null.
+    @Override
+    protected Executor prepareToClose() {
+        try {
+            // Check isOpen() first as otherwise it will throw a RuntimeException
+            // when call getSoLinger() as the fd is not valid anymore.
+            if (isOpen() && config().getSoLinger() > 0) {
+                // We need to cancel this key of the channel so we may not end up in a eventloop spin
+                // because we try to read or write until the actual close happens which may be later due
+                // SO_LINGER handling.
                 // See https://github.com/netty/netty/issues/4449
+                registration().cancel();
+                return GlobalEventExecutor.INSTANCE;
             }
-            return null;
+        } catch (Throwable ignore) {
+            // Ignore the error as the underlying channel may be closed in the meantime and so
+            // getSoLinger() may produce an exception. In this case we just return null.
+            // See https://github.com/netty/netty/issues/4449
         }
+        return null;
     }
 
     void setTcpMd5Sig(Map<InetAddress, byte[]> keys) throws IOException {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -67,6 +67,7 @@ import static io.netty.util.internal.StringUtil.className;
 abstract class AbstractIoUringChannel extends AbstractChannel implements UnixChannel {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(AbstractIoUringChannel.class);
     final LinuxSocket socket;
+    private final IoUringIoHandle ioHandle = new IoUringIoHandleImpl();
     protected volatile boolean active;
 
     // Different masks for outstanding I/O operations.
@@ -100,6 +101,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
 
     private ChannelPromise delayedClose;
     private boolean inputClosedSeenErrorOnRead;
+    private boolean socketIsEmpty;
 
     /**
      * The future of the current connection attempt.  If not null, subsequent connection attempts will fail.
@@ -196,10 +198,6 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
     @Override
     public final FileDescriptor fd() {
         return socket;
-    }
-
-    private AbstractUringUnsafe ioUringUnsafe() {
-        return (AbstractUringUnsafe) unsafe();
     }
 
     protected final ByteBuf newDirectBuffer(ByteBuf buf) {
@@ -307,7 +305,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
             } finally {
                 // It's important we cancel all outstanding connect, write and read operations now so
                 // we will be able to process a delayed close if needed.
-                ioUringUnsafe().cancelOps(cancelConnect);
+                cancelOps(cancelConnect);
             }
 
             if (socket.markClosed()) {
@@ -322,7 +320,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
             try {
                 // This one was never registered just use a syscall to close.
                 socket.close();
-                ioUringUnsafe().unregistered();
+                ioHandle.unregistered();
             } catch (Throwable cause) {
                 promise.setFailure(cause);
                 return;
@@ -362,9 +360,9 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
                 // read as POLLIN might be edge-triggered (in case of POLL_ADD_MULTI).
                 socketHasMoreData) {
             // If the socket is blocking we will directly call scheduleFirstReadIfNeeded() as we can use FASTPOLL.
-            ioUringUnsafe().scheduleFirstReadIfNeeded();
+            scheduleFirstReadIfNeeded();
         } else if ((ioState & POLL_IN_SCHEDULED) == 0) {
-            ioUringUnsafe().schedulePollIn();
+            schedulePollIn();
         }
     }
 
@@ -404,13 +402,13 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         Object msg = in.current();
 
         if (msgCount > 1 && in.current() instanceof ByteBuf) {
-            numOutstandingWrites = (short) ioUringUnsafe().scheduleWriteMultiple(in);
+            numOutstandingWrites = (short) scheduleWriteMultiple(in);
         } else if (msg instanceof ByteBuf && ((ByteBuf) msg).nioBufferCount() > 1 ||
                     (msg instanceof ByteBufHolder && ((ByteBufHolder) msg).content().nioBufferCount() > 1)) {
             // We also need some special handling for CompositeByteBuf
-            numOutstandingWrites = (short) ioUringUnsafe().scheduleWriteMultiple(in);
+            numOutstandingWrites = (short) scheduleWriteMultiple(in);
         } else {
-            numOutstandingWrites = (short) ioUringUnsafe().scheduleWriteSingle(msg);
+            numOutstandingWrites = (short) scheduleWriteSingle(msg);
         }
         // Ensure we never overflow
         assert numOutstandingWrites > 0;
@@ -453,25 +451,11 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         return (ioState & POLL_OUT_SCHEDULED) != 0;
     }
 
-    protected abstract class AbstractUringUnsafe extends AbstractUnsafe implements IoUringIoHandle {
-        private IoUringRecvByteAllocatorHandle allocHandle;
+    private final class IoUringIoHandleImpl implements IoUringIoHandle {
         private boolean closed;
-        private boolean socketIsEmpty;
-
-        /**
-         * Schedule the write of multiple messages in the {@link ChannelOutboundBuffer} and returns the number of
-         * {@link #writeComplete(byte, int, int, short)} calls that are expected because of the scheduled write.
-         */
-        protected abstract int scheduleWriteMultiple(ChannelOutboundBuffer in);
-
-        /**
-         * Schedule the write of a single message and returns the number of
-         * {@link #writeComplete(byte, int, int, short)} calls that are expected because of the scheduled write.
-         */
-        protected abstract int scheduleWriteSingle(Object msg);
 
         @Override
-        public final void handle(IoRegistration registration, IoEvent ioEvent) {
+        public void handle(IoRegistration registration, IoEvent ioEvent) {
             IoUringIoEvent event = (IoUringIoEvent) ioEvent;
             byte op = event.opcode();
             int res = event.res();
@@ -529,454 +513,471 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         public void unregistered() {
             freeMsgHdrArray();
             freeRemoteAddressMemory();
-        }
-
-        private void handleDelayedClosed() {
-            if (delayedClose != null && canCloseNow()) {
-                delayedClose.trySuccess();
-            }
-        }
-
-        private void pollAddComplete(int res, int flags, short data) {
-            if ((res & Native.POLLOUT) != 0) {
-                pollOut(res);
-            }
-            if ((res & Native.POLLIN) != 0) {
-                pollIn(res, flags, data);
-            }
-            if ((res & Native.POLLRDHUP) != 0) {
-                pollRdHup(res);
-            }
+            AbstractIoUringChannel.this.unregistered();
         }
 
         @Override
-        public final void close() throws Exception {
-            close(newPromise());
+        public void close() {
+            ioTransport().close(newPromise());
         }
+    }
 
-        private void cancelOps(boolean cancelConnect) {
-            if (registration == null || !registration.isValid()) {
-                return;
-            }
-            byte flags = (byte) 0;
-            if ((ioState & POLL_RDHUP_SCHEDULED) != 0 && pollRdhupId != 0) {
-                long id = registration.submit(
-                        IoUringIoOps.newAsyncCancel(flags, pollRdhupId, Native.IORING_OP_POLL_ADD));
-                assert id != 0;
-                pollRdhupId = 0;
-            }
-            if ((ioState & POLL_IN_SCHEDULED) != 0 && pollInId != 0) {
-                long id = registration.submit(
-                        IoUringIoOps.newAsyncCancel(flags, pollInId, Native.IORING_OP_POLL_ADD));
-                assert id != 0;
-                pollInId = 0;
-            }
-            if ((ioState & POLL_OUT_SCHEDULED) != 0 && pollOutId != 0) {
-                long id = registration.submit(
-                        IoUringIoOps.newAsyncCancel(flags, pollOutId, Native.IORING_OP_POLL_ADD));
-                assert id != 0;
-                pollOutId = 0;
-            }
-            if (cancelConnect && connectId != 0) {
-                // Best effort to cancel the already submitted connect request.
-                long id = registration.submit(IoUringIoOps.newAsyncCancel(flags, connectId, Native.IORING_OP_CONNECT));
-                assert id != 0;
-                connectId = 0;
-            }
-            cancelOutstandingReads(registration, numOutstandingReads);
-            cancelOutstandingWrites(registration, numOutstandingWrites);
+    protected void unregistered() {
+        freeMsgHdrArray();
+        freeRemoteAddressMemory();
+    }
+
+    @Override
+    protected RecvByteBufAllocator.Handle newRecvBufAllocHandle() {
+        return new IoUringRecvByteAllocatorHandle(
+                (RecvByteBufAllocator.ExtendedHandle) super.newRecvBufAllocHandle());
+    }
+
+    /**
+     * Schedule the write of multiple messages in the {@link ChannelOutboundBuffer} and returns the number of
+     * {@link #writeComplete(byte, int, int, short)} calls that are expected because of the scheduled write.
+     */
+    protected abstract int scheduleWriteMultiple(ChannelOutboundBuffer in);
+
+    /**
+     * Schedule the write of a single message and returns the number of
+     * {@link #writeComplete(byte, int, int, short)} calls that are expected because of the scheduled write.
+     */
+    protected abstract int scheduleWriteSingle(Object msg);
+
+    private void handleDelayedClosed() {
+        if (delayedClose != null && canCloseNow()) {
+            delayedClose.trySuccess();
         }
+    }
 
-        private boolean canCloseNow() {
-            // Currently there are is no WRITE and READ scheduled, we can close the channel now without
-            // problems related to re-ordering of completions.
-            return canCloseNow0() && (ioState & (WRITE_SCHEDULED | READ_SCHEDULED)) == 0;
+    private void pollAddComplete(int res, int flags, short data) {
+        if ((res & Native.POLLOUT) != 0) {
+            pollOut(res);
         }
-
-        protected boolean canCloseNow0() {
-            return true;
+        if ((res & Native.POLLIN) != 0) {
+            pollIn(res, flags, data);
         }
-
-        @Override
-        public final IoUringRecvByteAllocatorHandle recvBufAllocHandle() {
-            if (allocHandle == null) {
-                allocHandle = new IoUringRecvByteAllocatorHandle(
-                        (RecvByteBufAllocator.ExtendedHandle) super.recvBufAllocHandle());
-            }
-            return allocHandle;
+        if ((res & Native.POLLRDHUP) != 0) {
+            pollRdHup(res);
         }
+    }
 
-        final void shutdownInput(boolean allDataRead) {
-            logger.trace("shutdownInput Fd: {}", fd().intValue());
-            if (!socket.isInputShutdown()) {
-                if (isAllowHalfClosure(config())) {
-                    try {
-                        socket.shutdown(true, false);
-                    } catch (IOException ignored) {
-                        // We attempted to shutdown and failed, which means the input has already effectively been
-                        // shutdown.
-                        fireEventAndClose(ChannelInputShutdownEvent.INSTANCE);
-                        return;
-                    } catch (NotYetConnectedException ignore) {
-                        // We attempted to shutdown and failed, which means the input has already effectively been
-                        // shutdown.
-                    }
-                    pipeline().fireUserEventTriggered(ChannelInputShutdownEvent.INSTANCE);
-                } else {
-                    // Handle this same way as if we did read all data so we don't schedule another read.
-                    inputClosedSeenErrorOnRead = true;
-                    close(newPromise());
-                    return;
-                }
-            }
-            if (allDataRead && !inputClosedSeenErrorOnRead) {
-                inputClosedSeenErrorOnRead = true;
-                pipeline().fireUserEventTriggered(ChannelInputShutdownReadComplete.INSTANCE);
-            }
+    private void cancelOps(boolean cancelConnect) {
+        if (registration == null || !registration.isValid()) {
+            return;
         }
-
-        private void fireEventAndClose(Object evt) {
-            pipeline().fireUserEventTriggered(evt);
-            close(newPromise());
+        byte flags = (byte) 0;
+        if ((ioState & POLL_RDHUP_SCHEDULED) != 0 && pollRdhupId != 0) {
+            long id = registration.submit(
+                    IoUringIoOps.newAsyncCancel(flags, pollRdhupId, Native.IORING_OP_POLL_ADD));
+            assert id != 0;
+            pollRdhupId = 0;
         }
-
-        final void schedulePollIn() {
-            assert (ioState & POLL_IN_SCHEDULED) == 0;
-            if (!isActive() || shouldBreakIoUringInReady(config())) {
-                return;
-            }
-            pollInId = schedulePollAdd(POLL_IN_SCHEDULED, Native.POLLIN, allowMultiShotPollIn());
+        if ((ioState & POLL_IN_SCHEDULED) != 0 && pollInId != 0) {
+            long id = registration.submit(
+                    IoUringIoOps.newAsyncCancel(flags, pollInId, Native.IORING_OP_POLL_ADD));
+            assert id != 0;
+            pollInId = 0;
         }
+        if ((ioState & POLL_OUT_SCHEDULED) != 0 && pollOutId != 0) {
+            long id = registration.submit(
+                    IoUringIoOps.newAsyncCancel(flags, pollOutId, Native.IORING_OP_POLL_ADD));
+            assert id != 0;
+            pollOutId = 0;
+        }
+        if (cancelConnect && connectId != 0) {
+            // Best effort to cancel the already submitted connect request.
+            long id = registration.submit(IoUringIoOps.newAsyncCancel(flags, connectId, Native.IORING_OP_CONNECT));
+            assert id != 0;
+            connectId = 0;
+        }
+        cancelOutstandingReads(registration, numOutstandingReads);
+        cancelOutstandingWrites(registration, numOutstandingWrites);
+    }
 
-        private void readComplete(byte op, int res, int flags, short data) {
-            assert numOutstandingReads > 0 || numOutstandingReads == -1 : numOutstandingReads;
+    private boolean canCloseNow() {
+        // Currently there are is no WRITE and READ scheduled, we can close the channel now without
+        // problems related to re-ordering of completions.
+        return canCloseNow0() && (ioState & (WRITE_SCHEDULED | READ_SCHEDULED)) == 0;
+    }
 
-            boolean multishot = numOutstandingReads == -1;
-            boolean rearm = (flags & Native.IORING_CQE_F_MORE) == 0;
-            if (rearm) {
-                // Reset READ_SCHEDULED if there is nothing more to handle and so we need to re-arm. This works for
-                // multi-shot and non multi-shot variants.
-                ioState &= ~READ_SCHEDULED;
-            }
-            boolean pending = readPending;
-            if (multishot) {
-                // Reset readPending so we can still keep track if we might need to cancel the multi-shot read or
-                // not.
-                readPending = false;
-            } else if (--numOutstandingReads == 0) {
-                // We received all outstanding completions.
-                readPending = false;
-                ioState &= ~READ_SCHEDULED;
-            }
-            inReadComplete = true;
-            try {
-                socketIsEmpty = socketIsEmpty(flags);
-                socketHasMoreData = IoUring.isCqeFSockNonEmptySupported() &&
-                        (flags & Native.IORING_CQE_F_SOCK_NONEMPTY) != 0;
-                readComplete0(op, res, flags, data, numOutstandingReads);
-            } finally {
+    protected boolean canCloseNow0() {
+        return true;
+    }
+
+    final void shutdownInput(boolean allDataRead) {
+        logger.trace("shutdownInput Fd: {}", fd().intValue());
+        if (!socket.isInputShutdown()) {
+            if (isAllowHalfClosure(config())) {
                 try {
-                    // Check if we should consider the read loop to be done.
-                    if (recvBufAllocHandle().isReadComplete()) {
-                        // Reset the handle as we are done with the read-loop.
-                        recvBufAllocHandle().reset(config());
+                    socket.shutdown(true, false);
+                } catch (IOException ignored) {
+                    // We attempted to shutdown and failed, which means the input has already effectively been
+                    // shutdown.
+                    fireEventAndClose(ChannelInputShutdownEvent.INSTANCE);
+                    return;
+                } catch (NotYetConnectedException ignore) {
+                    // We attempted to shutdown and failed, which means the input has already effectively been
+                    // shutdown.
+                }
+                pipeline().fireUserEventTriggered(ChannelInputShutdownEvent.INSTANCE);
+            } else {
+                // Handle this same way as if we did read all data so we don't schedule another read.
+                inputClosedSeenErrorOnRead = true;
+                close(newPromise());
+                return;
+            }
+        }
+        if (allDataRead && !inputClosedSeenErrorOnRead) {
+            inputClosedSeenErrorOnRead = true;
+            pipeline().fireUserEventTriggered(ChannelInputShutdownReadComplete.INSTANCE);
+        }
+    }
 
-                        // Check if this was a readComplete(...) triggered by a read or multi-shot read.
-                        if (!multishot) {
-                            if (readPending) {
-                                // This was a "normal" read and the user did signal we should continue reading.
-                                // Let's schedule the read now.
-                                doBeginReadNow();
-                            }
-                        } else {
-                            // The readComplete(...) was triggered by a multi-shot read. Because of this the state
-                            // machine is a bit more complicated.
+    private void fireEventAndClose(Object evt) {
+        pipeline().fireUserEventTriggered(evt);
+        close(newPromise());
+    }
 
-                            if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
-                                // The readComplete(...) was triggered because the previous read was cancelled.
-                                // In this case we we need to check if the user did signal the desire to read again
-                                // in the meantime. If this is the case we need to schedule the read to ensure
-                                // we do not stall.
-                                if (pending) {
-                                    doBeginReadNow();
-                                }
-                            } else if (rearm) {
-                                // We need to rearm the multishot as otherwise we might miss some data.
-                                doBeginReadNow();
-                            } else if (!readPending) {
-                                // Cancel the multi-shot read now as the user did not signal that we want to keep
-                                // reading while we handle the completion event.
-                                cancelOutstandingReads(registration, numOutstandingReads);
-                            }
-                        }
-                    } else if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
-                        // The readComplete(...) was triggered because the previous read was cancelled.
-                        // In this case we we need to check if the user did signal the desire to read again
-                        // in the meantime. If this is the case we need to schedule the read to ensure
-                        // we do not stall.
-                        if (pending) {
+    final void schedulePollIn() {
+        assert (ioState & POLL_IN_SCHEDULED) == 0;
+        if (!isActive() || shouldBreakIoUringInReady(config())) {
+            return;
+        }
+        pollInId = schedulePollAdd(POLL_IN_SCHEDULED, Native.POLLIN, allowMultiShotPollIn());
+    }
+
+    private void readComplete(byte op, int res, int flags, short data) {
+        assert numOutstandingReads > 0 || numOutstandingReads == -1 : numOutstandingReads;
+
+        boolean multishot = numOutstandingReads == -1;
+        boolean rearm = (flags & Native.IORING_CQE_F_MORE) == 0;
+        if (rearm) {
+            // Reset READ_SCHEDULED if there is nothing more to handle and so we need to re-arm. This works for
+            // multi-shot and non multi-shot variants.
+            ioState &= ~READ_SCHEDULED;
+        }
+        boolean pending = readPending;
+        if (multishot) {
+            // Reset readPending so we can still keep track if we might need to cancel the multi-shot read or
+            // not.
+            readPending = false;
+        } else if (--numOutstandingReads == 0) {
+            // We received all outstanding completions.
+            readPending = false;
+            ioState &= ~READ_SCHEDULED;
+        }
+        inReadComplete = true;
+        try {
+            socketIsEmpty = socketIsEmpty(flags);
+            socketHasMoreData = IoUring.isCqeFSockNonEmptySupported() &&
+                    (flags & Native.IORING_CQE_F_SOCK_NONEMPTY) != 0;
+            readComplete0(op, res, flags, data, numOutstandingReads);
+        } finally {
+            IoUringRecvByteAllocatorHandle recvByteAllocatorHandle =
+                    (IoUringRecvByteAllocatorHandle) recvBufAllocHandle();
+            try {
+                // Check if we should consider the read loop to be done.
+                if (recvByteAllocatorHandle.isReadComplete()) {
+                    // Reset the handle as we are done with the read-loop.
+                    recvByteAllocatorHandle.reset(config());
+
+                    // Check if this was a readComplete(...) triggered by a read or multi-shot read.
+                    if (!multishot) {
+                        if (readPending) {
+                            // This was a "normal" read and the user did signal we should continue reading.
+                            // Let's schedule the read now.
                             doBeginReadNow();
                         }
-                    } else if (multishot && rearm) {
-                        // We need to rearm the multishot as otherwise we might miss some data.
+                    } else {
+                        // The readComplete(...) was triggered by a multi-shot read. Because of this the state
+                        // machine is a bit more complicated.
+
+                        if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
+                            // The readComplete(...) was triggered because the previous read was cancelled.
+                            // In this case we we need to check if the user did signal the desire to read again
+                            // in the meantime. If this is the case we need to schedule the read to ensure
+                            // we do not stall.
+                            if (pending) {
+                                doBeginReadNow();
+                            }
+                        } else if (rearm) {
+                            // We need to rearm the multishot as otherwise we might miss some data.
+                            doBeginReadNow();
+                        } else if (!readPending) {
+                            // Cancel the multi-shot read now as the user did not signal that we want to keep
+                            // reading while we handle the completion event.
+                            cancelOutstandingReads(registration, numOutstandingReads);
+                        }
+                    }
+                } else if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
+                    // The readComplete(...) was triggered because the previous read was cancelled.
+                    // In this case we we need to check if the user did signal the desire to read again
+                    // in the meantime. If this is the case we need to schedule the read to ensure
+                    // we do not stall.
+                    if (pending) {
                         doBeginReadNow();
                     }
-                } finally {
-                    inReadComplete = false;
-                    socketIsEmpty = false;
+                } else if (multishot && rearm) {
+                    // We need to rearm the multishot as otherwise we might miss some data.
+                    doBeginReadNow();
                 }
+            } finally {
+                inReadComplete = false;
+                socketIsEmpty = false;
             }
         }
+    }
 
-        /**
-         * Called once a read was completed.
-         */
-        protected abstract void readComplete0(byte op, int res, int flags, short data, int outstandingCompletes);
+    /**
+     * Called once a read was completed.
+     */
+    protected abstract void readComplete0(byte op, int res, int flags, short data, int outstandingCompletes);
 
-        /**
-         * Called once POLLRDHUP event is ready to be processed
-         */
-        private void pollRdHup(int res) {
-            ioState &= ~POLL_RDHUP_SCHEDULED;
-            pollRdhupId = 0;
-            if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
-                return;
-            }
-
-            // Mark that we received a POLLRDHUP and so need to continue reading until all the input ist drained.
-            recvBufAllocHandle().rdHupReceived();
-
-            if (isActive()) {
-                scheduleFirstReadIfNeeded();
-            } else {
-                // Just to be safe make sure the input marked as closed.
-                shutdownInput(false);
-            }
+    /**
+     * Called once POLLRDHUP event is ready to be processed
+     */
+    private void pollRdHup(int res) {
+        ioState &= ~POLL_RDHUP_SCHEDULED;
+        pollRdhupId = 0;
+        if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
+            return;
         }
 
-        /**
-         * Called once POLLIN event is ready to be processed
-         */
-        private void pollIn(int res, int flags, short data) {
-            // Check if we need to rearm. This works for both cases, POLL_ADD and POLL_ADD_MULTI.
-            boolean rearm = (flags & Native.IORING_CQE_F_MORE) == 0;
-            if (rearm) {
-                ioState &= ~POLL_IN_SCHEDULED;
-                pollInId = 0;
-            }
-            if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
-                return;
-            }
-            if (!readPending) {
-                // We received the POLLIN but the user is not interested yet in reading, just mark socketHasMoreData
-                // as true so we will trigger a read directly once the user calls read()
-                socketHasMoreData = true;
-                return;
-            }
+        // Mark that we received a POLLRDHUP and so need to continue reading until all the input ist drained.
+        ((IoUringRecvByteAllocatorHandle) recvBufAllocHandle()).rdHupReceived();
+
+        if (isActive()) {
             scheduleFirstReadIfNeeded();
+        } else {
+            // Just to be safe make sure the input marked as closed.
+            shutdownInput(false);
         }
+    }
 
-        private void scheduleFirstReadIfNeeded() {
-            if ((ioState & READ_SCHEDULED) == 0) {
-                scheduleFirstRead();
+    /**
+     * Called once POLLIN event is ready to be processed
+     */
+    private void pollIn(int res, int flags, short data) {
+        // Check if we need to rearm. This works for both cases, POLL_ADD and POLL_ADD_MULTI.
+        boolean rearm = (flags & Native.IORING_CQE_F_MORE) == 0;
+        if (rearm) {
+            ioState &= ~POLL_IN_SCHEDULED;
+            pollInId = 0;
+        }
+        if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
+            return;
+        }
+        if (!readPending) {
+            // We received the POLLIN but the user is not interested yet in reading, just mark socketHasMoreData
+            // as true so we will trigger a read directly once the user calls read()
+            socketHasMoreData = true;
+            return;
+        }
+        scheduleFirstReadIfNeeded();
+    }
+
+    private void scheduleFirstReadIfNeeded() {
+        if ((ioState & READ_SCHEDULED) == 0) {
+            scheduleFirstRead();
+        }
+    }
+
+    private void scheduleFirstRead() {
+        // This is a new "read loop" so we need to reset the allocHandle.
+        final ChannelConfig config = config();
+        final IoUringRecvByteAllocatorHandle allocHandle = (IoUringRecvByteAllocatorHandle) recvBufAllocHandle();
+        allocHandle.reset(config);
+        scheduleRead(true);
+    }
+
+    protected final void scheduleRead(boolean first) {
+        // Only schedule another read if the fd is still open.
+        if (delayedClose == null && fd().isOpen() && (ioState & READ_SCHEDULED) == 0) {
+            numOutstandingReads = (short) scheduleRead0(first, socketIsEmpty);
+            if (numOutstandingReads > 0 || numOutstandingReads == -1) {
+                ioState |= READ_SCHEDULED;
             }
         }
+    }
 
-        private void scheduleFirstRead() {
-            // This is a new "read loop" so we need to reset the allocHandle.
-            final ChannelConfig config = config();
-            final IoUringRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
-            allocHandle.reset(config);
-            scheduleRead(true);
+    /**
+     * Schedule a read and returns the number of {@link #readComplete(byte, int, int, short)}
+     * calls that are expected because of the scheduled read.
+     *
+     * @param first             {@code true} if this is the first read of a read loop.
+     * @param socketIsEmpty     {@code true} if the socket is guaranteed to be empty, {@code false} otherwise.
+     * @return                  the number of {@link #readComplete(byte, int, int, short)} calls expected or
+     *                          {@code -1} if {@link #readComplete(byte, int, int, short)} is called until
+     *                          the read is cancelled (multi-shot).
+     */
+    protected abstract int scheduleRead0(boolean first, boolean socketIsEmpty);
+
+    /**
+     * Called once POLLOUT event is ready to be processed
+     *
+     * @param res   the result.
+     */
+    private void pollOut(int res) {
+        ioState &= ~POLL_OUT_SCHEDULED;
+        pollOutId = 0;
+        if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
+            return;
         }
+        // pending connect
+        if (connectPromise != null && !connectPromise.isDone()) {
+            // Note this method is invoked by the event loop only if the connection attempt was
+            // neither cancelled nor timed out.
+            assert executor().inEventLoop();
 
-        protected final void scheduleRead(boolean first) {
-            // Only schedule another read if the fd is still open.
-            if (delayedClose == null && fd().isOpen() && (ioState & READ_SCHEDULED) == 0) {
-                numOutstandingReads = (short) scheduleRead0(first, socketIsEmpty);
-                if (numOutstandingReads > 0 || numOutstandingReads == -1) {
-                    ioState |= READ_SCHEDULED;
-                }
-            }
-        }
-
-        /**
-         * Schedule a read and returns the number of {@link #readComplete(byte, int, int, short)}
-         * calls that are expected because of the scheduled read.
-         *
-         * @param first             {@code true} if this is the first read of a read loop.
-         * @param socketIsEmpty     {@code true} if the socket is guaranteed to be empty, {@code false} otherwise.
-         * @return                  the number of {@link #readComplete(byte, int, int, short)} calls expected or
-         *                          {@code -1} if {@link #readComplete(byte, int, int, short)} is called until
-         *                          the read is cancelled (multi-shot).
-         */
-        protected abstract int scheduleRead0(boolean first, boolean socketIsEmpty);
-
-        /**
-         * Called once POLLOUT event is ready to be processed
-         *
-         * @param res   the result.
-         */
-        private void pollOut(int res) {
-            ioState &= ~POLL_OUT_SCHEDULED;
-            pollOutId = 0;
-            if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
+            ChannelPromise promise = connectPromise;
+            final boolean connected;
+            try {
+                connected = socket.finishConnect();
+            } catch (Throwable cause) {
+                connectPromise = null;
+                promise.setFailure(cause);
                 return;
             }
-            // pending connect
-            if (connectPromise != null && !connectPromise.isDone()) {
-                // Note this method is invoked by the event loop only if the connection attempt was
-                // neither cancelled nor timed out.
-                assert executor().inEventLoop();
+            if (connected) {
+                connectPromise = null;
+                active = true;
+                if (local == null) {
+                    local = socket.localAddress();
+                }
+                computeRemote();
 
-                ChannelPromise promise = connectPromise;
-                final boolean connected;
+                // Register POLLRDHUP
+                schedulePollRdHup();
+
+                promise.setSuccess();
+            } else {
+                // The connect was not done yet, register for POLLOUT again
+                schedulePollOut();
+            }
+        } else if (!socket.isOutputShutdown()) {
+            // Try writing again
+            writeFlushedNow();
+        }
+    }
+
+    /**
+     * Called once a write was completed.
+     *
+     * @param op    the op code.
+     * @param res   the result.
+     * @param flags the flags.
+     * @param data  the data that was passed when submitting the op.
+     */
+    private void writeComplete(byte op, int res, int flags, short data) {
+        if ((ioState & CONNECT_SCHEDULED) != 0) {
+            // The writeComplete(...) callback was called because of a sendmsg(...) result that was used for
+            // TCP_FASTOPEN_CONNECT.
+            freeMsgHdrArray();
+            if (res > 0) {
+                // Connect complete!
+                outboundBuffer().removeBytes(res);
+
+                // Explicit pass in 0 as this is returned by a connect(...) call when it was successful.
+                connectComplete(op, 0, flags, data);
+            } else if (res == ERRNO_EINPROGRESS_NEGATIVE || res == 0) {
+                // This happens when we (as a client) have no pre-existing cookie for doing a fast-open connection.
+                // In this case, our TCP connection will be established normally, but no data was transmitted at
+                // this time. We'll just transmit the data with normal writes later.
+                // Let's submit a normal connect.
+                submitConnect((InetSocketAddress) requestedRemoteAddress);
+            } else {
+                // There was an error, handle it as a normal connect error.
+                connectComplete(op, res, flags, data);
+            }
+            return;
+        }
+
+        if ((flags & Native.IORING_CQE_F_NOTIF) == 0) {
+            assert numOutstandingWrites > 0;
+            --numOutstandingWrites;
+        }
+
+        boolean writtenAll = writeComplete0(op, res, flags, data, numOutstandingWrites);
+        if (!writtenAll && (ioState & POLL_OUT_SCHEDULED) == 0) {
+
+            // We were not able to write everything, let's register for POLLOUT
+            schedulePollOut();
+        }
+
+        // We only reset this once we are done with calling removeBytes(...) as otherwise we may trigger a write
+        // while still removing messages internally in removeBytes(...) which then may corrupt state.
+        if (numOutstandingWrites == 0) {
+            ioState &= ~WRITE_SCHEDULED;
+
+            // If we could write all and we did not schedule a pollout yet let us try to write again
+            if (writtenAll && (ioState & POLL_OUT_SCHEDULED) == 0) {
+                scheduleWriteIfNeeded(outboundBuffer(), false);
+            }
+        }
+    }
+
+    /**
+     * Called once a write was completed.
+     * @param op            the op code
+     * @param res           the result.
+     * @param flags         the flags.
+     * @param data          the data that was passed when submitting the op.
+     * @param outstanding   the outstanding write completions.
+     */
+    abstract boolean writeComplete0(byte op, int res, int flags, short data, int outstanding);
+
+    /**
+     * Called once a cancel was completed.
+     *
+     * @param op            the op code
+     * @param res           the result.
+     * @param flags         the flags.
+     * @param data          the data that was passed when submitting the op.
+     */
+    void cancelComplete0(byte op, int res, int flags, short data) {
+        // NOOP
+    }
+
+    /**
+     * Called once a connect was completed.
+     * @param op            the op code.
+     * @param res           the result.
+     * @param flags         the flags.
+     * @param data          the data that was passed when submitting the op.
+     */
+    void connectComplete(byte op, int res, int flags, short data) {
+        ioState &= ~CONNECT_SCHEDULED;
+        assert connectPromise != null;
+        freeRemoteAddressMemory();
+
+        if (res == ERRNO_EINPROGRESS_NEGATIVE || res == ERROR_EALREADY_NEGATIVE) {
+            // connect not complete yet need to wait for poll_out event
+            schedulePollOut();
+        } else {
+            ChannelPromise promise = connectPromise;
+            connectPromise = null;
+            if (res == 0) {
+                active = true;
+                if (local == null) {
+                    local = socket.localAddress();
+                }
+                computeRemote();
+
+                // Register POLLRDHUP
+                schedulePollRdHup();
+
+                promise.setSuccess();
+                if (readPending) {
+                    doBeginReadNow();
+                }
+            } else if (!promise.isDone()) {
                 try {
-                    connected = socket.finishConnect();
+                    Errors.throwConnectException("io_uring connect", res);
                 } catch (Throwable cause) {
                     connectPromise = null;
                     promise.setFailure(cause);
-                    return;
-                }
-                if (connected) {
-                    connectPromise = null;
-                    active = true;
-                    if (local == null) {
-                        local = socket.localAddress();
-                    }
-                    computeRemote();
-
-                    // Register POLLRDHUP
-                    schedulePollRdHup();
-
-                    promise.setSuccess();
-                } else {
-                    // The connect was not done yet, register for POLLOUT again
-                    schedulePollOut();
-                }
-            } else if (!socket.isOutputShutdown()) {
-                // Try writing again
-                writeFlushedNow();
-            }
-        }
-
-        /**
-         * Called once a write was completed.
-         *
-         * @param op    the op code.
-         * @param res   the result.
-         * @param flags the flags.
-         * @param data  the data that was passed when submitting the op.
-         */
-        private void writeComplete(byte op, int res, int flags, short data) {
-            if ((ioState & CONNECT_SCHEDULED) != 0) {
-                // The writeComplete(...) callback was called because of a sendmsg(...) result that was used for
-                // TCP_FASTOPEN_CONNECT.
-                freeMsgHdrArray();
-                if (res > 0) {
-                    // Connect complete!
-                    outboundBuffer().removeBytes(res);
-
-                    // Explicit pass in 0 as this is returned by a connect(...) call when it was successful.
-                    connectComplete(op, 0, flags, data);
-                } else if (res == ERRNO_EINPROGRESS_NEGATIVE || res == 0) {
-                    // This happens when we (as a client) have no pre-existing cookie for doing a fast-open connection.
-                    // In this case, our TCP connection will be established normally, but no data was transmitted at
-                    // this time. We'll just transmit the data with normal writes later.
-                    // Let's submit a normal connect.
-                    submitConnect((InetSocketAddress) requestedRemoteAddress);
-                } else {
-                    // There was an error, handle it as a normal connect error.
-                    connectComplete(op, res, flags, data);
-                }
-                return;
-            }
-
-            if ((flags & Native.IORING_CQE_F_NOTIF) == 0) {
-                assert numOutstandingWrites > 0;
-                --numOutstandingWrites;
-            }
-
-            boolean writtenAll = writeComplete0(op, res, flags, data, numOutstandingWrites);
-            if (!writtenAll && (ioState & POLL_OUT_SCHEDULED) == 0) {
-
-                // We were not able to write everything, let's register for POLLOUT
-                schedulePollOut();
-            }
-
-            // We only reset this once we are done with calling removeBytes(...) as otherwise we may trigger a write
-            // while still removing messages internally in removeBytes(...) which then may corrupt state.
-            if (numOutstandingWrites == 0) {
-                ioState &= ~WRITE_SCHEDULED;
-
-                // If we could write all and we did not schedule a pollout yet let us try to write again
-                if (writtenAll && (ioState & POLL_OUT_SCHEDULED) == 0) {
-                    scheduleWriteIfNeeded(outboundBuffer(), false);
-                }
-            }
-        }
-
-        /**
-         * Called once a write was completed.
-         * @param op            the op code
-         * @param res           the result.
-         * @param flags         the flags.
-         * @param data          the data that was passed when submitting the op.
-         * @param outstanding   the outstanding write completions.
-         */
-        abstract boolean writeComplete0(byte op, int res, int flags, short data, int outstanding);
-
-        /**
-         * Called once a cancel was completed.
-         *
-         * @param op            the op code
-         * @param res           the result.
-         * @param flags         the flags.
-         * @param data          the data that was passed when submitting the op.
-         */
-        void cancelComplete0(byte op, int res, int flags, short data) {
-            // NOOP
-        }
-
-        /**
-         * Called once a connect was completed.
-         * @param op            the op code.
-         * @param res           the result.
-         * @param flags         the flags.
-         * @param data          the data that was passed when submitting the op.
-         */
-        void connectComplete(byte op, int res, int flags, short data) {
-            ioState &= ~CONNECT_SCHEDULED;
-            assert connectPromise != null;
-            freeRemoteAddressMemory();
-
-            if (res == ERRNO_EINPROGRESS_NEGATIVE || res == ERROR_EALREADY_NEGATIVE) {
-                // connect not complete yet need to wait for poll_out event
-                schedulePollOut();
-            } else {
-                ChannelPromise promise = connectPromise;
-                connectPromise = null;
-                if (res == 0) {
-                    active = true;
-                    if (local == null) {
-                        local = socket.localAddress();
-                    }
-                    computeRemote();
-
-                    // Register POLLRDHUP
-                    schedulePollRdHup();
-
-                    promise.setSuccess();
-                    if (readPending) {
-                        doBeginReadNow();
-                    }
-                } else if (!promise.isDone()) {
-                    try {
-                        Errors.throwConnectException("io_uring connect", res);
-                    } catch (Throwable cause) {
-                        connectPromise = null;
-                        promise.setFailure(cause);
-                    }
                 }
             }
         }
@@ -1104,7 +1105,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
     @Override
     protected void doRegister(ChannelPromise promise) {
         EventLoop eventLoop = executor();
-        eventLoop.register(ioUringUnsafe()).addListener(f -> {
+        eventLoop.register(ioHandle).addListener(f -> {
             if (f.isSuccess()) {
                 registration = (IoRegistration) f.getNow();
                 promise.setSuccess();
@@ -1117,7 +1118,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
     @Override
     protected final void doDeregister(ChannelPromise promise) {
         // Cancel all previous submitted ops.
-        ioUringUnsafe().cancelOps(connectPromise != null);
+        cancelOps(connectPromise != null);
         promise.setSuccess();
     }
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
@@ -106,11 +106,6 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
     }
 
     @Override
-    protected final AbstractUringUnsafe newUnsafe() {
-        return new UringServerChannelUnsafe();
-    }
-
-    @Override
     protected final void doWrite(ChannelOutboundBuffer in) {
         throw new UnsupportedOperationException();
     }
@@ -135,151 +130,148 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
     abstract Channel newChildChannel(
             EventLoop eventLoop, int fd, ByteBuffer acceptedAddressMemory) throws Exception;
 
-    private final class UringServerChannelUnsafe extends AbstractIoUringChannel.AbstractUringUnsafe {
+    @Override
+    protected int scheduleWriteMultiple(ChannelOutboundBuffer in) {
+        throw new UnsupportedOperationException();
+    }
 
-        @Override
-        protected int scheduleWriteMultiple(ChannelOutboundBuffer in) {
-            throw new UnsupportedOperationException();
-        }
+    @Override
+    protected int scheduleWriteSingle(Object msg) {
+        throw new UnsupportedOperationException();
+    }
 
-        @Override
-        protected int scheduleWriteSingle(Object msg) {
-            throw new UnsupportedOperationException();
-        }
+    @Override
+    boolean writeComplete0(byte op, int res, int flags, short data, int outstanding) {
+        throw new UnsupportedOperationException();
+    }
 
-        @Override
-        boolean writeComplete0(byte op, int res, int flags, short data, int outstanding) {
-            throw new UnsupportedOperationException();
-        }
+    @Override
+    protected int scheduleRead0(boolean first, boolean socketIsEmpty) {
+        assert acceptId == 0;
+        final IoUringRecvByteAllocatorHandle allocHandle = (IoUringRecvByteAllocatorHandle) recvBufAllocHandle();
+        allocHandle.attemptedBytesRead(1);
 
-        @Override
-        protected int scheduleRead0(boolean first, boolean socketIsEmpty) {
-            assert acceptId == 0;
-            final IoUringRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
-            allocHandle.attemptedBytesRead(1);
+        int fd = fd().intValue();
+        IoRegistration registration = registration();
 
-            int fd = fd().intValue();
-            IoRegistration registration = registration();
+        final short ioPrio;
 
-            final short ioPrio;
-
-            final long acceptedAddressMemoryAddress;
-            final long acceptedAddressLengthMemoryAddress;
-            if (IoUring.isAcceptMultishotEnabled()) {
-                // Let's use multi-shot accept to reduce overhead.
-                ioPrio = Native.IORING_ACCEPT_MULTISHOT;
-                acceptedAddressMemoryAddress = 0;
-                acceptedAddressLengthMemoryAddress = 0;
+        final long acceptedAddressMemoryAddress;
+        final long acceptedAddressLengthMemoryAddress;
+        if (IoUring.isAcceptMultishotEnabled()) {
+            // Let's use multi-shot accept to reduce overhead.
+            ioPrio = Native.IORING_ACCEPT_MULTISHOT;
+            acceptedAddressMemoryAddress = 0;
+            acceptedAddressLengthMemoryAddress = 0;
+        } else {
+            // Depending on if socketIsEmpty is true we will arm the poll upfront and skip the initial transfer
+            // attempt.
+            // See https://github.com/axboe/liburing/wiki/io_uring-and-networking-in-2023#socket-state
+            //
+            // Depending on if this is the first read or not we will use Native.IORING_ACCEPT_DONT_WAIT.
+            // The idea is that if the socket is blocking we can do the first read in a blocking fashion
+            // and so not need to also register POLLIN. As we can not 100 % sure if reads after the first will
+            // be possible directly we schedule these with Native.IORING_ACCEPT_DONT_WAIT. This allows us to still
+            // be able to signal the fireChannelReadComplete() in a timely manner and be consistent with other
+            // transports.
+            //
+            // IORING_ACCEPT_POLL_FIRST and IORING_ACCEPT_DONTWAIT were added in the same release.
+            // We need to check if its supported as otherwise providing these would result in an -EINVAL.
+            if (IoUring.isAcceptNoWaitSupported()) {
+                if (first) {
+                    ioPrio = socketIsEmpty ? Native.IORING_ACCEPT_POLL_FIRST : 0;
+                } else {
+                    ioPrio = Native.IORING_ACCEPT_DONTWAIT;
+                }
             } else {
-                // Depending on if socketIsEmpty is true we will arm the poll upfront and skip the initial transfer
-                // attempt.
-                // See https://github.com/axboe/liburing/wiki/io_uring-and-networking-in-2023#socket-state
-                //
-                // Depending on if this is the first read or not we will use Native.IORING_ACCEPT_DONT_WAIT.
-                // The idea is that if the socket is blocking we can do the first read in a blocking fashion
-                // and so not need to also register POLLIN. As we can not 100 % sure if reads after the first will
-                // be possible directly we schedule these with Native.IORING_ACCEPT_DONT_WAIT. This allows us to still
-                // be able to signal the fireChannelReadComplete() in a timely manner and be consistent with other
-                // transports.
-                //
-                // IORING_ACCEPT_POLL_FIRST and IORING_ACCEPT_DONTWAIT were added in the same release.
-                // We need to check if its supported as otherwise providing these would result in an -EINVAL.
-                if (IoUring.isAcceptNoWaitSupported()) {
-                    if (first) {
-                        ioPrio = socketIsEmpty ? Native.IORING_ACCEPT_POLL_FIRST : 0;
-                    } else {
-                        ioPrio = Native.IORING_ACCEPT_DONTWAIT;
-                    }
-                } else {
-                    ioPrio = 0;
-                }
-
-                assert acceptedAddressMemory != null;
-                acceptedAddressMemoryAddress = acceptedAddressMemory.acceptedAddressMemoryAddress;
-                acceptedAddressLengthMemoryAddress = acceptedAddressMemory.acceptedAddressLengthMemoryAddress;
+                ioPrio = 0;
             }
 
-            // See https://github.com/axboe/liburing/wiki/What's-new-with-io_uring-in-6.10#improvements-for-accept
-            IoUringIoOps ops = IoUringIoOps.newAccept(fd, (byte) 0, 0, ioPrio,
-                    acceptedAddressMemoryAddress, acceptedAddressLengthMemoryAddress, nextOpsId());
-            acceptId = registration.submit(ops);
-            if (acceptId == 0) {
-                return 0;
-            }
-            if ((ioPrio & Native.IORING_ACCEPT_MULTISHOT) != 0) {
-                // Let's return -1 to signal that we used multi-shot.
-                return -1;
-            }
-            return 1;
+            assert acceptedAddressMemory != null;
+            acceptedAddressMemoryAddress = acceptedAddressMemory.acceptedAddressMemoryAddress;
+            acceptedAddressLengthMemoryAddress = acceptedAddressMemory.acceptedAddressLengthMemoryAddress;
         }
 
-        @Override
-        protected void readComplete0(byte op, int res, int flags, short data, int outstanding) {
-            if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
-                acceptId = 0;
-                return;
-            }
-            boolean rearm = (flags & Native.IORING_CQE_F_MORE) == 0;
-            if (rearm) {
-                // Only reset if we don't use multi-shot or we need to re-arm because the multi-shot was cancelled.
-                acceptId = 0;
-            }
-            final IoUringRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
-            final ChannelPipeline pipeline = pipeline();
-            allocHandle.lastBytesRead(res);
+        // See https://github.com/axboe/liburing/wiki/What's-new-with-io_uring-in-6.10#improvements-for-accept
+        IoUringIoOps ops = IoUringIoOps.newAccept(fd, (byte) 0, 0, ioPrio,
+                acceptedAddressMemoryAddress, acceptedAddressLengthMemoryAddress, nextOpsId());
+        acceptId = registration.submit(ops);
+        if (acceptId == 0) {
+            return 0;
+        }
+        if ((ioPrio & Native.IORING_ACCEPT_MULTISHOT) != 0) {
+            // Let's return -1 to signal that we used multi-shot.
+            return -1;
+        }
+        return 1;
+    }
 
-            if (res >= 0) {
-                allocHandle.incMessagesRead(1);
-                final ByteBuffer acceptedAddressBuffer;
-                final long acceptedAddressLengthMemoryAddress;
-                if (acceptedAddressMemory == null) {
-                    acceptedAddressBuffer = null;
-                } else {
-                    acceptedAddressBuffer = acceptedAddressMemory.acceptedAddressMemory;
-                }
-                try {
-                    Channel channel = newChildChannel(childEventExecutorGroup().next(), res, acceptedAddressBuffer);
-                    pipeline.fireChannelRead(channel);
+    @Override
+    protected void readComplete0(byte op, int res, int flags, short data, int outstanding) {
+        if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
+            acceptId = 0;
+            return;
+        }
+        boolean rearm = (flags & Native.IORING_CQE_F_MORE) == 0;
+        if (rearm) {
+            // Only reset if we don't use multi-shot or we need to re-arm because the multi-shot was cancelled.
+            acceptId = 0;
+        }
+        final IoUringRecvByteAllocatorHandle allocHandle = (IoUringRecvByteAllocatorHandle) recvBufAllocHandle();
+        final ChannelPipeline pipeline = pipeline();
+        allocHandle.lastBytesRead(res);
 
-                    if (allocHandle.continueReading() &&
-                            // If IORING_CQE_F_SOCK_NONEMPTY is supported we should check for it first before
-                            // trying to schedule a read. If it's supported and not part of the flags we know for sure
-                            // that the next read (which would be using Native.IORING_ACCEPT_DONTWAIT) will complete
-                            // without be able to read any data. This is useless work and we can skip it.
-                            //
-                            // See https://github.com/axboe/liburing/wiki/What's-new-with-io_uring-in-6.10
-                            !socketIsEmpty(flags)) {
-                        if (rearm) {
-                            // We only should schedule another read if we need to rearm.
-                            // See https://github.com/axboe/liburing/wiki/io_uring-and-networking-in-2023#multi-shot
-                            scheduleRead(false);
-                        }
-                    } else {
-                        allocHandle.readComplete();
-                        pipeline.fireChannelReadComplete();
+        if (res >= 0) {
+            allocHandle.incMessagesRead(1);
+            final ByteBuffer acceptedAddressBuffer;
+            final long acceptedAddressLengthMemoryAddress;
+            if (acceptedAddressMemory == null) {
+                acceptedAddressBuffer = null;
+            } else {
+                acceptedAddressBuffer = acceptedAddressMemory.acceptedAddressMemory;
+            }
+            try {
+                Channel channel = newChildChannel(childEventExecutorGroup().next(), res, acceptedAddressBuffer);
+                pipeline.fireChannelRead(channel);
+
+                if (allocHandle.continueReading() &&
+                        // If IORING_CQE_F_SOCK_NONEMPTY is supported we should check for it first before
+                        // trying to schedule a read. If it's supported and not part of the flags we know for sure
+                        // that the next read (which would be using Native.IORING_ACCEPT_DONTWAIT) will complete
+                        // without be able to read any data. This is useless work and we can skip it.
+                        //
+                        // See https://github.com/axboe/liburing/wiki/What's-new-with-io_uring-in-6.10
+                        !socketIsEmpty(flags)) {
+                    if (rearm) {
+                        // We only should schedule another read if we need to rearm.
+                        // See https://github.com/axboe/liburing/wiki/io_uring-and-networking-in-2023#multi-shot
+                        scheduleRead(false);
                     }
-                } catch (Throwable cause) {
+                } else {
                     allocHandle.readComplete();
                     pipeline.fireChannelReadComplete();
-                    pipeline.fireExceptionCaught(cause);
                 }
-            } else {
+            } catch (Throwable cause) {
                 allocHandle.readComplete();
                 pipeline.fireChannelReadComplete();
-                // Check if we did fail because there was nothing to accept atm.
-                if (res != ERRNO_EAGAIN_NEGATIVE && res != ERRNO_EWOULDBLOCK_NEGATIVE) {
-                    // Something bad happened. Convert to an exception.
-                    pipeline.fireExceptionCaught(Errors.newIOException("io_uring accept", res));
-                }
+                pipeline.fireExceptionCaught(cause);
+            }
+        } else {
+            allocHandle.readComplete();
+            pipeline.fireChannelReadComplete();
+            // Check if we did fail because there was nothing to accept atm.
+            if (res != ERRNO_EAGAIN_NEGATIVE && res != ERRNO_EWOULDBLOCK_NEGATIVE) {
+                // Something bad happened. Convert to an exception.
+                pipeline.fireExceptionCaught(Errors.newIOException("io_uring accept", res));
             }
         }
+    }
 
-        @Override
-        public void unregistered() {
-            super.unregistered();
-            if (acceptedAddressMemory != null) {
-                acceptedAddressMemory.free();
-            }
+    @Override
+    protected void unregistered() {
+        super.unregistered();
+        if (acceptedAddressMemory != null) {
+            acceptedAddressMemory.free();
         }
     }
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -47,6 +47,8 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
     byte readOpCode;
     long readId;
 
+    private ByteBuf readBuffer;
+
     // The configured buffer ring if any
     private IoUringBufferRing bufferRing;
 
@@ -61,11 +63,6 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
     @Override
     public ChannelMetadata metadata() {
         return METADATA;
-    }
-
-    @Override
-    protected AbstractUringUnsafe newUnsafe() {
-        return new IoUringStreamUnsafe();
     }
 
     @Override
@@ -133,12 +130,12 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
     public final ChannelFuture shutdownOutput(final ChannelPromise promise) {
         EventLoop loop = executor();
         if (loop.inEventLoop()) {
-            ((AbstractUnsafe) unsafe()).shutdownOutput(promise);
+            shutdownOutput0(promise);
         } else {
             loop.execute(new Runnable() {
                 @Override
                 public void run() {
-                    ((AbstractUnsafe) unsafe()).shutdownOutput(promise);
+                    shutdownOutput0(promise);
                 }
             });
         }
@@ -237,391 +234,381 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
         return super.filterOutboundMessage(msg);
     }
 
-    protected class IoUringStreamUnsafe extends AbstractUringUnsafe {
+    @Override
+    protected int scheduleWriteMultiple(ChannelOutboundBuffer in) {
+        assert writeId == 0;
 
-        private ByteBuf readBuffer;
+        int fd = fd().intValue();
+        IoRegistration registration = registration();
+        IoUringIoHandler handler = registration.attachment();
+        IovArray iovArray = handler.iovArray();
+        int offset = iovArray.count();
 
-        @Override
-        protected int scheduleWriteMultiple(ChannelOutboundBuffer in) {
-            assert writeId == 0;
-
-            int fd = fd().intValue();
-            IoRegistration registration = registration();
-            IoUringIoHandler handler = registration.attachment();
-            IovArray iovArray = handler.iovArray();
-            int offset = iovArray.count();
-
-            try {
-                in.forEachFlushedMessage(iovArray);
-            } catch (Exception e) {
-                // This should never happen, anyway fallback to single write.
-                return scheduleWriteSingle(in.current());
-            }
-            long iovArrayAddress = iovArray.memoryAddress(offset);
-            int iovArrayLength = iovArray.count() - offset;
-            // Should not use sendmsg_zc, just use normal writev.
-            IoUringIoOps ops = IoUringIoOps.newWritev(fd, (byte) 0, 0, iovArrayAddress, iovArrayLength, nextOpsId());
-
-            byte opCode = ops.opcode();
-            writeId = registration.submit(ops);
-            writeOpCode = opCode;
-            if (writeId == 0) {
-                return 0;
-            }
-            return 1;
+        try {
+            in.forEachFlushedMessage(iovArray);
+        } catch (Exception e) {
+            // This should never happen, anyway fallback to single write.
+            return scheduleWriteSingle(in.current());
         }
+        long iovArrayAddress = iovArray.memoryAddress(offset);
+        int iovArrayLength = iovArray.count() - offset;
+        // Should not use sendmsg_zc, just use normal writev.
+        IoUringIoOps ops = IoUringIoOps.newWritev(fd, (byte) 0, 0, iovArrayAddress, iovArrayLength, nextOpsId());
 
-        @Override
-        protected int scheduleWriteSingle(Object msg) {
-            assert writeId == 0;
-
-            int fd = fd().intValue();
-            IoRegistration registration = registration();
-            final IoUringIoOps ops;
-            if (msg instanceof IoUringFileRegion) {
-                IoUringFileRegion fileRegion = (IoUringFileRegion) msg;
-                try {
-                    fileRegion.open();
-                } catch (IOException e) {
-                    this.handleWriteError(e);
-                    return 0;
-                }
-                ops = fileRegion.splice(fd);
-            } else {
-                ByteBuf buf = (ByteBuf) msg;
-                long address = IoUring.memoryAddress(buf) + buf.readerIndex();
-                int length = buf.readableBytes();
-                short opsid = nextOpsId();
-
-                ops = IoUringIoOps.newWrite(fd, (byte) 0, 0, address, length, opsid);
-            }
-            byte opCode = ops.opcode();
-            writeId = registration.submit(ops);
-            writeOpCode = opCode;
-            if (writeId == 0) {
-                return 0;
-            }
-            return 1;
-        }
-
-        private int calculateRecvFlags(boolean first) {
-            // Depending on if this is the first read or not we will use Native.MSG_DONTWAIT.
-            // The idea is that if the socket is blocking we can do the first read in a blocking fashion
-            // and so not need to also register POLLIN. As we can not 100 % sure if reads after the first will
-            // be possible directly we schedule these with Native.MSG_DONTWAIT. This allows us to still be
-            // able to signal the fireChannelReadComplete() in a timely manner and be consistent with other
-            // transports.
-            if (first) {
-                return 0;
-            }
-            return Native.MSG_DONTWAIT;
-        }
-
-        private short calculateRecvIoPrio(boolean first, boolean socketIsEmpty) {
-            // Depending on if socketIsEmpty is true we will arm the poll upfront and skip the initial transfer
-            // attempt.
-            // See https://github.com/axboe/liburing/wiki/io_uring-and-networking-in-2023#socket-state
-            if (first) {
-                // IORING_RECVSEND_POLL_FIRST and IORING_CQE_F_SOCK_NONEMPTY were added in the same release (5.19).
-                // We need to check if it's supported as otherwise providing these would result in an -EINVAL.
-                return socketIsEmpty && IoUring.isCqeFSockNonEmptySupported() ?
-                        Native.IORING_RECVSEND_POLL_FIRST : 0;
-            }
+        byte opCode = ops.opcode();
+        writeId = registration.submit(ops);
+        writeOpCode = opCode;
+        if (writeId == 0) {
             return 0;
         }
+        return 1;
+    }
 
-        @Override
-        protected int scheduleRead0(boolean first, boolean socketIsEmpty) {
-            assert readBuffer == null;
-            assert readId == 0 : readId;
-            final IoUringRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
+    @Override
+    protected int scheduleWriteSingle(Object msg) {
+        assert writeId == 0;
 
-            if (bufferRing != null && bufferRing.isUsable()) {
-                return scheduleReadProviderBuffer(bufferRing, first, socketIsEmpty);
-            }
-
-            // We either have no buffer ring configured or we force a recv without using a buffer ring.
-            ByteBuf byteBuf = allocHandle.allocate(alloc());
+        int fd = fd().intValue();
+        IoRegistration registration = registration();
+        final IoUringIoOps ops;
+        if (msg instanceof IoUringFileRegion) {
+            IoUringFileRegion fileRegion = (IoUringFileRegion) msg;
             try {
-                int fd = fd().intValue();
-                IoRegistration registration = registration();
-                short ioPrio = calculateRecvIoPrio(first, socketIsEmpty);
-                int recvFlags = calculateRecvFlags(first);
-
-                IoUringIoOps ops = IoUringIoOps.newRecv(fd, (byte) 0, ioPrio, recvFlags,
-                        IoUring.memoryAddress(byteBuf) + byteBuf.writerIndex(), byteBuf.writableBytes(), nextOpsId());
-                readId = registration.submit(ops);
-                readOpCode = Native.IORING_OP_RECV;
-                if (readId == 0) {
-                    return 0;
-                }
-                readBuffer = byteBuf;
-                byteBuf = null;
-                return 1;
-            } finally {
-                if (byteBuf != null) {
-                    byteBuf.release();
-                }
-            }
-        }
-
-        private int scheduleReadProviderBuffer(IoUringBufferRing bufferRing, boolean first, boolean socketIsEmpty) {
-            short bgId = bufferRing.bufferGroupId();
-            try {
-                boolean multishot = IoUring.isRecvMultishotEnabled();
-                byte flags = (byte) Native.IOSQE_BUFFER_SELECT;
-                short ioPrio;
-                final int recvFlags;
-                if (multishot) {
-                    ioPrio = Native.IORING_RECV_MULTISHOT;
-                    recvFlags = 0;
-                } else {
-                    // We should only use the calculate*() methods if this is not a multishot recv, as otherwise
-                    // the would be applied until the multishot will be re-armed.
-                    ioPrio = calculateRecvIoPrio(first, socketIsEmpty);
-                    recvFlags = calculateRecvFlags(first);
-                }
-                if (IoUring.isRecvsendBundleEnabled()) {
-                    // See https://github.com/axboe/liburing/wiki/
-                    // What's-new-with-io_uring-in-6.10#add-support-for-sendrecv-bundles
-                    ioPrio |= Native.IORING_RECVSEND_BUNDLE;
-                }
-                IoRegistration registration = registration();
-                int fd = fd().intValue();
-                IoUringIoOps ops = IoUringIoOps.newRecv(
-                        fd, flags, ioPrio, recvFlags, 0,
-                        0, nextOpsId(), bgId
-                );
-                readId = registration.submit(ops);
-                readOpCode = Native.IORING_OP_RECV;
-                if (readId == 0) {
-                    return 0;
-                }
-                if (multishot) {
-                    // Return -1 to signal we used multishot and so expect multiple recvComplete(...) calls.
-                    return -1;
-                }
-                return 1;
-            } catch (IllegalArgumentException illegalArgumentException) {
-                this.handleReadException(pipeline(), null, illegalArgumentException, false, recvBufAllocHandle());
+                fileRegion.open();
+            } catch (IOException e) {
+                this.handleWriteError(e);
                 return 0;
             }
+            ops = fileRegion.splice(fd);
+        } else {
+            ByteBuf buf = (ByteBuf) msg;
+            long address = IoUring.memoryAddress(buf) + buf.readerIndex();
+            int length = buf.readableBytes();
+            short opsid = nextOpsId();
+
+            ops = IoUringIoOps.newWrite(fd, (byte) 0, 0, address, length, opsid);
+        }
+        byte opCode = ops.opcode();
+        writeId = registration.submit(ops);
+        writeOpCode = opCode;
+        if (writeId == 0) {
+            return 0;
+        }
+        return 1;
+    }
+
+    private int calculateRecvFlags(boolean first) {
+        // Depending on if this is the first read or not we will use Native.MSG_DONTWAIT.
+        // The idea is that if the socket is blocking we can do the first read in a blocking fashion
+        // and so not need to also register POLLIN. As we can not 100 % sure if reads after the first will
+        // be possible directly we schedule these with Native.MSG_DONTWAIT. This allows us to still be
+        // able to signal the fireChannelReadComplete() in a timely manner and be consistent with other
+        // transports.
+        if (first) {
+            return 0;
+        }
+        return Native.MSG_DONTWAIT;
+    }
+
+    private short calculateRecvIoPrio(boolean first, boolean socketIsEmpty) {
+        // Depending on if socketIsEmpty is true we will arm the poll upfront and skip the initial transfer
+        // attempt.
+        // See https://github.com/axboe/liburing/wiki/io_uring-and-networking-in-2023#socket-state
+        if (first) {
+            // IORING_RECVSEND_POLL_FIRST and IORING_CQE_F_SOCK_NONEMPTY were added in the same release (5.19).
+            // We need to check if it's supported as otherwise providing these would result in an -EINVAL.
+            return socketIsEmpty && IoUring.isCqeFSockNonEmptySupported() ?
+                    Native.IORING_RECVSEND_POLL_FIRST : 0;
+        }
+        return 0;
+    }
+
+    @Override
+    protected int scheduleRead0(boolean first, boolean socketIsEmpty) {
+        assert readBuffer == null;
+        assert readId == 0 : readId;
+        final IoUringRecvByteAllocatorHandle allocHandle = (IoUringRecvByteAllocatorHandle) recvBufAllocHandle();
+
+        if (bufferRing != null && bufferRing.isUsable()) {
+            return scheduleReadProviderBuffer(bufferRing, first, socketIsEmpty);
         }
 
-        @Override
-        protected void readComplete0(byte op, int res, int flags, short data, int outstanding) {
-            ByteBuf byteBuf = readBuffer;
-            readBuffer = null;
-            if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
-                readId = 0;
-                // In case of cancellation we should reset the last used buffer ring to null as we will select a new one
-                // when calling scheduleRead(..)
-                if (byteBuf != null) {
-                    //recv without buffer ring
-                    byteBuf.release();
-                }
-                return;
+        // We either have no buffer ring configured or we force a recv without using a buffer ring.
+        ByteBuf byteBuf = allocHandle.allocate(alloc());
+        try {
+            int fd = fd().intValue();
+            IoRegistration registration = registration();
+            short ioPrio = calculateRecvIoPrio(first, socketIsEmpty);
+            int recvFlags = calculateRecvFlags(first);
+
+            IoUringIoOps ops = IoUringIoOps.newRecv(fd, (byte) 0, ioPrio, recvFlags,
+                    IoUring.memoryAddress(byteBuf) + byteBuf.writerIndex(), byteBuf.writableBytes(), nextOpsId());
+            readId = registration.submit(ops);
+            readOpCode = Native.IORING_OP_RECV;
+            if (readId == 0) {
+                return 0;
             }
-            boolean rearm = (flags & Native.IORING_CQE_F_MORE) == 0;
-            boolean useBufferRing = (flags & Native.IORING_CQE_F_BUFFER) != 0;
-            short bid = (short) (flags >> Native.IORING_CQE_BUFFER_SHIFT);
-            boolean more = (flags & Native.IORING_CQE_F_BUF_MORE) != 0;
-
-            boolean empty = socketIsEmpty(flags);
-            if (rearm) {
-                // Only reset if we don't use multi-shot or we need to re-arm because the multi-shot was cancelled.
-                readId = 0;
+            readBuffer = byteBuf;
+            byteBuf = null;
+            return 1;
+        } finally {
+            if (byteBuf != null) {
+                byteBuf.release();
             }
+        }
+    }
 
-            boolean allDataRead = false;
+    private int scheduleReadProviderBuffer(IoUringBufferRing bufferRing, boolean first, boolean socketIsEmpty) {
+        short bgId = bufferRing.bufferGroupId();
+        try {
+            boolean multishot = IoUring.isRecvMultishotEnabled();
+            byte flags = (byte) Native.IOSQE_BUFFER_SELECT;
+            short ioPrio;
+            final int recvFlags;
+            if (multishot) {
+                ioPrio = Native.IORING_RECV_MULTISHOT;
+                recvFlags = 0;
+            } else {
+                // We should only use the calculate*() methods if this is not a multishot recv, as otherwise
+                // the would be applied until the multishot will be re-armed.
+                ioPrio = calculateRecvIoPrio(first, socketIsEmpty);
+                recvFlags = calculateRecvFlags(first);
+            }
+            if (IoUring.isRecvsendBundleEnabled()) {
+                // See https://github.com/axboe/liburing/wiki/
+                // What's-new-with-io_uring-in-6.10#add-support-for-sendrecv-bundles
+                ioPrio |= Native.IORING_RECVSEND_BUNDLE;
+            }
+            IoRegistration registration = registration();
+            int fd = fd().intValue();
+            IoUringIoOps ops = IoUringIoOps.newRecv(
+                    fd, flags, ioPrio, recvFlags, 0,
+                    0, nextOpsId(), bgId
+            );
+            readId = registration.submit(ops);
+            readOpCode = Native.IORING_OP_RECV;
+            if (readId == 0) {
+                return 0;
+            }
+            if (multishot) {
+                // Return -1 to signal we used multishot and so expect multiple recvComplete(...) calls.
+                return -1;
+            }
+            return 1;
+        } catch (IllegalArgumentException illegalArgumentException) {
+            this.handleReadException(pipeline(), null, illegalArgumentException, false,
+                    (IoUringRecvByteAllocatorHandle) recvBufAllocHandle());
+            return 0;
+        }
+    }
 
-            final IoUringRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
-            final ChannelPipeline pipeline = pipeline();
+    @Override
+    protected void readComplete0(byte op, int res, int flags, short data, int outstanding) {
+        ByteBuf byteBuf = readBuffer;
+        readBuffer = null;
+        if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
+            readId = 0;
+            // In case of cancellation we should reset the last used buffer ring to null as we will select a new one
+            // when calling scheduleRead(..)
+            if (byteBuf != null) {
+                //recv without buffer ring
+                byteBuf.release();
+            }
+            return;
+        }
+        boolean rearm = (flags & Native.IORING_CQE_F_MORE) == 0;
+        boolean useBufferRing = (flags & Native.IORING_CQE_F_BUFFER) != 0;
+        short bid = (short) (flags >> Native.IORING_CQE_BUFFER_SHIFT);
+        boolean more = (flags & Native.IORING_CQE_F_BUF_MORE) != 0;
 
-            try {
-                if (res < 0) {
-                    if (res == Native.ERRNO_NOBUFS_NEGATIVE) {
-                        // try to expand the buffer ring by adding more buffers to it if there is any space left.
-                        if (!bufferRing.expand()) {
-                            // We couldn't expand the ring anymore so notify the user that we did run out of buffers
-                            // without the ability to expand it.
-                            // If this happens to often the user should most likely increase the buffer ring size.
-                            pipeline.fireUserEventTriggered(bufferRing.getExhaustedEvent());
-                        }
+        boolean empty = socketIsEmpty(flags);
+        if (rearm) {
+            // Only reset if we don't use multi-shot or we need to re-arm because the multi-shot was cancelled.
+            readId = 0;
+        }
 
-                        // Let's trigger a read again without consulting the RecvByteBufAllocator.Handle as
-                        // we can't count this as a "real" read operation.
-                        // Because of how our BufferRing works we should have it filled again.
-                        scheduleRead(allocHandle.isFirstRead());
-                        return;
+        boolean allDataRead = false;
+
+        final IoUringRecvByteAllocatorHandle allocHandle = (IoUringRecvByteAllocatorHandle) recvBufAllocHandle();
+        final ChannelPipeline pipeline = pipeline();
+
+        try {
+            if (res < 0) {
+                if (res == Native.ERRNO_NOBUFS_NEGATIVE) {
+                    // try to expand the buffer ring by adding more buffers to it if there is any space left.
+                    if (!bufferRing.expand()) {
+                        // We couldn't expand the ring anymore so notify the user that we did run out of buffers
+                        // without the ability to expand it.
+                        // If this happens to often the user should most likely increase the buffer ring size.
+                        pipeline.fireUserEventTriggered(bufferRing.getExhaustedEvent());
                     }
 
-                    // If res is negative we should pass it to ioResult(...) which will either throw
-                    // or convert it to 0 if we could not read because the socket was not readable.
-                    allocHandle.lastBytesRead(ioResult("io_uring read", res));
-                } else if (res > 0) {
-                    if (useBufferRing) {
-                        // If RECVSEND_BUNDLE is used we need to do a bit more work here.
-                        // In this case we might need to obtain multiple buffers out of the buffer ring as
-                        // multiple of them might have been filled for one recv operation.
-                        // See https://github.com/axboe/liburing/wiki/
-                        // What's-new-with-io_uring-in-6.10#add-support-for-sendrecv-bundles
-                        int read = res;
-                        for (;;) {
-                            int attemptedBytesRead = bufferRing.attemptedBytesRead(bid);
-                            byteBuf = bufferRing.useBuffer(bid, read, more);
-                            read -= byteBuf.readableBytes();
-                            allocHandle.attemptedBytesRead(attemptedBytesRead);
-                            allocHandle.lastBytesRead(byteBuf.readableBytes());
-
-                            assert read >= 0;
-                            if (read == 0) {
-                                // Just break here, we will handle the byteBuf below and also fill the bufferRing
-                                // if needed later.
-                                break;
-                            }
-                            allocHandle.incMessagesRead(1);
-                            pipeline.fireChannelRead(byteBuf);
-                            byteBuf = null;
-                            bid = bufferRing.nextBid(bid);
-                            if (!allocHandle.continueReading()) {
-                                // We should call fireChannelReadComplete() to mimic a normal read loop.
-                                allocHandle.readComplete();
-                                pipeline.fireChannelReadComplete();
-                                allocHandle.reset(config());
-                            }
-                        }
-                    } else {
-                        int attemptedBytesRead = byteBuf.writableBytes();
-                        byteBuf.writerIndex(byteBuf.writerIndex() + res);
-                        allocHandle.attemptedBytesRead(attemptedBytesRead);
-                        allocHandle.lastBytesRead(res);
-                    }
-                } else {
-                    // EOF which we signal with -1.
-                    allocHandle.lastBytesRead(-1);
-                }
-                if (allocHandle.lastBytesRead() <= 0) {
-                    // byteBuf might be null if we used a buffer ring.
-                    if (byteBuf != null) {
-                        // nothing was read, release the buffer.
-                        byteBuf.release();
-                        byteBuf = null;
-                    }
-                    allDataRead = allocHandle.lastBytesRead() < 0;
-                    if (allDataRead) {
-                        // There is nothing left to read as we received an EOF.
-                        shutdownInput(true);
-                    }
-                    allocHandle.readComplete();
-                    pipeline.fireChannelReadComplete();
+                    // Let's trigger a read again without consulting the RecvByteBufAllocator.Handle as
+                    // we can't count this as a "real" read operation.
+                    // Because of how our BufferRing works we should have it filled again.
+                    scheduleRead(allocHandle.isFirstRead());
                     return;
                 }
 
-                allocHandle.incMessagesRead(1);
-                pipeline.fireChannelRead(byteBuf);
-                byteBuf = null;
-                scheduleNextRead(pipeline, allocHandle, rearm, empty);
-            } catch (Throwable t) {
-                handleReadException(pipeline, byteBuf, t, allDataRead, allocHandle);
-            }
-        }
+                // If res is negative we should pass it to ioResult(...) which will either throw
+                // or convert it to 0 if we could not read because the socket was not readable.
+                allocHandle.lastBytesRead(ioResult("io_uring read", res));
+            } else if (res > 0) {
+                if (useBufferRing) {
+                    // If RECVSEND_BUNDLE is used we need to do a bit more work here.
+                    // In this case we might need to obtain multiple buffers out of the buffer ring as
+                    // multiple of them might have been filled for one recv operation.
+                    // See https://github.com/axboe/liburing/wiki/
+                    // What's-new-with-io_uring-in-6.10#add-support-for-sendrecv-bundles
+                    int read = res;
+                    for (;;) {
+                        int attemptedBytesRead = bufferRing.attemptedBytesRead(bid);
+                        byteBuf = bufferRing.useBuffer(bid, read, more);
+                        read -= byteBuf.readableBytes();
+                        allocHandle.attemptedBytesRead(attemptedBytesRead);
+                        allocHandle.lastBytesRead(byteBuf.readableBytes());
 
-        private void scheduleNextRead(ChannelPipeline pipeline, IoUringRecvByteAllocatorHandle allocHandle,
-                                      boolean rearm, boolean empty) {
-            if (allocHandle.continueReading() && !empty) {
-                if (rearm) {
-                    // We only should schedule another read if we need to rearm.
-                    // See https://github.com/axboe/liburing/wiki/io_uring-and-networking-in-2023#multi-shot
-                    scheduleRead(false);
+                        assert read >= 0;
+                        if (read == 0) {
+                            // Just break here, we will handle the byteBuf below and also fill the bufferRing
+                            // if needed later.
+                            break;
+                        }
+                        allocHandle.incMessagesRead(1);
+                        pipeline.fireChannelRead(byteBuf);
+                        byteBuf = null;
+                        bid = bufferRing.nextBid(bid);
+                        if (!allocHandle.continueReading()) {
+                            // We should call fireChannelReadComplete() to mimic a normal read loop.
+                            allocHandle.readComplete();
+                            pipeline.fireChannelReadComplete();
+                            allocHandle.reset(config());
+                        }
+                    }
+                } else {
+                    int attemptedBytesRead = byteBuf.writableBytes();
+                    byteBuf.writerIndex(byteBuf.writerIndex() + res);
+                    allocHandle.attemptedBytesRead(attemptedBytesRead);
+                    allocHandle.lastBytesRead(res);
                 }
             } else {
-                // We did not fill the whole ByteBuf so we should break the "read loop" and try again later.
+                // EOF which we signal with -1.
+                allocHandle.lastBytesRead(-1);
+            }
+            if (allocHandle.lastBytesRead() <= 0) {
+                // byteBuf might be null if we used a buffer ring.
+                if (byteBuf != null) {
+                    // nothing was read, release the buffer.
+                    byteBuf.release();
+                    byteBuf = null;
+                }
+                allDataRead = allocHandle.lastBytesRead() < 0;
+                if (allDataRead) {
+                    // There is nothing left to read as we received an EOF.
+                    shutdownInput(true);
+                }
                 allocHandle.readComplete();
                 pipeline.fireChannelReadComplete();
+                return;
             }
-        }
 
-        protected final void handleReadException(ChannelPipeline pipeline, ByteBuf byteBuf,
-                                         Throwable cause, boolean allDataRead,
-                                         IoUringRecvByteAllocatorHandle allocHandle) {
-            if (byteBuf != null) {
-                if (byteBuf.isReadable()) {
-                    pipeline.fireChannelRead(byteBuf);
-                } else {
-                    byteBuf.release();
-                }
+            allocHandle.incMessagesRead(1);
+            pipeline.fireChannelRead(byteBuf);
+            byteBuf = null;
+            scheduleNextRead(pipeline, allocHandle, rearm, empty);
+        } catch (Throwable t) {
+            handleReadException(pipeline, byteBuf, t, allDataRead, allocHandle);
+        }
+    }
+
+    private void scheduleNextRead(ChannelPipeline pipeline, IoUringRecvByteAllocatorHandle allocHandle,
+                                  boolean rearm, boolean empty) {
+        if (allocHandle.continueReading() && !empty) {
+            if (rearm) {
+                // We only should schedule another read if we need to rearm.
+                // See https://github.com/axboe/liburing/wiki/io_uring-and-networking-in-2023#multi-shot
+                scheduleRead(false);
             }
+        } else {
+            // We did not fill the whole ByteBuf so we should break the "read loop" and try again later.
             allocHandle.readComplete();
             pipeline.fireChannelReadComplete();
-            pipeline.fireExceptionCaught(cause);
-            if (allDataRead || cause instanceof IOException) {
-                shutdownInput(true);
+        }
+    }
+
+    protected final void handleReadException(ChannelPipeline pipeline, ByteBuf byteBuf,
+                                     Throwable cause, boolean allDataRead,
+                                     IoUringRecvByteAllocatorHandle allocHandle) {
+        if (byteBuf != null) {
+            if (byteBuf.isReadable()) {
+                pipeline.fireChannelRead(byteBuf);
+            } else {
+                byteBuf.release();
             }
         }
+        allocHandle.readComplete();
+        pipeline.fireChannelReadComplete();
+        pipeline.fireExceptionCaught(cause);
+        if (allDataRead || cause instanceof IOException) {
+            shutdownInput(true);
+        }
+    }
 
-        private boolean handleWriteCompleteFileRegion(ChannelOutboundBuffer channelOutboundBuffer,
-                                                      IoUringFileRegion fileRegion, int res, short data) {
+    private boolean handleWriteCompleteFileRegion(ChannelOutboundBuffer channelOutboundBuffer,
+                                                  IoUringFileRegion fileRegion, int res, short data) {
+        try {
+            if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
+                return true;
+            }
+            int result = res >= 0 ? res : ioResult("io_uring splice", res);
+            if (result == 0 && fileRegion.count() > 0) {
+                validateFileRegion(fileRegion.fileRegion, fileRegion.transfered());
+                return false;
+            }
+            int progress = fileRegion.handleResult(result, data);
+            if (progress == -1) {
+                // Done with writing
+                channelOutboundBuffer.remove();
+            } else if (progress > 0) {
+                channelOutboundBuffer.progress(progress);
+            }
+        } catch (Throwable cause) {
+            handleWriteError(cause);
+        }
+        return true;
+    }
+
+    @Override
+    boolean writeComplete0(byte op, int res, int flags, short data, int outstanding) {
+        if ((flags & Native.IORING_CQE_F_NOTIF) == 0) {
+            // We only want to reset these if IORING_CQE_F_NOTIF is not set.
+            // If it's set we know this is only an extra notification for a write but we already handled
+            // the write completions before.
+            // See https://man7.org/linux/man-pages/man2/io_uring_enter.2.html section: IORING_OP_SEND_ZC
+            writeId = 0;
+            writeOpCode = 0;
+        }
+        ChannelOutboundBuffer channelOutboundBuffer = outboundBuffer();
+        Object current = channelOutboundBuffer.current();
+        if (current instanceof IoUringFileRegion) {
+            IoUringFileRegion fileRegion = (IoUringFileRegion) current;
+            return handleWriteCompleteFileRegion(channelOutboundBuffer, fileRegion, res, data);
+        }
+
+        if (res >= 0) {
+            channelOutboundBuffer.removeBytes(res);
+        } else if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
+            return true;
+        } else {
             try {
-                if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
-                    return true;
-                }
-                int result = res >= 0 ? res : ioResult("io_uring splice", res);
-                if (result == 0 && fileRegion.count() > 0) {
-                    validateFileRegion(fileRegion.fileRegion, fileRegion.transfered());
+                if (ioResult("io_uring write", res) == 0) {
                     return false;
-                }
-                int progress = fileRegion.handleResult(result, data);
-                if (progress == -1) {
-                    // Done with writing
-                    channelOutboundBuffer.remove();
-                } else if (progress > 0) {
-                    channelOutboundBuffer.progress(progress);
                 }
             } catch (Throwable cause) {
                 handleWriteError(cause);
             }
-            return true;
         }
-
-        @Override
-        boolean writeComplete0(byte op, int res, int flags, short data, int outstanding) {
-            if ((flags & Native.IORING_CQE_F_NOTIF) == 0) {
-                // We only want to reset these if IORING_CQE_F_NOTIF is not set.
-                // If it's set we know this is only an extra notification for a write but we already handled
-                // the write completions before.
-                // See https://man7.org/linux/man-pages/man2/io_uring_enter.2.html section: IORING_OP_SEND_ZC
-                writeId = 0;
-                writeOpCode = 0;
-            }
-            ChannelOutboundBuffer channelOutboundBuffer = outboundBuffer();
-            Object current = channelOutboundBuffer.current();
-            if (current instanceof IoUringFileRegion) {
-                IoUringFileRegion fileRegion = (IoUringFileRegion) current;
-                return handleWriteCompleteFileRegion(channelOutboundBuffer, fileRegion, res, data);
-            }
-
-            if (res >= 0) {
-                channelOutboundBuffer.removeBytes(res);
-            } else if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
-                return true;
-            } else {
-                try {
-                    if (ioResult("io_uring write", res) == 0) {
-                        return false;
-                    }
-                } catch (Throwable cause) {
-                    handleWriteError(cause);
-                }
-            }
-            return true;
-        }
-
-        @Override
-        public void unregistered() {
-            super.unregistered();
-            assert readBuffer == null;
-        }
+        return true;
     }
 
     @Override

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
@@ -82,6 +82,9 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
     private final MsgHdrMemoryArray sendmsgHdrs = new MsgHdrMemoryArray((short) 256);
     private final int[] sendmsgResArray = new int[sendmsgHdrs.capacity()];
 
+    private final WriteProcessor writeProcessor = new WriteProcessor();
+    private ByteBuf readBuffer;
+
     /**
      * Create a new instance which selects the {@link SocketProtocolFamily} to use depending
      * on the Operation Systems default which will be chosen.
@@ -287,11 +290,6 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
     }
 
     @Override
-    protected AbstractUnsafe newUnsafe() {
-        return new IoUringDatagramChannelUnsafe();
-    }
-
-    @Override
     protected void doBind(SocketAddress localAddress, ChannelPromise promise) {
         if (localAddress instanceof InetSocketAddress) {
             InetSocketAddress socketAddress = (InetSocketAddress) localAddress;
@@ -384,276 +382,270 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
         }));
     }
 
-    private final class IoUringDatagramChannelUnsafe extends AbstractUringUnsafe {
-        private final WriteProcessor writeProcessor = new WriteProcessor();
-
-        private ByteBuf readBuffer;
-
-        private final class WriteProcessor implements ChannelOutboundBuffer.MessageProcessor {
-            private int written;
-            @Override
-            public boolean processMessage(Object msg) {
-                if (scheduleWrite(msg, written == 0)) {
-                    written++;
-                    return true;
-                }
-                return false;
+    private final class WriteProcessor implements ChannelOutboundBuffer.MessageProcessor {
+        private int written;
+        @Override
+        public boolean processMessage(Object msg) {
+            if (scheduleWrite(msg, written == 0)) {
+                written++;
+                return true;
             }
-
-            int write(ChannelOutboundBuffer in) {
-                written = 0;
-                try {
-                    in.forEachFlushedMessage(this);
-                } catch (Exception e) {
-                    // This should never happen as our processMessage(...) never throws.
-                    throw new IllegalStateException(e);
-                }
-                return written;
-            }
+            return false;
         }
 
-        @Override
-        protected void readComplete0(byte op, int res, int flags, short data, int outstanding) {
-            assert outstanding != -1 : "multi-shot not implemented yet";
-
-            final IoUringRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
-            final ChannelPipeline pipeline = pipeline();
-            ByteBuf byteBuf = this.readBuffer;
-            assert byteBuf != null;
+        int write(ChannelOutboundBuffer in) {
+            written = 0;
             try {
-                recvmsgComplete(pipeline, allocHandle, byteBuf, res, flags, data, outstanding);
-            } catch (Throwable t) {
-                Throwable e = (connected && t instanceof NativeIoException) ?
-                  translateForConnected((NativeIoException) t) : t;
-                pipeline.fireExceptionCaught(e);
+                in.forEachFlushedMessage(this);
+            } catch (Exception e) {
+                // This should never happen as our processMessage(...) never throws.
+                throw new IllegalStateException(e);
+            }
+            return written;
+        }
+    }
+
+    @Override
+    protected void readComplete0(byte op, int res, int flags, short data, int outstanding) {
+        assert outstanding != -1 : "multi-shot not implemented yet";
+
+        final IoUringRecvByteAllocatorHandle allocHandle = (IoUringRecvByteAllocatorHandle) recvBufAllocHandle();
+        final ChannelPipeline pipeline = pipeline();
+        ByteBuf byteBuf = this.readBuffer;
+        assert byteBuf != null;
+        try {
+            recvmsgComplete(pipeline, allocHandle, byteBuf, res, flags, data, outstanding);
+        } catch (Throwable t) {
+            Throwable e = (connected && t instanceof NativeIoException) ?
+              translateForConnected((NativeIoException) t) : t;
+            pipeline.fireExceptionCaught(e);
+        }
+    }
+
+    private void recvmsgComplete(ChannelPipeline pipeline, IoUringRecvByteAllocatorHandle allocHandle,
+                                  ByteBuf byteBuf, int res, int flags, int idx, int outstanding)
+            throws IOException {
+        MsgHdrMemory hdr = recvmsgHdrs.hdr(idx);
+        if (res < 0) {
+            if (res != Native.ERRNO_ECANCELED_NEGATIVE) {
+                // If res is negative we should pass it to ioResult(...) which will either throw
+                // or convert it to 0 if we could not read because the socket was not readable.
+                allocHandle.lastBytesRead(ioResult("io_uring recvmsg", res));
+            }
+        } else {
+            allocHandle.lastBytesRead(res);
+            if (hdr.hasPort(IoUringDatagramChannel.this)) {
+                allocHandle.incMessagesRead(1);
+                DatagramPacket packet = hdr.get(
+                        IoUringDatagramChannel.this, registration().attachment(), byteBuf, res);
+                pipeline.fireChannelRead(packet);
             }
         }
 
-        private void recvmsgComplete(ChannelPipeline pipeline, IoUringRecvByteAllocatorHandle allocHandle,
-                                      ByteBuf byteBuf, int res, int flags, int idx, int outstanding)
-                throws IOException {
-            MsgHdrMemory hdr = recvmsgHdrs.hdr(idx);
-            if (res < 0) {
-                if (res != Native.ERRNO_ECANCELED_NEGATIVE) {
-                    // If res is negative we should pass it to ioResult(...) which will either throw
-                    // or convert it to 0 if we could not read because the socket was not readable.
-                    allocHandle.lastBytesRead(ioResult("io_uring recvmsg", res));
-                }
-            } else {
-                allocHandle.lastBytesRead(res);
-                if (hdr.hasPort(IoUringDatagramChannel.this)) {
-                    allocHandle.incMessagesRead(1);
-                    DatagramPacket packet = hdr.get(
-                            IoUringDatagramChannel.this, registration().attachment(), byteBuf, res);
-                    pipeline.fireChannelRead(packet);
-                }
-            }
+        // Reset the id as this read was completed and so don't need to be cancelled later.
+        recvmsgHdrs.setId(idx, MsgHdrMemoryArray.NO_ID);
+        if (outstanding == 0) {
+            // There are no outstanding completion events, release the readBuffer and see if we need to schedule
+            // another one or if the user will do it.
+            this.readBuffer.release();
+            this.readBuffer = null;
+            recvmsgHdrs.clear();
 
-            // Reset the id as this read was completed and so don't need to be cancelled later.
-            recvmsgHdrs.setId(idx, MsgHdrMemoryArray.NO_ID);
-            if (outstanding == 0) {
-                // There are no outstanding completion events, release the readBuffer and see if we need to schedule
-                // another one or if the user will do it.
-                this.readBuffer.release();
-                this.readBuffer = null;
-                recvmsgHdrs.clear();
-
-                if (res != Native.ERRNO_ECANCELED_NEGATIVE) {
-                    if (allocHandle.lastBytesRead() > 0 &&
-                            allocHandle.continueReading(UncheckedBooleanSupplier.TRUE_SUPPLIER) &&
-                            // If IORING_CQE_F_SOCK_NONEMPTY is supported we should check for it first before
-                            // trying to schedule a read. If it's supported and not part of the flags we know for sure
-                            // that the next read (which would be using Native.MSG_DONTWAIT) will complete without
-                            // be able to read any data. This is useless work and we can skip it.
-                            (!IoUring.isCqeFSockNonEmptySupported() ||
-                                    (flags & Native.IORING_CQE_F_SOCK_NONEMPTY) != 0)) {
-                        // Let's schedule another read.
-                        scheduleRead(false);
-                    } else {
-                        // the read was completed with EAGAIN.
-                        allocHandle.readComplete();
-                        pipeline.fireChannelReadComplete();
-                    }
-                }
-            }
-        }
-
-        @Override
-        protected int scheduleRead0(boolean first, boolean socketIsEmpty) {
-            final IoUringRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
-            ByteBuf byteBuf = allocHandle.allocate(alloc());
-            assert readBuffer == null;
-            readBuffer = byteBuf;
-
-            int writable = byteBuf.writableBytes();
-            allocHandle.attemptedBytesRead(writable);
-            int datagramSize = ((IoUringDatagramChannelConfig) config()).getMaxDatagramPayloadSize();
-
-            int numDatagram = datagramSize == 0 ? 1 : Math.max(1, byteBuf.writableBytes() / datagramSize);
-
-            int scheduled = scheduleRecvmsg(byteBuf, numDatagram, datagramSize);
-            if (scheduled == 0) {
-                // We could not schedule any recvmmsg so we need to release the buffer as there will be no
-                // completion event.
-                readBuffer = null;
-                byteBuf.release();
-            }
-            return scheduled;
-        }
-
-        private int scheduleRecvmsg(ByteBuf byteBuf, int numDatagram, int datagramSize) {
-            int writable = byteBuf.writableBytes();
-            long bufferAddress = IoUring.memoryAddress(byteBuf) + byteBuf.writerIndex();
-            if (numDatagram <= 1) {
-                return scheduleRecvmsg0(bufferAddress, writable, true) ? 1 : 0;
-            }
-            int i = 0;
-            // Add multiple IORING_OP_RECVMSG to the submission queue. This basically emulates recvmmsg(...)
-            for (; i < numDatagram && writable >= datagramSize; i++) {
-                if (!scheduleRecvmsg0(bufferAddress, datagramSize, i == 0)) {
-                    break;
-                }
-                bufferAddress += datagramSize;
-                writable -= datagramSize;
-            }
-            return i;
-        }
-
-        private boolean scheduleRecvmsg0(long bufferAddress, int bufferLength, boolean first) {
-            MsgHdrMemory msgHdrMemory = recvmsgHdrs.nextHdr();
-            if (msgHdrMemory == null) {
-                // We can not continue reading before we did not submit the recvmsg(s) and received the results.
-                return false;
-            }
-            msgHdrMemory.set(socket, null, bufferAddress, bufferLength, (short) 0);
-
-            int fd = fd().intValue();
-            int msgFlags = first ? 0 : Native.MSG_DONTWAIT;
-            IoRegistration registration = registration();
-            // We always use idx here so we can detect if no idx was used by checking if data < 0 in
-            // readComplete0(...)
-            IoUringIoOps ops = IoUringIoOps.newRecvmsg(
-                    fd, (byte) 0, msgFlags, msgHdrMemory.address(), msgHdrMemory.idx());
-            long id = registration.submit(ops);
-            if (id == 0) {
-                // Submission failed we don't used the MsgHdrMemory and so should give it back.
-                recvmsgHdrs.restoreNextHdr(msgHdrMemory);
-                return false;
-            }
-            recvmsgHdrs.setId(msgHdrMemory.idx(), id);
-            return true;
-        }
-
-        @Override
-        boolean writeComplete0(byte op, int res, int flags, short data, int outstanding) {
-            ChannelOutboundBuffer outboundBuffer = outboundBuffer();
-
-            // Reset the id as this write was completed and so don't need to be cancelled later.
-            sendmsgHdrs.setId(data, MsgHdrMemoryArray.NO_ID);
-            sendmsgResArray[data] = res;
-            // Store the result so we can handle it as soon as we have no outstanding writes anymore.
-            if (outstanding == 0) {
-                // All writes are done as part of a batch. Let's remove these from the ChannelOutboundBuffer
-                boolean writtenSomething = false;
-                int numWritten = sendmsgHdrs.length();
-                sendmsgHdrs.clear();
-                for (int i = 0; i < numWritten; i++) {
-                    writtenSomething |= removeFromOutboundBuffer(
-                            outboundBuffer, sendmsgResArray[i], "io_uring sendmsg");
-                }
-                return writtenSomething;
-            }
-            return true;
-        }
-
-        private boolean removeFromOutboundBuffer(ChannelOutboundBuffer outboundBuffer, int res, String errormsg) {
-            if (res >= 0) {
-                // When using Datagram we should consider the message written as long as res is not negative.
-                return outboundBuffer.remove();
-            }
-            if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
-                return false;
-            }
-            try {
-                return ioResult(errormsg, res) != 0;
-            } catch (Throwable cause) {
-                return outboundBuffer.remove(cause);
-            }
-        }
-
-        @Override
-        void connectComplete(byte op, int res, int flags, short data) {
-            if (res >= 0) {
-                connected = true;
-            }
-            super.connectComplete(op, res, flags, data);
-        }
-
-        @Override
-        protected int scheduleWriteMultiple(ChannelOutboundBuffer in) {
-            return writeProcessor.write(in);
-        }
-
-        @Override
-        protected int scheduleWriteSingle(Object msg) {
-            return scheduleWrite(msg, true) ? 1 : 0;
-        }
-
-        private boolean scheduleWrite(Object msg, boolean first) {
-            final ByteBuf data;
-            final InetSocketAddress remoteAddress;
-            final int segmentSize;
-            if (msg instanceof AddressedEnvelope) {
-                @SuppressWarnings("unchecked")
-                AddressedEnvelope<ByteBuf, InetSocketAddress> envelope =
-                        (AddressedEnvelope<ByteBuf, InetSocketAddress>) msg;
-                data = envelope.content();
-                remoteAddress = envelope.recipient();
-                if (msg instanceof SegmentedDatagramPacket) {
-                    segmentSize = ((SegmentedDatagramPacket) msg).segmentSize();
+            if (res != Native.ERRNO_ECANCELED_NEGATIVE) {
+                if (allocHandle.lastBytesRead() > 0 &&
+                        allocHandle.continueReading(UncheckedBooleanSupplier.TRUE_SUPPLIER) &&
+                        // If IORING_CQE_F_SOCK_NONEMPTY is supported we should check for it first before
+                        // trying to schedule a read. If it's supported and not part of the flags we know for sure
+                        // that the next read (which would be using Native.MSG_DONTWAIT) will complete without
+                        // be able to read any data. This is useless work and we can skip it.
+                        (!IoUring.isCqeFSockNonEmptySupported() ||
+                                (flags & Native.IORING_CQE_F_SOCK_NONEMPTY) != 0)) {
+                    // Let's schedule another read.
+                    scheduleRead(false);
                 } else {
-                    segmentSize = 0;
+                    // the read was completed with EAGAIN.
+                    allocHandle.readComplete();
+                    pipeline.fireChannelReadComplete();
                 }
+            }
+        }
+    }
+
+    @Override
+    protected int scheduleRead0(boolean first, boolean socketIsEmpty) {
+        final IoUringRecvByteAllocatorHandle allocHandle = (IoUringRecvByteAllocatorHandle) recvBufAllocHandle();
+        ByteBuf byteBuf = allocHandle.allocate(alloc());
+        assert readBuffer == null;
+        readBuffer = byteBuf;
+
+        int writable = byteBuf.writableBytes();
+        allocHandle.attemptedBytesRead(writable);
+        int datagramSize = ((IoUringDatagramChannelConfig) config()).getMaxDatagramPayloadSize();
+
+        int numDatagram = datagramSize == 0 ? 1 : Math.max(1, byteBuf.writableBytes() / datagramSize);
+
+        int scheduled = scheduleRecvmsg(byteBuf, numDatagram, datagramSize);
+        if (scheduled == 0) {
+            // We could not schedule any recvmmsg so we need to release the buffer as there will be no
+            // completion event.
+            readBuffer = null;
+            byteBuf.release();
+        }
+        return scheduled;
+    }
+
+    private int scheduleRecvmsg(ByteBuf byteBuf, int numDatagram, int datagramSize) {
+        int writable = byteBuf.writableBytes();
+        long bufferAddress = IoUring.memoryAddress(byteBuf) + byteBuf.writerIndex();
+        if (numDatagram <= 1) {
+            return scheduleRecvmsg0(bufferAddress, writable, true) ? 1 : 0;
+        }
+        int i = 0;
+        // Add multiple IORING_OP_RECVMSG to the submission queue. This basically emulates recvmmsg(...)
+        for (; i < numDatagram && writable >= datagramSize; i++) {
+            if (!scheduleRecvmsg0(bufferAddress, datagramSize, i == 0)) {
+                break;
+            }
+            bufferAddress += datagramSize;
+            writable -= datagramSize;
+        }
+        return i;
+    }
+
+    private boolean scheduleRecvmsg0(long bufferAddress, int bufferLength, boolean first) {
+        MsgHdrMemory msgHdrMemory = recvmsgHdrs.nextHdr();
+        if (msgHdrMemory == null) {
+            // We can not continue reading before we did not submit the recvmsg(s) and received the results.
+            return false;
+        }
+        msgHdrMemory.set(socket, null, bufferAddress, bufferLength, (short) 0);
+
+        int fd = fd().intValue();
+        int msgFlags = first ? 0 : Native.MSG_DONTWAIT;
+        IoRegistration registration = registration();
+        // We always use idx here so we can detect if no idx was used by checking if data < 0 in
+        // readComplete0(...)
+        IoUringIoOps ops = IoUringIoOps.newRecvmsg(
+                fd, (byte) 0, msgFlags, msgHdrMemory.address(), msgHdrMemory.idx());
+        long id = registration.submit(ops);
+        if (id == 0) {
+            // Submission failed we don't used the MsgHdrMemory and so should give it back.
+            recvmsgHdrs.restoreNextHdr(msgHdrMemory);
+            return false;
+        }
+        recvmsgHdrs.setId(msgHdrMemory.idx(), id);
+        return true;
+    }
+
+    @Override
+    boolean writeComplete0(byte op, int res, int flags, short data, int outstanding) {
+        ChannelOutboundBuffer outboundBuffer = outboundBuffer();
+
+        // Reset the id as this write was completed and so don't need to be cancelled later.
+        sendmsgHdrs.setId(data, MsgHdrMemoryArray.NO_ID);
+        sendmsgResArray[data] = res;
+        // Store the result so we can handle it as soon as we have no outstanding writes anymore.
+        if (outstanding == 0) {
+            // All writes are done as part of a batch. Let's remove these from the ChannelOutboundBuffer
+            boolean writtenSomething = false;
+            int numWritten = sendmsgHdrs.length();
+            sendmsgHdrs.clear();
+            for (int i = 0; i < numWritten; i++) {
+                writtenSomething |= removeFromOutboundBuffer(
+                        outboundBuffer, sendmsgResArray[i], "io_uring sendmsg");
+            }
+            return writtenSomething;
+        }
+        return true;
+    }
+
+    private boolean removeFromOutboundBuffer(ChannelOutboundBuffer outboundBuffer, int res, String errormsg) {
+        if (res >= 0) {
+            // When using Datagram we should consider the message written as long as res is not negative.
+            return outboundBuffer.remove();
+        }
+        if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
+            return false;
+        }
+        try {
+            return ioResult(errormsg, res) != 0;
+        } catch (Throwable cause) {
+            return outboundBuffer.remove(cause);
+        }
+    }
+
+    @Override
+    void connectComplete(byte op, int res, int flags, short data) {
+        if (res >= 0) {
+            connected = true;
+        }
+        super.connectComplete(op, res, flags, data);
+    }
+
+    @Override
+    protected int scheduleWriteMultiple(ChannelOutboundBuffer in) {
+        return writeProcessor.write(in);
+    }
+
+    @Override
+    protected int scheduleWriteSingle(Object msg) {
+        return scheduleWrite(msg, true) ? 1 : 0;
+    }
+
+    private boolean scheduleWrite(Object msg, boolean first) {
+        final ByteBuf data;
+        final InetSocketAddress remoteAddress;
+        final int segmentSize;
+        if (msg instanceof AddressedEnvelope) {
+            @SuppressWarnings("unchecked")
+            AddressedEnvelope<ByteBuf, InetSocketAddress> envelope =
+                    (AddressedEnvelope<ByteBuf, InetSocketAddress>) msg;
+            data = envelope.content();
+            remoteAddress = envelope.recipient();
+            if (msg instanceof SegmentedDatagramPacket) {
+                segmentSize = ((SegmentedDatagramPacket) msg).segmentSize();
             } else {
-                data = (ByteBuf) msg;
-                remoteAddress = (InetSocketAddress) remoteAddress();
                 segmentSize = 0;
             }
-
-            long bufferAddress = IoUring.memoryAddress(data);
-            return scheduleSendmsg(remoteAddress, bufferAddress, data.readableBytes(), segmentSize, first);
+        } else {
+            data = (ByteBuf) msg;
+            remoteAddress = (InetSocketAddress) remoteAddress();
+            segmentSize = 0;
         }
 
-        private boolean scheduleSendmsg(InetSocketAddress remoteAddress, long bufferAddress,
-                                        int bufferLength, int segmentSize, boolean first) {
-            MsgHdrMemory hdr = sendmsgHdrs.nextHdr();
-            if (hdr == null) {
-                // There is no MsgHdrMemory left to use. We need to submit and wait for the writes to complete
-                // before we can write again.
-                return false;
-            }
-            hdr.set(socket, remoteAddress, bufferAddress, bufferLength, (short) segmentSize);
+        long bufferAddress = IoUring.memoryAddress(data);
+        return scheduleSendmsg(remoteAddress, bufferAddress, data.readableBytes(), segmentSize, first);
+    }
 
-            int fd = fd().intValue();
-            int msgFlags = first ? 0 : Native.MSG_DONTWAIT;
-            IoRegistration registration = registration();
-            IoUringIoOps ops = IoUringIoOps.newSendmsg(fd, (byte) 0, msgFlags, hdr.address(), hdr.idx());
-            long id = registration.submit(ops);
-            if (id == 0) {
-                // Submission failed we don't used the MsgHdrMemory and so should give it back.
-                sendmsgHdrs.restoreNextHdr(hdr);
-                return false;
-            }
-            sendmsgHdrs.setId(hdr.idx(), id);
-            return true;
+    private boolean scheduleSendmsg(InetSocketAddress remoteAddress, long bufferAddress,
+                                    int bufferLength, int segmentSize, boolean first) {
+        MsgHdrMemory hdr = sendmsgHdrs.nextHdr();
+        if (hdr == null) {
+            // There is no MsgHdrMemory left to use. We need to submit and wait for the writes to complete
+            // before we can write again.
+            return false;
         }
+        hdr.set(socket, remoteAddress, bufferAddress, bufferLength, (short) segmentSize);
 
-        @Override
-        public void unregistered() {
-            super.unregistered();
-            sendmsgHdrs.release();
-            recvmsgHdrs.release();
+        int fd = fd().intValue();
+        int msgFlags = first ? 0 : Native.MSG_DONTWAIT;
+        IoRegistration registration = registration();
+        IoUringIoOps ops = IoUringIoOps.newSendmsg(fd, (byte) 0, msgFlags, hdr.address(), hdr.idx());
+        long id = registration.submit(ops);
+        if (id == 0) {
+            // Submission failed we don't used the MsgHdrMemory and so should give it back.
+            sendmsgHdrs.restoreNextHdr(hdr);
+            return false;
         }
+        sendmsgHdrs.setId(hdr.idx(), id);
+        return true;
+    }
+
+    @Override
+    protected void unregistered() {
+        super.unregistered();
+        sendmsgHdrs.release();
+        recvmsgHdrs.release();
     }
 
     private static IOException translateForConnected(NativeIoException e) {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDomainSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDomainSocketChannel.java
@@ -41,6 +41,9 @@ public final class IoUringDomainSocketChannel extends AbstractIoUringStreamChann
 
     private final IoUringDomainSocketChannelConfig config;
 
+    private MsgHdrMemory writeMsgHdrMemory;
+    private MsgHdrMemory readMsgHdrMemory;
+
     private volatile DomainSocketAddress local;
     private volatile DomainSocketAddress remote;
 
@@ -92,144 +95,133 @@ public final class IoUringDomainSocketChannel extends AbstractIoUringStreamChann
     }
 
     @Override
-    protected AbstractUringUnsafe newUnsafe() {
-        return new IoUringDomainSocketUnsafe();
-    }
-
-    @Override
     protected boolean allowMultiShotPollIn() {
         // UNIX domain sockets do not support IORING_CQE_F_SOCK_NONEMPTY and POLL_ADD_MULTI is edge-triggered
         // so we should disable it
         return false;
     }
 
-    private final class IoUringDomainSocketUnsafe extends IoUringStreamUnsafe {
-
-        private MsgHdrMemory writeMsgHdrMemory;
-        private MsgHdrMemory readMsgHdrMemory;
-
-        @Override
-        protected int scheduleWriteSingle(Object msg) {
-            if (msg instanceof FileDescriptor) {
-                // we can reuse the same memory for any fd
-                // because we never have more than a single outstanding write.
-                if (writeMsgHdrMemory == null) {
-                    writeMsgHdrMemory = new MsgHdrMemory();
-                }
-                IoRegistration registration = registration();
-                IoUringIoOps ioUringIoOps = prepSendFdIoOps((FileDescriptor) msg, writeMsgHdrMemory);
-                writeId = registration.submit(ioUringIoOps);
-                writeOpCode = Native.IORING_OP_SENDMSG;
-                if (writeId == 0) {
-                    MsgHdrMemory memory = writeMsgHdrMemory;
-                    writeMsgHdrMemory = null;
-                    memory.release();
-                    return 0;
-                }
-                return 1;
-            }
-            return super.scheduleWriteSingle(msg);
-        }
-
-        @Override
-        boolean writeComplete0(byte op, int res, int flags, short data, int outstanding) {
-            if (op == Native.IORING_OP_SENDMSG) {
-                writeId = 0;
-                writeOpCode = 0;
-                if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
-                    return true;
-                }
-                try {
-                    int nativeCallResult = res >= 0 ? res : Errors.ioResult("io_uring sendmsg", res);
-                    if (nativeCallResult >= 0) {
-                        ChannelOutboundBuffer channelOutboundBuffer = outboundBuffer();
-                        channelOutboundBuffer.remove();
-                    }
-                } catch (Throwable throwable) {
-                   handleWriteError(throwable);
-                }
-                return true;
-            }
-            return super.writeComplete0(op, res, flags, data, outstanding);
-        }
-
-        private IoUringIoOps prepSendFdIoOps(FileDescriptor fileDescriptor, MsgHdrMemory msgHdrMemory) {
-            msgHdrMemory.setScmRightsFd(fileDescriptor.intValue());
-            return IoUringIoOps.newSendmsg(
-                    fd().intValue(), (byte) 0, 0, msgHdrMemory.address(), msgHdrMemory.idx());
-        }
-
-        @Override
-        protected int scheduleRead0(boolean first, boolean socketIsEmpty) {
-            DomainSocketReadMode readMode = config.getReadMode();
-            switch (readMode) {
-                case FILE_DESCRIPTORS:
-                    return scheduleRecvReadFd();
-                case BYTES:
-                    return super.scheduleRead0(first, socketIsEmpty);
-                default:
-                    throw new Error("Unexpected read mode: " + readMode);
-            }
-        }
-
-        private int scheduleRecvReadFd() {
+    @Override
+    protected int scheduleWriteSingle(Object msg) {
+        if (msg instanceof FileDescriptor) {
             // we can reuse the same memory for any fd
-            // because we only submit one outstanding read
-            if (readMsgHdrMemory == null) {
-                readMsgHdrMemory = new MsgHdrMemory();
+            // because we never have more than a single outstanding write.
+            if (writeMsgHdrMemory == null) {
+                writeMsgHdrMemory = new MsgHdrMemory();
             }
-            readMsgHdrMemory.prepRecvReadFd();
             IoRegistration registration = registration();
-            IoUringIoOps ioUringIoOps = IoUringIoOps.newRecvmsg(
-                    fd().intValue(), (byte) 0, 0, readMsgHdrMemory.address(), readMsgHdrMemory.idx());
-            readId = registration.submit(ioUringIoOps);
-            readOpCode = Native.IORING_OP_RECVMSG;
-            if (readId == 0) {
-                MsgHdrMemory memory = readMsgHdrMemory;
-                readMsgHdrMemory = null;
+            IoUringIoOps ioUringIoOps = prepSendFdIoOps((FileDescriptor) msg, writeMsgHdrMemory);
+            writeId = registration.submit(ioUringIoOps);
+            writeOpCode = Native.IORING_OP_SENDMSG;
+            if (writeId == 0) {
+                MsgHdrMemory memory = writeMsgHdrMemory;
+                writeMsgHdrMemory = null;
                 memory.release();
                 return 0;
             }
             return 1;
         }
+        return super.scheduleWriteSingle(msg);
+    }
 
-        @Override
-        protected void readComplete0(byte op, int res, int flags, short data, int outstanding) {
-            if (op == Native.IORING_OP_RECVMSG) {
-                readId = 0;
-                if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
-                    return;
+    @Override
+    boolean writeComplete0(byte op, int res, int flags, short data, int outstanding) {
+        if (op == Native.IORING_OP_SENDMSG) {
+            writeId = 0;
+            writeOpCode = 0;
+            if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
+                return true;
+            }
+            try {
+                int nativeCallResult = res >= 0 ? res : Errors.ioResult("io_uring sendmsg", res);
+                if (nativeCallResult >= 0) {
+                    ChannelOutboundBuffer channelOutboundBuffer = outboundBuffer();
+                    channelOutboundBuffer.remove();
                 }
-                final IoUringRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
-                final ChannelPipeline pipeline = pipeline();
-                try {
-                    int nativeCallResult = res >= 0 ? res : Errors.ioResult("io_uring recvmsg", res);
-                    int nativeFd = readMsgHdrMemory.getScmRightsFd();
-                    allocHandle.lastBytesRead(nativeFd);
-                    allocHandle.incMessagesRead(1);
-                    pipeline.fireChannelRead(new FileDescriptor(nativeFd));
-                } catch (Throwable throwable) {
-                    handleReadException(pipeline, null, throwable, false, allocHandle);
-                } finally {
-                    allocHandle.readComplete();
-                    pipeline.fireChannelReadComplete();
-                }
+            } catch (Throwable throwable) {
+               handleWriteError(throwable);
+            }
+            return true;
+        }
+        return super.writeComplete0(op, res, flags, data, outstanding);
+    }
+
+    private IoUringIoOps prepSendFdIoOps(FileDescriptor fileDescriptor, MsgHdrMemory msgHdrMemory) {
+        msgHdrMemory.setScmRightsFd(fileDescriptor.intValue());
+        return IoUringIoOps.newSendmsg(
+                fd().intValue(), (byte) 0, 0, msgHdrMemory.address(), msgHdrMemory.idx());
+    }
+
+    @Override
+    protected int scheduleRead0(boolean first, boolean socketIsEmpty) {
+        DomainSocketReadMode readMode = config.getReadMode();
+        switch (readMode) {
+            case FILE_DESCRIPTORS:
+                return scheduleRecvReadFd();
+            case BYTES:
+                return super.scheduleRead0(first, socketIsEmpty);
+            default:
+                throw new Error("Unexpected read mode: " + readMode);
+        }
+    }
+
+    private int scheduleRecvReadFd() {
+        // we can reuse the same memory for any fd
+        // because we only submit one outstanding read
+        if (readMsgHdrMemory == null) {
+            readMsgHdrMemory = new MsgHdrMemory();
+        }
+        readMsgHdrMemory.prepRecvReadFd();
+        IoRegistration registration = registration();
+        IoUringIoOps ioUringIoOps = IoUringIoOps.newRecvmsg(
+                fd().intValue(), (byte) 0, 0, readMsgHdrMemory.address(), readMsgHdrMemory.idx());
+        readId = registration.submit(ioUringIoOps);
+        readOpCode = Native.IORING_OP_RECVMSG;
+        if (readId == 0) {
+            MsgHdrMemory memory = readMsgHdrMemory;
+            readMsgHdrMemory = null;
+            memory.release();
+            return 0;
+        }
+        return 1;
+    }
+
+    @Override
+    protected void readComplete0(byte op, int res, int flags, short data, int outstanding) {
+        if (op == Native.IORING_OP_RECVMSG) {
+            readId = 0;
+            if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
                 return;
             }
-            super.readComplete0(op, res, flags, data, outstanding);
+            final IoUringRecvByteAllocatorHandle allocHandle = (IoUringRecvByteAllocatorHandle) recvBufAllocHandle();
+            final ChannelPipeline pipeline = pipeline();
+            try {
+                int nativeCallResult = res >= 0 ? res : Errors.ioResult("io_uring recvmsg", res);
+                int nativeFd = readMsgHdrMemory.getScmRightsFd();
+                allocHandle.lastBytesRead(nativeFd);
+                allocHandle.incMessagesRead(1);
+                pipeline.fireChannelRead(new FileDescriptor(nativeFd));
+            } catch (Throwable throwable) {
+                handleReadException(pipeline, null, throwable, false, allocHandle);
+            } finally {
+                allocHandle.readComplete();
+                pipeline.fireChannelReadComplete();
+            }
+            return;
         }
+        super.readComplete0(op, res, flags, data, outstanding);
+    }
 
-        @Override
-        public void unregistered() {
-            super.unregistered();
-            if (readMsgHdrMemory != null) {
-                readMsgHdrMemory.release();
-                readMsgHdrMemory = null;
-            }
-            if (writeMsgHdrMemory != null) {
-                writeMsgHdrMemory.release();
-                writeMsgHdrMemory = null;
-            }
+    @Override
+    protected void unregistered() {
+        super.unregistered();
+        if (readMsgHdrMemory != null) {
+            readMsgHdrMemory.release();
+            readMsgHdrMemory = null;
+        }
+        if (writeMsgHdrMemory != null) {
+            writeMsgHdrMemory.release();
+            writeMsgHdrMemory = null;
         }
     }
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
@@ -33,6 +33,14 @@ import static io.netty.channel.unix.Errors.ioResult;
 public final class IoUringSocketChannel extends AbstractIoUringStreamChannel implements SocketChannel {
     private final IoUringSocketChannelConfig config;
 
+    // Marker object that is used to mark a batch of buffers that were used with zero-copy write operations.
+    private static final Object ZC_BATCH_MARKER = new Object();
+
+    /**
+     * Queue that holds buffers that we can't release yet as the kernel still holds a reference to these.
+     */
+    private Queue<Object> zcWriteQueue;
+
     public IoUringSocketChannel(EventLoop eventLoop) {
        super(eventLoop, null, LinuxSocket.newSocketStream(), false);
        this.config = new IoUringSocketChannelConfig(this);
@@ -59,69 +67,15 @@ public final class IoUringSocketChannel extends AbstractIoUringStreamChannel imp
     }
 
     @Override
-    protected AbstractUringUnsafe newUnsafe() {
-        return new IoUringSocketUnsafe();
-    }
+    protected int scheduleWriteSingle(Object msg) {
+        assert writeId == 0;
 
-    // Marker object that is used to mark a batch of buffers that were used with zero-copy write operations.
-    private static final Object ZC_BATCH_MARKER = new Object();
-
-    private final class IoUringSocketUnsafe extends IoUringStreamUnsafe {
-        /**
-         * Queue that holds buffers that we can't release yet as the kernel still holds a reference to these.
-         */
-        private Queue<Object> zcWriteQueue;
-
-        @Override
-        protected int scheduleWriteSingle(Object msg) {
-            assert writeId == 0;
-
-            if (IoUring.isSendZcSupported() && msg instanceof ByteBuf) {
-                ByteBuf buf = (ByteBuf) msg;
-                int length = buf.readableBytes();
-                if (((IoUringSocketChannelConfig) config()).shouldWriteZeroCopy(length)) {
-                    long address = IoUring.memoryAddress(buf) + buf.readerIndex();
-                    IoUringIoOps ops = IoUringIoOps.newSendZc(fd().intValue(), address, length, 0, nextOpsId(), 0);
-                    byte opCode = ops.opcode();
-                    writeId = registration().submit(ops);
-                    writeOpCode = opCode;
-                    if (writeId == 0) {
-                        return 0;
-                    }
-                    return 1;
-                }
-                // Should not use send_zc, just use normal write.
-            }
-            return super.scheduleWriteSingle(msg);
-        }
-
-        @Override
-        protected int scheduleWriteMultiple(ChannelOutboundBuffer in) {
-            assert writeId == 0;
-
-            if (IoUring.isSendmsgZcSupported() && (
-                    (IoUringSocketChannelConfig) config()).shouldWriteZeroCopy((int) in.totalPendingWriteBytes())) {
-                IoUringIoHandler handler = registration().attachment();
-
-                IovArray iovArray = handler.iovArray();
-                int offset = iovArray.count();
-                // Limit to the maximum number of fragments to ensure we don't get an error when we have too many
-                // buffers.
-                iovArray.maxCount(Native.MAX_SKB_FRAGS);
-                try {
-                    in.forEachFlushedMessage(iovArray);
-                } catch (Exception e) {
-                    // This should never happen, anyway fallback to single write.
-                    return scheduleWriteSingle(in.current());
-                }
-                long iovArrayAddress = iovArray.memoryAddress(offset);
-                int iovArrayLength = iovArray.count() - offset;
-
-                MsgHdrMemoryArray msgHdrArray = handler.msgHdrMemoryArray();
-                MsgHdrMemory hdr = msgHdrArray.nextHdr();
-                assert hdr != null;
-                hdr.set(iovArrayAddress, iovArrayLength);
-                IoUringIoOps ops = IoUringIoOps.newSendmsgZc(fd().intValue(), (byte) 0, 0, hdr.address(), nextOpsId());
+        if (IoUring.isSendZcSupported() && msg instanceof ByteBuf) {
+            ByteBuf buf = (ByteBuf) msg;
+            int length = buf.readableBytes();
+            if (((IoUringSocketChannelConfig) config()).shouldWriteZeroCopy(length)) {
+                long address = IoUring.memoryAddress(buf) + buf.readerIndex();
+                IoUringIoOps ops = IoUringIoOps.newSendZc(fd().intValue(), address, length, 0, nextOpsId(), 0);
                 byte opCode = ops.opcode();
                 writeId = registration().submit(ops);
                 writeOpCode = opCode;
@@ -130,140 +84,179 @@ public final class IoUringSocketChannel extends AbstractIoUringStreamChannel imp
                 }
                 return 1;
             }
-            // Should not use sendmsg_zc, just use normal writev.
-            return super.scheduleWriteMultiple(in);
+            // Should not use send_zc, just use normal write.
         }
+        return super.scheduleWriteSingle(msg);
+    }
 
-        @Override
-        boolean writeComplete0(byte op, int res, int flags, short data, int outstanding) {
-            ChannelOutboundBuffer channelOutboundBuffer = outboundBuffer();
-            if (op == Native.IORING_OP_SEND_ZC || op == Native.IORING_OP_SENDMSG_ZC) {
-                return handleWriteCompleteZeroCopy(op, channelOutboundBuffer, res, flags);
+    @Override
+    protected int scheduleWriteMultiple(ChannelOutboundBuffer in) {
+        assert writeId == 0;
+
+        if (IoUring.isSendmsgZcSupported() && (
+                (IoUringSocketChannelConfig) config()).shouldWriteZeroCopy((int) in.totalPendingWriteBytes())) {
+            IoUringIoHandler handler = registration().attachment();
+
+            IovArray iovArray = handler.iovArray();
+            int offset = iovArray.count();
+            // Limit to the maximum number of fragments to ensure we don't get an error when we have too many
+            // buffers.
+            iovArray.maxCount(Native.MAX_SKB_FRAGS);
+            try {
+                in.forEachFlushedMessage(iovArray);
+            } catch (Exception e) {
+                // This should never happen, anyway fallback to single write.
+                return scheduleWriteSingle(in.current());
             }
-            return super.writeComplete0(op, res, flags, data, outstanding);
+            long iovArrayAddress = iovArray.memoryAddress(offset);
+            int iovArrayLength = iovArray.count() - offset;
+
+            MsgHdrMemoryArray msgHdrArray = handler.msgHdrMemoryArray();
+            MsgHdrMemory hdr = msgHdrArray.nextHdr();
+            assert hdr != null;
+            hdr.set(iovArrayAddress, iovArrayLength);
+            IoUringIoOps ops = IoUringIoOps.newSendmsgZc(fd().intValue(), (byte) 0, 0, hdr.address(), nextOpsId());
+            byte opCode = ops.opcode();
+            writeId = registration().submit(ops);
+            writeOpCode = opCode;
+            if (writeId == 0) {
+                return 0;
+            }
+            return 1;
         }
+        // Should not use sendmsg_zc, just use normal writev.
+        return super.scheduleWriteMultiple(in);
+    }
 
-        private boolean handleWriteCompleteZeroCopy(byte op, ChannelOutboundBuffer channelOutboundBuffer,
-                                                    int res, int flags) {
-            if ((flags & Native.IORING_CQE_F_NOTIF) == 0) {
-                // We only want to reset these if IORING_CQE_F_NOTIF is not set.
-                // If it's set we know this is only an extra notification for a write but we already handled
-                // the write completions before.
-                // See https://man7.org/linux/man-pages/man2/io_uring_enter.2.html section: IORING_OP_SEND_ZC
-                writeId = 0;
-                writeOpCode = 0;
+    @Override
+    boolean writeComplete0(byte op, int res, int flags, short data, int outstanding) {
+        ChannelOutboundBuffer channelOutboundBuffer = outboundBuffer();
+        if (op == Native.IORING_OP_SEND_ZC || op == Native.IORING_OP_SENDMSG_ZC) {
+            return handleWriteCompleteZeroCopy(op, channelOutboundBuffer, res, flags);
+        }
+        return super.writeComplete0(op, res, flags, data, outstanding);
+    }
 
-                boolean more = (flags & Native.IORING_CQE_F_MORE) != 0;
-                if (more) {
-                    // This is the result of send_sz or sendmsg_sc but there will also be another notification
-                    // which will let us know that we can release the buffer(s). In this case let's retain the
-                    // buffer(s) once and store it in an internal queue. Once we receive the notification we will
-                    // call release() on the buffer(s) as it's not used by the kernel anymore.
-                    if (zcWriteQueue == null) {
-                        zcWriteQueue = new ArrayDeque<>(8);
-                    }
+    private boolean handleWriteCompleteZeroCopy(byte op, ChannelOutboundBuffer channelOutboundBuffer,
+                                                int res, int flags) {
+        if ((flags & Native.IORING_CQE_F_NOTIF) == 0) {
+            // We only want to reset these if IORING_CQE_F_NOTIF is not set.
+            // If it's set we know this is only an extra notification for a write but we already handled
+            // the write completions before.
+            // See https://man7.org/linux/man-pages/man2/io_uring_enter.2.html section: IORING_OP_SEND_ZC
+            writeId = 0;
+            writeOpCode = 0;
+
+            boolean more = (flags & Native.IORING_CQE_F_MORE) != 0;
+            if (more) {
+                // This is the result of send_sz or sendmsg_sc but there will also be another notification
+                // which will let us know that we can release the buffer(s). In this case let's retain the
+                // buffer(s) once and store it in an internal queue. Once we receive the notification we will
+                // call release() on the buffer(s) as it's not used by the kernel anymore.
+                if (zcWriteQueue == null) {
+                    zcWriteQueue = new ArrayDeque<>(8);
                 }
-                if (res >= 0) {
-                    if (more) {
+            }
+            if (res >= 0) {
+                if (more) {
 
-                        // Loop through all the buffers that were part of the operation so we can add them to our
-                        // internal queue to release later.
-                        do {
-                            ByteBuf currentBuffer = (ByteBuf) channelOutboundBuffer.current();
-                            assert currentBuffer != null;
-                            zcWriteQueue.add(currentBuffer);
-                            currentBuffer.retain();
-                            int readable = currentBuffer.readableBytes();
-                            int skip = Math.min(readable, res);
-                            currentBuffer.skipBytes(skip);
-                            channelOutboundBuffer.progress(readable);
-                            if (readable <= res) {
-                                boolean removed = channelOutboundBuffer.remove();
-                                assert removed;
-                            }
-                            res -= readable;
-                        } while (res > 0);
-                        // Add the marker so we know when we need to stop releasing
+                    // Loop through all the buffers that were part of the operation so we can add them to our
+                    // internal queue to release later.
+                    do {
+                        ByteBuf currentBuffer = (ByteBuf) channelOutboundBuffer.current();
+                        assert currentBuffer != null;
+                        zcWriteQueue.add(currentBuffer);
+                        currentBuffer.retain();
+                        int readable = currentBuffer.readableBytes();
+                        int skip = Math.min(readable, res);
+                        currentBuffer.skipBytes(skip);
+                        channelOutboundBuffer.progress(readable);
+                        if (readable <= res) {
+                            boolean removed = channelOutboundBuffer.remove();
+                            assert removed;
+                        }
+                        res -= readable;
+                    } while (res > 0);
+                    // Add the marker so we know when we need to stop releasing
+                    zcWriteQueue.add(ZC_BATCH_MARKER);
+                } else {
+                    // We don't expect any extra notification, just directly let the buffer be released.
+                    channelOutboundBuffer.removeBytes(res);
+                }
+                return true;
+            } else {
+                if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
+                    if (more) {
+                        // The send was cancelled but we expect another notification. Just add the marker to the
+                        // queue so we don't get into trouble once the final notification for this operation is
+                        // received.
                         zcWriteQueue.add(ZC_BATCH_MARKER);
-                    } else {
-                        // We don't expect any extra notification, just directly let the buffer be released.
-                        channelOutboundBuffer.removeBytes(res);
                     }
                     return true;
-                } else {
-                    if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
-                        if (more) {
-                            // The send was cancelled but we expect another notification. Just add the marker to the
-                            // queue so we don't get into trouble once the final notification for this operation is
-                            // received.
-                            zcWriteQueue.add(ZC_BATCH_MARKER);
-                        }
-                        return true;
-                    }
-                    try {
-                        String msg = op == Native.IORING_OP_SEND_ZC ? "io_uring sendzc" : "io_uring sendmsg_zc";
-                        int result = ioResult(msg, res);
-                        if (more) {
-                            try {
-                                // We expect another notification so we need to ensure we retain these buffers
-                                // so we can release these once we see IORING_CQE_F_NOTIF set.
-                                addFlushedToZcWriteQueue(channelOutboundBuffer);
-                            } catch (Exception e) {
-                                // should never happen but let's handle it anyway.
-                                handleWriteError(e);
-                            }
-                        }
-                        if (result == 0) {
-                            return false;
-                        }
-                    } catch (Throwable cause) {
-                        if (more) {
-                            try {
-                                // We expect another notification as handleWriteError(...) will fail all flushed writes
-                                // and also release any buffers we need to ensure we retain these buffers
-                                // so we can release these once we see IORING_CQE_F_NOTIF set.
-                                addFlushedToZcWriteQueue(channelOutboundBuffer);
-                            } catch (Exception e) {
-                                // should never happen but let's handle it anyway.
-                                cause.addSuppressed(e);
-                            }
-                        }
-                        handleWriteError(cause);
-                    }
                 }
-            } else {
-                if (zcWriteQueue != null) {
-                    for (;;) {
-                        Object queued = zcWriteQueue.remove();
-                        assert queued != null;
-                        if (queued == ZC_BATCH_MARKER) {
-                            // Done releasing the buffers of the zero-copy batch.
-                            break;
+                try {
+                    String msg = op == Native.IORING_OP_SEND_ZC ? "io_uring sendzc" : "io_uring sendmsg_zc";
+                    int result = ioResult(msg, res);
+                    if (more) {
+                        try {
+                            // We expect another notification so we need to ensure we retain these buffers
+                            // so we can release these once we see IORING_CQE_F_NOTIF set.
+                            addFlushedToZcWriteQueue(channelOutboundBuffer);
+                        } catch (Exception e) {
+                            // should never happen but let's handle it anyway.
+                            handleWriteError(e);
                         }
-                        // The buffer can now be released.
-                        ((ByteBuf) queued).release();
                     }
-                }
-            }
-            return true;
-        }
-
-        private void addFlushedToZcWriteQueue(ChannelOutboundBuffer channelOutboundBuffer) throws Exception {
-            // We expect another notification as handleWriteError(...) will fail all flushed writes
-            // and also release any buffers we need to ensure we retain these buffers
-            // so we can release these once we see IORING_CQE_F_NOTIF set.
-            try {
-                channelOutboundBuffer.forEachFlushedMessage(m -> {
-                    if (!(m instanceof ByteBuf)) {
+                    if (result == 0) {
                         return false;
                     }
-                    zcWriteQueue.add(m);
-                    ((ByteBuf) m).retain();
-                    return true;
-                });
-            } finally {
-                zcWriteQueue.add(ZC_BATCH_MARKER);
+                } catch (Throwable cause) {
+                    if (more) {
+                        try {
+                            // We expect another notification as handleWriteError(...) will fail all flushed writes
+                            // and also release any buffers we need to ensure we retain these buffers
+                            // so we can release these once we see IORING_CQE_F_NOTIF set.
+                            addFlushedToZcWriteQueue(channelOutboundBuffer);
+                        } catch (Exception e) {
+                            // should never happen but let's handle it anyway.
+                            cause.addSuppressed(e);
+                        }
+                    }
+                    handleWriteError(cause);
+                }
             }
+        } else {
+            if (zcWriteQueue != null) {
+                for (;;) {
+                    Object queued = zcWriteQueue.remove();
+                    assert queued != null;
+                    if (queued == ZC_BATCH_MARKER) {
+                        // Done releasing the buffers of the zero-copy batch.
+                        break;
+                    }
+                    // The buffer can now be released.
+                    ((ByteBuf) queued).release();
+                }
+            }
+        }
+        return true;
+    }
+
+    private void addFlushedToZcWriteQueue(ChannelOutboundBuffer channelOutboundBuffer) throws Exception {
+        // We expect another notification as handleWriteError(...) will fail all flushed writes
+        // and also release any buffers we need to ensure we retain these buffers
+        // so we can release these once we see IORING_CQE_F_NOTIF set.
+        try {
+            channelOutboundBuffer.forEachFlushedMessage(m -> {
+                if (!(m instanceof ByteBuf)) {
+                    return false;
+                }
+                zcWriteQueue.add(m);
+                ((ByteBuf) m).retain();
+                return true;
+            });
+        } finally {
+            zcWriteQueue.add(ZC_BATCH_MARKER);
         }
     }
 }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
@@ -36,7 +36,6 @@ import io.netty.channel.socket.SocketChannelConfig;
 import io.netty.channel.unix.FileDescriptor;
 import io.netty.channel.unix.UnixChannel;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.internal.UnstableApi;
 
 import java.io.IOException;
 import java.net.ConnectException;
@@ -61,6 +60,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
     private ChannelPromise connectPromise;
     private SocketAddress requestedRemoteAddress;
 
+    private final KQueueIoHandle ioHandle = new KQueueIoHandleImpl();
     final BsdSocket socket;
     private IoRegistration registration;
     private boolean readFilterEnabled;
@@ -184,8 +184,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
     @Override
     protected final void doBeginRead() throws Exception {
         // Channel.read() or ChannelHandlerContext.read() was called
-        final AbstractKQueueUnsafe unsafe = (AbstractKQueueUnsafe) unsafe();
-        unsafe.readPending = true;
+        readPending = true;
 
         // We must set the read flag here as it is possible the user didn't read in the last read loop, the
         // executeReadReadyRunnable could read nothing, and if the user doesn't explicitly call read they will
@@ -195,7 +194,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
 
     @Override
     protected void doRegister(ChannelPromise promise) {
-        executor().register((AbstractKQueueUnsafe) unsafe()).addListener(f -> {
+        executor().register(ioHandle).addListener(f -> {
             if (f.isSuccess()) {
                 this.registration = (IoRegistration) f.getNow();
                 // Just in case the previous EventLoop was shutdown abruptly, or an event is still pending on the old
@@ -218,9 +217,6 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
             }
         });
     }
-
-    @Override
-    protected abstract AbstractKQueueUnsafe newUnsafe();
 
     @Override
     public abstract KQueueChannelConfig config();
@@ -278,7 +274,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
     protected final int doReadBytes(ByteBuf byteBuf) throws Exception {
         int writerIndex = byteBuf.writerIndex();
         int localReadAmount;
-        ((AbstractUnsafe) unsafe()).recvBufAllocHandle().attemptedBytesRead(byteBuf.writableBytes());
+        recvBufAllocHandle().attemptedBytesRead(byteBuf.writableBytes());
         if (byteBuf.hasMemoryAddress()) {
             localReadAmount = socket.readAddress(byteBuf.memoryAddress(), writerIndex, byteBuf.capacity());
         } else {
@@ -328,17 +324,16 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
         // Only clear if registered with an EventLoop as otherwise
         if (isRegistered()) {
             final EventLoop loop = executor();
-            final AbstractKQueueUnsafe unsafe = (AbstractKQueueUnsafe) unsafe();
             if (loop.inEventLoop()) {
-                unsafe.clearReadFilter0();
+                clearReadFilter0();
             } else {
                 // schedule a task to clear the EPOLLIN as it is not safe to modify it directly
                 loop.execute(new Runnable() {
                     @Override
                     public void run() {
-                        if (!unsafe.readPending && !config().isAutoRead()) {
+                        if (!readPending && !config().isAutoRead()) {
                             // Still no read triggered so clear it now
-                            unsafe.clearReadFilter0();
+                            clearReadFilter0();
                         }
                     }
                 });
@@ -387,15 +382,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
         return writeFilterEnabled;
     }
 
-    @UnstableApi
-    public abstract class AbstractKQueueUnsafe extends AbstractUnsafe implements KQueueIoHandle {
-        boolean readPending;
-        private KQueueRecvByteAllocatorHandle allocHandle;
-
-        Channel channel() {
-            return AbstractKQueueChannel.this;
-        }
-
+    private final class KQueueIoHandleImpl  implements KQueueIoHandle {
         @Override
         public int ident() {
             return fd().intValue();
@@ -403,7 +390,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
 
         @Override
         public void close() {
-            close(newPromise());
+            ioTransport().close(newPromise());
         }
 
         @Override
@@ -420,8 +407,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
                 writeReady();
             } else if (filter == Native.EVFILT_READ) {
                 // Check READ before EOF to ensure all data is read before shutting down the input.
-                KQueueRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
-                readReady(allocHandle);
+                readReady();
             } else if (filter == Native.EVFILT_SOCK && (fflags & Native.NOTE_RDHUP) != 0) {
                 readEOF();
                 return;
@@ -434,158 +420,163 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
                 readEOF();
             }
         }
+    }
 
-        abstract void readReady(KQueueRecvByteAllocatorHandle allocHandle);
+    boolean readPending;
+    private KQueueRecvByteAllocatorHandle allocHandle;
 
-        final boolean shouldStopReading(ChannelConfig config) {
-            // Check if there is a readPending which was not processed yet.
-            // This could be for two reasons:
-            // * The user called Channel.read() or ChannelHandlerContext.read() in channelRead(...) method
-            // * The user called Channel.read() or ChannelHandlerContext.read() in channelReadComplete(...) method
-            //
-            // See https://github.com/netty/netty/issues/2254
-            return !readPending && !config.isAutoRead();
-        }
+    final void readReady() {
+        // Check READ before EOF to ensure all data is read before shutting down the input.
+        KQueueRecvByteAllocatorHandle allocHandle = (KQueueRecvByteAllocatorHandle) recvBufAllocHandle();
+        readReady(allocHandle);
+    }
 
-        final boolean failConnectPromise(Throwable cause) {
-            if (connectPromise != null) {
-                // SO_ERROR has been shown to return 0 on macOS if detect an error via read() and the write filter was
-                // not set before calling connect. This means finishConnect will not detect any error and would
-                // successfully complete the connectPromise and update the channel state to active (which is incorrect).
-                ChannelPromise connectPromise = AbstractKQueueChannel.this.connectPromise;
-                AbstractKQueueChannel.this.connectPromise = null;
-                if (connectPromise.tryFailure((cause instanceof ConnectException) ? cause
-                                : new ConnectException("failed to connect").initCause(cause))) {
-                    closeIfClosed();
-                    return true;
-                }
-            }
-            return false;
-        }
+    abstract void readReady(KQueueRecvByteAllocatorHandle allocHandle);
 
-        private void writeReady() {
-            if (connectPromise != null) {
-                // pending connect which is now complete so handle it.
-                finishConnect();
-            } else if (!socket.isOutputShutdown()) {
-                // directly call writeFlushedNow() to force a flush now
-                writeFlushedNow();
-            }
-        }
+    final boolean shouldStopReading(ChannelConfig config) {
+        // Check if there is a readPending which was not processed yet.
+        // This could be for two reasons:
+        // * The user called Channel.read() or ChannelHandlerContext.read() in channelRead(...) method
+        // * The user called Channel.read() or ChannelHandlerContext.read() in channelReadComplete(...) method
+        //
+        // See https://github.com/netty/netty/issues/2254
+        return !readPending && !config.isAutoRead();
+    }
 
-        /**
-         * Shutdown the input side of the channel.
-         */
-        void shutdownInput(boolean readEOF) {
-            // We need to take special care of calling finishConnect() if readEOF is true and we not
-            // fulfilled the connectPromise yet. If we fail to do so the connectPromise will be failed
-            // with a ClosedChannelException as a close() will happen and so the FD is closed before we
-            // have a chance to call finishConnect() later on. Calling finishConnect() here will ensure
-            // we observe the correct exception in case of a connect failure.
-            if (readEOF && connectPromise != null) {
-                finishConnect();
-            }
-            if (!socket.isInputShutdown()) {
-                if (isAllowHalfClosure(config())) {
-                    try {
-                        socket.shutdown(true, false);
-                    } catch (IOException ignored) {
-                        // We attempted to shutdown and failed, which means the input has already effectively been
-                        // shutdown.
-                        fireEventAndClose(ChannelInputShutdownEvent.INSTANCE);
-                        return;
-                    } catch (NotYetConnectedException ignore) {
-                        // We attempted to shutdown and failed, which means the input has already effectively been
-                        // shutdown.
-                    }
-                    if (shouldStopReading(config())) {
-                        clearReadFilter0();
-                    }
-                    pipeline().fireUserEventTriggered(ChannelInputShutdownEvent.INSTANCE);
-                } else {
-                    close(newPromise());
-                    return;
-                }
-            }
-            if (!readEOF && !inputClosedSeenErrorOnRead) {
-                inputClosedSeenErrorOnRead = true;
-                pipeline().fireUserEventTriggered(ChannelInputShutdownReadComplete.INSTANCE);
-            }
-        }
-
-        private void readEOF() {
-            // This must happen before we attempt to read. This will ensure reading continues until an error occurs.
-            final KQueueRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
-            allocHandle.readEOF();
-
-            if (isActive()) {
-                // If it is still active, we need to call readReady as otherwise we may miss to
-                // read pending data from the underlying file descriptor.
-                // See https://github.com/netty/netty/issues/3709
-                readReady(allocHandle);
-            } else {
-                // Just to be safe make sure the input marked as closed.
-                shutdownInput(true);
-            }
-
-            // Clear the RDHUP flag to prevent continuously getting woken up on this event.
-            clearRdHup0();
-        }
-
-        @Override
-        public KQueueRecvByteAllocatorHandle recvBufAllocHandle() {
-            if (allocHandle == null) {
-                allocHandle = new KQueueRecvByteAllocatorHandle(
-                        (RecvByteBufAllocator.ExtendedHandle) super.recvBufAllocHandle());
-            }
-            return allocHandle;
-        }
-
-        protected final void clearReadFilter0() {
-            assert executor().inEventLoop();
-            readPending = false;
-            readFilter(false);
-        }
-
-        private void fireEventAndClose(Object evt) {
-            pipeline().fireUserEventTriggered(evt);
-            close(newPromise());
-        }
-
-        private void finishConnect() {
-            // Note this method is invoked by the event loop only if the connection attempt was
-            // neither cancelled nor timed out.
-
-            assert executor().inEventLoop();
-            assert connectPromise != null;
-            ChannelPromise promise = connectPromise;
-            final boolean connected;
-            try {
-                connected = doFinishConnect();
-            } catch (Throwable cause) {
-                connectPromise = null;
-                promise.setFailure(cause);
-                return;
-            }
-            if (connected) {
-                active = true;
-                connectPromise = null;
-                promise.setSuccess();
-            }
-        }
-
-        private boolean doFinishConnect() throws Exception {
-            if (socket.finishConnect()) {
-                writeFilter(false);
-                if (requestedRemoteAddress instanceof InetSocketAddress) {
-                    remote = computeRemoteAddr((InetSocketAddress) requestedRemoteAddress, socket.remoteAddress());
-                }
-                requestedRemoteAddress = null;
+    final boolean failConnectPromise(Throwable cause) {
+        if (connectPromise != null) {
+            // SO_ERROR has been shown to return 0 on macOS if detect an error via read() and the write filter was
+            // not set before calling connect. This means finishConnect will not detect any error and would
+            // successfully complete the connectPromise and update the channel state to active (which is incorrect).
+            ChannelPromise connectPromise = AbstractKQueueChannel.this.connectPromise;
+            AbstractKQueueChannel.this.connectPromise = null;
+            if (connectPromise.tryFailure((cause instanceof ConnectException) ? cause
+                            : new ConnectException("failed to connect").initCause(cause))) {
                 return true;
             }
-            writeFilter(true);
-            return false;
         }
+        return false;
+    }
+
+    private void writeReady() {
+        if (connectPromise != null) {
+            // pending connect which is now complete so handle it.
+            finishConnect();
+        } else if (!socket.isOutputShutdown()) {
+            // directly call writeFlushedNow() to force a flush now
+            writeFlushedNow();
+        }
+    }
+
+    /**
+     * Shutdown the input side of the channel.
+     */
+    void shutdownInput(boolean readEOF) {
+        // We need to take special care of calling finishConnect() if readEOF is true and we not
+        // fulfilled the connectPromise yet. If we fail to do so the connectPromise will be failed
+        // with a ClosedChannelException as a close() will happen and so the FD is closed before we
+        // have a chance to call finishConnect() later on. Calling finishConnect() here will ensure
+        // we observe the correct exception in case of a connect failure.
+        if (readEOF && connectPromise != null) {
+            finishConnect();
+        }
+        if (!socket.isInputShutdown()) {
+            if (isAllowHalfClosure(config())) {
+                try {
+                    socket.shutdown(true, false);
+                } catch (IOException ignored) {
+                    // We attempted to shutdown and failed, which means the input has already effectively been
+                    // shutdown.
+                    fireEventAndClose(ChannelInputShutdownEvent.INSTANCE);
+                    return;
+                } catch (NotYetConnectedException ignore) {
+                    // We attempted to shutdown and failed, which means the input has already effectively been
+                    // shutdown.
+                }
+                if (shouldStopReading(config())) {
+                    clearReadFilter0();
+                }
+                pipeline().fireUserEventTriggered(ChannelInputShutdownEvent.INSTANCE);
+            } else {
+                close(newPromise());
+                return;
+            }
+        }
+        if (!readEOF && !inputClosedSeenErrorOnRead) {
+            inputClosedSeenErrorOnRead = true;
+            pipeline().fireUserEventTriggered(ChannelInputShutdownReadComplete.INSTANCE);
+        }
+    }
+
+    private void readEOF() {
+        // This must happen before we attempt to read. This will ensure reading continues until an error occurs.
+        final KQueueRecvByteAllocatorHandle allocHandle = (KQueueRecvByteAllocatorHandle) recvBufAllocHandle();
+        allocHandle.readEOF();
+
+        if (isActive()) {
+            // If it is still active, we need to call readReady as otherwise we may miss to
+            // read pending data from the underlying file descriptor.
+            // See https://github.com/netty/netty/issues/3709
+            readReady(allocHandle);
+        } else {
+            // Just to be safe make sure the input marked as closed.
+            shutdownInput(true);
+        }
+
+        // Clear the RDHUP flag to prevent continuously getting woken up on this event.
+        clearRdHup0();
+    }
+
+    @Override
+    protected RecvByteBufAllocator.Handle newRecvBufAllocHandle() {
+        return new KQueueRecvByteAllocatorHandle(
+                (RecvByteBufAllocator.ExtendedHandle) super.newRecvBufAllocHandle());
+    }
+
+    protected final void clearReadFilter0() {
+        assert executor().inEventLoop();
+        readPending = false;
+        readFilter(false);
+    }
+
+    private void fireEventAndClose(Object evt) {
+        pipeline().fireUserEventTriggered(evt);
+        close(newPromise());
+    }
+
+    private void finishConnect() {
+        // Note this method is invoked by the event loop only if the connection attempt was
+        // neither cancelled nor timed out.
+
+        assert executor().inEventLoop();
+        assert connectPromise != null;
+        ChannelPromise promise = connectPromise;
+        final boolean connected;
+        try {
+            connected = doFinishConnect();
+        } catch (Throwable cause) {
+            connectPromise = null;
+            promise.setFailure(cause);
+            return;
+        }
+        if (connected) {
+            active = true;
+            connectPromise = null;
+            promise.setSuccess();
+        }
+    }
+
+    private boolean doFinishConnect() throws Exception {
+        if (socket.finishConnect()) {
+            writeFilter(false);
+            if (requestedRemoteAddress instanceof InetSocketAddress) {
+                remote = computeRemoteAddr((InetSocketAddress) requestedRemoteAddress, socket.remoteAddress());
+            }
+            requestedRemoteAddress = null;
+            return true;
+        }
+        writeFilter(true);
+        return false;
     }
 
     @Override

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueServerChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueServerChannel.java
@@ -32,6 +32,11 @@ public abstract class AbstractKQueueServerChannel extends AbstractKQueueChannel 
 
     private final EventLoopGroup childEventLoopGroup;
 
+    // Will hold the remote address after accept(...) was successful.
+    // We need 24 bytes for the address as maximum + 1 byte for storing the capacity.
+    // So use 26 bytes as it's a power of two.
+    private final byte[] acceptedAddress = new byte[26];
+
     AbstractKQueueServerChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup, BsdSocket fd) {
         this(eventLoop, childEventLoopGroup, fd, isSoErrorZero(fd));
     }
@@ -58,11 +63,6 @@ public abstract class AbstractKQueueServerChannel extends AbstractKQueueChannel 
     }
 
     @Override
-    protected AbstractKQueueUnsafe newUnsafe() {
-        return new KQueueServerSocketUnsafe();
-    }
-
-    @Override
     protected void doWrite(ChannelOutboundBuffer in) throws Exception {
         throw new UnsupportedOperationException();
     }
@@ -79,54 +79,47 @@ public abstract class AbstractKQueueServerChannel extends AbstractKQueueChannel 
         throw new UnsupportedOperationException();
     }
 
-    final class KQueueServerSocketUnsafe extends AbstractKQueueUnsafe {
-        // Will hold the remote address after accept(...) was successful.
-        // We need 24 bytes for the address as maximum + 1 byte for storing the capacity.
-        // So use 26 bytes as it's a power of two.
-        private final byte[] acceptedAddress = new byte[26];
+    @Override
+    void readReady(KQueueRecvByteAllocatorHandle allocHandle) {
+        assert executor().inEventLoop();
+        final ChannelConfig config = config();
+        if (shouldBreakReadReady(config)) {
+            clearReadFilter0();
+            return;
+        }
+        final ChannelPipeline pipeline = pipeline();
+        allocHandle.reset(config);
+        allocHandle.attemptedBytesRead(1);
 
-        @Override
-        void readReady(KQueueRecvByteAllocatorHandle allocHandle) {
-            assert executor().inEventLoop();
-            final ChannelConfig config = config();
-            if (shouldBreakReadReady(config)) {
-                clearReadFilter0();
-                return;
-            }
-            final ChannelPipeline pipeline = pipeline();
-            allocHandle.reset(config);
-            allocHandle.attemptedBytesRead(1);
-
-            Throwable exception = null;
+        Throwable exception = null;
+        try {
             try {
-                try {
-                    do {
-                        int acceptFd = socket.accept(acceptedAddress);
-                        if (acceptFd == -1) {
-                            // this means everything was handled for now
-                            allocHandle.lastBytesRead(-1);
-                            break;
-                        }
-                        allocHandle.lastBytesRead(1);
-                        allocHandle.incMessagesRead(1);
+                do {
+                    int acceptFd = socket.accept(acceptedAddress);
+                    if (acceptFd == -1) {
+                        // this means everything was handled for now
+                        allocHandle.lastBytesRead(-1);
+                        break;
+                    }
+                    allocHandle.lastBytesRead(1);
+                    allocHandle.incMessagesRead(1);
 
-                        readPending = false;
-                        pipeline.fireChannelRead(newChildChannel(childEventExecutorGroup().next(),
-                                acceptFd, acceptedAddress, 1, acceptedAddress[0]));
-                    } while (allocHandle.continueReading());
-                } catch (Throwable t) {
-                    exception = t;
-                }
-                allocHandle.readComplete();
-                pipeline.fireChannelReadComplete();
+                    readPending = false;
+                    pipeline.fireChannelRead(newChildChannel(childEventExecutorGroup().next(),
+                            acceptFd, acceptedAddress, 1, acceptedAddress[0]));
+                } while (allocHandle.continueReading());
+            } catch (Throwable t) {
+                exception = t;
+            }
+            allocHandle.readComplete();
+            pipeline.fireChannelReadComplete();
 
-                if (exception != null) {
-                    pipeline.fireExceptionCaught(exception);
-                }
-            } finally {
-                if (shouldStopReading(config)) {
-                    clearReadFilter0();
-                }
+            if (exception != null) {
+                pipeline.fireExceptionCaught(exception);
+            }
+        } finally {
+            if (shouldStopReading(config)) {
+                clearReadFilter0();
             }
         }
     }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
@@ -43,7 +43,6 @@ import java.io.IOException;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
-import java.util.concurrent.Executor;
 
 import static io.netty.channel.internal.ChannelUtils.MAX_BYTES_PER_GATHERING_WRITE_ATTEMPTED_LOW_THRESHOLD;
 import static io.netty.channel.internal.ChannelUtils.WRITE_STATUS_SNDBUF_FULL;
@@ -75,11 +74,6 @@ public abstract class AbstractKQueueStreamChannel extends AbstractKQueueChannel 
 
     AbstractKQueueStreamChannel(EventLoop eventLoop, BsdSocket fd) {
         this(eventLoop, null, fd, isSoErrorZero(fd));
-    }
-
-    @Override
-    protected AbstractKQueueUnsafe newUnsafe() {
-        return new KQueueStreamUnsafe();
     }
 
     @Override
@@ -412,12 +406,12 @@ public abstract class AbstractKQueueStreamChannel extends AbstractKQueueChannel 
     public ChannelFuture shutdownOutput(final ChannelPromise promise) {
         EventLoop loop = executor();
         if (loop.inEventLoop()) {
-            ((AbstractUnsafe) unsafe()).shutdownOutput(promise);
+            shutdownOutput0(promise);
         } else {
             loop.execute(new Runnable() {
                 @Override
                 public void run() {
-                    ((AbstractUnsafe) unsafe()).shutdownOutput(promise);
+                    shutdownOutput0(promise);
                 }
             });
         }
@@ -508,102 +502,94 @@ public abstract class AbstractKQueueStreamChannel extends AbstractKQueueChannel 
         }
     }
 
-    class KQueueStreamUnsafe extends AbstractKQueueUnsafe {
-        // Overridden here just to be able to access this method from AbstractKQueueStreamChannel
-        @Override
-        protected Executor prepareToClose() {
-            return super.prepareToClose();
+    @Override
+    void readReady(final KQueueRecvByteAllocatorHandle allocHandle) {
+        final ChannelConfig config = config();
+        if (shouldBreakReadReady(config)) {
+            clearReadFilter0();
+            return;
         }
+        final ChannelPipeline pipeline = pipeline();
+        final ByteBufAllocator allocator = config.getAllocator();
+        allocHandle.reset(config);
 
-        @Override
-        void readReady(final KQueueRecvByteAllocatorHandle allocHandle) {
-            final ChannelConfig config = config();
-            if (shouldBreakReadReady(config)) {
-                clearReadFilter0();
-                return;
-            }
-            final ChannelPipeline pipeline = pipeline();
-            final ByteBufAllocator allocator = config.getAllocator();
-            allocHandle.reset(config);
-
-            ByteBuf byteBuf = null;
-            boolean close = false;
-            try {
-                do {
-                    // we use a direct buffer here as the native implementations only be able
-                    // to handle direct buffers.
-                    byteBuf = allocHandle.allocate(allocator);
-                    allocHandle.lastBytesRead(doReadBytes(byteBuf));
-                    if (allocHandle.lastBytesRead() <= 0) {
-                        // nothing was read, release the buffer.
-                        byteBuf.release();
-                        byteBuf = null;
-                        close = allocHandle.lastBytesRead() < 0;
-                        if (close) {
-                            // There is nothing left to read as we received an EOF.
-                            readPending = false;
-                        }
-                        break;
-                    }
-                    allocHandle.incMessagesRead(1);
-                    readPending = false;
-                    pipeline.fireChannelRead(byteBuf);
-                    byteBuf = null;
-
-                    if (shouldBreakReadReady(config)) {
-                        // We need to do this for two reasons:
-                        //
-                        // - If the input was shutdown in between (which may be the case when the user did it in the
-                        //   fireChannelRead(...) method we should not try to read again to not produce any
-                        //   miss-leading exceptions.
-                        //
-                        // - If the user closes the channel we need to ensure we not try to read from it again as
-                        //   the filedescriptor may be re-used already by the OS if the system is handling a lot of
-                        //   concurrent connections and so needs a lot of filedescriptors. If not do this we risk
-                        //   reading data from a filedescriptor that belongs to another socket then the socket that
-                        //   was "wrapped" by this Channel implementation.
-                        break;
-                    }
-                } while (allocHandle.continueReading());
-
-                allocHandle.readComplete();
-                pipeline.fireChannelReadComplete();
-
-                if (close) {
-                    shutdownInput(false);
-                }
-            } catch (Throwable t) {
-                handleReadException(pipeline, byteBuf, t, close, allocHandle);
-            } finally {
-                if (shouldStopReading(config)) {
-                    clearReadFilter0();
-                }
-            }
-        }
-
-        private void handleReadException(ChannelPipeline pipeline, ByteBuf byteBuf, Throwable cause, boolean close,
-                                         KQueueRecvByteAllocatorHandle allocHandle) {
-            if (byteBuf != null) {
-                if (byteBuf.isReadable()) {
-                    readPending = false;
-                    pipeline.fireChannelRead(byteBuf);
-                } else {
+        ByteBuf byteBuf = null;
+        boolean close = false;
+        try {
+            do {
+                // we use a direct buffer here as the native implementations only be able
+                // to handle direct buffers.
+                byteBuf = allocHandle.allocate(allocator);
+                allocHandle.lastBytesRead(doReadBytes(byteBuf));
+                if (allocHandle.lastBytesRead() <= 0) {
+                    // nothing was read, release the buffer.
                     byteBuf.release();
+                    byteBuf = null;
+                    close = allocHandle.lastBytesRead() < 0;
+                    if (close) {
+                        // There is nothing left to read as we received an EOF.
+                        readPending = false;
+                    }
+                    break;
                 }
-            }
-            if (!failConnectPromise(cause)) {
-                allocHandle.readComplete();
-                pipeline.fireChannelReadComplete();
-                pipeline.fireExceptionCaught(cause);
+                allocHandle.incMessagesRead(1);
+                readPending = false;
+                pipeline.fireChannelRead(byteBuf);
+                byteBuf = null;
 
-                // If oom will close the read event, release connection.
-                // See https://github.com/netty/netty/issues/10434
-                if (close ||
-                        cause instanceof OutOfMemoryError ||
-                        cause instanceof LeakPresenceDetector.AllocationProhibitedException ||
-                        cause instanceof IOException) {
-                    shutdownInput(false);
+                if (shouldBreakReadReady(config)) {
+                    // We need to do this for two reasons:
+                    //
+                    // - If the input was shutdown in between (which may be the case when the user did it in the
+                    //   fireChannelRead(...) method we should not try to read again to not produce any
+                    //   miss-leading exceptions.
+                    //
+                    // - If the user closes the channel we need to ensure we not try to read from it again as
+                    //   the filedescriptor may be re-used already by the OS if the system is handling a lot of
+                    //   concurrent connections and so needs a lot of filedescriptors. If not do this we risk
+                    //   reading data from a filedescriptor that belongs to another socket then the socket that
+                    //   was "wrapped" by this Channel implementation.
+                    break;
                 }
+            } while (allocHandle.continueReading());
+
+            allocHandle.readComplete();
+            pipeline.fireChannelReadComplete();
+
+            if (close) {
+                shutdownInput(false);
+            }
+        } catch (Throwable t) {
+            handleReadException(pipeline, byteBuf, t, close, allocHandle);
+        } finally {
+            if (shouldStopReading(config)) {
+                clearReadFilter0();
+            }
+        }
+    }
+
+    private void handleReadException(ChannelPipeline pipeline, ByteBuf byteBuf, Throwable cause, boolean close,
+                                     KQueueRecvByteAllocatorHandle allocHandle) {
+        if (byteBuf != null) {
+            if (byteBuf.isReadable()) {
+                readPending = false;
+                pipeline.fireChannelRead(byteBuf);
+            } else {
+                byteBuf.release();
+            }
+        }
+        if (!failConnectPromise(cause)) {
+            allocHandle.readComplete();
+            pipeline.fireChannelReadComplete();
+            pipeline.fireExceptionCaught(cause);
+
+            // If oom will close the read event, release connection.
+            // See https://github.com/netty/netty/issues/10434
+            if (close ||
+                    cause instanceof OutOfMemoryError ||
+                    cause instanceof LeakPresenceDetector.AllocationProhibitedException ||
+                    cause instanceof IOException) {
+                shutdownInput(false);
             }
         }
     }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
@@ -223,11 +223,6 @@ public final class KQueueDatagramChannel extends AbstractKQueueDatagramChannel i
     }
 
     @Override
-    protected AbstractKQueueUnsafe newUnsafe() {
-        return new KQueueDatagramChannelUnsafe();
-    }
-
-    @Override
     protected void doBind(SocketAddress localAddress, ChannelPromise promise) {
         super.doBind(localAddress, newPromise().addListener(f -> {
             if (f.isSuccess()) {
@@ -367,105 +362,102 @@ public final class KQueueDatagramChannel extends AbstractKQueueDatagramChannel i
         connected = false;
     }
 
-    final class KQueueDatagramChannelUnsafe extends AbstractKQueueUnsafe {
+    @Override
+    void readReady(KQueueRecvByteAllocatorHandle allocHandle) {
+        assert executor().inEventLoop();
+        final DatagramChannelConfig config = config();
+        if (shouldBreakReadReady(config)) {
+            clearReadFilter0();
+            return;
+        }
+        final ChannelPipeline pipeline = pipeline();
+        final ByteBufAllocator allocator = config.getAllocator();
+        allocHandle.reset(config);
 
-        @Override
-        void readReady(KQueueRecvByteAllocatorHandle allocHandle) {
-            assert executor().inEventLoop();
-            final DatagramChannelConfig config = config();
-            if (shouldBreakReadReady(config)) {
-                clearReadFilter0();
-                return;
-            }
-            final ChannelPipeline pipeline = pipeline();
-            final ByteBufAllocator allocator = config.getAllocator();
-            allocHandle.reset(config);
-
-            Throwable exception = null;
+        Throwable exception = null;
+        try {
+            ByteBuf byteBuf = null;
             try {
-                ByteBuf byteBuf = null;
-                try {
-                    boolean connected = isConnected();
-                    do {
-                        byteBuf = allocHandle.allocate(allocator);
-                        allocHandle.attemptedBytesRead(byteBuf.writableBytes());
+                boolean connected = isConnected();
+                do {
+                    byteBuf = allocHandle.allocate(allocator);
+                    allocHandle.attemptedBytesRead(byteBuf.writableBytes());
 
-                        final DatagramPacket packet;
-                        if (connected) {
-                            try {
-                                allocHandle.lastBytesRead(doReadBytes(byteBuf));
-                            } catch (Errors.NativeIoException e) {
-                                // We need to correctly translate connect errors to match NIO behaviour.
-                                if (e.expectedErr() == Errors.ERROR_ECONNREFUSED_NEGATIVE) {
-                                    PortUnreachableException error = new PortUnreachableException(e.getMessage());
-                                    error.initCause(e);
-                                    throw error;
-                                }
-                                throw e;
+                    final DatagramPacket packet;
+                    if (connected) {
+                        try {
+                            allocHandle.lastBytesRead(doReadBytes(byteBuf));
+                        } catch (Errors.NativeIoException e) {
+                            // We need to correctly translate connect errors to match NIO behaviour.
+                            if (e.expectedErr() == Errors.ERROR_ECONNREFUSED_NEGATIVE) {
+                                PortUnreachableException error = new PortUnreachableException(e.getMessage());
+                                error.initCause(e);
+                                throw error;
                             }
-                            if (allocHandle.lastBytesRead() <= 0) {
-                                // nothing was read, release the buffer.
-                                byteBuf.release();
-                                byteBuf = null;
-                                break;
-                            }
-                            packet = new DatagramPacket(byteBuf,
-                                    (InetSocketAddress) localAddress(), (InetSocketAddress) remoteAddress());
+                            throw e;
+                        }
+                        if (allocHandle.lastBytesRead() <= 0) {
+                            // nothing was read, release the buffer.
+                            byteBuf.release();
+                            byteBuf = null;
+                            break;
+                        }
+                        packet = new DatagramPacket(byteBuf,
+                                (InetSocketAddress) localAddress(), (InetSocketAddress) remoteAddress());
+                    } else {
+                        final DatagramSocketAddress remoteAddress;
+                        if (byteBuf.hasMemoryAddress()) {
+                            // has a memory address so use optimized call
+                            remoteAddress = socket.recvFromAddress(byteBuf.memoryAddress(), byteBuf.writerIndex(),
+                                    byteBuf.capacity());
                         } else {
-                            final DatagramSocketAddress remoteAddress;
-                            if (byteBuf.hasMemoryAddress()) {
-                                // has a memory address so use optimized call
-                                remoteAddress = socket.recvFromAddress(byteBuf.memoryAddress(), byteBuf.writerIndex(),
-                                        byteBuf.capacity());
-                            } else {
-                                ByteBuffer nioData = byteBuf.internalNioBuffer(
-                                        byteBuf.writerIndex(), byteBuf.writableBytes());
-                                remoteAddress = socket.recvFrom(nioData, nioData.position(), nioData.limit());
-                            }
-
-                            if (remoteAddress == null) {
-                                allocHandle.lastBytesRead(-1);
-                                byteBuf.release();
-                                byteBuf = null;
-                                break;
-                            }
-                            InetSocketAddress localAddress = remoteAddress.localAddress();
-                            if (localAddress == null) {
-                                localAddress = (InetSocketAddress) localAddress();
-                            }
-                            allocHandle.lastBytesRead(remoteAddress.receivedAmount());
-                            byteBuf.writerIndex(byteBuf.writerIndex() + allocHandle.lastBytesRead());
-
-                            packet = new DatagramPacket(byteBuf, localAddress, remoteAddress);
+                            ByteBuffer nioData = byteBuf.internalNioBuffer(
+                                    byteBuf.writerIndex(), byteBuf.writableBytes());
+                            remoteAddress = socket.recvFrom(nioData, nioData.position(), nioData.limit());
                         }
 
-                        allocHandle.incMessagesRead(1);
+                        if (remoteAddress == null) {
+                            allocHandle.lastBytesRead(-1);
+                            byteBuf.release();
+                            byteBuf = null;
+                            break;
+                        }
+                        InetSocketAddress localAddress = remoteAddress.localAddress();
+                        if (localAddress == null) {
+                            localAddress = (InetSocketAddress) localAddress();
+                        }
+                        allocHandle.lastBytesRead(remoteAddress.receivedAmount());
+                        byteBuf.writerIndex(byteBuf.writerIndex() + allocHandle.lastBytesRead());
 
-                        readPending = false;
-                        pipeline.fireChannelRead(packet);
-
-                        byteBuf = null;
-
-                    // We use the TRUE_SUPPLIER as it is also ok to read less then what we did try to read (as long
-                    // as we read anything).
-                    } while (allocHandle.continueReading(UncheckedBooleanSupplier.TRUE_SUPPLIER));
-                } catch (Throwable t) {
-                    if (byteBuf != null) {
-                        byteBuf.release();
+                        packet = new DatagramPacket(byteBuf, localAddress, remoteAddress);
                     }
-                    exception = t;
-                }
 
-                allocHandle.readComplete();
-                pipeline.fireChannelReadComplete();
+                    allocHandle.incMessagesRead(1);
 
-                if (exception != null) {
-                    pipeline.fireExceptionCaught(exception);
+                    readPending = false;
+                    pipeline.fireChannelRead(packet);
+
+                    byteBuf = null;
+
+                // We use the TRUE_SUPPLIER as it is also ok to read less then what we did try to read (as long
+                // as we read anything).
+                } while (allocHandle.continueReading(UncheckedBooleanSupplier.TRUE_SUPPLIER));
+            } catch (Throwable t) {
+                if (byteBuf != null) {
+                    byteBuf.release();
                 }
-            } finally {
-                if (shouldStopReading(config)) {
-                    clearReadFilter0();
-                }
+                exception = t;
+            }
+
+            allocHandle.readComplete();
+            pipeline.fireChannelReadComplete();
+
+            if (exception != null) {
+                pipeline.fireExceptionCaught(exception);
+            }
+        } finally {
+            if (shouldStopReading(config)) {
+                clearReadFilter0();
             }
         }
     }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainDatagramChannel.java
@@ -18,7 +18,6 @@ package io.netty.channel.kqueue;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.AddressedEnvelope;
-import io.netty.channel.Channel;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultAddressedEnvelope;
@@ -225,11 +224,6 @@ public final class KQueueDomainDatagramChannel extends AbstractKQueueDatagramCha
         return local;
     }
 
-    @Override
-    protected AbstractKQueueUnsafe newUnsafe() {
-        return new KQueueDomainDatagramChannelUnsafe();
-    }
-
     /**
      * Returns the unix credentials (uid, gid, pid) of the peer
      * <a href=https://man7.org/linux/man-pages/man7/socket.7.html>SO_PEERCRED</a>
@@ -248,94 +242,91 @@ public final class KQueueDomainDatagramChannel extends AbstractKQueueDatagramCha
         return remote;
     }
 
-    final class KQueueDomainDatagramChannelUnsafe extends AbstractKQueueUnsafe {
+    @Override
+    void readReady(KQueueRecvByteAllocatorHandle allocHandle) {
+        assert executor().inEventLoop();
+        final DomainDatagramChannelConfig config = config();
+        if (shouldBreakReadReady(config)) {
+            clearReadFilter0();
+            return;
+        }
+        final ChannelPipeline pipeline = pipeline();
+        final ByteBufAllocator allocator = config.getAllocator();
+        allocHandle.reset(config);
 
-        @Override
-        void readReady(KQueueRecvByteAllocatorHandle allocHandle) {
-            assert executor().inEventLoop();
-            final DomainDatagramChannelConfig config = config();
-            if (shouldBreakReadReady(config)) {
-                clearReadFilter0();
-                return;
-            }
-            final ChannelPipeline pipeline = pipeline();
-            final ByteBufAllocator allocator = config.getAllocator();
-            allocHandle.reset(config);
-
-            Throwable exception = null;
+        Throwable exception = null;
+        try {
+            ByteBuf byteBuf = null;
             try {
-                ByteBuf byteBuf = null;
-                try {
-                    boolean connected = isConnected();
-                    do {
-                        byteBuf = allocHandle.allocate(allocator);
-                        allocHandle.attemptedBytesRead(byteBuf.writableBytes());
+                boolean connected = isConnected();
+                do {
+                    byteBuf = allocHandle.allocate(allocator);
+                    allocHandle.attemptedBytesRead(byteBuf.writableBytes());
 
-                        final DomainDatagramPacket packet;
-                        if (connected) {
-                            allocHandle.lastBytesRead(doReadBytes(byteBuf));
-                            if (allocHandle.lastBytesRead() <= 0) {
-                                // nothing was read, release the buffer.
-                                byteBuf.release();
-                                break;
-                            }
-                            packet = new DomainDatagramPacket(byteBuf, (DomainSocketAddress) localAddress(),
-                                    (DomainSocketAddress) remoteAddress());
+                    final DomainDatagramPacket packet;
+                    if (connected) {
+                        allocHandle.lastBytesRead(doReadBytes(byteBuf));
+                        if (allocHandle.lastBytesRead() <= 0) {
+                            // nothing was read, release the buffer.
+                            byteBuf.release();
+                            break;
+                        }
+                        packet = new DomainDatagramPacket(byteBuf, (DomainSocketAddress) localAddress(),
+                                (DomainSocketAddress) remoteAddress());
+                    } else {
+                        final DomainDatagramSocketAddress remoteAddress;
+                        if (byteBuf.hasMemoryAddress()) {
+                            // has a memory address so use optimized call
+                            remoteAddress = socket.recvFromAddressDomainSocket(byteBuf.memoryAddress(),
+                                    byteBuf.writerIndex(), byteBuf.capacity());
                         } else {
-                            final DomainDatagramSocketAddress remoteAddress;
-                            if (byteBuf.hasMemoryAddress()) {
-                                // has a memory address so use optimized call
-                                remoteAddress = socket.recvFromAddressDomainSocket(byteBuf.memoryAddress(),
-                                        byteBuf.writerIndex(), byteBuf.capacity());
-                            } else {
-                                ByteBuffer nioData = byteBuf.internalNioBuffer(
-                                        byteBuf.writerIndex(), byteBuf.writableBytes());
-                                remoteAddress =
-                                        socket.recvFromDomainSocket(nioData, nioData.position(), nioData.limit());
-                            }
-
-                            if (remoteAddress == null) {
-                                allocHandle.lastBytesRead(-1);
-                                byteBuf.release();
-                                break;
-                            }
-                            DomainSocketAddress localAddress = remoteAddress.localAddress();
-                            if (localAddress == null) {
-                                localAddress = (DomainSocketAddress) localAddress();
-                            }
-                            allocHandle.lastBytesRead(remoteAddress.receivedAmount());
-                            byteBuf.writerIndex(byteBuf.writerIndex() + allocHandle.lastBytesRead());
-
-                            packet = new DomainDatagramPacket(byteBuf, localAddress, remoteAddress);
+                            ByteBuffer nioData = byteBuf.internalNioBuffer(
+                                    byteBuf.writerIndex(), byteBuf.writableBytes());
+                            remoteAddress =
+                                    socket.recvFromDomainSocket(nioData, nioData.position(), nioData.limit());
                         }
 
-                        allocHandle.incMessagesRead(1);
+                        if (remoteAddress == null) {
+                            allocHandle.lastBytesRead(-1);
+                            byteBuf.release();
+                            break;
+                        }
+                        DomainSocketAddress localAddress = remoteAddress.localAddress();
+                        if (localAddress == null) {
+                            localAddress = (DomainSocketAddress) localAddress();
+                        }
+                        allocHandle.lastBytesRead(remoteAddress.receivedAmount());
+                        byteBuf.writerIndex(byteBuf.writerIndex() + allocHandle.lastBytesRead());
 
-                        readPending = false;
-                        pipeline.fireChannelRead(packet);
-
-                        byteBuf = null;
-
-                        // We use the TRUE_SUPPLIER as it is also ok to read less then what we did try to read (as long
-                        // as we read anything).
-                    } while (allocHandle.continueReading(UncheckedBooleanSupplier.TRUE_SUPPLIER));
-                } catch (Throwable t) {
-                    if (byteBuf != null) {
-                        byteBuf.release();
+                        packet = new DomainDatagramPacket(byteBuf, localAddress, remoteAddress);
                     }
-                    exception = t;
-                }
 
-                allocHandle.readComplete();
-                pipeline.fireChannelReadComplete();
+                    allocHandle.incMessagesRead(1);
 
-                if (exception != null) {
-                    pipeline.fireExceptionCaught(exception);
+                    readPending = false;
+                    pipeline.fireChannelRead(packet);
+
+                    byteBuf = null;
+
+                    // We use the TRUE_SUPPLIER as it is also ok to read less then what we did try to read (as long
+                    // as we read anything).
+                } while (allocHandle.continueReading(UncheckedBooleanSupplier.TRUE_SUPPLIER));
+            } catch (Throwable t) {
+                if (byteBuf != null) {
+                    byteBuf.release();
                 }
-            } finally {
-                if (shouldStopReading(config)) {
-                    clearReadFilter0();
-                }
+                exception = t;
+            }
+
+            allocHandle.readComplete();
+            pipeline.fireChannelReadComplete();
+
+            if (exception != null) {
+                pipeline.fireExceptionCaught(exception);
+            }
+        } finally {
+            if (shouldStopReading(config)) {
+                clearReadFilter0();
             }
         }
     }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainSocketChannel.java
@@ -53,11 +53,6 @@ public final class KQueueDomainSocketChannel extends AbstractKQueueStreamChannel
     }
 
     @Override
-    protected AbstractKQueueUnsafe newUnsafe() {
-        return new KQueueDomainUnsafe();
-    }
-
-    @Override
     protected DomainSocketAddress localAddress0() {
         return local;
     }
@@ -132,65 +127,63 @@ public final class KQueueDomainSocketChannel extends AbstractKQueueStreamChannel
         return socket.getPeerCredentials();
     }
 
-    private final class KQueueDomainUnsafe extends KQueueStreamUnsafe {
-        @Override
-        void readReady(KQueueRecvByteAllocatorHandle allocHandle) {
-            switch (config().getReadMode()) {
-                case BYTES:
-                    super.readReady(allocHandle);
-                    break;
-                case FILE_DESCRIPTORS:
-                    readReadyFd();
-                    break;
-                default:
-                    throw new Error("Unexpected read mode: " + config().getReadMode());
-            }
+    @Override
+    void readReady(KQueueRecvByteAllocatorHandle allocHandle) {
+        switch (config().getReadMode()) {
+            case BYTES:
+                super.readReady(allocHandle);
+                break;
+            case FILE_DESCRIPTORS:
+                readReadyFd();
+                break;
+            default:
+                throw new Error("Unexpected read mode: " + config().getReadMode());
         }
+    }
 
-        private void readReadyFd() {
-            if (socket.isInputShutdown()) {
-                super.clearReadFilter0();
-                return;
-            }
-            final ChannelConfig config = config();
-            final KQueueRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
+    private void readReadyFd() {
+        if (socket.isInputShutdown()) {
+            super.clearReadFilter0();
+            return;
+        }
+        final ChannelConfig config = config();
+        final KQueueRecvByteAllocatorHandle allocHandle = (KQueueRecvByteAllocatorHandle) recvBufAllocHandle();
 
-            final ChannelPipeline pipeline = pipeline();
-            allocHandle.reset(config);
+        final ChannelPipeline pipeline = pipeline();
+        allocHandle.reset(config);
 
-            try {
-                readLoop: do {
-                    // lastBytesRead represents the fd. We use lastBytesRead because it must be set so that the
-                    // KQueueRecvByteAllocatorHandle knows if it should try to read again or not when autoRead is
-                    // enabled.
-                    int recvFd = socket.recvFd();
-                    switch(recvFd) {
-                        case 0:
-                            allocHandle.lastBytesRead(0);
-                            break readLoop;
-                        case -1:
-                            allocHandle.lastBytesRead(-1);
-                            close(newPromise());
-                            return;
-                        default:
-                            allocHandle.lastBytesRead(1);
-                            allocHandle.incMessagesRead(1);
-                            readPending = false;
-                            pipeline.fireChannelRead(new FileDescriptor(recvFd));
-                            break;
-                    }
-                } while (allocHandle.continueReading());
-
-                allocHandle.readComplete();
-                pipeline.fireChannelReadComplete();
-            } catch (Throwable t) {
-                allocHandle.readComplete();
-                pipeline.fireChannelReadComplete();
-                pipeline.fireExceptionCaught(t);
-            } finally {
-                if (shouldStopReading(config)) {
-                    clearReadFilter0();
+        try {
+            readLoop: do {
+                // lastBytesRead represents the fd. We use lastBytesRead because it must be set so that the
+                // KQueueRecvByteAllocatorHandle knows if it should try to read again or not when autoRead is
+                // enabled.
+                int recvFd = socket.recvFd();
+                switch(recvFd) {
+                    case 0:
+                        allocHandle.lastBytesRead(0);
+                        break readLoop;
+                    case -1:
+                        allocHandle.lastBytesRead(-1);
+                        close(newPromise());
+                        return;
+                    default:
+                        allocHandle.lastBytesRead(1);
+                        allocHandle.incMessagesRead(1);
+                        readPending = false;
+                        pipeline.fireChannelRead(new FileDescriptor(recvFd));
+                        break;
                 }
+            } while (allocHandle.continueReading());
+
+            allocHandle.readComplete();
+            pipeline.fireChannelReadComplete();
+        } catch (Throwable t) {
+            allocHandle.readComplete();
+            pipeline.fireChannelReadComplete();
+            pipeline.fireExceptionCaught(t);
+        } finally {
+            if (shouldStopReading(config)) {
+                clearReadFilter0();
             }
         }
     }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoHandler.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoHandler.java
@@ -15,7 +15,6 @@
  */
 package io.netty.channel.kqueue;
 
-import io.netty.channel.Channel;
 import io.netty.channel.DefaultSelectStrategyFactory;
 import io.netty.channel.IoHandle;
 import io.netty.channel.IoHandler;
@@ -37,9 +36,6 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
@@ -78,7 +74,6 @@ public final class KQueueIoHandler implements IoHandler {
     private final ThreadAwareExecutor executor;
     private final Queue<DefaultKqueueIoRegistration> cancelledRegistrations = new ArrayDeque<>();
     private final LongObjectMap<DefaultKqueueIoRegistration> registrations = new LongObjectHashMap<>(4096);
-    private int numChannels;
     private long nextId;
 
     private volatile int wakenUp;
@@ -306,31 +301,8 @@ public final class KQueueIoHandler implements IoHandler {
             }
             DefaultKqueueIoRegistration removed = registrations.remove(cancelledRegistration.id);
             assert removed == cancelledRegistration;
-            if (removed.isHandleForChannel()) {
-                numChannels--;
-            }
             removed.handle.unregistered();
         }
-    }
-
-    int numRegisteredChannels() {
-        return numChannels;
-    }
-
-    List<Channel> registeredChannelsList() {
-        LongObjectMap<DefaultKqueueIoRegistration> ch = registrations;
-        if (ch.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        List<Channel> channels = new ArrayList<>(ch.size());
-
-        for (DefaultKqueueIoRegistration registration : ch.values()) {
-            if (registration.handle instanceof AbstractKQueueChannel.AbstractKQueueUnsafe) {
-                channels.add(((AbstractKQueueChannel.AbstractKQueueUnsafe) registration.handle).channel());
-            }
-        }
-        return Collections.unmodifiableList(channels);
     }
 
     private static void handleLoopException(Throwable t) {
@@ -395,9 +367,6 @@ public final class KQueueIoHandler implements IoHandler {
             registrations.put(old.id, old);
             throw new IllegalStateException();
         }
-        if (registration.isHandleForChannel()) {
-            numChannels++;
-        }
         handle.registered();
         return registration;
     }
@@ -434,10 +403,6 @@ public final class KQueueIoHandler implements IoHandler {
             this.executor = executor;
             this.handle = handle;
             id = generateNextId();
-        }
-
-        boolean isHandleForChannel() {
-            return handle instanceof AbstractKQueueChannel.AbstractKQueueUnsafe;
         }
 
         @SuppressWarnings("unchecked")

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannel.java
@@ -92,30 +92,23 @@ public final class KQueueSocketChannel extends AbstractKQueueStreamChannel imple
     }
 
     @Override
-    protected AbstractKQueueUnsafe newUnsafe() {
-        return new KQueueSocketChannelUnsafe();
-    }
-
-    private final class KQueueSocketChannelUnsafe extends KQueueStreamUnsafe {
-        @Override
-        protected Executor prepareToClose() {
-            try {
-                // Check isOpen() first as otherwise it will throw a RuntimeException
-                // when call getSoLinger() as the fd is not valid anymore.
-                if (isOpen() && config().getSoLinger() > 0) {
-                    // We need to cancel this key of the channel so we may not end up in a eventloop spin
-                    // because we try to read or write until the actual close happens which may be later due
-                    // SO_LINGER handling.
-                    // See https://github.com/netty/netty/issues/4449
-                    doDeregister(newPromise());
-                    return GlobalEventExecutor.INSTANCE;
-                }
-            } catch (Throwable ignore) {
-                // Ignore the error as the underlying channel may be closed in the meantime and so
-                // getSoLinger() may produce an exception. In this case we just return null.
+    protected Executor prepareToClose() {
+        try {
+            // Check isOpen() first as otherwise it will throw a RuntimeException
+            // when call getSoLinger() as the fd is not valid anymore.
+            if (isOpen() && config().getSoLinger() > 0) {
+                // We need to cancel this key of the channel so we may not end up in a eventloop spin
+                // because we try to read or write until the actual close happens which may be later due
+                // SO_LINGER handling.
                 // See https://github.com/netty/netty/issues/4449
+                doDeregister(newPromise());
+                return GlobalEventExecutor.INSTANCE;
             }
-            return null;
+        } catch (Throwable ignore) {
+            // Ignore the error as the underlying channel may be closed in the meantime and so
+            // getSoLinger() may produce an exception. In this case we just return null.
+            // See https://github.com/netty/netty/issues/4449
         }
+        return null;
     }
 }

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
@@ -278,7 +278,7 @@ public class NioSctpChannel extends AbstractNioMessageChannel implements io.nett
     protected int doReadMessages(List<Object> buf) throws Exception {
         SctpChannel ch = javaChannel();
 
-        RecvByteBufAllocator.Handle allocHandle = ((AbstractUnsafe) unsafe()).recvBufAllocHandle();
+        RecvByteBufAllocator.Handle allocHandle = recvBufAllocHandle();
         ByteBuf buffer = allocHandle.allocate(config().getAllocator());
         boolean free = true;
         try {

--- a/transport/src/main/java/io/netty/bootstrap/FailedChannel.java
+++ b/transport/src/main/java/io/netty/bootstrap/FailedChannel.java
@@ -34,11 +34,6 @@ final class FailedChannel extends AbstractChannel {
     }
 
     @Override
-    protected AbstractUnsafe newUnsafe() {
-        return new AbstractUnsafe() { };
-    }
-
-    @Override
     protected SocketAddress localAddress0() {
         return null;
     }

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -50,7 +50,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
 
     private final Channel parent;
     private final ChannelId id;
-    private final AbstractUnsafe unsafe;
+    private final IoTransportImpl ioTransport = new IoTransportImpl();
     private final ChannelPipeline pipeline;
     private final CloseFuture closeFuture = new CloseFuture(this);
     private final EventLoop eventLoop;
@@ -69,6 +69,9 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
      */
     private ChannelPromise connectPromise;
     private Future<?> connectTimeoutFuture;
+
+    private RecvByteBufAllocator.Handle recvHandle;
+    private MessageSizeEstimator.Handle estimatorHandle;
 
     /** Cache for the string representation of this channel */
     private boolean strValActive;
@@ -94,7 +97,6 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         this.parent = parent;
         this.eventLoop = validateEventLoopGroup(eventLoop, "eventLoop", handleType);
         this.id = id == null ? DefaultChannelId.newInstance() : id;
-        unsafe = newUnsafe();
         pipeline = newChannelPipeline();
         closeFuture.addListener(f -> {
             ChannelPromise connectPromise = this.connectPromise;
@@ -256,15 +258,9 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         return closeFuture;
     }
 
-    @Override
-    public Unsafe unsafe() {
-        return unsafe;
+    protected IoTransport ioTransport() {
+        return ioTransport;
     }
-
-    /**
-     * Create a new {@link AbstractUnsafe} instance which will be used for the life-time of the {@link Channel}
-     */
-    protected abstract AbstractUnsafe newUnsafe();
 
     /**
      * Returns the ID of this channel.
@@ -343,32 +339,17 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
     }
 
     /**
-     * {@link Unsafe} implementation which sub-classes must extend and use.
+     * {@link IoTransport} implementation which sub-classes must extend and use.
      */
-    protected class AbstractUnsafe implements Unsafe {
-
-        private RecvByteBufAllocator.Handle recvHandle;
-        private MessageSizeEstimator.Handle estimatorHandle;
+    private final class IoTransportImpl implements IoTransport {
 
         /** true if the channel has never been registered, false otherwise */
         private boolean neverRegistered = true;
 
-        MessageSizeEstimator.Handle estimatorHandle() {
-            if (estimatorHandle == null) {
-                estimatorHandle = config().getMessageSizeEstimator().newHandle();
-            }
-            return estimatorHandle;
-        }
-
-        public RecvByteBufAllocator.Handle recvBufAllocHandle() {
-            if (recvHandle == null) {
-                recvHandle = config().getRecvByteBufAllocator().newHandle();
-            }
-            return recvHandle;
-        }
-
         @Override
-        public final void register(final ChannelPromise promise) {
+        public void register(final ChannelPromise promise) {
+            assertEventLoop();
+
             // check if the channel is still open as it could be closed in the mean time when the register
             // call was outside of the eventLoop
             if (!promise.setUncancellable() || !ensureOpen(promise)) {
@@ -400,7 +381,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                                 // begin read again so that we process inbound data.
                                 //
                                 // See https://github.com/netty/netty/issues/4805
-                                beginRead();
+                                read();
                             }
                         }
                     } else {
@@ -415,7 +396,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         }
 
         @Override
-        public final void bind(final SocketAddress localAddress, final ChannelPromise promise) {
+        public void bind(final SocketAddress localAddress, final ChannelPromise promise) {
             assertEventLoop();
 
             if (!promise.setUncancellable() || !ensureOpen(promise)) {
@@ -456,8 +437,10 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         }
 
         @Override
-        public final void connect(
+        public void connect(
                 final SocketAddress remoteAddress, final SocketAddress localAddress, final ChannelPromise promise) {
+            assertEventLoop();
+
             // Don't mark the connect promise as uncancellable as in fact we can cancel it as it is using
             // non-blocking io.
             if (promise.isDone() || !ensureOpen(promise)) {
@@ -544,7 +527,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         }
 
         @Override
-        public final void disconnect(final ChannelPromise promise) {
+        public void disconnect(final ChannelPromise promise) {
             assertEventLoop();
 
             if (!promise.setUncancellable()) {
@@ -573,58 +556,12 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         }
 
         @Override
-        public final void close(final ChannelPromise promise) {
+        public void close(final ChannelPromise promise) {
             assertEventLoop();
 
             ClosedChannelException closedChannelException =
                     StacklessClosedChannelException.newInstance(AbstractChannel.class, "close(ChannelPromise)");
             close(promise, closedChannelException, closedChannelException);
-        }
-
-        /**
-         * Shutdown the output portion of the corresponding {@link Channel}.
-         * For example this will clean up the {@link ChannelOutboundBuffer} and not allow any more writes.
-         */
-        public final void shutdownOutput(final ChannelPromise promise) {
-            assertEventLoop();
-            shutdownOutput(promise, null);
-        }
-
-        /**
-         * Shutdown the output portion of the corresponding {@link Channel}.
-         * For example this will clean up the {@link ChannelOutboundBuffer} and not allow any more writes.
-         * @param cause The cause which may provide rational for the shutdown.
-         */
-        private void shutdownOutput(final ChannelPromise promise, Throwable cause) {
-            if (!promise.setUncancellable()) {
-                return;
-            }
-
-            final ChannelOutboundBuffer outboundBuffer = AbstractChannel.this.outboundBuffer;
-            if (outboundBuffer == null) {
-                promise.setFailure(new ClosedChannelException());
-                return;
-            }
-
-            final Throwable shutdownCause = cause == null ?
-                    new ChannelOutputShutdownException("Channel output shutdown") :
-                    new ChannelOutputShutdownException("Channel output shutdown", cause);
-
-            // When a side enables SO_LINGER and calls showdownOutput(...) to start TCP half-closure
-            // we can not call doDeregister here because we should ensure this side in fin_wait2 state
-            // can still receive and process the data which is send by another side in the close_wait state。
-            // See https://github.com/netty/netty/issues/11981
-
-            // The shutdown function does not block regardless of the SO_LINGER setting on the socket
-            // so we don't need to use GlobalEventExecutor to execute the shutdown
-            ChannelPromise shutdownPromise = newPromise().addListener(f -> {
-                // Disallow adding any messages and flushes to outboundBuffer.
-                AbstractChannel.this.outboundBuffer = null;
-
-                safeCascade(f, promise);
-                closeOutboundBufferForShutdown(pipeline, outboundBuffer, shutdownCause);
-            });
-            doShutdownOutput(shutdownPromise);
         }
 
         private void closeOutboundBufferForShutdown(
@@ -709,7 +646,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         }
 
         @Override
-        public final void deregister(final ChannelPromise promise) {
+        public void deregister(final ChannelPromise promise) {
             assertEventLoop();
 
             deregister(promise, false);
@@ -760,7 +697,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         }
 
         @Override
-        public final void beginRead() {
+        public void read() {
             assertEventLoop();
 
             try {
@@ -777,7 +714,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         }
 
         @Override
-        public final void write(Object msg, ChannelPromise promise) {
+        public void write(Object msg, ChannelPromise promise) {
             assertEventLoop();
 
             ChannelOutboundBuffer outboundBuffer = AbstractChannel.this.outboundBuffer;
@@ -791,7 +728,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                     // will be done in flush0()
                     // See https://github.com/netty/netty/issues/2362
                     safeSetFailure(promise, newClosedChannelException(
-                            AbstractUnsafe.class, initialCloseCause, "write(Object, ChannelPromise)"));
+                            IoTransportImpl.class, initialCloseCause, "write(Object, ChannelPromise)"));
                 }
                 return;
             }
@@ -816,7 +753,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         }
 
         @Override
-        public final void flush() {
+        public void flush() {
             assertEventLoop();
 
             ChannelOutboundBuffer outboundBuffer = AbstractChannel.this.outboundBuffer;
@@ -828,7 +765,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             writeFlushed();
         }
 
-        protected final void handleWriteError(Throwable t) {
+        private void handleWriteError(Throwable t) {
             if (t instanceof IOException && config().isAutoClose()) {
                 /**
                  * Just call {@link #close(ChannelPromise, Throwable, boolean)} here which will take care of
@@ -839,13 +776,13 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                  * may still return {@code true} even if the channel should be closed as result of the exception.
                  */
                 initialCloseCause = t;
-                close(newPromise(), t, newClosedChannelException(AbstractUnsafe.class, t, "handleWriteError()"));
+                close(newPromise(), t, newClosedChannelException(IoTransportImpl.class, t, "handleWriteError()"));
             } else {
                 try {
                     shutdownOutput(newPromise(), t);
                 } catch (Throwable t2) {
                     initialCloseCause = t;
-                    close(newPromise(), t2, newClosedChannelException(AbstractUnsafe.class, t, "handleWriteError()"));
+                    close(newPromise(), t2, newClosedChannelException(IoTransportImpl.class, t, "handleWriteError()"));
                 }
             }
         }
@@ -859,17 +796,17 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             return exception;
         }
 
-        protected final boolean ensureOpen(ChannelPromise promise) {
+        private boolean ensureOpen(ChannelPromise promise) {
             if (isOpen()) {
                 return true;
             }
 
             safeSetFailure(promise, newClosedChannelException(
-                    AbstractUnsafe.class, initialCloseCause, "ensureOpen(ChannelPromise)"));
+                    IoTransportImpl.class, initialCloseCause, "ensureOpen(ChannelPromise)"));
             return false;
         }
 
-        protected final void safeCascade(Future<?> future, ChannelPromise promise) {
+        private void safeCascade(Future<?> future, ChannelPromise promise) {
             if (future.isSuccess()) {
                 safeSetSuccess(promise);
             } else {
@@ -880,7 +817,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         /**
          * Marks the specified {@code promise} as success.  If the {@code promise} is done already, log a message.
          */
-        protected final void safeSetSuccess(ChannelPromise promise) {
+        private void safeSetSuccess(ChannelPromise promise) {
             if (!promise.trySuccess()) {
                 logger.warn("Failed to mark a promise as success because it is done already: {}", promise);
             }
@@ -889,13 +826,13 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         /**
          * Marks the specified {@code promise} as failure.  If the {@code promise} is done already, log a message.
          */
-        protected final void safeSetFailure(ChannelPromise promise, Throwable cause) {
+        private void safeSetFailure(ChannelPromise promise, Throwable cause) {
             if (!promise.tryFailure(cause)) {
                 logger.warn("Failed to mark a promise as failure because it's done already: {}", promise, cause);
             }
         }
 
-        protected final void closeIfClosed() {
+        private void closeIfClosed() {
             if (isOpen()) {
                 return;
             }
@@ -924,7 +861,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         /**
          * Appends the remote address to the message of the exceptions caused by connection attempt failure.
          */
-        protected final Throwable annotateConnectException(Throwable cause, SocketAddress remoteAddress) {
+        private Throwable annotateConnectException(Throwable cause, SocketAddress remoteAddress) {
             if (cause instanceof ConnectException) {
                 return new AnnotatedConnectException((ConnectException) cause, remoteAddress);
             }
@@ -937,16 +874,95 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
 
             return cause;
         }
+    }
 
-        /**
-         * Prepares to close the {@link Channel}. If this method returns an {@link Executor}, the
-         * caller must call the {@link Executor#execute(Runnable)} method with a task that calls
-         * {@link #doClose(ChannelPromise)} on the returned {@link Executor}. If this method returns {@code null},
-         * {@link #doClose(ChannelPromise)} must be called from the caller thread. (i.e. {@link EventLoop})
-         */
-        protected Executor prepareToClose() {
-            return null;
+    protected final void handleWriteError(Throwable t) {
+        ioTransport.handleWriteError(t);
+    }
+
+    /**
+     * Prepares to close the {@link Channel}. If this method returns an {@link Executor}, the
+     * caller must call the {@link Executor#execute(Runnable)} method with a task that calls
+     * {@link #doClose(ChannelPromise)} on the returned {@link Executor}. If this method returns {@code null},
+     * {@link #doClose(ChannelPromise)} must be called from the caller thread. (i.e. {@link EventLoop})
+     */
+    protected Executor prepareToClose() {
+        return null;
+    }
+
+    /**
+     * Shutdown the output portion of the corresponding {@link Channel}.
+     * For example this will clean up the {@link ChannelOutboundBuffer} and not allow any more writes.
+     */
+    // TODO: Make this a concept of the Unsafe.
+    protected final void shutdownOutput0(final ChannelPromise promise) {
+        assertEventLoop();
+        shutdownOutput(promise, null);
+    }
+
+    /**
+     * Shutdown the output portion of the corresponding {@link Channel}.
+     * For example this will clean up the {@link ChannelOutboundBuffer} and not allow any more writes.
+     * @param cause The cause which may provide rational for the shutdown.
+     */
+    private void shutdownOutput(final ChannelPromise promise, Throwable cause) {
+        if (!promise.setUncancellable()) {
+            return;
         }
+
+        final ChannelOutboundBuffer outboundBuffer = AbstractChannel.this.outboundBuffer;
+        if (outboundBuffer == null) {
+            promise.setFailure(new ClosedChannelException());
+            return;
+        }
+
+        final Throwable shutdownCause = cause == null ?
+                new ChannelOutputShutdownException("Channel output shutdown") :
+                new ChannelOutputShutdownException("Channel output shutdown", cause);
+
+        // When a side enables SO_LINGER and calls showdownOutput(...) to start TCP half-closure
+        // we can not call doDeregister here because we should ensure this side in fin_wait2 state
+        // can still receive and process the data which is send by another side in the close_wait state。
+        // See https://github.com/netty/netty/issues/11981
+
+        // The shutdown function does not block regardless of the SO_LINGER setting on the socket
+        // so we don't need to use GlobalEventExecutor to execute the shutdown
+        ChannelPromise shutdownPromise = newPromise().addListener(f -> {
+            // Disallow adding any messages and flushes to outboundBuffer.
+            AbstractChannel.this.outboundBuffer = null;
+
+            ioTransport.safeCascade(f, promise);
+            ioTransport.closeOutboundBufferForShutdown(pipeline, outboundBuffer, shutdownCause);
+        });
+        doShutdownOutput(shutdownPromise);
+    }
+
+    private MessageSizeEstimator.Handle estimatorHandle() {
+        if (estimatorHandle == null) {
+            estimatorHandle = config().getMessageSizeEstimator().newHandle();
+        }
+        return estimatorHandle;
+    }
+
+    /**
+     * Returns the {@link RecvByteBufAllocator.Handle} that should be used while reading from the transport.
+     *
+     * @return  handle
+     */
+    protected final RecvByteBufAllocator.Handle recvBufAllocHandle() {
+        if (recvHandle == null) {
+            recvHandle = newRecvBufAllocHandle();
+        }
+        return recvHandle;
+    }
+
+    /**
+     * Create a new {@link RecvByteBufAllocator.Handle} that will be used for reading.
+     *
+     * @return newHandle.
+     */
+    protected RecvByteBufAllocator.Handle newRecvBufAllocHandle() {
+        return config().getRecvByteBufAllocator().newHandle();
     }
 
     private void assertEventLoop() {
@@ -1004,7 +1020,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                         outboundBuffer.failFlushed(new NotYetConnectedException(), true);
                     } else {
                         // Do not trigger channelWritabilityChanged because the channel is closed already.
-                        outboundBuffer.failFlushed(unsafe.newClosedChannelException(
+                        outboundBuffer.failFlushed(ioTransport.newClosedChannelException(
                                 AbstractChannel.class, initialCloseCause, "writeFlushedNow()"), false);
                     }
                 }
@@ -1017,7 +1033,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         try {
             doWrite(outboundBuffer);
         } catch (Throwable t) {
-            unsafe.handleWriteError(t);
+            ioTransport.handleWriteError(t);
         } finally {
             inWriteFlushed = false;
         }
@@ -1094,7 +1110,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         return msg;
     }
 
-    protected void validateFileRegion(DefaultFileRegion region, long position) throws IOException {
+    protected final void validateFileRegion(DefaultFileRegion region, long position) throws IOException {
         DefaultFileRegion.validate(region, position);
     }
 
@@ -1180,7 +1196,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
     protected class DefaultAbstractChannelPipeline extends DefaultChannelPipeline {
 
         protected DefaultAbstractChannelPipeline(AbstractChannel channel) {
-            super(channel);
+            super(channel, channel.ioTransport);
         }
 
         @Override

--- a/transport/src/main/java/io/netty/channel/AbstractServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractServerChannel.java
@@ -73,11 +73,6 @@ public abstract class AbstractServerChannel extends AbstractChannel implements S
     }
 
     @Override
-    protected AbstractUnsafe newUnsafe() {
-        return new AbstractUnsafe();
-    }
-
-    @Override
     protected void doWrite(ChannelOutboundBuffer in)  {
         throw new UnsupportedOperationException();
     }

--- a/transport/src/main/java/io/netty/channel/Channel.java
+++ b/transport/src/main/java/io/netty/channel/Channel.java
@@ -189,11 +189,6 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparabl
     long bytesBeforeWritable();
 
     /**
-     * Returns an <em>internal-use-only</em> object that provides unsafe operations.
-     */
-    Unsafe unsafe();
-
-    /**
      * Return the assigned {@link ChannelPipeline}.
      */
     ChannelPipeline pipeline();
@@ -356,72 +351,5 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparabl
     @Override
     default ChannelFuture register(ChannelPromise promise) {
         return pipeline().register(promise);
-    }
-
-    /**
-     * <em>Unsafe</em> operations that should <em>never</em> be called from user-code. These methods
-     * are only provided to implement the actual transport, and must be invoked from an I/O thread except for the
-     * following methods:
-     * <ul>
-     *   <li>{@link #register(ChannelPromise)}</li>
-     *   <li>{@link #deregister(ChannelPromise)}</li>
-     * </ul>
-     */
-    interface Unsafe {
-
-        /**
-         * Register the {@link Channel} of the {@link ChannelPromise} and notify
-         * the {@link ChannelPromise} once the registration was complete.
-         */
-        void register(ChannelPromise promise);
-
-        /**
-         * Bind the {@link SocketAddress} to the {@link Channel} of the {@link ChannelPromise} and notify
-         * it once its done.
-         */
-        void bind(SocketAddress localAddress, ChannelPromise promise);
-
-        /**
-         * Connect the {@link Channel} of the given {@link ChannelFuture} with the given remote {@link SocketAddress}.
-         * If a specific local {@link SocketAddress} should be used it need to be given as argument. Otherwise just
-         * pass {@code null} to it.
-         *
-         * The {@link ChannelPromise} will get notified once the connect operation was complete.
-         */
-        void connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise);
-
-        /**
-         * Disconnect the {@link Channel} of the {@link ChannelFuture} and notify the {@link ChannelPromise} once the
-         * operation was complete.
-         */
-        void disconnect(ChannelPromise promise);
-
-        /**
-         * Close the {@link Channel} of the {@link ChannelPromise} and notify the {@link ChannelPromise} once the
-         * operation was complete.
-         */
-        void close(ChannelPromise promise);
-
-        /**
-         * Deregister the {@link Channel} of the {@link ChannelPromise} from {@link EventLoop} and notify the
-         * {@link ChannelPromise} once the operation was complete.
-         */
-        void deregister(ChannelPromise promise);
-
-        /**
-         * Schedules a read operation that fills the inbound buffer of the first {@link ChannelInboundHandler} in the
-         * {@link ChannelPipeline}.  If there's already a pending read operation, this method does nothing.
-         */
-        void beginRead();
-
-        /**
-         * Schedules a write operation.
-         */
-        void write(Object msg, ChannelPromise promise);
-
-        /**
-         * Flush out all write operations scheduled via {@link #write(Object, ChannelPromise)}.
-         */
-        void flush();
     }
 }

--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -15,7 +15,6 @@
  */
 package io.netty.channel;
 
-import io.netty.channel.Channel.Unsafe;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ResourceLeakDetector;
 import io.netty.util.concurrent.EventExecutor;
@@ -84,12 +83,12 @@ public class DefaultChannelPipeline implements ChannelPipeline {
      */
     private boolean registered;
 
-    protected DefaultChannelPipeline(Channel channel) {
+    protected DefaultChannelPipeline(Channel channel, IoTransport transport) {
         this.channel = ObjectUtil.checkNotNull(channel, "channel");
         succeededFuture = new SucceededChannelFuture(channel, null);
 
         tail = new TailContext(this);
-        head = new HeadContext(this);
+        head = new HeadContext(this, ObjectUtil.checkNotNull(transport, "transport"));
 
         head.next = tail;
         tail.prev = head;
@@ -1269,11 +1268,11 @@ public class DefaultChannelPipeline implements ChannelPipeline {
     final class HeadContext extends AbstractChannelHandlerContext
             implements ChannelOutboundHandler, ChannelInboundHandler {
 
-        private final Unsafe unsafe;
+        private final IoTransport transport;
 
-        HeadContext(DefaultChannelPipeline pipeline) {
+        HeadContext(DefaultChannelPipeline pipeline, IoTransport transport) {
             super(pipeline, HEAD_NAME, HeadContext.class);
-            unsafe = pipeline.channel().unsafe();
+            this.transport = transport;
             setAddComplete();
         }
 
@@ -1313,13 +1312,13 @@ public class DefaultChannelPipeline implements ChannelPipeline {
                     promise.setFailure(f.cause());
                 }
             });
-            unsafe.register(registerPromise);
+            transport.register(registerPromise);
         }
 
         @Override
         public void bind(
                 ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) {
-            unsafe.bind(localAddress, promise);
+            transport.bind(localAddress, promise);
         }
 
         @Override
@@ -1327,37 +1326,37 @@ public class DefaultChannelPipeline implements ChannelPipeline {
                 ChannelHandlerContext ctx,
                 SocketAddress remoteAddress, SocketAddress localAddress,
                 ChannelPromise promise) {
-            unsafe.connect(remoteAddress, localAddress, promise);
+            transport.connect(remoteAddress, localAddress, promise);
         }
 
         @Override
         public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) {
-            unsafe.disconnect(promise);
+            transport.disconnect(promise);
         }
 
         @Override
         public void close(ChannelHandlerContext ctx, ChannelPromise promise) {
-            unsafe.close(promise);
+            transport.close(promise);
         }
 
         @Override
         public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) {
-            unsafe.deregister(promise);
+            transport.deregister(promise);
         }
 
         @Override
         public void read(ChannelHandlerContext ctx) {
-            unsafe.beginRead();
+            transport.read();
         }
 
         @Override
         public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
-            unsafe.write(msg, promise);
+            transport.write(msg, promise);
         }
 
         @Override
         public void flush(ChannelHandlerContext ctx) {
-            unsafe.flush();
+            transport.flush();
         }
 
         @Override

--- a/transport/src/main/java/io/netty/channel/IoTransport.java
+++ b/transport/src/main/java/io/netty/channel/IoTransport.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel;
+
+import java.net.SocketAddress;
+
+/**
+ * Transport which actually submit IO operations to the underlying OS.
+ */
+public interface IoTransport {
+
+    /**
+     * Register the {@link Channel} of the {@link ChannelPromise} and notify
+     * the {@link ChannelPromise} once the registration was complete.
+     */
+    void register(ChannelPromise promise);
+
+    /**
+     * Bind the {@link SocketAddress} to the {@link Channel} of the {@link ChannelPromise} and notify
+     * it once its done.
+     */
+    void bind(SocketAddress localAddress, ChannelPromise promise);
+
+    /**
+     * Connect the {@link Channel} of the given {@link ChannelFuture} with the given remote {@link SocketAddress}.
+     * If a specific local {@link SocketAddress} should be used it need to be given as argument. Otherwise just
+     * pass {@code null} to it.
+     * <p>
+     * The {@link ChannelPromise} will get notified once the connect operation was complete.
+     */
+    void connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise);
+
+    /**
+     * Disconnect the {@link Channel} of the {@link ChannelFuture} and notify the {@link ChannelPromise} once the
+     * operation was complete.
+     */
+    void disconnect(ChannelPromise promise);
+
+    /**
+     * Close the {@link Channel} of the {@link ChannelPromise} and notify the {@link ChannelPromise} once the
+     * operation was complete.
+     */
+    void close(ChannelPromise promise);
+
+    /**
+     * Deregister the {@link Channel} of the {@link ChannelPromise} from {@link EventLoop} and notify the
+     * {@link ChannelPromise} once the operation was complete.
+     */
+    void deregister(ChannelPromise promise);
+
+    /**
+     * Schedules a read operation that fills the inbound buffer of the first {@link ChannelInboundHandler} in the
+     * {@link ChannelPipeline}.  If there's already a pending read operation, this method does nothing.
+     */
+    void read();
+
+    /**
+     * Schedules a write operation.
+     */
+    void write(Object msg, ChannelPromise promise);
+
+    /**
+     * Flush out all write operations scheduled via {@link #write(Object, ChannelPromise)}.
+     */
+    void flush();
+}

--- a/transport/src/main/java/io/netty/channel/PendingBytesTracker.java
+++ b/transport/src/main/java/io/netty/channel/PendingBytesTracker.java
@@ -36,7 +36,7 @@ abstract class PendingBytesTracker implements MessageSizeEstimator.Handle {
         if (channel instanceof AbstractChannel) {
             ChannelOutboundBuffer buffer = ((AbstractChannel) channel).outboundBuffer();
             MessageSizeEstimator.Handle handle = channel.config().getMessageSizeEstimator().newHandle();
-            // We need to guard against null as channel.unsafe().outboundBuffer() may returned null
+            // We need to guard against null as channel.outboundBuffer() may returned null
             // if the channel was already closed when constructing the PendingBytesTracker.
             // See https://github.com/netty/netty/issues/3967
             return buffer == null ?

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
@@ -34,6 +34,7 @@ import io.netty.channel.EventLoop;
 import io.netty.channel.IoEvent;
 import io.netty.channel.IoHandle;
 import io.netty.channel.IoRegistration;
+import io.netty.channel.IoTransport;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Ticker;
 import io.netty.util.internal.PlatformDependent;
@@ -57,6 +58,8 @@ public class EmbeddedChannel extends AbstractChannel {
     private static final SocketAddress REMOTE_ADDRESS = new EmbeddedSocketAddress();
 
     private static final ChannelHandler[] EMPTY_HANDLERS = new ChannelHandler[0];
+    private static final EmbeddedIoHandle IO_HANDLE = new EmbeddedIoHandle();
+
     private enum State { OPEN, ACTIVE, CLOSED }
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(EmbeddedChannel.class);
@@ -215,7 +218,7 @@ public class EmbeddedChannel extends AbstractChannel {
      */
     protected EmbeddedChannel(Builder builder) {
         super(new EmbeddedEventLoop(builder.ticker == null ? new EmbeddedEventLoop.FreezableTicker() : builder.ticker),
-                EmbeddedUnsafe.class, builder.parent, builder.channelId);
+                EmbeddedIoHandle.class, builder.parent, builder.channelId);
         metadata = metadata(builder.hasDisconnect);
         config = builder.config == null ? new DefaultChannelConfig(this) : builder.config;
         if (builder.handler == null) {
@@ -265,7 +268,7 @@ public class EmbeddedChannel extends AbstractChannel {
 
     private void register0() {
         ChannelPromise promise = newPromise();
-        unsafe().register(promise);
+        ioTransport().register(promise);
         assert promise.isDone();
         Throwable cause = promise.cause();
         if (cause != null) {
@@ -1028,16 +1031,6 @@ public class EmbeddedChannel extends AbstractChannel {
     }
 
     @Override
-    protected AbstractUnsafe newUnsafe() {
-        return new EmbeddedUnsafe();
-    }
-
-    @Override
-    public Unsafe unsafe() {
-        return ((EmbeddedUnsafe) super.unsafe()).wrapped;
-    }
-
-    @Override
     protected void doWrite(ChannelOutboundBuffer in) {
         for (;;) {
             Object msg = in.current();
@@ -1195,114 +1188,7 @@ public class EmbeddedChannel extends AbstractChannel {
         promise.setSuccess();
     }
 
-    final class EmbeddedUnsafe extends AbstractUnsafe implements IoHandle {
-
-        // Delegates to the EmbeddedUnsafe instance but ensures runPendingTasks() is called after each operation
-        // that may change the state of the Channel and may schedule tasks for later execution.
-        final Unsafe wrapped = new Unsafe() {
-
-            private final ChannelFutureListener futureListener = f ->  maybeRunPendingTasks();
-
-            @Override
-            public void register(ChannelPromise promise) {
-                executingStackCnt++;
-                try {
-                    EmbeddedUnsafe.this.register(promise.addListener(futureListener));
-                } finally {
-                    executingStackCnt--;
-                    maybeRunPendingTasks();
-                }
-            }
-
-            @Override
-            public void bind(SocketAddress localAddress, ChannelPromise promise) {
-                executingStackCnt++;
-                try {
-                    EmbeddedUnsafe.this.bind(localAddress, promise.addListener(futureListener));
-                } finally {
-                    executingStackCnt--;
-                    maybeRunPendingTasks();
-                }
-            }
-
-            @Override
-            public void connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
-                executingStackCnt++;
-                try {
-                    EmbeddedUnsafe.this.connect(remoteAddress, localAddress, promise.addListener(futureListener));
-                } finally {
-                    executingStackCnt--;
-                    maybeRunPendingTasks();
-                }
-            }
-
-            @Override
-            public void disconnect(ChannelPromise promise) {
-                executingStackCnt++;
-                try {
-                    EmbeddedUnsafe.this.disconnect(promise.addListener(futureListener));
-                } finally {
-                    executingStackCnt--;
-                    maybeRunPendingTasks();
-                }
-            }
-
-            @Override
-            public void close(ChannelPromise promise) {
-                executingStackCnt++;
-                try {
-                    EmbeddedUnsafe.this.close(promise.addListener(futureListener));
-                } finally {
-                    executingStackCnt--;
-                    maybeRunPendingTasks();
-                }
-            }
-
-            @Override
-            public void deregister(ChannelPromise promise) {
-                executingStackCnt++;
-                try {
-                    EmbeddedUnsafe.this.deregister(promise.addListener(futureListener));
-                } finally {
-                    executingStackCnt--;
-                    maybeRunPendingTasks();
-                }
-            }
-
-            @Override
-            public void beginRead() {
-                executingStackCnt++;
-                try {
-                    EmbeddedUnsafe.this.beginRead();
-                } finally {
-                    executingStackCnt--;
-                    maybeRunPendingTasks();
-                }
-            }
-
-            @Override
-            public void write(Object msg, ChannelPromise promise) {
-                executingStackCnt++;
-                try {
-                    EmbeddedUnsafe.this.write(msg, promise.addListener(futureListener));
-                } finally {
-                    executingStackCnt--;
-                    maybeRunPendingTasks();
-                }
-            }
-
-            @Override
-            public void flush() {
-                executingStackCnt++;
-                try {
-                    EmbeddedUnsafe.this.flush();
-                } finally {
-                    executingStackCnt--;
-                    maybeRunPendingTasks();
-                }
-            }
-        };
-
+    static final class EmbeddedIoHandle implements IoHandle {
         @Override
         public void handle(IoRegistration registration, IoEvent ioEvent) {
             throw new UnsupportedOperationException();
@@ -1314,9 +1200,117 @@ public class EmbeddedChannel extends AbstractChannel {
         }
     }
 
-    private final class EmbeddedChannelPipeline extends DefaultAbstractChannelPipeline {
+    final class EmbeddedIoTransport implements IoTransport {
+        private final IoTransport transport;
+        private final ChannelFutureListener futureListener = f ->  maybeRunPendingTasks();
+
+        EmbeddedIoTransport(IoTransport transport) {
+            this.transport = transport;
+        }
+
+        @Override
+        public void register(ChannelPromise promise) {
+            executingStackCnt++;
+            try {
+                transport.register(promise.addListener(futureListener));
+            } finally {
+                executingStackCnt--;
+                maybeRunPendingTasks();
+            }
+        }
+
+        @Override
+        public void bind(SocketAddress localAddress, ChannelPromise promise) {
+            executingStackCnt++;
+            try {
+                transport.bind(localAddress, promise.addListener(futureListener));
+            } finally {
+                executingStackCnt--;
+                maybeRunPendingTasks();
+            }
+        }
+
+        @Override
+        public void connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+            executingStackCnt++;
+            try {
+                transport.connect(remoteAddress, localAddress, promise.addListener(futureListener));
+            } finally {
+                executingStackCnt--;
+                maybeRunPendingTasks();
+            }
+        }
+
+        @Override
+        public void disconnect(ChannelPromise promise) {
+            executingStackCnt++;
+            try {
+                transport.disconnect(promise.addListener(futureListener));
+            } finally {
+                executingStackCnt--;
+                maybeRunPendingTasks();
+            }
+        }
+
+        @Override
+        public void close(ChannelPromise promise) {
+            executingStackCnt++;
+            try {
+                transport.close(promise.addListener(futureListener));
+            } finally {
+                executingStackCnt--;
+                maybeRunPendingTasks();
+            }
+        }
+
+        @Override
+        public void deregister(ChannelPromise promise) {
+            executingStackCnt++;
+            try {
+                transport.deregister(promise.addListener(futureListener));
+            } finally {
+                executingStackCnt--;
+                maybeRunPendingTasks();
+            }
+        }
+
+        @Override
+        public void read() {
+            executingStackCnt++;
+            try {
+                transport.read();
+            } finally {
+                executingStackCnt--;
+                maybeRunPendingTasks();
+            }
+        }
+
+        @Override
+        public void write(Object msg, ChannelPromise promise) {
+            executingStackCnt++;
+            try {
+                transport.write(msg, promise.addListener(futureListener));
+            } finally {
+                executingStackCnt--;
+                maybeRunPendingTasks();
+            }
+        }
+
+        @Override
+        public void flush() {
+            executingStackCnt++;
+            try {
+                transport.flush();
+            } finally {
+                executingStackCnt--;
+                maybeRunPendingTasks();
+            }
+        }
+    }
+
+    private final class EmbeddedChannelPipeline extends DefaultChannelPipeline {
         EmbeddedChannelPipeline(EmbeddedChannel channel) {
-            super(channel);
+            super(channel, new EmbeddedIoTransport(channel.ioTransport()));
         }
 
         @Override

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedEventLoop.java
@@ -143,7 +143,7 @@ final class EmbeddedEventLoop extends AbstractScheduledEventExecutor implements 
 
     @Override
     public boolean isCompatible(Class<? extends IoHandle> handleType) {
-        return handleType == EmbeddedChannel.EmbeddedUnsafe.class;
+        return handleType == EmbeddedChannel.EmbeddedIoHandle.class;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -29,7 +29,6 @@ import io.netty.channel.IoEvent;
 import io.netty.channel.IoRegistration;
 import io.netty.channel.PreferHeapByteBufAllocator;
 import io.netty.channel.RecvByteBufAllocator;
-import io.netty.channel.group.ChannelGroup;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.SingleThreadEventExecutor;
@@ -40,7 +39,6 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.net.ConnectException;
 import java.net.SocketAddress;
-import java.nio.channels.AlreadyBoundException;
 import java.nio.channels.AlreadyConnectedException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ConnectionPendingException;
@@ -74,12 +72,7 @@ public class LocalChannel extends AbstractChannel {
         }
     };
 
-    private final Runnable shutdownHook = new Runnable() {
-        @Override
-        public void run() {
-            unsafe().close(newPromise());
-        }
-    };
+    private final LocalIoHandle ioHandle = new LocalIoHandleImpl();
 
     private IoRegistration registration;
 
@@ -145,11 +138,6 @@ public class LocalChannel extends AbstractChannel {
         return state == State.CONNECTED;
     }
 
-    @Override
-    protected AbstractUnsafe newUnsafe() {
-        return new LocalUnsafe();
-    }
-
     protected SocketAddress localAddress0() {
         return localAddress;
     }
@@ -163,7 +151,7 @@ public class LocalChannel extends AbstractChannel {
     protected void doRegister(ChannelPromise promise) {
         EventLoop loop = executor();
         assert registration == null;
-        loop.register((LocalUnsafe) unsafe()).addListener(f -> {
+        loop.register(ioHandle).addListener(f -> {
             if (f.isSuccess()) {
                 registration = (IoRegistration) f.getNow();
                 promise.setSuccess();
@@ -280,14 +268,14 @@ public class LocalChannel extends AbstractChannel {
 
     private void tryClose(boolean isActive) {
         if (isActive) {
-            unsafe().close(newPromise());
+            ioTransport().close(newPromise());
         } else {
             releaseInboundBuffers();
         }
     }
 
     private void readInbound() {
-        RecvByteBufAllocator.Handle handle = ((AbstractUnsafe) unsafe()).recvBufAllocHandle();
+        RecvByteBufAllocator.Handle handle = recvBufAllocHandle();
         handle.reset(config());
         ChannelPipeline pipeline = pipeline();
         do {
@@ -468,11 +456,17 @@ public class LocalChannel extends AbstractChannel {
         }
     }
 
-    private class LocalUnsafe extends AbstractUnsafe implements LocalIoHandle {
+    private final class LocalIoHandleImpl implements LocalIoHandle {
+        private final Runnable shutdownHook = new Runnable() {
+            @Override
+            public void run() {
+                closeNow();
+            }
+        };
 
         @Override
         public void close() {
-            close(newPromise());
+            closeNow();
         }
 
         @Override
@@ -521,7 +515,7 @@ public class LocalChannel extends AbstractChannel {
 
         @Override
         public void closeNow() {
-            close(newPromise());
+           ioTransport().close(newPromise());
         }
     }
 

--- a/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
@@ -25,6 +25,7 @@ import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.IoEvent;
 import io.netty.channel.IoRegistration;
+import io.netty.channel.IoTransport;
 import io.netty.channel.PreferHeapByteBufAllocator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.ServerChannel;
@@ -43,12 +44,7 @@ public class LocalServerChannel extends AbstractServerChannel {
     private final ChannelConfig config =
             new DefaultChannelConfig(this, new ServerChannelRecvByteBufAllocator()) { };
     private final Queue<Object> inboundBuffer = new ArrayDeque<Object>();
-    private final Runnable shutdownHook = new Runnable() {
-        @Override
-        public void run() {
-            unsafe().close(newPromise());
-        }
-    };
+    private final LocalIoHandle ioHandle = new LocalServerIoHandle();
 
     private IoRegistration registration;
 
@@ -101,7 +97,7 @@ public class LocalServerChannel extends AbstractServerChannel {
     protected void doRegister(ChannelPromise promise) {
         EventLoop loop = executor();
         assert registration == null;
-        loop.register((LocalServerUnsafe) unsafe()).addListener(f -> {
+        loop.register(ioHandle).addListener(f -> {
             if (f.isSuccess()) {
                 registration = (IoRegistration) f.getNow();
                 promise.setSuccess();
@@ -177,7 +173,7 @@ public class LocalServerChannel extends AbstractServerChannel {
     }
 
     private void readInbound() {
-        RecvByteBufAllocator.Handle handle = ((AbstractUnsafe) unsafe()).recvBufAllocHandle();
+        RecvByteBufAllocator.Handle handle = recvBufAllocHandle();
         handle.reset(config());
         ChannelPipeline pipeline = pipeline();
         do {
@@ -208,15 +204,17 @@ public class LocalServerChannel extends AbstractServerChannel {
         }
     }
 
-    @Override
-    protected AbstractUnsafe newUnsafe() {
-        return new LocalServerUnsafe();
-    }
+    private final class LocalServerIoHandle  implements LocalIoHandle {
+        private final Runnable shutdownHook = new Runnable() {
+            @Override
+            public void run() {
+                closeNow();
+            }
+        };
 
-    private class LocalServerUnsafe extends AbstractUnsafe implements LocalIoHandle {
         @Override
         public void close() {
-            close(newPromise());
+            closeNow();
         }
 
         @Override
@@ -236,7 +234,7 @@ public class LocalServerChannel extends AbstractServerChannel {
 
         @Override
         public void closeNow() {
-            close(newPromise());
+            ioTransport().close(newPromise());
         }
     }
 }

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
@@ -81,11 +81,6 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
     }
 
     @Override
-    protected AbstractNioUnsafe newUnsafe() {
-        return new NioByteUnsafe();
-    }
-
-    @Override
     public ChannelMetadata metadata() {
         return METADATA;
     }
@@ -99,100 +94,97 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
                 ((SocketChannelConfig) config).isAllowHalfClosure();
     }
 
-    protected class NioByteUnsafe extends AbstractNioUnsafe {
+    private void closeOnRead(ChannelPipeline pipeline) {
+        if (!isInputShutdown0()) {
+            if (isAllowHalfClosure(config())) {
+                shutdownInput();
+                pipeline.fireUserEventTriggered(ChannelInputShutdownEvent.INSTANCE);
+            } else {
+                close(newPromise());
+            }
+        } else if (!inputClosedSeenErrorOnRead) {
+            inputClosedSeenErrorOnRead = true;
+            pipeline.fireUserEventTriggered(ChannelInputShutdownReadComplete.INSTANCE);
+        }
+    }
 
-        private void closeOnRead(ChannelPipeline pipeline) {
-            if (!isInputShutdown0()) {
-                if (isAllowHalfClosure(config())) {
-                    shutdownInput();
-                    pipeline.fireUserEventTriggered(ChannelInputShutdownEvent.INSTANCE);
-                } else {
-                    close(newPromise());
-                }
-            } else if (!inputClosedSeenErrorOnRead) {
-                inputClosedSeenErrorOnRead = true;
-                pipeline.fireUserEventTriggered(ChannelInputShutdownReadComplete.INSTANCE);
+    private void handleReadException(ChannelPipeline pipeline, ByteBuf byteBuf, Throwable cause, boolean close,
+            RecvByteBufAllocator.Handle allocHandle) {
+        if (byteBuf != null) {
+            if (byteBuf.isReadable()) {
+                readPending = false;
+                pipeline.fireChannelRead(byteBuf);
+            } else {
+                byteBuf.release();
             }
         }
+        allocHandle.readComplete();
+        pipeline.fireChannelReadComplete();
+        pipeline.fireExceptionCaught(cause);
 
-        private void handleReadException(ChannelPipeline pipeline, ByteBuf byteBuf, Throwable cause, boolean close,
-                RecvByteBufAllocator.Handle allocHandle) {
-            if (byteBuf != null) {
-                if (byteBuf.isReadable()) {
-                    readPending = false;
-                    pipeline.fireChannelRead(byteBuf);
-                } else {
+        // If oom will close the read event, release connection.
+        // See https://github.com/netty/netty/issues/10434
+        if (close ||
+                cause instanceof OutOfMemoryError ||
+                cause instanceof LeakPresenceDetector.AllocationProhibitedException ||
+                cause instanceof IOException) {
+            closeOnRead(pipeline);
+        }
+    }
+
+    @Override
+    protected final void readNow() {
+        final ChannelConfig config = config();
+        if (shouldBreakReadReady(config)) {
+            clearReadPending();
+            return;
+        }
+        final ChannelPipeline pipeline = pipeline();
+        final ByteBufAllocator allocator = config.getAllocator();
+        final RecvByteBufAllocator.Handle allocHandle = recvBufAllocHandle();
+        allocHandle.reset(config);
+
+        ByteBuf byteBuf = null;
+        boolean close = false;
+        try {
+            do {
+                byteBuf = allocHandle.allocate(allocator);
+                allocHandle.lastBytesRead(doReadBytes(byteBuf));
+                if (allocHandle.lastBytesRead() <= 0) {
+                    // nothing was read. release the buffer.
                     byteBuf.release();
+                    byteBuf = null;
+                    close = allocHandle.lastBytesRead() < 0;
+                    if (close) {
+                        // There is nothing left to read as we received an EOF.
+                        readPending = false;
+                    }
+                    break;
                 }
-            }
+
+                allocHandle.incMessagesRead(1);
+                readPending = false;
+                pipeline.fireChannelRead(byteBuf);
+                byteBuf = null;
+            } while (allocHandle.continueReading());
+
             allocHandle.readComplete();
             pipeline.fireChannelReadComplete();
-            pipeline.fireExceptionCaught(cause);
 
-            // If oom will close the read event, release connection.
-            // See https://github.com/netty/netty/issues/10434
-            if (close ||
-                    cause instanceof OutOfMemoryError ||
-                    cause instanceof LeakPresenceDetector.AllocationProhibitedException ||
-                    cause instanceof IOException) {
+            if (close) {
                 closeOnRead(pipeline);
             }
-        }
-
-        @Override
-        public final void read() {
-            final ChannelConfig config = config();
-            if (shouldBreakReadReady(config)) {
-                clearReadPending();
-                return;
-            }
-            final ChannelPipeline pipeline = pipeline();
-            final ByteBufAllocator allocator = config.getAllocator();
-            final RecvByteBufAllocator.Handle allocHandle = recvBufAllocHandle();
-            allocHandle.reset(config);
-
-            ByteBuf byteBuf = null;
-            boolean close = false;
-            try {
-                do {
-                    byteBuf = allocHandle.allocate(allocator);
-                    allocHandle.lastBytesRead(doReadBytes(byteBuf));
-                    if (allocHandle.lastBytesRead() <= 0) {
-                        // nothing was read. release the buffer.
-                        byteBuf.release();
-                        byteBuf = null;
-                        close = allocHandle.lastBytesRead() < 0;
-                        if (close) {
-                            // There is nothing left to read as we received an EOF.
-                            readPending = false;
-                        }
-                        break;
-                    }
-
-                    allocHandle.incMessagesRead(1);
-                    readPending = false;
-                    pipeline.fireChannelRead(byteBuf);
-                    byteBuf = null;
-                } while (allocHandle.continueReading());
-
-                allocHandle.readComplete();
-                pipeline.fireChannelReadComplete();
-
-                if (close) {
-                    closeOnRead(pipeline);
-                }
-            } catch (Throwable t) {
-                handleReadException(pipeline, byteBuf, t, close, allocHandle);
-            } finally {
-                // Check if there is a readPending which was not processed yet.
-                // This could be for two reasons:
-                // * The user called Channel.read() or ChannelHandlerContext.read() in channelRead(...) method
-                // * The user called Channel.read() or ChannelHandlerContext.read() in channelReadComplete(...) method
-                //
-                // See https://github.com/netty/netty/issues/2254
-                if (!readPending && !config.isAutoRead()) {
-                    removeReadOp();
-                }
+        } catch (Throwable t) {
+            handleReadException(pipeline, byteBuf, t, close, allocHandle);
+        } finally {
+            // Check if there is a readPending which was not processed yet.
+            // This could be for two reasons:
+            // * The user called Channel.read() or ChannelHandlerContext.read() in channelRead(...) method
+            // * The user called Channel.read() or ChannelHandlerContext.read() in channelReadComplete(...) method
+            //
+            // See https://github.com/netty/netty/issues/2254
+            if (!readPending && !config.isAutoRead()) {
+                removeReadOp();
             }
         }
     }

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
@@ -46,6 +46,7 @@ public abstract class AbstractNioChannel extends AbstractChannel {
     private static final InternalLogger logger =
             InternalLoggerFactory.getInstance(AbstractNioChannel.class);
 
+    private final NioIoHandle ioHandle = new NioIoHandleImpl();
     private final SelectableChannel ch;
     protected final int readInterestOp;
     protected final NioIoOps readOps;
@@ -54,7 +55,7 @@ public abstract class AbstractNioChannel extends AbstractChannel {
     private final Runnable clearReadPendingRunnable = new Runnable() {
         @Override
         public void run() {
-            clearReadPending0();
+            setReadPending0(false);
         }
     };
 
@@ -116,11 +117,6 @@ public abstract class AbstractNioChannel extends AbstractChannel {
     @Override
     public boolean isOpen() {
         return ch.isOpen();
-    }
-
-    @Override
-    public NioUnsafe unsafe() {
-        return (NioUnsafe) super.unsafe();
     }
 
     protected SelectableChannel javaChannel() {
@@ -185,7 +181,7 @@ public abstract class AbstractNioChannel extends AbstractChannel {
         if (isRegistered()) {
             EventLoop eventLoop = executor();
             if (eventLoop.inEventLoop()) {
-                clearReadPending0();
+                setReadPending0(false);
             } else {
                 eventLoop.execute(clearReadPendingRunnable);
             }
@@ -200,35 +196,8 @@ public abstract class AbstractNioChannel extends AbstractChannel {
     private void setReadPending0(boolean readPending) {
         this.readPending = readPending;
         if (!readPending) {
-            ((AbstractNioUnsafe) unsafe()).removeReadOp();
+            removeReadOp();
         }
-    }
-
-    private void clearReadPending0() {
-        readPending = false;
-        ((AbstractNioUnsafe) unsafe()).removeReadOp();
-    }
-
-    /**
-     * Special {@link Unsafe} sub-type which allows to access the underlying {@link SelectableChannel}
-     */
-    public interface NioUnsafe extends Unsafe {
-        /**
-         * Return underlying {@link SelectableChannel}
-         */
-        SelectableChannel ch();
-
-        /**
-         * Finish connect
-         */
-        void finishConnect();
-
-        /**
-         * Read from underlying {@link SelectableChannel}
-         */
-        void read();
-
-        void forceFlush();
     }
 
     @Override
@@ -254,59 +223,15 @@ public abstract class AbstractNioChannel extends AbstractChannel {
                 (SelectionKey) registration.attachment()).interestOps());
     }
 
-    protected abstract class AbstractNioUnsafe extends AbstractUnsafe implements NioUnsafe, NioIoHandle {
+    private final class NioIoHandleImpl implements NioIoHandle {
         @Override
         public void close() {
-            close(newPromise());
+            ioTransport().close(newPromise());
         }
 
         @Override
         public SelectableChannel selectableChannel() {
-            return ch();
-        }
-
-        Channel channel() {
-            return AbstractNioChannel.this;
-        }
-
-        protected final void removeReadOp() {
-            IoRegistration registration = registration();
-            // Check first if the key is still valid as it may be canceled as part of the deregistration
-            // from the EventLoop
-            // See https://github.com/netty/netty/issues/2104
-            if (!registration.isValid()) {
-                return;
-            }
-            removeAndSubmit(readOps);
-        }
-
-        @Override
-        public final SelectableChannel ch() {
             return javaChannel();
-        }
-
-        @Override
-        public final void finishConnect() {
-            // Note this method is invoked by the event loop only if the connection attempt was
-            // neither cancelled nor timed out.
-
-            assert executor().inEventLoop();
-            assert pendingConnectPromise != null;
-            ChannelPromise promise = pendingConnectPromise;
-            pendingConnectPromise = null;
-            try {
-                doFinishConnect();
-            } catch (Throwable cause) {
-                promise.setFailure(cause);
-                return;
-            }
-            promise.setSuccess();
-        }
-
-        @Override
-        public final void forceFlush() {
-            // directly call super.flush0() to force a flush now
-            writeFlushedNow();
         }
 
         @Override
@@ -320,33 +245,62 @@ public abstract class AbstractNioChannel extends AbstractChannel {
                     // remove OP_CONNECT as otherwise Selector.select(..) will always return without blocking
                     // See https://github.com/netty/netty/issues/924
                     removeAndSubmit(NioIoOps.CONNECT);
-
-                    unsafe().finishConnect();
+                    finishConnect();
                 }
 
                 // Process OP_WRITE first as we may be able to write some queued buffers and so free memory.
                 if (nioReadyOps.contains(NioIoOps.WRITE)) {
-                    // Call forceFlush which will also take care of clear the OP_WRITE once there is nothing left to
-                    // write
-                    forceFlush();
+                    // Call writeFlushedNow which will also take care of clear the OP_WRITE once there is nothing left
+                    // to write
+                    writeFlushedNow();
                 }
 
                 // Also check for readOps of 0 to workaround possible JDK bug which may otherwise lead
                 // to a spin loop
                 if (nioReadyOps.contains(NioIoOps.READ_AND_ACCEPT) || nioReadyOps.equals(NioIoOps.NONE)) {
-                    read();
+                    readNow();
                 }
             } catch (CancelledKeyException ignored) {
-                close(newPromise());
+                ioTransport().close(newPromise());
             }
         }
+    }
+
+    protected abstract void readNow();
+
+    protected final void finishConnect() {
+        // Note this method is invoked by the event loop only if the connection attempt was
+        // neither cancelled nor timed out.
+
+        assert executor().inEventLoop();
+        assert pendingConnectPromise != null;
+        ChannelPromise promise = pendingConnectPromise;
+        pendingConnectPromise = null;
+        try {
+            doFinishConnect();
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
+            return;
+        }
+        promise.setSuccess();
+    }
+
+    protected final void removeReadOp() {
+        IoRegistration registration = registration();
+        // Check first if the key is still valid as it may be canceled as part of the deregistration
+        // from the EventLoop
+        // See https://github.com/netty/netty/issues/2104
+        if (!registration.isValid()) {
+            return;
+        }
+        removeAndSubmit(readOps);
     }
 
     @SuppressWarnings("unchecked")
     @Override
     protected void doRegister(ChannelPromise promise) {
         assert registration == null;
-        executor().register((AbstractNioUnsafe) unsafe()).addListener(f -> {
+        executor().register(ioHandle).addListener(f -> {
             if (f.isSuccess()) {
                 registration = (IoRegistration) f.getNow();
                 promise.setSuccess();

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioMessageChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioMessageChannel.java
@@ -33,6 +33,8 @@ import java.util.List;
  * {@link AbstractNioChannel} base class for {@link Channel}s that operate on messages.
  */
 public abstract class AbstractNioMessageChannel extends AbstractNioChannel {
+    private final List<Object> readBuf = new ArrayList<Object>();
+
     boolean inputShutdown;
 
     protected AbstractNioMessageChannel(EventLoop eventLoop, Channel parent,
@@ -43,11 +45,6 @@ public abstract class AbstractNioMessageChannel extends AbstractNioChannel {
     protected AbstractNioMessageChannel(EventLoop eventLoop, Channel parent,
                                         SelectableChannel ch, NioIoOps readOps) {
         super(eventLoop, parent, ch, readOps);
-    }
-
-    @Override
-    protected AbstractNioUnsafe newUnsafe() {
-        return new NioMessageUnsafe();
     }
 
     @Override
@@ -62,72 +59,67 @@ public abstract class AbstractNioMessageChannel extends AbstractNioChannel {
         return allocHandle.continueReading();
     }
 
-    private final class NioMessageUnsafe extends AbstractNioUnsafe {
+    @Override
+    protected void readNow() {
+        assert executor().inEventLoop();
+        final ChannelConfig config = config();
+        final ChannelPipeline pipeline = pipeline();
+        final RecvByteBufAllocator.Handle allocHandle = recvBufAllocHandle();
+        allocHandle.reset(config);
 
-        private final List<Object> readBuf = new ArrayList<Object>();
-
-        @Override
-        public void read() {
-            assert executor().inEventLoop();
-            final ChannelConfig config = config();
-            final ChannelPipeline pipeline = pipeline();
-            final RecvByteBufAllocator.Handle allocHandle = recvBufAllocHandle();
-            allocHandle.reset(config);
-
-            boolean closed = false;
-            Throwable exception = null;
+        boolean closed = false;
+        Throwable exception = null;
+        try {
             try {
-                try {
-                    do {
-                        int localRead = doReadMessages(readBuf);
-                        if (localRead == 0) {
-                            break;
-                        }
-                        if (localRead < 0) {
-                            closed = true;
-                            break;
-                        }
-
-                        allocHandle.incMessagesRead(localRead);
-                    } while (continueReading(allocHandle));
-                } catch (Throwable t) {
-                    exception = t;
-                }
-
-                int size = readBuf.size();
-                for (int i = 0; i < size; i ++) {
-                    readPending = false;
-                    pipeline.fireChannelRead(readBuf.get(i));
-                }
-                readBuf.clear();
-                allocHandle.readComplete();
-                pipeline.fireChannelReadComplete();
-
-                if (exception != null) {
-                    closed = closeOnReadError(exception);
-
-                    pipeline.fireExceptionCaught(exception);
-                }
-
-                if (closed) {
-                    inputShutdown = true;
-                    if (isOpen()) {
-                        close(newPromise());
+                do {
+                    int localRead = doReadMessages(readBuf);
+                    if (localRead == 0) {
+                        break;
                     }
-                }
-            } finally {
-                // Check if there is a readPending which was not processed yet.
-                // This could be for two reasons:
-                // * The user called Channel.read() or ChannelHandlerContext.read() in channelRead(...) method
-                // * The user called Channel.read() or ChannelHandlerContext.read() in channelReadComplete(...) method
-                //
-                // See https://github.com/netty/netty/issues/2254
-                if (!readPending && !config.isAutoRead()) {
-                    removeReadOp();
+                    if (localRead < 0) {
+                        closed = true;
+                        break;
+                    }
+
+                    allocHandle.incMessagesRead(localRead);
+                } while (continueReading(allocHandle));
+            } catch (Throwable t) {
+                exception = t;
+            }
+
+            int size = readBuf.size();
+            for (int i = 0; i < size; i ++) {
+                readPending = false;
+                pipeline.fireChannelRead(readBuf.get(i));
+            }
+            readBuf.clear();
+            allocHandle.readComplete();
+            pipeline.fireChannelReadComplete();
+
+            if (exception != null) {
+                closed = closeOnReadError(exception);
+
+                pipeline.fireExceptionCaught(exception);
+            }
+
+            if (closed) {
+                inputShutdown = true;
+                if (isOpen()) {
+                    close(newPromise());
                 }
             }
+        } finally {
+            // Check if there is a readPending which was not processed yet.
+            // This could be for two reasons:
+            // * The user called Channel.read() or ChannelHandlerContext.read() in channelRead(...) method
+            // * The user called Channel.read() or ChannelHandlerContext.read() in channelReadComplete(...) method
+            //
+            // See https://github.com/netty/netty/issues/2254
+            if (!readPending && !config.isAutoRead()) {
+                removeReadOp();
+            }
         }
-    }
+}
 
     @Override
     protected void doWrite(ChannelOutboundBuffer in) throws Exception {

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
@@ -279,7 +279,7 @@ public final class NioDatagramChannel
     protected int doReadMessages(List<Object> buf) throws Exception {
         DatagramChannel ch = javaChannel();
         DatagramChannelConfig config = config();
-        RecvByteBufAllocator.Handle allocHandle = ((AbstractUnsafe) unsafe()).recvBufAllocHandle();
+        RecvByteBufAllocator.Handle allocHandle = recvBufAllocHandle();
 
         ByteBuf data = allocHandle.allocate(config.getAllocator());
         allocHandle.attemptedBytesRead(data.writableBytes());

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
@@ -192,12 +192,12 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
     public ChannelFuture shutdownOutput(final ChannelPromise promise) {
         final EventLoop loop = executor();
         if (loop.inEventLoop()) {
-            ((AbstractUnsafe) unsafe()).shutdownOutput(promise);
+            shutdownOutput0(promise);
         } else {
             loop.execute(new Runnable() {
                 @Override
                 public void run() {
-                    ((AbstractUnsafe) unsafe()).shutdownOutput(promise);
+                    shutdownOutput0(promise);
                 }
             });
         }
@@ -366,7 +366,7 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
 
     @Override
     protected int doReadBytes(ByteBuf byteBuf) throws Exception {
-        final RecvByteBufAllocator.Handle allocHandle = ((AbstractUnsafe) unsafe()).recvBufAllocHandle();
+        final RecvByteBufAllocator.Handle allocHandle = recvBufAllocHandle();
         allocHandle.attemptedBytesRead(byteBuf.writableBytes());
         return byteBuf.writeBytes(javaChannel(), allocHandle.attemptedBytesRead());
     }
@@ -460,29 +460,22 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
     }
 
     @Override
-    protected AbstractNioUnsafe newUnsafe() {
-        return new NioSocketChannelUnsafe();
-    }
-
-    private final class NioSocketChannelUnsafe extends NioByteUnsafe {
-        @Override
-        protected Executor prepareToClose() {
-            try {
-                if (javaChannel().isOpen() && config().getSoLinger() > 0) {
-                    // We need to cancel this key of the channel so we may not end up in a eventloop spin
-                    // because we try to read or write until the actual close happens which may be later due
-                    // SO_LINGER handling.
-                    // See https://github.com/netty/netty/issues/4449
-                    doDeregister(newPromise());
-                    return GlobalEventExecutor.INSTANCE;
-                }
-            } catch (Throwable ignore) {
-                // Ignore the error as the underlying channel may be closed in the meantime and so
-                // getSoLinger() may produce an exception. In this case we just return null.
+    protected Executor prepareToClose() {
+        try {
+            if (javaChannel().isOpen() && config().getSoLinger() > 0) {
+                // We need to cancel this key of the channel so we may not end up in a eventloop spin
+                // because we try to read or write until the actual close happens which may be later due
+                // SO_LINGER handling.
                 // See https://github.com/netty/netty/issues/4449
+                doDeregister(newPromise());
+                return GlobalEventExecutor.INSTANCE;
             }
-            return null;
+        } catch (Throwable ignore) {
+            // Ignore the error as the underlying channel may be closed in the meantime and so
+            // getSoLinger() may produce an exception. In this case we just return null.
+            // See https://github.com/netty/netty/issues/4449
         }
+        return null;
     }
 
     private static final class NioSocketChannelConfig extends DefaultChannelConfig

--- a/transport/src/test/java/io/netty/channel/AbstractChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/AbstractChannelTest.java
@@ -74,7 +74,7 @@ public class AbstractChannelTest {
         channel.pipeline().addLast(handler);
 
         registerChannel(channel);
-        channel.unsafe().deregister(new DefaultChannelPromise(channel));
+        channel.deregister(new DefaultChannelPromise(channel));
 
         registerChannel(channel);
 
@@ -174,11 +174,6 @@ public class AbstractChannelTest {
             private boolean active;
 
             @Override
-            protected AbstractUnsafe newUnsafe() {
-                return new AbstractUnsafe() { };
-            }
-
-            @Override
             protected void doConnect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
                 active = true;
                 promise.setSuccess();
@@ -230,7 +225,7 @@ public class AbstractChannelTest {
 
     private static void registerChannel(Channel channel) throws Exception {
         DefaultChannelPromise future = new DefaultChannelPromise(channel);
-        channel.unsafe().register(future);
+        channel.register(future);
         future.sync(); // Cause any exceptions to be thrown
     }
 
@@ -261,11 +256,6 @@ public class AbstractChannelTest {
         @Override
         public ChannelMetadata metadata() {
             return TEST_METADATA;
-        }
-
-        @Override
-        protected AbstractUnsafe newUnsafe() {
-            return new AbstractUnsafe() { };
         }
 
         @Override

--- a/transport/src/test/java/io/netty/channel/ChannelOutboundBufferTest.java
+++ b/transport/src/test/java/io/netty/channel/ChannelOutboundBufferTest.java
@@ -200,11 +200,6 @@ public class ChannelOutboundBufferTest {
         }
 
         @Override
-        protected AbstractUnsafe newUnsafe() {
-            return new TestUnsafe();
-        }
-
-        @Override
         protected SocketAddress localAddress0() {
             throw new UnsupportedOperationException();
         }
@@ -272,9 +267,6 @@ public class ChannelOutboundBufferTest {
         @Override
         public ChannelMetadata metadata() {
             return TEST_METADATA;
-        }
-
-        final class TestUnsafe extends AbstractUnsafe {
         }
     }
 

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTailTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTailTest.java
@@ -259,11 +259,6 @@ public class DefaultChannelPipelineTailTest {
         }
 
         @Override
-        protected AbstractUnsafe newUnsafe() {
-            return new MyUnsafe();
-        }
-
-        @Override
         protected SocketAddress localAddress0() {
             return null;
         }
@@ -338,12 +333,9 @@ public class DefaultChannelPipelineTailTest {
         protected void onUnhandledInboundWritabilityChanged() {
         }
 
-        private class MyUnsafe extends AbstractUnsafe {
-        }
+        private class MyChannelPipeline extends DefaultAbstractChannelPipeline {
 
-        private class MyChannelPipeline extends DefaultChannelPipeline {
-
-            MyChannelPipeline(Channel channel) {
+            MyChannelPipeline(AbstractChannel channel) {
                 super(channel);
             }
 

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
@@ -192,7 +192,7 @@ public class DefaultChannelPipelineTest {
 
     @Test
     public void testRemoveIfExists() {
-        DefaultChannelPipeline pipeline = new DefaultChannelPipeline(new LocalChannel(group.next()));
+        DefaultChannelPipeline pipeline = (DefaultChannelPipeline) new LocalChannel(group.next()).pipeline();
 
         ChannelHandler handler1 = newHandler();
         ChannelHandler handler2 = newHandler();
@@ -214,7 +214,7 @@ public class DefaultChannelPipelineTest {
 
     @Test
     public void testRemoveIfExistsDoesNotThrowException() {
-        DefaultChannelPipeline pipeline = new DefaultChannelPipeline(new LocalChannel(group.next()));
+        DefaultChannelPipeline pipeline = (DefaultChannelPipeline) new LocalChannel(group.next()).pipeline();
 
         ChannelHandler handler1 = newHandler();
         ChannelHandler handler2 = newHandler();
@@ -228,7 +228,7 @@ public class DefaultChannelPipelineTest {
 
     @Test
     public void testRemoveThrowNoSuchElementException() {
-        final DefaultChannelPipeline pipeline = new DefaultChannelPipeline(new LocalChannel(group.next()));
+        DefaultChannelPipeline pipeline = (DefaultChannelPipeline) new LocalChannel(group.next()).pipeline();
 
         ChannelHandler handler1 = newHandler();
         pipeline.addLast("handler1", handler1);

--- a/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
@@ -29,12 +29,9 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultMaxMessagesRecvByteBufAllocator;
-import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
-import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.channel.SingleThreadEventLoop;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
@@ -49,8 +46,6 @@ import org.junit.jupiter.api.function.Executable;
 import java.net.ConnectException;
 import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executor;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -182,7 +177,7 @@ public class LocalChannelTest {
                 // the ClosedChannelException has been created by AbstractUnsafe rather than transport implementations.
                 if (e.getStackTrace().length > 0) {
                    assertEquals(AbstractChannel.class.getName() +
-                           "$AbstractUnsafe", e.getStackTrace()[0].getClassName());
+                           "$IoTransportImpl", e.getStackTrace()[0].getClassName());
                 }
             }
         } finally {


### PR DESCRIPTION
…nel.Unsafe to IoTransport

Motivation:

The whole Channel.Unsafe concept made it easy for people to mess up internals and so we shouldn't really allow them to access it. Because of this we should remove the access to it completely and just make it a concept for the DefaultChannelPipeline and AbstractChannel.

Modifications:

- Rename Channel.Unsafe and IoTransport and just have a final implementation of it in AbstractChannel
- Remove all the AbstractUnsafe extensions and just merge the methods into the Channel implementation itself.
- Rework IoHandle implementations to not extends AbstractUnsafe

Result:

Cleaner API and hiding internals from user