### PR TITLE
ChannelOutboundHandler: Remove throws Exception from method signature

### DIFF
--- a/codec-base/src/main/java/io/netty/handler/codec/ByteToMessageCodec.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/ByteToMessageCodec.java
@@ -104,7 +104,7 @@ public abstract class ByteToMessageCodec<I> extends ChannelDuplexHandler {
     }
 
     @Override
-    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         encoder.write(ctx, msg, promise);
     }
 

--- a/codec-base/src/main/java/io/netty/handler/codec/DatagramPacketEncoder.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/DatagramPacketEncoder.java
@@ -89,39 +89,39 @@ public class DatagramPacketEncoder<M> extends MessageToMessageEncoder<AddressedE
     }
 
     @Override
-    public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) throws Exception {
+    public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) {
         encoder.bind(ctx, localAddress, promise);
     }
 
     @Override
     public void connect(
             ChannelHandlerContext ctx, SocketAddress remoteAddress,
-            SocketAddress localAddress, ChannelPromise promise) throws Exception {
+            SocketAddress localAddress, ChannelPromise promise) {
         encoder.connect(ctx, remoteAddress, localAddress, promise);
     }
 
     @Override
-    public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) {
         encoder.disconnect(ctx, promise);
     }
 
     @Override
-    public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void close(ChannelHandlerContext ctx, ChannelPromise promise) {
         encoder.close(ctx, promise);
     }
 
     @Override
-    public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) {
         encoder.deregister(ctx, promise);
     }
 
     @Override
-    public void read(ChannelHandlerContext ctx) throws Exception {
+    public void read(ChannelHandlerContext ctx) {
         encoder.read(ctx);
     }
 
     @Override
-    public void flush(ChannelHandlerContext ctx) throws Exception {
+    public void flush(ChannelHandlerContext ctx) {
         encoder.flush(ctx);
     }
 

--- a/codec-base/src/main/java/io/netty/handler/codec/MessageToByteEncoder.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/MessageToByteEncoder.java
@@ -96,7 +96,7 @@ public abstract class MessageToByteEncoder<I> extends ChannelOutboundHandlerAdap
     }
 
     @Override
-    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         ByteBuf buf = null;
         try {
             if (acceptOutboundMessage(msg)) {

--- a/codec-base/src/main/java/io/netty/handler/codec/MessageToMessageCodec.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/MessageToMessageCodec.java
@@ -126,7 +126,7 @@ public abstract class MessageToMessageCodec<INBOUND_IN, OUTBOUND_IN> extends Cha
     }
 
     @Override
-    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         encoder.write(ctx, msg, promise);
     }
 

--- a/codec-base/src/main/java/io/netty/handler/codec/MessageToMessageEncoder.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/MessageToMessageEncoder.java
@@ -79,7 +79,7 @@ public abstract class MessageToMessageEncoder<I> extends ChannelOutboundHandlerA
     }
 
     @Override
