### PR TITLE
Fix HTTP startline validation (#16022)

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
@@ -109,16 +109,16 @@ public final class HttpUtil {
         int modulo = lenBytes % 4;
         int lenInts = modulo == 0 ? lenBytes : lenBytes - modulo;
         for (; i < lenInts; i += 4) {
-            long chars = 1L << token.charAt(i) |
-                    1L << token.charAt(i + 1) |
-                    1L << token.charAt(i + 2) |
-                    1L << token.charAt(i + 3);
+            long chars = charMask(token, i) |
+                    charMask(token, i + 1) |
+                    charMask(token, i + 2) |
+                    charMask(token, i + 3);
             if ((chars & ILLEGAL_REQUEST_LINE_TOKEN_OCTET_MASK) != 0) {
                 return false;
             }
         }
         for (; i < lenBytes; i++) {
-            long ch = 1L << token.charAt(i);
+            long ch = charMask(token, i);
             if ((ch & ILLEGAL_REQUEST_LINE_TOKEN_OCTET_MASK) != 0) {
                 return false;
             }
@@ -126,10 +126,14 @@ public final class HttpUtil {
         return true;
     }
 
+    private static long charMask(CharSequence token, int i) {
+        char c = token.charAt(i);
+        return c < 64 ? 1L << c : 0;
+    }
+
     /**
      * Returns {@code true} if and only if the connection can remain open and
-     * thus 'kept alive'.  This methods respects the value of the.
-     *
+     * thus 'kept alive'. This method respects the value of the
      * {@code "Connection"} header first and then the return value of
      * {@link HttpVersion#isKeepAliveDefault()}.
      */

--- a/codec-http/src/test/java/io/netty/handler/codec/http/DefaultHttpRequestTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/DefaultHttpRequestTest.java
@@ -18,7 +18,11 @@ package io.netty.handler.codec.http;
 import io.netty.util.AsciiString;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.SplittableRandom;
+import java.util.stream.Stream;
 
 import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -46,6 +50,83 @@ public class DefaultHttpRequestTest {
     void constructorMustRejectIllegalUrisByDefault(String uri) {
         assertThrows(IllegalArgumentException.class, () ->
                 new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri));
+    }
+
+    public static Stream<String> validUris() {
+        String pdigit = "123456789";
+        String digit = '0' + pdigit;
+        String digitcolon = digit + ':';
+        String alpha = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        String alphanum = alpha + digit;
+        String alphanumdot = alphanum + '.';
+        String unreserved = alphanumdot + "-_~";
+        String subdelims = "$&%=!+,;'()";
+        String userinfochars = unreserved + subdelims + ':';
+        String pathchars = unreserved + '/';
+        String querychars = pathchars + subdelims + '?';
+        return new SplittableRandom().longs(1000)
+                .mapToObj(seed -> {
+                    SplittableRandom rng = new SplittableRandom(seed);
+                    String start;
+                    String path;
+                    String query;
+                    String fragment;
+                    if (rng.nextBoolean()) {
+                        String scheme = rng.nextBoolean() ? "http://" : "HTTP://";
+                        String userinfo = rng.nextBoolean() ? "" : pick(rng, userinfochars, 1, 8) + '@';
+                        String host;
+                        String port;
+                        switch (rng.nextInt(3)) {
+                            case 0:
+                                host = pick(rng, alphanum, 1, 1) + pick(rng, alphanumdot, 1, 5);
+                                break;
+                            case 1:
+                                host = pick(rng, pdigit, 1, 1) + pick(rng, digit, 0, 2) + '.' +
+                                        pick(rng, pdigit, 1, 1) + pick(rng, digit, 0, 2) + '.' +
+                                        pick(rng, pdigit, 1, 1) + pick(rng, digit, 0, 2) + '.' +
+                                        pick(rng, pdigit, 1, 1) + pick(rng, digit, 0, 2);
+                                break;
+                            default:
+                                host = '[' + pick(rng, digitcolon, 1, 8) + ']';
+                                break;
+                        }
+                        if (rng.nextBoolean()) {
+                            port = ':' + pick(rng, pdigit, 1, 1) + pick(rng, digit, 0, 4);
+                        } else {
+                            port = "";
+                        }
+                        start = scheme + userinfo + host + port;
+                    } else {
+                        start = "";
+                    }
+                    path = '/' + pick(rng, pathchars, 0, 8);
+                    if (rng.nextBoolean()) {
+                        query = '?' + pick(rng, querychars, 0, 8);
+                    } else {
+                        query = "";
+                    }
+                    if (rng.nextBoolean()) {
+                        fragment = '#' + pick(rng, querychars, 0, 8);
+                    } else {
+                        fragment = "";
+                    }
+                    return start + path + query + fragment;
+                });
+    }
+
+    private static String pick(SplittableRandom rng, String cs, int lowerBound, int upperBound) {
+        int length = rng.nextInt(lowerBound, upperBound + 1);
+        StringBuilder sb = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            sb.append(cs.charAt(rng.nextInt(cs.length())));
+        }
+        return sb.toString();
+    }
+
+    @ParameterizedTest
+    @MethodSource("validUris")
+    void constructorMustAcceptValidUris(String uri) {
+        new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
     }
 
     @ParameterizedTest
@@ -98,6 +179,30 @@ public class DefaultHttpRequestTest {
                 }
             }, "/");
         });
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "GET",
+            "POST",
+            "PUT",
+            "HEAD",
+            "DELETE",
+            "OPTIONS",
+            "CONNECT",
+            "TRACE",
+            "PATCH",
+            "QUERY"
+    })
+    void constructorMustAcceptAllHttpMethods(String method) {
+        new DefaultHttpRequest(HttpVersion.HTTP_1_0, new HttpMethod("GET") {
+            @Override
+            public AsciiString asciiName() {
+                return new AsciiString(method);
+            }
+        }, "/");
+
+        new DefaultHttpRequest(HttpVersion.HTTP_1_0, new HttpMethod(method), "/");
     }
 
     @Test


### PR DESCRIPTION
Motivation:
The code assumed that oversized bit shifting would result in zeroing out values due to overflow. However, the Java Language Specification instead says that shifts effectively only consider the lower six bits of the shift amount, resulting in modular-arithmetic shifts. The consequence is that, for instance, shifing by the capital letter 'M' produces the same bit mask as carriage-return '\r', which is an illegal character in an HTTP start line. This incorrectly rejected valid URIs.

Modification:
Make the shifting conditional and only use it on character values less than or equal to 64 (the Long bit size). Also add tests to check that valid URLs are accepted.

Result:
Fixes https://github.com/netty/netty/issues/16020