### PR TITLE
ChannelHandlerContext: Don't extend AttributeMap

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameInboundWriter.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameInboundWriter.java
@@ -26,8 +26,6 @@ import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.util.Attribute;
-import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.EventExecutor;
 
 import java.net.SocketAddress;
@@ -212,16 +210,6 @@ final class Http2FrameInboundWriter {
         @Override
         public ByteBufAllocator alloc() {
             return channel.alloc();
-        }
-
-        @Override
-        public <T> Attribute<T> attr(AttributeKey<T> key) {
-            return channel.attr(key);
-        }
-
-        @Override
-        public <T> boolean hasAttr(AttributeKey<T> key) {
-            return channel.hasAttr(key);
         }
 
         @Override

--- a/microbench/src/main/java/io/netty/microbench/channel/EmbeddedChannelHandlerContext.java
+++ b/microbench/src/main/java/io/netty/microbench/channel/EmbeddedChannelHandlerContext.java
@@ -23,8 +23,6 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoop;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.util.Attribute;
-import io.netty.util.AttributeKey;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.EventExecutor;
 
@@ -48,16 +46,6 @@ public abstract class EmbeddedChannelHandlerContext implements ChannelHandlerCon
     }
 
     protected abstract void handleException(Throwable t);
-
-    @Override
-    public final <T> Attribute<T> attr(AttributeKey<T> key) {
-        return null;
-    }
-
-    @Override
-    public final <T> boolean hasAttr(AttributeKey<T> key) {
-        return false;
-    }
 
     @Override
     public final Channel channel() {

--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -1066,16 +1066,6 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         return handlerState == REMOVE_COMPLETE;
     }
 
-    @Override
-    public <T> Attribute<T> attr(AttributeKey<T> key) {
-        return channel().attr(key);
-    }
-
-    @Override
-    public <T> boolean hasAttr(AttributeKey<T> key) {
-        return channel().hasAttr(key);
-    }
-
     private static boolean safeExecute(EventExecutor executor, Runnable runnable,
             ChannelPromise promise, Object msg, boolean lazy) {
         try {

--- a/transport/src/main/java/io/netty/channel/ChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandlerContext.java
@@ -17,10 +17,7 @@ package io.netty.channel;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
-import io.netty.util.AttributeMap;
-import io.netty.util.concurrent.EventExecutor;
 
 /**
  * Enables a {@link ChannelHandler} to interact with its {@link ChannelPipeline}
@@ -62,9 +59,9 @@ import io.netty.util.concurrent.EventExecutor;
  *
  * <h3>Storing stateful information</h3>
  *
- * {@link #attr(AttributeKey)} allow you to
- * store and access stateful information that is related with a {@link ChannelHandler} / {@link Channel} and its
- * context. Please refer to {@link ChannelHandler} to learn various recommended
+ * {@link Channel#attr(AttributeKey)} allow you to
+ * store and access stateful information that is related with a {@link Channel}.
+ * Please refer to {@link ChannelHandler} to learn various recommended
  * ways to manage stateful information.
  *
  * <h3>A handler can have more than one {@link ChannelHandlerContext}</h3>
@@ -84,7 +81,7 @@ import io.netty.util.concurrent.EventExecutor;
  * what fundamental differences they have, how they flow in a  pipeline,  and how to handle
  * the operation in your application.
  */
-public interface ChannelHandlerContext extends AttributeMap, ChannelInboundInvoker, ChannelOutboundInvoker {
+public interface ChannelHandlerContext extends ChannelInboundInvoker, ChannelOutboundInvoker {
 
     /**
      * Return the {@link Channel} which is bound to the {@link ChannelHandlerContext}.
@@ -152,18 +149,4 @@ public interface ChannelHandlerContext extends AttributeMap, ChannelInboundInvok
      * Return the assigned {@link ByteBufAllocator} which will be used to allocate {@link ByteBuf}s.
      */
     ByteBufAllocator alloc();
-
-    /**
-     * @deprecated Use {@link Channel#attr(AttributeKey)}
-     */
-    @Deprecated
-    @Override
-    <T> Attribute<T> attr(AttributeKey<T> key);
-
-    /**
-     * @deprecated Use {@link Channel#hasAttr(AttributeKey)}
-     */
-    @Deprecated
-    @Override
-    <T> boolean hasAttr(AttributeKey<T> key);
 }

--- a/transport/src/main/java/io/netty/channel/CombinedChannelDuplexHandler.java
+++ b/transport/src/main/java/io/netty/channel/CombinedChannelDuplexHandler.java
@@ -16,8 +16,6 @@
 package io.netty.channel;
 
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.util.Attribute;
-import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.logging.InternalLogger;
@@ -573,16 +571,6 @@ public class CombinedChannelDuplexHandler<I extends ChannelInboundHandler, O ext
         @Override
         public ChannelFuture newFailedFuture(Throwable cause) {
             return ctx.newFailedFuture(cause);
-        }
-
-        @Override
-        public <T> Attribute<T> attr(AttributeKey<T> key) {
-            return ctx.channel().attr(key);
-        }
-
-        @Override
-        public <T> boolean hasAttr(AttributeKey<T> key) {
-            return ctx.channel().hasAttr(key);
         }
 
         final void remove() {


### PR DESCRIPTION
Motivation:

We deprecated the AttributeMap related methods in ChannelHandlerContext already, let's remove these in 5.0

Modifications:

Remove deprecated methods

Result:

Cleanup
