### PR TITLE
Remove throws Exception from listener method

### DIFF
--- a/codec-base/src/main/java/io/netty/handler/codec/MessageAggregator.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/MessageAggregator.java
@@ -225,7 +225,7 @@ public abstract class MessageAggregator<I, S, C extends ByteBufHolder, O extends
                 if (listener == null) {
                     continueResponseWriteListener = listener = new ChannelFutureListener() {
                         @Override
-                        public void operationComplete(ChannelFuture future) throws Exception {
+                        public void operationComplete(ChannelFuture future) {
                             if (!future.isSuccess()) {
                                 ctx.fireExceptionCaught(future.cause());
                             }

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/EncoderUtil.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/EncoderUtil.java
@@ -39,7 +39,7 @@ final class EncoderUtil {
 
             finishFuture.addListener(new ChannelFutureListener() {
                 @Override
-                public void operationComplete(ChannelFuture f)  {
+                public void operationComplete(ChannelFuture f) {
                     // Cancel the scheduled timeout.
                     future.cancel(true);
                     if (!promise.isDone()) {

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/Lz4FrameEncoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/Lz4FrameEncoderTest.java
@@ -282,7 +282,7 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
                     finalClientChannel.writeAndFlush(buf.writerIndex(buf.writerIndex() + size))
                             .addListener(new ChannelFutureListener() {
                         @Override
-                        public void operationComplete(ChannelFuture future) throws Exception {
+                        public void operationComplete(ChannelFuture future) {
                             try {
                                 writeFailCauseRef.set(future.cause());
                             } finally {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
@@ -251,7 +251,7 @@ public class HttpObjectAggregator
                 ChannelFuture future = ctx.writeAndFlush(TOO_LARGE_CLOSE.retainedDuplicate());
                 future.addListener(new ChannelFutureListener() {
                     @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
+                    public void operationComplete(ChannelFuture future) {
                         if (!future.isSuccess()) {
                             logger.debug("Failed to send a 413 Request Entity Too Large.", future.cause());
                         }
@@ -261,7 +261,7 @@ public class HttpObjectAggregator
             } else {
                 ctx.writeAndFlush(TOO_LARGE.retainedDuplicate()).addListener(new ChannelFutureListener() {
                     @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
+                    public void operationComplete(ChannelFuture future) {
                         if (!future.isSuccess()) {
                             logger.debug("Failed to send a 413 Request Entity Too Large.", future.cause());
                             ctx.close();

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker.java
@@ -708,7 +708,7 @@ public abstract class WebSocketClientHandshaker {
 
                     channel.closeFuture().addListener(new ChannelFutureListener() {
                         @Override
-                        public void operationComplete(ChannelFuture future) throws Exception {
+                        public void operationComplete(ChannelFuture future) {
                             forceCloseFuture.cancel(false);
                         }
                     });

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
@@ -57,7 +57,7 @@ class WebSocketClientProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
         super.channelActive(ctx);
         handshaker.handshake(ctx.channel()).addListener(new ChannelFutureListener() {
             @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
+            public void operationComplete(ChannelFuture future) {
                 if (!future.isSuccess()) {
                     handshakePromise.tryFailure(future.cause());
                     ctx.fireExceptionCaught(future.cause());
@@ -127,7 +127,7 @@ class WebSocketClientProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
         // Cancel the handshake timeout when handshake is finished.
         localHandshakePromise.addListener(new FutureListener<Void>() {
             @Override
-            public void operationComplete(Future<Void> f) throws Exception {
+            public void operationComplete(Future<Void> f) {
                 timeoutFuture.cancel(false);
             }
         });

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
@@ -230,7 +230,7 @@ public abstract class WebSocketServerHandshaker {
         }
         channel.writeAndFlush(response).addListener(new ChannelFutureListener() {
             @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
+            public void operationComplete(ChannelFuture future) {
                 if (future.isSuccess()) {
                     ChannelPipeline p = future.channel().pipeline();
                     p.remove(encoderName);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
@@ -24,7 +24,6 @@ import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpRequest;
-import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler.ServerHandshakeStateEvent;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.ReferenceCountUtil;
@@ -33,7 +32,6 @@ import io.netty.util.concurrent.FutureListener;
 
 import java.util.concurrent.TimeUnit;
 
-import static io.netty.handler.codec.http.HttpUtil.*;
 import static io.netty.util.internal.ObjectUtil.*;
 
 /**

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameCodec.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameCodec.java
@@ -151,7 +151,7 @@ public class SpdyFrameCodec extends ByteToMessageDecoder
         this.ctx = ctx;
         ctx.channel().closeFuture().addListener(new ChannelFutureListener() {
             @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
+            public void operationComplete(ChannelFuture future) {
                 spdyHeaderBlockDecoder.end();
                 spdyHeaderBlockEncoder.end();
             }

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySessionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySessionHandler.java
@@ -502,7 +502,7 @@ public class SpdySessionHandler extends ChannelDuplexHandler {
                 final ChannelHandlerContext context = ctx;
                 ctx.write(partialDataFrame).addListener(new ChannelFutureListener() {
                     @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
+                    public void operationComplete(ChannelFuture future) {
                         if (!future.isSuccess()) {
                             issueSessionError(context, SpdySessionStatus.INTERNAL_ERROR);
                         }
@@ -519,7 +519,7 @@ public class SpdySessionHandler extends ChannelDuplexHandler {
                 final ChannelHandlerContext context = ctx;
                 promise.addListener(new ChannelFutureListener() {
                     @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
+                    public void operationComplete(ChannelFuture future) {
                         if (!future.isSuccess()) {
                             issueSessionError(context, SpdySessionStatus.INTERNAL_ERROR);
                         }
@@ -779,7 +779,7 @@ public class SpdySessionHandler extends ChannelDuplexHandler {
                 // Close the session on write failures that leave the transfer window in a corrupt state.
                 ctx.writeAndFlush(partialDataFrame).addListener(new ChannelFutureListener() {
                     @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
+                    public void operationComplete(ChannelFuture future) {
                         if (!future.isSuccess()) {
                             issueSessionError(ctx, SpdySessionStatus.INTERNAL_ERROR);
                         }
@@ -800,7 +800,7 @@ public class SpdySessionHandler extends ChannelDuplexHandler {
                 // Close the session on write failures that leave the transfer window in a corrupt state.
                 ctx.writeAndFlush(spdyDataFrame, pendingWrite.promise).addListener(new ChannelFutureListener() {
                     @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
+                    public void operationComplete(ChannelFuture future) {
                         if (!future.isSuccess()) {
                             issueSessionError(ctx, SpdySessionStatus.INTERNAL_ERROR);
                         }
@@ -847,7 +847,7 @@ public class SpdySessionHandler extends ChannelDuplexHandler {
         }
 
         @Override
-        public void operationComplete(ChannelFuture sentGoAwayFuture) throws Exception {
+        public void operationComplete(ChannelFuture sentGoAwayFuture) {
             ctx.close(promise);
         }
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpClientCodecTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpClientCodecTest.java
@@ -155,14 +155,14 @@ public class HttpClientCodecTest {
                             "Content-Type: text/html\r\n\r\n").getBytes(CharsetUtil.ISO_8859_1)))
                                     .addListener(new ChannelFutureListener() {
                                 @Override
-                                public void operationComplete(ChannelFuture future) throws Exception {
+                                public void operationComplete(ChannelFuture future) {
                                     assertTrue(future.isSuccess());
                                     sChannel.writeAndFlush(Unpooled.wrappedBuffer(
                                             "<html><body>hello half closed!</body></html>\r\n"
                                             .getBytes(CharsetUtil.ISO_8859_1)))
                                             .addListener(new ChannelFutureListener() {
                                         @Override
-                                        public void operationComplete(ChannelFuture future) throws Exception {
+                                        public void operationComplete(ChannelFuture future) {
                                             assertTrue(future.isSuccess());
                                             sChannel.shutdownOutput();
                                         }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
@@ -251,7 +251,7 @@ public class WebSocketHandshakeHandOverTest {
                 if (evt == ClientHandshakeStateEvent.HANDSHAKE_COMPLETE) {
                     ctx.channel().closeFuture().addListener(new ChannelFutureListener() {
                         @Override
-                        public void operationComplete(ChannelFuture future) throws Exception {
+                        public void operationComplete(ChannelFuture future) {
                             clientForceClosed = true;
                         }
                     });

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
@@ -524,7 +524,7 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder, Ht
     private void notifyLifecycleManagerOnError(ChannelFuture future, final ChannelHandlerContext ctx) {
         future.addListener(new ChannelFutureListener() {
             @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
+            public void operationComplete(ChannelFuture future) {
                 Throwable cause = future.cause();
                 if (cause != null) {
                     lifecycleManager.onError(ctx, true, cause);
@@ -620,7 +620,7 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder, Ht
         }
 
         @Override
-        public void operationComplete(ChannelFuture future) throws Exception {
+        public void operationComplete(ChannelFuture future) {
             if (!future.isSuccess()) {
                 error(flowController().channelHandlerContext(), future.cause());
             }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -519,7 +519,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
                 final ChannelFutureListener oldCloseListener = closeListener;
                 closeListener = new ChannelFutureListener() {
                     @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
+                    public void operationComplete(ChannelFuture future) {
                         try {
                             oldCloseListener.operationComplete(future);
                         } finally {
@@ -773,7 +773,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         } else {
             future.addListener(new ChannelFutureListener() {
                 @Override
-                public void operationComplete(ChannelFuture future) throws Exception {
+                public void operationComplete(ChannelFuture future) {
                     closeConnectionOnError(ctx, future);
                 }
             });
@@ -819,7 +819,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         } else {
             future.addListener(new ChannelFutureListener() {
                 @Override
-                public void operationComplete(ChannelFuture future) throws Exception {
+                public void operationComplete(ChannelFuture future) {
                     processRstStreamWriteResult(ctx, stream, future);
                 }
             });
@@ -854,7 +854,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         } else {
             future.addListener(new ChannelFutureListener() {
                 @Override
-                public void operationComplete(ChannelFuture future) throws Exception {
+                public void operationComplete(ChannelFuture future) {
                     processGoAwayWriteResult(ctx, lastStreamId, errorCode, debugData, future);
                 }
             });

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
@@ -170,7 +170,7 @@ public class DefaultHttp2ConnectionTest {
             public boolean visit(Http2Stream stream) {
                 client.close(promise).addListener(new FutureListener<Void>() {
                     @Override
-                    public void operationComplete(Future<Void> future) throws Exception {
+                    public void operationComplete(Future<Void> future) {
                         assertTrue(promise.isDone());
                         latch.countDown();
                     }
@@ -206,7 +206,7 @@ public class DefaultHttp2ConnectionTest {
         } catch (Http2Exception ignored) {
             client.close(promise).addListener(new FutureListener<Void>() {
                 @Override
-                public void operationComplete(Future<Void> future) throws Exception {
+                public void operationComplete(Future<Void> future) {
                     assertTrue(promise.isDone());
                     latch.countDown();
                 }
@@ -685,7 +685,7 @@ public class DefaultHttp2ConnectionTest {
         final Promise<Void> promise = group.next().newPromise();
         client.close(promise).addListener(new FutureListener<Void>() {
             @Override
-            public void operationComplete(Future<Void> future) throws Exception {
+            public void operationComplete(Future<Void> future) {
                 assertTrue(promise.isDone());
                 latch.countDown();
             }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2PushPromiseFrameTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2PushPromiseFrameTest.java
@@ -136,7 +136,7 @@ public class DefaultHttp2PushPromiseFrameTest {
                         // Write Data of actual request
                         channelFuture.addListener(new ChannelFutureListener() {
                             @Override
-                            public void operationComplete(ChannelFuture future) throws Exception {
+                            public void operationComplete(ChannelFuture future) {
                                 Http2DataFrame dataFrame = new DefaultHttp2DataFrame(
                                         Unpooled.wrappedBuffer("Meow".getBytes()), true);
                                 dataFrame.stream(receivedFrame.stream());

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -293,7 +293,7 @@ public class Http2ConnectionRoundtripTest {
                 http2Client.encoder().writeHeaders(ctx(), 3, headers, 0, false, newPromise())
                         .addListener(new ChannelFutureListener() {
                     @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
+                    public void operationComplete(ChannelFuture future) {
                         clientHeadersWriteException.set(future.cause());
                     }
                 });
@@ -301,7 +301,7 @@ public class Http2ConnectionRoundtripTest {
                 http2Client.encoder().writeData(ctx(), 3, Unpooled.buffer(), 0, true, newPromise())
                     .addListener(new ChannelFutureListener() {
                         @Override
-                        public void operationComplete(ChannelFuture future) throws Exception {
+                        public void operationComplete(ChannelFuture future) {
                             clientDataWriteException.set(future.cause());
                             clientDataWrite.countDown();
                         }
@@ -335,7 +335,7 @@ public class Http2ConnectionRoundtripTest {
                 http2Client.encoder().writeHeaders(ctx(), 5, headers, 0, true,
                         newPromise()).addListener(new ChannelFutureListener() {
                     @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
+                    public void operationComplete(ChannelFuture future) {
                         clientHeadersWriteException2.set(future.cause());
                         clientHeadersLatch.countDown();
                     }
@@ -559,7 +559,7 @@ public class Http2ConnectionRoundtripTest {
                 http2Server.encoder().writeHeaders(serverCtx(), streamId, headers, 0, true, serverNewPromise())
                         .addListener(new ChannelFutureListener() {
                             @Override
-                            public void operationComplete(ChannelFuture future) throws Exception {
+                            public void operationComplete(ChannelFuture future) {
                                 serverWriteHeadersCauseRef.set(future.cause());
                                 serverWriteHeadersLatch.countDown();
                             }
@@ -589,7 +589,7 @@ public class Http2ConnectionRoundtripTest {
         final CountDownLatch closeLatch = new CountDownLatch(1);
         clientChannel.closeFuture().addListener(new ChannelFutureListener() {
             @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
+            public void operationComplete(ChannelFuture future) {
                 closeLatch.countDown();
             }
         });
@@ -635,7 +635,7 @@ public class Http2ConnectionRoundtripTest {
         final CountDownLatch closeLatch = new CountDownLatch(1);
         clientChannel.closeFuture().addListener(new ChannelFutureListener() {
             @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
+            public void operationComplete(ChannelFuture future) {
                 closeLatch.countDown();
             }
         });
@@ -794,7 +794,7 @@ public class Http2ConnectionRoundtripTest {
         final CountDownLatch closeLatch = new CountDownLatch(1);
         clientChannel.closeFuture().addListener(new ChannelFutureListener() {
             @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
+            public void operationComplete(ChannelFuture future) {
                 closeLatch.countDown();
             }
         });
@@ -921,7 +921,7 @@ public class Http2ConnectionRoundtripTest {
                 http2Client.flush(ctx());
                 f.addListener(new ChannelFutureListener() {
                     @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
+                    public void operationComplete(ChannelFuture future) {
                         clientWriteAfterGoAwayLatch.countDown();
                     }
                 });

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
@@ -664,7 +664,7 @@ public class Http2FrameCodecTest {
         channel.writeAndFlush(new DefaultHttp2HeadersFrame(new DefaultHttp2Headers(), false).stream(stream))
                .addListener(new ChannelFutureListener() {
                     @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
+                    public void operationComplete(ChannelFuture future) {
                         assertTrue(future.isSuccess());
                         assertTrue(isStreamIdValid(stream.id()));
                         listenerExecuted.setSuccess(null);
@@ -905,7 +905,7 @@ public class Http2FrameCodecTest {
         channel.writeAndFlush(new DefaultHttp2HeadersFrame(new DefaultHttp2Headers()).stream(stream2))
                 .addListener(new ChannelFutureListener() {
                     @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
+                    public void operationComplete(ChannelFuture future) {
                         assertTrue(future.isSuccess());
                         assertEquals(State.OPEN, stream2.state());
                         listenerExecuted.set(true);
@@ -942,7 +942,7 @@ public class Http2FrameCodecTest {
                     ctx.writeAndFlush(new DefaultHttp2WindowUpdateFrame(data.initialFlowControlledBytes())
                             .stream(data.stream())).addListener(new ChannelFutureListener() {
                         @Override
-                        public void operationComplete(ChannelFuture future) throws Exception {
+                        public void operationComplete(ChannelFuture future) {
                             Throwable cause = future.cause();
                             if (cause != null) {
                                 ctx.fireExceptionCaught(cause);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
@@ -1056,7 +1056,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
         assertFalse(f.isDone());
         f.addListener(new ChannelFutureListener() {
             @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
+            public void operationComplete(ChannelFuture future) {
                 channelOpen.set(future.channel().isOpen());
                 channelActive.set(future.channel().isActive());
             }

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3FrameCodecTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3FrameCodecTest.java
@@ -112,7 +112,11 @@ public class Http3FrameCodecTest {
                 new ChannelOutboundHandlerAdapter()).get();
         qpackAttributes.whenEncoderStreamAvailable(future -> {
             if (future.isSuccess()) {
-                encoder.configureDynamicTable(qpackAttributes, maxTableCapacity, maxBlockedStreams);
+                try {
+                    encoder.configureDynamicTable(qpackAttributes, maxTableCapacity, maxBlockedStreams);
+                } catch (QpackException e) {
+                    parent.close();
+                }
             }
         });
         if (!delayQpackStreams) {

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicStreamShutdownTest.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicStreamShutdownTest.java
@@ -103,7 +103,7 @@ public class QuicStreamShutdownTest extends AbstractQuicTest {
                             QuicStreamChannel streamChannel = (QuicStreamChannel) ctx.channel();
                             streamChannel.shutdownInput().addListener(new ChannelFutureListener() {
                                 @Override
-                                public void operationComplete(ChannelFuture f) throws Exception {
+                                public void operationComplete(ChannelFuture f) {
                                     ByteBuf buffer = (ByteBuf) msg;
                                     if (!f.isSuccess()) {
                                         errorRef.compareAndSet(null, f.cause());

--- a/common/src/main/java/io/netty/util/concurrent/GenericFutureListener.java
+++ b/common/src/main/java/io/netty/util/concurrent/GenericFutureListener.java
@@ -28,5 +28,5 @@ public interface GenericFutureListener<F extends Future<?>> extends EventListene
      *
      * @param future  the source {@link Future} which called this callback
      */
-    void operationComplete(F future) throws Exception;
+    void operationComplete(F future);
 }

--- a/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java
@@ -116,7 +116,7 @@ public abstract class MultithreadEventExecutorGroup extends AbstractEventExecuto
 
         final FutureListener<Object> terminationListener = new FutureListener<Object>() {
             @Override
-            public void operationComplete(Future<Object> future) throws Exception {
+            public void operationComplete(Future<Object> future) {
                 if (terminatedChildren.incrementAndGet() == children.length) {
                     terminationFuture.setSuccess(null);
                 }

--- a/common/src/main/java/io/netty/util/concurrent/PromiseAggregator.java
+++ b/common/src/main/java/io/netty/util/concurrent/PromiseAggregator.java
@@ -88,7 +88,7 @@ public class PromiseAggregator<V, F extends Future<V>> implements GenericFutureL
     }
 
     @Override
-    public synchronized void operationComplete(F future) throws Exception {
+    public synchronized void operationComplete(F future) {
         if (pendingPromises == null) {
             aggregatePromise.setSuccess(null);
         } else {

--- a/common/src/main/java/io/netty/util/concurrent/PromiseNotifier.java
+++ b/common/src/main/java/io/netty/util/concurrent/PromiseNotifier.java
@@ -101,7 +101,7 @@ public class PromiseNotifier<V, F extends Future<V>> implements GenericFutureLis
         });
         future.addListener(new PromiseNotifier(logNotifyFailure, promise) {
             @Override
-            public void operationComplete(Future f) throws Exception {
+            public void operationComplete(Future f) {
                 if (promise.isCancelled() && f.isCancelled()) {
                     // Just return if we propagate a cancel from the promise to the future and both are notified already
                     return;
@@ -113,10 +113,10 @@ public class PromiseNotifier<V, F extends Future<V>> implements GenericFutureLis
     }
 
     @Override
-    public void operationComplete(F future) throws Exception {
+    public void operationComplete(F future) {
         InternalLogger internalLogger = logNotifyFailure ? logger : null;
         if (future.isSuccess()) {
-            V result = future.get();
+            V result = future.getNow();
             for (Promise<? super V> p: promises) {
                 PromiseNotificationUtil.trySuccess(p, result, internalLogger);
             }

--- a/common/src/main/java/io/netty/util/concurrent/UnaryPromiseNotifier.java
+++ b/common/src/main/java/io/netty/util/concurrent/UnaryPromiseNotifier.java
@@ -33,7 +33,7 @@ public final class UnaryPromiseNotifier<T> implements FutureListener<T> {
     }
 
     @Override
-    public void operationComplete(Future<T> future) throws Exception {
+    public void operationComplete(Future<T> future) {
         cascadeTo(future, promise);
     }
 

--- a/common/src/test/java/io/netty/util/concurrent/DefaultPromiseTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/DefaultPromiseTest.java
@@ -252,25 +252,25 @@ public class DefaultPromiseTest {
                 final Promise<Void> promise = new DefaultPromise<Void>(executor);
                 final FutureListener<Void> listener1 = new FutureListener<Void>() {
                     @Override
-                    public void operationComplete(Future<Void> future) throws Exception {
+                    public void operationComplete(Future<Void> future) {
                         listeners.add(this);
                     }
                 };
                 final FutureListener<Void> listener2 = new FutureListener<Void>() {
                     @Override
-                    public void operationComplete(Future<Void> future) throws Exception {
+                    public void operationComplete(Future<Void> future) {
                         listeners.add(this);
                     }
                 };
                 final FutureListener<Void> listener4 = new FutureListener<Void>() {
                     @Override
-                    public void operationComplete(Future<Void> future) throws Exception {
+                    public void operationComplete(Future<Void> future) {
                         listeners.add(this);
                     }
                 };
                 final FutureListener<Void> listener3 = new FutureListener<Void>() {
                     @Override
-                    public void operationComplete(Future<Void> future) throws Exception {
+                    public void operationComplete(Future<Void> future) {
                         listeners.add(this);
                         future.addListener(listener4);
                     }
@@ -424,7 +424,7 @@ public class DefaultPromiseTest {
             p[i] = new DefaultPromise<Void>(executor);
             p[i].addListener(new FutureListener<Void>() {
                 @Override
-                public void operationComplete(Future<Void> future) throws Exception {
+                public void operationComplete(Future<Void> future) {
                     if (finalI + 1 < p.length) {
                         p[finalI + 1].setSuccess(null);
                     }
@@ -466,10 +466,10 @@ public class DefaultPromiseTest {
             p[i] = new DefaultPromise<Void>(executor);
             p[i].addListener(new FutureListener<Void>() {
                 @Override
-                public void operationComplete(Future<Void> future) throws Exception {
+                public void operationComplete(Future<Void> future) {
                     future.addListener(new FutureListener<Void>() {
                         @Override
-                        public void operationComplete(Future<Void> future) throws Exception {
+                        public void operationComplete(Future<Void> future) {
                             if (finalI + 1 < p.length) {
                                 p[finalI + 1].setSuccess(null);
                             }
@@ -504,7 +504,7 @@ public class DefaultPromiseTest {
             // Add a listener before completion so "lateListener" is used next time we add a listener.
             promise.addListener(new FutureListener<Void>() {
                 @Override
-                public void operationComplete(Future<Void> future) throws Exception {
+                public void operationComplete(Future<Void> future) {
                     assertTrue(state.compareAndSet(0, 1));
                 }
             });
@@ -519,7 +519,7 @@ public class DefaultPromiseTest {
             // Add a "late listener"
             promise.addListener(new FutureListener<Void>() {
                 @Override
-                public void operationComplete(Future<Void> future) throws Exception {
+                public void operationComplete(Future<Void> future) {
                     assertTrue(state.compareAndSet(1, 2));
                     latch1.countDown();
                 }
@@ -536,7 +536,7 @@ public class DefaultPromiseTest {
                 public void run() {
                     promise.addListener(new FutureListener<Void>() {
                         @Override
-                        public void operationComplete(Future<Void> future) throws Exception {
+                        public void operationComplete(Future<Void> future) {
                             assertTrue(state.compareAndSet(2, 3));
                             latch2.countDown();
                         }
@@ -565,10 +565,10 @@ public class DefaultPromiseTest {
         final Promise<Void> promise = new DefaultPromise<Void>(ImmediateEventExecutor.INSTANCE);
         promise.addListener(new FutureListener<Void>() {
             @Override
-            public void operationComplete(Future<Void> future) throws Exception {
+            public void operationComplete(Future<Void> future) {
                 promise.addListener(new FutureListener<Void>() {
                     @Override
-                    public void operationComplete(Future<Void> future) throws Exception {
+                    public void operationComplete(Future<Void> future) {
                         latch.countDown();
                     }
                 });
@@ -588,7 +588,7 @@ public class DefaultPromiseTest {
         final CountDownLatch latch = new CountDownLatch(expectedCount);
         final FutureListener<Void> listener = new FutureListener<Void>() {
             @Override
-            public void operationComplete(Future<Void> future) throws Exception {
+            public void operationComplete(Future<Void> future) {
                 latch.countDown();
             }
         };

--- a/common/src/test/java/io/netty/util/concurrent/UnorderedThreadPoolEventExecutorTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/UnorderedThreadPoolEventExecutorTest.java
@@ -60,7 +60,7 @@ public class UnorderedThreadPoolEventExecutorTest {
                 }
             }).addListener(new FutureListener<Object>() {
                 @Override
-                public void operationComplete(Future<Object> future) throws Exception {
+                public void operationComplete(Future<Object> future) {
                     latch.countDown();
                 }
             });

--- a/example/src/main/java/io/netty/example/factorial/FactorialClientHandler.java
+++ b/example/src/main/java/io/netty/example/factorial/FactorialClientHandler.java
@@ -98,7 +98,7 @@ public class FactorialClientHandler extends SimpleChannelInboundHandler<BigInteg
 
     private final ChannelFutureListener numberSender = new ChannelFutureListener() {
         @Override
-        public void operationComplete(ChannelFuture future) throws Exception {
+        public void operationComplete(ChannelFuture future) {
             if (future.isSuccess()) {
                 sendNumbers();
             } else {

--- a/example/src/main/java/io/netty/example/haproxy/HAProxyHandler.java
+++ b/example/src/main/java/io/netty/example/haproxy/HAProxyHandler.java
@@ -38,7 +38,7 @@ public class HAProxyHandler extends ChannelOutboundHandlerAdapter {
         if (msg instanceof HAProxyMessage) {
             future.addListener(new ChannelFutureListener() {
                 @Override
-                public void operationComplete(ChannelFuture future) throws Exception {
+                public void operationComplete(ChannelFuture future) {
                     if (future.isSuccess()) {
                         ctx.pipeline().remove(HAProxyMessageEncoder.INSTANCE);
                         ctx.pipeline().remove(HAProxyHandler.this);

--- a/example/src/main/java/io/netty/example/redis/RedisClient.java
+++ b/example/src/main/java/io/netty/example/redis/RedisClient.java
@@ -79,7 +79,7 @@ public class RedisClient {
                 lastWriteFuture = ch.writeAndFlush(line);
                 lastWriteFuture.addListener(new GenericFutureListener<ChannelFuture>() {
                     @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
+                    public void operationComplete(ChannelFuture future) {
                         if (!future.isSuccess()) {
                             System.err.print("write failed: ");
                             future.cause().printStackTrace(System.err);

--- a/example/src/main/java/io/netty/example/securechat/SecureChatServerHandler.java
+++ b/example/src/main/java/io/netty/example/securechat/SecureChatServerHandler.java
@@ -25,8 +25,6 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.GlobalEventExecutor;
 
-import java.net.InetAddress;
-
 /**
  * Handles a server-side channel.
  */
@@ -35,15 +33,15 @@ public class SecureChatServerHandler extends SimpleChannelInboundHandler<String>
     static final ChannelGroup channels = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);
 
     @Override
-    public void channelActive(final ChannelHandlerContext ctx) {
+    public void channelActive(final ChannelHandlerContext ctx) throws Exception {
         // Once session is secured, send a greeting and register the channel to the global channel
         // list so the channel received the messages from others.
         ctx.pipeline().get(SslHandler.class).handshakeFuture().addListener(
                 new GenericFutureListener<Future<Channel>>() {
                     @Override
-                    public void operationComplete(Future<Channel> future) throws Exception {
+                    public void operationComplete(Future<Channel> future) {
                         ctx.writeAndFlush(
-                                "Welcome to " + InetAddress.getLocalHost().getHostName() + " secure chat service!\n");
+                                "Welcome to secure chat service!\n");
                         ctx.writeAndFlush(
                                 "Your session is protected by " +
                                         ctx.pipeline().get(SslHandler.class).engine().getSession().getCipherSuite() +

--- a/example/src/main/java/io/netty/example/socksproxy/SocksServerConnectHandler.java
+++ b/example/src/main/java/io/netty/example/socksproxy/SocksServerConnectHandler.java
@@ -48,7 +48,7 @@ public final class SocksServerConnectHandler extends SimpleChannelInboundHandler
             promise.addListener(
                     new FutureListener<Channel>() {
                         @Override
-                        public void operationComplete(final Future<Channel> future) throws Exception {
+                        public void operationComplete(final Future<Channel> future) {
                             final Channel outboundChannel = future.getNow();
                             if (future.isSuccess()) {
                                 ChannelFuture responseFuture = ctx.channel().writeAndFlush(
@@ -79,7 +79,7 @@ public final class SocksServerConnectHandler extends SimpleChannelInboundHandler
 
             b.connect(request.dstAddr(), request.dstPort()).addListener(new ChannelFutureListener() {
                 @Override
-                public void operationComplete(ChannelFuture future) throws Exception {
+                public void operationComplete(ChannelFuture future) {
                     if (future.isSuccess()) {
                         // Connection established use handler provided results
                     } else {
@@ -97,7 +97,7 @@ public final class SocksServerConnectHandler extends SimpleChannelInboundHandler
             promise.addListener(
                     new FutureListener<Channel>() {
                         @Override
-                        public void operationComplete(final Future<Channel> future) throws Exception {
+                        public void operationComplete(final Future<Channel> future) {
                             final Channel outboundChannel = future.getNow();
                             if (future.isSuccess()) {
                                 ChannelFuture responseFuture =
@@ -132,7 +132,7 @@ public final class SocksServerConnectHandler extends SimpleChannelInboundHandler
 
             b.connect(request.dstAddr(), request.dstPort()).addListener(new ChannelFutureListener() {
                 @Override
-                public void operationComplete(ChannelFuture future) throws Exception {
+                public void operationComplete(ChannelFuture future) {
                     if (future.isSuccess()) {
                         // Connection established use handler provided results
                     } else {

--- a/example/src/main/java/io/netty/example/uptime/UptimeClient.java
+++ b/example/src/main/java/io/netty/example/uptime/UptimeClient.java
@@ -61,7 +61,7 @@ public final class UptimeClient {
     static void connect() {
         bs.connect().addListener(new ChannelFutureListener() {
             @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
+            public void operationComplete(ChannelFuture future) {
                 if (future.cause() != null) {
                     handler.startTime = -1;
                     handler.println("Failed to connect: " + future.cause());

--- a/handler-proxy/src/main/java/io/netty/handler/proxy/ProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/handler/proxy/ProxyHandler.java
@@ -65,7 +65,7 @@ public abstract class ProxyHandler extends ChannelDuplexHandler {
     private Future<?> connectTimeoutFuture;
     private final ChannelFutureListener writeListener = new ChannelFutureListener() {
         @Override
-        public void operationComplete(ChannelFuture future) throws Exception {
+        public void operationComplete(ChannelFuture future) {
             if (!future.isSuccess()) {
                 setConnectFailure(future.cause());
             }

--- a/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyHandlerTest.java
+++ b/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyHandlerTest.java
@@ -575,7 +575,7 @@ public class ProxyHandlerTest {
             ctx.writeAndFlush(Unpooled.copiedBuffer("A\n", CharsetUtil.US_ASCII)).addListener(
                     new ChannelFutureListener() {
                         @Override
-                        public void operationComplete(ChannelFuture future) throws Exception {
+                        public void operationComplete(ChannelFuture future) {
                             latch.countDown();
                             if (!(future.cause() instanceof ProxyConnectException)) {
                                 exceptions.add(new AssertionError(

--- a/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyServer.java
+++ b/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyServer.java
@@ -171,7 +171,7 @@ abstract class ProxyServer {
                 ChannelFuture f = connectToDestination(ctx.channel().executor(), new BackendHandler(ctx));
                 f.addListener(new ChannelFutureListener() {
                     @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
+                    public void operationComplete(ChannelFuture future) {
                         if (!future.isSuccess()) {
                             recordException(future.cause());
                             ctx.close();

--- a/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspClient.java
+++ b/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspClient.java
@@ -145,12 +145,16 @@ final class OcspClient {
                     // Validate OCSP response
                     ocspResponsePromise.addListener(new GenericFutureListener<Future<OCSPResp>>() {
                         @Override
-                        public void operationComplete(Future<OCSPResp> future) throws Exception {
+                        public void operationComplete(Future<OCSPResp> future) {
                             // If Future was successful then we have received OCSP response
                             // We will now validate it.
                             if (future.isSuccess()) {
-                                BasicOCSPResp resp = (BasicOCSPResp) future.get().getResponseObject();
-                                validateResponse(responsePromise, resp, derNonce, issuer, validateResponseNonce);
+                                try {
+                                    BasicOCSPResp resp = (BasicOCSPResp) future.getNow().getResponseObject();
+                                    validateResponse(responsePromise, resp, derNonce, issuer, validateResponseNonce);
+                                } catch (Throwable t) {
+                                    responsePromise.tryFailure(t);
+                                }
                             } else {
                                 responsePromise.tryFailure(future.cause());
                             }
@@ -191,13 +195,13 @@ final class OcspClient {
 
             dnsNameResolver.resolve(host).addListener(new FutureListener<InetAddress>() {
                 @Override
-                public void operationComplete(Future<InetAddress> future) throws Exception {
+                public void operationComplete(Future<InetAddress> future) {
 
                     // If Future was successful then we have successfully resolved OCSP server address.
                     // If not, mark 'responsePromise' as failure.
                     if (future.isSuccess()) {
                         // Get the resolved InetAddress
-                        InetAddress hostAddress = future.get();
+                        InetAddress hostAddress = future.getNow();
                         final ChannelFuture channelFuture = bootstrap.connect(hostAddress, port);
                         channelFuture.addListener(new ChannelFutureListener() {
                             @Override

--- a/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspServerCertificateValidator.java
+++ b/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspServerCertificateValidator.java
@@ -149,11 +149,11 @@ public class OcspServerCertificateValidator extends ChannelInboundHandlerAdapter
 
                 ocspRespPromise.addListener(new GenericFutureListener<Future<BasicOCSPResp>>() {
                     @Override
-                    public void operationComplete(Future<BasicOCSPResp> future) throws Exception {
+                    public void operationComplete(Future<BasicOCSPResp> future) {
                         // If Future is success then we have successfully received OCSP response
                         // from OCSP responder. We will validate it now and process.
                         if (future.isSuccess()) {
-                            SingleResp response = future.get().getResponses()[0];
+                            SingleResp response = future.getNow().getResponses()[0];
 
                             Date current = new Date();
                             if (!(current.after(response.getThisUpdate()) &&

--- a/handler/src/main/java/io/netty/handler/ipfilter/UniqueIpFilter.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/UniqueIpFilter.java
@@ -43,7 +43,7 @@ public class UniqueIpFilter extends AbstractRemoteAddressFilter<InetSocketAddres
         } else {
             ctx.channel().closeFuture().addListener(new ChannelFutureListener() {
                 @Override
-                public void operationComplete(ChannelFuture future) throws Exception {
+                public void operationComplete(ChannelFuture future) {
                     connected.remove(remoteIp);
                 }
             });

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -2318,7 +2318,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         // Cancel the handshake timeout when handshake is finished.
         localHandshakePromise.addListener(new FutureListener<Channel>() {
             @Override
-            public void operationComplete(Future<Channel> f) throws Exception {
+            public void operationComplete(Future<Channel> f) {
                 timeoutFuture.cancel(false);
             }
         });
@@ -2414,7 +2414,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                     // Do the close once the we received the close_notify.
                     sslClosePromise.addListener(new FutureListener<Channel>() {
                         @Override
-                        public void operationComplete(Future<Channel> future) throws Exception {
+                        public void operationComplete(Future<Channel> future) {
                             if (closeNotifyReadTimeoutFuture != null) {
                                 closeNotifyReadTimeoutFuture.cancel(false);
                             }

--- a/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
+++ b/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
@@ -101,7 +101,7 @@ public class IdleStateHandler extends ChannelDuplexHandler {
     // Not create a new ChannelFutureListener per write operation to reduce GC pressure.
     private final ChannelFutureListener writeListener = new ChannelFutureListener() {
         @Override
-        public void operationComplete(ChannelFuture future) throws Exception {
+        public void operationComplete(ChannelFuture future) {
             lastWriteTime = ticker.nanoTime();
             firstWriterIdleEvent = firstAllIdleEvent = true;
         }

--- a/handler/src/main/java/io/netty/handler/timeout/WriteTimeoutHandler.java
+++ b/handler/src/main/java/io/netty/handler/timeout/WriteTimeoutHandler.java
@@ -214,7 +214,7 @@ public class WriteTimeoutHandler extends ChannelOutboundHandlerAdapter {
         }
 
         @Override
-        public void operationComplete(ChannelFuture future) throws Exception {
+        public void operationComplete(ChannelFuture future) {
             // scheduledFuture has already be set when reaching here
             scheduledFuture.cancel(false);
 

--- a/handler/src/test/java/io/netty/handler/flush/FlushConsolidationHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/flush/FlushConsolidationHandlerTest.java
@@ -174,7 +174,7 @@ public class FlushConsolidationHandlerTest {
         final EmbeddedChannel channel = newChannel(flushCount, true);
         channel.writeAndFlush(1L).addListener(new GenericFutureListener<Future<? super Void>>() {
             @Override
-            public void operationComplete(Future<? super Void> future) throws Exception {
+            public void operationComplete(Future<? super Void> future) {
                 channel.writeAndFlush(1L);
             }
         });

--- a/handler/src/test/java/io/netty/handler/ssl/ParameterizedSslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ParameterizedSslHandlerTest.java
@@ -60,7 +60,6 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.net.InetSocketAddress;
@@ -187,7 +186,7 @@ public class ParameterizedSslHandlerTest {
                                             }
                                             ctx.writeAndFlush(content).addListener(new ChannelFutureListener() {
                                                 @Override
-                                                public void operationComplete(ChannelFuture future) throws Exception {
+                                                public void operationComplete(ChannelFuture future) {
                                                     writeCause = future.cause();
                                                     if (writeCause == null) {
                                                         sentData = true;

--- a/handler/src/test/java/io/netty/handler/ssl/RenegotiateTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/RenegotiateTest.java
@@ -83,7 +83,7 @@ public abstract class RenegotiateTest {
                                             renegotiate = true;
                                             handler.renegotiate().addListener(new FutureListener<Channel>() {
                                                 @Override
-                                                public void operationComplete(Future<Channel> future) throws Exception {
+                                                public void operationComplete(Future<Channel> future) {
                                                     if (!future.isSuccess()) {
                                                         error.compareAndSet(null, future.cause());
                                                         ctx.close();

--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -887,7 +887,7 @@ public class SslHandlerTest {
                         }
                     }).connect(sc.localAddress()).addListener(new ChannelFutureListener() {
                         @Override
-                        public void operationComplete(ChannelFuture future) throws Exception {
+                        public void operationComplete(ChannelFuture future) {
                             // Write something to trigger the handshake before fireChannelActive is called.
                             future.channel().writeAndFlush(wrappedBuffer(new byte [] { 1, 2, 3, 4 }));
                         }
@@ -966,7 +966,7 @@ public class SslHandlerTest {
             if (!startTls) {
                 future.addListener(new ChannelFutureListener() {
                     @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
+                    public void operationComplete(ChannelFuture future) {
                         // Write something to trigger the handshake before fireChannelActive is called.
                         future.channel().writeAndFlush(wrappedBuffer(new byte [] { 1, 2, 3, 4 }));
                     }

--- a/handler/src/test/java/io/netty/handler/stream/ChunkedWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/stream/ChunkedWriteHandlerTest.java
@@ -200,7 +200,7 @@ public class ChunkedWriteHandlerTest {
         final ChannelFutureListener listener = new ChannelFutureListener() {
 
             @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
+            public void operationComplete(ChannelFuture future) {
                 listenerNotified.set(true);
             }
         };

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/InflightNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/InflightNameResolver.java
@@ -83,7 +83,7 @@ final class InflightNameResolver<T> implements NameResolver<T> {
             } else {
                 earlyPromise.addListener(new FutureListener<U>() {
                     @Override
-                    public void operationComplete(Future<U> f) throws Exception {
+                    public void operationComplete(Future<U> f) {
                         transferResult(f, promise);
                     }
                 });
@@ -105,7 +105,7 @@ final class InflightNameResolver<T> implements NameResolver<T> {
                 } else {
                     promise.addListener(new FutureListener<U>() {
                         @Override
-                        public void operationComplete(Future<U> f) throws Exception {
+                        public void operationComplete(Future<U> f) {
                             resolveMap.remove(inetHost);
                         }
                     });

--- a/resolver/src/main/java/io/netty/resolver/CompositeNameResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/CompositeNameResolver.java
@@ -61,14 +61,14 @@ public final class CompositeNameResolver<T> extends SimpleNameResolver<T> {
     private void doResolveRec(final String inetHost,
                               final Promise<T> promise,
                               final int resolverIndex,
-                              Throwable lastFailure) throws Exception {
+                              Throwable lastFailure) {
         if (resolverIndex >= resolvers.length) {
             promise.setFailure(lastFailure);
         } else {
             NameResolver<T> resolver = resolvers[resolverIndex];
             resolver.resolve(inetHost).addListener(new FutureListener<T>() {
                 @Override
-                public void operationComplete(Future<T> future) throws Exception {
+                public void operationComplete(Future<T> future) {
                     if (future.isSuccess()) {
                         promise.setSuccess(future.getNow());
                     } else {
@@ -87,14 +87,14 @@ public final class CompositeNameResolver<T> extends SimpleNameResolver<T> {
     private void doResolveAllRec(final String inetHost,
                               final Promise<List<T>> promise,
                               final int resolverIndex,
-                              Throwable lastFailure) throws Exception {
+                              Throwable lastFailure) {
         if (resolverIndex >= resolvers.length) {
             promise.setFailure(lastFailure);
         } else {
             NameResolver<T> resolver = resolvers[resolverIndex];
             resolver.resolveAll(inetHost).addListener(new FutureListener<List<T>>() {
                 @Override
-                public void operationComplete(Future<List<T>> future) throws Exception {
+                public void operationComplete(Future<List<T>> future) {
                     if (future.isSuccess()) {
                         promise.setSuccess(future.getNow());
                     } else {

--- a/resolver/src/main/java/io/netty/resolver/InetSocketAddressResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/InetSocketAddressResolver.java
@@ -55,7 +55,7 @@ public class InetSocketAddressResolver extends AbstractAddressResolver<InetSocke
         nameResolver.resolve(unresolvedAddress.getHostName())
                 .addListener(new FutureListener<InetAddress>() {
                     @Override
-                    public void operationComplete(Future<InetAddress> future) throws Exception {
+                    public void operationComplete(Future<InetAddress> future) {
                         if (future.isSuccess()) {
                             promise.setSuccess(new InetSocketAddress(future.getNow(), unresolvedAddress.getPort()));
                         } else {
@@ -73,7 +73,7 @@ public class InetSocketAddressResolver extends AbstractAddressResolver<InetSocke
         nameResolver.resolveAll(unresolvedAddress.getHostName())
                 .addListener(new FutureListener<List<InetAddress>>() {
                     @Override
-                    public void operationComplete(Future<List<InetAddress>> future) throws Exception {
+                    public void operationComplete(Future<List<InetAddress>> future) {
                         if (future.isSuccess()) {
                             List<InetAddress> inetAddresses = future.getNow();
                             List<InetSocketAddress> socketAddresses =

--- a/resolver/src/main/java/io/netty/resolver/RoundRobinInetAddressResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/RoundRobinInetAddressResolver.java
@@ -54,7 +54,7 @@ public class RoundRobinInetAddressResolver extends InetNameResolver {
         // because an unresolved address always has a host name.
         nameResolver.resolveAll(inetHost).addListener(new FutureListener<List<InetAddress>>() {
             @Override
-            public void operationComplete(Future<List<InetAddress>> future) throws Exception {
+            public void operationComplete(Future<List<InetAddress>> future) {
                 if (future.isSuccess()) {
                     List<InetAddress> inetAddresses = future.getNow();
                     int numAddresses = inetAddresses.size();
@@ -76,7 +76,7 @@ public class RoundRobinInetAddressResolver extends InetNameResolver {
     protected void doResolveAll(String inetHost, final Promise<List<InetAddress>> promise) throws Exception {
         nameResolver.resolveAll(inetHost).addListener(new FutureListener<List<InetAddress>>() {
             @Override
-            public void operationComplete(Future<List<InetAddress>> future) throws Exception {
+            public void operationComplete(Future<List<InetAddress>> future) {
                 if (future.isSuccess()) {
                     List<InetAddress> inetAddresses = future.getNow();
                     if (!inetAddresses.isEmpty()) {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketBufReleaseTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketBufReleaseTest.java
@@ -98,7 +98,7 @@ public class SocketBufReleaseTest extends AbstractSocketTest {
 
             ctx.channel().writeAndFlush(buf).addListener(new ChannelFutureListener() {
                 @Override
-                public void operationComplete(ChannelFuture future) throws Exception {
+                public void operationComplete(ChannelFuture future) {
                     latch.countDown();
                 }
             });

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -383,7 +383,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                             buf.writerIndex(buf.capacity());
                             ctx.writeAndFlush(buf).addListener(new ChannelFutureListener() {
                                 @Override
-                                public void operationComplete(ChannelFuture future) throws Exception {
+                                public void operationComplete(ChannelFuture future) {
                                     ((DuplexChannel) future.channel()).shutdownOutput();
                                 }
                             });
@@ -577,10 +577,10 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                 buf.writerIndex(buf.writerIndex() + expectedBytes);
                 ctx.writeAndFlush(buf).addListener(new ChannelFutureListener() {
                     @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
+                    public void operationComplete(ChannelFuture future) {
                         future.channel().close().addListener(new ChannelFutureListener() {
                             @Override
-                            public void operationComplete(final ChannelFuture future) throws Exception {
+                            public void operationComplete(final ChannelFuture future) {
                                 // This is a bit racy but there is no better way how to handle this in Java11.
                                 // The problem is that on close() the underlying FD will not actually be closed directly
                                 // but the close will be done after the Selector did process all events. Because of
@@ -636,7 +636,7 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
             // This write should fail, but we should still be allowed to read the peer's data
             ctx.writeAndFlush(buf).addListener(new ChannelFutureListener() {
                 @Override
-                public void operationComplete(ChannelFuture future) throws Exception {
+                public void operationComplete(ChannelFuture future) {
                     if (future.cause() == null) {
                         causeRef.set(new IllegalStateException("second write should have failed!"));
                         doneLatch.countDown();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslLargeCertificateTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslLargeCertificateTest.java
@@ -53,7 +53,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
-import java.security.Provider;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
@@ -212,7 +211,7 @@ public class SocketSslLargeCertificateTest {
                                     ctx.writeAndFlush(Unpooled.buffer()).addListener(ChannelFutureListener.CLOSE);
                                     ctx.channel().closeFuture().addListener(new ChannelFutureListener() {
                                         @Override
-                                        public void operationComplete(ChannelFuture future) throws Exception {
+                                        public void operationComplete(ChannelFuture future) {
                                             completion.setSuccess(null);
                                         }
                                     });

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannel.java
@@ -540,7 +540,7 @@ public final class EpollSocketChannel extends AbstractEpollChannel implements So
         } else {
             shutdownOutputFuture.addListener(new ChannelFutureListener() {
                 @Override
-                public void operationComplete(final ChannelFuture shutdownOutputFuture) throws Exception {
+                public void operationComplete(final ChannelFuture shutdownOutputFuture) {
                     shutdownOutputDone(shutdownOutputFuture, promise);
                 }
             });
@@ -555,7 +555,7 @@ public final class EpollSocketChannel extends AbstractEpollChannel implements So
         } else {
             shutdownInputFuture.addListener(new ChannelFutureListener() {
                 @Override
-                public void operationComplete(ChannelFuture shutdownInputFuture) throws Exception {
+                public void operationComplete(ChannelFuture shutdownInputFuture) {
                     shutdownDone(shutdownOutputFuture, shutdownInputFuture, promise);
                 }
             });

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
@@ -115,7 +115,7 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
         } else {
             shutdownOutputFuture.addListener(new ChannelFutureListener() {
                 @Override
-                public void operationComplete(final ChannelFuture shutdownOutputFuture) throws Exception {
+                public void operationComplete(final ChannelFuture shutdownOutputFuture) {
                     shutdownOutputDone(shutdownOutputFuture, promise);
                 }
             });
@@ -208,7 +208,7 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
         } else {
             shutdownInputFuture.addListener(new ChannelFutureListener() {
                 @Override
-                public void operationComplete(ChannelFuture shutdownInputFuture) throws Exception {
+                public void operationComplete(ChannelFuture shutdownInputFuture) {
                     shutdownDone(shutdownOutputFuture, shutdownInputFuture, promise);
                 }
             });

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
@@ -468,7 +468,7 @@ public abstract class AbstractKQueueStreamChannel extends AbstractKQueueChannel 
         } else {
             shutdownOutputFuture.addListener(new ChannelFutureListener() {
                 @Override
-                public void operationComplete(final ChannelFuture shutdownOutputFuture) throws Exception {
+                public void operationComplete(final ChannelFuture shutdownOutputFuture) {
                     shutdownOutputDone(shutdownOutputFuture, promise);
                 }
             });
@@ -483,7 +483,7 @@ public abstract class AbstractKQueueStreamChannel extends AbstractKQueueChannel 
         } else {
             shutdownInputFuture.addListener(new ChannelFutureListener() {
                 @Override
-                public void operationComplete(ChannelFuture shutdownInputFuture) throws Exception {
+                public void operationComplete(ChannelFuture shutdownInputFuture) {
                     shutdownDone(shutdownOutputFuture, shutdownInputFuture, promise);
                 }
             });

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannel.java
@@ -500,7 +500,7 @@ public final class KQueueSocketChannel extends AbstractKQueueChannel implements 
         } else {
             shutdownOutputFuture.addListener(new ChannelFutureListener() {
                 @Override
-                public void operationComplete(final ChannelFuture shutdownOutputFuture) throws Exception {
+                public void operationComplete(final ChannelFuture shutdownOutputFuture) {
                     shutdownOutputDone(shutdownOutputFuture, promise);
                 }
             });
@@ -515,7 +515,7 @@ public final class KQueueSocketChannel extends AbstractKQueueChannel implements 
         } else {
             shutdownInputFuture.addListener(new ChannelFutureListener() {
                 @Override
-                public void operationComplete(ChannelFuture shutdownInputFuture) throws Exception {
+                public void operationComplete(ChannelFuture shutdownInputFuture) {
                     shutdownDone(shutdownOutputFuture, shutdownInputFuture, promise);
                 }
             });

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketFdTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketFdTest.java
@@ -74,7 +74,7 @@ public class EpollDomainSocketFdTest extends AbstractSocketTest {
 
                 ctx.writeAndFlush(ch.fd()).addListener(new ChannelFutureListener() {
                     @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
+                    public void operationComplete(ChannelFuture future) {
                         if (!future.isSuccess()) {
                             Throwable cause = future.cause();
                             queue.offer(cause);

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketFdTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketFdTest.java
@@ -82,7 +82,7 @@ public class IoUringDomainSocketFdTest extends AbstractSocketTest {
 
                 ctx.writeAndFlush(ch.fd()).addListener(new ChannelFutureListener() {
                     @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
+                    public void operationComplete(ChannelFuture future) {
                         if (!future.isSuccess()) {
                             Throwable cause = future.cause();
                             recvFdFuture.completeExceptionally(cause);
@@ -91,7 +91,7 @@ public class IoUringDomainSocketFdTest extends AbstractSocketTest {
                             sendBuffer.writeBytes(expected.getBytes());
                             ctx.writeAndFlush(sendBuffer).addListener(new ChannelFutureListener() {
                                 @Override
-                                public void operationComplete(ChannelFuture future) throws Exception {
+                                public void operationComplete(ChannelFuture future) {
                                     if (!future.isSuccess()) {
                                         Throwable cause = future.cause();
                                         recvByteBufFuture.completeExceptionally(cause);

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainSocketFdTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainSocketFdTest.java
@@ -74,7 +74,7 @@ public class KQueueDomainSocketFdTest extends AbstractSocketTest {
 
                 ctx.writeAndFlush(ch.fd()).addListener(new ChannelFutureListener() {
                     @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
+                    public void operationComplete(ChannelFuture future) {
                         if (!future.isSuccess()) {
                             Throwable cause = future.cause();
                             queue.offer(cause);

--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -257,7 +257,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
             final PendingRegistrationPromise promise = new PendingRegistrationPromise(channel);
             regFuture.addListener(new ChannelFutureListener() {
                 @Override
-                public void operationComplete(ChannelFuture future) throws Exception {
+                public void operationComplete(ChannelFuture future) {
                     Throwable cause = future.cause();
                     if (cause != null) {
                         // Registration on the EventLoop failed so fail the ChannelPromise directly to not cause an

--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -205,7 +205,7 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
             final PendingRegistrationPromise promise = new PendingRegistrationPromise(channel);
             regFuture.addListener(new ChannelFutureListener() {
                 @Override
-                public void operationComplete(ChannelFuture future) throws Exception {
+                public void operationComplete(ChannelFuture future) {
                     // Directly obtain the cause and do a null check so we only need one volatile read in case of a
                     // failure.
                     Throwable cause = future.cause();
@@ -267,7 +267,7 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
             // Wait until the name resolution is finished.
             resolveFuture.addListener(new FutureListener<SocketAddress>() {
                 @Override
-                public void operationComplete(Future<SocketAddress> future) throws Exception {
+                public void operationComplete(Future<SocketAddress> future) {
                     if (future.cause() != null) {
                         channel.close();
                         promise.setFailure(future.cause());

--- a/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
@@ -292,7 +292,7 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
             try {
                 child.register().addListener(new ChannelFutureListener() {
                     @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
+                    public void operationComplete(ChannelFuture future) {
                         if (!future.isSuccess()) {
                             forceClose(child, future.cause());
                         }

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -364,7 +364,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             boolean firstRegistration = neverRegistered;
             registerPromise.addListener(new ChannelFutureListener() {
                 @Override
-                public void operationComplete(ChannelFuture future) throws Exception {
+                public void operationComplete(ChannelFuture future) {
                     if (future.isSuccess()) {
                         neverRegistered = false;
                         registered = true;
@@ -585,7 +585,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                     // This means close() was called before so we just register a listener and return
                     closeFuture.addListener(new ChannelFutureListener() {
                         @Override
-                        public void operationComplete(ChannelFuture future) throws Exception {
+                        public void operationComplete(ChannelFuture future) {
                             promise.setSuccess();
                         }
                     });

--- a/transport/src/main/java/io/netty/channel/DelegatingChannelPromiseNotifier.java
+++ b/transport/src/main/java/io/netty/channel/DelegatingChannelPromiseNotifier.java
@@ -45,10 +45,10 @@ public final class DelegatingChannelPromiseNotifier implements ChannelPromise, C
     }
 
     @Override
-    public void operationComplete(ChannelFuture future) throws Exception {
+    public void operationComplete(ChannelFuture future) {
         InternalLogger internalLogger = logNotifyFailure ? logger : null;
         if (future.isSuccess()) {
-            Void result = future.get();
+            Void result = future.getNow();
             PromiseNotificationUtil.trySuccess(delegate, result, internalLogger);
         } else if (future.isCancelled()) {
             PromiseNotificationUtil.tryCancel(delegate, internalLogger);

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
@@ -69,7 +69,7 @@ public class EmbeddedChannel extends AbstractChannel {
 
     private final ChannelFutureListener recordExceptionListener = new ChannelFutureListener() {
         @Override
-        public void operationComplete(ChannelFuture future) throws Exception {
+        public void operationComplete(ChannelFuture future) {
             recordException(future);
         }
     };

--- a/transport/src/main/java/io/netty/channel/group/DefaultChannelGroup.java
+++ b/transport/src/main/java/io/netty/channel/group/DefaultChannelGroup.java
@@ -49,7 +49,7 @@ public class DefaultChannelGroup extends AbstractSet<Channel> implements Channel
     private final ConcurrentMap<ChannelId, Channel> nonServerChannels = new ConcurrentHashMap<>();
     private final ChannelFutureListener remover = new ChannelFutureListener() {
         @Override
-        public void operationComplete(ChannelFuture future) throws Exception {
+        public void operationComplete(ChannelFuture future) {
             remove(future.channel());
         }
     };

--- a/transport/src/main/java/io/netty/channel/group/DefaultChannelGroupFuture.java
+++ b/transport/src/main/java/io/netty/channel/group/DefaultChannelGroupFuture.java
@@ -47,7 +47,7 @@ final class DefaultChannelGroupFuture extends DefaultPromise<Void> implements Ch
 
     private final ChannelFutureListener childListener = new ChannelFutureListener() {
         @Override
-        public void operationComplete(ChannelFuture future) throws Exception {
+        public void operationComplete(ChannelFuture future) {
             boolean success = future.isSuccess();
             boolean callSetDone;
             synchronized (DefaultChannelGroupFuture.this) {

--- a/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
@@ -25,7 +25,6 @@ import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.IoEvent;
 import io.netty.channel.IoRegistration;
-import io.netty.channel.IoTransport;
 import io.netty.channel.PreferHeapByteBufAllocator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.ServerChannel;

--- a/transport/src/main/java/io/netty/channel/pool/AbstractChannelPoolMap.java
+++ b/transport/src/main/java/io/netty/channel/pool/AbstractChannelPoolMap.java
@@ -82,7 +82,7 @@ public abstract class AbstractChannelPoolMap<K, P extends ChannelPool>
             final Promise<Boolean> removePromise = GlobalEventExecutor.INSTANCE.newPromise();
             poolCloseAsyncIfSupported(pool).addListener(new GenericFutureListener<Future<? super Void>>() {
                 @Override
-                public void operationComplete(Future<? super Void> future) throws Exception {
+                public void operationComplete(Future<? super Void> future) {
                     if (future.isSuccess()) {
                         removePromise.setSuccess(Boolean.TRUE);
                     } else {

--- a/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
@@ -407,7 +407,7 @@ public class FixedChannelPool extends SimpleChannelPool {
         }
 
         @Override
-        public void operationComplete(Future<Channel> future) throws Exception {
+        public void operationComplete(Future<Channel> future) {
             try {
                 assert executor.inEventLoop();
 
@@ -471,7 +471,7 @@ public class FixedChannelPool extends SimpleChannelPool {
                 public void run() {
                     close0().addListener(new FutureListener<Void>() {
                         @Override
-                        public void operationComplete(Future<Void> f) throws Exception {
+                        public void operationComplete(Future<Void> f) {
                             if (f.isSuccess()) {
                                 closeComplete.setSuccess(null);
                             } else {

--- a/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
@@ -180,7 +180,7 @@ public class SimpleChannelPool implements ChannelPool {
                 } else {
                     f.addListener(new ChannelFutureListener() {
                         @Override
-                        public void operationComplete(ChannelFuture future) throws Exception {
+                        public void operationComplete(ChannelFuture future) {
                             notifyConnect(future, promise);
                         }
                     });
@@ -323,7 +323,7 @@ public class SimpleChannelPool implements ChannelPool {
         } else {
             f.addListener(new FutureListener<Boolean>() {
                 @Override
-                public void operationComplete(Future<Boolean> future) throws Exception {
+                public void operationComplete(Future<Boolean> future) {
                     releaseAndOfferIfHealthy(channel, promise, f);
                 }
             });

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
@@ -244,7 +244,7 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
         } else {
             shutdownOutputFuture.addListener(new ChannelFutureListener() {
                 @Override
-                public void operationComplete(final ChannelFuture shutdownOutputFuture) throws Exception {
+                public void operationComplete(final ChannelFuture shutdownOutputFuture) {
                     shutdownOutputDone(shutdownOutputFuture, promise);
                 }
             });
@@ -259,7 +259,7 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
         } else {
             shutdownInputFuture.addListener(new ChannelFutureListener() {
                 @Override
-                public void operationComplete(ChannelFuture shutdownInputFuture) throws Exception {
+                public void operationComplete(ChannelFuture shutdownInputFuture) {
                     shutdownDone(shutdownOutputFuture, shutdownInputFuture, promise);
                 }
             });

--- a/transport/src/test/java/io/netty/channel/CoalescingBufferQueueTest.java
+++ b/transport/src/test/java/io/netty/channel/CoalescingBufferQueueTest.java
@@ -54,7 +54,7 @@ public class CoalescingBufferQueueTest {
         catPromise = newPromise();
         mouseListener = new ChannelFutureListener() {
             @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
+            public void operationComplete(ChannelFuture future) {
                 mouseDone = true;
                 mouseSuccess = future.isSuccess();
             }

--- a/transport/src/test/java/io/netty/channel/ReentrantChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/ReentrantChannelTest.java
@@ -241,7 +241,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
             public void write(final ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
                 promise.addListener(new GenericFutureListener<Future<? super Void>>() {
                     @Override
-                    public void operationComplete(Future<? super Void> future) throws Exception {
+                    public void operationComplete(Future<? super Void> future) {
                         ctx.channel().close();
                     }
                 });

--- a/transport/src/test/java/io/netty/channel/SingleThreadEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/SingleThreadEventLoopTest.java
@@ -412,7 +412,7 @@ public class SingleThreadEventLoopTest {
         ChannelPromise promise = ch.newPromise();
         promise.addListener(new ChannelFutureListener() {
             @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
+            public void operationComplete(ChannelFuture future) {
                 latch.countDown();
             }
         });

--- a/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
@@ -96,7 +96,7 @@ public class EmbeddedChannelTest {
         EmbeddedChannel channel = new EmbeddedChannel();
         channel.closeFuture().addListener(new ChannelFutureListener() {
             @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
+            public void operationComplete(ChannelFuture future) {
                 future.channel().close();
             }
         });
@@ -144,7 +144,7 @@ public class EmbeddedChannelTest {
         }, 1, TimeUnit.SECONDS);
         future.addListener(new FutureListener() {
             @Override
-            public void operationComplete(Future future) throws Exception {
+            public void operationComplete(Future future) {
                 latch.countDown();
             }
         });

--- a/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
@@ -373,7 +373,7 @@ public class LocalChannelTest {
                         ChannelPromise promise = ccCpy.newPromise();
                         promise.addListener(new ChannelFutureListener() {
                             @Override
-                            public void operationComplete(ChannelFuture future) throws Exception {
+                            public void operationComplete(ChannelFuture future) {
                                 ccCpy.pipeline().lastContext().close();
                             }
                         });
@@ -516,7 +516,7 @@ public class LocalChannelTest {
                         ChannelPromise promise = ccCpy.newPromise();
                         promise.addListener(new ChannelFutureListener() {
                             @Override
-                            public void operationComplete(ChannelFuture future) throws Exception {
+                            public void operationComplete(ChannelFuture future) {
                                 ccCpy.writeAndFlush(data2.retainedDuplicate(), ccCpy.newPromise());
                             }
                         });
@@ -598,7 +598,7 @@ public class LocalChannelTest {
                     ChannelPromise promise = ccCpy.newPromise();
                     promise.addListener(new ChannelFutureListener() {
                         @Override
-                        public void operationComplete(ChannelFuture future) throws Exception {
+                        public void operationComplete(ChannelFuture future) {
                             Channel serverChannelCpy = serverChannelRef.get();
                             serverChannelCpy.writeAndFlush(data2.retainedDuplicate(), serverChannelCpy.newPromise());
                         }
@@ -680,7 +680,7 @@ public class LocalChannelTest {
                         ChannelPromise promise = ccCpy.newPromise();
                         promise.addListener(new ChannelFutureListener() {
                             @Override
-                            public void operationComplete(ChannelFuture future) throws Exception {
+                            public void operationComplete(ChannelFuture future) {
                                 Channel serverChannelCpy = serverChannelRef.get();
                                 serverChannelCpy.writeAndFlush(
                                         data2.retainedDuplicate(), serverChannelCpy.newPromise());
@@ -762,7 +762,7 @@ public class LocalChannelTest {
                         ccCpy.writeAndFlush(data.retainedDuplicate(), ccCpy.newPromise())
                         .addListener(new ChannelFutureListener() {
                             @Override
-                            public void operationComplete(ChannelFuture future) throws Exception {
+                            public void operationComplete(ChannelFuture future) {
                                 serverChannelCpy.executor().execute(new Runnable() {
                                     @Override
                                     public void run() {
@@ -783,7 +783,7 @@ public class LocalChannelTest {
                                                                        serverChannelCpy.newPromise())
                                             .addListener(new ChannelFutureListener() {
                                             @Override
-                                            public void operationComplete(ChannelFuture future) throws Exception {
+                                            public void operationComplete(ChannelFuture future) {
                                                 if (!future.isSuccess() &&
                                                     future.cause() instanceof ClosedChannelException) {
                                                     writeFailLatch.countDown();
@@ -886,7 +886,7 @@ public class LocalChannelTest {
         }
 
         @Override
-        public void operationComplete(ChannelFuture future) throws Exception {
+        public void operationComplete(ChannelFuture future) {
             countDown();
         }
     }

--- a/transport/src/test/java/io/netty/channel/pool/AbstractChannelPoolMapTest.java
+++ b/transport/src/test/java/io/netty/channel/pool/AbstractChannelPoolMapTest.java
@@ -160,7 +160,7 @@ public class AbstractChannelPoolMapTest {
             Future<Void> poolClose = super.closeAsync();
             poolClose.addListener(new GenericFutureListener<Future<? super Void>>() {
                 @Override
-                public void operationComplete(Future<? super Void> future) throws Exception {
+                public void operationComplete(Future<? super Void> future) {
                     if (future.isSuccess()) {
                         closeFuture.setSuccess(null);
                     } else {

--- a/transport/src/test/java/io/netty/channel/pool/FixedChannelPoolTest.java
+++ b/transport/src/test/java/io/netty/channel/pool/FixedChannelPoolTest.java
@@ -281,7 +281,7 @@ public class FixedChannelPoolTest {
         final ChannelPromise closePromise = sc.newPromise();
         pool.closeAsync().addListener(new GenericFutureListener<Future<? super Void>>() {
             @Override
-            public void operationComplete(Future<? super Void> future) throws Exception {
+            public void operationComplete(Future<? super Void> future) {
                 assertEquals(0, pool.acquiredChannelCount());
                 sc.close(closePromise).syncUninterruptibly();
             }

--- a/transport/src/test/java/io/netty/channel/socket/nio/NioSocketChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/nio/NioSocketChannelTest.java
@@ -27,7 +27,6 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
-import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
@@ -138,7 +137,7 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
                     ChannelFuture f = ctx.write(Unpooled.wrappedBuffer(new byte[] { 'b' }));
                     f.addListener(new ChannelFutureListener() {
                         @Override
-                        public void operationComplete(ChannelFuture future) throws Exception {
+                        public void operationComplete(ChannelFuture future) {
                             // This message must be flushed
                             ctx.writeAndFlush(Unpooled.wrappedBuffer(new byte[]{'c'}));
                         }


### PR DESCRIPTION
Motivation:

Our `Listener` did have throws Exception on the methods signature. This could lead to problems as people were not really aware that something could throw that is executed inside the listener. Better let people explict handle exceptions.

Modifications:

- Remove throws Exception from signature
- Adjust code to correct handle exceptions

Result:

More explicit handling of exception and better API