### PR TITLE
ChannelConfig: Remove deprecated methods to change watermarks

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
@@ -256,7 +256,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
         }
 
         long newWriteBufferSize = TOTAL_PENDING_SIZE_UPDATER.addAndGet(this, size);
-        if (newWriteBufferSize > config().getWriteBufferHighWaterMark()) {
+        if (newWriteBufferSize > config().getWriteBufferWaterMark().high()) {
             setUnwritable(invokeLater);
         }
     }
@@ -272,7 +272,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
         // prevent excessive buffering in the parent outbound buffer. If the parent is not writable
         // we will mark the child channel as writable once the parent becomes writable by calling
         // trySetWritable() later.
-        if (newWriteBufferSize < config().getWriteBufferLowWaterMark() && parent().isWritable()) {
+        if (newWriteBufferSize < config().getWriteBufferWaterMark().low() && parent().isWritable()) {
             setWritable(invokeLater);
         }
     }
@@ -282,7 +282,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
         // Lets try to set the child channel writable to match the state of the parent channel
         // if (and only if) the totalPendingSize is smaller then the low water-mark.
         // If this is not the case we will try again later once we drop under it.
-        if (totalPendingSize < config().getWriteBufferLowWaterMark()) {
+        if (totalPendingSize < config().getWriteBufferWaterMark().low()) {
             setWritable(false);
         }
     }
