### PR TITLE
ChannelConfig: Cleanup implementations

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollChannelConfig.java
@@ -15,14 +15,12 @@
  */
 package io.netty.channel.epoll;
 
-import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.DefaultChannelConfig;
-import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
-import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.unix.IntegerUnixChannelOption;
 import io.netty.channel.unix.RawUnixChannelOption;
 
@@ -95,69 +93,12 @@ public class EpollChannelConfig extends DefaultChannelConfig {
     }
 
     @Override
-    public EpollChannelConfig setConnectTimeoutMillis(int connectTimeoutMillis) {
-        super.setConnectTimeoutMillis(connectTimeoutMillis);
-        return this;
-    }
-
-    @Override
-    @Deprecated
-    public EpollChannelConfig setMaxMessagesPerRead(int maxMessagesPerRead) {
-        super.setMaxMessagesPerRead(maxMessagesPerRead);
-        return this;
-    }
-
-    @Override
-    public EpollChannelConfig setWriteSpinCount(int writeSpinCount) {
-        super.setWriteSpinCount(writeSpinCount);
-        return this;
-    }
-
-    @Override
-    public EpollChannelConfig setAllocator(ByteBufAllocator allocator) {
-        super.setAllocator(allocator);
-        return this;
-    }
-
-    @Override
-    public EpollChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
+    public ChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
         if (!(allocator.newHandle() instanceof RecvByteBufAllocator.ExtendedHandle)) {
             throw new IllegalArgumentException("allocator.newHandle() must return an object of type: " +
                     RecvByteBufAllocator.ExtendedHandle.class);
         }
         super.setRecvByteBufAllocator(allocator);
-        return this;
-    }
-
-    @Override
-    public EpollChannelConfig setAutoRead(boolean autoRead) {
-        super.setAutoRead(autoRead);
-        return this;
-    }
-
-    @Override
-    @Deprecated
-    public EpollChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
-        super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
-        return this;
-    }
-
-    @Override
-    @Deprecated
-    public EpollChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
-        super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
-        return this;
-    }
-
-    @Override
-    public EpollChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark) {
-        super.setWriteBufferWaterMark(writeBufferWaterMark);
-        return this;
-    }
-
-    @Override
-    public EpollChannelConfig setMessageSizeEstimator(MessageSizeEstimator estimator) {
-        super.setMessageSizeEstimator(estimator);
         return this;
     }
 

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
@@ -146,7 +147,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
             case INET6:
             case INET:
                 try {
-                    NetworkInterface iface = config().getNetworkInterface();
+                    NetworkInterface iface = config.getOption(ChannelOption.IP_MULTICAST_IF);
                     if (iface == null) {
                         iface = NetworkInterface.getByInetAddress(((InetSocketAddress) localAddress()).getAddress());
                     }

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannelConfig.java
@@ -172,10 +172,9 @@ final class EpollDatagramChannelConfig extends EpollChannelConfig {
         }
     }
 
