### PR TITLE
LoggingHandler: Also log read(..) operations

### DIFF
--- a/handler/src/main/java/io/netty/handler/logging/LoggingHandler.java
+++ b/handler/src/main/java/io/netty/handler/logging/LoggingHandler.java
@@ -177,7 +177,7 @@ public class LoggingHandler extends ChannelDuplexHandler {
     @Override
     public void channelRegistered(ChannelHandlerContext ctx) throws Exception {
         if (logger.isEnabled(internalLevel)) {
-            logger.log(internalLevel, format(ctx, "REGISTERED"));
+            logger.log(internalLevel, format(ctx, "CHANNEL_REGISTERED"));
         }
         ctx.fireChannelRegistered();
     }
@@ -185,7 +185,7 @@ public class LoggingHandler extends ChannelDuplexHandler {
     @Override
     public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
         if (logger.isEnabled(internalLevel)) {
-            logger.log(internalLevel, format(ctx, "UNREGISTERED"));
+            logger.log(internalLevel, format(ctx, "CHANNEL_UNREGISTERED"));
         }
         ctx.fireChannelUnregistered();
     }
@@ -193,7 +193,7 @@ public class LoggingHandler extends ChannelDuplexHandler {
     @Override
     public void channelActive(ChannelHandlerContext ctx) throws Exception {
         if (logger.isEnabled(internalLevel)) {
-            logger.log(internalLevel, format(ctx, "ACTIVE"));
+            logger.log(internalLevel, format(ctx, "CHANNEL_ACTIVE"));
         }
         ctx.fireChannelActive();
     }
@@ -201,7 +201,7 @@ public class LoggingHandler extends ChannelDuplexHandler {
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
         if (logger.isEnabled(internalLevel)) {
-            logger.log(internalLevel, format(ctx, "INACTIVE"));
+            logger.log(internalLevel, format(ctx, "CHANNEL_INACTIVE"));
         }
         ctx.fireChannelInactive();
     }
@@ -209,7 +209,7 @@ public class LoggingHandler extends ChannelDuplexHandler {
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         if (logger.isEnabled(internalLevel)) {
-            logger.log(internalLevel, format(ctx, "EXCEPTION", cause), cause);
+            logger.log(internalLevel, format(ctx, "EXCEPTION_CAUGHT", cause), cause);
         }
         ctx.fireExceptionCaught(cause);
     }
@@ -217,7 +217,7 @@ public class LoggingHandler extends ChannelDuplexHandler {
     @Override
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
         if (logger.isEnabled(internalLevel)) {
-            logger.log(internalLevel, format(ctx, "USER_EVENT", evt));
+            logger.log(internalLevel, format(ctx, "USER_EVENT_TRIGGERED", evt));
         }
         ctx.fireUserEventTriggered(evt);
     }
@@ -267,7 +267,7 @@ public class LoggingHandler extends ChannelDuplexHandler {
     @Override
     public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
         if (logger.isEnabled(internalLevel)) {
-            logger.log(internalLevel, format(ctx, "READ COMPLETE"));
+            logger.log(internalLevel, format(ctx, "CHANNEL_READ_COMPLETE"));
         }
         ctx.fireChannelReadComplete();
     }
@@ -275,7 +275,7 @@ public class LoggingHandler extends ChannelDuplexHandler {
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         if (logger.isEnabled(internalLevel)) {
-            logger.log(internalLevel, format(ctx, "READ", msg));
+            logger.log(internalLevel, format(ctx, "CHANNEL_READ", msg));
         }
         ctx.fireChannelRead(msg);
     }
@@ -291,7 +291,7 @@ public class LoggingHandler extends ChannelDuplexHandler {
     @Override
     public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
         if (logger.isEnabled(internalLevel)) {
-            logger.log(internalLevel, format(ctx, "WRITABILITY CHANGED"));
+            logger.log(internalLevel, format(ctx, "CHANNEL_WRITABILITY_CHANGED"));
         }
         ctx.fireChannelWritabilityChanged();
     }
@@ -302,6 +302,14 @@ public class LoggingHandler extends ChannelDuplexHandler {
             logger.log(internalLevel, format(ctx, "FLUSH"));
         }
         ctx.flush();
+    }
+
+    @Override
+    public void read(ChannelHandlerContext ctx) throws Exception {
+        if (logger.isEnabled(internalLevel)) {
+            logger.log(internalLevel, format(ctx, "READ"));
+        }
+        ctx.read();
     }
 
     /**

--- a/handler/src/test/java/io/netty/handler/logging/LoggingHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/logging/LoggingHandlerTest.java
@@ -117,7 +117,7 @@ public class LoggingHandlerTest {
     @Test
     public void shouldLogChannelActive() {
         new EmbeddedChannel(new LoggingHandler(LogLevel.WARN));
-        verify(appender).doAppend(argThat(new RegexLogMatcher(".+ACTIVE$")));
+        verify(appender).doAppend(argThat(new RegexLogMatcher(".+CHANNEL_ACTIVE$")));
     }
 
     @Test
@@ -128,13 +128,13 @@ public class LoggingHandlerTest {
         channel.config().setWriteBufferHighWaterMark(10);
         channel.write("hello", channel.newPromise());
 
-        verify(appender).doAppend(argThat(new RegexLogMatcher(".+WRITABILITY CHANGED$")));
+        verify(appender).doAppend(argThat(new RegexLogMatcher(".+CHANNEL_WRITABILITY_CHANGED$")));
     }
 
     @Test
     public void shouldLogChannelRegistered() {
         new EmbeddedChannel(new LoggingHandler(LogLevel.WARN));
-        verify(appender).doAppend(argThat(new RegexLogMatcher(".+REGISTERED$")));
+        verify(appender).doAppend(argThat(new RegexLogMatcher(".+CHANNEL_REGISTERED$")));
     }
 
     @Test
@@ -171,7 +171,7 @@ public class LoggingHandlerTest {
     public void shouldLogChannelInactive() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new LoggingHandler(LogLevel.WARN));
         channel.pipeline().fireChannelInactive();
-        verify(appender).doAppend(argThat(new RegexLogMatcher(".+INACTIVE$")));
+        verify(appender).doAppend(argThat(new RegexLogMatcher(".+CHANNEL_INACTIVE$")));
     }
 
     @Test
@@ -187,7 +187,7 @@ public class LoggingHandlerTest {
         String userTriggered = "iAmCustom!";
         EmbeddedChannel channel = new EmbeddedChannel(new LoggingHandler(LogLevel.WARN));
         channel.pipeline().fireUserEventTriggered(new String(userTriggered));
-        verify(appender).doAppend(argThat(new RegexLogMatcher(".+USER_EVENT: " + userTriggered + '$')));
+        verify(appender).doAppend(argThat(new RegexLogMatcher(".+USER_EVENT_TRIGGERED: " + userTriggered + '$')));
     }
 
     @Test
@@ -197,7 +197,7 @@ public class LoggingHandlerTest {
         EmbeddedChannel channel = new EmbeddedChannel(new LoggingHandler(LogLevel.WARN));
         channel.pipeline().fireExceptionCaught(cause);
         verify(appender).doAppend(argThat(new RegexLogMatcher(
-                ".+EXCEPTION: " + cause.getClass().getCanonicalName() + ": " + msg + '$')));
+                ".+EXCEPTION_CAUGHT: " + cause.getClass().getCanonicalName() + ": " + msg + '$')));
     }
 
     @Test
@@ -214,7 +214,7 @@ public class LoggingHandlerTest {
         String msg = "hello";
         EmbeddedChannel channel = new EmbeddedChannel(new LoggingHandler(LogLevel.WARN));
         channel.writeInbound(msg);
-        verify(appender).doAppend(argThat(new RegexLogMatcher(".+READ: " + msg + '$')));
+        verify(appender).doAppend(argThat(new RegexLogMatcher(".+CHANNEL_READ: " + msg + '$')));
 
         String handledMsg = channel.readInbound();
         assertSame(msg, handledMsg);
@@ -226,7 +226,7 @@ public class LoggingHandlerTest {
         ByteBuf msg = Unpooled.copiedBuffer("hello", CharsetUtil.UTF_8);
         EmbeddedChannel channel = new EmbeddedChannel(new LoggingHandler(LogLevel.WARN));
         channel.writeInbound(msg);
-        verify(appender).doAppend(argThat(new RegexLogMatcher(".+READ: " + msg.readableBytes() + "B$", true)));
+        verify(appender).doAppend(argThat(new RegexLogMatcher(".+CHANNEL_READ: " + msg.readableBytes() + "B$", true)));
 
         ByteBuf handledMsg = channel.readInbound();
         assertSame(msg, handledMsg);
@@ -239,7 +239,7 @@ public class LoggingHandlerTest {
         ByteBuf msg = Unpooled.copiedBuffer("hello", CharsetUtil.UTF_8);
         EmbeddedChannel channel = new EmbeddedChannel(new LoggingHandler(LogLevel.WARN, ByteBufFormat.SIMPLE));
         channel.writeInbound(msg);
-        verify(appender).doAppend(argThat(new RegexLogMatcher(".+READ: " + msg.readableBytes() + "B$", false)));
+        verify(appender).doAppend(argThat(new RegexLogMatcher(".+CHANNEL_READ: " + msg.readableBytes() + "B$", false)));
 
         ByteBuf handledMsg = channel.readInbound();
         assertSame(msg, handledMsg);
@@ -252,7 +252,7 @@ public class LoggingHandlerTest {
         ByteBuf msg = Unpooled.EMPTY_BUFFER;
         EmbeddedChannel channel = new EmbeddedChannel(new LoggingHandler(LogLevel.WARN));
         channel.writeInbound(msg);
-        verify(appender).doAppend(argThat(new RegexLogMatcher(".+READ: 0B$", false)));
+        verify(appender).doAppend(argThat(new RegexLogMatcher(".+CHANNEL_READ: 0B$", false)));
 
         ByteBuf handledMsg = channel.readInbound();
         assertSame(msg, handledMsg);
@@ -270,7 +270,7 @@ public class LoggingHandlerTest {
 
         EmbeddedChannel channel = new EmbeddedChannel(new LoggingHandler(LogLevel.WARN));
         channel.writeInbound(msg);
-        verify(appender).doAppend(argThat(new RegexLogMatcher(".+READ: foobar, 5B$", true)));
+        verify(appender).doAppend(argThat(new RegexLogMatcher(".+CHANNEL_READ: foobar, 5B$", true)));
 
         ByteBufHolder handledMsg = channel.readInbound();
         assertSame(msg, handledMsg);
@@ -283,7 +283,16 @@ public class LoggingHandlerTest {
         ByteBuf msg = Unpooled.EMPTY_BUFFER;
         EmbeddedChannel channel = new EmbeddedChannel(new LoggingHandler(LogLevel.WARN));
         channel.writeInbound(msg);
-        verify(appender).doAppend(argThat(new RegexLogMatcher(".+READ COMPLETE$")));
+        verify(appender).doAppend(argThat(new RegexLogMatcher(".+CHANNEL_READ_COMPLETE$")));
+    }
+
+    @Test
+    public void shouldLogRead() {
+        EmbeddedChannel channel = new EmbeddedChannel();
+        channel.pipeline().addLast(new LoggingHandler(LogLevel.WARN));
+        channel.read();
+        verify(appender).doAppend(argThat(new RegexLogMatcher(".+ READ$")));
+        channel.finishAndReleaseAll();
     }
 
     /**


### PR DESCRIPTION
Motivation:

We missed to log read(...) operations in LoggingHandler. We should also log these as otherwise we miss some important operation

Modifications:

- Add logging for read operation and add test
- Rename events to better match their real method name. This was also done as otherwise we would not be able to tell the difference between channelRead(...) and read(...)

Result:

Correctly log all operations