### PR TITLE
Fix HTTP startline validation (#16022)

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
@@ -109,16 +109,16 @@ public final class HttpUtil {
         int modulo = lenBytes % 4;
         int lenInts = modulo == 0 ? lenBytes : lenBytes - modulo;
         for (; i < lenInts; i += 4) {
-            long chars = 1L << token.charAt(i) |
-                    1L << token.charAt(i + 1) |
-                    1L << token.charAt(i + 2) |
-                    1L << token.charAt(i + 3);
+            long chars = charMask(token, i) |
+                    charMask(token, i + 1) |
+                    charMask(token, i + 2) |
+                    charMask(token, i + 3);
             if ((chars & ILLEGAL_REQUEST_LINE_TOKEN_OCTET_MASK) != 0) {
                 return false;
             }
         }
         for (; i < lenBytes; i++) {
-            long ch = 1L << token.charAt(i);
+            long ch = charMask(token, i);
             if ((ch & ILLEGAL_REQUEST_LINE_TOKEN_OCTET_MASK) != 0) {
                 return false;
             }
@@ -126,10 +126,14 @@ public final class HttpUtil {
         return true;
     }
 
+    private static long charMask(CharSequence token, int i) {
+        char c = token.charAt(i);
+        return c < 64 ? 1L << c : 0;
+    }
+
     /**
      * Returns {@code true} if and only if the connection can remain open and
-     * thus 'kept alive'.  This methods respects the value of the.
-     *
+     * thus 'kept alive'. This method respects the value of the
      * {@code "Connection"} header first and then the return value of
      * {@link HttpVersion#isKeepAliveDefault()}.
      */


### PR DESCRIPTION
Motivation:
The code assumed that oversized bit shifting would result in zeroing out values due to overflow. However, the Java Language Specification instead says that shifts effectively only consider the lower six bits of the shift amount, resulting in modular-arithmetic shifts. The consequence is that, for instance, shifing by the capital letter 'M' produces the same bit mask as carriage-return '\r', which is an illegal character in an HTTP start line. This incorrectly rejected valid URIs.

Modification:
Make the shifting conditional and only use it on character values less than or equal to 64 (the Long bit size). Also add tests to check that valid URLs are accepted.

Result:
Fixes https://github.com/netty/netty/issues/16020