-    EpollDatagramChannelConfig setSendBufferSize(int sendBufferSize) {
+    private void setSendBufferSize(int sendBufferSize) {
         try {
             ((AbstractEpollChannel) channel).socket.setSendBufferSize(sendBufferSize);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -189,16 +188,15 @@ final class EpollDatagramChannelConfig extends EpollChannelConfig {
         }
     }
 
-    EpollDatagramChannelConfig setReceiveBufferSize(int receiveBufferSize) {
+    private void setReceiveBufferSize(int receiveBufferSize) {
         try {
             ((AbstractEpollChannel) channel).socket.setReceiveBufferSize(receiveBufferSize);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    int getTrafficClass() {
+    private int getTrafficClass() {
         try {
             return ((AbstractEpollChannel) channel).socket.getTrafficClass();
         } catch (IOException e) {
@@ -206,16 +204,15 @@ final class EpollDatagramChannelConfig extends EpollChannelConfig {
         }
     }
 
-    EpollDatagramChannelConfig setTrafficClass(int trafficClass) {
+    private void setTrafficClass(int trafficClass) {
         try {
             ((AbstractEpollChannel) channel).socket.setTrafficClass(trafficClass);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    boolean isReuseAddress() {
+    private boolean isReuseAddress() {
         try {
             return ((AbstractEpollChannel) channel).socket.isReuseAddress();
         } catch (IOException e) {
@@ -223,16 +220,15 @@ final class EpollDatagramChannelConfig extends EpollChannelConfig {
         }
     }
 
-    EpollDatagramChannelConfig setReuseAddress(boolean reuseAddress) {
+    private void setReuseAddress(boolean reuseAddress) {
         try {
             ((AbstractEpollChannel) channel).socket.setReuseAddress(reuseAddress);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    boolean isBroadcast() {
+    private boolean isBroadcast() {
         try {
             return ((AbstractEpollChannel) channel).socket.isBroadcast();
         } catch (IOException e) {
@@ -240,16 +236,15 @@ final class EpollDatagramChannelConfig extends EpollChannelConfig {
         }
     }
 
-    EpollDatagramChannelConfig setBroadcast(boolean broadcast) {
+    private void setBroadcast(boolean broadcast) {
         try {
             ((AbstractEpollChannel) channel).socket.setBroadcast(broadcast);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    boolean isLoopbackModeDisabled() {
+    private boolean isLoopbackModeDisabled() {
         try {
             return ((AbstractEpollChannel) channel).socket.isLoopbackModeDisabled();
         } catch (IOException e) {
@@ -257,10 +252,9 @@ final class EpollDatagramChannelConfig extends EpollChannelConfig {
         }
     }
 
-    EpollDatagramChannelConfig setLoopbackModeDisabled(boolean loopbackModeDisabled) {
+    private void setLoopbackModeDisabled(boolean loopbackModeDisabled) {
         try {
             ((AbstractEpollChannel) channel).socket.setLoopbackModeDisabled(loopbackModeDisabled);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -274,16 +268,15 @@ final class EpollDatagramChannelConfig extends EpollChannelConfig {
         }
     }
 
-    EpollDatagramChannelConfig setTimeToLive(int ttl) {
+    private void setTimeToLive(int ttl) {
         try {
             ((AbstractEpollChannel) channel).socket.setTimeToLive(ttl);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    InetAddress getInterface() {
+    private InetAddress getInterface() {
         try {
             return ((AbstractEpollChannel) channel).socket.getInterface();
         } catch (IOException e) {
@@ -291,16 +284,15 @@ final class EpollDatagramChannelConfig extends EpollChannelConfig {
         }
     }
 
-    EpollDatagramChannelConfig setInterface(InetAddress interfaceAddress) {
+    private void setInterface(InetAddress interfaceAddress) {
         try {
             ((AbstractEpollChannel) channel).socket.setInterface(interfaceAddress);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    NetworkInterface getNetworkInterface() {
+    private NetworkInterface getNetworkInterface() {
         try {
             return ((AbstractEpollChannel) channel).socket.getNetworkInterface();
         } catch (IOException e) {
@@ -308,11 +300,10 @@ final class EpollDatagramChannelConfig extends EpollChannelConfig {
         }
     }
 
-    EpollDatagramChannelConfig setNetworkInterface(NetworkInterface networkInterface) {
+    private void setNetworkInterface(NetworkInterface networkInterface) {
         try {
             AbstractEpollChannel datagramChannel = (AbstractEpollChannel) channel;
             datagramChannel.socket.setNetworkInterface(networkInterface);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -321,7 +312,7 @@ final class EpollDatagramChannelConfig extends EpollChannelConfig {
     /**
      * Returns {@code true} if the SO_REUSEPORT option is set.
      */
-    boolean isReusePort() {
+    private boolean isReusePort() {
         try {
             return ((AbstractEpollChannel) channel).socket.isReusePort();
         } catch (IOException e) {
@@ -336,10 +327,9 @@ final class EpollDatagramChannelConfig extends EpollChannelConfig {
      * Be aware this method needs be called before {@link EpollDatagramChannel#bind(java.net.SocketAddress)} to have
      * any affect.
      */
-    EpollDatagramChannelConfig setReusePort(boolean reusePort) {
+    private void setReusePort(boolean reusePort) {
         try {
             ((AbstractEpollChannel) channel).socket.setReusePort(reusePort);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -349,7 +339,7 @@ final class EpollDatagramChannelConfig extends EpollChannelConfig {
      * Returns {@code true} if <a href="https://man7.org/linux/man-pages/man7/ip.7.html">IP_TRANSPARENT</a> is enabled,
      * {@code false} otherwise.
      */
-    boolean isIpTransparent() {
+    private boolean isIpTransparent() {
         try {
             return ((AbstractEpollChannel) channel).socket.isIpTransparent();
         } catch (IOException e) {
@@ -361,10 +351,9 @@ final class EpollDatagramChannelConfig extends EpollChannelConfig {
      * If {@code true} is used <a href="https://man7.org/linux/man-pages/man7/ip.7.html">IP_TRANSPARENT</a> is enabled,
      * {@code false} for disable it. Default is disabled.
      */
-    EpollDatagramChannelConfig setIpTransparent(boolean ipTransparent) {
+    private void setIpTransparent(boolean ipTransparent) {
         try {
             ((AbstractEpollChannel) channel).socket.setIpTransparent(ipTransparent);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -374,7 +363,7 @@ final class EpollDatagramChannelConfig extends EpollChannelConfig {
      * Returns {@code true} if <a href="https://man7.org/linux/man-pages/man7/ip.7.html">IP_FREEBIND</a> is enabled,
      * {@code false} otherwise.
      */
-    boolean isFreeBind() {
+    private boolean isFreeBind() {
         try {
             return ((AbstractEpollChannel) channel).socket.isIpFreeBind();
         } catch (IOException e) {
@@ -386,10 +375,9 @@ final class EpollDatagramChannelConfig extends EpollChannelConfig {
      * If {@code true} is used <a href="https://man7.org/linux/man-pages/man7/ip.7.html">IP_FREEBIND</a> is enabled,
      * {@code false} for disable it. Default is disabled.
      */
-    EpollDatagramChannelConfig setFreeBind(boolean freeBind) {
+    private void setFreeBind(boolean freeBind) {
         try {
             ((AbstractEpollChannel) channel).socket.setIpFreeBind(freeBind);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -399,7 +387,7 @@ final class EpollDatagramChannelConfig extends EpollChannelConfig {
      * Returns {@code true} if <a href="https://man7.org/linux/man-pages/man7/ip.7.html">IP_RECVORIGDSTADDR</a> is
      * enabled, {@code false} otherwise.
      */
-    boolean isIpRecvOrigDestAddr() {
+    private boolean isIpRecvOrigDestAddr() {
         try {
             return ((AbstractEpollChannel) channel).socket.isIpRecvOrigDestAddr();
         } catch (IOException e) {
@@ -411,10 +399,9 @@ final class EpollDatagramChannelConfig extends EpollChannelConfig {
      * If {@code true} is used <a href="https://man7.org/linux/man-pages/man7/ip.7.html">IP_RECVORIGDSTADDR</a> is
      * enabled, {@code false} for disable it. Default is disabled.
      */
-    EpollDatagramChannelConfig setIpRecvOrigDestAddr(boolean ipTransparent) {
+    private void setIpRecvOrigDestAddr(boolean ipTransparent) {
         try {
             ((AbstractEpollChannel) channel).socket.setIpRecvOrigDestAddr(ipTransparent);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -424,7 +411,7 @@ final class EpollDatagramChannelConfig extends EpollChannelConfig {
      * Returns {@code true} if <a href="https://man7.org/linux/man-pages/man7/ip.7.html">IP_MULTICAST_ALL</a> (or
      * IPV6_MULTICAST_ALL for IPV6) is enabled, {@code false} otherwise.
      */
-    boolean isIpMulticastAll() {
+    private boolean isIpMulticastAll() {
         try {
             return ((AbstractEpollChannel) channel).socket.isIpMulticastAll();
         } catch (IOException e) {
@@ -436,10 +423,9 @@ final class EpollDatagramChannelConfig extends EpollChannelConfig {
      * If {@code true} is used <a href="https://man7.org/linux/man-pages/man7/ip.7.html">IP_MULTICAST_ALL</a> is
      * enabled (or IPV6_MULTICAST_ALL for IPV6), {@code false} for disable it. Default is enabled.
      */
-    EpollDatagramChannelConfig setIpMulticastAll(boolean multicastAll) {
+    private void setIpMulticastAll(boolean multicastAll) {
         try {
             ((AbstractEpollChannel) channel).socket.setIpMulticastAll(multicastAll);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -453,9 +439,8 @@ final class EpollDatagramChannelConfig extends EpollChannelConfig {
      * {@link RecvByteBufAllocator}. You can use {@code 0} to disable the usage of recvmmsg, any other bigger value
      * will enable it.
      */
-    EpollDatagramChannelConfig setMaxDatagramPayloadSize(int maxDatagramSize) {
+    private void setMaxDatagramPayloadSize(int maxDatagramSize) {
         this.maxDatagramSize = ObjectUtil.checkPositiveOrZero(maxDatagramSize, "maxDatagramSize");
-        return this;
     }
 
     /**
@@ -470,14 +455,13 @@ final class EpollDatagramChannelConfig extends EpollChannelConfig {
      * @param gro {@code true} if {@code UDP_GRO} should be enabled, {@code false} otherwise.
      * @return this.
      */
-    EpollDatagramChannelConfig setUdpGro(boolean gro) {
+    private void setUdpGro(boolean gro) {
         try {
             ((AbstractEpollChannel) channel).socket.setUdpGro(gro);
         } catch (IOException e) {
             throw new ChannelException(e);
         }
         this.gro = gro;
-        return this;
     }
 
     /**

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannelConfig.java
@@ -111,7 +111,7 @@ final class EpollServerSocketChannelConfig extends EpollChannelConfig {
         return true;
     }
 
-    boolean isReuseAddress() {
+    private boolean isReuseAddress() {
         try {
             return ((AbstractEpollChannel) channel).socket.isReuseAddress();
         } catch (IOException e) {
@@ -119,16 +119,15 @@ final class EpollServerSocketChannelConfig extends EpollChannelConfig {
         }
     }
 
-    EpollServerSocketChannelConfig setReuseAddress(boolean reuseAddress) {
+    private void setReuseAddress(boolean reuseAddress) {
         try {
             ((AbstractEpollChannel) channel).socket.setReuseAddress(reuseAddress);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    int getReceiveBufferSize() {
+    private int getReceiveBufferSize() {
         try {
             return ((AbstractEpollChannel) channel).socket.getReceiveBufferSize();
         } catch (IOException e) {
@@ -136,10 +135,9 @@ final class EpollServerSocketChannelConfig extends EpollChannelConfig {
         }
     }
 
-    EpollServerSocketChannelConfig setReceiveBufferSize(int receiveBufferSize) {
+    private void setReceiveBufferSize(int receiveBufferSize) {
         try {
             ((AbstractEpollChannel) channel).socket.setReceiveBufferSize(receiveBufferSize);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -149,10 +147,9 @@ final class EpollServerSocketChannelConfig extends EpollChannelConfig {
         return backlog;
     }
 
-    EpollServerSocketChannelConfig setBacklog(int backlog) {
+    private void setBacklog(int backlog) {
         checkPositiveOrZero(backlog, "backlog");
         this.backlog = backlog;
-        return this;
     }
 
     /**
@@ -173,10 +170,9 @@ final class EpollServerSocketChannelConfig extends EpollChannelConfig {
      *
      * @see <a href="https://tools.ietf.org/html/rfc7413#appendix-A.2">RFC 7413 Passive Open</a>
      */
-    EpollServerSocketChannelConfig setTcpFastopen(int pendingFastOpenRequestsThreshold) {
+    private void setTcpFastopen(int pendingFastOpenRequestsThreshold) {
         this.pendingFastOpenRequestsThreshold = checkPositiveOrZero(pendingFastOpenRequestsThreshold,
                 "pendingFastOpenRequestsThreshold");
-        return this;
     }
 
     /**
@@ -184,10 +180,9 @@ final class EpollServerSocketChannelConfig extends EpollChannelConfig {
      * Keys can only be set on, not read to prevent a potential leak, as they are confidential.
      * Allowing them being read would mean anyone with access to the channel could get them.
      */
-    EpollServerSocketChannelConfig setTcpMd5Sig(Map<InetAddress, byte[]> keys) {
+    private void setTcpMd5Sig(Map<InetAddress, byte[]> keys) {
         try {
             ((EpollServerSocketChannel) channel).setTcpMd5Sig(keys);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -196,7 +191,7 @@ final class EpollServerSocketChannelConfig extends EpollChannelConfig {
     /**
      * Returns {@code true} if the SO_REUSEPORT option is set.
      */
-    boolean isReusePort() {
+    private boolean isReusePort() {
         try {
             return ((EpollServerSocketChannel) channel).socket.isReusePort();
         } catch (IOException e) {
@@ -211,10 +206,9 @@ final class EpollServerSocketChannelConfig extends EpollChannelConfig {
      * Be aware this method needs be called before {@link EpollSocketChannel#bind(java.net.SocketAddress)} to have
      * any affect.
      */
-    EpollServerSocketChannelConfig setReusePort(boolean reusePort) {
+    private void setReusePort(boolean reusePort) {
         try {
             ((EpollServerSocketChannel) channel).socket.setReusePort(reusePort);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -224,7 +218,7 @@ final class EpollServerSocketChannelConfig extends EpollChannelConfig {
      * Returns {@code true} if <a href="https://man7.org/linux/man-pages/man7/ip.7.html">IP_FREEBIND</a> is enabled,
      * {@code false} otherwise.
      */
-    boolean isFreeBind() {
+    private boolean isFreeBind() {
         try {
             return ((EpollServerSocketChannel) channel).socket.isIpFreeBind();
         } catch (IOException e) {
@@ -236,10 +230,9 @@ final class EpollServerSocketChannelConfig extends EpollChannelConfig {
      * If {@code true} is used <a href="https://man7.org/linux/man-pages/man7/ip.7.html">IP_FREEBIND</a> is enabled,
      * {@code false} for disable it. Default is disabled.
      */
-    EpollServerSocketChannelConfig setFreeBind(boolean freeBind) {
+    private void setFreeBind(boolean freeBind) {
         try {
             ((EpollServerSocketChannel) channel).socket.setIpFreeBind(freeBind);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -249,7 +242,7 @@ final class EpollServerSocketChannelConfig extends EpollChannelConfig {
      * Returns {@code true} if <a href="https://man7.org/linux/man-pages/man7/ip.7.html">IP_TRANSPARENT</a> is enabled,
      * {@code false} otherwise.
      */
-    boolean isIpTransparent() {
+    private boolean isIpTransparent() {
         try {
             return ((EpollServerSocketChannel) channel).socket.isIpTransparent();
         } catch (IOException e) {
@@ -261,10 +254,9 @@ final class EpollServerSocketChannelConfig extends EpollChannelConfig {
      * If {@code true} is used <a href="https://man7.org/linux/man-pages/man7/ip.7.html">IP_TRANSPARENT</a> is enabled,
      * {@code false} for disable it. Default is disabled.
      */
-    EpollServerSocketChannelConfig setIpTransparent(boolean transparent) {
+    private void setIpTransparent(boolean transparent) {
         try {
             ((EpollServerSocketChannel) channel).socket.setIpTransparent(transparent);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -273,10 +265,9 @@ final class EpollServerSocketChannelConfig extends EpollChannelConfig {
     /**
      * Set the {@code TCP_DEFER_ACCEPT} option on the socket. See {@code man 7 tcp} for more details.
      */
-    EpollServerSocketChannelConfig setTcpDeferAccept(int deferAccept) {
+    private void setTcpDeferAccept(int deferAccept) {
         try {
             ((EpollServerSocketChannel) channel).socket.setTcpDeferAccept(deferAccept);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -285,7 +276,7 @@ final class EpollServerSocketChannelConfig extends EpollChannelConfig {
     /**
      * Returns a positive value if <a href="https://linux.die.net//man/7/tcp">TCP_DEFER_ACCEPT</a> is enabled.
      */
-    int getTcpDeferAccept() {
+    private int getTcpDeferAccept() {
         try {
             return ((EpollServerSocketChannel) channel).socket.getTcpDeferAccept();
         } catch (IOException e) {

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannelConfig.java
@@ -327,56 +327,50 @@ final class EpollSocketChannelConfig extends EpollChannelConfig {
         }
     }
 
-    EpollSocketChannelConfig setKeepAlive(boolean keepAlive) {
+    private void setKeepAlive(boolean keepAlive) {
         try {
             ((EpollSocketChannel) channel).socket.setKeepAlive(keepAlive);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    EpollSocketChannelConfig setReceiveBufferSize(int receiveBufferSize) {
+    private void setReceiveBufferSize(int receiveBufferSize) {
         try {
             ((EpollSocketChannel) channel).socket.setReceiveBufferSize(receiveBufferSize);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    EpollSocketChannelConfig setReuseAddress(boolean reuseAddress) {
+    private void setReuseAddress(boolean reuseAddress) {
         try {
             ((EpollSocketChannel) channel).socket.setReuseAddress(reuseAddress);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    EpollSocketChannelConfig setSendBufferSize(int sendBufferSize) {
+    private void setSendBufferSize(int sendBufferSize) {
         try {
             ((EpollSocketChannel) channel).socket.setSendBufferSize(sendBufferSize);
             calculateMaxBytesPerGatheringWrite();
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    EpollSocketChannelConfig setSoLinger(int soLinger) {
+    private void setSoLinger(int soLinger) {
         try {
             ((EpollSocketChannel) channel).socket.setSoLinger(soLinger);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    EpollSocketChannelConfig setTcpNoDelay(boolean tcpNoDelay) {
+    private void setTcpNoDelay(boolean tcpNoDelay) {
         try {
             ((EpollSocketChannel) channel).socket.setTcpNoDelay(tcpNoDelay);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -385,10 +379,9 @@ final class EpollSocketChannelConfig extends EpollChannelConfig {
     /**
      * Set the {@code TCP_CORK} option on the socket. See {@code man 7 tcp} for more details.
      */
-    EpollSocketChannelConfig setTcpCork(boolean tcpCork) {
+    private void setTcpCork(boolean tcpCork) {
         try {
             ((EpollSocketChannel) channel).socket.setTcpCork(tcpCork);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -397,10 +390,9 @@ final class EpollSocketChannelConfig extends EpollChannelConfig {
     /**
      * Set the {@code SO_BUSY_POLL} option on the socket. See {@code man 7 tcp} for more details.
      */
-    EpollSocketChannelConfig setSoBusyPoll(int loopMicros) {
+    private void setSoBusyPoll(int loopMicros) {
         try {
             ((EpollSocketChannel) channel).socket.setSoBusyPoll(loopMicros);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -410,19 +402,17 @@ final class EpollSocketChannelConfig extends EpollChannelConfig {
      * Set the {@code TCP_NOTSENT_LOWAT} option on the socket. See {@code man 7 tcp} for more details.
      * @param tcpNotSentLowAt is a uint32_t
      */
-    EpollSocketChannelConfig setTcpNotSentLowAt(long tcpNotSentLowAt) {
+    private void setTcpNotSentLowAt(long tcpNotSentLowAt) {
         try {
             ((EpollSocketChannel) channel).socket.setTcpNotSentLowAt(tcpNotSentLowAt);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    EpollSocketChannelConfig setTrafficClass(int trafficClass) {
+    private void setTrafficClass(int trafficClass) {
         try {
             ((EpollSocketChannel) channel).socket.setTrafficClass(trafficClass);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -431,10 +421,9 @@ final class EpollSocketChannelConfig extends EpollChannelConfig {
     /**
      * Set the {@code TCP_KEEPIDLE} option on the socket. See {@code man 7 tcp} for more details.
      */
-    EpollSocketChannelConfig setTcpKeepIdle(int seconds) {
+    private void setTcpKeepIdle(int seconds) {
         try {
             ((EpollSocketChannel) channel).socket.setTcpKeepIdle(seconds);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -443,10 +432,9 @@ final class EpollSocketChannelConfig extends EpollChannelConfig {
     /**
      * Set the {@code TCP_KEEPINTVL} option on the socket. See {@code man 7 tcp} for more details.
      */
-    EpollSocketChannelConfig setTcpKeepIntvl(int seconds) {
+    private void setTcpKeepIntvl(int seconds) {
         try {
             ((EpollSocketChannel) channel).socket.setTcpKeepIntvl(seconds);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -455,10 +443,9 @@ final class EpollSocketChannelConfig extends EpollChannelConfig {
     /**
      * Set the {@code TCP_KEEPCNT} option on the socket. See {@code man 7 tcp} for more details.
      */
-    EpollSocketChannelConfig setTcpKeepCnt(int probes) {
+    private void setTcpKeepCnt(int probes) {
         try {
             ((EpollSocketChannel) channel).socket.setTcpKeepCnt(probes);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -467,10 +454,9 @@ final class EpollSocketChannelConfig extends EpollChannelConfig {
     /**
      * Set the {@code TCP_USER_TIMEOUT} option on the socket. See {@code man 7 tcp} for more details.
      */
-    EpollSocketChannelConfig setTcpUserTimeout(int milliseconds) {
+    private void setTcpUserTimeout(int milliseconds) {
         try {
             ((EpollSocketChannel) channel).socket.setTcpUserTimeout(milliseconds);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -479,7 +465,7 @@ final class EpollSocketChannelConfig extends EpollChannelConfig {
     /**
      * Returns {@code true} if the IP_BIND_ADDRESS_NO_PORT option is set.
      */
-    boolean isIpBindAddressNoPort() {
+    private boolean isIpBindAddressNoPort() {
         try {
             return ((EpollSocketChannel) channel).socket.isIpBindAddressNoPort();
         } catch (IOException e) {
@@ -493,10 +479,9 @@ final class EpollSocketChannelConfig extends EpollChannelConfig {
      * Be aware this method needs be called before {@link EpollSocketChannel#bind(java.net.SocketAddress)} to have
      * any affect.
      */
-    EpollSocketChannelConfig setIpBindAddressNoPort(boolean ipBindAddressNoPort) {
+    private void setIpBindAddressNoPort(boolean ipBindAddressNoPort) {
         try {
             ((EpollSocketChannel) channel).socket.setIpBindAddressNoPort(ipBindAddressNoPort);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -506,7 +491,7 @@ final class EpollSocketChannelConfig extends EpollChannelConfig {
      * Returns {@code true} if <a href="https://man7.org/linux/man-pages/man7/ip.7.html">IP_TRANSPARENT</a> is enabled,
      * {@code false} otherwise.
      */
-     boolean isIpTransparent() {
+     private boolean isIpTransparent() {
         try {
             return ((EpollSocketChannel) channel).socket.isIpTransparent();
         } catch (IOException e) {
@@ -518,10 +503,9 @@ final class EpollSocketChannelConfig extends EpollChannelConfig {
      * If {@code true} is used <a href="https://man7.org/linux/man-pages/man7/ip.7.html">IP_TRANSPARENT</a> is enabled,
      * {@code false} for disable it. Default is disabled.
      */
-    EpollSocketChannelConfig setIpTransparent(boolean transparent) {
+    private void setIpTransparent(boolean transparent) {
         try {
             ((EpollSocketChannel) channel).socket.setIpTransparent(transparent);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -532,10 +516,9 @@ final class EpollSocketChannelConfig extends EpollChannelConfig {
      * Keys can only be set on, not read to prevent a potential leak, as they are confidential.
      * Allowing them being read would mean anyone with access to the channel could get them.
      */
-    EpollSocketChannelConfig setTcpMd5Sig(Map<InetAddress, byte[]> keys) {
+    private void setTcpMd5Sig(Map<InetAddress, byte[]> keys) {
         try {
             ((EpollSocketChannel) channel).setTcpMd5Sig(keys);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -546,10 +529,9 @@ final class EpollSocketChannelConfig extends EpollChannelConfig {
      * See <a href="https://linux.die.net//man/7/tcp">TCP_QUICKACK</a>
      * for more details.
      */
-    EpollSocketChannelConfig setTcpQuickAck(boolean quickAck) {
+    private void setTcpQuickAck(boolean quickAck) {
         try {
             ((EpollSocketChannel) channel).socket.setTcpQuickAck(quickAck);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -559,7 +541,7 @@ final class EpollSocketChannelConfig extends EpollChannelConfig {
      * Returns {@code true} if <a href="https://linux.die.net//man/7/tcp">TCP_QUICKACK</a> is enabled,
      * {@code false} otherwise.
      */
-    boolean isTcpQuickAck() {
+    private boolean isTcpQuickAck() {
         try {
             return ((EpollSocketChannel) channel).socket.isTcpQuickAck();
         } catch (IOException e) {
@@ -573,9 +555,8 @@ final class EpollSocketChannelConfig extends EpollChannelConfig {
      * client socket mechanics that work with kernel 3.6 and later. See this
      * <a href="https://lwn.net/Articles/508865/">LWN article</a> for more info.
      */
-    EpollSocketChannelConfig setTcpFastOpenConnect(boolean fastOpenConnect) {
+    private void setTcpFastOpenConnect(boolean fastOpenConnect) {
         tcpFastopen = fastOpenConnect;
-        return this;
     }
 
     /**
@@ -589,7 +570,7 @@ final class EpollSocketChannelConfig extends EpollChannelConfig {
         return allowHalfClosure;
     }
 
-    EpollSocketChannelConfig setAllowHalfClosure(boolean allowHalfClosure) {
+    private EpollSocketChannelConfig setAllowHalfClosure(boolean allowHalfClosure) {
         this.allowHalfClosure = allowHalfClosure;
         return this;
     }
@@ -602,9 +583,8 @@ final class EpollSocketChannelConfig extends EpollChannelConfig {
         }
     }
 
-    EpollSocketChannelConfig setReadMode(DomainSocketReadMode mode) {
+    private void setReadMode(DomainSocketReadMode mode) {
         this.mode = ObjectUtil.checkNotNull(mode, "mode");
-        return this;
     }
 
     DomainSocketReadMode getReadMode() {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringChannelConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringChannelConfig.java
@@ -15,13 +15,10 @@
  */
 package io.netty.channel.uring;
 
-import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.DefaultChannelConfig;
-import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
-import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.unix.IntegerUnixChannelOption;
 import io.netty.channel.unix.RawUnixChannelOption;
 
@@ -78,79 +75,7 @@ abstract class IoUringChannelConfig extends DefaultChannelConfig {
     }
 
     @Override
-    public IoUringChannelConfig setMaxMessagesPerRead(int maxMessagesPerRead) {
-        super.setMaxMessagesPerRead(maxMessagesPerRead);
-        return this;
-    }
-
-    @Override
-    public IoUringChannelConfig setConnectTimeoutMillis(int connectTimeoutMillis) {
-        super.setConnectTimeoutMillis(connectTimeoutMillis);
-        return this;
-    }
-
-    @Override
-    public IoUringChannelConfig setMaxMessagesPerWrite(int maxMessagesPerWrite) {
-        super.setMaxMessagesPerWrite(maxMessagesPerWrite);
-        return this;
-    }
-
-    @Override
-    public IoUringChannelConfig setWriteSpinCount(int writeSpinCount) {
-        super.setWriteSpinCount(writeSpinCount);
-        return this;
-    }
-
-    @Override
-    public IoUringChannelConfig setAllocator(ByteBufAllocator allocator) {
-        super.setAllocator(allocator);
-        return this;
-    }
-
-    @Override
-    public IoUringChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
-        super.setRecvByteBufAllocator(allocator);
-        return this;
-    }
-
-    @Override
-    public IoUringChannelConfig setAutoRead(boolean autoRead) {
-        super.setAutoRead(autoRead);
-        return this;
-    }
-
-    @Override
-    public IoUringChannelConfig setAutoClose(boolean autoClose) {
-        super.setAutoClose(autoClose);
-        return this;
-    }
-
-    @Override
-    public IoUringChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
-        super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
-        return this;
-    }
-
-    @Override
-    public IoUringChannelConfig setMessageSizeEstimator(MessageSizeEstimator estimator) {
-        super.setMessageSizeEstimator(estimator);
-        return this;
-    }
-
-    @Override
-    public IoUringChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark) {
-        super.setWriteBufferWaterMark(writeBufferWaterMark);
-        return this;
-    }
-
-    @Override
-    public IoUringChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
-        super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
-        return this;
-    }
-
-    @Override
-    protected void autoReadCleared() {
+    protected final void autoReadCleared() {
         ((AbstractIoUringChannel) channel).autoReadCleared();
     }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannelConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannelConfig.java
@@ -155,7 +155,7 @@ final class IoUringDatagramChannelConfig extends IoUringChannelConfig {
         return activeOnOpen;
     }
 
-    int getSendBufferSize() {
+    private int getSendBufferSize() {
         try {
             return ((AbstractIoUringChannel) channel).socket.getSendBufferSize();
         } catch (IOException e) {
@@ -163,16 +163,15 @@ final class IoUringDatagramChannelConfig extends IoUringChannelConfig {
         }
     }
 
-    IoUringDatagramChannelConfig setSendBufferSize(int sendBufferSize) {
+    private void setSendBufferSize(int sendBufferSize) {
         try {
             ((AbstractIoUringChannel) channel).socket.setSendBufferSize(sendBufferSize);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    int getReceiveBufferSize() {
+    private int getReceiveBufferSize() {
         try {
             return ((AbstractIoUringChannel) channel).socket.getReceiveBufferSize();
         } catch (IOException e) {
@@ -180,16 +179,15 @@ final class IoUringDatagramChannelConfig extends IoUringChannelConfig {
         }
     }
 
-    IoUringDatagramChannelConfig setReceiveBufferSize(int receiveBufferSize) {
+    private void setReceiveBufferSize(int receiveBufferSize) {
         try {
             ((AbstractIoUringChannel) channel).socket.setReceiveBufferSize(receiveBufferSize);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    int getTrafficClass() {
+    private int getTrafficClass() {
         try {
             return ((AbstractIoUringChannel) channel).socket.getTrafficClass();
         } catch (IOException e) {
@@ -197,16 +195,15 @@ final class IoUringDatagramChannelConfig extends IoUringChannelConfig {
         }
     }
 
-    IoUringDatagramChannelConfig setTrafficClass(int trafficClass) {
+    private void setTrafficClass(int trafficClass) {
         try {
             ((AbstractIoUringChannel) channel).socket.setTrafficClass(trafficClass);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    boolean isReuseAddress() {
+    private boolean isReuseAddress() {
         try {
             return ((AbstractIoUringChannel) channel).socket.isReuseAddress();
         } catch (IOException e) {
@@ -214,16 +211,15 @@ final class IoUringDatagramChannelConfig extends IoUringChannelConfig {
         }
     }
 
-    IoUringDatagramChannelConfig setReuseAddress(boolean reuseAddress) {
+    private void setReuseAddress(boolean reuseAddress) {
         try {
             ((AbstractIoUringChannel) channel).socket.setReuseAddress(reuseAddress);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    boolean isBroadcast() {
+    private boolean isBroadcast() {
         try {
             return ((AbstractIoUringChannel) channel).socket.isBroadcast();
         } catch (IOException e) {
@@ -231,16 +227,15 @@ final class IoUringDatagramChannelConfig extends IoUringChannelConfig {
         }
     }
 
-    IoUringDatagramChannelConfig setBroadcast(boolean broadcast) {
+    private void setBroadcast(boolean broadcast) {
         try {
             ((AbstractIoUringChannel) channel).socket.setBroadcast(broadcast);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    boolean isLoopbackModeDisabled() {
+    private boolean isLoopbackModeDisabled() {
         try {
             return ((AbstractIoUringChannel) channel).socket.isLoopbackModeDisabled();
         } catch (IOException e) {
@@ -248,16 +243,15 @@ final class IoUringDatagramChannelConfig extends IoUringChannelConfig {
         }
     }
 
-    IoUringDatagramChannelConfig setLoopbackModeDisabled(boolean loopbackModeDisabled) {
+    private void setLoopbackModeDisabled(boolean loopbackModeDisabled) {
         try {
             ((AbstractIoUringChannel) channel).socket.setLoopbackModeDisabled(loopbackModeDisabled);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    int getTimeToLive() {
+    private int getTimeToLive() {
         try {
             return ((AbstractIoUringChannel) channel).socket.getTimeToLive();
         } catch (IOException e) {
@@ -265,16 +259,15 @@ final class IoUringDatagramChannelConfig extends IoUringChannelConfig {
         }
     }
 
-    IoUringDatagramChannelConfig setTimeToLive(int ttl) {
+    private void setTimeToLive(int ttl) {
         try {
             ((AbstractIoUringChannel) channel).socket.setTimeToLive(ttl);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    InetAddress getInterface() {
+    private InetAddress getInterface() {
         try {
             return ((AbstractIoUringChannel) channel).socket.getInterface();
         } catch (IOException e) {
@@ -282,16 +275,15 @@ final class IoUringDatagramChannelConfig extends IoUringChannelConfig {
         }
     }
 
-    IoUringDatagramChannelConfig setInterface(InetAddress interfaceAddress) {
+    private void setInterface(InetAddress interfaceAddress) {
         try {
             ((AbstractIoUringChannel) channel).socket.setInterface(interfaceAddress);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    NetworkInterface getNetworkInterface() {
+    private NetworkInterface getNetworkInterface() {
         try {
             return ((AbstractIoUringChannel) channel).socket.getNetworkInterface();
         } catch (IOException e) {
@@ -299,10 +291,9 @@ final class IoUringDatagramChannelConfig extends IoUringChannelConfig {
         }
     }
 
-    IoUringDatagramChannelConfig setNetworkInterface(NetworkInterface networkInterface) {
+    private void setNetworkInterface(NetworkInterface networkInterface) {
         try {
             ((AbstractIoUringChannel) channel).socket.setNetworkInterface(networkInterface);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -311,7 +302,7 @@ final class IoUringDatagramChannelConfig extends IoUringChannelConfig {
     /**
      * Returns {@code true} if the SO_REUSEPORT option is set.
      */
-    boolean isReusePort() {
+    private boolean isReusePort() {
         try {
             return ((AbstractIoUringChannel) channel).socket.isReusePort();
         } catch (IOException e) {
@@ -327,10 +318,9 @@ final class IoUringDatagramChannelConfig extends IoUringChannelConfig {
      * {@link io.netty.channel.socket.DatagramChannel#bind(java.net.SocketAddress)} to have
      * any affect.
      */
-    IoUringDatagramChannelConfig setReusePort(boolean reusePort) {
+    private void setReusePort(boolean reusePort) {
         try {
             ((AbstractIoUringChannel) channel).socket.setReusePort(reusePort);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -340,7 +330,7 @@ final class IoUringDatagramChannelConfig extends IoUringChannelConfig {
      * Returns {@code true} if <a href="https://man7.org/linux/man-pages/man7/ip.7.html">IP_TRANSPARENT</a> is enabled,
      * {@code false} otherwise.
      */
-    boolean isIpTransparent() {
+    private boolean isIpTransparent() {
         try {
             return ((AbstractIoUringChannel) channel).socket.isIpTransparent();
         } catch (IOException e) {
@@ -352,10 +342,9 @@ final class IoUringDatagramChannelConfig extends IoUringChannelConfig {
      * If {@code true} is used <a href="https://man7.org/linux/man-pages/man7/ip.7.html">IP_TRANSPARENT</a> is enabled,
      * {@code false} for disable it. Default is disabled.
      */
-    IoUringDatagramChannelConfig setIpTransparent(boolean ipTransparent) {
+    private void setIpTransparent(boolean ipTransparent) {
         try {
             ((AbstractIoUringChannel) channel).socket.setIpTransparent(ipTransparent);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -365,7 +354,7 @@ final class IoUringDatagramChannelConfig extends IoUringChannelConfig {
      * Returns {@code true} if <a href="https://man7.org/linux/man-pages/man7/ip.7.html">IP_FREEBIND</a> is enabled,
      * {@code false} otherwise.
      */
-    boolean isFreeBind() {
+    private boolean isFreeBind() {
         try {
             return ((AbstractIoUringChannel) channel).socket.isIpFreeBind();
         } catch (IOException e) {
@@ -377,10 +366,9 @@ final class IoUringDatagramChannelConfig extends IoUringChannelConfig {
      * If {@code true} is used <a href="https://man7.org/linux/man-pages/man7/ip.7.html">IP_FREEBIND</a> is enabled,
      * {@code false} for disable it. Default is disabled.
      */
-    IoUringDatagramChannelConfig setFreeBind(boolean freeBind) {
+    private void setFreeBind(boolean freeBind) {
         try {
             ((AbstractIoUringChannel) channel).socket.setIpFreeBind(freeBind);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -395,9 +383,8 @@ final class IoUringDatagramChannelConfig extends IoUringChannelConfig {
      * {@link RecvByteBufAllocator}. You can use {@code 0} to disable the usage of batching, any other bigger value
      * will enable it.
      */
-    IoUringDatagramChannelConfig setMaxDatagramPayloadSize(int maxDatagramSize) {
+    private void setMaxDatagramPayloadSize(int maxDatagramSize) {
         this.maxDatagramSize = ObjectUtil.checkPositiveOrZero(maxDatagramSize, "maxDatagramSize");
-        return this;
     }
 
     /**
@@ -411,10 +398,9 @@ final class IoUringDatagramChannelConfig extends IoUringChannelConfig {
      * If {@code true} is used <a href="https://man7.org/linux/man-pages/man7/ip.7.html">IP_MULTICAST_ALL</a> is
      * enabled (or IPV6_MULTICAST_ALL for IPV6), {@code false} for disable it. Default is enabled.
      */
-    IoUringDatagramChannelConfig setIpMulticastAll(boolean multicastAll) {
+    private void setIpMulticastAll(boolean multicastAll) {
         try {
             ((IoUringDatagramChannel) channel).socket.setIpMulticastAll(multicastAll);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -424,7 +410,7 @@ final class IoUringDatagramChannelConfig extends IoUringChannelConfig {
      * Returns {@code true} if <a href="https://man7.org/linux/man-pages/man7/ip.7.html">IP_MULTICAST_ALL</a> (or
      * IPV6_MULTICAST_ALL for IPV6) is enabled, {@code false} otherwise.
      */
-    boolean isIpMulticastAll() {
+    private boolean isIpMulticastAll() {
         try {
             return ((IoUringDatagramChannel) channel).socket.isIpMulticastAll();
         } catch (IOException e) {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringServerSocketChannelConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringServerSocketChannelConfig.java
@@ -98,7 +98,7 @@ final class IoUringServerSocketChannelConfig extends IoUringChannelConfig {
         return true;
     }
 
-    boolean isReuseAddress() {
+    private boolean isReuseAddress() {
         try {
             return ((AbstractIoUringChannel) channel).socket.isReuseAddress();
         } catch (IOException e) {
@@ -106,16 +106,15 @@ final class IoUringServerSocketChannelConfig extends IoUringChannelConfig {
         }
     }
 
-    IoUringServerSocketChannelConfig setReuseAddress(boolean reuseAddress) {
+    private void setReuseAddress(boolean reuseAddress) {
         try {
             ((AbstractIoUringChannel) channel).socket.setReuseAddress(reuseAddress);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    int getReceiveBufferSize() {
+    private int getReceiveBufferSize() {
         try {
             return ((AbstractIoUringChannel) channel).socket.getReceiveBufferSize();
         } catch (IOException e) {
@@ -123,10 +122,9 @@ final class IoUringServerSocketChannelConfig extends IoUringChannelConfig {
         }
     }
 
-    IoUringServerSocketChannelConfig setReceiveBufferSize(int receiveBufferSize) {
+    private void setReceiveBufferSize(int receiveBufferSize) {
         try {
             ((AbstractIoUringChannel) channel).socket.setReceiveBufferSize(receiveBufferSize);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -136,16 +134,15 @@ final class IoUringServerSocketChannelConfig extends IoUringChannelConfig {
         return backlog;
     }
 
-    IoUringServerSocketChannelConfig setBacklog(int backlog) {
+    private void setBacklog(int backlog) {
         checkPositiveOrZero(backlog, "backlog");
         this.backlog = backlog;
-        return this;
     }
 
     /**
      * Returns {@code true} if the SO_REUSEPORT option is set.
      */
-    boolean isReusePort() {
+    private boolean isReusePort() {
         try {
             return ((IoUringServerSocketChannel) channel).socket.isReusePort();
         } catch (IOException e) {
@@ -161,10 +158,9 @@ final class IoUringServerSocketChannelConfig extends IoUringChannelConfig {
      * Be aware this method needs be called before
      * {@link io.netty.channel.socket.ServerSocketChannel#bind(java.net.SocketAddress)} to have any affect.
      */
-    IoUringServerSocketChannelConfig setReusePort(boolean reusePort) {
+    private void setReusePort(boolean reusePort) {
         try {
             ((IoUringServerSocketChannel) channel).socket.setReusePort(reusePort);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -174,7 +170,7 @@ final class IoUringServerSocketChannelConfig extends IoUringChannelConfig {
      * Returns {@code true} if <a href="https://man7.org/linux/man-pages/man7/ip.7.html">IP_FREEBIND</a> is enabled,
      * {@code false} otherwise.
      */
-    boolean isFreeBind() {
+    private boolean isFreeBind() {
         try {
             return ((IoUringServerSocketChannel) channel).socket.isIpFreeBind();
         } catch (IOException e) {
@@ -186,10 +182,9 @@ final class IoUringServerSocketChannelConfig extends IoUringChannelConfig {
      * If {@code true} is used <a href="https://man7.org/linux/man-pages/man7/ip.7.html">IP_FREEBIND</a> is enabled,
      * {@code false} for disable it. Default is disabled.
      */
-    IoUringServerSocketChannelConfig setFreeBind(boolean freeBind) {
+    private void setFreeBind(boolean freeBind) {
         try {
             ((IoUringServerSocketChannel) channel).socket.setIpFreeBind(freeBind);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -199,7 +194,7 @@ final class IoUringServerSocketChannelConfig extends IoUringChannelConfig {
      * Returns {@code true} if <a href="https://man7.org/linux/man-pages/man7/ip.7.html">IP_TRANSPARENT</a> is enabled,
      * {@code false} otherwise.
      */
-    boolean isIpTransparent() {
+    private boolean isIpTransparent() {
         try {
             return ((IoUringServerSocketChannel) channel).socket.isIpTransparent();
         } catch (IOException e) {
@@ -211,10 +206,9 @@ final class IoUringServerSocketChannelConfig extends IoUringChannelConfig {
      * If {@code true} is used <a href="https://man7.org/linux/man-pages/man7/ip.7.html">IP_TRANSPARENT</a> is enabled,
      * {@code false} for disable it. Default is disabled.
      */
-    IoUringServerSocketChannelConfig setIpTransparent(boolean transparent) {
+    private void setIpTransparent(boolean transparent) {
         try {
             ((IoUringServerSocketChannel) channel).socket.setIpTransparent(transparent);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -223,10 +217,9 @@ final class IoUringServerSocketChannelConfig extends IoUringChannelConfig {
     /**
      * Set the {@code TCP_DEFER_ACCEPT} option on the socket. See {@code man 7 tcp} for more details.
      */
-    IoUringServerSocketChannelConfig setTcpDeferAccept(int deferAccept) {
+    private void setTcpDeferAccept(int deferAccept) {
         try {
             ((IoUringServerSocketChannel) channel).socket.setTcpDeferAccept(deferAccept);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -235,7 +228,7 @@ final class IoUringServerSocketChannelConfig extends IoUringChannelConfig {
     /**
      * Returns a positive value if <a href="https://linux.die.net/man/7/tcp">TCP_DEFER_ACCEPT</a> is enabled.
      */
-    int getTcpDeferAccept() {
+    private int getTcpDeferAccept() {
         try {
             return ((IoUringServerSocketChannel) channel).socket.getTcpDeferAccept();
         } catch (IOException e) {
@@ -248,7 +241,7 @@ final class IoUringServerSocketChannelConfig extends IoUringChannelConfig {
      *
      * @see <a href="https://tools.ietf.org/html/rfc7413#appendix-A.2">RFC 7413 Passive Open</a>
      */
-     int getTcpFastopen() {
+     private int getTcpFastopen() {
         return pendingFastOpenRequestsThreshold;
     }
 
@@ -261,9 +254,8 @@ final class IoUringServerSocketChannelConfig extends IoUringChannelConfig {
      *
      * @see <a href="https://tools.ietf.org/html/rfc7413#appendix-A.2">RFC 7413 Passive Open</a>
      */
-    IoUringServerSocketChannelConfig setTcpFastopen(int pendingFastOpenRequestsThreshold) {
+    private void setTcpFastopen(int pendingFastOpenRequestsThreshold) {
         this.pendingFastOpenRequestsThreshold = checkPositiveOrZero(pendingFastOpenRequestsThreshold,
                 "pendingFastOpenRequestsThreshold");
-        return this;
     }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannelConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannelConfig.java
@@ -478,19 +478,6 @@ final class IoUringSocketChannelConfig extends IoUringChannelConfig {
         }
     }
 
-//    /**
-//     * Set the {@code TCP_MD5SIG} option on the socket. See {@code linux/tcp.h} for more details. Keys can only be set
-//     * on, not read to prevent a potential leak, as they are confidential. Allowing them being read would mean anyone
-//     * with access to the channel could get them.
-//     */
-//    private void setTcpMd5Sig(Map<InetAddress, byte[]> keys) {
-//        try {
-//            ((IOUringSocketChannel) channel).setTcpMd5Sig(keys);
-//        } catch (IOException e) {
-//            throw new ChannelException(e);
-//        }
-//    }
-
     /**
      * Set the {@code TCP_QUICKACK} option on the socket. See <a href="https://linux.die.net/man/7/tcp">TCP_QUICKACK</a>
      * for more details.

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannelConfig.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannelConfig.java
@@ -184,7 +184,7 @@ final class IoUringSocketChannelConfig extends IoUringChannelConfig {
         return true;
     }
 
-    int getSendBufferSize() {
+    private int getSendBufferSize() {
         try {
             return ((IoUringSocketChannel) channel).socket.getSendBufferSize();
         } catch (IOException e) {
@@ -192,7 +192,7 @@ final class IoUringSocketChannelConfig extends IoUringChannelConfig {
         }
     }
 
-    int getSoLinger() {
+    private int getSoLinger() {
         try {
             return ((IoUringSocketChannel) channel).socket.getSoLinger();
         } catch (IOException e) {
@@ -200,7 +200,7 @@ final class IoUringSocketChannelConfig extends IoUringChannelConfig {
         }
     }
 
-    int getTrafficClass() {
+    private int getTrafficClass() {
         try {
             return ((IoUringSocketChannel) channel).socket.getTrafficClass();
         } catch (IOException e) {
@@ -208,7 +208,7 @@ final class IoUringSocketChannelConfig extends IoUringChannelConfig {
         }
     }
 
-    boolean isKeepAlive() {
+    private boolean isKeepAlive() {
         try {
             return ((IoUringSocketChannel) channel).socket.isKeepAlive();
         } catch (IOException e) {
@@ -216,7 +216,7 @@ final class IoUringSocketChannelConfig extends IoUringChannelConfig {
         }
     }
 
-    boolean isReuseAddress() {
+    private boolean isReuseAddress() {
         try {
             return ((IoUringSocketChannel) channel).socket.isReuseAddress();
         } catch (IOException e) {
@@ -224,7 +224,7 @@ final class IoUringSocketChannelConfig extends IoUringChannelConfig {
         }
     }
 
-    boolean isTcpNoDelay() {
+    private boolean isTcpNoDelay() {
         try {
             return ((IoUringSocketChannel) channel).socket.isTcpNoDelay();
         } catch (IOException e) {
@@ -235,7 +235,7 @@ final class IoUringSocketChannelConfig extends IoUringChannelConfig {
     /**
      * Get the {@code TCP_CORK} option on the socket. See {@code man 7 tcp} for more details.
      */
-    boolean isTcpCork() {
+    private boolean isTcpCork() {
         try {
             return ((IoUringSocketChannel) channel).socket.isTcpCork();
         } catch (IOException e) {
@@ -246,7 +246,7 @@ final class IoUringSocketChannelConfig extends IoUringChannelConfig {
     /**
      * Get the {@code SO_BUSY_POLL} option on the socket. See {@code man 7 tcp} for more details.
      */
-    int getSoBusyPoll() {
+    private int getSoBusyPoll() {
         try {
             return ((IoUringSocketChannel) channel).socket.getSoBusyPoll();
         } catch (IOException e) {
@@ -259,7 +259,7 @@ final class IoUringSocketChannelConfig extends IoUringChannelConfig {
      *
      * @return value is a uint32_t
      */
-    long getTcpNotSentLowAt() {
+    private long getTcpNotSentLowAt() {
         try {
             return ((IoUringSocketChannel) channel).socket.getTcpNotSentLowAt();
         } catch (IOException e) {
@@ -270,7 +270,7 @@ final class IoUringSocketChannelConfig extends IoUringChannelConfig {
     /**
      * Get the {@code TCP_KEEPIDLE} option on the socket. See {@code man 7 tcp} for more details.
      */
-    int getTcpKeepIdle() {
+    private int getTcpKeepIdle() {
         try {
             return ((IoUringSocketChannel) channel).socket.getTcpKeepIdle();
         } catch (IOException e) {
@@ -281,7 +281,7 @@ final class IoUringSocketChannelConfig extends IoUringChannelConfig {
     /**
      * Get the {@code TCP_KEEPINTVL} option on the socket. See {@code man 7 tcp} for more details.
      */
-    int getTcpKeepIntvl() {
+    private int getTcpKeepIntvl() {
         try {
             return ((IoUringSocketChannel) channel).socket.getTcpKeepIntvl();
         } catch (IOException e) {
@@ -292,7 +292,7 @@ final class IoUringSocketChannelConfig extends IoUringChannelConfig {
     /**
      * Get the {@code TCP_KEEPCNT} option on the socket. See {@code man 7 tcp} for more details.
      */
-    int getTcpKeepCnt() {
+    private int getTcpKeepCnt() {
         try {
             return ((IoUringSocketChannel) channel).socket.getTcpKeepCnt();
         } catch (IOException e) {
@@ -303,7 +303,7 @@ final class IoUringSocketChannelConfig extends IoUringChannelConfig {
     /**
      * Get the {@code TCP_USER_TIMEOUT} option on the socket. See {@code man 7 tcp} for more details.
      */
-    int getTcpUserTimeout() {
+    private int getTcpUserTimeout() {
         try {
             return ((IoUringSocketChannel) channel).socket.getTcpUserTimeout();
         } catch (IOException e) {
@@ -311,43 +311,39 @@ final class IoUringSocketChannelConfig extends IoUringChannelConfig {
         }
     }
 
-    IoUringSocketChannelConfig setKeepAlive(boolean keepAlive) {
+    private void setKeepAlive(boolean keepAlive) {
         try {
             ((IoUringSocketChannel) channel).socket.setKeepAlive(keepAlive);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    IoUringSocketChannelConfig setReceiveBufferSize(int receiveBufferSize) {
+    private void setReceiveBufferSize(int receiveBufferSize) {
         try {
             ((IoUringSocketChannel) channel).socket.setReceiveBufferSize(receiveBufferSize);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    IoUringSocketChannelConfig setReuseAddress(boolean reuseAddress) {
+    private void setReuseAddress(boolean reuseAddress) {
         try {
             ((IoUringSocketChannel) channel).socket.setReuseAddress(reuseAddress);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    IoUringSocketChannelConfig setSendBufferSize(int sendBufferSize) {
+    private void setSendBufferSize(int sendBufferSize) {
         try {
             ((IoUringSocketChannel) channel).socket.setSendBufferSize(sendBufferSize);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    int getReceiveBufferSize() {
+    private int getReceiveBufferSize() {
         try {
             return ((IoUringSocketChannel) channel).socket.getReceiveBufferSize();
         } catch (IOException e) {
@@ -355,19 +351,17 @@ final class IoUringSocketChannelConfig extends IoUringChannelConfig {
         }
     }
 
-    IoUringSocketChannelConfig setSoLinger(int soLinger) {
+    private void setSoLinger(int soLinger) {
         try {
             ((IoUringSocketChannel) channel).socket.setSoLinger(soLinger);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    IoUringSocketChannelConfig setTcpNoDelay(boolean tcpNoDelay) {
+    private void setTcpNoDelay(boolean tcpNoDelay) {
         try {
             ((IoUringSocketChannel) channel).socket.setTcpNoDelay(tcpNoDelay);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -376,10 +370,9 @@ final class IoUringSocketChannelConfig extends IoUringChannelConfig {
     /**
      * Set the {@code TCP_CORK} option on the socket. See {@code man 7 tcp} for more details.
      */
-    IoUringSocketChannelConfig setTcpCork(boolean tcpCork) {
+    private void setTcpCork(boolean tcpCork) {
         try {
             ((IoUringSocketChannel) channel).socket.setTcpCork(tcpCork);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -388,10 +381,9 @@ final class IoUringSocketChannelConfig extends IoUringChannelConfig {
     /**
      * Set the {@code SO_BUSY_POLL} option on the socket. See {@code man 7 tcp} for more details.
      */
-    IoUringSocketChannelConfig setSoBusyPoll(int loopMicros) {
+    private void setSoBusyPoll(int loopMicros) {
         try {
             ((IoUringSocketChannel) channel).socket.setSoBusyPoll(loopMicros);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -402,19 +394,17 @@ final class IoUringSocketChannelConfig extends IoUringChannelConfig {
      *
      * @param tcpNotSentLowAt is a uint32_t
      */
-    IoUringSocketChannelConfig setTcpNotSentLowAt(long tcpNotSentLowAt) {
+    private void setTcpNotSentLowAt(long tcpNotSentLowAt) {
         try {
             ((IoUringSocketChannel) channel).socket.setTcpNotSentLowAt(tcpNotSentLowAt);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    IoUringSocketChannelConfig setTrafficClass(int trafficClass) {
+    private void setTrafficClass(int trafficClass) {
         try {
             ((IoUringSocketChannel) channel).socket.setTrafficClass(trafficClass);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -423,10 +413,9 @@ final class IoUringSocketChannelConfig extends IoUringChannelConfig {
     /**
      * Set the {@code TCP_KEEPIDLE} option on the socket. See {@code man 7 tcp} for more details.
      */
-    IoUringSocketChannelConfig setTcpKeepIdle(int seconds) {
+    private void setTcpKeepIdle(int seconds) {
         try {
             ((IoUringSocketChannel) channel).socket.setTcpKeepIdle(seconds);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -435,10 +424,9 @@ final class IoUringSocketChannelConfig extends IoUringChannelConfig {
     /**
      * Set the {@code TCP_KEEPINTVL} option on the socket. See {@code man 7 tcp} for more details.
      */
-    IoUringSocketChannelConfig setTcpKeepIntvl(int seconds) {
+    private void setTcpKeepIntvl(int seconds) {
         try {
             ((IoUringSocketChannel) channel).socket.setTcpKeepIntvl(seconds);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -447,10 +435,9 @@ final class IoUringSocketChannelConfig extends IoUringChannelConfig {
     /**
      * Set the {@code TCP_KEEPCNT} option on the socket. See {@code man 7 tcp} for more details.
      */
-    IoUringSocketChannelConfig setTcpKeepCnt(int probes) {
+    private void setTcpKeepCnt(int probes) {
         try {
             ((IoUringSocketChannel) channel).socket.setTcpKeepCnt(probes);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -459,10 +446,9 @@ final class IoUringSocketChannelConfig extends IoUringChannelConfig {
     /**
      * Set the {@code TCP_USER_TIMEOUT} option on the socket. See {@code man 7 tcp} for more details.
      */
-    IoUringSocketChannelConfig setTcpUserTimeout(int milliseconds) {
+    private void setTcpUserTimeout(int milliseconds) {
         try {
             ((IoUringSocketChannel) channel).socket.setTcpUserTimeout(milliseconds);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -484,10 +470,9 @@ final class IoUringSocketChannelConfig extends IoUringChannelConfig {
      * If {@code true} is used <a href="https://man7.org/linux/man-pages/man7/ip.7.html">IP_TRANSPARENT</a> is enabled,
      * {@code false} for disable it. Default is disabled.
      */
-    IoUringSocketChannelConfig setIpTransparent(boolean transparent) {
+    private void setIpTransparent(boolean transparent) {
         try {
             ((IoUringSocketChannel) channel).socket.setIpTransparent(transparent);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -498,10 +483,9 @@ final class IoUringSocketChannelConfig extends IoUringChannelConfig {
 //     * on, not read to prevent a potential leak, as they are confidential. Allowing them being read would mean anyone
 //     * with access to the channel could get them.
 //     */
-//    public IOUringSocketChannelConfig setTcpMd5Sig(Map<InetAddress, byte[]> keys) {
+//    private void setTcpMd5Sig(Map<InetAddress, byte[]> keys) {
 //        try {
 //            ((IOUringSocketChannel) channel).setTcpMd5Sig(keys);
-//            return this;
 //        } catch (IOException e) {
 //            throw new ChannelException(e);
 //        }
@@ -511,10 +495,9 @@ final class IoUringSocketChannelConfig extends IoUringChannelConfig {
      * Set the {@code TCP_QUICKACK} option on the socket. See <a href="https://linux.die.net/man/7/tcp">TCP_QUICKACK</a>
      * for more details.
      */
-    IoUringSocketChannelConfig setTcpQuickAck(boolean quickAck) {
+    private void setTcpQuickAck(boolean quickAck) {
         try {
             ((IoUringSocketChannel) channel).socket.setTcpQuickAck(quickAck);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -524,7 +507,7 @@ final class IoUringSocketChannelConfig extends IoUringChannelConfig {
      * Returns {@code true} if <a href="https://linux.die.net/man/7/tcp">TCP_QUICKACK</a> is enabled, {@code false}
      * otherwise.
      */
-    boolean isTcpQuickAck() {
+    private boolean isTcpQuickAck() {
         try {
             return ((IoUringSocketChannel) channel).socket.isTcpQuickAck();
         } catch (IOException e) {
@@ -535,15 +518,14 @@ final class IoUringSocketChannelConfig extends IoUringChannelConfig {
     /**
      * Enables client TCP fast open. See this <a href="https://lwn.net/Articles/508865/">LWN article</a> for more info.
      */
-    IoUringSocketChannelConfig setTcpFastOpenConnect(boolean fastOpenConnect) {
+    private void setTcpFastOpenConnect(boolean fastOpenConnect) {
         this.tcpFastopen = fastOpenConnect;
-        return this;
     }
 
     /**
      * Returns {@code true} if {@code TCP_FASTOPEN_CONNECT} is enabled, {@code false} otherwise.
      */
-    boolean isTcpFastOpenConnect() {
+    private boolean isTcpFastOpenConnect() {
         return tcpFastopen;
     }
 
@@ -551,23 +533,21 @@ final class IoUringSocketChannelConfig extends IoUringChannelConfig {
         return allowHalfClosure;
     }
 
-    IoUringSocketChannelConfig setAllowHalfClosure(boolean allowHalfClosure) {
+    private void setAllowHalfClosure(boolean allowHalfClosure) {
         this.allowHalfClosure = allowHalfClosure;
-        return this;
     }
 
     private int getWriteZeroCopyThreshold() {
         return writeZeroCopyThreshold;
     }
 
-    IoUringSocketChannelConfig setWriteZeroCopyThreshold(int setWriteZeroCopyThreshold) {
+    private void setWriteZeroCopyThreshold(int setWriteZeroCopyThreshold) {
         if (setWriteZeroCopyThreshold == DISABLE_WRITE_ZERO_COPY) {
             this.writeZeroCopyThreshold = DISABLE_WRITE_ZERO_COPY;
         } else {
             this.writeZeroCopyThreshold =
                     ObjectUtil.checkPositiveOrZero(setWriteZeroCopyThreshold, "setWriteZeroCopyThreshold");
         }
-        return this;
     }
 
     boolean shouldWriteZeroCopy(int amount) {
@@ -576,7 +556,7 @@ final class IoUringSocketChannelConfig extends IoUringChannelConfig {
         return threshold != DISABLE_WRITE_ZERO_COPY && amount >= threshold;
     }
 
-    IoUringSocketChannelConfig setReadMode(DomainSocketReadMode mode) {
+    private void setReadMode(DomainSocketReadMode mode) {
         ObjectUtil.checkNotNull(mode, "mode");
         DomainSocketReadMode expectedMode = mode == DomainSocketReadMode.BYTES ?
                 DomainSocketReadMode.FILE_DESCRIPTORS : DomainSocketReadMode.BYTES;
@@ -587,7 +567,6 @@ final class IoUringSocketChannelConfig extends IoUringChannelConfig {
                 ((AbstractIoUringChannel) channel).autoReadCleared();
             }
         }
-        return this;
     }
 
     DomainSocketReadMode getReadMode() {

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueChannelConfig.java
@@ -15,26 +15,21 @@
  */
 package io.netty.channel.kqueue;
 
-import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.DefaultChannelConfig;
-import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
-import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.unix.IntegerUnixChannelOption;
 import io.netty.channel.unix.RawUnixChannelOption;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Map;
 
-import static io.netty.channel.kqueue.KQueueChannelOption.RCV_ALLOC_TRANSPORT_PROVIDES_GUESS;
 import static io.netty.channel.unix.Limits.SSIZE_MAX;
 import static java.lang.Math.min;
 
-public class KQueueChannelConfig extends DefaultChannelConfig {
-    private volatile boolean transportProvidesGuess;
+class KQueueChannelConfig extends DefaultChannelConfig {
     private volatile long maxBytesPerGatheringWrite = SSIZE_MAX;
 
     KQueueChannelConfig(AbstractKQueueChannel channel) {
@@ -45,18 +40,9 @@ public class KQueueChannelConfig extends DefaultChannelConfig {
         super(channel, recvByteBufAllocator);
     }
 
-    @Override
-    @SuppressWarnings("deprecation")
-    public Map<ChannelOption<?>, Object> getOptions() {
-        return getOptions(super.getOptions(), RCV_ALLOC_TRANSPORT_PROVIDES_GUESS);
-    }
-
     @SuppressWarnings("unchecked")
     @Override
     public <T> T getOption(ChannelOption<T> option) {
-        if (option == RCV_ALLOC_TRANSPORT_PROVIDES_GUESS) {
-            return (T) Boolean.valueOf(getRcvAllocTransportProvidesGuess());
-        }
         try {
             if (option instanceof IntegerUnixChannelOption) {
                 IntegerUnixChannelOption opt = (IntegerUnixChannelOption) option;
@@ -79,115 +65,29 @@ public class KQueueChannelConfig extends DefaultChannelConfig {
     public <T> boolean setOption(ChannelOption<T> option, T value) {
         validate(option, value);
 
-        if (option == RCV_ALLOC_TRANSPORT_PROVIDES_GUESS) {
-            setRcvAllocTransportProvidesGuess((Boolean) value);
-        } else {
-            try {
-                if (option instanceof IntegerUnixChannelOption) {
-                    IntegerUnixChannelOption opt = (IntegerUnixChannelOption) option;
-                    ((AbstractKQueueChannel) channel).socket.setIntOpt(opt.level(), opt.optname(), (Integer) value);
-                    return true;
-                } else if (option instanceof RawUnixChannelOption) {
-                    RawUnixChannelOption opt = (RawUnixChannelOption) option;
-                    ((AbstractKQueueChannel) channel).socket.setRawOpt(opt.level(), opt.optname(), (ByteBuffer) value);
-                    return true;
-                }
-            } catch (IOException e) {
-                throw new ChannelException(e);
+        try {
+            if (option instanceof IntegerUnixChannelOption) {
+                IntegerUnixChannelOption opt = (IntegerUnixChannelOption) option;
+                ((AbstractKQueueChannel) channel).socket.setIntOpt(opt.level(), opt.optname(), (Integer) value);
+                return true;
+            } else if (option instanceof RawUnixChannelOption) {
+                RawUnixChannelOption opt = (RawUnixChannelOption) option;
+                ((AbstractKQueueChannel) channel).socket.setRawOpt(opt.level(), opt.optname(), (ByteBuffer) value);
+                return true;
             }
-            return super.setOption(option, value);
+        } catch (IOException e) {
+            throw new ChannelException(e);
         }
-
-        return true;
-    }
-
-    /**
-     * If this is {@code true} then the {@link RecvByteBufAllocator.Handle#guess()} will be overridden to always attempt
-     * to read as many bytes as kqueue says are available.
-     *
-     * @deprecated will be removed and is ignored.
-     */
-    @Deprecated
-    public KQueueChannelConfig setRcvAllocTransportProvidesGuess(boolean transportProvidesGuess) {
-        this.transportProvidesGuess = transportProvidesGuess;
-        return this;
-    }
-
-    /**
-     * If this is {@code true} then the {@link RecvByteBufAllocator.Handle#guess()} will be overridden to always attempt
-     * to read as many bytes as kqueue says are available.
-     *
-     * @deprecated will be removed and is ignored.
-     */
-    @Deprecated
-    public boolean getRcvAllocTransportProvidesGuess() {
-        return transportProvidesGuess;
+        return super.setOption(option, value);
     }
 
     @Override
-    public KQueueChannelConfig setConnectTimeoutMillis(int connectTimeoutMillis) {
-        super.setConnectTimeoutMillis(connectTimeoutMillis);
-        return this;
-    }
-
-    @Override
-    @Deprecated
-    public KQueueChannelConfig setMaxMessagesPerRead(int maxMessagesPerRead) {
-        super.setMaxMessagesPerRead(maxMessagesPerRead);
-        return this;
-    }
-
-    @Override
-    public KQueueChannelConfig setWriteSpinCount(int writeSpinCount) {
-        super.setWriteSpinCount(writeSpinCount);
-        return this;
-    }
-
-    @Override
-    public KQueueChannelConfig setAllocator(ByteBufAllocator allocator) {
-        super.setAllocator(allocator);
-        return this;
-    }
-
-    @Override
-    public KQueueChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
+    public ChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
         if (!(allocator.newHandle() instanceof RecvByteBufAllocator.ExtendedHandle)) {
             throw new IllegalArgumentException("allocator.newHandle() must return an object of type: " +
                     RecvByteBufAllocator.ExtendedHandle.class);
         }
         super.setRecvByteBufAllocator(allocator);
-        return this;
-    }
-
-    @Override
-    public KQueueChannelConfig setAutoRead(boolean autoRead) {
-        super.setAutoRead(autoRead);
-        return this;
-    }
-
-    @Override
-    @Deprecated
-    public KQueueChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
-        super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
-        return this;
-    }
-
-    @Override
-    @Deprecated
-    public KQueueChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
-        super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
-        return this;
-    }
-
-    @Override
-    public KQueueChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark) {
-        super.setWriteBufferWaterMark(writeBufferWaterMark);
-        return this;
-    }
-
-    @Override
-    public KQueueChannelConfig setMessageSizeEstimator(MessageSizeEstimator estimator) {
-        super.setMessageSizeEstimator(estimator);
         return this;
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueChannelOption.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueChannelOption.java
@@ -16,7 +16,6 @@
 package io.netty.channel.kqueue;
 
 import io.netty.channel.ChannelOption;
-import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.unix.UnixChannelOption;
 
 public final class KQueueChannelOption<T> extends UnixChannelOption<T> {
@@ -24,14 +23,6 @@ public final class KQueueChannelOption<T> extends UnixChannelOption<T> {
     public static final ChannelOption<Boolean> TCP_NOPUSH = valueOf(KQueueChannelOption.class, "TCP_NOPUSH");
     public static final ChannelOption<AcceptFilter> SO_ACCEPTFILTER =
             valueOf(KQueueChannelOption.class, "SO_ACCEPTFILTER");
-    /**
-     * If this is {@code true} then the {@link RecvByteBufAllocator.Handle#guess()} will be overridden to always attempt
-     * to read as many bytes as kqueue says are available.
-     */
-    @Deprecated
-    public static final ChannelOption<Boolean> RCV_ALLOC_TRANSPORT_PROVIDES_GUESS =
-            valueOf(KQueueChannelOption.class, "RCV_ALLOC_TRANSPORT_PROVIDES_GUESS");
-
     @SuppressWarnings({ "unused", "deprecation" })
     private KQueueChannelOption() {
     }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
@@ -180,7 +180,7 @@ public final class KQueueDatagramChannel extends AbstractKQueueChannel implement
             case INET6:
             case INET:
                 try {
-                    NetworkInterface iface = config().getNetworkInterface();
+                    NetworkInterface iface = config().getOption(KQueueChannelOption.IP_MULTICAST_IF);
                     if (iface == null) {
                         iface = NetworkInterface.getByInetAddress(((InetSocketAddress) localAddress()).getAddress());
                     }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannelConfig.java
@@ -140,7 +140,7 @@ public final class KQueueDatagramChannelConfig extends KQueueChannelConfig {
     /**
      * Returns {@code true} if the SO_REUSEPORT option is set.
      */
-    public boolean isReusePort() {
+    private boolean isReusePort() {
         try {
             return ((KQueueDatagramChannel) channel).socket.isReusePort();
         } catch (IOException e) {
@@ -155,16 +155,15 @@ public final class KQueueDatagramChannelConfig extends KQueueChannelConfig {
      * Be aware this method needs be called before {@link KQueueDatagramChannel#bind(java.net.SocketAddress)} to have
      * any affect.
      */
-    public KQueueDatagramChannelConfig setReusePort(boolean reusePort) {
+    private void setReusePort(boolean reusePort) {
         try {
             ((KQueueDatagramChannel) channel).socket.setReusePort(reusePort);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    int getSendBufferSize() {
+    private int getSendBufferSize() {
         try {
             return ((KQueueDatagramChannel) channel).socket.getSendBufferSize();
         } catch (IOException e) {
@@ -172,16 +171,15 @@ public final class KQueueDatagramChannelConfig extends KQueueChannelConfig {
         }
     }
 
-    KQueueDatagramChannelConfig setSendBufferSize(int sendBufferSize) {
+    private void setSendBufferSize(int sendBufferSize) {
         try {
             ((KQueueDatagramChannel) channel).socket.setSendBufferSize(sendBufferSize);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    int getReceiveBufferSize() {
+    private int getReceiveBufferSize() {
         try {
             return ((KQueueDatagramChannel) channel).socket.getReceiveBufferSize();
         } catch (IOException e) {
@@ -189,16 +187,15 @@ public final class KQueueDatagramChannelConfig extends KQueueChannelConfig {
         }
     }
 
-    KQueueDatagramChannelConfig setReceiveBufferSize(int receiveBufferSize) {
+    private void setReceiveBufferSize(int receiveBufferSize) {
         try {
             ((KQueueDatagramChannel) channel).socket.setReceiveBufferSize(receiveBufferSize);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    int getTrafficClass() {
+    private int getTrafficClass() {
         try {
             return ((KQueueDatagramChannel) channel).socket.getTrafficClass();
         } catch (IOException e) {
@@ -206,16 +203,15 @@ public final class KQueueDatagramChannelConfig extends KQueueChannelConfig {
         }
     }
 
-    KQueueDatagramChannelConfig setTrafficClass(int trafficClass) {
+    private void setTrafficClass(int trafficClass) {
         try {
             ((KQueueDatagramChannel) channel).socket.setTrafficClass(trafficClass);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    boolean isReuseAddress() {
+    private boolean isReuseAddress() {
         try {
             return ((KQueueDatagramChannel) channel).socket.isReuseAddress();
         } catch (IOException e) {
@@ -223,16 +219,15 @@ public final class KQueueDatagramChannelConfig extends KQueueChannelConfig {
         }
     }
 
-    KQueueDatagramChannelConfig setReuseAddress(boolean reuseAddress) {
+    private void setReuseAddress(boolean reuseAddress) {
         try {
             ((KQueueDatagramChannel) channel).socket.setReuseAddress(reuseAddress);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    boolean isBroadcast() {
+    private boolean isBroadcast() {
         try {
             return ((KQueueDatagramChannel) channel).socket.isBroadcast();
         } catch (IOException e) {
@@ -240,20 +235,19 @@ public final class KQueueDatagramChannelConfig extends KQueueChannelConfig {
         }
     }
 
-    KQueueDatagramChannelConfig setBroadcast(boolean broadcast) {
+    private void setBroadcast(boolean broadcast) {
         try {
             ((KQueueDatagramChannel) channel).socket.setBroadcast(broadcast);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    boolean isLoopbackModeDisabled() {
+    private boolean isLoopbackModeDisabled() {
         return false;
     }
 
-    KQueueDatagramChannelConfig setLoopbackModeDisabled(boolean loopbackModeDisabled) {
+    private void setLoopbackModeDisabled(boolean loopbackModeDisabled) {
         throw new UnsupportedOperationException("Multicast not supported");
     }
 
@@ -261,23 +255,23 @@ public final class KQueueDatagramChannelConfig extends KQueueChannelConfig {
         return -1;
     }
 
-    KQueueDatagramChannelConfig setTimeToLive(int ttl) {
+    private void setTimeToLive(int ttl) {
         throw new UnsupportedOperationException("Multicast not supported");
     }
 
-    InetAddress getInterface() {
+    private InetAddress getInterface() {
         return null;
     }
 
-    KQueueDatagramChannelConfig setInterface(InetAddress interfaceAddress) {
+    private void setInterface(InetAddress interfaceAddress) {
         throw new UnsupportedOperationException("Multicast not supported");
     }
 
-    NetworkInterface getNetworkInterface() {
+    private NetworkInterface getNetworkInterface() {
         return null;
     }
 
-    KQueueDatagramChannelConfig setNetworkInterface(NetworkInterface networkInterface) {
+    private void setNetworkInterface(NetworkInterface networkInterface) {
         throw new UnsupportedOperationException("Multicast not supported");
     }
 }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerSocketChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerSocketChannelConfig.java
@@ -15,12 +15,8 @@
  */
 package io.netty.channel.kqueue;
 
-import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOption;
-import io.netty.channel.MessageSizeEstimator;
-import io.netty.channel.RecvByteBufAllocator;
-import io.netty.channel.WriteBufferWaterMark;
 import io.netty.util.NetUtil;
 
 import java.io.IOException;
@@ -100,16 +96,15 @@ final class KQueueServerSocketChannelConfig extends KQueueChannelConfig {
         return true;
     }
 
-    public KQueueServerSocketChannelConfig setReusePort(boolean reusePort) {
+    private void setReusePort(boolean reusePort) {
         try {
             ((AbstractKQueueChannel) channel).socket.setReusePort(reusePort);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    public boolean isReusePort() {
+    private boolean isReusePort() {
         try {
             return ((AbstractKQueueChannel) channel).socket.isReusePort();
         } catch (IOException e) {
@@ -117,16 +112,15 @@ final class KQueueServerSocketChannelConfig extends KQueueChannelConfig {
         }
     }
 
-    public KQueueServerSocketChannelConfig setAcceptFilter(AcceptFilter acceptFilter) {
+    private void setAcceptFilter(AcceptFilter acceptFilter) {
         try {
             ((AbstractKQueueChannel) channel).socket.setAcceptFilter(acceptFilter);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    public AcceptFilter getAcceptFilter() {
+    private AcceptFilter getAcceptFilter() {
         try {
             return ((AbstractKQueueChannel) channel).socket.getAcceptFilter();
         } catch (IOException e) {
@@ -134,7 +128,7 @@ final class KQueueServerSocketChannelConfig extends KQueueChannelConfig {
         }
     }
 
-    boolean isReuseAddress() {
+    private boolean isReuseAddress() {
         try {
             return ((AbstractKQueueChannel) channel).socket.isReuseAddress();
         } catch (IOException e) {
@@ -142,16 +136,15 @@ final class KQueueServerSocketChannelConfig extends KQueueChannelConfig {
         }
     }
 
-    KQueueServerSocketChannelConfig setReuseAddress(boolean reuseAddress) {
+    private void setReuseAddress(boolean reuseAddress) {
         try {
             ((AbstractKQueueChannel) channel).socket.setReuseAddress(reuseAddress);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    int getReceiveBufferSize() {
+    private int getReceiveBufferSize() {
         try {
             return ((AbstractKQueueChannel) channel).socket.getReceiveBufferSize();
         } catch (IOException e) {
@@ -159,10 +152,9 @@ final class KQueueServerSocketChannelConfig extends KQueueChannelConfig {
         }
     }
 
-    KQueueServerSocketChannelConfig setReceiveBufferSize(int receiveBufferSize) {
+    private void setReceiveBufferSize(int receiveBufferSize) {
         try {
             ((AbstractKQueueChannel) channel).socket.setReceiveBufferSize(receiveBufferSize);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -172,10 +164,9 @@ final class KQueueServerSocketChannelConfig extends KQueueChannelConfig {
         return backlog;
     }
 
-    KQueueServerSocketChannelConfig setBacklog(int backlog) {
+    private void setBacklog(int backlog) {
         checkPositiveOrZero(backlog, "backlog");
         this.backlog = backlog;
-        return this;
     }
 
     /**
@@ -195,77 +186,7 @@ final class KQueueServerSocketChannelConfig extends KQueueChannelConfig {
      *
      * @see <a href="https://tools.ietf.org/html/rfc7413#appendix-A.2">RFC 7413 Passive Open</a>
      */
-    KQueueServerSocketChannelConfig setTcpFastOpen(boolean enableTcpFastOpen) {
+    private void setTcpFastOpen(boolean enableTcpFastOpen) {
         this.enableTcpFastOpen = enableTcpFastOpen;
-        return this;
-    }
-
-    @Override
-    public KQueueServerSocketChannelConfig setRcvAllocTransportProvidesGuess(boolean transportProvidesGuess) {
-        super.setRcvAllocTransportProvidesGuess(transportProvidesGuess);
-        return this;
-    }
-
-    @Override
-    public KQueueServerSocketChannelConfig setConnectTimeoutMillis(int connectTimeoutMillis) {
-        super.setConnectTimeoutMillis(connectTimeoutMillis);
-        return this;
-    }
-
-    @Override
-    @Deprecated
-    public KQueueServerSocketChannelConfig setMaxMessagesPerRead(int maxMessagesPerRead) {
-        super.setMaxMessagesPerRead(maxMessagesPerRead);
-        return this;
-    }
-
-    @Override
-    public KQueueServerSocketChannelConfig setWriteSpinCount(int writeSpinCount) {
-        super.setWriteSpinCount(writeSpinCount);
-        return this;
-    }
-
-    @Override
-    public KQueueServerSocketChannelConfig setAllocator(ByteBufAllocator allocator) {
-        super.setAllocator(allocator);
-        return this;
-    }
-
-    @Override
-    public KQueueServerSocketChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
-        super.setRecvByteBufAllocator(allocator);
-        return this;
-    }
-
-    @Override
-    public KQueueServerSocketChannelConfig setAutoRead(boolean autoRead) {
-        super.setAutoRead(autoRead);
-        return this;
-    }
-
-    @Override
-    @Deprecated
-    public KQueueServerSocketChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
-        super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
-        return this;
-    }
-
-    @Override
-    @Deprecated
-    public KQueueServerSocketChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
-        super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
-        return this;
-    }
-
-    @Override
-    public KQueueServerSocketChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark) {
-        super.setWriteBufferWaterMark(writeBufferWaterMark);
-        return this;
-    }
-
-    @Override
-    public KQueueServerSocketChannelConfig setMessageSizeEstimator(MessageSizeEstimator estimator) {
-        super.setMessageSizeEstimator(estimator);
-        return this;
     }
 }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannelConfig.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannelConfig.java
@@ -63,9 +63,8 @@ final class KQueueSocketChannelConfig extends KQueueChannelConfig {
         return options;
     }
 
-    KQueueSocketChannelConfig setReadMode(DomainSocketReadMode mode) {
+    private void setReadMode(DomainSocketReadMode mode) {
         this.mode = ObjectUtil.checkNotNull(mode, "mode");
-        return this;
     }
 
     DomainSocketReadMode getReadMode() {
@@ -151,7 +150,7 @@ final class KQueueSocketChannelConfig extends KQueueChannelConfig {
         return true;
     }
 
-    int getReceiveBufferSize() {
+    private int getReceiveBufferSize() {
         try {
             return ((AbstractKQueueChannel) channel).socket.getReceiveBufferSize();
         } catch (IOException e) {
@@ -159,7 +158,7 @@ final class KQueueSocketChannelConfig extends KQueueChannelConfig {
         }
     }
 
-    int getSendBufferSize() {
+    private int getSendBufferSize() {
         try {
             return ((AbstractKQueueChannel) channel).socket.getSendBufferSize();
         } catch (IOException e) {
@@ -175,7 +174,7 @@ final class KQueueSocketChannelConfig extends KQueueChannelConfig {
         }
     }
 
-    int getTrafficClass() {
+    private int getTrafficClass() {
         try {
             return ((AbstractKQueueChannel) channel).socket.getTrafficClass();
         } catch (IOException e) {
@@ -183,7 +182,7 @@ final class KQueueSocketChannelConfig extends KQueueChannelConfig {
         }
     }
 
-    boolean isKeepAlive() {
+    private boolean isKeepAlive() {
         try {
             return ((AbstractKQueueChannel) channel).socket.isKeepAlive();
         } catch (IOException e) {
@@ -191,7 +190,7 @@ final class KQueueSocketChannelConfig extends KQueueChannelConfig {
         }
     }
 
-    boolean isReuseAddress() {
+    private boolean isReuseAddress() {
         try {
             return ((AbstractKQueueChannel) channel).socket.isReuseAddress();
         } catch (IOException e) {
@@ -199,7 +198,7 @@ final class KQueueSocketChannelConfig extends KQueueChannelConfig {
         }
     }
 
-    boolean isTcpNoDelay() {
+    private boolean isTcpNoDelay() {
         try {
             return ((AbstractKQueueChannel) channel).socket.isTcpNoDelay();
         } catch (IOException e) {
@@ -207,7 +206,7 @@ final class KQueueSocketChannelConfig extends KQueueChannelConfig {
         }
     }
 
-    int getSndLowAt() {
+    private int getSndLowAt() {
         try {
             return ((AbstractKQueueChannel) channel).socket.getSndLowAt();
         } catch (IOException e) {
@@ -215,7 +214,7 @@ final class KQueueSocketChannelConfig extends KQueueChannelConfig {
         }
     }
 
-    void setSndLowAt(int sndLowAt)  {
+    private void setSndLowAt(int sndLowAt)  {
         try {
             ((AbstractKQueueChannel) channel).socket.setSndLowAt(sndLowAt);
         } catch (IOException e) {
@@ -223,7 +222,7 @@ final class KQueueSocketChannelConfig extends KQueueChannelConfig {
         }
     }
 
-    boolean isTcpNoPush() {
+    private boolean isTcpNoPush() {
         try {
             return ((AbstractKQueueChannel) channel).socket.isTcpNoPush();
         } catch (IOException e) {
@@ -231,7 +230,7 @@ final class KQueueSocketChannelConfig extends KQueueChannelConfig {
         }
     }
 
-    void setTcpNoPush(boolean tcpNoPush)  {
+    private void setTcpNoPush(boolean tcpNoPush)  {
         try {
             ((AbstractKQueueChannel) channel).socket.setTcpNoPush(tcpNoPush);
         } catch (IOException e) {
@@ -239,65 +238,58 @@ final class KQueueSocketChannelConfig extends KQueueChannelConfig {
         }
     }
 
-    KQueueSocketChannelConfig setKeepAlive(boolean keepAlive) {
+    private void setKeepAlive(boolean keepAlive) {
         try {
             ((AbstractKQueueChannel) channel).socket.setKeepAlive(keepAlive);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    KQueueSocketChannelConfig setReceiveBufferSize(int receiveBufferSize) {
+    private void setReceiveBufferSize(int receiveBufferSize) {
         try {
             ((AbstractKQueueChannel) channel).socket.setReceiveBufferSize(receiveBufferSize);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    KQueueSocketChannelConfig setReuseAddress(boolean reuseAddress) {
+    private void setReuseAddress(boolean reuseAddress) {
         try {
             ((AbstractKQueueChannel) channel).socket.setReuseAddress(reuseAddress);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    KQueueSocketChannelConfig setSendBufferSize(int sendBufferSize) {
+    private void setSendBufferSize(int sendBufferSize) {
         try {
             ((AbstractKQueueChannel) channel).socket.setSendBufferSize(sendBufferSize);
             calculateMaxBytesPerGatheringWrite();
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    KQueueSocketChannelConfig setSoLinger(int soLinger) {
+    private void setSoLinger(int soLinger) {
         try {
             ((AbstractKQueueChannel) channel).socket.setSoLinger(soLinger);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    KQueueSocketChannelConfig setTcpNoDelay(boolean tcpNoDelay) {
+    private void setTcpNoDelay(boolean tcpNoDelay) {
         try {
             ((AbstractKQueueChannel) channel).socket.setTcpNoDelay(tcpNoDelay);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
-    KQueueSocketChannelConfig setTrafficClass(int trafficClass) {
+    private void setTrafficClass(int trafficClass) {
         try {
             ((AbstractKQueueChannel) channel).socket.setTrafficClass(trafficClass);
-            return this;
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -310,9 +302,8 @@ final class KQueueSocketChannelConfig extends KQueueChannelConfig {
     /**
      * Enables client TCP fast open, if available.
      */
-    KQueueSocketChannelConfig setTcpFastOpenConnect(boolean fastOpenConnect) {
+    private void setTcpFastOpenConnect(boolean fastOpenConnect) {
         tcpFastopen = fastOpenConnect;
-        return this;
     }
 
     /**
@@ -322,9 +313,8 @@ final class KQueueSocketChannelConfig extends KQueueChannelConfig {
         return tcpFastopen;
     }
 
-    public KQueueSocketChannelConfig setAllowHalfClosure(boolean allowHalfClosure) {
+    private void setAllowHalfClosure(boolean allowHalfClosure) {
         this.allowHalfClosure = allowHalfClosure;
-        return this;
     }
 
     private void calculateMaxBytesPerGatheringWrite() {

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpServerChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpServerChannel.java
@@ -305,7 +305,7 @@ public class NioSctpServerChannel extends AbstractNioMessageChannel
             return true;
         }
 
-        int getSendBufferSize() {
+        private int getSendBufferSize() {
             try {
                 return javaChannel.getOption(SctpStandardSocketOptions.SO_SNDBUF);
             } catch (IOException e) {
@@ -313,16 +313,15 @@ public class NioSctpServerChannel extends AbstractNioMessageChannel
             }
         }
 
-        NioSctpServerChannelConfig setSendBufferSize(int sendBufferSize) {
+        private void setSendBufferSize(int sendBufferSize) {
             try {
                 javaChannel.setOption(SctpStandardSocketOptions.SO_SNDBUF, sendBufferSize);
             } catch (IOException e) {
                 throw new ChannelException(e);
             }
-            return this;
         }
 
-        int getReceiveBufferSize() {
+        private int getReceiveBufferSize() {
             try {
                 return javaChannel.getOption(SctpStandardSocketOptions.SO_RCVBUF);
             } catch (IOException e) {
@@ -330,13 +329,12 @@ public class NioSctpServerChannel extends AbstractNioMessageChannel
             }
         }
 
-        NioSctpServerChannelConfig setReceiveBufferSize(int receiveBufferSize) {
+        private void setReceiveBufferSize(int receiveBufferSize) {
             try {
                 javaChannel.setOption(SctpStandardSocketOptions.SO_RCVBUF, receiveBufferSize);
             } catch (IOException e) {
                 throw new ChannelException(e);
             }
-            return this;
         }
 
         SctpStandardSocketOptions.InitMaxStreams getInitMaxStreams() {
@@ -347,23 +345,21 @@ public class NioSctpServerChannel extends AbstractNioMessageChannel
             }
         }
 
-        NioSctpServerChannelConfig setInitMaxStreams(SctpStandardSocketOptions.InitMaxStreams initMaxStreams) {
+        private void setInitMaxStreams(SctpStandardSocketOptions.InitMaxStreams initMaxStreams) {
             try {
                 javaChannel.setOption(SctpStandardSocketOptions.SCTP_INIT_MAXSTREAMS, initMaxStreams);
             } catch (IOException e) {
                 throw new ChannelException(e);
             }
-            return this;
         }
 
         int getBacklog() {
             return backlog;
         }
 
-        NioSctpServerChannelConfig setBacklog(int backlog) {
+        private void setBacklog(int backlog) {
             checkPositiveOrZero(backlog, "backlog");
             this.backlog = backlog;
-            return this;
         }
 
         @Override

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
@@ -725,7 +725,7 @@ public final class NioDatagramChannel
             }
         }
 
-        NioDatagramChannelConfig setBroadcast(boolean broadcast) {
+        private void setBroadcast(boolean broadcast) {
             try {
                 // See: https://github.com/netty/netty/issues/576
                 if (broadcast &&
@@ -750,7 +750,6 @@ public final class NioDatagramChannel
             } catch (IOException e) {
                 throw new ChannelException(e);
             }
-            return this;
         }
 
         InetAddress getInterface() {
@@ -765,13 +764,12 @@ public final class NioDatagramChannel
             return null;
         }
 
-        NioDatagramChannelConfig setInterface(InetAddress interfaceAddress) {
+        private void setInterface(InetAddress interfaceAddress) {
             try {
                 setNetworkInterface(NetworkInterface.getByInetAddress(interfaceAddress));
             } catch (SocketException e) {
                 throw new ChannelException(e);
             }
-            return this;
         }
 
         boolean isLoopbackModeDisabled() {
@@ -782,13 +780,12 @@ public final class NioDatagramChannel
             }
         }
 
-        NioDatagramChannelConfig setLoopbackModeDisabled(boolean loopbackModeDisabled) {
+        private void setLoopbackModeDisabled(boolean loopbackModeDisabled) {
             try {
                 jdkChannel.setOption(StandardSocketOptions.IP_MULTICAST_LOOP, loopbackModeDisabled);
             } catch (IOException e) {
                 throw new ChannelException(e);
             }
-            return this;
         }
 
         NetworkInterface getNetworkInterface() {
@@ -799,16 +796,15 @@ public final class NioDatagramChannel
             }
         }
 
-        NioDatagramChannelConfig setNetworkInterface(NetworkInterface networkInterface) {
+        private void setNetworkInterface(NetworkInterface networkInterface) {
             try {
                 jdkChannel.setOption(StandardSocketOptions.IP_MULTICAST_IF, networkInterface);
             } catch (IOException e) {
                 throw new ChannelException(e);
             }
-            return this;
         }
 
-        boolean isReuseAddress() {
+        private boolean isReuseAddress() {
             try {
                 return jdkChannel.getOption(StandardSocketOptions.SO_REUSEADDR);
             } catch (IOException e) {
@@ -816,16 +812,15 @@ public final class NioDatagramChannel
             }
         }
 
-        NioDatagramChannelConfig setReuseAddress(boolean reuseAddress) {
+        private void setReuseAddress(boolean reuseAddress) {
             try {
                 jdkChannel.setOption(StandardSocketOptions.SO_REUSEADDR, reuseAddress);
             } catch (IOException e) {
                 throw new ChannelException(e);
             }
-            return this;
         }
 
-        int getReceiveBufferSize() {
+        private int getReceiveBufferSize() {
             try {
                 return jdkChannel.getOption(StandardSocketOptions.SO_RCVBUF);
             } catch (IOException e) {
@@ -833,16 +828,15 @@ public final class NioDatagramChannel
             }
         }
 
-        NioDatagramChannelConfig setReceiveBufferSize(int receiveBufferSize) {
+        private void setReceiveBufferSize(int receiveBufferSize) {
             try {
                 jdkChannel.setOption(StandardSocketOptions.SO_RCVBUF, receiveBufferSize);
             } catch (IOException e) {
                 throw new ChannelException(e);
             }
-            return this;
         }
 
-        int getSendBufferSize() {
+        private int getSendBufferSize() {
             try {
                 return jdkChannel.getOption(StandardSocketOptions.SO_SNDBUF);
             } catch (IOException e) {
@@ -850,16 +844,15 @@ public final class NioDatagramChannel
             }
         }
 
-        NioDatagramChannelConfig setSendBufferSize(int sendBufferSize) {
+        private void setSendBufferSize(int sendBufferSize) {
             try {
                 jdkChannel.setOption(StandardSocketOptions.SO_SNDBUF, sendBufferSize);
             } catch (IOException e) {
                 throw new ChannelException(e);
             }
-            return this;
         }
 
-        int getTimeToLive() {
+        private int getTimeToLive() {
             try {
                 return jdkChannel.getOption(StandardSocketOptions.IP_MULTICAST_TTL);
             } catch (IOException e) {
@@ -867,16 +860,15 @@ public final class NioDatagramChannel
             }
         }
 
-        NioDatagramChannelConfig setTimeToLive(int ttl) {
+        private void setTimeToLive(int ttl) {
             try {
                 jdkChannel.setOption(StandardSocketOptions.IP_MULTICAST_TTL, ttl);
             } catch (IOException e) {
                 throw new ChannelException(e);
             }
-            return this;
         }
 
-        int getTrafficClass() {
+        private int getTrafficClass() {
             try {
                 return jdkChannel.getOption(StandardSocketOptions.IP_TOS);
             } catch (IOException e) {
@@ -884,13 +876,12 @@ public final class NioDatagramChannel
             }
         }
 
-        NioDatagramChannelConfig setTrafficClass(int trafficClass) {
+        private void setTrafficClass(int trafficClass) {
             try {
                 jdkChannel.setOption(StandardSocketOptions.IP_TOS, trafficClass);
             } catch (IOException e) {
                 throw new ChannelException(e);
             }
-            return this;
         }
 
         @Override

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioServerSocketChannel.java
@@ -312,28 +312,25 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel
             return NioChannelOption.getOption0(jdkChannel, StandardSocketOptions.SO_REUSEADDR);
         }
 
-        private NioServerSocketChannelConfig setReuseAddress(boolean reuseAddress) {
+        private void setReuseAddress(boolean reuseAddress) {
             NioChannelOption.setOption0(jdkChannel, StandardSocketOptions.SO_REUSEADDR, reuseAddress);
-            return this;
         }
 
         private int getReceiveBufferSize() {
             return NioChannelOption.getOption0(jdkChannel, StandardSocketOptions.SO_RCVBUF);
         }
 
-        private NioServerSocketChannelConfig setReceiveBufferSize(int receiveBufferSize) {
+        private void setReceiveBufferSize(int receiveBufferSize) {
             NioChannelOption.setOption0(jdkChannel, StandardSocketOptions.SO_RCVBUF, receiveBufferSize);
-            return this;
         }
 
         private int getBacklog() {
             return backlog;
         }
 
-        private NioServerSocketChannelConfig setBacklog(int backlog) {
+        private void setBacklog(int backlog) {
             checkPositiveOrZero(backlog, "backlog");
             this.backlog = backlog;
-            return this;
         }
     }
 

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
@@ -576,77 +576,69 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
             return true;
         }
 
-        int getReceiveBufferSize() {
+        private int getReceiveBufferSize() {
             return NioChannelOption.getOption0(jdkChannel, StandardSocketOptions.SO_RCVBUF);
         }
 
-        int getSendBufferSize() {
+        private int getSendBufferSize() {
             return NioChannelOption.getOption0(jdkChannel, StandardSocketOptions.SO_SNDBUF);
         }
 
-        int getSoLinger() {
+        private int getSoLinger() {
             return NioChannelOption.getOption0(jdkChannel, StandardSocketOptions.SO_LINGER);
         }
 
-        int getTrafficClass() {
+        private int getTrafficClass() {
             return NioChannelOption.getOption0(jdkChannel, StandardSocketOptions.IP_TOS);
         }
 
-        boolean isKeepAlive() {
+        private boolean isKeepAlive() {
             return NioChannelOption.getOption0(jdkChannel, StandardSocketOptions.SO_KEEPALIVE);
         }
 
-        boolean isReuseAddress() {
+        private boolean isReuseAddress() {
             return NioChannelOption.getOption0(jdkChannel, StandardSocketOptions.SO_REUSEADDR);
         }
 
-        boolean isTcpNoDelay() {
+        private boolean isTcpNoDelay() {
             return NioChannelOption.getOption0(jdkChannel, StandardSocketOptions.TCP_NODELAY);
         }
 
-        NioSocketChannelConfig setKeepAlive(boolean keepAlive) {
+        private void setKeepAlive(boolean keepAlive) {
             NioChannelOption.setOption0(jdkChannel, StandardSocketOptions.SO_KEEPALIVE, keepAlive);
-            return this;
         }
 
-        NioSocketChannelConfig setReceiveBufferSize(int receiveBufferSize) {
+        private void setReceiveBufferSize(int receiveBufferSize) {
             NioChannelOption.setOption0(jdkChannel, StandardSocketOptions.SO_RCVBUF, receiveBufferSize);
-            return this;
         }
 
-        NioSocketChannelConfig setReuseAddress(boolean reuseAddress) {
+        private void setReuseAddress(boolean reuseAddress) {
             NioChannelOption.setOption0(jdkChannel, StandardSocketOptions.SO_REUSEADDR, reuseAddress);
-            return this;
         }
 
-        NioSocketChannelConfig setSendBufferSize(int sendBufferSize) {
+        private void setSendBufferSize(int sendBufferSize) {
             NioChannelOption.setOption0(jdkChannel, StandardSocketOptions.SO_SNDBUF, sendBufferSize);
             calculateMaxBytesPerGatheringWrite();
-            return this;
         }
 
-        NioSocketChannelConfig setSoLinger(int soLinger) {
+        private void setSoLinger(int soLinger) {
             NioChannelOption.setOption0(jdkChannel, StandardSocketOptions.SO_LINGER, soLinger);
-            return this;
         }
 
-        NioSocketChannelConfig setTcpNoDelay(boolean tcpNoDelay) {
+        private void setTcpNoDelay(boolean tcpNoDelay) {
             NioChannelOption.setOption0(jdkChannel, StandardSocketOptions.TCP_NODELAY, tcpNoDelay);
-            return this;
         }
 
-        NioSocketChannelConfig setTrafficClass(int trafficClass) {
+        private void setTrafficClass(int trafficClass) {
             NioChannelOption.setOption0(jdkChannel, StandardSocketOptions.IP_TOS, trafficClass);
-            return this;
         }
 
-        boolean isAllowHalfClosure() {
+        private boolean isAllowHalfClosure() {
             return allowHalfClosure;
         }
 
-        NioSocketChannelConfig setAllowHalfClosure(boolean allowHalfClosure) {
+        private void setAllowHalfClosure(boolean allowHalfClosure) {
             this.allowHalfClosure = allowHalfClosure;
-            return this;
         }
 
         void setMaxBytesPerGatheringWrite(int maxBytesPerGatheringWrite) {


### PR DESCRIPTION
Motivation:

We had a lot of methods return itself which is not useful anymore now that we removed most of the methods from the public interface. Beside this most of the methods now can be privivate

Modifications:

- Remove return from methods when they make no sense.
- Tighten up visiblity of methods / classes

Result:

Cleanup
