### PR TITLE
Fix MpscIntQueue bug (#16023)

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/MpscIntQueue.java
+++ b/common/src/main/java/io/netty/util/concurrent/MpscIntQueue.java
@@ -111,7 +111,7 @@ public interface MpscIntQueue {
             super(MathUtil.safeFindNextPositivePowerOfTwo(capacity));
             if (emptyValue != 0) {
                 this.emptyValue = emptyValue;
-                int end = capacity - 1;
+                int end = length() - 1;
                 for (int i = 0; i < end; i++) {
                     lazySet(i, emptyValue);
                 }

--- a/common/src/test/java/io/netty/util/concurrent/MpscIntQueueTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/MpscIntQueueTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.concurrent;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MpscIntQueueTest {
+    @ParameterizedTest
+    @ValueSource(ints = {1, 7, 8, 15, 16, 17})
+    void mustFillWithSpecifiedEmptyEntry(int size) throws Exception {
+        MpscIntQueue queue = MpscIntQueue.create(size, -1);
+        int filled = queue.fill(size, () -> 42);
+        assertEquals(size, filled);
+        for (int i = 0; i < size; i++) {
+            assertEquals(42, queue.poll());
+        }
+        assertEquals(-1, queue.poll());
+        assertTrue(queue.isEmpty());
+    }
+}


### PR DESCRIPTION
Motivation:
The int queue is always sized as a power of two, but the empty value was only set for the specified capacity number of entries.

Modification:
Fill the full length of the underlying array with the empty entry value.

Result:
No surprise zero values when the empty value is different from zero.