-    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         CodecOutputList out = null;
         try {
             if (acceptOutboundMessage(msg)) {

--- a/codec-base/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
@@ -441,7 +441,7 @@ public class ByteToMessageDecoderTest {
         private int readsTriggered;
 
         @Override
-        public void read(ChannelHandlerContext ctx) throws Exception {
+        public void read(ChannelHandlerContext ctx) {
             readsTriggered++;
             super.read(ctx);
         }

--- a/codec-base/src/test/java/io/netty/handler/codec/MessageAggregatorTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/MessageAggregatorTest.java
@@ -39,7 +39,7 @@ public class MessageAggregatorTest {
         int value;
 
         @Override
-        public void read(ChannelHandlerContext ctx) throws Exception {
+        public void read(ChannelHandlerContext ctx) {
             value++;
             ctx.read();
         }

--- a/codec-base/src/test/java/io/netty/handler/codec/MessageToMessageDecoderTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/MessageToMessageDecoderTest.java
@@ -56,7 +56,7 @@ public class MessageToMessageDecoderTest {
     private static final class ReadCountHandler extends ChannelOutboundHandlerAdapter {
         final AtomicInteger readCount = new AtomicInteger();
         @Override
-        public void read(ChannelHandlerContext ctx) throws Exception {
+        public void read(ChannelHandlerContext ctx) {
             readCount.incrementAndGet();
             super.read(ctx);
         }

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicCodec.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicCodec.java
@@ -277,7 +277,7 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
     }
 
     @Override
-    public final void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise)  {
+    public final void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         pendingPackets ++;
         int size = estimatorHandle.size(msg);
         if (size > 0) {
@@ -303,7 +303,7 @@ abstract class QuicheQuicCodec extends ChannelDuplexHandler {
 
     @Override
     public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress, SocketAddress localAddress,
-                        ChannelPromise promise) throws Exception {
+                        ChannelPromise promise) {
         if (remoteAddress instanceof QuicheQuicChannelAddress) {
             QuicheQuicChannelAddress addr = (QuicheQuicChannelAddress) remoteAddress;
             QuicheQuicChannel channel = addr.channel;

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/BrotliEncoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/BrotliEncoder.java
@@ -157,7 +157,7 @@ public final class BrotliEncoder extends MessageToByteEncoder<ByteBuf> {
         finishEncode(ctx, ctx.newPromise());
     }
 
-    private ChannelFuture finishEncode(ChannelHandlerContext ctx, ChannelPromise promise) throws IOException {
+    private ChannelFuture finishEncode(ChannelHandlerContext ctx, ChannelPromise promise) {
         Writer writer;
 
         if (isSharable) {
@@ -174,7 +174,7 @@ public final class BrotliEncoder extends MessageToByteEncoder<ByteBuf> {
     }
 
     @Override
-    public void close(final ChannelHandlerContext ctx, final ChannelPromise promise) throws Exception {
+    public void close(final ChannelHandlerContext ctx, final ChannelPromise promise) {
         ChannelFuture f = finishEncode(ctx, ctx.newPromise());
         EncoderUtil.closeAfterFinishEncode(ctx, f, promise);
     }

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/Bzip2Encoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/Bzip2Encoder.java
@@ -199,7 +199,7 @@ public class Bzip2Encoder extends MessageToByteEncoder<ByteBuf> {
     }
 
     @Override
-    public void close(final ChannelHandlerContext ctx, final ChannelPromise promise) throws Exception {
+    public void close(final ChannelHandlerContext ctx, final ChannelPromise promise) {
         ChannelFuture f = finishEncode(ctx, ctx.newPromise());
         EncoderUtil.closeAfterFinishEncode(ctx, f, promise);
     }

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
@@ -300,7 +300,7 @@ public class JdkZlibEncoder extends ZlibEncoder {
     }
 
     @Override
-    public void close(final ChannelHandlerContext ctx, final ChannelPromise promise) throws Exception {
+    public void close(final ChannelHandlerContext ctx, final ChannelPromise promise) {
         ChannelFuture f = finishEncode(ctx, ctx.newPromise());
         EncoderUtil.closeAfterFinishEncode(ctx, f, promise);
     }

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/Lz4FrameEncoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/Lz4FrameEncoder.java
@@ -294,7 +294,7 @@ public class Lz4FrameEncoder extends MessageToByteEncoder<ByteBuf> {
     }
 
     @Override
-    public void flush(final ChannelHandlerContext ctx) throws Exception {
+    public void flush(final ChannelHandlerContext ctx) {
         if (buffer != null && buffer.isReadable()) {
             final ByteBuf buf = allocateBuffer(ctx, Unpooled.EMPTY_BUFFER, isPreferDirect(), false);
             flushBufferedData(buf);
@@ -366,7 +366,7 @@ public class Lz4FrameEncoder extends MessageToByteEncoder<ByteBuf> {
     }
 
     @Override
-    public void close(final ChannelHandlerContext ctx, final ChannelPromise promise) throws Exception {
+    public void close(final ChannelHandlerContext ctx, final ChannelPromise promise) {
         ChannelFuture f = finishEncode(ctx, ctx.newPromise());
 
         EncoderUtil.closeAfterFinishEncode(ctx, f, promise);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientUpgradeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientUpgradeHandler.java
@@ -122,44 +122,43 @@ public class HttpClientUpgradeHandler extends HttpObjectAggregator implements Ch
     }
 
     @Override
-    public void register(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void register(ChannelHandlerContext ctx, ChannelPromise promise) {
         ctx.register(promise);
     }
 
     @Override
-    public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) throws Exception {
+    public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) {
         ctx.bind(localAddress, promise);
     }
 
     @Override
     public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress, SocketAddress localAddress,
-                        ChannelPromise promise) throws Exception {
+                        ChannelPromise promise) {
         ctx.connect(remoteAddress, localAddress, promise);
     }
 
     @Override
-    public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) {
         ctx.disconnect(promise);
     }
 
     @Override
-    public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void close(ChannelHandlerContext ctx, ChannelPromise promise) {
         ctx.close(promise);
     }
 
     @Override
-    public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) {
         ctx.deregister(promise);
     }
 
     @Override
-    public void read(ChannelHandlerContext ctx) throws Exception {
+    public void read(ChannelHandlerContext ctx) {
         ctx.read();
     }
 
     @Override
-    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise)
-            throws Exception {
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         if (!(msg instanceof HttpRequest) || currentUpgradeEvent == UpgradeEvent.UPGRADE_SUCCESSFUL) {
             ctx.write(msg, promise);
             return;
@@ -185,7 +184,7 @@ public class HttpClientUpgradeHandler extends HttpObjectAggregator implements Ch
     }
 
     @Override
-    public void flush(ChannelHandlerContext ctx) throws Exception {
+    public void flush(ChannelHandlerContext ctx) {
         ctx.flush();
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectEncoder.java
@@ -99,7 +99,7 @@ public abstract class HttpObjectEncoder<H extends HttpMessage> extends MessageTo
     }
 
     @Override
-    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         try {
             if (acceptOutboundMessage(msg)) {
                 encode(ctx, msg, out);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerKeepAliveHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerKeepAliveHandler.java
@@ -65,7 +65,7 @@ public class HttpServerKeepAliveHandler extends ChannelDuplexHandler {
     }
 
     @Override
-    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         // modify message on way out to add headers if needed
         if (msg instanceof HttpResponse) {
             final HttpResponse response = (HttpResponse) msg;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsHandler.java
@@ -251,8 +251,7 @@ public class CorsHandler extends ChannelDuplexHandler {
     }
 
     @Override
-    public void write(final ChannelHandlerContext ctx, final Object msg, final ChannelPromise promise)
-            throws Exception {
+    public void write(final ChannelHandlerContext ctx, final Object msg, final ChannelPromise promise) {
         if (config != null && config.isCorsSupportEnabled() && msg instanceof HttpResponse) {
             final HttpResponse response = (HttpResponse) msg;
             if (setOrigin(response)) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketProtocolHandler.java
@@ -89,7 +89,7 @@ abstract class WebSocketProtocolHandler extends MessageToMessageDecoder<WebSocke
     }
 
     @Override
-    public void close(final ChannelHandlerContext ctx, final ChannelPromise promise) throws Exception {
+    public void close(final ChannelHandlerContext ctx, final ChannelPromise promise) {
         if (closeStatus == null || !ctx.channel().isActive()) {
             ctx.close(promise);
         } else {
@@ -108,7 +108,7 @@ abstract class WebSocketProtocolHandler extends MessageToMessageDecoder<WebSocke
     }
 
     @Override
-    public void write(final ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    public void write(final ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         if (closeSent != null) {
             ReferenceCountUtil.release(msg);
             promise.setFailure(new ClosedChannelException());
@@ -155,40 +155,39 @@ abstract class WebSocketProtocolHandler extends MessageToMessageDecoder<WebSocke
     }
 
     @Override
-    public void register(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void register(ChannelHandlerContext ctx, ChannelPromise promise) {
         ctx.register(promise);
     }
 
     @Override
     public void bind(ChannelHandlerContext ctx, SocketAddress localAddress,
-                     ChannelPromise promise) throws Exception {
+                     ChannelPromise promise) {
         ctx.bind(localAddress, promise);
     }
 
     @Override
     public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress,
-                        SocketAddress localAddress, ChannelPromise promise) throws Exception {
+                        SocketAddress localAddress, ChannelPromise promise) {
         ctx.connect(remoteAddress, localAddress, promise);
     }
 
     @Override
-    public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise)
-            throws Exception {
+    public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) {
         ctx.disconnect(promise);
     }
 
     @Override
-    public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) {
         ctx.deregister(promise);
     }
 
     @Override
-    public void read(ChannelHandlerContext ctx) throws Exception {
+    public void read(ChannelHandlerContext ctx) {
         ctx.read();
     }
 
     @Override
-    public void flush(ChannelHandlerContext ctx) throws Exception {
+    public void flush(ChannelHandlerContext ctx) {
         ctx.flush();
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketClientExtensionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketClientExtensionHandler.java
@@ -56,7 +56,7 @@ public class WebSocketClientExtensionHandler extends ChannelDuplexHandler {
     }
 
     @Override
-    public void write(final ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    public void write(final ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         if (msg instanceof HttpRequest && WebSocketExtensionUtil.isWebsocketUpgrade(((HttpRequest) msg).headers())) {
             HttpRequest request = (HttpRequest) msg;
             String headerValue = request.headers().getAsString(HttpHeaderNames.SEC_WEBSOCKET_EXTENSIONS);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandler.java
@@ -159,7 +159,7 @@ public class WebSocketServerExtensionHandler extends ChannelDuplexHandler {
     }
 
     @Override
-    public void write(final ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    public void write(final ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         if (msg != Unpooled.EMPTY_BUFFER && !(msg instanceof ByteBuf)) {
             if (msg instanceof DefaultHttpResponse) {
                 onHttpResponseWrite(ctx, (DefaultHttpResponse) msg, promise);
@@ -199,8 +199,7 @@ public class WebSocketServerExtensionHandler extends ChannelDuplexHandler {
      * <strong>IMPORTANT:</strong>
      * It already call {@code super.write(ctx, response, promise)} before returning.
      */
-    protected void onHttpResponseWrite(ChannelHandlerContext ctx, HttpResponse response, ChannelPromise promise)
-            throws Exception {
+    protected void onHttpResponseWrite(ChannelHandlerContext ctx, HttpResponse response, ChannelPromise promise) {
         List<WebSocketServerExtension> validExtensionsList = validExtensions.poll();
         // checking the status is faster than looking at headers so we do this first
         if (HttpResponseStatus.SWITCHING_PROTOCOLS.equals(response.status())) {

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameCodec.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameCodec.java
@@ -24,6 +24,7 @@ import io.netty.channel.ChannelOutboundHandler;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.UnsupportedMessageTypeException;
+import io.netty.util.ReferenceCountUtil;
 
 import java.net.SocketAddress;
 import java.util.List;
@@ -175,48 +176,48 @@ public class SpdyFrameCodec extends ByteToMessageDecoder
     }
 
     @Override
-    public void register(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void register(ChannelHandlerContext ctx, ChannelPromise promise) {
         ctx.register(promise);
     }
 
     @Override
-    public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) throws Exception {
+    public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) {
         ctx.bind(localAddress, promise);
     }
 
     @Override
     public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress, SocketAddress localAddress,
-                        ChannelPromise promise) throws Exception {
+                        ChannelPromise promise) {
         ctx.connect(remoteAddress, localAddress, promise);
     }
 
     @Override
-    public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) {
         ctx.disconnect(promise);
     }
 
     @Override
-    public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void close(ChannelHandlerContext ctx, ChannelPromise promise) {
         ctx.close(promise);
     }
 
     @Override
-    public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) {
         ctx.deregister(promise);
     }
 
     @Override
-    public void read(ChannelHandlerContext ctx) throws Exception {
+    public void read(ChannelHandlerContext ctx) {
         ctx.read();
     }
 
     @Override
-    public void flush(ChannelHandlerContext ctx) throws Exception {
+    public void flush(ChannelHandlerContext ctx) {
         ctx.flush();
     }
 
     @Override
-    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         ByteBuf frame;
 
         if (msg instanceof SpdyDataFrame) {
@@ -235,9 +236,15 @@ public class SpdyFrameCodec extends ByteToMessageDecoder
             }
 
         } else if (msg instanceof SpdySynStreamFrame) {
-
             SpdySynStreamFrame spdySynStreamFrame = (SpdySynStreamFrame) msg;
-            ByteBuf headerBlock = spdyHeaderBlockEncoder.encode(ctx.alloc(), spdySynStreamFrame);
+            final ByteBuf headerBlock;
+            try {
+                headerBlock = spdyHeaderBlockEncoder.encode(ctx.alloc(), spdySynStreamFrame);
+            } catch (Exception e) {
+                ReferenceCountUtil.release(spdySynStreamFrame);
+                promise.setFailure(e);
+                return;
+            }
             try {
                 frame = spdyFrameEncoder.encodeSynStreamFrame(
                         ctx.alloc(),
@@ -254,9 +261,16 @@ public class SpdyFrameCodec extends ByteToMessageDecoder
             ctx.write(frame, promise);
 
         } else if (msg instanceof SpdySynReplyFrame) {
-
             SpdySynReplyFrame spdySynReplyFrame = (SpdySynReplyFrame) msg;
-            ByteBuf headerBlock = spdyHeaderBlockEncoder.encode(ctx.alloc(), spdySynReplyFrame);
+            final ByteBuf headerBlock;
+            try {
+                headerBlock = spdyHeaderBlockEncoder.encode(ctx.alloc(), spdySynReplyFrame);
+            } catch (Exception e) {
+                ReferenceCountUtil.release(spdySynReplyFrame);
+                promise.setFailure(e);
+                return;
+            }
+
             try {
                 frame = spdyFrameEncoder.encodeSynReplyFrame(
                         ctx.alloc(),
@@ -308,9 +322,16 @@ public class SpdyFrameCodec extends ByteToMessageDecoder
             ctx.write(frame, promise);
 
         } else if (msg instanceof SpdyHeadersFrame) {
-
             SpdyHeadersFrame spdyHeadersFrame = (SpdyHeadersFrame) msg;
-            ByteBuf headerBlock = spdyHeaderBlockEncoder.encode(ctx.alloc(), spdyHeadersFrame);
+            final ByteBuf headerBlock;
+            try {
+                headerBlock = spdyHeaderBlockEncoder.encode(ctx.alloc(), spdyHeadersFrame);
+            } catch (Exception e) {
+                ReferenceCountUtil.release(spdyHeadersFrame);
+                promise.setFailure(e);
+                return;
+            }
+
             try {
                 frame = spdyFrameEncoder.encodeHeadersFrame(
                         ctx.alloc(),

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySessionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySessionHandler.java
@@ -428,12 +428,12 @@ public class SpdySessionHandler extends ChannelDuplexHandler {
     }
 
     @Override
-    public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void close(ChannelHandlerContext ctx, ChannelPromise promise) {
         sendGoAwayFrame(ctx, promise);
     }
 
     @Override
-    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         if (msg instanceof SpdyDataFrame ||
             msg instanceof SpdySynStreamFrame ||
             msg instanceof SpdySynReplyFrame ||
@@ -450,7 +450,7 @@ public class SpdySessionHandler extends ChannelDuplexHandler {
         }
     }
 
-    private void handleOutboundMessage(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    private void handleOutboundMessage(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         if (msg instanceof SpdyDataFrame) {
 
             SpdyDataFrame spdyDataFrame = (SpdyDataFrame) msg;

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentDecompressorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentDecompressorTest.java
@@ -15,7 +15,6 @@
  */
 package io.netty.handler.codec.http;
 
-import io.netty.buffer.AdaptiveByteBufAllocator;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -452,28 +452,28 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
     }
 
     @Override
-    public void register(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void register(ChannelHandlerContext ctx, ChannelPromise promise) {
         ctx.register(promise);
     }
 
     @Override
-    public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) throws Exception {
+    public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) {
         ctx.bind(localAddress, promise);
     }
 
     @Override
     public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress, SocketAddress localAddress,
-                        ChannelPromise promise) throws Exception {
+                        ChannelPromise promise) {
         ctx.connect(remoteAddress, localAddress, promise);
     }
 
     @Override
-    public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) {
         ctx.disconnect(promise);
     }
 
     @Override
-    public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void close(ChannelHandlerContext ctx, ChannelPromise promise) {
         if (decoupleCloseAndGoAway) {
             ctx.close(promise);
             return;
@@ -532,17 +532,17 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
     }
 
     @Override
-    public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) {
         ctx.deregister(promise);
     }
 
     @Override
-    public void read(ChannelHandlerContext ctx) throws Exception {
+    public void read(ChannelHandlerContext ctx) {
         ctx.read();
     }
 
     @Override
-    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         ctx.write(msg, promise);
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -748,12 +748,17 @@ public class Http2ConnectionRoundtripTest {
                         newPromise());
                 clientChannel.pipeline().addFirst(new ChannelOutboundHandlerAdapter() {
                     @Override
-                    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+                    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
                         ReferenceCountUtil.release(msg);
 
                         // Ensure we update the window size so we will try to write the rest of the frame while
                         // processing the flush.
-                        http2Client.encoder().flowController().initialWindowSize(8);
+                        try {
+                            http2Client.encoder().flowController().initialWindowSize(8);
+                        } catch (Http2Exception e) {
+                            promise.setFailure(e);
+                            return;
+                        }
                         promise.setFailure(new IllegalStateException());
                     }
                 });

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
@@ -1553,7 +1553,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
         }
 
         @Override
-        public void flush(ChannelHandlerContext ctx) throws Exception {
+        public void flush(ChannelHandlerContext ctx) {
             didFlush = true;
             super.flush(ctx);
         }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodecTest.java
@@ -455,7 +455,7 @@ public class Http2StreamFrameToHttpObjectCodecTest {
         EmbeddedChannel ch = new EmbeddedChannel(ctx.newHandler(ByteBufAllocator.DEFAULT),
                 new ChannelOutboundHandlerAdapter() {
                     @Override
-                    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+                    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
                         if (msg instanceof Http2StreamFrame) {
                             frames.add((Http2StreamFrame) msg);
                             ctx.write(Unpooled.EMPTY_BUFFER, promise);

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3FrameToHttpObjectCodec.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3FrameToHttpObjectCodec.java
@@ -133,7 +133,7 @@ public final class Http3FrameToHttpObjectCodec extends Http3RequestStreamInbound
      * @throws Exception    is thrown if an error occurs
      */
     @Override
-    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         if (!(msg instanceof HttpObject)) {
             throw new UnsupportedMessageTypeException(msg, HttpObject.class);
         }
@@ -261,7 +261,7 @@ public final class Http3FrameToHttpObjectCodec extends Http3RequestStreamInbound
     }
 
     @Override
-    public void register(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void register(ChannelHandlerContext ctx, ChannelPromise promise) {
         ctx.register(promise);
     }
 
@@ -292,7 +292,7 @@ public final class Http3FrameToHttpObjectCodec extends Http3RequestStreamInbound
     }
 
     @Override
-    public void read(ChannelHandlerContext ctx) throws Exception {
+    public void read(ChannelHandlerContext ctx) {
         ctx.read();
     }
 }

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3FrameTypeDuplexValidationHandler.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3FrameTypeDuplexValidationHandler.java
@@ -66,7 +66,7 @@ class Http3FrameTypeDuplexValidationHandler<T extends Http3Frame> extends Http3F
 
     @Override
     public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress, SocketAddress localAddress,
-                        ChannelPromise promise) throws Exception {
+                        ChannelPromise promise) {
         ctx.connect(remoteAddress, localAddress, promise);
     }
 
@@ -76,17 +76,17 @@ class Http3FrameTypeDuplexValidationHandler<T extends Http3Frame> extends Http3F
     }
 
     @Override
-    public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void close(ChannelHandlerContext ctx, ChannelPromise promise) {
         ctx.close(promise);
     }
 
     @Override
-    public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) {
         ctx.deregister(promise);
     }
 
     @Override
-    public void read(ChannelHandlerContext ctx) throws Exception {
+    public void read(ChannelHandlerContext ctx) {
         ctx.read();
     }
 }

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3RequestStreamEncodeStateValidator.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3RequestStreamEncodeStateValidator.java
@@ -34,7 +34,7 @@ final class Http3RequestStreamEncodeStateValidator extends ChannelOutboundHandle
     private State state = State.None;
 
     @Override
-    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         if (!(msg instanceof Http3RequestStreamFrame)) {
             super.write(ctx, msg, promise);
             return;

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/EmbeddedQuicStreamChannel.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/EmbeddedQuicStreamChannel.java
@@ -66,7 +66,7 @@ final class EmbeddedQuicStreamChannel extends EmbeddedChannel implements QuicStr
                 }, handlers));
         pipeline().addFirst(new ChannelOutboundHandlerAdapter() {
             @Override
-            public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+            public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
                 if (msg instanceof QuicStreamFrame && ((QuicStreamFrame) msg).hasFin()) {
                     // Mimic the API.
                     promise.addListener(f -> outputShutdown = 0);

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3FrameToHttpObjectCodecTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3FrameToHttpObjectCodecTest.java
@@ -756,7 +756,7 @@ public class Http3FrameToHttpObjectCodecTest {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(
                 new ChannelOutboundHandlerAdapter() {
                     @Override
-                    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+                    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
                         framePromises.add(promise);
                         ctx.write(msg, ctx.newPromise());
                     }

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3ServerPushStreamManagerTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3ServerPushStreamManagerTest.java
@@ -197,7 +197,7 @@ public class Http3ServerPushStreamManagerTest {
         final List<Http3PushStreamFrame> framesWritten = new ArrayList<>();
 
         @Override
-        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
             if (msg instanceof Http3PushStreamFrame) {
                 framesWritten.add((Http3PushStreamFrame) msg);
             }

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/QpackEncoderDecoderTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/QpackEncoderDecoderTest.java
@@ -525,15 +525,27 @@ public class QpackEncoderDecoderTest {
         }
 
         @Override
-        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
             if (msg instanceof ByteBuf) {
                 if (suspendQueue != null) {
                     suspendQueue.offer(() -> {
-                        other.channelRead(ctx, msg);
+                        try {
+                            other.channelRead(ctx, msg);
+                        } catch (Exception e) {
+                            promise.setFailure(e);
+                            return null;
+                        }
+                        promise.setSuccess();
                         return null;
                     });
                 } else {
-                    other.channelRead(ctx, msg);
+                    try {
+                        other.channelRead(ctx, msg);
+                    } catch (Exception e) {
+                        promise.setFailure(e);
+                        return;
+                    }
+                    promise.setSuccess();
                 }
             } else {
                 super.write(ctx, msg, promise);

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicheQuicCodecTest.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicheQuicCodecTest.java
@@ -71,7 +71,7 @@ public abstract class QuicheQuicCodecTest<B extends QuicCodecBuilder<B>> extends
 
         EmbeddedChannel channel = new EmbeddedChannel(new ChannelOutboundHandlerAdapter() {
             @Override
-            public void flush(ChannelHandlerContext ctx) throws Exception {
+            public void flush(ChannelHandlerContext ctx) {
                 flushCount.incrementAndGet();
                 super.flush(ctx);
             }

--- a/example/src/main/java/io/netty/example/haproxy/HAProxyHandler.java
+++ b/example/src/main/java/io/netty/example/haproxy/HAProxyHandler.java
@@ -33,7 +33,7 @@ public class HAProxyHandler extends ChannelOutboundHandlerAdapter {
     }
 
     @Override
-    public void write(final ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    public void write(final ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         ChannelFuture future = ctx.write(msg, promise);
         if (msg instanceof HAProxyMessage) {
             future.addListener(new ChannelFutureListener() {

--- a/handler-proxy/src/main/java/io/netty/handler/proxy/HttpProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/handler/proxy/HttpProxyHandler.java
@@ -300,49 +300,49 @@ public final class HttpProxyHandler extends ProxyHandler {
         }
 
         @Override
-        public void register(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        public void register(ChannelHandlerContext ctx, ChannelPromise promise) {
             codec.register(ctx, promise);
         }
 
         @Override
         public void bind(ChannelHandlerContext ctx, SocketAddress localAddress,
-                         ChannelPromise promise) throws Exception {
+                         ChannelPromise promise) {
             codec.bind(ctx, localAddress, promise);
         }
 
         @Override
         public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress, SocketAddress localAddress,
-                            ChannelPromise promise) throws Exception {
+                            ChannelPromise promise) {
             codec.connect(ctx, remoteAddress, localAddress, promise);
         }
 
         @Override
-        public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) {
             codec.disconnect(ctx, promise);
         }
 
         @Override
-        public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        public void close(ChannelHandlerContext ctx, ChannelPromise promise) {
             codec.close(ctx, promise);
         }
 
         @Override
-        public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) {
             codec.deregister(ctx, promise);
         }
 
         @Override
-        public void read(ChannelHandlerContext ctx) throws Exception {
+        public void read(ChannelHandlerContext ctx) {
             codec.read(ctx);
         }
 
         @Override
-        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
             codec.write(ctx, msg, promise);
         }
 
         @Override
-        public void flush(ChannelHandlerContext ctx) throws Exception {
+        public void flush(ChannelHandlerContext ctx) {
             codec.flush(ctx);
         }
     }

--- a/handler-proxy/src/main/java/io/netty/handler/proxy/ProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/handler/proxy/ProxyHandler.java
@@ -170,7 +170,7 @@ public abstract class ProxyHandler extends ChannelDuplexHandler {
     @Override
     public final void connect(
             ChannelHandlerContext ctx, SocketAddress remoteAddress, SocketAddress localAddress,
-            ChannelPromise promise) throws Exception {
+            ChannelPromise promise) {
 
         if (destinationAddress != null) {
             promise.setFailure(new ConnectionPendingException());
@@ -400,7 +400,7 @@ public abstract class ProxyHandler extends ChannelDuplexHandler {
     }
 
     @Override
-    public final void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    public final void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         if (finished) {
             writePendingWrites();
             ctx.write(msg, promise);
@@ -410,7 +410,7 @@ public abstract class ProxyHandler extends ChannelDuplexHandler {
     }
 
     @Override
-    public final void flush(ChannelHandlerContext ctx) throws Exception {
+    public final void flush(ChannelHandlerContext ctx) {
         if (finished) {
             writePendingWrites();
             ctx.flush();

--- a/handler/src/main/java/io/netty/handler/address/ResolveAddressHandler.java
+++ b/handler/src/main/java/io/netty/handler/address/ResolveAddressHandler.java
@@ -43,7 +43,7 @@ public class ResolveAddressHandler extends ChannelOutboundHandlerAdapter {
 
     @Override
     public void connect(final ChannelHandlerContext ctx, SocketAddress remoteAddress,
-                        final SocketAddress localAddress, final ChannelPromise promise)  {
+                        final SocketAddress localAddress, final ChannelPromise promise) {
         AddressResolver<? extends SocketAddress> resolver = resolverGroup.getResolver(ctx.executor());
         if (resolver.isSupported(remoteAddress) && !resolver.isResolved(remoteAddress)) {
             resolver.resolve(remoteAddress).addListener(new FutureListener<SocketAddress>() {

--- a/handler/src/main/java/io/netty/handler/flow/FlowControlHandler.java
+++ b/handler/src/main/java/io/netty/handler/flow/FlowControlHandler.java
@@ -134,7 +134,7 @@ public class FlowControlHandler extends ChannelDuplexHandler {
     }
 
     @Override
-    public void read(ChannelHandlerContext ctx) throws Exception {
+    public void read(ChannelHandlerContext ctx) {
         if (dequeue(ctx, 1) == 0) {
             // It seems no messages were consumed. We need to read() some
             // messages from upstream and once one arrives it need to be

--- a/handler/src/main/java/io/netty/handler/flush/FlushConsolidationHandler.java
+++ b/handler/src/main/java/io/netty/handler/flush/FlushConsolidationHandler.java
@@ -119,7 +119,7 @@ public class FlushConsolidationHandler extends ChannelDuplexHandler {
     }
 
     @Override
-    public void flush(ChannelHandlerContext ctx) throws Exception {
+    public void flush(ChannelHandlerContext ctx) {
         if (readInProgress) {
             // If there is still a read in progress we are sure we will see a channelReadComplete(...) call. Thus
             // we only need to flush if we reach the explicitFlushAfterFlushes limit.
@@ -160,14 +160,14 @@ public class FlushConsolidationHandler extends ChannelDuplexHandler {
     }
 
     @Override
-    public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) {
         // Try to flush one last time if flushes are pending before disconnect the channel.
         resetReadAndFlushIfNeeded(ctx);
         ctx.disconnect(promise);
     }
 
     @Override
-    public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void close(ChannelHandlerContext ctx, ChannelPromise promise) {
         // Try to flush one last time if flushes are pending before close the channel.
         resetReadAndFlushIfNeeded(ctx);
         ctx.close(promise);

--- a/handler/src/main/java/io/netty/handler/logging/LoggingHandler.java
+++ b/handler/src/main/java/io/netty/handler/logging/LoggingHandler.java
@@ -223,7 +223,7 @@ public class LoggingHandler extends ChannelDuplexHandler {
     }
 
     @Override
-    public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) throws Exception {
+    public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) {
         if (logger.isEnabled(internalLevel)) {
             logger.log(internalLevel, format(ctx, "BIND", localAddress));
         }
@@ -233,7 +233,7 @@ public class LoggingHandler extends ChannelDuplexHandler {
     @Override
     public void connect(
             ChannelHandlerContext ctx,
-            SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) throws Exception {
+            SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
         if (logger.isEnabled(internalLevel)) {
             logger.log(internalLevel, format(ctx, "CONNECT", remoteAddress, localAddress));
         }
@@ -241,7 +241,7 @@ public class LoggingHandler extends ChannelDuplexHandler {
     }
 
     @Override
-    public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) {
         if (logger.isEnabled(internalLevel)) {
             logger.log(internalLevel, format(ctx, "DISCONNECT"));
         }
@@ -249,7 +249,7 @@ public class LoggingHandler extends ChannelDuplexHandler {
     }
 
     @Override
-    public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void close(ChannelHandlerContext ctx, ChannelPromise promise) {
         if (logger.isEnabled(internalLevel)) {
             logger.log(internalLevel, format(ctx, "CLOSE"));
         }
@@ -257,7 +257,7 @@ public class LoggingHandler extends ChannelDuplexHandler {
     }
 
     @Override
-    public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) {
         if (logger.isEnabled(internalLevel)) {
             logger.log(internalLevel, format(ctx, "DEREGISTER"));
         }
@@ -281,7 +281,7 @@ public class LoggingHandler extends ChannelDuplexHandler {
     }
 
     @Override
-    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         if (logger.isEnabled(internalLevel)) {
             logger.log(internalLevel, format(ctx, "WRITE", msg));
         }
@@ -297,7 +297,7 @@ public class LoggingHandler extends ChannelDuplexHandler {
     }
 
     @Override
-    public void flush(ChannelHandlerContext ctx) throws Exception {
+    public void flush(ChannelHandlerContext ctx) {
         if (logger.isEnabled(internalLevel)) {
             logger.log(internalLevel, format(ctx, "FLUSH"));
         }

--- a/handler/src/main/java/io/netty/handler/pcap/PcapWriteHandler.java
+++ b/handler/src/main/java/io/netty/handler/pcap/PcapWriteHandler.java
@@ -28,6 +28,7 @@ import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.util.NetUtil;
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -277,7 +278,12 @@ public final class PcapWriteHandler extends ChannelDuplexHandler implements Clos
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         // Initialize if needed
         if (state.get() == State.INIT) {
-            initializeIfNecessary(ctx);
+            try {
+                initializeIfNecessary(ctx);
+            } catch (Exception ex) {
+                ReferenceCountUtil.release(msg);
+                throw ex;
+            }
         }
 
         // Only write if State is STARTED
@@ -294,10 +300,16 @@ public final class PcapWriteHandler extends ChannelDuplexHandler implements Clos
     }
 
     @Override
-    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         // Initialize if needed
         if (state.get() == State.INIT) {
-            initializeIfNecessary(ctx);
+            try {
+                initializeIfNecessary(ctx);
+            } catch (Exception e) {
+                ReferenceCountUtil.release(msg);
+                promise.setFailure(e);
+                return;
+            }
         }
 
         // Only write if State is STARTED

--- a/handler/src/main/java/io/netty/handler/ssl/SslClientHelloHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslClientHelloHandler.java
@@ -298,7 +298,7 @@ public abstract class SslClientHelloHandler<T> extends ByteToMessageDecoder impl
     protected abstract void onLookupComplete(ChannelHandlerContext ctx, Future<T> future) throws Exception;
 
     @Override
-    public void read(ChannelHandlerContext ctx) throws Exception {
+    public void read(ChannelHandlerContext ctx) {
         if (suppressRead) {
             readPending = true;
         } else {
@@ -307,43 +307,43 @@ public abstract class SslClientHelloHandler<T> extends ByteToMessageDecoder impl
     }
 
     @Override
-    public void register(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void register(ChannelHandlerContext ctx, ChannelPromise promise) {
         ctx.register(promise);
     }
 
     @Override
-    public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) throws Exception {
+    public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) {
         ctx.bind(localAddress, promise);
     }
 
     @Override
     public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress, SocketAddress localAddress,
-                        ChannelPromise promise) throws Exception {
+                        ChannelPromise promise) {
         ctx.connect(remoteAddress, localAddress, promise);
     }
 
     @Override
-    public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) {
         ctx.disconnect(promise);
     }
 
     @Override
-    public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void close(ChannelHandlerContext ctx, ChannelPromise promise) {
         ctx.close(promise);
     }
 
     @Override
-    public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) {
         ctx.deregister(promise);
     }
 
     @Override
-    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         ctx.write(msg, promise);
     }
 
     @Override
-    public void flush(ChannelHandlerContext ctx) throws Exception {
+    public void flush(ChannelHandlerContext ctx) {
         ctx.flush();
     }
 }

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -518,7 +518,8 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
      * Sets the number of bytes to pass to each {@link SSLEngine#wrap(ByteBuffer[], int, int, ByteBuffer)} call.
      * <p>
      * This value will partition data which is passed to write
-     * {@link #write(ChannelHandlerContext, Object, ChannelPromise)}. The partitioning will work as follows:
+     * {@link ChannelOutboundHandler#write(ChannelHandlerContext, Object, ChannelPromise)}.
+     * The partitioning will work as follows:
      * <ul>
      * <li>If {@code wrapDataSize <= 0} then we will write each data chunk as is.</li>
      * <li>If {@code wrapDataSize > data size} then we will attempt to aggregate multiple data chunks together.</li>
@@ -749,40 +750,40 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
     }
 
     @Override
-    public void register(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void register(ChannelHandlerContext ctx, ChannelPromise promise) {
         ctx.register(promise);
     }
 
     @Override
-    public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) throws Exception {
+    public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) {
         ctx.bind(localAddress, promise);
     }
 
     @Override
     public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress, SocketAddress localAddress,
-                        ChannelPromise promise) throws Exception {
+                        ChannelPromise promise) {
         ctx.connect(remoteAddress, localAddress, promise);
     }
 
     @Override
-    public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) {
         ctx.deregister(promise);
     }
 
     @Override
     public void disconnect(final ChannelHandlerContext ctx,
-                           final ChannelPromise promise) throws Exception {
+                           final ChannelPromise promise) {
         closeOutboundAndChannel(ctx, promise, true);
     }
 
     @Override
     public void close(final ChannelHandlerContext ctx,
-                      final ChannelPromise promise) throws Exception {
+                      final ChannelPromise promise) {
         closeOutboundAndChannel(ctx, promise, false);
     }
 
     @Override
-    public void read(ChannelHandlerContext ctx) throws Exception {
+    public void read(ChannelHandlerContext ctx) {
         if (!handshakePromise.isDone()) {
             setState(STATE_READ_DURING_HANDSHAKE);
         }
@@ -795,7 +796,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
     }
 
     @Override
-    public void write(final ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    public void write(final ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         if (!(msg instanceof ByteBuf)) {
             UnsupportedMessageTypeException exception = new UnsupportedMessageTypeException(msg, ByteBuf.class);
             ReferenceCountUtil.safeRelease(msg);
@@ -809,7 +810,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
     }
 
     @Override
-    public void flush(ChannelHandlerContext ctx) throws Exception {
+    public void flush(ChannelHandlerContext ctx) {
         // Do not encrypt the first write request if this handler is
         // created with startTLS flag turned on.
         if (startTls && !isStateSet(STATE_SENT_FIRST_MESSAGE)) {
@@ -2110,7 +2111,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
     }
 
     private void closeOutboundAndChannel(
-            final ChannelHandlerContext ctx, final ChannelPromise promise, boolean disconnect) throws Exception {
+            final ChannelHandlerContext ctx, final ChannelPromise promise, boolean disconnect) {
         setState(STATE_OUTBOUND_CLOSED);
         engine.closeOutbound();
 
@@ -2150,7 +2151,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         }
     }
 
-    private void flush(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    private void flush(ChannelHandlerContext ctx, ChannelPromise promise) {
         if (pendingUnencryptedWrites != null) {
             pendingUnencryptedWrites.add(Unpooled.EMPTY_BUFFER, promise);
         } else {

--- a/handler/src/main/java/io/netty/handler/stream/ChunkedWriteHandler.java
+++ b/handler/src/main/java/io/netty/handler/stream/ChunkedWriteHandler.java
@@ -131,7 +131,7 @@ public class ChunkedWriteHandler extends ChannelDuplexHandler {
     }
 
     @Override
-    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         if (!queueIsEmpty() || msg instanceof ChunkedInput) {
             allocateQueue();
             queue.add(new PendingWrite(msg, promise));
@@ -141,7 +141,7 @@ public class ChunkedWriteHandler extends ChannelDuplexHandler {
     }
 
     @Override
-    public void flush(ChannelHandlerContext ctx) throws Exception {
+    public void flush(ChannelHandlerContext ctx) {
         doFlush(ctx);
     }
 

--- a/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
+++ b/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
@@ -280,7 +280,7 @@ public class IdleStateHandler extends ChannelDuplexHandler {
     }
 
     @Override
-    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         // Allow writing with void promise if handler is only configured for read timeout events.
         if (writerIdleTimeNanos > 0 || allIdleTimeNanos > 0) {
             ctx.write(msg, promise).addListener(writeListener);

--- a/handler/src/main/java/io/netty/handler/timeout/WriteTimeoutHandler.java
+++ b/handler/src/main/java/io/netty/handler/timeout/WriteTimeoutHandler.java
@@ -104,7 +104,7 @@ public class WriteTimeoutHandler extends ChannelOutboundHandlerAdapter {
     }
 
     @Override
-    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         if (timeoutNanos > 0) {
             scheduleTimeout(ctx, promise);
         }

--- a/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
@@ -548,8 +548,7 @@ public abstract class AbstractTrafficShapingHandler extends ChannelDuplexHandler
     }
 
     @Override
-    public void write(final ChannelHandlerContext ctx, final Object msg, final ChannelPromise promise)
-            throws Exception {
+    public void write(final ChannelHandlerContext ctx, final Object msg, final ChannelPromise promise) {
         long size = calculateSize(msg);
         long now = TrafficCounter.milliSecondFromNano();
         if (size > 0) {

--- a/handler/src/main/java/io/netty/handler/traffic/GlobalChannelTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/GlobalChannelTrafficShapingHandler.java
@@ -648,8 +648,7 @@ public class GlobalChannelTrafficShapingHandler extends AbstractTrafficShapingHa
     }
 
     @Override
-    public void write(final ChannelHandlerContext ctx, final Object msg, final ChannelPromise promise)
-            throws Exception {
+    public void write(final ChannelHandlerContext ctx, final Object msg, final ChannelPromise promise) {
         long size = calculateSize(msg);
         long now = TrafficCounter.milliSecondFromNano();
         if (size > 0) {

--- a/handler/src/test/java/io/netty/handler/flush/FlushConsolidationHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/flush/FlushConsolidationHandlerTest.java
@@ -189,7 +189,7 @@ public class FlushConsolidationHandlerTest {
         return new EmbeddedChannel(
                 new ChannelOutboundHandlerAdapter() {
                     @Override
-                    public void flush(ChannelHandlerContext ctx) throws Exception {
+                    public void flush(ChannelHandlerContext ctx) {
                         flushCount.incrementAndGet();
                         ctx.flush();
                     }

--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -123,7 +123,7 @@ public class SslHandlerTest {
         SSLEngine engine = newClientModeSSLEngine();
         SslHandler handler = new SslHandler(engine) {
             @Override
-            public void write(final ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+            public void write(final ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
                 super.write(ctx, msg, promise);
                 writeLatch.countDown();
             }
@@ -423,7 +423,7 @@ public class SslHandlerTest {
         private volatile boolean readIssued;
 
         @Override
-        public void read(ChannelHandlerContext ctx) throws Exception {
+        public void read(ChannelHandlerContext ctx) {
             readIssued = true;
             super.read(ctx);
         }

--- a/handler/src/test/java/io/netty/handler/stream/ChunkedWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/stream/ChunkedWriteHandlerTest.java
@@ -623,7 +623,7 @@ public class ChunkedWriteHandlerTest {
 
         EmbeddedChannel ch = new EmbeddedChannel(new ChannelOutboundHandlerAdapter() {
             @Override
-            public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+            public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
                 ReferenceCountUtil.release(msg);
                 // Calling close so we will drop all queued messages in the ChunkedWriteHandler.
                 ctx.close();

--- a/microbench/src/main/java/io/netty/microbench/channel/DefaultChannelPipelineBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/channel/DefaultChannelPipelineBenchmark.java
@@ -89,17 +89,17 @@ public class DefaultChannelPipelineBenchmark extends AbstractMicrobenchmark {
 
     private static final ChannelHandler OUTBOUND_CONSUMING_HANDLER = new SharableOutboundHandlerAdapter() {
         @Override
-        public void read(ChannelHandlerContext ctx) throws Exception {
+        public void read(ChannelHandlerContext ctx) {
             // NOOP
         }
 
         @Override
-        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
             // NOOP
         }
 
         @Override
-        public void flush(ChannelHandlerContext ctx) throws Exception {
+        public void flush(ChannelHandlerContext ctx) {
             // NOOP
         }
     };
@@ -247,52 +247,52 @@ public class DefaultChannelPipelineBenchmark extends AbstractMicrobenchmark {
             },
             new SharableOutboundHandlerAdapter() {
                 @Override
-                public void read(ChannelHandlerContext ctx) throws Exception {
+                public void read(ChannelHandlerContext ctx) {
                     ctx.read();
                 }
             },
             new SharableOutboundHandlerAdapter() {
                 @Override
-                public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+                public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
                     ctx.write(msg, promise);
                 }
             },
             new SharableOutboundHandlerAdapter() {
                 @Override
-                public void flush(ChannelHandlerContext ctx) throws Exception {
+                public void flush(ChannelHandlerContext ctx) {
                     ctx.flush();
                 }
             },
             new SharableOutboundHandlerAdapter() {
                 @Override
-                public void read(ChannelHandlerContext ctx) throws Exception {
+                public void read(ChannelHandlerContext ctx) {
                     ctx.read();
                 }
 
                 @Override
-                public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+                public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
                     ctx.write(msg, promise);
                 }
             },
             new SharableOutboundHandlerAdapter() {
                 @Override
-                public void read(ChannelHandlerContext ctx) throws Exception {
+                public void read(ChannelHandlerContext ctx) {
                     ctx.read();
                 }
 
                 @Override
-                public void flush(ChannelHandlerContext ctx) throws Exception {
+                public void flush(ChannelHandlerContext ctx) {
                     ctx.flush();
                 }
             },
             new SharableOutboundHandlerAdapter() {
                 @Override
-                public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+                public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
                     ctx.write(msg, promise);
                 }
 
                 @Override
-                public void flush(ChannelHandlerContext ctx) throws Exception {
+                public void flush(ChannelHandlerContext ctx) {
                     ctx.flush();
                 }
             },

--- a/microbench/src/main/java/io/netty/microbench/channel/epoll/EpollSocketChannelBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/channel/epoll/EpollSocketChannelBenchmark.java
@@ -111,8 +111,7 @@ public class EpollSocketChannelBenchmark extends AbstractMicrobenchmark {
                     }
 
                     @Override
-                    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise)
-                            throws Exception {
+                    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
                         if (lastWritePromise != null) {
                             throw new IllegalStateException();
                         }

--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -770,7 +770,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
                         ((ChannelOutboundHandler) handler).read(next);
                     }
                 } catch (Throwable t) {
-                    invokeExceptionCaught(t);
+                    handleFatalOutboundHandlerException(t);
                 }
             } else {
                 next.read();
@@ -836,7 +836,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
                 ((ChannelOutboundHandler) handler).flush(this);
             }
         } catch (Throwable t) {
-            invokeExceptionCaught(t);
+            handleFatalOutboundHandlerException(t);
         }
     }
 
@@ -914,6 +914,15 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         // Only log if the given promise is not of type VoidChannelPromise as tryFailure(...) is expected to return
         // false.
         PromiseNotificationUtil.tryFailure(promise, cause, logger);
+    }
+
+    private void handleFatalOutboundHandlerException(Throwable cause) {
+        if (logger.isWarnEnabled()) {
+            logger.warn(
+                    "An exception was thrown by an ChannelOutboundHandler" +
+                            " which can't be handled, closing the channel.", cause);
+        }
+        close();
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/ChannelDuplexHandler.java
+++ b/transport/src/main/java/io/netty/channel/ChannelDuplexHandler.java
@@ -36,7 +36,7 @@ public class ChannelDuplexHandler extends ChannelInboundHandlerAdapter implement
      */
     @Skip
     @Override
-    public void register(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void register(ChannelHandlerContext ctx, ChannelPromise promise) {
         ctx.register(promise);
     }
 
@@ -49,7 +49,7 @@ public class ChannelDuplexHandler extends ChannelInboundHandlerAdapter implement
     @Skip
     @Override
     public void bind(ChannelHandlerContext ctx, SocketAddress localAddress,
-                     ChannelPromise promise) throws Exception {
+                     ChannelPromise promise) {
         ctx.bind(localAddress, promise);
     }
 
@@ -62,7 +62,7 @@ public class ChannelDuplexHandler extends ChannelInboundHandlerAdapter implement
     @Skip
     @Override
     public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress,
-                        SocketAddress localAddress, ChannelPromise promise) throws Exception {
+                        SocketAddress localAddress, ChannelPromise promise) {
         ctx.connect(remoteAddress, localAddress, promise);
     }
 
@@ -74,8 +74,7 @@ public class ChannelDuplexHandler extends ChannelInboundHandlerAdapter implement
      */
     @Skip
     @Override
-    public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise)
-            throws Exception {
+    public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) {
         ctx.disconnect(promise);
     }
 
@@ -87,7 +86,7 @@ public class ChannelDuplexHandler extends ChannelInboundHandlerAdapter implement
      */
     @Skip
     @Override
-    public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void close(ChannelHandlerContext ctx, ChannelPromise promise) {
         ctx.close(promise);
     }
 
@@ -99,7 +98,7 @@ public class ChannelDuplexHandler extends ChannelInboundHandlerAdapter implement
      */
     @Skip
     @Override
-    public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) {
         ctx.deregister(promise);
     }
 
@@ -111,7 +110,7 @@ public class ChannelDuplexHandler extends ChannelInboundHandlerAdapter implement
      */
     @Skip
     @Override
-    public void read(ChannelHandlerContext ctx) throws Exception {
+    public void read(ChannelHandlerContext ctx) {
         ctx.read();
     }
 
@@ -123,7 +122,7 @@ public class ChannelDuplexHandler extends ChannelInboundHandlerAdapter implement
      */
     @Skip
     @Override
-    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         ctx.write(msg, promise);
     }
 
@@ -135,7 +134,7 @@ public class ChannelDuplexHandler extends ChannelInboundHandlerAdapter implement
      */
     @Skip
     @Override
-    public void flush(ChannelHandlerContext ctx) throws Exception {
+    public void flush(ChannelHandlerContext ctx) {
         ctx.flush();
     }
 }

--- a/transport/src/main/java/io/netty/channel/ChannelOutboundHandler.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundHandler.java
@@ -27,9 +27,8 @@ public interface ChannelOutboundHandler extends ChannelHandler {
      *
      * @param ctx               the {@link ChannelHandlerContext} for which the close operation is made
      * @param promise           the {@link ChannelPromise} to notify once the operation completes
-     * @throws Exception        thrown if an error occurs
      */
-    void register(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception;
+    void register(ChannelHandlerContext ctx, ChannelPromise promise);
 
     /**
      * Called once a bind operation is made.
@@ -37,9 +36,8 @@ public interface ChannelOutboundHandler extends ChannelHandler {
      * @param ctx           the {@link ChannelHandlerContext} for which the bind operation is made
      * @param localAddress  the {@link SocketAddress} to which it should bound
      * @param promise       the {@link ChannelPromise} to notify once the operation completes
-     * @throws Exception    thrown if an error occurs
      */
-    void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) throws Exception;
+    void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise);
 
     /**
      * Called once a connect operation is made.
@@ -48,43 +46,39 @@ public interface ChannelOutboundHandler extends ChannelHandler {
      * @param remoteAddress     the {@link SocketAddress} to which it should connect
      * @param localAddress      the {@link SocketAddress} which is used as source on connect
      * @param promise           the {@link ChannelPromise} to notify once the operation completes
-     * @throws Exception        thrown if an error occurs
      */
     void connect(
             ChannelHandlerContext ctx, SocketAddress remoteAddress,
-            SocketAddress localAddress, ChannelPromise promise) throws Exception;
+            SocketAddress localAddress, ChannelPromise promise);
 
     /**
      * Called once a disconnect operation is made.
      *
      * @param ctx               the {@link ChannelHandlerContext} for which the disconnect operation is made
      * @param promise           the {@link ChannelPromise} to notify once the operation completes
-     * @throws Exception        thrown if an error occurs
      */
-    void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception;
+    void disconnect(ChannelHandlerContext ctx, ChannelPromise promise);
 
     /**
      * Called once a close operation is made.
      *
      * @param ctx               the {@link ChannelHandlerContext} for which the close operation is made
      * @param promise           the {@link ChannelPromise} to notify once the operation completes
-     * @throws Exception        thrown if an error occurs
      */
-    void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception;
+    void close(ChannelHandlerContext ctx, ChannelPromise promise);
 
     /**
      * Called once a deregister operation is made from the current registered {@link EventLoop}.
      *
-     * @param ctx               the {@link ChannelHandlerContext} for which the close operation is made
+     * @param ctx               the {@link ChannelHandlerContext} for which the deregister operation is made
      * @param promise           the {@link ChannelPromise} to notify once the operation completes
-     * @throws Exception        thrown if an error occurs
      */
-    void deregister(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception;
+    void deregister(ChannelHandlerContext ctx, ChannelPromise promise);
 
     /**
      * Intercepts {@link ChannelHandlerContext#read()}.
      */
-    void read(ChannelHandlerContext ctx) throws Exception;
+    void read(ChannelHandlerContext ctx);
 
     /**
     * Called once a write operation is made. The write operation will write the messages through the
@@ -96,7 +90,7 @@ public interface ChannelOutboundHandler extends ChannelHandler {
      * @param promise           the {@link ChannelPromise} to notify once the operation completes
      * @throws Exception        thrown if an error occurs
      */
-    void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception;
+    void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise);
 
     /**
      * Called once a flush operation is made. The flush operation will try to flush out all previous written messages
@@ -105,5 +99,5 @@ public interface ChannelOutboundHandler extends ChannelHandler {
      * @param ctx               the {@link ChannelHandlerContext} for which the flush operation is made
      * @throws Exception        thrown if an error occurs
      */
-    void flush(ChannelHandlerContext ctx) throws Exception;
+    void flush(ChannelHandlerContext ctx);
 }

--- a/transport/src/main/java/io/netty/channel/ChannelOutboundHandlerAdapter.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundHandlerAdapter.java
@@ -33,7 +33,7 @@ public class ChannelOutboundHandlerAdapter extends ChannelHandlerAdapter impleme
      */
     @Skip
     @Override
-    public void register(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void register(ChannelHandlerContext ctx, ChannelPromise promise) {
         ctx.register(promise);
     }
 
@@ -46,7 +46,7 @@ public class ChannelOutboundHandlerAdapter extends ChannelHandlerAdapter impleme
     @Skip
     @Override
     public void bind(ChannelHandlerContext ctx, SocketAddress localAddress,
-            ChannelPromise promise) throws Exception {
+            ChannelPromise promise) {
         ctx.bind(localAddress, promise);
     }
 
@@ -59,7 +59,7 @@ public class ChannelOutboundHandlerAdapter extends ChannelHandlerAdapter impleme
     @Skip
     @Override
     public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress,
-            SocketAddress localAddress, ChannelPromise promise) throws Exception {
+            SocketAddress localAddress, ChannelPromise promise) {
         ctx.connect(remoteAddress, localAddress, promise);
     }
 
@@ -71,8 +71,7 @@ public class ChannelOutboundHandlerAdapter extends ChannelHandlerAdapter impleme
      */
     @Skip
     @Override
-    public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise)
-            throws Exception {
+    public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) {
         ctx.disconnect(promise);
     }
 
@@ -84,8 +83,7 @@ public class ChannelOutboundHandlerAdapter extends ChannelHandlerAdapter impleme
      */
     @Skip
     @Override
-    public void close(ChannelHandlerContext ctx, ChannelPromise promise)
-            throws Exception {
+    public void close(ChannelHandlerContext ctx, ChannelPromise promise) {
         ctx.close(promise);
     }
 
@@ -97,7 +95,7 @@ public class ChannelOutboundHandlerAdapter extends ChannelHandlerAdapter impleme
      */
     @Skip
     @Override
-    public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) {
         ctx.deregister(promise);
     }
 
@@ -109,7 +107,7 @@ public class ChannelOutboundHandlerAdapter extends ChannelHandlerAdapter impleme
      */
     @Skip
     @Override
-    public void read(ChannelHandlerContext ctx) throws Exception {
+    public void read(ChannelHandlerContext ctx) {
         ctx.read();
     }
 
@@ -121,7 +119,7 @@ public class ChannelOutboundHandlerAdapter extends ChannelHandlerAdapter impleme
      */
     @Skip
     @Override
-    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         ctx.write(msg, promise);
     }
 
@@ -133,7 +131,7 @@ public class ChannelOutboundHandlerAdapter extends ChannelHandlerAdapter impleme
      */
     @Skip
     @Override
-    public void flush(ChannelHandlerContext ctx) throws Exception {
+    public void flush(ChannelHandlerContext ctx) {
         ctx.flush();
     }
 }

--- a/transport/src/main/java/io/netty/channel/CombinedChannelDuplexHandler.java
+++ b/transport/src/main/java/io/netty/channel/CombinedChannelDuplexHandler.java
@@ -275,7 +275,7 @@ public class CombinedChannelDuplexHandler<I extends ChannelInboundHandler, O ext
     @Override
     public void bind(
             ChannelHandlerContext ctx,
-            SocketAddress localAddress, ChannelPromise promise) throws Exception {
+            SocketAddress localAddress, ChannelPromise promise) {
         assert ctx == outboundCtx.ctx;
         if (!outboundCtx.removed) {
             outboundHandler.bind(outboundCtx, localAddress, promise);
@@ -288,7 +288,7 @@ public class CombinedChannelDuplexHandler<I extends ChannelInboundHandler, O ext
     public void connect(
             ChannelHandlerContext ctx,
             SocketAddress remoteAddress, SocketAddress localAddress,
-            ChannelPromise promise) throws Exception {
+            ChannelPromise promise) {
         assert ctx == outboundCtx.ctx;
         if (!outboundCtx.removed) {
             outboundHandler.connect(outboundCtx, remoteAddress, localAddress, promise);
@@ -298,7 +298,7 @@ public class CombinedChannelDuplexHandler<I extends ChannelInboundHandler, O ext
     }
 
     @Override
-    public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) {
         assert ctx == outboundCtx.ctx;
         if (!outboundCtx.removed) {
             outboundHandler.disconnect(outboundCtx, promise);
@@ -308,7 +308,7 @@ public class CombinedChannelDuplexHandler<I extends ChannelInboundHandler, O ext
     }
 
     @Override
-    public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void close(ChannelHandlerContext ctx, ChannelPromise promise) {
         assert ctx == outboundCtx.ctx;
         if (!outboundCtx.removed) {
             outboundHandler.close(outboundCtx, promise);
@@ -318,7 +318,7 @@ public class CombinedChannelDuplexHandler<I extends ChannelInboundHandler, O ext
     }
 
     @Override
-    public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) {
         assert ctx == outboundCtx.ctx;
         if (!outboundCtx.removed) {
             outboundHandler.deregister(outboundCtx, promise);
@@ -328,7 +328,7 @@ public class CombinedChannelDuplexHandler<I extends ChannelInboundHandler, O ext
     }
 
     @Override
-    public void read(ChannelHandlerContext ctx) throws Exception {
+    public void read(ChannelHandlerContext ctx) {
         assert ctx == outboundCtx.ctx;
         if (!outboundCtx.removed) {
             outboundHandler.read(outboundCtx);
@@ -338,7 +338,7 @@ public class CombinedChannelDuplexHandler<I extends ChannelInboundHandler, O ext
     }
 
     @Override
-    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         assert ctx == outboundCtx.ctx;
         if (!outboundCtx.removed) {
             outboundHandler.write(outboundCtx, msg, promise);
@@ -348,7 +348,7 @@ public class CombinedChannelDuplexHandler<I extends ChannelInboundHandler, O ext
     }
 
     @Override
-    public void flush(ChannelHandlerContext ctx) throws Exception {
+    public void flush(ChannelHandlerContext ctx) {
         assert ctx == outboundCtx.ctx;
         if (!outboundCtx.removed) {
             outboundHandler.flush(outboundCtx);

--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -1287,7 +1287,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
         }
 
         @Override
-        public void register(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        public void register(ChannelHandlerContext ctx, ChannelPromise promise) {
             ChannelPromise registerPromise = newPromise();
             registerPromise.addListener(f -> {
                 if (f.isSuccess()) {

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
@@ -1824,7 +1824,7 @@ public class DefaultChannelPipelineTest {
         final Queue<Object> outboundBuffer = new ArrayDeque<Object>();
 
         @Override
-        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
             outboundBuffer.add(msg);
         }
 

--- a/transport/src/test/java/io/netty/channel/LoggingHandler.java
+++ b/transport/src/test/java/io/netty/channel/LoggingHandler.java
@@ -30,57 +30,56 @@ final class LoggingHandler implements ChannelInboundHandler, ChannelOutboundHand
     private final EnumSet<Event> interest = EnumSet.allOf(Event.class);
 
     @Override
-    public void register(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void register(ChannelHandlerContext ctx, ChannelPromise promise) {
         log(Event.REGISTER);
         ctx.register(promise);
     }
 
     @Override
-    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         log(Event.WRITE);
         ctx.write(msg, promise);
     }
 
     @Override
-    public void flush(ChannelHandlerContext ctx) throws Exception {
+    public void flush(ChannelHandlerContext ctx) {
         log(Event.FLUSH);
         ctx.flush();
     }
 
     @Override
-    public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise)
-            throws Exception {
+    public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) {
         log(Event.BIND, "localAddress=" + localAddress);
         ctx.bind(localAddress, promise);
     }
 
     @Override
     public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress, SocketAddress localAddress,
-            ChannelPromise promise) throws Exception {
+            ChannelPromise promise) {
         log(Event.CONNECT, "remoteAddress=" + remoteAddress + " localAddress=" + localAddress);
         ctx.connect(remoteAddress, localAddress, promise);
     }
 
     @Override
-    public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) {
         log(Event.DISCONNECT);
         ctx.disconnect(promise);
     }
 
     @Override
-    public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void close(ChannelHandlerContext ctx, ChannelPromise promise) {
         log(Event.CLOSE);
         ctx.close(promise);
     }
 
     @Override
-    public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+    public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) {
         log(Event.DEREGISTER);
         ctx.deregister(promise);
     }
 
     @Override
-    public void read(ChannelHandlerContext ctx) throws Exception {
+    public void read(ChannelHandlerContext ctx) {
         log(Event.READ);
         ctx.read();
     }

--- a/transport/src/test/java/io/netty/channel/PendingWriteQueueTest.java
+++ b/transport/src/test/java/io/netty/channel/PendingWriteQueueTest.java
@@ -42,7 +42,7 @@ public class PendingWriteQueueTest {
     public void testRemoveAndWrite() {
         assertWrite(new TestHandler() {
             @Override
-            public void flush(ChannelHandlerContext ctx) throws Exception {
+            public void flush(ChannelHandlerContext ctx) {
                 assertFalse(ctx.channel().isWritable(), "Should not be writable anymore");
 
                 ChannelFuture future = queue.removeAndWrite();
@@ -61,7 +61,7 @@ public class PendingWriteQueueTest {
     public void testRemoveAndWriteAll() {
         assertWrite(new TestHandler() {
             @Override
-            public void flush(ChannelHandlerContext ctx) throws Exception {
+            public void flush(ChannelHandlerContext ctx) {
                 assertFalse(ctx.channel().isWritable(), "Should not be writable anymore");
 
                 ChannelFuture future = queue.removeAndWriteAll();
@@ -81,7 +81,7 @@ public class PendingWriteQueueTest {
         assertWriteFails(new TestHandler() {
 
             @Override
-            public void flush(ChannelHandlerContext ctx) throws Exception {
+            public void flush(ChannelHandlerContext ctx) {
                 queue.removeAndFail(new TestException());
                 super.flush(ctx);
             }
@@ -92,7 +92,7 @@ public class PendingWriteQueueTest {
     public void testRemoveAndFailAll() {
         assertWriteFails(new TestHandler() {
             @Override
-            public void flush(ChannelHandlerContext ctx) throws Exception {
+            public void flush(ChannelHandlerContext ctx) {
                 queue.removeAndFailAll(new TestException());
                 super.flush(ctx);
             }
@@ -370,7 +370,7 @@ public class PendingWriteQueueTest {
         }
 
         @Override
-        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
             queue.add(msg, promise);
             assertFalse(queue.isEmpty());
             assertEquals(++expectedSize, queue.size());

--- a/transport/src/test/java/io/netty/channel/ReentrantChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/ReentrantChannelTest.java
@@ -184,7 +184,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
             int flushCount;
 
             @Override
-            public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+            public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
                 if (writeCount < 5) {
                     writeCount++;
                     ctx.channel().flush();
@@ -193,7 +193,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
             }
 
             @Override
-            public void flush(ChannelHandlerContext ctx) throws Exception {
+            public void flush(ChannelHandlerContext ctx) {
                 if (flushCount < 5) {
                     flushCount++;
                     ctx.channel().write(createTestBuf(2000));
@@ -238,7 +238,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
         clientChannel.pipeline().addLast(new ChannelOutboundHandlerAdapter() {
 
             @Override
-            public void write(final ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+            public void write(final ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
                 promise.addListener(new GenericFutureListener<Future<? super Void>>() {
                     @Override
                     public void operationComplete(Future<? super Void> future) {
@@ -273,8 +273,8 @@ public class ReentrantChannelTest extends BaseChannelTest {
         clientChannel.pipeline().addLast(new ChannelOutboundHandlerAdapter() {
 
             @Override
-            public void flush(ChannelHandlerContext ctx) throws Exception {
-                throw new Exception("intentional failure");
+            public void flush(ChannelHandlerContext ctx) {
+                throw new IllegalStateException("intentional failure");
             }
 
             @Override

--- a/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
@@ -303,7 +303,7 @@ public class EmbeddedChannelTest {
     public void testHasNoDisconnectSkipDisconnect() throws InterruptedException {
         EmbeddedChannel channel = new EmbeddedChannel(false, new ChannelOutboundHandlerAdapter() {
             @Override
-            public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+            public void close(ChannelHandlerContext ctx, ChannelPromise promise) {
                 promise.tryFailure(new Throwable());
             }
         });
@@ -395,8 +395,7 @@ public class EmbeddedChannelTest {
     public void testWriteLater() {
         EmbeddedChannel channel = new EmbeddedChannel(new ChannelOutboundHandlerAdapter() {
             @Override
-            public void write(final ChannelHandlerContext ctx, final Object msg, final ChannelPromise promise)
-                    throws Exception {
+            public void write(final ChannelHandlerContext ctx, final Object msg, final ChannelPromise promise) {
                 ctx.executor().execute(new Runnable() {
                     @Override
                     public void run() {
@@ -418,8 +417,7 @@ public class EmbeddedChannelTest {
         final int delay = 500;
         EmbeddedChannel channel = new EmbeddedChannel(new ChannelOutboundHandlerAdapter() {
             @Override
-            public void write(final ChannelHandlerContext ctx, final Object msg, final ChannelPromise promise)
-                    throws Exception {
+            public void write(final ChannelHandlerContext ctx, final Object msg, final ChannelPromise promise) {
                 ctx.executor().schedule(new Runnable() {
                     @Override
                     public void run() {
@@ -490,7 +488,7 @@ public class EmbeddedChannelTest {
         final CountDownLatch latch = new CountDownLatch(1);
         EmbeddedChannel channel = new EmbeddedChannel(new ChannelOutboundHandlerAdapter() {
             @Override
-            public void flush(ChannelHandlerContext ctx) throws Exception {
+            public void flush(ChannelHandlerContext ctx) {
                 latch.countDown();
             }
         });
@@ -509,13 +507,13 @@ public class EmbeddedChannelTest {
 
         EmbeddedChannel channel = new EmbeddedChannel(new ChannelOutboundHandlerAdapter() {
             @Override
-            public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+            public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
                 ctx.write(msg, promise);
                 latch.countDown();
             }
 
             @Override
-            public void flush(ChannelHandlerContext ctx) throws Exception {
+            public void flush(ChannelHandlerContext ctx) {
                 flushCount.incrementAndGet();
             }
         });
@@ -850,13 +848,13 @@ public class EmbeddedChannelTest {
         private final Queue<Integer> queue = new ArrayDeque<Integer>();
 
         @Override
-        public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) {
             queue.add(DISCONNECT);
             promise.setSuccess();
         }
 
         @Override
-        public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        public void close(ChannelHandlerContext ctx, ChannelPromise promise) {
             queue.add(CLOSE);
             promise.setSuccess();
         }


### PR DESCRIPTION
Motivation:

ChannelOutboundHandler methods take a ChannelPromise which should be used to report errors and so it makes no sense to have throws Exception on the method signature.

Modifications:

- Remove throws Exception from method signature
- Adjust code to correctly handle exceptions
- log warn message and close channel if an outbound operation throws an exception but there is not way to report the error (flush and read).

Result:

API cleanup and make clear how errors should be reported back