### PR TITLE
Transport: Only allow DatagramPacket and ByteBuf to be be written for…

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -18,19 +18,16 @@ package io.netty.channel.epoll;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.AddressedEnvelope;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
-import io.netty.channel.DefaultAddressedEnvelope;
 import io.netty.channel.EventLoop;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.socket.SocketProtocolFamily;
 import io.netty.channel.unix.DomainDatagramSocketAddress;
-import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.channel.unix.Errors;
 import io.netty.channel.unix.Errors.NativeIoException;
 import io.netty.channel.unix.UnixChannelUtil;
@@ -67,18 +64,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
     private static final ChannelMetadata METADATA = new ChannelMetadata(true, 16);
     private static final String EXPECTED_TYPES =
             " (expected: " + StringUtil.simpleClassName(DatagramPacket.class) + ", " +
-            StringUtil.simpleClassName(AddressedEnvelope.class) + '<' +
-            StringUtil.simpleClassName(ByteBuf.class) + ", " +
-            StringUtil.simpleClassName(InetSocketAddress.class) + ">, " +
             StringUtil.simpleClassName(ByteBuf.class) + ')';
-
-    private static final String EXPECTED_TYPES_UNIX =
-            " (expected: " +
-                    StringUtil.simpleClassName(DatagramPacket.class) + ", " +
-                    StringUtil.simpleClassName(AddressedEnvelope.class) + '<' +
-                    StringUtil.simpleClassName(ByteBuf.class) + ", " +
-                    StringUtil.simpleClassName(DomainSocketAddress.class) + ">, " +
-                    StringUtil.simpleClassName(ByteBuf.class) + ')';
 
     private final EpollDatagramChannelConfig config;
     private volatile boolean connected;
@@ -461,12 +447,10 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
     private boolean doWriteMessage(Object msg) throws Exception {
         final ByteBuf data;
         final SocketAddress remoteAddress;
-        if (msg instanceof AddressedEnvelope) {
-            @SuppressWarnings("unchecked")
-            AddressedEnvelope<ByteBuf, SocketAddress> envelope =
-                    (AddressedEnvelope<ByteBuf, SocketAddress>) msg;
-            data = envelope.content();
-            remoteAddress = envelope.recipient();
+        if (msg instanceof DatagramPacket) {
+            DatagramPacket packet = (DatagramPacket) msg;
+            data = packet.content();
+            remoteAddress = packet.recipient();
         } else {
             data = (ByteBuf) msg;
             remoteAddress = null;
@@ -480,25 +464,10 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
         return doWriteOrSendBytes(data, remoteAddress, false) > 0;
     }
 
-    private void checkEnvelope(AddressedEnvelope<?, ?> envelope) {
-        if (envelope == null) {
-            return;
-        }
-
-        if (socket.protocolFamily() == SocketProtocolFamily.UNIX) {
-            if (!(envelope.content() instanceof ByteBuf) || !(envelope.recipient() instanceof DomainSocketAddress)) {
-                throw new UnsupportedOperationException(
-                        "unsupported message type: " + StringUtil.simpleClassName(envelope) + EXPECTED_TYPES_UNIX);
-            }
-        } else {
-            if (envelope.content() instanceof ByteBuf && envelope.recipient() instanceof InetSocketAddress) {
-                if (((InetSocketAddress) envelope.recipient()).isUnresolved()) {
-                    throw new UnresolvedAddressException();
-                }
-            } else {
-                throw new UnsupportedOperationException(
-                        "unsupported message type: " + StringUtil.simpleClassName(envelope) + EXPECTED_TYPES);
-            }
+    private static void checkUnresolved(SocketAddress address) {
+        if (address instanceof InetSocketAddress
+                && (((InetSocketAddress) address).isUnresolved())) {
+            throw new UnresolvedAddressException();
         }
     }
 
@@ -510,7 +479,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
                         "unsupported message type: " + StringUtil.simpleClassName(msg) + EXPECTED_TYPES);
             }
             io.netty.channel.unix.SegmentedDatagramPacket packet = (io.netty.channel.unix.SegmentedDatagramPacket) msg;
-            checkEnvelope(packet);
+            checkUnresolved(packet.recipient());
 
             ByteBuf content = packet.content();
             return UnixChannelUtil.isBufferCopyNeededForWrite(content) ?
@@ -518,7 +487,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
         }
         if (msg instanceof DatagramPacket) {
             DatagramPacket packet = (DatagramPacket) msg;
-            checkEnvelope(packet);
+            checkUnresolved(packet.recipient());
             ByteBuf content = packet.content();
             return UnixChannelUtil.isBufferCopyNeededForWrite(content) ?
                     new DatagramPacket(newDirectBuffer(packet, content), packet.recipient()) : msg;
@@ -528,20 +497,8 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
             ByteBuf buf = (ByteBuf) msg;
             return UnixChannelUtil.isBufferCopyNeededForWrite(buf)? newDirectBuffer(buf) : buf;
         }
-
-        if (msg instanceof AddressedEnvelope) {
-            @SuppressWarnings("unchecked")
-            AddressedEnvelope<Object, SocketAddress> e = (AddressedEnvelope<Object, SocketAddress>) msg;
-            checkEnvelope(e);
-
-            ByteBuf content = (ByteBuf) e.content();
-            return UnixChannelUtil.isBufferCopyNeededForWrite(content)?
-                    new DefaultAddressedEnvelope<ByteBuf, InetSocketAddress>(
-                            newDirectBuffer(e, content), (InetSocketAddress) e.recipient()) : e;
-        }
         throw new UnsupportedOperationException(
-                "unsupported message type: " + StringUtil.simpleClassName(msg) +
-                        (socket.protocolFamily() == SocketProtocolFamily.UNIX ? EXPECTED_TYPES_UNIX : EXPECTED_TYPES));
+                "unsupported message type: " + StringUtil.simpleClassName(msg) + EXPECTED_TYPES);
     }
 
     @Override

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
@@ -16,13 +16,11 @@
 package io.netty.channel.uring;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.AddressedEnvelope;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
