### PR TITLE
Use exact length when allocating the acceptedAddress byte[] (#15973)

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
@@ -71,8 +71,7 @@ public abstract class AbstractEpollServerChannel extends AbstractEpollChannel im
     final class EpollServerSocketUnsafe extends AbstractEpollUnsafe {
         // Will hold the remote address after accept(...) was successful.
         // We need 24 bytes for the address as maximum + 1 byte for storing the length.
-        // So use 26 bytes as it's a power of two.
-        private final byte[] acceptedAddress = new byte[26];
+        private final byte[] acceptedAddress = new byte[25];
 
         @Override
         public void connect(SocketAddress socketAddress, SocketAddress socketAddress2, ChannelPromise channelPromise) {

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueServerChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueServerChannel.java
@@ -71,8 +71,7 @@ public abstract class AbstractKQueueServerChannel extends AbstractKQueueChannel 
     final class KQueueServerSocketUnsafe extends AbstractKQueueUnsafe {
         // Will hold the remote address after accept(...) was successful.
         // We need 24 bytes for the address as maximum + 1 byte for storing the capacity.
-        // So use 26 bytes as it's a power of two.
-        private final byte[] acceptedAddress = new byte[26];
+        private final byte[] acceptedAddress = new byte[25];
 
         @Override
         void readReady(KQueueRecvByteAllocatorHandle allocHandle) {


### PR DESCRIPTION
Motivation:

We used some odd number for the length, just use the exact length that we need.

Modifications:

- Allocate a byte[] of 25 length and remove odd comment

Result:

Cleanup