### PR TITLE
Fix Socket reading of abstract unix domain addresses

### DIFF
--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/LinuxSocketTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/LinuxSocketTest.java
@@ -28,6 +28,7 @@ import java.net.InetSocketAddress;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class LinuxSocketTest {
@@ -90,6 +91,21 @@ public class LinuxSocketTest {
                 }
             });
             Assertions.assertTrue(exception.getMessage().contains("too long"));
+        } finally {
+            socket.close();
+        }
+    }
+
+    @Test
+    public void testUnixAbstractDomainSocket() throws IOException {
+        String address  = "\0" + UUID.randomUUID();
+
+        final DomainSocketAddress domainSocketAddress = new DomainSocketAddress(address);
+        final Socket socket = Socket.newSocketDomain();
+        try {
+            socket.bind(domainSocketAddress);
+            DomainSocketAddress local = socket.localDomainSocketAddress();
+            assertEquals(domainSocketAddress, local);
         } finally {
             socket.close();
         }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/LinuxSocketTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/LinuxSocketTest.java
@@ -106,6 +106,8 @@ public class LinuxSocketTest {
             socket.bind(domainSocketAddress);
             DomainSocketAddress local = socket.localDomainSocketAddress();
             assertEquals(domainSocketAddress, local);
+            assertEquals(address, domainSocketAddress.path());
+            assertEquals(address, local.path());
         } finally {
             socket.close();
         }

--- a/transport-native-unix-common/src/main/c/netty_unix_socket.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_socket.c
@@ -141,9 +141,8 @@ static int domainSocketPathLength(const struct sockaddr_un* s, const socklen_t a
        // This is an abstract domain socket address
        return (addrlen - sizeof(sa_family_t));
     }
-#else
-    return strlen(s->sun_path);
 #endif
+    return strlen(s->sun_path);
 }
 
 static jobject createDomainDatagramSocketAddress(JNIEnv* env, const struct sockaddr_storage* addr, const socklen_t addrlen, int len, jobject local) {

--- a/transport-native-unix-common/src/main/c/netty_unix_socket.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_socket.c
@@ -133,23 +133,24 @@ done:
     return obj;
 }
 