-import io.netty.channel.DefaultAddressedEnvelope;
 import io.netty.channel.EventLoop;
 import io.netty.channel.IoRegistration;
 import io.netty.channel.socket.DatagramChannel;
@@ -58,9 +56,6 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
     private static final ChannelMetadata METADATA = new ChannelMetadata(true, 16);
     private static final String EXPECTED_TYPES =
             " (expected: " + StringUtil.simpleClassName(DatagramPacket.class) + ", " +
-            StringUtil.simpleClassName(AddressedEnvelope.class) + '<' +
-            StringUtil.simpleClassName(ByteBuf.class) + ", " +
-            StringUtil.simpleClassName(InetSocketAddress.class) + ">, " +
             StringUtil.simpleClassName(ByteBuf.class) + ')';
 
     private final IoUringDatagramChannelConfig config;
@@ -311,9 +306,9 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
         }));
     }
 
-    private static void checkUnresolved(AddressedEnvelope<?, ?> envelope) {
-        if (envelope.recipient() instanceof InetSocketAddress
-                && (((InetSocketAddress) envelope.recipient()).isUnresolved())) {
+    private static void checkUnresolved(SocketAddress address) {
+        if (address instanceof InetSocketAddress
+                && (((InetSocketAddress) address).isUnresolved())) {
             throw new UnresolvedAddressException();
         }
     }
@@ -322,7 +317,7 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
     protected Object filterOutboundMessage(Object msg) {
         if (msg instanceof DatagramPacket) {
             DatagramPacket packet = (DatagramPacket) msg;
-            checkUnresolved(packet);
+            checkUnresolved(packet.recipient());
             ByteBuf content = packet.content();
             return !content.hasMemoryAddress() ?
                     packet.replace(newDirectBuffer(packet, content)) : msg;
@@ -331,20 +326,6 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
         if (msg instanceof ByteBuf) {
             ByteBuf buf = (ByteBuf) msg;
             return !buf.hasMemoryAddress()? newDirectBuffer(buf) : buf;
-        }
-
-        if (msg instanceof AddressedEnvelope) {
-            @SuppressWarnings("unchecked")
-            AddressedEnvelope<Object, SocketAddress> e = (AddressedEnvelope<Object, SocketAddress>) msg;
-            checkUnresolved(e);
-            if (e.content() instanceof ByteBuf &&
-                (e.recipient() == null || e.recipient() instanceof InetSocketAddress)) {
-
-                ByteBuf content = (ByteBuf) e.content();
-                return !content.hasMemoryAddress()?
-                        new DefaultAddressedEnvelope<>(
-                            newDirectBuffer(e, content), (InetSocketAddress) e.recipient()) : e;
-            }
         }
 
         throw new UnsupportedOperationException(
@@ -597,12 +578,11 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
         final ByteBuf data;
         final InetSocketAddress remoteAddress;
         final int segmentSize;
-        if (msg instanceof AddressedEnvelope) {
+        if (msg instanceof DatagramPacket) {
             @SuppressWarnings("unchecked")
-            AddressedEnvelope<ByteBuf, InetSocketAddress> envelope =
-                    (AddressedEnvelope<ByteBuf, InetSocketAddress>) msg;
-            data = envelope.content();
-            remoteAddress = envelope.recipient();
+            DatagramPacket packet = (DatagramPacket) msg;
+            data = packet.content();
+            remoteAddress = (InetSocketAddress) packet.recipient();
             if (msg instanceof SegmentedDatagramPacket) {
                 segmentSize = ((SegmentedDatagramPacket) msg).segmentSize();
             } else {

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
@@ -17,13 +17,11 @@ package io.netty.channel.kqueue;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.channel.AddressedEnvelope;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
-import io.netty.channel.DefaultAddressedEnvelope;
 import io.netty.channel.EventLoop;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.DatagramChannelConfig;
@@ -56,17 +54,6 @@ import static io.netty.channel.unix.Socket.isIPv6Preferred;
 public final class KQueueDatagramChannel extends AbstractKQueueChannel implements DatagramChannel {
     private static final String EXPECTED_TYPES =
             " (expected: " + StringUtil.simpleClassName(DatagramPacket.class) + ", " +
-                    StringUtil.simpleClassName(AddressedEnvelope.class) + '<' +
-                    StringUtil.simpleClassName(ByteBuf.class) + ", " +
-                    StringUtil.simpleClassName(InetSocketAddress.class) + ">, " +
-                    StringUtil.simpleClassName(ByteBuf.class) + ')';
-
-    private static final String EXPECTED_TYPES_UNIX =
-            " (expected: " +
-                    StringUtil.simpleClassName(DatagramPacket.class) + ", " +
-                    StringUtil.simpleClassName(AddressedEnvelope.class) + '<' +
-                    StringUtil.simpleClassName(ByteBuf.class) + ", " +
-                    StringUtil.simpleClassName(DomainSocketAddress.class) + ">, " +
                     StringUtil.simpleClassName(ByteBuf.class) + ')';
 
     private static final ChannelMetadata METADATA = new ChannelMetadata(true, 16);
@@ -345,12 +332,10 @@ public final class KQueueDatagramChannel extends AbstractKQueueChannel implement
     private boolean doWriteMessage(Object msg) throws Exception {
         final ByteBuf data;
         SocketAddress remoteAddress;
-        if (msg instanceof AddressedEnvelope) {
-            @SuppressWarnings("unchecked")
-            AddressedEnvelope<ByteBuf, SocketAddress> envelope =
-                    (AddressedEnvelope<ByteBuf, SocketAddress>) msg;
-            data = envelope.content();
-            remoteAddress = envelope.recipient();
+        if (msg instanceof DatagramPacket) {
+            DatagramPacket packet = (DatagramPacket) msg;
+            data = packet.content();
+            remoteAddress = packet.recipient();
         } else {
             data = (ByteBuf) msg;
             remoteAddress = null;
@@ -416,25 +401,10 @@ public final class KQueueDatagramChannel extends AbstractKQueueChannel implement
         return writtenBytes > 0;
     }
 
-    private void checkEnvelope(AddressedEnvelope<?, ?> envelope) {
-        if (envelope == null) {
-            return;
-        }
-
-        if (socket.protocolFamily() == SocketProtocolFamily.UNIX) {
-            if (!(envelope.content() instanceof ByteBuf) || !(envelope.recipient() instanceof DomainSocketAddress)) {
-                throw new UnsupportedOperationException(
-                        "unsupported message type: " + StringUtil.simpleClassName(envelope) + EXPECTED_TYPES_UNIX);
-            }
-        } else {
-            if (envelope.content() instanceof ByteBuf && envelope.recipient() instanceof InetSocketAddress) {
-                if (((InetSocketAddress) envelope.recipient()).isUnresolved()) {
-                    throw new UnresolvedAddressException();
-                }
-            } else {
-                throw new UnsupportedOperationException(
-                        "unsupported message type: " + StringUtil.simpleClassName(envelope) + EXPECTED_TYPES);
-            }
+    private static void checkUnresolved(SocketAddress address) {
+        if (address instanceof InetSocketAddress
+                && (((InetSocketAddress) address).isUnresolved())) {
+            throw new UnresolvedAddressException();
         }
     }
 
@@ -442,7 +412,7 @@ public final class KQueueDatagramChannel extends AbstractKQueueChannel implement
     protected Object filterOutboundMessage(Object msg) {
         if (msg instanceof DatagramPacket) {
             DatagramPacket packet = (DatagramPacket) msg;
-            checkEnvelope(packet);
+            checkUnresolved(packet.recipient());
             ByteBuf content = packet.content();
             return UnixChannelUtil.isBufferCopyNeededForWrite(content) ?
                     new DatagramPacket(newDirectBuffer(packet, content), packet.recipient()) : msg;
@@ -452,19 +422,8 @@ public final class KQueueDatagramChannel extends AbstractKQueueChannel implement
             ByteBuf buf = (ByteBuf) msg;
             return UnixChannelUtil.isBufferCopyNeededForWrite(buf) ? newDirectBuffer(buf) : buf;
         }
-
-        if (msg instanceof AddressedEnvelope) {
-            @SuppressWarnings("unchecked")
-            AddressedEnvelope<Object, SocketAddress> e = (AddressedEnvelope<Object, SocketAddress>) msg;
-            checkEnvelope(e);
-            ByteBuf content = (ByteBuf) e.content();
-            return UnixChannelUtil.isBufferCopyNeededForWrite(content) ?
-                    new DefaultAddressedEnvelope<>(
-                            newDirectBuffer(e, content), e.recipient()) : e;
-        }
         throw new UnsupportedOperationException(
-                "unsupported message type: " + StringUtil.simpleClassName(msg) +
-                        (socket.protocolFamily() == SocketProtocolFamily.UNIX ? EXPECTED_TYPES_UNIX : EXPECTED_TYPES));
+                "unsupported message type: " + StringUtil.simpleClassName(msg) + EXPECTED_TYPES);
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
@@ -17,7 +17,6 @@ package io.netty.channel.socket.nio;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.channel.AddressedEnvelope;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelFuture;
@@ -25,7 +24,6 @@ import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPromise;
-import io.netty.channel.DefaultAddressedEnvelope;
 import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.EventLoop;
 import io.netty.channel.FixedRecvByteBufAllocator;
@@ -77,9 +75,8 @@ import static io.netty.channel.ChannelOption.SO_SNDBUF;
 
 /**
  * An NIO datagram {@link Channel} that sends and receives an
- * {@link AddressedEnvelope AddressedEnvelope<ByteBuf, SocketAddress>}.
+ * {@link DatagramPacket}.
  *
- * @see AddressedEnvelope
  * @see DatagramPacket
  */
 public final class NioDatagramChannel
@@ -89,9 +86,6 @@ public final class NioDatagramChannel
     private static final SelectorProvider DEFAULT_SELECTOR_PROVIDER = SelectorProvider.provider();
     private static final String EXPECTED_TYPES =
             " (expected: " + StringUtil.simpleClassName(DatagramPacket.class) + ", " +
-            StringUtil.simpleClassName(AddressedEnvelope.class) + '<' +
-            StringUtil.simpleClassName(ByteBuf.class) + ", " +
-            StringUtil.simpleClassName(SocketAddress.class) + ">, " +
             StringUtil.simpleClassName(ByteBuf.class) + ')';
 
     private final DatagramChannelConfig config;
@@ -311,11 +305,10 @@ public final class NioDatagramChannel
     protected boolean doWriteMessage(Object msg, ChannelOutboundBuffer in) throws Exception {
         final SocketAddress remoteAddress;
         final ByteBuf data;
-        if (msg instanceof AddressedEnvelope) {
-            @SuppressWarnings("unchecked")
-            AddressedEnvelope<ByteBuf, SocketAddress> envelope = (AddressedEnvelope<ByteBuf, SocketAddress>) msg;
-            remoteAddress = envelope.recipient();
-            data = envelope.content();
+        if (msg instanceof DatagramPacket) {
+            DatagramPacket packet = (DatagramPacket) msg;
+            remoteAddress = packet.recipient();
+            data = packet.content();
         } else {
             data = (ByteBuf) msg;
             remoteAddress = null;
@@ -337,9 +330,9 @@ public final class NioDatagramChannel
         return writtenBytes > 0;
     }
 
-    private static void checkUnresolved(AddressedEnvelope<?, ?> envelope) {
-        if (envelope.recipient() instanceof InetSocketAddress
-                && (((InetSocketAddress) envelope.recipient()).isUnresolved())) {
+    private static void checkUnresolved(SocketAddress address) {
+        if (address instanceof InetSocketAddress
+                && (((InetSocketAddress) address).isUnresolved())) {
             throw new UnresolvedAddressException();
         }
     }
@@ -348,7 +341,7 @@ public final class NioDatagramChannel
     protected Object filterOutboundMessage(Object msg) {
         if (msg instanceof DatagramPacket) {
             DatagramPacket p = (DatagramPacket) msg;
-            checkUnresolved(p);
+            checkUnresolved(p.recipient());
             ByteBuf content = p.content();
             if (isSingleDirectBuffer(content)) {
                 return p;
@@ -362,19 +355,6 @@ public final class NioDatagramChannel
                 return buf;
             }
             return newDirectBuffer(buf);
-        }
-
-        if (msg instanceof AddressedEnvelope) {
-            @SuppressWarnings("unchecked")
-            AddressedEnvelope<Object, SocketAddress> e = (AddressedEnvelope<Object, SocketAddress>) msg;
-            checkUnresolved(e);
-            if (e.content() instanceof ByteBuf) {
-                ByteBuf content = (ByteBuf) e.content();
-                if (isSingleDirectBuffer(content)) {
-                    return e;
-                }
-                return new DefaultAddressedEnvelope<ByteBuf, SocketAddress>(newDirectBuffer(e, content), e.recipient());
-            }
         }
 
         throw new UnsupportedOperationException(


### PR DESCRIPTION
… DatagramChannel implementations

Motivation:

We also allowed AddressEnvelope before which just made things more complicated. People should use DatagramPacket.

Modifications:

Only support DatagramPacket and ByteBuf when writing to DatagramChannels

Result:

Simplify and cleanup