### PR TITLE
LocalChannel: Don't fire exception throught pipeline on connect failu…

### DIFF
--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -482,7 +482,6 @@ public class LocalChannel extends AbstractChannel {
             if (state == State.CONNECTED) {
                 Exception cause = new AlreadyConnectedException();
                 safeSetFailure(promise, cause);
-                pipeline().fireExceptionCaught(cause);
                 return;
             }
 


### PR DESCRIPTION
…re (#15949)

Motivation:

Connect is an outbound operation and so should onyl fail the promise.

Modifications:

- Don'T call fireExceptionCaught(...)
- Add unit test

Result:

Correct exception reporting for connect failures
