### PR TITLE
LocalChannel: Reduce GC by re-using same Runnable (#16014)

### DIFF
--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -73,6 +73,13 @@ public class LocalChannel extends AbstractChannel {
 
     private final LocalIoHandle ioHandle = new LocalIoHandleImpl();
 
+    private final Runnable finishReadTask = new Runnable() {
+        @Override
+        public void run() {
+            finishPeerRead0(LocalChannel.this);
+        }
+    };
+
     private IoRegistration registration;
 
     private volatile State state;
@@ -403,21 +410,19 @@ public class LocalChannel extends AbstractChannel {
         }
     }
 
-    private void runFinishPeerReadTask(final LocalChannel peer) {
+    private void runFinishTask0() {
         // If the peer is writing, we must wait until after reads are completed for that peer before we can read. So
         // we keep track of the task, and coordinate later that our read can't happen until the peer is done.
-        final Runnable finishPeerReadTask = new Runnable() {
-            @Override
-            public void run() {
-                finishPeerRead0(peer);
-            }
-        };
+        if (writeInProgress) {
+            finishReadFuture = executor().submit(finishReadTask);
+        } else {
+            executor().execute(finishReadTask);
+        }
+    }
+
+    private void runFinishPeerReadTask(final LocalChannel peer) {
         try {
-            if (peer.writeInProgress) {
-                peer.finishReadFuture = peer.executor().submit(finishPeerReadTask);
-            } else {
-                peer.executor().execute(finishPeerReadTask);
-            }
+            peer.runFinishTask0();
         } catch (Throwable cause) {
             logger.warn("Closing Local channels {}-{} because exception occurred!", this, peer, cause);
             close();


### PR DESCRIPTION
Motivation:

We reduce the GC that is produced by using the same Runnable and not
allocate a new one everytime.

Modifications:

Refactor code to be able to reuse the same Runnable

Result:

Less GC. Fixes some parts of https://github.com/netty/netty/issues/15994
