### PR TITLE
Fix [15908] - Ignore unknown Http3Setting Identifier in Http3Settings…

### DIFF
--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ErrorCode.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ErrorCode.java
@@ -16,9 +16,19 @@
 package io.netty.handler.codec.http3;
 
 /**
- * Different <a href="https://tools.ietf.org/html/draft-ietf-quic-http-32#section-8.1">HTTP3 error codes</a>.
+ * Different <a href="https://datatracker.ietf.org/doc/html/rfc9114#name-http-3-error-codes">HTTP3 error codes</a>.
  */
 public enum Http3ErrorCode {
+
+    /**
+     * Datagram or Capsule Protocol parse error
+     * <a href="https://www.rfc-editor.org/rfc/rfc9297.html#name-http-3-error-code">rfc9297</a>
+     * registered in IANA http3
+     * <a href="https://www.iana.org/assignments/http3-parameters/http3-parameters.xhtml#http3-parameters-error-codes"
+     * >
+     *     IANA Http3 Error Codes</a>
+     */
+    H3_DATAGRAM_ERROR(0x33),
 
     /**
      *  No error. This is used when the connection or stream needs to be closed, but there is no error to signal.

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3SettingIdentifier.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3SettingIdentifier.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http3;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public enum Http3SettingIdentifier {
+
+    /**
+     * QPACK maximum table capacity setting identifier (<b>0x1</b>).
+     * <p>
+     * Defined in <a href="https://datatracker.ietf.org/doc/html/rfc9204#section-5">
+     * RFC 9204, Section 5 (SETTINGS_QPACK_MAX_TABLE_CAPACITY)</a> and registered in
+     * the <a href="https://www.iana.org/assignments/http3-parameters/http3-parameters.xhtml#settings">
+     * HTTP/3 SETTINGS registry (IANA)</a>.
+     * <br>
+     * Controls the maximum size of the dynamic table used by QPACK.
+     */
+    HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY(0x1),
+
+    /**
+     * Maximum field section size setting identifier (<b>0x6</b>).
+     * <p>
+     * Defined in <a href="https://datatracker.ietf.org/doc/html/rfc9114#section-7.2.4.1">
+     * RFC 9114, Section 7.2.4.1 (SETTINGS_MAX_FIELD_SECTION_SIZE)</a> , also referenced
+     * in the <a href="https://datatracker.ietf.org/doc/html/rfc9114#section-7.2.4.1">
+     * HTTP/3 SETTINGS registry (RFC 9114, Section 7.2.4.1)</a> and registered in
+     * the <a href="https://www.iana.org/assignments/http3-parameters/http3-parameters.xhtml#settings">
+     * HTTP/3 SETTINGS registry (IANA)</a>.
+     * <br>
+     * Specifies the upper bound on the total size of HTTP field sections accepted by a peer.
+     */
+    HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE(0x6),
+
+    /**
+     * QPACK blocked streams setting identifier (<b>0x7</b>).
+     * <p>
+     * Defined in <a href="https://datatracker.ietf.org/doc/html/rfc9204#section-5">
+     * RFC 9204, Section 5 (SETTINGS_QPACK_BLOCKED_STREAMS)</a> and registered in
+     * the <a href="https://www.iana.org/assignments/http3-parameters/http3-parameters.xhtml#settings">
+     * HTTP/3 SETTINGS registry (IANA)</a>.
+     * <br>
+     * Indicates the maximum number of streams that can be blocked waiting for QPACK instructions.
+     */
+    HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS(0x7),
+
+    /**
+     * ENABLE_CONNECT_PROTOCOL setting identifier (<b>0x8</b>).
+     * <p>
+     * Defined and registered in <a href="https://datatracker.ietf.org/doc/html/rfc9220#section-5">
+     * RFC 9220, Section 5 (IANA Considerations)</a> and registered in
+     * the <a href="https://www.iana.org/assignments/http3-parameters/http3-parameters.xhtml#settings">
+     * HTTP/3 SETTINGS registry (IANA)</a>.
+     * <br>
+     * Enables use of the CONNECT protocol in HTTP/3 when set to 1; disabled when 0.
+     */
+    HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL(0x8),
+
+    /**
+     * ENABLE_H3_DATAGRAM setting identifier (<b>0x8</b>).
+     * <p>
+     * Defined and registered in <a href="https://datatracker.ietf.org/doc/html/rfc9297#name-http-3-setting">
+     * RFC 9220, Section 5 (IANA Considerations)</a> and registered in
+     * the <a href="https://www.iana.org/assignments/http3-parameters/http3-parameters.xhtml#settings">
+     * HTTP/3 SETTINGS registry (IANA)</a>.
+     * <br>
+     * Enables use of the CONNECT protocol in HTTP/3 when set to 1; disabled when 0.
+     */
+    HTTP3_SETTINGS_H3_DATAGRAM(0x33);
+
+    private final long id;
+
+    private static final Map<Long, Http3SettingIdentifier> LOOKUP = Collections.unmodifiableMap(
+        Arrays.stream(values())
+                    .collect(Collectors.toMap(
+                            Http3SettingIdentifier::id,
+                            Function.identity()
+                    ))
+    );
+
+    Http3SettingIdentifier(long id) {
+        this.id = id;
+    }
+
+    /**
+     * Returns the Identifier of {@link Http3SettingIdentifier}
+     * for example:
+     * SETTINGS_QPACK_MAX_TABLE_CAPACITY = 0x1 = 1 in the settings frame
+     * <br>
+     * @return long(represented as hexadecimal above) value of the Identifier
+     */
+    public long id() {
+        return id;
+    }
+
+    /**
+     * Returns {@link Http3SettingIdentifier}
+     * @param id
+     * @return {@link Http3SettingIdentifier} enum which represents @param id, null otherwise
+     */
+    @Nullable
+    public static Http3SettingIdentifier fromId(long id) {
+        return LOOKUP.get(id);
+    }
+}

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3SettingsFrame.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3SettingsFrame.java
@@ -25,36 +25,36 @@ import java.util.Map;
 public interface Http3SettingsFrame extends Http3ControlStreamFrame, Iterable<Map.Entry<Long, Long>> {
 
     /**
-     * @deprecated Use {@link Http3Settings#HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY} instead.
+     * @deprecated Use {@link Http3SettingIdentifier#HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY} instead.
      * See <a href="https://tools.ietf.org/html/draft-ietf-quic-qpack-19#section-5">
      * SETTINGS_QPACK_MAX_TABLE_CAPACITY</a>.
      */
     @Deprecated
-    long HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY = Http3Settings.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY;
+    long HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY = Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY.id();
 
     /**
-     * @deprecated Use {@link Http3Settings#HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS} instead.
+     * @deprecated Use {@link Http3SettingIdentifier#HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS} instead.
      * See <a href="https://tools.ietf.org/html/draft-ietf-quic-qpack-19#section-5">
      * SETTINGS_QPACK_BLOCKED_STREAMS</a>.
      */
     @Deprecated
-    long HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS = Http3Settings.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS;
+    long HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS = Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id();
 
     /**
-     * @deprecated Use {@link Http3Settings#HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL} instead.
+     * @deprecated Use {@link Http3SettingIdentifier#HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL} instead.
      * See <a href="https://www.rfc-editor.org/rfc/rfc9220.html#section-5">
      * SETTINGS_ENABLE_CONNECT_PROTOCOL</a>.
      */
     @Deprecated
-    long HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL = Http3Settings.HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL;
+    long HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL = Http3SettingIdentifier.HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL.id();
 
     /**
-     * @deprecated Use {@link Http3Settings#HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE} instead.
+     * @deprecated Use {@link Http3SettingIdentifier#HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE} instead.
      * See <a href="https://tools.ietf.org/html/draft-ietf-quic-http-32#section-7.2.4.1">
      * SETTINGS_MAX_FIELD_SECTION_SIZE</a>.
      */
     @Deprecated
-    long HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE = Http3Settings.HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE;
+    long HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE = Http3SettingIdentifier.HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE.id();
 
     default Http3Settings settings() {
         throw new UnsupportedOperationException(

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/DefaultHttp3SettingsFrameTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/DefaultHttp3SettingsFrameTest.java
@@ -41,19 +41,19 @@ class DefaultHttp3SettingsFrameTest {
 
         assertNotNull(frame.settings());
         assertFalse(frame.iterator().hasNext());
-        assertNull(frame.get(Http3Settings.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY));
+        assertNull(frame.get(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY.id()));
     }
 
     @Test
     void testPutAndGetDelegatesToSettings() {
         DefaultHttp3SettingsFrame frame = new DefaultHttp3SettingsFrame();
 
-        frame.put(Http3Settings.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY, 256L);
-        frame.put(Http3Settings.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS, 8L);
+        frame.put(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY.id(), 256L);
+        frame.put(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id(), 8L);
 
         assertEquals(256L, frame.settings().qpackMaxTableCapacity());
         assertEquals(8L, frame.settings().qpackBlockedStreams());
-        assertEquals(8L, frame.get(Http3Settings.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS));
+        assertEquals(8L, frame.get(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id()));
     }
 
     @Test
@@ -72,7 +72,7 @@ class DefaultHttp3SettingsFrameTest {
 
         // Modify settings externally and verify frame sees update
         settings.qpackBlockedStreams(3);
-        assertEquals(3L, frame.get(Http3Settings.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS));
+        assertEquals(3L, frame.get(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id()));
     }
 
     @Test
@@ -130,17 +130,17 @@ class DefaultHttp3SettingsFrameTest {
         assertEquals(original, copy);
 
         // Modify original and ensure copy remains unchanged
-        original.put(Http3Settings.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS, 5L);
+        original.put(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id(), 5L);
         assertNotEquals(original, copy);
     }
 
     @Test
     void testDeprecatedMethodsStillWork() {
         DefaultHttp3SettingsFrame frame = new DefaultHttp3SettingsFrame();
-        frame.put(Http3Settings.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS, 5L);
+        frame.put(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id(), 5L);
 
         // Uses old get() API
-        assertEquals(5L, frame.get(Http3Settings.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS));
+        assertEquals(5L, frame.get(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id()));
 
         // New typed accessor matches
         assertEquals(5L, frame.settings().qpackBlockedStreams());

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3FrameCodecTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3FrameCodecTest.java
@@ -272,7 +272,9 @@ public class Http3FrameCodecTest {
         settingsFrame.put(Http3SettingsFrame.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS, 1L);
         settingsFrame.put(Http3SettingsFrame.HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE, 128L);
         settingsFrame.put(Http3SettingsFrame.HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL, 0L);
+        settingsFrame.put(Http3SettingIdentifier.HTTP3_SETTINGS_H3_DATAGRAM.id(), 1L);
         // Ensure we can encode and decode all sizes correctly.
+        // unknown settings id/key will be ignored
         settingsFrame.put(63, 63L);
         settingsFrame.put(16383, 16383L);
         settingsFrame.put(1073741823, 1073741823L);

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3SettingsTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3SettingsTest.java
@@ -47,6 +47,7 @@ public class Http3SettingsTest {
         assertEquals(0L, settings.qpackBlockedStreams());
         assertEquals(Boolean.FALSE, settings.connectProtocolEnabled());
         assertEquals(Long.MAX_VALUE, settings.maxFieldSectionSize());
+        assertEquals(Boolean.FALSE, settings.h3DatagramEnabled());
     }
 
     @Test
@@ -62,11 +63,13 @@ public class Http3SettingsTest {
         assertEquals(4L, settings.qpackBlockedStreams());
         assertEquals(Boolean.TRUE, settings.connectProtocolEnabled());
         assertEquals(4096L, settings.maxFieldSectionSize());
+        assertNull(settings.h3DatagramEnabled());
     }
 
     @Test
     void testEqualsAndHashCode() {
         Http3Settings s1 = new Http3Settings()
+                .enableH3Datagram(true)
                 .qpackMaxTableCapacity(256)
                 .qpackBlockedStreams(8)
                 .enableConnectProtocol(true);
@@ -74,7 +77,8 @@ public class Http3SettingsTest {
         Http3Settings s2 = new Http3Settings()
                 .qpackMaxTableCapacity(256)
                 .qpackBlockedStreams(8)
-                .enableConnectProtocol(true);
+                .enableConnectProtocol(true)
+                .enableH3Datagram(true);
 
         Http3Settings s3 = new Http3Settings().qpackMaxTableCapacity(999);
 
@@ -97,19 +101,23 @@ public class Http3SettingsTest {
             assertNotNull(e.getValue());
             count.incrementAndGet();
         }
-        assertTrue(count.get() >= 2);
+        assertTrue(count.get() == 2);
     }
 
     @Test
     void testForEachConsumer() {
         Http3Settings settings = new Http3Settings()
                 .qpackMaxTableCapacity(5)
-                .qpackBlockedStreams(7);
+                .qpackBlockedStreams(7)
+                .enableH3Datagram(true)
+                .maxFieldSectionSize(1);
 
         List<Long> keys = new ArrayList<>();
         settings.forEach(entry -> keys.add(entry.getKey()));
-        assertTrue(keys.contains(Http3Settings.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY));
-        assertTrue(keys.contains(Http3Settings.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS));
+        assertTrue(keys.contains(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY.id()));
+        assertTrue(keys.contains(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id()));
+        assertTrue(keys.contains(Http3SettingIdentifier.HTTP3_SETTINGS_H3_DATAGRAM.id()));
+        assertTrue(keys.contains(Http3SettingIdentifier.HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE.id()));
     }
 
     @Test
@@ -150,31 +158,31 @@ public class Http3SettingsTest {
 
         // Invalid ENABLE_CONNECT_PROTOCOL (must be 0 or 1)
         assertThrows(IllegalArgumentException.class,
-                () -> settings.put(Http3Settings.HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL, 5L));
+                () -> settings.put(Http3SettingIdentifier.HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL.id(), 5L));
 
-        // Non-standard but negative key
         assertThrows(IllegalArgumentException.class,
-                () -> settings.put(0x9999, -99L));
+                () -> settings.put(Http3SettingIdentifier.HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL.id(), 15L));
     }
 
     @Test
     void testVerifyStandardSettingValidCases() {
         Http3Settings settings = new Http3Settings();
-        settings.put(Http3Settings.HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL, 1L);
-        settings.put(Http3Settings.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY, 0L);
-        settings.put(Http3Settings.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS, 5L);
-        settings.put(Http3Settings.HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE, 4096L);
+        settings.put(Http3SettingIdentifier.HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL.id(), 1L);
+        settings.put(Http3SettingIdentifier.HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL.id(), 1L);
+        settings.put(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY.id(), 0L);
+        settings.put(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id(), 5L);
+        settings.put(Http3SettingIdentifier.HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE.id(), 4096L);
 
         assertEquals(Boolean.TRUE, settings.connectProtocolEnabled());
         assertEquals(4096L, settings.maxFieldSectionSize());
     }
 
     @Test
-    void testCustomSettingsAllowed() {
+    void testCustomSettingsIgnored() {
         Http3Settings settings = new Http3Settings();
         long customKey = 0xdeadbeefL;
         settings.put(customKey, 123L);
-        assertEquals(123L, settings.get(customKey));
+        assertNull(settings.get(customKey));
     }
 
     @Test
@@ -241,7 +249,7 @@ public class Http3SettingsTest {
     void testPutOverridesExistingKey() {
         Http3Settings settings = new Http3Settings();
         settings.qpackMaxTableCapacity(10);
-        settings.put(Http3Settings.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY, 20L);
+        settings.put(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY.id(), 20L);
         assertEquals(20L, settings.qpackMaxTableCapacity());
     }
 
@@ -249,13 +257,6 @@ public class Http3SettingsTest {
     void testNullValueRejected() {
         Http3Settings settings = new Http3Settings();
         assertThrows(NullPointerException.class, () -> settings.put(1, null));
-    }
-
-    @Test
-    void testUnknownCustomSettingPositiveValueAllowed() {
-        Http3Settings settings = new Http3Settings();
-        assertDoesNotThrow(() -> settings.put(0xABCD, 1L));
-        assertEquals(1L, settings.get(0xABCD));
     }
 
     @Test


### PR DESCRIPTION
…Frame (#15909)

## Motivation

* According to the spec https://www.rfc-editor.org/rfc/rfc9114.html#section-7.2.4-9 , endpoints **must ignore unknown settings identifiers**. Netty’s previous behavior incorrectly **stored** unknown settings values, which contradicts RFC behaviour.
* A **HTTP/3 error code** was missing - H3_DATAGRAM_ERROR
* The **SETTINGS_H3_DATAGRAM (0x33)** identifier was not added.
* Prior behaviour fixed in [https://github.com/netty/netty/pull/15835](https://github.com/netty/netty/pull/15835) still allowed direct injection of unsupported settings; this PR effectively deprecates that direct-settings behaviour completely.

---

## Modification

* [x] **Ignore unknown HTTP/3 SETTINGS identifiers**

  * Updated parsing logic to skip unknown settings identifiers:

    ```java // When Non-Standard/Unknown settings identifier present - Ignore if (Http3SettingIdentifier.fromId(key) == null) { return value; } ```

  * Unknown settings are **no longer stored** in `Http3Settings`.

  * Fully aligns with HTTP/3 specification behaviour.

* Effectively **deprecates the old direct-settings behavior** introduced/fixed in PR #15835.

* [x] **Added missing HTTP/3 error codes**

  * Implemented the remaining H3 error codes defined in the RFC.
  * Ensures accurate error propagation and complete protocol support.

* [x] **Added `SETTINGS_H3_DATAGRAM (0x33)`**

  * Introduced the identifier:

    ```java SETTINGS_H3_DATAGRAM(0x33) ```

  * Added proper handling in both encoder and decoder paths.

* [x] **Added unit tests**

  * Tests covering:

    * Ignoring unknown setting identifiers
    * Correct handling of `SETTINGS_H3_DATAGRAM`
    * Verification of newly added error codes
    * Ensuring unknown settings do **not** appear in `Http3Settings`

---

## Result

* [x] Netty now **correctly ignores unknown HTTP/3 settings**, as required by the specification.
* [x] `Http3Settings` no longer stores invalid or non-standard identifiers.
* [x] Full support for **`SETTINGS_H3_DATAGRAM (0x33)`**.
* [x] Complete coverage of **HTTP/3 error codes**.
* [x] Added unit tests ensure long-term correctness.
* [x] Behaviour from PR #15835 is effectively superseded and corrected.

Fixes #[15908](https://github.com/netty/netty/issues/15908)
