### PR TITLE
Optimize HTTP startline validation

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpRequest.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpRequest.java
@@ -92,7 +92,7 @@ public class DefaultHttpRequest extends DefaultHttpMessage implements HttpReques
         this.method = checkNotNull(method, "method");
         this.uri = checkNotNull(uri, "uri");
         if (validateRequestLine) {
-            HttpUtil.validateRequestLineTokens(httpVersion, method, uri);
+            HttpUtil.validateRequestLineTokens(method, uri);
         }
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
@@ -40,7 +40,6 @@ public final class HttpUtil {
     private static final AsciiString CHARSET_EQUALS = AsciiString.of(HttpHeaderValues.CHARSET + "=");
     private static final AsciiString SEMICOLON = AsciiString.cached(";");
     private static final String COMMA_STRING = String.valueOf(COMMA);
-    private static final long ILLEGAL_REQUEST_LINE_TOKEN_OCTET_MASK = 1L << '\n' | 1L << '\r' | 1L << ' ';
 
     private HttpUtil() { }
 
@@ -76,7 +75,7 @@ public final class HttpUtil {
         return "*".equals(uri);
     }
 
-    static void validateRequestLineTokens(HttpVersion httpVersion, HttpMethod method, String uri) {
+    static void validateRequestLineTokens(HttpMethod method, String uri) {
         // The HttpVersion class does its own validation, and it's not possible for subclasses to circumvent it.
         // The HttpMethod class does its own validation, but subclasses might circumvent it.
         if (method.getClass() != HttpMethod.class) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
@@ -107,11 +107,14 @@ public final class HttpUtil {
         int lenBytes = token.length();
         for (int i = 0; i < lenBytes; i++) {
             char ch = token.charAt(i);
-            switch (ch) {
-                case '\n':
-                case '\r':
-                case ' ':
-                    return false;
+            // this is to help AOT compiled code which cannot profile the switch
+            if (ch <= ' ') {
+                switch (ch) {
+                    case '\n':
+                    case '\r':
+                    case ' ':
+                        return false;
+                }
             }
         }
         return true;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
@@ -104,31 +104,17 @@ public final class HttpUtil {
      * otherwise {@code false}.
      */
     public static boolean isEncodingSafeStartLineToken(CharSequence token) {
-        int i = 0;
         int lenBytes = token.length();
-        int modulo = lenBytes % 4;
-        int lenInts = modulo == 0 ? lenBytes : lenBytes - modulo;
-        for (; i < lenInts; i += 4) {
-            long chars = charMask(token, i) |
-                    charMask(token, i + 1) |
-                    charMask(token, i + 2) |
-                    charMask(token, i + 3);
-            if ((chars & ILLEGAL_REQUEST_LINE_TOKEN_OCTET_MASK) != 0) {
-                return false;
-            }
-        }
-        for (; i < lenBytes; i++) {
-            long ch = charMask(token, i);
-            if ((ch & ILLEGAL_REQUEST_LINE_TOKEN_OCTET_MASK) != 0) {
-                return false;
+        for (int i = 0; i < lenBytes; i++) {
+            char ch = token.charAt(i);
+            switch (ch) {
+                case '\n':
+                case '\r':
+                case ' ':
+                    return false;
             }
         }
         return true;
-    }
-
-    private static long charMask(CharSequence token, int i) {
-        char c = token.charAt(i);
-        return c < 64 ? 1L << c : 0;
     }
 
     /**

--- a/microbench/src/main/java/io/netty/handler/codec/http/HttpRequestEncoderInsertBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http/HttpRequestEncoderInsertBenchmark.java
@@ -24,26 +24,86 @@ import io.netty.util.CharsetUtil;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
-import static io.netty.handler.codec.http.HttpConstants.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static io.netty.handler.codec.http.HttpConstants.CR;
+import static io.netty.handler.codec.http.HttpConstants.LF;
+import static io.netty.handler.codec.http.HttpConstants.SP;
 
 @State(Scope.Benchmark)
 @Warmup(iterations = 10)
 @Measurement(iterations = 20)
 public class HttpRequestEncoderInsertBenchmark extends AbstractMicrobenchmark {
 
-    private final String uri = "http://localhost?eventType=CRITICAL&from=0&to=1497437160327&limit=10&offset=0";
+    private static final String[] PARAMS = {
+            "eventType=CRITICAL",
+            "from=0",
+            "to=1497437160327",
+            "limit=10",
+            "offset=0"
+    };
+    private String[] uris;
+    private int index;
     private final OldHttpRequestEncoder encoderOld = new OldHttpRequestEncoder();
     private final HttpRequestEncoder encoderNew = new HttpRequestEncoder();
+
+    @Setup
+    public void setup() {
+        List<String[]> permutations = new ArrayList<>();
+        permute(PARAMS.clone(), 0, permutations);
+
+        uris = new String[permutations.size()];
+        String base = "http://localhost?";
+        for (int i = 0; i < permutations.size(); i++) {
+            StringBuilder sb = new StringBuilder(base);
+            String[] p = permutations.get(i);
+            for (int j = 0; j < p.length; j++) {
+                if (j != 0) {
+                    sb.append('&');
+                }
+                sb.append(p[j]);
+            }
+            uris[i] = sb.toString();
+        }
+    }
+
+    private static void permute(String[] arr, int start, List<String[]> out) {
+        if (start == arr.length - 1) {
+            out.add(Arrays.copyOf(arr, arr.length));
+            return;
+        }
+        for (int i = start; i < arr.length; i++) {
+            swap(arr, start, i);
+            permute(arr, start + 1, out);
+            swap(arr, start, i);
+        }
+    }
+
+    private static void swap(String[] a, int i, int j) {
+        String t = a[i];
+        a[i] = a[j];
+        a[j] = t;
+    }
+
+    private String nextUri() {
+        if (index >= uris.length) {
+            index = 0;
+        }
+        return uris[index++];
+    }
 
     @Benchmark
     public ByteBuf oldEncoder() throws Exception {
         ByteBuf buffer = Unpooled.buffer(100);
         try {
             encoderOld.encodeInitialLine(buffer, new DefaultHttpRequest(HttpVersion.HTTP_1_1,
-                    HttpMethod.GET, uri));
+                    HttpMethod.GET, nextUri()));
             return buffer;
         } finally {
             buffer.release();
@@ -55,7 +115,7 @@ public class HttpRequestEncoderInsertBenchmark extends AbstractMicrobenchmark {
         ByteBuf buffer = Unpooled.buffer(100);
         try {
             encoderNew.encodeInitialLine(buffer, new DefaultHttpRequest(HttpVersion.HTTP_1_1,
-                    HttpMethod.GET, uri));
+                    HttpMethod.GET, nextUri()));
             return buffer;
         } finally {
             buffer.release();

--- a/microbench/src/main/java/io/netty/handler/codec/http/HttpRequestEncoderInsertBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http/HttpRequestEncoderInsertBenchmark.java
@@ -23,6 +23,7 @@ import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
@@ -31,6 +32,7 @@ import org.openjdk.jmh.annotations.Warmup;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.SplittableRandom;
 
 import static io.netty.handler.codec.http.HttpConstants.CR;
 import static io.netty.handler.codec.http.HttpConstants.LF;
@@ -48,6 +50,9 @@ public class HttpRequestEncoderInsertBenchmark extends AbstractMicrobenchmark {
             "limit=10",
             "offset=0"
     };
+    @Param({"1024", "128000"})
+    private int samples;
+
     private String[] uris;
     private int index;
     private final OldHttpRequestEncoder encoderOld = new OldHttpRequestEncoder();
@@ -58,7 +63,7 @@ public class HttpRequestEncoderInsertBenchmark extends AbstractMicrobenchmark {
         List<String[]> permutations = new ArrayList<>();
         permute(PARAMS.clone(), 0, permutations);
 
-        uris = new String[permutations.size()];
+        String[] allCombinations = new String[permutations.size()];
         String base = "http://localhost?";
         for (int i = 0; i < permutations.size(); i++) {
             StringBuilder sb = new StringBuilder(base);
@@ -69,8 +74,14 @@ public class HttpRequestEncoderInsertBenchmark extends AbstractMicrobenchmark {
                 }
                 sb.append(p[j]);
             }
-            uris[i] = sb.toString();
+            allCombinations[i] = sb.toString();
         }
+        uris = new String[samples];
+        SplittableRandom rand = new SplittableRandom(42);
+        for (int i = 0; i < uris.length; i++) {
+            uris[i] = allCombinations[rand.nextInt(allCombinations.length)];
+        }
+        index = 0;
     }
 
     private static void permute(String[] arr, int start, List<String[]> out) {


### PR DESCRIPTION
Motivation:
#16020 has introduced too many math operations for something which should really be to handle an exceptional case, impacting performance

Modification:
Simplify the validation logic and allow the JVM to do its magic

Result:
Fixes #16020 with less perf impacts