### PR TITLE
Use exact length when allocating the acceptedAddress byte[]

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
@@ -57,8 +57,7 @@ public final class EpollServerSocketChannel extends AbstractEpollChannel impleme
 
     // Will hold the remote address after accept(...) was successful.
     // We need 24 bytes for the address as maximum + 1 byte for storing the length.
-    // So use 26 bytes as it's a power of two.
-    private final byte[] acceptedAddress = new byte[26];
+    private final byte[] acceptedAddress = new byte[25];
 
     private final EpollServerSocketChannelConfig config;
     private volatile Collection<InetAddress> tcpMd5SigAddresses = Collections.emptyList();

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerSocketChannel.java
@@ -47,8 +47,7 @@ public final class KQueueServerSocketChannel extends AbstractKQueueChannel imple
 
     // Will hold the remote address after accept(...) was successful.
     // We need 24 bytes for the address as maximum + 1 byte for storing the capacity.
-    // So use 26 bytes as it's a power of two.
-    private final byte[] acceptedAddress = new byte[26];
+    private final byte[] acceptedAddress = new byte[25];
 
     public KQueueServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup, int fd) {
         // Must call this constructor to ensure this object's local address is configured correctly.


### PR DESCRIPTION
Motivation:

We used some odd number for the length, just use the exact length that we need.

Modifications:

- Allocate a byte[] of 25 length and remove odd comment

Result:

Cleanup