@@ -410,7 +410,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
     @Override
     public long bytesBeforeUnwritable() {
         // +1 because writability doesn't change until the threshold is crossed (not equal to).
-        long bytes = config().getWriteBufferHighWaterMark() - totalPendingSize + 1;
+        long bytes = config().getWriteBufferWaterMark().high() - totalPendingSize + 1;
         // If bytes is negative we know we are not writable, but if bytes is non-negative we have to check
         // writability. Note that totalPendingSize and isWritable() use different volatile variables that are not
         // synchronized together. totalPendingSize will be updated before isWritable().
@@ -420,7 +420,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
     @Override
     public long bytesBeforeWritable() {
         // +1 because writability doesn't change until the threshold is crossed (not equal to).
-        long bytes = totalPendingSize - config().getWriteBufferLowWaterMark() + 1;
+        long bytes = totalPendingSize - config().getWriteBufferWaterMark().low() + 1;
         // If bytes is negative we know we are writable, but if bytes is non-negative we have to check writability.
         // Note that totalPendingSize and isWritable() use different volatile variables that are not synchronized
         // together. totalPendingSize will be updated before isWritable().

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
@@ -240,7 +240,7 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
         // an "adequate" amount of connection window before allocation is attempted. This is not foolproof as if the
         // number of streams is >= this minimal number then we may still have the issue, but the idea is to narrow the
         // circumstances in which this can happen without rewriting the allocation algorithm.
-        return max(ctx.channel().config().getWriteBufferLowWaterMark(), MIN_WRITABLE_CHUNK);
+        return max(ctx.channel().config().getWriteBufferWaterMark().low(), MIN_WRITABLE_CHUNK);
     }
 
     private int maxUsableChannelBytes() {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
@@ -19,6 +19,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
+import io.netty.channel.WriteBufferWaterMark;
 import io.netty.util.concurrent.EventExecutor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -91,6 +92,7 @@ public abstract class DefaultHttp2RemoteFlowControllerTest {
     public void setup() throws Http2Exception {
         MockitoAnnotations.initMocks(this);
 
+        when(config.getWriteBufferWaterMark()).thenReturn(new WriteBufferWaterMark(0, Integer.MAX_VALUE));
         when(ctx.newPromise()).thenReturn(promise);
         when(ctx.flush()).thenThrow(new AssertionFailedError("forbidden"));
         setChannelWritability(true);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ControlFrameLimitEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ControlFrameLimitEncoderTest.java
@@ -24,6 +24,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelPromise;
 import io.netty.channel.DefaultMessageSizeEstimator;
+import io.netty.channel.WriteBufferWaterMark;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.ImmediateEventExecutor;
@@ -151,7 +152,7 @@ public class Http2ControlFrameLimitEncoderTest {
         when(channel.config()).thenReturn(config);
         when(channel.isWritable()).thenReturn(true);
         when(channel.bytesBeforeUnwritable()).thenReturn(Long.MAX_VALUE);
-        when(config.getWriteBufferHighWaterMark()).thenReturn(Integer.MAX_VALUE);
+        when(config.getWriteBufferWaterMark()).thenReturn(new WriteBufferWaterMark(0, Integer.MAX_VALUE));
         when(config.getMessageSizeEstimator()).thenReturn(DefaultMessageSizeEstimator.DEFAULT);
         handler.handlerAdded(ctx);
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MaxRstFrameLimitEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MaxRstFrameLimitEncoderTest.java
@@ -24,6 +24,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelPromise;
 import io.netty.channel.DefaultMessageSizeEstimator;
+import io.netty.channel.WriteBufferWaterMark;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.ImmediateEventExecutor;
@@ -142,7 +143,7 @@ public class Http2MaxRstFrameLimitEncoderTest {
         when(channel.config()).thenReturn(config);
         when(channel.isWritable()).thenReturn(true);
         when(channel.bytesBeforeUnwritable()).thenReturn(Long.MAX_VALUE);
-        when(config.getWriteBufferHighWaterMark()).thenReturn(Integer.MAX_VALUE);
+        when(config.getWriteBufferWaterMark()).thenReturn(new WriteBufferWaterMark(0, Integer.MAX_VALUE));
         when(config.getMessageSizeEstimator()).thenReturn(DefaultMessageSizeEstimator.DEFAULT);
         handler.handlerAdded(ctx);
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
@@ -1107,7 +1107,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
         parentChannel.flush();
 
         // Test for initial window size
-        assertTrue(initialRemoteStreamWindow < childChannel.config().getWriteBufferHighWaterMark());
+        assertTrue(initialRemoteStreamWindow < childChannel.config().getWriteBufferWaterMark().high());
 
         assertTrue(childChannel.isWritable());
         childChannel.write(new DefaultHttp2DataFrame(Unpooled.buffer().writeZero(16 * 1024 * 1024)));

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
@@ -25,6 +25,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelPromise;
 import io.netty.channel.DefaultMessageSizeEstimator;
+import io.netty.channel.WriteBufferWaterMark;
 import io.netty.handler.codec.http2.StreamBufferingEncoder.Http2GoAwayException;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.EventExecutor;
@@ -148,7 +149,7 @@ public class StreamBufferingEncoderTest {
         when(channel.config()).thenReturn(config);
         when(channel.isWritable()).thenReturn(true);
         when(channel.bytesBeforeUnwritable()).thenReturn(Long.MAX_VALUE);
-        when(config.getWriteBufferHighWaterMark()).thenReturn(Integer.MAX_VALUE);
+        when(config.getWriteBufferWaterMark()).thenReturn(new WriteBufferWaterMark(0, Integer.MAX_VALUE));
         when(config.getMessageSizeEstimator()).thenReturn(DefaultMessageSizeEstimator.DEFAULT);
         handler.handlerAdded(ctx);
     }

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/EmbeddedQuicChannel.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/EmbeddedQuicChannel.java
@@ -299,28 +299,6 @@ final class EmbeddedQuicChannel extends EmbeddedChannel implements QuicChannel {
         }
 
         @Override
-        public int getWriteBufferHighWaterMark() {
-            return delegate.getWriteBufferHighWaterMark();
-        }
-
-        @Override
-        public EmbeddedQuicChannelConfig setWriteBufferHighWaterMark(int i) {
-            delegate.setWriteBufferHighWaterMark(i);
-            return this;
-        }
-
-        @Override
-        public int getWriteBufferLowWaterMark() {
-            return delegate.getWriteBufferLowWaterMark();
-        }
-
-        @Override
-        public EmbeddedQuicChannelConfig setWriteBufferLowWaterMark(int i) {
-            delegate.setWriteBufferLowWaterMark(i);
-            return this;
-        }
-
-        @Override
         public MessageSizeEstimator getMessageSizeEstimator() {
             return delegate.getMessageSizeEstimator();
         }

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/EmbeddedQuicStreamChannel.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/EmbeddedQuicStreamChannel.java
@@ -293,18 +293,6 @@ final class EmbeddedQuicStreamChannel extends EmbeddedChannel implements QuicStr
             return this;
         }
 
-        @Override
-        public EmbeddedQuicStreamChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
-            config.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
-            return this;
-        }
-
-        @Override
-        public EmbeddedQuicStreamChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
-            config.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
-            return this;
-        }
-
         boolean isAllowHalfClosure() {
             return allowHalfClosure;
         }
@@ -362,16 +350,6 @@ final class EmbeddedQuicStreamChannel extends EmbeddedChannel implements QuicStr
         @Override
         public boolean isAutoClose() {
             return config.isAutoClose();
-        }
-
-        @Override
-        public int getWriteBufferHighWaterMark() {
-            return config.getWriteBufferHighWaterMark();
-        }
-
-        @Override
-        public int getWriteBufferLowWaterMark() {
-            return config.getWriteBufferLowWaterMark();
         }
 
         @Override

--- a/handler/src/test/java/io/netty/handler/logging/LoggingHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/logging/LoggingHandlerTest.java
@@ -23,6 +23,7 @@ import io.netty.buffer.ByteBufHolder;
 import io.netty.buffer.DefaultByteBufHolder;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandler;
+import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
 
@@ -123,8 +124,7 @@ public class LoggingHandlerTest {
     public void shouldLogChannelWritabilityChanged() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new LoggingHandler(LogLevel.WARN));
         // this is used to switch the channel to become unwritable
-        channel.config().setWriteBufferLowWaterMark(5);
-        channel.config().setWriteBufferHighWaterMark(10);
+        channel.config().setWriteBufferWaterMark(new WriteBufferWaterMark(5, 10));
         channel.write("hello", channel.newPromise());
 
         verify(appender).doAppend(argThat(new RegexLogMatcher(".+WRITABILITY CHANGED$")));

--- a/transport/src/main/java/io/netty/channel/ChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/ChannelConfig.java
@@ -197,40 +197,6 @@ public interface ChannelConfig {
     ChannelConfig setAutoClose(boolean autoClose);
 
     /**
-     * Returns the high water mark of the write buffer.  If the number of bytes
-     * queued in the write buffer exceeds this value, {@link Channel#isWritable()}
-     * will start to return {@code false}.
-     */
-    int getWriteBufferHighWaterMark();
-
-    /**
-     * <p>
-     * Sets the high water mark of the write buffer.  If the number of bytes
-     * queued in the write buffer exceeds this value, {@link Channel#isWritable()}
-     * will start to return {@code false}.
-     */
-    ChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark);
-
-    /**
-     * Returns the low water mark of the write buffer.  Once the number of bytes
-     * queued in the write buffer exceeded the
-     * {@linkplain #setWriteBufferHighWaterMark(int) high water mark} and then
-     * dropped down below this value, {@link Channel#isWritable()} will start to return
-     * {@code true} again.
-     */
-    int getWriteBufferLowWaterMark();
-
-    /**
-     * <p>
-     * Sets the low water mark of the write buffer.  Once the number of bytes
-     * queued in the write buffer exceeded the
-     * {@linkplain #setWriteBufferHighWaterMark(int) high water mark} and then
-     * dropped down below this value, {@link Channel#isWritable()} will start to return
-     * {@code true} again.
-     */
-    ChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark);
-
-    /**
      * Returns {@link MessageSizeEstimator} which is used for the channel
      * to detect the size of a message.
      */

--- a/transport/src/main/java/io/netty/channel/ChannelOption.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOption.java
@@ -97,16 +97,7 @@ public class ChannelOption<T> extends AbstractConstant<ChannelOption<T>> {
     public static final ChannelOption<Integer> MAX_MESSAGES_PER_WRITE = valueOf("MAX_MESSAGES_PER_WRITE");
 
     public static final ChannelOption<Integer> WRITE_SPIN_COUNT = valueOf("WRITE_SPIN_COUNT");
-    /**
-     * @deprecated Use {@link #WRITE_BUFFER_WATER_MARK}
-     */
-    @Deprecated
-    public static final ChannelOption<Integer> WRITE_BUFFER_HIGH_WATER_MARK = valueOf("WRITE_BUFFER_HIGH_WATER_MARK");
-    /**
-     * @deprecated Use {@link #WRITE_BUFFER_WATER_MARK}
-     */
-    @Deprecated
-    public static final ChannelOption<Integer> WRITE_BUFFER_LOW_WATER_MARK = valueOf("WRITE_BUFFER_LOW_WATER_MARK");
+
     public static final ChannelOption<WriteBufferWaterMark> WRITE_BUFFER_WATER_MARK =
             valueOf("WRITE_BUFFER_WATER_MARK");
 

--- a/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
@@ -182,7 +182,7 @@ public final class ChannelOutboundBuffer {
         }
 
         long newWriteBufferSize = TOTAL_PENDING_SIZE_UPDATER.addAndGet(this, size);
-        if (newWriteBufferSize > channel.config().getWriteBufferHighWaterMark()) {
+        if (newWriteBufferSize > channel.config().getWriteBufferWaterMark().high()) {
             setUnwritable(invokeLater);
         }
     }
@@ -201,7 +201,7 @@ public final class ChannelOutboundBuffer {
         }
 
         long newWriteBufferSize = TOTAL_PENDING_SIZE_UPDATER.addAndGet(this, -size);
-        if (notifyWritability && newWriteBufferSize < channel.config().getWriteBufferLowWaterMark()) {
+        if (notifyWritability && newWriteBufferSize < channel.config().getWriteBufferWaterMark().low()) {
             setWritable(invokeLater);
         }
     }
@@ -755,7 +755,7 @@ public final class ChannelOutboundBuffer {
      */
     public long bytesBeforeUnwritable() {
         // +1 because writability doesn't change until the threshold is crossed (not equal to).
-        long bytes = channel.config().getWriteBufferHighWaterMark() - totalPendingSize + 1;
+        long bytes = channel.config().getWriteBufferWaterMark().high() - totalPendingSize + 1;
         // If bytes is negative we know we are not writable, but if bytes is non-negative we have to check writability.
         // Note that totalPendingSize and isWritable() use different volatile variables that are not synchronized
         // together. totalPendingSize will be updated before isWritable().
@@ -768,7 +768,7 @@ public final class ChannelOutboundBuffer {
      */
     public long bytesBeforeWritable() {
         // +1 because writability doesn't change until the threshold is crossed (not equal to).
-        long bytes = totalPendingSize - channel.config().getWriteBufferLowWaterMark() + 1;
+        long bytes = totalPendingSize - channel.config().getWriteBufferWaterMark().low() + 1;
         // If bytes is negative we know we are writable, but if bytes is non-negative we have to check writability.
         // Note that totalPendingSize and isWritable() use different volatile variables that are not synchronized
         // together. totalPendingSize will be updated before isWritable().

--- a/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
@@ -22,7 +22,6 @@ import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import static io.netty.channel.ChannelOption.ALLOCATOR;
 import static io.netty.channel.ChannelOption.AUTO_CLOSE;
@@ -32,8 +31,6 @@ import static io.netty.channel.ChannelOption.MAX_MESSAGES_PER_READ;
 import static io.netty.channel.ChannelOption.MAX_MESSAGES_PER_WRITE;
 import static io.netty.channel.ChannelOption.MESSAGE_SIZE_ESTIMATOR;
 import static io.netty.channel.ChannelOption.RECVBUF_ALLOCATOR;
-import static io.netty.channel.ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK;
-import static io.netty.channel.ChannelOption.WRITE_BUFFER_LOW_WATER_MARK;
 import static io.netty.channel.ChannelOption.WRITE_BUFFER_WATER_MARK;
 import static io.netty.channel.ChannelOption.WRITE_SPIN_COUNT;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
@@ -50,10 +47,6 @@ public class DefaultChannelConfig implements ChannelConfig {
 
     private static final AtomicIntegerFieldUpdater<DefaultChannelConfig> AUTOREAD_UPDATER =
             AtomicIntegerFieldUpdater.newUpdater(DefaultChannelConfig.class, "autoRead");
-    private static final AtomicReferenceFieldUpdater<DefaultChannelConfig, WriteBufferWaterMark> WATERMARK_UPDATER =
-            AtomicReferenceFieldUpdater.newUpdater(
-                    DefaultChannelConfig.class, WriteBufferWaterMark.class, "writeBufferWaterMark");
-
     protected final Channel channel;
 
     private volatile ByteBufAllocator allocator = ByteBufAllocator.DEFAULT;
@@ -93,8 +86,8 @@ public class DefaultChannelConfig implements ChannelConfig {
         return getOptions(
                 null,
                 CONNECT_TIMEOUT_MILLIS, MAX_MESSAGES_PER_READ, WRITE_SPIN_COUNT,
-                ALLOCATOR, AUTO_READ, AUTO_CLOSE, RECVBUF_ALLOCATOR, WRITE_BUFFER_HIGH_WATER_MARK,
-                WRITE_BUFFER_LOW_WATER_MARK, WRITE_BUFFER_WATER_MARK, MESSAGE_SIZE_ESTIMATOR,
+                ALLOCATOR, AUTO_READ, AUTO_CLOSE, RECVBUF_ALLOCATOR,
+                WRITE_BUFFER_WATER_MARK, MESSAGE_SIZE_ESTIMATOR,
                 MAX_MESSAGES_PER_WRITE);
     }
 
@@ -150,12 +143,6 @@ public class DefaultChannelConfig implements ChannelConfig {
         if (option == AUTO_CLOSE) {
             return (T) Boolean.valueOf(isAutoClose());
         }
-        if (option == WRITE_BUFFER_HIGH_WATER_MARK) {
-            return (T) Integer.valueOf(getWriteBufferHighWaterMark());
-        }
-        if (option == WRITE_BUFFER_LOW_WATER_MARK) {
-            return (T) Integer.valueOf(getWriteBufferLowWaterMark());
-        }
         if (option == WRITE_BUFFER_WATER_MARK) {
             return (T) getWriteBufferWaterMark();
         }
@@ -187,10 +174,6 @@ public class DefaultChannelConfig implements ChannelConfig {
             setAutoRead((Boolean) value);
         } else if (option == AUTO_CLOSE) {
             setAutoClose((Boolean) value);
-        } else if (option == WRITE_BUFFER_HIGH_WATER_MARK) {
-            setWriteBufferHighWaterMark((Integer) value);
-        } else if (option == WRITE_BUFFER_LOW_WATER_MARK) {
-            setWriteBufferLowWaterMark((Integer) value);
         } else if (option == WRITE_BUFFER_WATER_MARK) {
             setWriteBufferWaterMark((WriteBufferWaterMark) value);
         } else if (option == MESSAGE_SIZE_ESTIMATOR) {
@@ -361,52 +344,6 @@ public class DefaultChannelConfig implements ChannelConfig {
     public ChannelConfig setAutoClose(boolean autoClose) {
         this.autoClose = autoClose;
         return this;
-    }
-
-    @Override
-    public int getWriteBufferHighWaterMark() {
-        return writeBufferWaterMark.high();
-    }
-
-    @Override
-    public ChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
-        checkPositiveOrZero(writeBufferHighWaterMark, "writeBufferHighWaterMark");
-        for (;;) {
-            WriteBufferWaterMark waterMark = writeBufferWaterMark;
-            if (writeBufferHighWaterMark < waterMark.low()) {
-                throw new IllegalArgumentException(
-                        "writeBufferHighWaterMark cannot be less than " +
-                                "writeBufferLowWaterMark (" + waterMark.low() + "): " +
-                                writeBufferHighWaterMark);
-            }
-            if (WATERMARK_UPDATER.compareAndSet(this, waterMark,
-                    new WriteBufferWaterMark(waterMark.low(), writeBufferHighWaterMark, false))) {
-                return this;
-            }
-        }
-    }
-
-    @Override
-    public int getWriteBufferLowWaterMark() {
-        return writeBufferWaterMark.low();
-    }
-
-    @Override
-    public ChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
-        checkPositiveOrZero(writeBufferLowWaterMark, "writeBufferLowWaterMark");
-        for (;;) {
-            WriteBufferWaterMark waterMark = writeBufferWaterMark;
-            if (writeBufferLowWaterMark > waterMark.high()) {
-                throw new IllegalArgumentException(
-                        "writeBufferLowWaterMark cannot be greater than " +
-                                "writeBufferHighWaterMark (" + waterMark.high() + "): " +
-                                writeBufferLowWaterMark);
-            }
-            if (WATERMARK_UPDATER.compareAndSet(this, waterMark,
-                    new WriteBufferWaterMark(writeBufferLowWaterMark, waterMark.high(), false))) {
-                return this;
-            }
-        }
     }
 
     @Override

--- a/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
@@ -17,7 +17,6 @@
 package io.netty.bootstrap;
 
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelFactory;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler.Sharable;
@@ -25,7 +24,6 @@ import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
-import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.IoHandle;
@@ -60,10 +58,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -359,56 +354,6 @@ public class BootstrapTest {
         assertTrue(connectFuture.await(10000));
         assertSame(exception, connectFuture.cause());
         assertNotNull(connectFuture.channel());
-    }
-
-    @Test
-    public void testChannelOptionOrderPreserve() throws InterruptedException {
-        final BlockingQueue<ChannelOption<?>> options = new LinkedBlockingQueue<ChannelOption<?>>();
-        class ChannelConfigValidator extends DefaultChannelConfig {
-            ChannelConfigValidator(Channel channel) {
-                super(channel);
-            }
-
-            @Override
-            public <T> boolean setOption(ChannelOption<T> option, T value) {
-                options.add(option);
-                return super.setOption(option, value);
-            }
-        }
-        final CountDownLatch latch = new CountDownLatch(1);
-        final Bootstrap bootstrap = new Bootstrap()
-                .handler(new ChannelInitializer<Channel>() {
-                    @Override
-                    protected void initChannel(Channel ch) {
-                        latch.countDown();
-                    }
-                })
-                .group(groupA)
-                .channelFactory(new ChannelFactory<Channel>() {
-                    @Override
-                    public Channel newChannel(EventLoop eventLoop) {
-                        return new LocalChannel(eventLoop) {
-                            private ChannelConfigValidator config;
-                            @Override
-                            public synchronized ChannelConfig config() {
-                                if (config == null) {
-                                    config = new ChannelConfigValidator(this);
-                                }
-                                return config;
-                            }
-                        };
-                    }
-                })
-                .option(ChannelOption.WRITE_BUFFER_LOW_WATER_MARK, 1)
-                .option(ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK, 2);
-
-        bootstrap.register().syncUninterruptibly();
-
-        latch.await();
-
-        // Check the order is the same as what we defined before.
-        assertSame(ChannelOption.WRITE_BUFFER_LOW_WATER_MARK, options.take());
-        assertSame(ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK, options.take());
     }
 
     @Test

--- a/transport/src/test/java/io/netty/channel/ChannelOutboundBufferTest.java
+++ b/transport/src/test/java/io/netty/channel/ChannelOutboundBufferTest.java
@@ -275,8 +275,9 @@ public class ChannelOutboundBufferTest {
             }
         });
 
-        ch.config().setWriteBufferLowWaterMark(128 + ChannelOutboundBuffer.CHANNEL_OUTBOUND_BUFFER_ENTRY_OVERHEAD);
-        ch.config().setWriteBufferHighWaterMark(256 + ChannelOutboundBuffer.CHANNEL_OUTBOUND_BUFFER_ENTRY_OVERHEAD);
+        ch.config().setWriteBufferWaterMark(
+                new WriteBufferWaterMark(128 + ChannelOutboundBuffer.CHANNEL_OUTBOUND_BUFFER_ENTRY_OVERHEAD,
+                        256 + ChannelOutboundBuffer.CHANNEL_OUTBOUND_BUFFER_ENTRY_OVERHEAD));
 
         ch.write(buffer().writeZero(128));
         // Ensure exceeding the low watermark does not make channel unwritable.
@@ -310,8 +311,7 @@ public class ChannelOutboundBufferTest {
             }
         });
 
-        ch.config().setWriteBufferLowWaterMark(128);
-        ch.config().setWriteBufferHighWaterMark(256);
+        ch.config().setWriteBufferWaterMark(new WriteBufferWaterMark(128, 256));
 
         ChannelOutboundBuffer cob = ch.outboundBuffer();
 
@@ -344,8 +344,7 @@ public class ChannelOutboundBufferTest {
             }
         });
 
-        ch.config().setWriteBufferLowWaterMark(128);
-        ch.config().setWriteBufferHighWaterMark(256);
+        ch.config().setWriteBufferWaterMark(new WriteBufferWaterMark(128, 256));
 
         ChannelOutboundBuffer cob = ch.outboundBuffer();
 
@@ -384,8 +383,7 @@ public class ChannelOutboundBufferTest {
             }
         });
 
-        ch.config().setWriteBufferLowWaterMark(128);
-        ch.config().setWriteBufferHighWaterMark(256);
+        ch.config().setWriteBufferWaterMark(new WriteBufferWaterMark(128, 256));
 
         ChannelOutboundBuffer cob = ch.outboundBuffer();
 

--- a/transport/src/test/java/io/netty/channel/PendingWriteQueueTest.java
+++ b/transport/src/test/java/io/netty/channel/PendingWriteQueueTest.java
@@ -135,8 +135,7 @@ public class PendingWriteQueueTest {
             }
         });
 
