### PR TITLE
Update lz4-java version to 1.10.1 (#15978)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1059,7 +1059,7 @@
       <dependency>
         <groupId>at.yawk.lz4</groupId>
         <artifactId>lz4-java</artifactId>
-        <version>1.9.0</version>
+        <version>1.10.1</version>
       </dependency>
       <dependency>
         <groupId>com.github.jponge</groupId>


### PR DESCRIPTION
New vulnerability:
[CVE-2025-66566](https://github.com/yawkat/lz4-java/security/advisories/GHSA-cmp6-m4wj-q63q)