### PR TITLE
LocalChannel: Reduce GC by re-using same Runnable

### DIFF
--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -81,6 +81,13 @@ public class LocalChannel extends AbstractChannel {
         }
     };
 
+    private final Runnable finishReadTask = new Runnable() {
+        @Override
+        public void run() {
+            finishPeerRead0(LocalChannel.this);
+        }
+    };
+
     private IoRegistration registration;
 
     private volatile State state;
@@ -419,21 +426,19 @@ public class LocalChannel extends AbstractChannel {
         }
     }
 
+    private void runFinishTask0() {
+        if (writeInProgress) {
+            finishReadFuture = eventLoop().submit(finishReadTask);
+        } else {
+            eventLoop().execute(finishReadTask);
+        }
+    }
+
     private void runFinishPeerReadTask(final LocalChannel peer) {
         // If the peer is writing, we must wait until after reads are completed for that peer before we can read. So
         // we keep track of the task, and coordinate later that our read can't happen until the peer is done.
-        final Runnable finishPeerReadTask = new Runnable() {
-            @Override
-            public void run() {
-                finishPeerRead0(peer);
-            }
-        };
         try {
-            if (peer.writeInProgress) {
-                peer.finishReadFuture = peer.eventLoop().submit(finishPeerReadTask);
-            } else {
-                peer.eventLoop().execute(finishPeerReadTask);
-            }
+            peer.runFinishTask0();
         } catch (Throwable cause) {
             logger.warn("Closing Local channels {}-{} because exception occurred!", this, peer, cause);
             close();

--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -427,6 +427,8 @@ public class LocalChannel extends AbstractChannel {
     }
 
     private void runFinishTask0() {
+        // If the peer is writing, we must wait until after reads are completed for that peer before we can read. So
+        // we keep track of the task, and coordinate later that our read can't happen until the peer is done.
         if (writeInProgress) {
             finishReadFuture = eventLoop().submit(finishReadTask);
         } else {
@@ -435,8 +437,6 @@ public class LocalChannel extends AbstractChannel {
     }
 
     private void runFinishPeerReadTask(final LocalChannel peer) {
-        // If the peer is writing, we must wait until after reads are completed for that peer before we can read. So
-        // we keep track of the task, and coordinate later that our read can't happen until the peer is done.
         try {
             peer.runFinishTask0();
         } catch (Throwable cause) {


### PR DESCRIPTION
Motivation:

We reduce the GC that is produced by using the same Runnable and not allocate a new one everytime.

Modifications:

Refactor code to be able to reuse the same Runnable

Result:

Less GC. Fixes some parts of https://github.com/netty/netty/issues/15994