### PR TITLE
Correct codec-native-quic Fragment-Host (#16015)

### DIFF
--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -32,7 +32,7 @@
     <javaModuleNameWithClassifier>${javaModuleName}.${javaModuleNameClassifier}</javaModuleNameWithClassifier>
     <fallbackModuleName>io.netty.codec.quic</fallbackModuleName>
     <javaModuleName>${fallbackModuleName}.${javaModuleNameClassifier}</javaModuleName>
-    <fragmentHost>io.netty.netty5-codec-classes-quic</fragmentHost>
+    <fragmentHost>io.netty.codec-classes-quic</fragmentHost>
     <logging.config>${project.basedir}/../codec-native-quic/src/test/resources/logback-test.xml</logging.config>
     <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
     <fallbackOutputDirectory>${project.build.directory}/fallback-classes</fallbackOutputDirectory>


### PR DESCRIPTION
Motivation:

The way native library loading works in OSGi is by attaching the native jar as a fragment to the corresponding classes bundle. Unfortunately codec-native-quic contains a typo, so the attachment does not work.

Modification:
Correct the fragmentHost to point to 'io.netty.codec-classes-quic'.

Result:
Fixes #16006.