### PR TITLE
Build fixes to allow using the epoll native transport on Android (#16…

### DIFF
--- a/transport-native-unix-common/src/main/c/netty_unix_errors.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_errors.c
@@ -37,8 +37,11 @@ static jmethodID closedChannelExceptionMethodId = NULL;
  even on platforms where the GNU variant is exposed.
  Note: `strerrbuf` must be initialized to all zeros prior to calling this function.
  XSI or GNU functions do not have such a requirement, but our wrappers do.
+
+ Android exposes the XSI variant by default, see
+ https://cs.android.com/android/platform/superproject/+/android16-release:bionic/libc/include/string.h;l=145?q=string.h
  */
-#if (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || __APPLE__) && ! _GNU_SOURCE
+#if (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || __APPLE__ || __ANDROID__) && ! _GNU_SOURCE
     static inline int strerror_r_xsi(int errnum, char *strerrbuf, size_t buflen) {
         return strerror_r(errnum, strerrbuf, buflen);
     }

--- a/transport-native-unix-common/src/main/c/netty_unix_socket.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_socket.c
@@ -458,7 +458,7 @@ static jobject _recvFromDomainSocket(JNIEnv* env, jint fd, void* buffer, jint po
     int err;
 
     do {
-        bzero(&addr, sizeof(addr)); // Zap addr so we can strlen(addr.sun_path) later. See unix(4).
+        memset(&addr, 0, sizeof(addr)); // Zap addr so we can strlen(addr.sun_path) later. See unix(4).
         res = recvfrom(fd, buffer + pos, (size_t) (limit - pos), 0, (struct sockaddr*) &addr, &addrlen);
         // Keep on reading if it was interrupted
     } while (res == -1 && ((err = errno) == EINTR));


### PR DESCRIPTION
…016)

**Note**: more details are provided in the single commit messages.

## Motivation:
the epoll native transport currently fails to compile on Android, due to a couple of compilation failures
```
transport-native-unix-common/src/main/c/netty_unix_errors.c:47:15: error: incompatible integer to pointer conversion initializing 'char *' with an expression of type 'int' [-Wint-conversion]
   47 |         char* tmp = strerror_r(errnum, strerrbuf, buflen);
      |               ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
and
```
transport-native-unix-common/src/main/c/netty_unix_socket.c:449:9: error: call to undeclared library function 'bzero' with type 'void (void *, unsigned long)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  449 |         bzero(&addr, sizeof(addr)); // Zap addr so we can strlen(addr.sun_path) later. See unix(4).
      |         ^
transport-native-unix-common/src/main/c/netty_unix_socket.c:449:9: note: include the header <strings.h> or explicitly provide a declaration for 'bzero'
```
- `netty_unix_socket.c` uses `bzero` (in a single place). `bzero` is defined in `strings.h`, which however does not seem to be pulled in by default in Android with the current includes.
Moreover, `bzero` is deprecated and was dropped in POSIX 2018. See [POSIX 2018
docs](https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xsh_chap03.html) and [relevant AOSP 16
code](https://cs.android.com/android/platform/superproject/+/android16-release:bionic/libc/include/strings.h;l=69).
- `netty_unix_errors.c` currently uses the GNU `strerror_r` on Android. Android, however, only exposes the GNU `strerror_r` when `_GNU_SOURCE` is defined and only on API level 23+.
See [relevant AOSP 16
code](https://cs.android.com/android/platform/superproject/+/android16-release:bionic/libc/include/string.h;l=145?q=string.h)

## Modification:
- a [dedicated repository](https://github.com/faenil/NettyEpollAndroidBuildFailureTest) was spun up to allow reproducing the build failures
- it is an Android project containing the necessary plumbing to build the epoll native transport
- it can be easily built by following the instructions in the `README` in the project repo
- replace the deprecated `bzero` with `memset`, already used for the very same purpose in many places in the same file.
- use the XSI `strerror_r` on Android, when `_GNU_SOURCE` is not defined

## Result:
- epoll native transport builds and `Epoll.ensureAvailability()` succeeds on Android.
Tested on Android 16 emulator image `BP41.250916.009.A1` (x86_64), NDK `27.0.12077973`

Motivation:

Explain here the context, and why you're making that change.
What is the problem you're trying to solve.

Modification:

Describe the modifications you've done.

Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
