### PR TITLE
EPOLL: Fail correct connect promise on closure

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -155,7 +155,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
         ChannelPromise connectPromise = this.connectPromise;
         if (connectPromise != null) {
             // Use tryFailure() instead of setFailure() to avoid the race against cancel().
-            promise.tryFailure(new ClosedChannelException());
+            connectPromise.tryFailure(new ClosedChannelException());
             this.connectPromise = null;
         }
 


### PR DESCRIPTION
Motivation:

Du a bug we did fail the incorrect promise when there was a pending connect operation we are closing the channel. This could lead to an exception later on when trying to fail the promise again during closure:

2025-12-09T20:14:14.2841266Z 20:14:14.278 [testsuite-epoll-4-4] WARN  i.n.util.concurrent.DefaultPromise - An exception was thrown by io.netty.channel.epoll.AbstractEpollChannel$$Lambda/0x0000000027214690.operationComplete() 2025-12-09T20:14:14.2843468Z java.lang.IllegalStateException: complete already: DefaultChannelPromise@1f0a56be(failure: java.nio.channels.ClosedChannelException) 2025-12-09T20:14:14.2845627Z 	at io.netty.util.concurrent.DefaultPromise.setSuccess(DefaultPromise.java:114) 2025-12-09T20:14:14.2846562Z 	at io.netty.channel.DefaultChannelPromise.setSuccess(DefaultChannelPromise.java:78) 2025-12-09T20:14:14.2847510Z 	at io.netty.channel.DefaultChannelPromise.setSuccess(DefaultChannelPromise.java:73) 2025-12-09T20:14:14.2848514Z 	at io.netty.channel.epoll.AbstractEpollChannel.lambda$doClose$0(AbstractEpollChannel.java:181) 2025-12-09T20:14:14.2849565Z 	at io.netty.util.concurrent.DefaultPromise.notifyListener0(DefaultPromise.java:604) 2025-12-09T20:14:14.2850512Z 	at io.netty.util.concurrent.DefaultPromise.notifyListenersNow(DefaultPromise.java:571) 2025-12-09T20:14:14.2851465Z 	at io.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:506) 2025-12-09T20:14:14.2852362Z 	at io.netty.util.concurrent.DefaultPromise.setValue0(DefaultPromise.java:650) 2025-12-09T20:14:14.2853390Z 	at io.netty.util.concurrent.DefaultPromise.setSuccess0(DefaultPromise.java:639) 2025-12-09T20:14:14.2854262Z 	at io.netty.util.concurrent.DefaultPromise.setSuccess(DefaultPromise.java:111) 2025-12-09T20:14:14.2855358Z 	at io.netty.channel.DefaultChannelPromise.setSuccess(DefaultChannelPromise.java:78) 2025-12-09T20:14:14.2856294Z 	at io.netty.channel.DefaultChannelPromise.setSuccess(DefaultChannelPromise.java:73) 2025-12-09T20:14:14.2857272Z 	at io.netty.channel.epoll.AbstractEpollChannel.doDeregister(AbstractEpollChannel.java:230) 2025-12-09T20:14:14.2858272Z 	at io.netty.channel.epoll.AbstractEpollChannel.doClose(AbstractEpollChannel.java:184) 2025-12-09T20:14:14.2859217Z 	at io.netty.channel.AbstractChannel$IoTransportImpl.doClose0(AbstractChannel.java:643) 2025-12-09T20:14:14.2860124Z 	at io.netty.channel.AbstractChannel$IoTransportImpl.close(AbstractChannel.java:633) 2025-12-09T20:14:14.2861130Z 	at io.netty.channel.AbstractChannel$IoTransportImpl.close(AbstractChannel.java:566) 2025-12-09T20:14:14.2862104Z 	at io.netty.channel.DefaultChannelPipeline$HeadContext.close(DefaultChannelPipeline.java:1336) 2025-12-09T20:14:14.2867221Z 	at io.netty.channel.AbstractChannelHandlerContext.invokeClose(AbstractChannelHandlerContext.java:688) 2025-12-09T20:14:14.2876819Z 	at io.netty.channel.AbstractChannelHandlerContext$4.run(AbstractChannelHandlerContext.java:671) 2025-12-09T20:14:14.2878022Z 	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:148) 2025-12-09T20:14:14.2879242Z 	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:141) 2025-12-09T20:14:14.2880388Z 	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:535) 2025-12-09T20:14:14.2881468Z 	at io.netty.channel.SingleThreadIoEventLoop.run(SingleThreadIoEventLoop.java:201) 2025-12-09T20:14:14.2882501Z 	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:1195) 2025-12-09T20:14:14.2883803Z 	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) 2025-12-09T20:14:14.2884717Z 	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) 2025-12-09T20:14:14.2885502Z 	at java.base/java.lang.Thread.run(Thread.java:1474)

Modifications:

Fail correct promise

Result:

No more failure during close when connect is pending