+static int domainSocketPathLength(const struct sockaddr_un* s, const socklen_t addrlen) {
+#ifdef __linux__
+    // Linux supports abstract domain sockets so we need to handle it.
+    // https://man7.org/linux/man-pages/man7/unix.7.html
+    if (s->sun_path[0] == '\0') {
+       // This is an abstract domain socket address
+       return (addrlen - sizeof(sa_family_t));
+    }
+#else
+    return strlen(s->sun_path);
+#endif
+}
+
 static jobject createDomainDatagramSocketAddress(JNIEnv* env, const struct sockaddr_storage* addr, const socklen_t addrlen, int len, jobject local) {
     jclass domainDatagramSocketAddressClass = NULL;
     jobject obj  = NULL;
     struct sockaddr_un* s = (struct sockaddr_un*) addr;
-#ifdef __linux__
-    // Linux supports abstract domain sockets so we need to handle it.
-    // https://man7.org/linux/man-pages/man7/unix.7.html
-    int pathLength = 0;
-    if (s->sun_path[0] == '\0') {
-       // This is an abstract domain socket address
-       pathLength = (addrlen - sizeof(sa_family_t));
-    } else {
-       pathLength = strlen(s->sun_path);
-    }
-#else
-    int pathLength = strlen(s->sun_path);
-#endif
+    int pathLength = domainSocketPathLength(s, addrlen);
     jbyteArray pathBytes = (*env)->NewByteArray(env, pathLength);
     if (pathBytes == NULL) {
         return NULL;
@@ -171,19 +172,7 @@ done:
 
 static jbyteArray netty_unix_socket_createDomainSocketAddressArray(JNIEnv* env, const struct sockaddr_storage* addr, const socklen_t addrlen) {
     struct sockaddr_un* s = (struct sockaddr_un*) addr;
-#ifdef __linux__
-    // Linux supports abstract domain sockets so we need to handle it.
-    // https://man7.org/linux/man-pages/man7/unix.7.html
-    int pathLength = 0;
-    if (s->sun_path[0] == '\0') {
-       // This is an abstract domain socket address
-       pathLength = (addrlen - sizeof(sa_family_t));
-    } else {
-       pathLength = strlen(s->sun_path);
-    }
-#else
-    int pathLength = strlen(s->sun_path);
-#endif
+    int pathLength = domainSocketPathLength(s, addrlen);
     jbyteArray pathBytes = (*env)->NewByteArray(env, pathLength);
     if (pathBytes == NULL) {
         return NULL;

--- a/transport-native-unix-common/src/main/c/netty_unix_socket.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_socket.c
@@ -133,7 +133,7 @@ done:
     return obj;
 }
 
-static jobject createDomainDatagramSocketAddress(JNIEnv* env, const struct sockaddr_storage* addr, int len, jobject local) {
+static jobject createDomainDatagramSocketAddress(JNIEnv* env, const struct sockaddr_storage* addr, const socklen_t addrlen, int len, jobject local) {
     jclass domainDatagramSocketAddressClass = NULL;
     jobject obj  = NULL;
     struct sockaddr_un* s = (struct sockaddr_un*) addr;
@@ -143,7 +143,7 @@ static jobject createDomainDatagramSocketAddress(JNIEnv* env, const struct socka
     int pathLength = 0;
     if (s->sun_path[0] == '\0') {
        // This is an abstract domain socket address
-       pathLength = strlen(&(s->sun_path[1])) + 1;
+       pathLength = (addrlen - sizeof(sa_family_t));
     } else {
        pathLength = strlen(s->sun_path);
     }
@@ -169,7 +169,7 @@ done:
     return obj;
 }
 
-static jbyteArray netty_unix_socket_createDomainSocketAddressArray(JNIEnv* env, const struct sockaddr_storage* addr) {
+static jbyteArray netty_unix_socket_createDomainSocketAddressArray(JNIEnv* env, const struct sockaddr_storage* addr, const socklen_t addrlen) {
     struct sockaddr_un* s = (struct sockaddr_un*) addr;
 #ifdef __linux__
     // Linux supports abstract domain sockets so we need to handle it.
@@ -177,7 +177,7 @@ static jbyteArray netty_unix_socket_createDomainSocketAddressArray(JNIEnv* env, 
     int pathLength = 0;
     if (s->sun_path[0] == '\0') {
        // This is an abstract domain socket address
-       pathLength = strlen(&(s->sun_path[1])) + 1;
+       pathLength = (addrlen - sizeof(sa_family_t));
     } else {
        pathLength = strlen(s->sun_path);
     }
@@ -488,7 +488,7 @@ static jobject _recvFromDomainSocket(JNIEnv* env, jint fd, void* buffer, jint po
         return NULL;
     }
 
-    return createDomainDatagramSocketAddress(env, &addr, res, NULL);
+    return createDomainDatagramSocketAddress(env, &addr, addrlen, res, NULL);
 }
 
 static jint _send(JNIEnv* env, jclass clazz, jint fd, void* buffer, jint pos, jint limit) {
@@ -733,7 +733,7 @@ static jbyteArray netty_unix_socket_remoteDomainSocketAddress(JNIEnv* env, jclas
     if (getpeername(fd, (struct sockaddr*) &addr, &len) == -1) {
         return NULL;
     }
-    return netty_unix_socket_createDomainSocketAddressArray(env, &addr);
+    return netty_unix_socket_createDomainSocketAddressArray(env, &addr, len);
 }
 
 static jbyteArray netty_unix_socket_localAddress(JNIEnv* env, jclass clazz, jint fd) {
@@ -751,7 +751,7 @@ static jbyteArray netty_unix_socket_localDomainSocketAddress(JNIEnv* env, jclass
     if (getsockname(fd, (struct sockaddr*) &addr, &len) == -1) {
         return NULL;
     }
-    return netty_unix_socket_createDomainSocketAddressArray(env, &addr);
+    return netty_unix_socket_createDomainSocketAddressArray(env, &addr, len);
 }
 
 static jint netty_unix_socket_newSocketDgramFd(JNIEnv* env, jclass clazz, jboolean ipv6) {

--- a/transport-native-unix-common/src/main/c/netty_unix_socket.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_socket.c
@@ -137,7 +137,7 @@ static int domainSocketPathLength(const struct sockaddr_un* s, const socklen_t a
 #ifdef __linux__
     // Linux supports abstract domain sockets so we need to handle it.
     // https://man7.org/linux/man-pages/man7/unix.7.html
-    if (s->sun_path[0] == '\0') {
+    if (addrlen >= sizeof(sa_family_t) && s->sun_path[0] == '\0') {
        // This is an abstract domain socket address
        return (addrlen - sizeof(sa_family_t));
     }


### PR DESCRIPTION
Motivation:

How we calculated the length of the unix domain socket address was not correct.

Motification:

Follow the manpage in how the length is calculated

Result:

Always return the correct name for abstract unix domain sockets