### PR TITLE
Close Channel and fail bootstrap when setting a ChannelOption causes …

### DIFF
--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -31,6 +31,7 @@ import io.netty.util.concurrent.GlobalEventExecutor;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.SocketUtils;
 import io.netty.util.internal.StringUtil;
+import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
 
 import java.net.InetAddress;
@@ -51,6 +52,9 @@ import java.util.concurrent.ConcurrentHashMap;
  * transports such as datagram (UDP).</p>
  */
 public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C extends Channel> implements Cloneable {
+
+    private static final boolean CLOSE_ON_SET_OPTION_FAILURE = SystemPropertyUtil.getBoolean(
+            "io.netty.bootstrap.closeOnSetOptionFailure", true);
     @SuppressWarnings("unchecked")
     private static final Map.Entry<ChannelOption<?>, Object>[] EMPTY_OPTION_ARRAY = new Map.Entry[0];
     @SuppressWarnings("unchecked")
@@ -311,7 +315,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
         return reqFut;
     }
 
-    abstract void init(Channel channel) throws Exception;
+    abstract void init(Channel channel) throws Throwable;
 
     Collection<ChannelInitializerExtension> getInitializerExtensions() {
         ClassLoader loader = extensionsClassLoader;
@@ -423,7 +427,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
     }
 
     static void setChannelOptions(
-            Channel channel, Map.Entry<ChannelOption<?>, Object>[] options, InternalLogger logger) {
+            Channel channel, Map.Entry<ChannelOption<?>, Object>[] options, InternalLogger logger) throws Throwable {
         for (Map.Entry<ChannelOption<?>, Object> e: options) {
             setChannelOption(channel, e.getKey(), e.getValue(), logger);
         }
@@ -431,7 +435,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
 
     @SuppressWarnings("unchecked")
     private static void setChannelOption(
-            Channel channel, ChannelOption<?> option, Object value, InternalLogger logger) {
+            Channel channel, ChannelOption<?> option, Object value, InternalLogger logger) throws Throwable {
         try {
             if (!channel.config().setOption((ChannelOption<Object>) option, value)) {
                 logger.warn("Unknown channel option '{}' for channel '{}' of type '{}'",
@@ -441,6 +445,10 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
             logger.warn(
                     "Failed to set channel option '{}' with value '{}' for channel '{}' of type '{}'",
                     option, value, channel, channel.getClass(), t);
+            if (CLOSE_ON_SET_OPTION_FAILURE) {
+                // Only rethrow if we want to close the channel in case of a failure.
+                throw t;
+            }
         }
     }
 

--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -302,11 +302,12 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
     }
 
     @Override
-    void init(Channel channel) {
+    void init(Channel channel) throws Throwable {
         ChannelPipeline p = channel.pipeline();
         p.addLast(config.handler());
 
         setChannelOptions(channel, newOptionsArray(), logger);
+
         setAttributes(channel, newAttributesArray());
         Collection<ChannelInitializerExtension> extensions = getInitializerExtensions();
         if (!extensions.isEmpty()) {

--- a/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
@@ -168,8 +168,7 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
         return channelFactory.newChannel(eventLoop, childGroup);
     }
 
-    @Override
-    void init(Channel channel) {
+    void init(Channel channel) throws Throwable {
         setChannelOptions(channel, newOptionsArray(), logger);
         setAttributes(channel, newAttributesArray());
 
@@ -276,7 +275,12 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
         private void initChildChannel(Channel child) {
             child.pipeline().addLast(childHandler);
 
-            setChannelOptions(child, childOptions, logger);
+            try {
+                setChannelOptions(child, childOptions, logger);
+            } catch (Throwable cause) {
+                forceClose(child, cause);
+                return;
+            }
             setAttributes(child, childAttrs);
 
             if (!extensions.isEmpty()) {

--- a/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
@@ -90,6 +90,24 @@ public class BootstrapTest {
     }
 
     @Test
+    public void testSetOptionsThrow() {
+        final ChannelFuture cf = new Bootstrap()
+                .group(groupA)
+                .channelFactory(TestChannel::new)
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 4242)
+                .handler(new ChannelInboundHandlerAdapter())
+                .register();
+
+        assertThrows(UnsupportedOperationException.class, new  Executable() {
+            @Override
+            public void execute() throws Throwable {
+                cf.syncUninterruptibly();
+            }
+        });
+        assertFalse(cf.channel().isActive());
+    }
+
+    @Test
     public void testOptionsCopied() {
         final Bootstrap bootstrapA = new Bootstrap();
         bootstrapA.option(ChannelOption.AUTO_READ, true);
@@ -537,4 +555,5 @@ public class BootstrapTest {
             };
         }
     }
+
 }

--- a/transport/src/test/java/io/netty/bootstrap/ServerBootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/ServerBootstrapTest.java
@@ -16,14 +16,18 @@
 package io.netty.bootstrap;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.ServerChannel;
 import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalChannel;
 import io.netty.channel.local.LocalIoHandler;
@@ -31,7 +35,9 @@ import io.netty.channel.local.LocalServerChannel;
 import io.netty.util.AttributeKey;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.function.Executable;
 
+import java.net.SocketAddress;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -40,11 +46,37 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ServerBootstrapTest {
+
+    @Test
+    public void testSetOptionsThrow() {
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, LocalIoHandler.newFactory());
+        try {
+            final ChannelFuture cf = new ServerBootstrap()
+                    .group(group)
+                    .channelFactory((e, c) -> new TestServerChannel(e))
+                    .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 4242)
+                    .handler(new ChannelInboundHandlerAdapter())
+                    .childHandler(new ChannelInboundHandlerAdapter())
+                    .register();
+
+            assertThrows(UnsupportedOperationException.class, new Executable() {
+                @Override
+                public void execute() throws Throwable {
+                    cf.syncUninterruptibly();
+                }
+            });
+            assertFalse(cf.channel().isActive());
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
 
     @Test
     @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
@@ -239,5 +271,22 @@ public class ServerBootstrapTest {
         serverChannel.close().syncUninterruptibly();
         clientChannel.close().syncUninterruptibly();
         group.shutdownGracefully();
+    }
+
+    private static final class TestServerChannel extends TestChannel implements ServerChannel {
+        TestServerChannel(EventLoop eventLoop) {
+            super(eventLoop);
+        }
+
+        @Override
+        protected void doBind(SocketAddress localAddress, ChannelPromise promise) {
+            active = true;
+            promise.setSuccess();
+        }
+
+        @Override
+        public EventLoopGroup childEventExecutorGroup() {
+            return executor();
+        }
     }
 }

--- a/transport/src/test/java/io/netty/bootstrap/TestChannel.java
+++ b/transport/src/test/java/io/netty/bootstrap/TestChannel.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.bootstrap;
+
+import io.netty.channel.AbstractChannel;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelConfig;
+import io.netty.channel.ChannelMetadata;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelOutboundBuffer;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.DefaultChannelConfig;
+import io.netty.channel.EventLoop;
+
+import java.net.SocketAddress;
+
+class TestChannel extends AbstractChannel {
+    private static final ChannelMetadata METADATA = new ChannelMetadata(false);
+    private final ChannelConfig config;
+    volatile boolean active;
+    volatile boolean closed;
+
+    TestChannel(EventLoop eventLoop) {
+        this(eventLoop, null);
+    }
+
+    TestChannel(EventLoop eventLoop, Channel parent) {
+        super(eventLoop, null, parent);
+        config = new TestConfig(this);
+    }
+
+    @Override
+    protected void doRegister(ChannelPromise promise) {
+        promise.setSuccess();
+    }
+
+    @Override
+    protected void doBind(SocketAddress localAddress, ChannelPromise promise) {
+        promise.setSuccess();
+    }
+
+    @Override
+    protected void doConnect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+        active = true;
+        promise.setSuccess();
+    }
+
+    @Override
+    protected void doDisconnect(ChannelPromise promise) {
+        active = false;
+        closed = true;
+        promise.setSuccess();
+    }
+
+    @Override
+    protected void doClose(ChannelPromise promise) {
+        active = false;
+        closed = true;
+        promise.setSuccess();
+    }
+
+    @Override
+    protected void doDeregister(ChannelPromise promise) {
+        promise.setSuccess();
+    }
+
+    @Override
+    protected SocketAddress localAddress0() {
+        return null;
+    }
+
+    @Override
+    protected SocketAddress remoteAddress0() {
+        return null;
+    }
+
+    @Override
+    protected void doBeginRead() {
+        // NOOP
+    }
+
+    @Override
+    protected void doWrite(ChannelOutboundBuffer in) {
+        // NOOP
+    }
+
+    @Override
+    public ChannelConfig config() {
+        return config;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return !closed;
+    }
+
+    @Override
+    public boolean isActive() {
+        return active;
+    }
+
+    @Override
+    public ChannelMetadata metadata() {
+        return METADATA;
+    }
+
+    private static final class TestConfig extends DefaultChannelConfig {
+        TestConfig(Channel channel) {
+            super(channel);
+        }
+
+        @Override
+        public <T> boolean setOption(ChannelOption<T> option, T value) {
+            throw new UnsupportedOperationException("Unsupported channel option: " + option);
+        }
+    }
+}


### PR DESCRIPTION
…… (#15896)

…an error

Motivation:

We should close the Channel and fail the future of the bootstrap if during setting a ChannelOption we observe an error. At the moment we just log which might make things hard to debug and leave the Channel in an unexpected state.

People can go back to the old behavior by using `-Dio.netty.bootstrap.closeOnSetOptionFailure=false`.

Modifications:

- Adjust code to also close and faile the future
- Add testcases

Result:

Related to
https://github.com/netty/netty/issues/15860#issuecomment-3548588098