### PR TITLE
Close Channel and fail bootstrap when setting a ChannelOption causes …

### DIFF
--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -271,11 +271,12 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
     }
 
     @Override
-    void init(Channel channel) {
+    void init(Channel channel) throws Throwable {
         ChannelPipeline p = channel.pipeline();
         p.addLast(config.handler());
 
         setChannelOptions(channel, newOptionsArray(), logger);
+
         setAttributes(channel, newAttributesArray());
         Collection<ChannelInitializerExtension> extensions = getInitializerExtensions();
         if (!extensions.isEmpty()) {

--- a/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
@@ -132,7 +132,7 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
     }
 
     @Override
-    void init(Channel channel) {
+    void init(Channel channel) throws Throwable {
         setChannelOptions(channel, newOptionsArray(), logger);
         setAttributes(channel, newAttributesArray());
 
@@ -227,7 +227,12 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
 
             child.pipeline().addLast(childHandler);
 
-            setChannelOptions(child, childOptions, logger);
+            try {
+                setChannelOptions(child, childOptions, logger);
+            } catch (Throwable cause) {
+                forceClose(child, cause);
+                return;
+            }
             setAttributes(child, childAttrs);
 
             if (!extensions.isEmpty()) {

--- a/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
@@ -86,6 +86,29 @@ public class BootstrapTest {
     }
 
     @Test
+    public void testSetOptionsThrow() {
+        final ChannelFuture cf = new Bootstrap()
+                .group(groupA)
+                .channelFactory(new ChannelFactory<Channel>() {
+                    @Override
+                    public Channel newChannel() {
+                        return new TestChannel();
+                    }
+                })
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 4242)
+                .handler(new ChannelInboundHandlerAdapter())
+                .register();
+
+        assertThrows(UnsupportedOperationException.class, new  Executable() {
+            @Override
+            public void execute() throws Throwable {
+                cf.syncUninterruptibly();
+            }
+        });
+        assertFalse(cf.channel().isActive());
+    }
+
+    @Test
     public void testOptionsCopied() {
         final Bootstrap bootstrapA = new Bootstrap();
         bootstrapA.option(ChannelOption.AUTO_READ, true);
@@ -578,4 +601,5 @@ public class BootstrapTest {
             };
         }
     }
+
 }

--- a/transport/src/test/java/io/netty/bootstrap/TestChannel.java
+++ b/transport/src/test/java/io/netty/bootstrap/TestChannel.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.bootstrap;
+
+import io.netty.channel.AbstractChannel;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelConfig;
+import io.netty.channel.ChannelMetadata;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelOutboundBuffer;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.DefaultChannelConfig;
+import io.netty.channel.EventLoop;
+
+import java.net.SocketAddress;
+
+class TestChannel extends AbstractChannel {
+    private static final ChannelMetadata METADATA = new ChannelMetadata(false);
+    private final ChannelConfig config;
+    private volatile boolean closed;
+
+    TestChannel() {
+        this(null);
+    }
+
+    TestChannel(Channel parent) {
+        super(parent);
+        config = new TestConfig(this);
+    }
+
+    @Override
+    protected AbstractUnsafe newUnsafe() {
+        return new AbstractUnsafe() {
+            @Override
+            public void connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+                promise.setSuccess();
+            }
+        };
+    }
+
+    @Override
+    protected boolean isCompatible(EventLoop loop) {
+        return true;
+    }
+
+    @Override
+    protected SocketAddress localAddress0() {
+        return null;
+    }
+
+    @Override
+    protected SocketAddress remoteAddress0() {
+        return null;
+    }
+
+    @Override
+    protected void doBind(SocketAddress localAddress) {
+        // NOOP
+    }
+
+    @Override
+    protected void doDisconnect() {
+        closed = true;
+    }
+
+    @Override
+    protected void doClose() {
+        closed = true;
+    }
+
+    @Override
+    protected void doBeginRead() {
+        // NOOP
+    }
+
+    @Override
+    protected void doWrite(ChannelOutboundBuffer in) {
+        // NOOP
+    }
+
+    @Override
+    public ChannelConfig config() {
+        return config;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return !closed;
+    }
+
+    @Override
+    public boolean isActive() {
+        return !closed;
+    }
+
+    @Override
+    public ChannelMetadata metadata() {
+        return METADATA;
+    }
+
+    private static final class TestConfig extends DefaultChannelConfig {
+        TestConfig(Channel channel) {
+            super(channel);
+        }
+
+        @Override
+        public <T> boolean setOption(ChannelOption<T> option, T value) {
+            throw new UnsupportedOperationException("Unsupported channel option: " + option);
+        }
+    }
+}


### PR DESCRIPTION
…… (#15896)

…an error

Motivation:

We should close the Channel and fail the future of the bootstrap if during setting a ChannelOption we observe an error. At the moment we just log which might make things hard to debug and leave the Channel in an unexpected state.

People can go back to the old behavior by using `-Dio.netty.bootstrap.closeOnSetOptionFailure=false`.

Modifications:

- Adjust code to also close and faile the future
- Add testcases

Result:

Related to
https://github.com/netty/netty/issues/15860#issuecomment-3548588098