### PR TITLE
CombinedChannelDuplexHandler: Add missing override for register(...)

### DIFF
--- a/transport/src/main/java/io/netty/channel/CombinedChannelDuplexHandler.java
+++ b/transport/src/main/java/io/netty/channel/CombinedChannelDuplexHandler.java
@@ -355,6 +355,16 @@ public class CombinedChannelDuplexHandler<I extends ChannelInboundHandler, O ext
         }
     }
 
+    @Override
+    public void register(ChannelHandlerContext ctx, ChannelPromise promise) {
+        assert ctx == outboundCtx.ctx;
+        if (!outboundCtx.removed) {
+            outboundHandler.register(outboundCtx, promise);
+        } else {
+            outboundCtx.register(promise);
+        }
+    }
+
     private static class DelegatingChannelHandlerContext implements ChannelHandlerContext {
 
         private final ChannelHandlerContext ctx;


### PR DESCRIPTION
Motivation:

We recently also added a register method to ChannelOutboundHandler. Unfortunally we forgot to also implement this one in CombinedChannelDuplexHandler

Modifications:

Add missing override

Result:

CombinedChannelDuplexHandler correctly delegates register(...) calls