### PR TITLE
Prevent ManualEventLoop to block on a racy task submission (#15937)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1069,6 +1069,28 @@
                   <new>interface org.jboss.marshalling.UnmarshallingObjectInputFilter</new>
                   <justification>We need to build with upgraded JBoss Marshalling version. Otherwise, testsuite-jpms won't compile.</justification>
                 </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.modifierChanged</code>
+                  <old>final class io.netty.channel.ManualIoEventLoop</old>
+                  <new>class io.netty.channel.ManualIoEventLoop</new>
+                  <justification>ManualIoEventLoop was made non-final to allow subclassing.</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.nowFinal</code>
+                  <classQualifiedName>io.netty.channel.ManualIoEventLoop</classQualifiedName>
+                  <justification>Several methods were intentionally made final; these API changes are acceptable for
+                   this class.
+                  </justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.finalMethodAddedToNonFinalClass</code>
+                  <classQualifiedName>io.netty.channel.ManualIoEventLoop</classQualifiedName>
+                  <justification>Final methods added to an inheritable class are intentional and safe in this context.
+                  </justification>
+                </item>
               </differences>
             </revapi.differences>
           </analysisConfiguration>

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
@@ -57,7 +57,7 @@ public class EpollIoHandler implements IoHandler {
     }
 
     // Pick a number that no task could have previously used.
-    private long prevDeadlineNanos = nanoTime() - 1;
+    private long prevDeadlineNanos = NONE;
     private FileDescriptor epollFd;
     private FileDescriptor eventFd;
     private FileDescriptor timerFd;

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/ManualEventLoopTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/ManualEventLoopTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.epoll;
+
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.IoHandlerFactory;
+import io.netty.channel.ManualIoEventLoop;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.util.concurrent.Future;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+@Timeout(5)
+public class ManualEventLoopTest {
+
+    @Test
+    void firstRacySubmissionMissWakeupEpoll() throws Exception {
+        racySubmissionMissWakeup(EpollIoHandler.newFactory(), 1);
+    }
+
+    @Test
+    void secondRacySubmissionMissWakeupEpoll() throws Exception {
+        racySubmissionMissWakeup(EpollIoHandler.newFactory(), 2);
+    }
+
+    @Test
+    void firstRacyOtherSubmissionMissWakeupEpoll() throws Exception {
+        racyOtherSubmissionMissWakeup(EpollIoHandler.newFactory(), 1);
+    }
+
+    @Test
+    void secondRacyOtherSubmissionMissWakeupEpoll() throws Exception {
+        racyOtherSubmissionMissWakeup(EpollIoHandler.newFactory(), 2);
+    }
+
+    private void racySubmissionMissWakeup(IoHandlerFactory handlerFactory, long canBlockAttempt)
+            throws Exception {
+        CyclicBarrier waitBeforeSubmittingTask = new CyclicBarrier(2);
+        CountDownLatch taskSubmitted = new CountDownLatch(1);
+        AtomicLong canBlock = new AtomicLong(0);
+        ManualMultithreadedIoEventLoopGroup group = new ManualMultithreadedIoEventLoopGroup(handlerFactory) {
+            @Override
+            protected void beforeCanBlock(Executor executor) {
+                if (canBlock.incrementAndGet() == canBlockAttempt) {
+                    try {
+                        waitBeforeSubmittingTask.await();
+                    } catch (Throwable ignore) {
+                        //
+                    }
+                    try {
+                        taskSubmitted.await();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        };
+        waitBeforeSubmittingTask.await();
+        // depending on canBlockAttempt this submission could observe an AWAKE event loop
+        // or with a setup NONE deadline (e.g. Long.MAX_VALUE).
+        // In the latter case, it can be already asleep or ready to do it.
+        Future<?> submitted = group.submit(() -> {
+        });
+        // unblock canBlock
+        taskSubmitted.countDown();
+        submitted.get();
+        group.shutdownGracefully(0, 0, TimeUnit.SECONDS).get();
+    }
+
+    private void racyOtherSubmissionMissWakeup(IoHandlerFactory handlerFactory, long canBlockAttempt)
+            throws Exception {
+        CyclicBarrier waitBeforeSubmittingTask = new CyclicBarrier(2);
+        CountDownLatch taskSubmitted = new CountDownLatch(1);
+        AtomicLong canBlock = new AtomicLong(0);
+        ManualMultithreadedIoEventLoopGroup group = new ManualMultithreadedIoEventLoopGroup(handlerFactory) {
+            @Override
+            protected void beforeCanBlock(Executor executor) {
+                // this should be called when canBlock is called after setting the wakeup flag!
+                if (canBlock.incrementAndGet() == canBlockAttempt) {
+                    try {
+                        waitBeforeSubmittingTask.await();
+                    } catch (Throwable ignore) {
+                        //
+                    }
+                    try {
+                        taskSubmitted.await();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        };
+        waitBeforeSubmittingTask.await();
+        CountDownLatch completed = new CountDownLatch(1);
+        // depending on canBlockAttempt this submission could observe an AWAKE event loop
+        // or with a setup NONE deadline (e.g. Long.MAX_VALUE).
+        // In the latter case, it can be already asleep or ready to do it.
+        group.ioEventLoopRunner.execute(completed::countDown);
+        taskSubmitted.countDown();
+        completed.await();
+        group.shutdownGracefully(0, 0, TimeUnit.SECONDS).get();
+    }
+
+    @RepeatedTest(value = 100, failureThreshold = 1)
+    void testTightShutodownEpoll() throws InterruptedException, ExecutionException {
+        ManualMultithreadedIoEventLoopGroup group = new ManualMultithreadedIoEventLoopGroup(
+                EpollIoHandler.newFactory());
+        group.shutdownGracefully(0, 0, TimeUnit.SECONDS).get();
+    }
+
+    public static class ManualMultithreadedIoEventLoopGroup extends MultiThreadIoEventLoopGroup {
+
+        private ManualIoEventLoopRunner ioEventLoopRunner;
+        private Consumer<ManualIoEventLoopRunner> beforeCanBlock;
+
+        public ManualMultithreadedIoEventLoopGroup(IoHandlerFactory ioHandlerFactory) {
+            super(1, ioHandlerFactory);
+        }
+
+        @Override
+        protected EventLoop newChild(Executor executor, IoHandlerFactory ioHandlerFactory, Object... args) {
+            this.ioEventLoopRunner = new ManualIoEventLoopRunner(this, ioHandlerFactory,
+                    executor, this::beforeCanBlock);
+            return ioEventLoopRunner.ioEventLoop;
+        }
+
+        protected void beforeCanBlock(Executor executor) {
+        }
+
+        private static class ManualIoEventLoopRunner implements Executor {
+
+            private final ManualIoEventLoop ioEventLoop;
+            private final Queue<Runnable> otherTasks = new ConcurrentLinkedQueue<>();
+
+            ManualIoEventLoopRunner(EventLoopGroup parent, IoHandlerFactory factory,
+                                    Executor executor, Consumer<Executor> beforeCanBlock) {
+                this.ioEventLoop = new ManualIoEventLoop(parent, null, factory) {
+                    @Override
+                    protected boolean canBlock() {
+                        if (beforeCanBlock != null) {
+                            beforeCanBlock.accept(ManualIoEventLoopRunner.this);
+                        }
+                        return otherTasks.isEmpty();
+                    }
+                };
+                CountDownLatch started = new CountDownLatch(1);
+                executor.execute(() -> {
+                    ioEventLoop.setOwningThread(Thread.currentThread());
+                    // it would force a first init
+                    ioEventLoop.runNow();
+                    started.countDown();
+                    mainLoop();
+                });
+                try {
+                    started.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+            }
+
+            private void mainLoop() {
+                while (!ioEventLoop.isShuttingDown()) {
+                    ioEventLoop.run(0);
+                    Runnable otherTask = otherTasks.poll();
+                    if (otherTask != null) {
+                        safeExecute(otherTask);
+                    }
+                }
+                while (!ioEventLoop.isTerminated() || !otherTasks.isEmpty()) {
+                    ioEventLoop.runNow();
+                    Runnable otherTask = otherTasks.poll();
+                    if (otherTask != null) {
+                        safeExecute(otherTask);
+                    }
+                }
+            }
+
+            private void safeExecute(Runnable task) {
+                try {
+                    task.run();
+                } catch (Throwable ignore) {
+                    //
+                }
+            }
+
+            public void execute(Runnable otherTask) {
+                otherTasks.add(otherTask);
+                if (ioEventLoop.isShutdown()) {
+                    if (otherTasks.remove(otherTask)) {
+                        throw new RejectedExecutionException("Event loop shut down");
+                    }
+                }
+                ioEventLoop.wakeup();
+            }
+        }
+    }
+}

--- a/transport/src/main/java/io/netty/channel/ManualIoEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/ManualIoEventLoop.java
@@ -47,7 +47,11 @@ import java.util.concurrent.atomic.AtomicReference;
  * {@link EventLoop} to also do other work. Care must be taken that the {@link #runNow() or
  * {@link #waitAndRun()}} methods are called in a timely fashion.
  */
-public final class ManualIoEventLoop extends AbstractScheduledEventExecutor implements EventLoop {
+
+public class ManualIoEventLoop extends AbstractScheduledEventExecutor implements EventLoop {
+    private static final Runnable WAKEUP_TASK = () -> {
+        // NOOP
+    };
     private static final int ST_STARTED = 0;
     private static final int ST_SHUTTING_DOWN = 1;
     private static final int ST_SHUTDOWN = 2;
@@ -143,8 +147,16 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
         state = new AtomicInteger(ST_STARTED);
     }
 
+    /**
+     * This allows to specify additional blocking conditions which will be used by the {@link IoHandler} to decide
+     * whether it is allowed to block or not.
+     */
+    protected boolean canBlock() {
+        return true;
+    }
+
     @Override
-    public Ticker ticker() {
+    public final Ticker ticker() {
         return ticker;
     }
 
@@ -154,7 +166,7 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
      *
      * @param timeoutNanos the maximum time in nanoseconds to run tasks.
      */
-    public int runNonBlockingTasks(long timeoutNanos) {
+    public final int runNonBlockingTasks(long timeoutNanos) {
         return runAllTasks(timeoutNanos, true);
     }
 
@@ -266,7 +278,7 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
      * @return the number of IO and tasks executed.
      * @throws IllegalStateException if the method is not called from the owning {@link Thread}.
      */
-    public int runNow(long runAllTasksTimeoutNanos) {
+    public final int runNow(long runAllTasksTimeoutNanos) {
         checkCurrentThread();
         return run(nonBlockingContext, runAllTasksTimeoutNanos);
     }
@@ -280,7 +292,7 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
      *
      * @return the number of IO and tasks executed.
      */
-    public int runNow() {
+    public final int runNow() {
         checkCurrentThread();
         return run(nonBlockingContext, 0);
     }
@@ -299,7 +311,7 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
      *                  if there is nothing to run (like {@link #runNow()}).
      * @return          the number of IO and tasks executed.
      */
-    public int run(long waitNanos, long runAllTasksTimeoutNanos) {
+    public final int run(long waitNanos, long runAllTasksTimeoutNanos) {
         checkCurrentThread();
 
         final IoHandlerContext context;
@@ -324,7 +336,7 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
      *                  if there is nothing to run (like {@link #runNow()}).
      * @return          the number of IO and tasks executed.
      */
-    public int run(long waitNanos) {
+    public final int run(long waitNanos) {
         return run(waitNanos, 0);
     }
 
@@ -337,7 +349,7 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
     /**
      * Force a wakeup and so the {@link #run(long)} method will unblock and return even if there was nothing to do.
      */
-    public void wakeup() {
+    public final void wakeup() {
         if (isShuttingDown()) {
             return;
         }
@@ -345,7 +357,7 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
     }
 
     @Override
-    public ManualIoEventLoop next() {
+    public final ManualIoEventLoop next() {
         return this;
     }
 
@@ -355,7 +367,7 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
     }
 
     @Override
-    public Future<IoRegistration> register(final IoHandle handle) {
+    public final Future<IoRegistration> register(final IoHandle handle) {
         Promise<IoRegistration> promise = newPromise();
         if (inEventLoop()) {
             registerForIo0(handle, promise);
@@ -379,17 +391,17 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
     }
 
     @Override
-    public boolean isCompatible(Class<? extends IoHandle> handleType) {
+    public final boolean isCompatible(Class<? extends IoHandle> handleType) {
         return handler.isCompatible(handleType);
     }
 
     @Override
-    public boolean isIoType(Class<? extends IoHandler> handlerType) {
+    public final boolean isIoType(Class<? extends IoHandler> handlerType) {
         return handler.getClass().equals(handlerType);
     }
 
     @Override
-    public boolean inEventLoop(Thread thread) {
+    public final boolean inEventLoop(Thread thread) {
         return this.owningThread.get() == thread;
     }
 
@@ -399,7 +411,7 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
      *
      * @param owningThread The owning thread
      */
-    public void setOwningThread(Thread owningThread) {
+    public final void setOwningThread(Thread owningThread) {
         Objects.requireNonNull(owningThread, "owningThread");
         if (!this.owningThread.compareAndSet(null, owningThread)) {
             throw new IllegalStateException("Owning thread already set");
@@ -438,12 +450,14 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
         }
 
         if (wakeup) {
+            // same as AbstractScheduledEventExecutor.WAKEUP_TASK
+            taskQueue.offer(WAKEUP_TASK);
             handler.wakeup();
         }
     }
 
     @Override
-    public Future<?> shutdownGracefully(long quietPeriod, long timeout, TimeUnit unit) {
+    public final Future<?> shutdownGracefully(long quietPeriod, long timeout, TimeUnit unit) {
         ObjectUtil.checkPositiveOrZero(quietPeriod, "quietPeriod");
         if (timeout < quietPeriod) {
             throw new IllegalArgumentException(
@@ -457,37 +471,37 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
 
     @Override
     @Deprecated
-    public void shutdown() {
+    public final void shutdown() {
         shutdown0(-1, -1, ST_SHUTDOWN);
     }
 
     @Override
-    public Future<?> terminationFuture() {
+    public final Future<?> terminationFuture() {
         return terminationFuture;
     }
 
     @Override
-    public boolean isShuttingDown() {
+    public final boolean isShuttingDown() {
         return state.get() >= ST_SHUTTING_DOWN;
     }
 
     @Override
-    public boolean isShutdown() {
+    public final boolean isShutdown() {
         return state.get() >= ST_SHUTDOWN;
     }
 
     @Override
-    public boolean isTerminated() {
+    public final boolean isTerminated() {
         return state.get() == ST_TERMINATED;
     }
 
     @Override
-    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+    public final boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
         return terminationFuture.await(timeout, unit);
     }
 
     @Override
-    public void execute(Runnable command) {
+    public final void execute(Runnable command) {
         Objects.requireNonNull(command, "command");
         boolean inEventLoop = inEventLoop();
         if (inEventLoop) {
@@ -572,14 +586,15 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
     }
 
     @Override
-    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+    public final <T> T invokeAny(Collection<? extends Callable<T>> tasks)
+            throws InterruptedException, ExecutionException {
         // We need to check if the method was called from within the EventLoop as this would cause a deadlock.
         throwIfInEventLoop("invokeAny");
         return super.invokeAny(tasks);
     }
 
     @Override
-    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+    public final <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
             throws InterruptedException, ExecutionException, TimeoutException {
         // We need to check if the method was called from within the EventLoop as this would cause a deadlock.
         throwIfInEventLoop("invokeAny");
@@ -587,7 +602,7 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
     }
 
     @Override
-    public <T> List<java.util.concurrent.Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
+    public final <T> List<java.util.concurrent.Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
             throws InterruptedException {
         // We need to check if the method was called from within the EventLoop as this would cause a deadlock.
         throwIfInEventLoop("invokeAll");
@@ -595,7 +610,7 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
     }
 
     @Override
-    public <T> List<java.util.concurrent.Future<T>> invokeAll(
+    public final <T> List<java.util.concurrent.Future<T>> invokeAll(
             Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
         // We need to check if the method was called from within the EventLoop as this would cause a deadlock.
         throwIfInEventLoop("invokeAll");
@@ -609,13 +624,14 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
         }
     }
 
-    private final class BlockingIoHandlerContext implements IoHandlerContext {
+    private class BlockingIoHandlerContext implements IoHandlerContext {
+        // this is a positive amount of nanos or Long.MAX_VALUE for no limit
         long maxBlockingNanos = Long.MAX_VALUE;
 
         @Override
         public boolean canBlock() {
             assert inEventLoop();
-            return !hasTasks() && !hasScheduledTasks();
+            return !hasTasks() && !hasScheduledTasks() && ManualIoEventLoop.this.canBlock();
         }
 
         @Override
@@ -628,11 +644,16 @@ public final class ManualIoEventLoop extends AbstractScheduledEventExecutor impl
         public long deadlineNanos() {
             assert inEventLoop();
             long next = nextScheduledTaskDeadlineNanos();
-            long maxDeadlineNanos = ticker.nanoTime() + maxBlockingNanos;
-            if (next == -1) {
-                return maxDeadlineNanos;
+            if (maxBlockingNanos == Long.MAX_VALUE) {
+                // next == -1? -1 : next i.e. return next
+                return next;
             }
-            return Math.min(next, maxDeadlineNanos);
+            long now = ticker.nanoTime();
+            // we cannot just check Math.min as nanoTime can be negative or wrap around!
+            if (next == -1 || next - now > maxBlockingNanos) {
+                return now + maxBlockingNanos;
+            }
+            return next;
         }
-    };
+    }
 }


### PR DESCRIPTION
Motivation:

ManualEventLoop can be blocked forever if not aware of task submissions before getting asleep

Modification:

Expands the ManualIoEventLoop API to make it aware of additional non-blocking conditions and correctly enqueue an empty task while shutting down to prevent a racy sleep to happen. Additionally, fix the blocking deadline math computation taking in account negativeness and whilst no deadline is set: for the latter, change the default previous deadline value of EpollIoHandler into NONE, to save performing timed wait, if no deadline is specified

Result:

ManualIoEventLoop correctly make progress if there's work to perform and terminate, while shutdown

Fixes #15922