-        channel.config().setWriteBufferLowWaterMark(1);
-        channel.config().setWriteBufferHighWaterMark(3);
+        channel.config().setWriteBufferWaterMark(new WriteBufferWaterMark(1, 3));
 
         final PendingWriteQueue queue = queueRef.get();
 
@@ -151,8 +150,7 @@ public class PendingWriteQueueTest {
     private static void assertWrite(ChannelHandler handler, int count) {
         final ByteBuf buffer = Unpooled.copiedBuffer("Test", CharsetUtil.US_ASCII);
         final EmbeddedChannel channel = new EmbeddedChannel(handler);
-        channel.config().setWriteBufferLowWaterMark(1);
-        channel.config().setWriteBufferHighWaterMark(3);
+        channel.config().setWriteBufferWaterMark(new WriteBufferWaterMark(1, 3));
 
         ByteBuf[] buffers = new ByteBuf[count];
         for (int i = 0; i < buffers.length; i++) {

--- a/transport/src/test/java/io/netty/channel/ReentrantChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/ReentrantChannelTest.java
@@ -55,8 +55,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
         setInterest(Event.WRITE, Event.FLUSH, Event.WRITABILITY);
 
         Channel clientChannel = cb.connect(addr).sync().channel();
-        clientChannel.config().setWriteBufferLowWaterMark(512);
-        clientChannel.config().setWriteBufferHighWaterMark(1024);
+        clientChannel.config().setWriteBufferWaterMark(new WriteBufferWaterMark(512, 1024));
 
         // What is supposed to happen from this point:
         //
@@ -127,8 +126,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
         setInterest(Event.WRITE, Event.FLUSH, Event.WRITABILITY);
 
         Channel clientChannel = cb.connect(addr).sync().channel();
-        clientChannel.config().setWriteBufferLowWaterMark(512);
-        clientChannel.config().setWriteBufferHighWaterMark(1024);
+        clientChannel.config().setWriteBufferWaterMark(new WriteBufferWaterMark(512, 1024));
 
         clientChannel.pipeline().addLast(new ChannelInboundHandlerAdapter() {
             @Override


### PR DESCRIPTION
Motivation:

Let's remove the deprecated methosd now that we have the chance and just use the alternative api

Modifications:

Remove methods to set / get low and high watermarks seperatly.

Result:

API cleanup