### PR TITLE
Replace *FutureListener* usage with Lambda where possible

### DIFF
--- a/codec-base/src/main/java/io/netty/handler/codec/MessageAggregator.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/MessageAggregator.java
@@ -223,12 +223,9 @@ public abstract class MessageAggregator<I, S, C extends ByteBufHolder, O extends
                 // Cache the write listener for reuse.
                 ChannelFutureListener listener = continueResponseWriteListener;
                 if (listener == null) {
-                    continueResponseWriteListener = listener = new ChannelFutureListener() {
-                        @Override
-                        public void operationComplete(ChannelFuture future) {
-                            if (!future.isSuccess()) {
-                                ctx.fireExceptionCaught(future.cause());
-                            }
+                    continueResponseWriteListener = listener = future -> {
+                        if (!future.isSuccess()) {
+                            ctx.fireExceptionCaught(future.cause());
                         }
                     };
                 }

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/EncoderUtil.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/EncoderUtil.java
@@ -37,14 +37,11 @@ final class EncoderUtil {
                 }
             }, THREAD_POOL_DELAY_SECONDS, TimeUnit.SECONDS);
 
-            finishFuture.addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture f) {
-                    // Cancel the scheduled timeout.
-                    future.cancel(true);
-                    if (!promise.isDone()) {
-                        ctx.close(promise);
-                    }
+            finishFuture.addListener(f -> {
+                // Cancel the scheduled timeout.
+                future.cancel(true);
+                if (!promise.isDone()) {
+                    ctx.close(promise);
                 }
             });
         } else {

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/JZlibEncoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/JZlibEncoder.java
@@ -337,14 +337,11 @@ public class JZlibEncoder extends ZlibEncoder {
                 }
             }, THREAD_POOL_DELAY_SECONDS, TimeUnit.SECONDS);
 
-            f.addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture f) {
-                    // Cancel the scheduled timeout.
-                    future.cancel(true);
-                    if (!promise.isDone()) {
-                        ctx.close(promise);
-                    }
+            f.addListener(f1 -> {
+                // Cancel the scheduled timeout.
+                future.cancel(true);
+                if (!promise.isDone()) {
+                    ctx.close(promise);
                 }
             });
         } else {

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/Lz4FrameEncoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/Lz4FrameEncoderTest.java
@@ -280,16 +280,13 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
                     final int size = 27;
                     ByteBuf buf = ByteBufAllocator.DEFAULT.buffer(size, size);
                     finalClientChannel.writeAndFlush(buf.writerIndex(buf.writerIndex() + size))
-                            .addListener(new ChannelFutureListener() {
-                        @Override
-                        public void operationComplete(ChannelFuture future) {
-                            try {
-                                writeFailCauseRef.set(future.cause());
-                            } finally {
-                                latch.countDown();
-                            }
-                        }
-                    });
+                            .addListener(future -> {
+                                try {
+                                    writeFailCauseRef.set(future.cause());
+                                } finally {
+                                    latch.countDown();
+                                }
+                            });
                 }
             });
             latch.await();

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
@@ -18,7 +18,6 @@ package io.netty.handler.codec.http;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
@@ -249,23 +248,17 @@ public class HttpObjectAggregator
             if (oversized instanceof FullHttpMessage ||
                 !HttpUtil.is100ContinueExpected(oversized) && !HttpUtil.isKeepAlive(oversized)) {
                 ChannelFuture future = ctx.writeAndFlush(TOO_LARGE_CLOSE.retainedDuplicate());
-                future.addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) {
-                        if (!future.isSuccess()) {
-                            logger.debug("Failed to send a 413 Request Entity Too Large.", future.cause());
-                        }
-                        ctx.close();
+                future.addListener(f -> {
+                    if (!f.isSuccess()) {
+                        logger.debug("Failed to send a 413 Request Entity Too Large.", f.cause());
                     }
+                    ctx.close();
                 });
             } else {
-                ctx.writeAndFlush(TOO_LARGE.retainedDuplicate()).addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) {
-                        if (!future.isSuccess()) {
-                            logger.debug("Failed to send a 413 Request Entity Too Large.", future.cause());
-                            ctx.close();
-                        }
+                ctx.writeAndFlush(TOO_LARGE.retainedDuplicate()).addListener(future -> {
+                    if (!future.isSuccess()) {
+                        logger.debug("Failed to send a 413 Request Entity Too Large.", future.cause());
+                        ctx.close();
                     }
                 });
             }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker.java
@@ -287,7 +287,7 @@ public abstract class WebSocketClientHandshaker {
      *            the {@link ChannelPromise} to be notified when the opening handshake is sent
      */
     public final ChannelFuture handshake(Channel channel, final ChannelPromise promise) {
-        ChannelPipeline pipeline = channel.pipeline();
+        final ChannelPipeline pipeline = channel.pipeline();
         HttpResponseDecoder decoder = pipeline.get(HttpResponseDecoder.class);
         if (decoder == null) {
             HttpClientCodec codec = pipeline.get(HttpClientCodec.class);
@@ -322,26 +322,22 @@ public abstract class WebSocketClientHandshaker {
 
         FullHttpRequest request = newHandshakeRequest();
 
-        channel.writeAndFlush(request).addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                if (future.isSuccess()) {
-                    ChannelPipeline p = future.channel().pipeline();
-                    ChannelHandlerContext ctx = p.context(HttpRequestEncoder.class);
-                    if (ctx == null) {
-                        ctx = p.context(HttpClientCodec.class);
-                    }
-                    if (ctx == null) {
-                        promise.setFailure(new IllegalStateException("ChannelPipeline does not contain " +
-                                "an HttpRequestEncoder or HttpClientCodec"));
-                        return;
-                    }
-                    p.addAfter(ctx.name(), "ws-encoder", newWebSocketEncoder());
-
-                    promise.setSuccess();
-                } else {
-                    promise.setFailure(future.cause());
+        channel.writeAndFlush(request).addListener(future -> {
+            if (future.isSuccess()) {
+                ChannelHandlerContext ctx = pipeline.context(HttpRequestEncoder.class);
+                if (ctx == null) {
+                    ctx = pipeline.context(HttpClientCodec.class);
                 }
+                if (ctx == null) {
+                    promise.setFailure(new IllegalStateException("ChannelPipeline does not contain " +
+                            "an HttpRequestEncoder or HttpClientCodec"));
+                    return;
+                }
+                pipeline.addAfter(ctx.name(), "ws-encoder", newWebSocketEncoder());
+
+                promise.setSuccess();
+            } else {
+                promise.setFailure(future.cause());
             }
         });
         return promise;
@@ -687,32 +683,24 @@ public abstract class WebSocketClientHandshaker {
             return promise;
         }
 
-        promise.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                // If flush operation failed, there is no reason to expect
-                // a server to receive CloseFrame. Thus this should be handled
-                // by the application separately.
-                // Also, close might be called twice from different threads.
-                if (future.isSuccess() && channel.isActive() &&
-                        FORCE_CLOSE_INIT_UPDATER.compareAndSet(handshaker, 0, 1)) {
-                    final Future<?> forceCloseFuture = channel.executor().schedule(new Runnable() {
-                        @Override
-                        public void run() {
-                            if (channel.isActive()) {
-                                invoker.close();
-                                forceCloseComplete = true;
-                            }
+        promise.addListener(future -> {
+            // If flush operation failed, there is no reason to expect
+            // a server to receive CloseFrame. Thus this should be handled
+            // by the application separately.
+            // Also, close might be called twice from different threads.
+            if (future.isSuccess() && channel.isActive() &&
+                    FORCE_CLOSE_INIT_UPDATER.compareAndSet(handshaker, 0, 1)) {
+                final Future<?> forceCloseFuture = channel.executor().schedule(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (channel.isActive()) {
+                            invoker.close();
+                            forceCloseComplete = true;
                         }
-                    }, forceCloseTimeoutMillis, TimeUnit.MILLISECONDS);
+                    }
+                }, forceCloseTimeoutMillis, TimeUnit.MILLISECONDS);
 
-                    channel.closeFuture().addListener(new ChannelFutureListener() {
-                        @Override
-                        public void operationComplete(ChannelFuture future) {
-                            forceCloseFuture.cancel(false);
-                        }
-                    });
-                }
+                channel.closeFuture().addListener(f -> forceCloseFuture.cancel(false));
             }
         });
         return promise;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
@@ -16,14 +16,12 @@
 package io.netty.handler.codec.http.websocketx;
 
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.websocketx.WebSocketClientProtocolHandler.ClientHandshakeStateEvent;
 import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.FutureListener;
 
 import java.util.concurrent.TimeUnit;
 
@@ -55,16 +53,13 @@ class WebSocketClientProtocolHandshakeHandler implements ChannelInboundHandler {
     @Override
     public void channelActive(final ChannelHandlerContext ctx) throws Exception {
         ctx.fireChannelActive();
-        handshaker.handshake(ctx.channel()).addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                if (!future.isSuccess()) {
-                    handshakePromise.tryFailure(future.cause());
-                    ctx.fireExceptionCaught(future.cause());
-                } else {
-                    ctx.fireUserEventTriggered(
-                            WebSocketClientProtocolHandler.ClientHandshakeStateEvent.HANDSHAKE_ISSUED);
-                }
+        handshaker.handshake(ctx.channel()).addListener(future -> {
+            if (!future.isSuccess()) {
+                handshakePromise.tryFailure(future.cause());
+                ctx.fireExceptionCaught(future.cause());
+            } else {
+                ctx.fireUserEventTriggered(
+                        ClientHandshakeStateEvent.HANDSHAKE_ISSUED);
             }
         });
         applyHandshakeTimeout();
@@ -125,12 +120,7 @@ class WebSocketClientProtocolHandshakeHandler implements ChannelInboundHandler {
         }, handshakeTimeoutMillis, TimeUnit.MILLISECONDS);
 
         // Cancel the handshake timeout when handshake is finished.
-        localHandshakePromise.addListener(new FutureListener<Void>() {
-            @Override
-            public void operationComplete(Future<Void> f) {
-                timeoutFuture.cancel(false);
-            }
-        });
+        localHandshakePromise.addListener(f -> timeoutFuture.cancel(false));
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketProtocolHandler.java
@@ -99,12 +99,7 @@ abstract class WebSocketProtocolHandler extends MessageToMessageDecoder<WebSocke
             }
             flush(ctx);
             applyCloseSentTimeout(ctx);
-            closeSent.addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) {
-                    ctx.close(promise);
-                }
-            });
+            closeSent.addListener(future -> ctx.close(promise));
         }
     }
 
@@ -139,12 +134,7 @@ abstract class WebSocketProtocolHandler extends MessageToMessageDecoder<WebSocke
             }
         }, forceCloseTimeoutMillis, TimeUnit.MILLISECONDS);
 
-        closeSent.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                timeoutTask.cancel(false);
-            }
-        });
+        closeSent.addListener(future -> timeoutTask.cancel(false));
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
@@ -228,16 +228,13 @@ public abstract class WebSocketServerHandshaker {
             encoderName = p.context(HttpResponseEncoder.class).name();
             p.addBefore(encoderName, "wsencoder", newWebSocketEncoder());
         }
-        channel.writeAndFlush(response).addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                if (future.isSuccess()) {
-                    ChannelPipeline p = future.channel().pipeline();
-                    p.remove(encoderName);
-                    promise.setSuccess();
-                } else {
-                    promise.setFailure(future.cause());
-                }
+        channel.writeAndFlush(response).addListener(future -> {
+            if (future.isSuccess()) {
+                ChannelPipeline p1 = channel.pipeline();
+                p1.remove(encoderName);
+                promise.setSuccess();
+            } else {
+                promise.setFailure(future.cause());
             }
         });
         return promise;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
@@ -16,7 +16,6 @@
 package io.netty.handler.codec.http.websocketx;
 
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelPipeline;
@@ -28,7 +27,6 @@ import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler.Ser
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.FutureListener;
 
 import java.util.concurrent.TimeUnit;
 
@@ -84,21 +82,18 @@ class WebSocketServerProtocolHandshakeHandler implements ChannelInboundHandler {
                     ctx.pipeline().remove(this);
 
                     final ChannelFuture handshakeFuture = handshaker.handshake(ctx.channel(), req);
-                    handshakeFuture.addListener(new ChannelFutureListener() {
-                        @Override
-                        public void operationComplete(ChannelFuture future) {
-                            if (!future.isSuccess()) {
-                                localHandshakePromise.tryFailure(future.cause());
-                                ctx.fireExceptionCaught(future.cause());
-                            } else {
-                                localHandshakePromise.trySuccess();
-                                // Kept for compatibility
-                                ctx.fireUserEventTriggered(
-                                        WebSocketServerProtocolHandler.ServerHandshakeStateEvent.HANDSHAKE_COMPLETE);
-                                ctx.fireUserEventTriggered(
-                                        new WebSocketServerProtocolHandler.HandshakeComplete(
-                                                req.uri(), req.headers(), handshaker.selectedSubprotocol()));
-                            }
+                    handshakeFuture.addListener(future -> {
+                        if (!future.isSuccess()) {
+                            localHandshakePromise.tryFailure(future.cause());
+                            ctx.fireExceptionCaught(future.cause());
+                        } else {
+                            localHandshakePromise.trySuccess();
+                            // Kept for compatibility
+                            ctx.fireUserEventTriggered(
+                                    ServerHandshakeStateEvent.HANDSHAKE_COMPLETE);
+                            ctx.fireUserEventTriggered(
+                                    new WebSocketServerProtocolHandler.HandshakeComplete(
+                                            req.uri(), req.headers(), handshaker.selectedSubprotocol()));
                         }
                     });
                     applyHandshakeTimeout();
@@ -160,11 +155,6 @@ class WebSocketServerProtocolHandshakeHandler implements ChannelInboundHandler {
         }, handshakeTimeoutMillis, TimeUnit.MILLISECONDS);
 
         // Cancel the handshake timeout when handshake is finished.
-        localHandshakePromise.addListener(new FutureListener<Void>() {
-            @Override
-            public void operationComplete(Future<Void> f) {
-                timeoutFuture.cancel(false);
-            }
-        });
+        localHandshakePromise.addListener(f -> timeoutFuture.cancel(false));
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandler.java
@@ -19,8 +19,6 @@ import static io.netty.util.internal.ObjectUtil.checkNonEmpty;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelOutboundHandler;
@@ -224,18 +222,15 @@ public class WebSocketServerExtensionHandler implements ChannelInboundHandler, C
                 }
                 String newHeaderValue = WebSocketExtensionUtil
                   .computeMergeExtensionsHeaderValue(headerValue, extraExtensions);
-                promise.addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) {
-                        if (future.isSuccess()) {
-                            for (WebSocketServerExtension extension : validExtensionsList) {
-                                WebSocketExtensionDecoder decoder = extension.newExtensionDecoder();
-                                WebSocketExtensionEncoder encoder = extension.newExtensionEncoder();
-                                String name = ctx.name();
-                                ctx.pipeline()
-                                    .addAfter(name, decoder.getClass().getName(), decoder)
-                                    .addAfter(name, encoder.getClass().getName(), encoder);
-                            }
+                promise.addListener(future -> {
+                    if (future.isSuccess()) {
+                        for (WebSocketServerExtension extension : validExtensionsList) {
+                            WebSocketExtensionDecoder decoder = extension.newExtensionDecoder();
+                            WebSocketExtensionEncoder encoder = extension.newExtensionEncoder();
+                            String name = ctx.name();
+                            ctx.pipeline()
+                                .addAfter(name, decoder.getClass().getName(), decoder)
+                                .addAfter(name, encoder.getClass().getName(), encoder);
                         }
                     }
                 });
@@ -245,12 +240,9 @@ public class WebSocketServerExtensionHandler implements ChannelInboundHandler, C
                 }
             }
 
-            promise.addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) {
-                    if (future.isSuccess()) {
-                        ctx.pipeline().remove(WebSocketServerExtensionHandler.this);
-                    }
+            promise.addListener(future -> {
+                if (future.isSuccess()) {
+                    ctx.pipeline().remove(WebSocketServerExtensionHandler.this);
                 }
             });
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameCodec.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameCodec.java
@@ -16,8 +16,6 @@
 package io.netty.handler.codec.spdy;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandler;
@@ -151,12 +149,9 @@ public class SpdyFrameCodec extends ByteToMessageDecoder
     public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
         super.handlerAdded(ctx);
         this.ctx = ctx;
-        ctx.channel().closeFuture().addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                spdyHeaderBlockDecoder.end();
-                spdyHeaderBlockEncoder.end();
-            }
+        ctx.channel().closeFuture().addListener(future -> {
+            spdyHeaderBlockDecoder.end();
+            spdyHeaderBlockEncoder.end();
         });
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySessionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySessionHandler.java
@@ -501,12 +501,9 @@ public class SpdySessionHandler implements ChannelInboundHandler, ChannelOutboun
                 // The transfer window size is pre-decremented when sending a data frame downstream.
                 // Close the session on write failures that leave the transfer window in a corrupt state.
                 final ChannelHandlerContext context = ctx;
-                ctx.write(partialDataFrame).addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) {
-                        if (!future.isSuccess()) {
-                            issueSessionError(context, SpdySessionStatus.INTERNAL_ERROR);
-                        }
+                ctx.write(partialDataFrame).addListener(future -> {
+                    if (!future.isSuccess()) {
+                        issueSessionError(context, SpdySessionStatus.INTERNAL_ERROR);
                     }
                 });
                 return;
@@ -518,12 +515,9 @@ public class SpdySessionHandler implements ChannelInboundHandler, ChannelOutboun
                 // The transfer window size is pre-decremented when sending a data frame downstream.
                 // Close the session on write failures that leave the transfer window in a corrupt state.
                 final ChannelHandlerContext context = ctx;
-                promise.addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) {
-                        if (!future.isSuccess()) {
-                            issueSessionError(context, SpdySessionStatus.INTERNAL_ERROR);
-                        }
+                promise.addListener(future -> {
+                    if (!future.isSuccess()) {
+                        issueSessionError(context, SpdySessionStatus.INTERNAL_ERROR);
                     }
                 });
             }
@@ -778,12 +772,9 @@ public class SpdySessionHandler implements ChannelInboundHandler, ChannelOutboun
 
                 // The transfer window size is pre-decremented when sending a data frame downstream.
                 // Close the session on write failures that leave the transfer window in a corrupt state.
-                ctx.writeAndFlush(partialDataFrame).addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) {
-                        if (!future.isSuccess()) {
-                            issueSessionError(ctx, SpdySessionStatus.INTERNAL_ERROR);
-                        }
+                ctx.writeAndFlush(partialDataFrame).addListener(future -> {
+                    if (!future.isSuccess()) {
+                        issueSessionError(ctx, SpdySessionStatus.INTERNAL_ERROR);
                     }
                 });
             } else {
@@ -799,12 +790,9 @@ public class SpdySessionHandler implements ChannelInboundHandler, ChannelOutboun
 
                 // The transfer window size is pre-decremented when sending a data frame downstream.
                 // Close the session on write failures that leave the transfer window in a corrupt state.
-                ctx.writeAndFlush(spdyDataFrame, pendingWrite.promise).addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) {
-                        if (!future.isSuccess()) {
-                            issueSessionError(ctx, SpdySessionStatus.INTERNAL_ERROR);
-                        }
+                ctx.writeAndFlush(spdyDataFrame, pendingWrite.promise).addListener(future -> {
+                    if (!future.isSuccess()) {
+                        issueSessionError(ctx, SpdySessionStatus.INTERNAL_ERROR);
                     }
                 });
             }

--- a/codec-http/src/main/resources/META-INF/native-image/io.netty/netty5-codec-http/generated/handlers/reflect-config.json
+++ b/codec-http/src/main/resources/META-INF/native-image/io.netty/netty5-codec-http/generated/handlers/reflect-config.json
@@ -308,9 +308,9 @@
     "queryAllPublicMethods": true
   },
   {
-    "name": "io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker$4",
+    "name": "io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker$3",
     "condition": {
-      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker$4"
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker$3"
     },
     "queryAllPublicMethods": true
   },
@@ -357,9 +357,9 @@
     "queryAllPublicMethods": true
   },
   {
-    "name": "io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker$2",
+    "name": "io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker$1",
     "condition": {
-      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker$2"
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker$1"
     },
     "queryAllPublicMethods": true
   },

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpClientCodecTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpClientCodecTest.java
@@ -21,11 +21,9 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
-import io.netty.channel.ChannelShutdownDirection;
 import io.netty.channel.ChannelShutdownType;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
@@ -155,22 +153,16 @@ public class HttpClientCodecTest {
                             sChannel.writeAndFlush(Unpooled.wrappedBuffer(("HTTP/1.0 200 OK\r\n" +
                             "Date: Fri, 31 Dec 1999 23:59:59 GMT\r\n" +
                             "Content-Type: text/html\r\n\r\n").getBytes(CharsetUtil.ISO_8859_1)))
-                                    .addListener(new ChannelFutureListener() {
-                                @Override
-                                public void operationComplete(ChannelFuture future) {
-                                    assertTrue(future.isSuccess());
-                                    sChannel.writeAndFlush(Unpooled.wrappedBuffer(
-                                            "<html><body>hello half closed!</body></html>\r\n"
-                                            .getBytes(CharsetUtil.ISO_8859_1)))
-                                            .addListener(new ChannelFutureListener() {
-                                        @Override
-                                        public void operationComplete(ChannelFuture future) {
-                                            assertTrue(future.isSuccess());
-                                            sChannel.shutdown(ChannelShutdownType.newOutbound());
-                                        }
+                                    .addListener(future -> {
+                                        assertTrue(future.isSuccess());
+                                        sChannel.writeAndFlush(Unpooled.wrappedBuffer(
+                                                "<html><body>hello half closed!</body></html>\r\n"
+                                                .getBytes(CharsetUtil.ISO_8859_1)))
+                                                .addListener(f -> {
+                                                    assertTrue(f.isSuccess());
+                                                    sChannel.shutdown(ChannelShutdownType.newOutbound());
+                                                });
                                     });
-                                }
-                            });
                         }
                     });
                     serverChannelLatch.countDown();

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerUpgradeHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerUpgradeHandlerTest.java
@@ -20,8 +20,6 @@ import java.util.Collections;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelOutboundHandler;
@@ -115,12 +113,7 @@ public class HttpServerUpgradeHandlerTest {
                         ctx.write(msg, promise);
                     }
                 });
-                promise.addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) {
-                        writeFlushed = true;
-                    }
-                });
+                promise.addListener(future -> writeFlushed = true);
             }
         }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
@@ -249,12 +249,7 @@ public class WebSocketHandshakeHandOverTest {
             @Override
             public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
                 if (evt == ClientHandshakeStateEvent.HANDSHAKE_COMPLETE) {
-                    ctx.channel().closeFuture().addListener(new ChannelFutureListener() {
-                        @Override
-                        public void operationComplete(ChannelFuture future) {
-                            clientForceClosed = true;
-                        }
-                    });
+                    ctx.channel().closeFuture().addListener(future -> clientForceClosed = true);
                     handshaker.close(ctx.channel(), new CloseWebSocketFrame());
                 }
             }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
@@ -39,6 +39,7 @@ import io.netty.handler.codec.http2.Http2FrameCodec.DefaultHttp2FrameStream;
 import io.netty.handler.ssl.SslCloseCompletionEvent;
 import io.netty.util.DefaultAttributeMap;
 import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.Future;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.logging.InternalLogger;
@@ -158,12 +159,8 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
         }
     }
 
-    private final ChannelFutureListener windowUpdateFrameWriteListener = new ChannelFutureListener() {
-        @Override
-        public void operationComplete(ChannelFuture future) {
+    private final ChannelFutureListener windowUpdateFrameWriteListener = future ->
             windowUpdateFrameWriteComplete(future, AbstractHttp2StreamChannel.this);
-        }
-    };
 
     /**
      * The current status of the read-processing for a {@link AbstractHttp2StreamChannel}.
@@ -718,12 +715,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
                     promise.setSuccess();
                 } else {
                     // This means close() was called before so we just register a listener and return
-                    closePromise.addListener(new ChannelFutureListener() {
-                        @Override
-                        public void operationComplete(ChannelFuture future) {
-                            promise.setSuccess();
-                        }
-                    });
+                    closePromise.addListener(future -> promise.setSuccess());
                 }
                 return;
             }
@@ -1047,12 +1039,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
                         if (f.isDone()) {
                             writeComplete(f, promise);
                         } else {
-                            f.addListener(new ChannelFutureListener() {
-                                @Override
-                                public void operationComplete(ChannelFuture future) {
-                                    writeComplete(future, promise);
-                                }
-                            });
+                            f.addListener(future -> writeComplete(future, promise));
                         }
                     } else {
                         writeHttp2StreamFrame(frame, promise);
@@ -1108,22 +1095,19 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
             } else {
                 final long bytes = FlowControlledFrameSizeEstimator.HANDLE_INSTANCE.size(frame);
                 incrementPendingOutboundBytes(bytes, false);
-                f.addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) {
-                        if (firstWrite) {
-                            firstWriteComplete(future, promise);
-                        } else {
-                            writeComplete(future, promise);
-                        }
-                        decrementPendingOutboundBytes(bytes, false);
+                f.addListener(future -> {
+                    if (firstWrite) {
+                        firstWriteComplete(future, promise);
+                    } else {
+                        writeComplete(future, promise);
                     }
+                    decrementPendingOutboundBytes(bytes, false);
                 });
                 writeDoneAndNoFlush = true;
             }
         }
 
-        private void firstWriteComplete(ChannelFuture future, ChannelPromise promise) {
+        private void firstWriteComplete(Future<?> future, ChannelPromise promise) {
             Throwable cause = future.cause();
             if (cause == null) {
                 promise.setSuccess();
@@ -1134,7 +1118,7 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
             }
         }
 
-        private void writeComplete(ChannelFuture future, ChannelPromise promise) {
+        private void writeComplete(Future<?> future, ChannelPromise promise) {
             Throwable cause = future.cause();
             if (cause == null) {
                 promise.setSuccess();

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
@@ -522,13 +522,10 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder, Ht
     }
 
     private void notifyLifecycleManagerOnError(ChannelFuture future, final ChannelHandlerContext ctx) {
-        future.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                Throwable cause = future.cause();
-                if (cause != null) {
-                    lifecycleManager.onError(ctx, true, cause);
-                }
+        future.addListener(future1 -> {
+            Throwable cause = future1.cause();
+            if (cause != null) {
+                lifecycleManager.onError(ctx, true, cause);
             }
         });
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -518,14 +518,11 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
                 closeListener = listener;
             } else if (promise != null) {
                 final ChannelFutureListener oldCloseListener = closeListener;
-                closeListener = new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) {
-                        try {
-                            oldCloseListener.operationComplete(future);
-                        } finally {
-                            listener.operationComplete(future);
-                        }
+                closeListener = future1 -> {
+                    try {
+                        oldCloseListener.operationComplete(future1);
+                    } finally {
+                        listener.operationComplete(future1);
                     }
                 };
             }
@@ -637,12 +634,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         if (future.isDone()) {
             doCloseStream(stream, future);
         } else {
-            future.addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) {
-                    doCloseStream(stream, future);
-                }
-            });
+            future.addListener((ChannelFutureListener) future1 -> doCloseStream(stream, future1));
         }
     }
 
@@ -778,12 +770,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         if (future.isDone()) {
             closeConnectionOnError(ctx, future);
         } else {
-            future.addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) {
-                    closeConnectionOnError(ctx, future);
-                }
-            });
+            future.addListener((ChannelFutureListener) f -> closeConnectionOnError(ctx, f));
         }
         return future;
     }
@@ -824,12 +811,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         if (future.isDone()) {
             processRstStreamWriteResult(ctx, stream, future);
         } else {
-            future.addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) {
-                    processRstStreamWriteResult(ctx, stream, future);
-                }
-            });
+            future.addListener((ChannelFutureListener) f -> processRstStreamWriteResult(ctx, stream, f));
         }
 
         return future;
@@ -859,12 +841,8 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         if (future.isDone()) {
             processGoAwayWriteResult(ctx, lastStreamId, errorCode, debugData, future);
         } else {
-            future.addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) {
-                    processGoAwayWriteResult(ctx, lastStreamId, errorCode, debugData, future);
-                }
-            });
+            future.addListener((ChannelFutureListener) f ->
+                    processGoAwayWriteResult(ctx, lastStreamId, errorCode, debugData, f));
         }
 
         return future;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ControlFrameLimitEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ControlFrameLimitEncoder.java
@@ -29,16 +29,11 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
  */
 final class Http2ControlFrameLimitEncoder extends DecoratingHttp2ConnectionEncoder {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(Http2ControlFrameLimitEncoder.class);
+    private int outstandingControlFrames;
 
     private final int maxOutstandingControlFrames;
-    private final ChannelFutureListener outstandingControlFramesListener = new ChannelFutureListener() {
-        @Override
-        public void operationComplete(ChannelFuture future) {
-            outstandingControlFrames--;
-        }
-    };
+    private final ChannelFutureListener outstandingControlFramesListener = f-> outstandingControlFrames--;
     private Http2LifecycleManager lifecycleManager;
-    private int outstandingControlFrames;
     private boolean limitReached;
 
     Http2ControlFrameLimitEncoder(Http2ConnectionEncoder delegate, int maxOutstandingControlFrames) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
@@ -414,12 +414,9 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
                 numBufferedStreams++;
                 // Clean up the stream being initialized if writing the headers fails and also
                 // decrement the number of buffered streams.
-                promise.addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture channelFuture) {
-                        numBufferedStreams--;
-                        handleHeaderFuture(channelFuture, streamId);
-                    }
+                promise.addListener((ChannelFutureListener) channelFuture -> {
+                    numBufferedStreams--;
+                    handleHeaderFuture(channelFuture, streamId);
                 });
             } else {
                 handleHeaderFuture(promise, streamId);
@@ -443,12 +440,9 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
                 numBufferedStreams++;
                 // Clean up the stream being initialized if writing the headers fails and also
                 // decrement the number of buffered streams.
-                promise.addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture channelFuture) {
-                        numBufferedStreams--;
-                        handleHeaderFuture(channelFuture, streamId);
-                    }
+                promise.addListener((ChannelFutureListener) channelFuture -> {
+                    numBufferedStreams--;
+                    handleHeaderFuture(channelFuture, streamId);
                 });
             }
         }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexHandler.java
@@ -98,12 +98,7 @@ import static io.netty.handler.codec.http2.Http2Exception.connectionError;
  */
 public final class Http2MultiplexHandler extends Http2ChannelDuplexHandler {
 
-    static final ChannelFutureListener CHILD_CHANNEL_REGISTRATION_LISTENER = new ChannelFutureListener() {
-        @Override
-        public void operationComplete(ChannelFuture future) {
-            registerDone(future);
-        }
-    };
+    static final ChannelFutureListener CHILD_CHANNEL_REGISTRATION_LISTENER = Http2MultiplexHandler::registerDone;
 
     private final ChannelHandler inboundStreamHandler;
     private final ChannelHandler upgradeStreamHandler;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrap.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrap.java
@@ -17,7 +17,6 @@ package io.netty.handler.codec.http2;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOption;
@@ -187,17 +186,14 @@ public final class Http2StreamChannelBootstrap {
         }
 
         ChannelFuture future = streamChannel.register();
-        future.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                if (future.isSuccess()) {
-                    promise.setSuccess(streamChannel);
-                } else if (future.isCancelled()) {
-                    promise.cancel(false);
-                } else {
-                    streamChannel.close();
-                    promise.setFailure(future.cause());
-                }
+        future.addListener(f -> {
+            if (f.isSuccess()) {
+                promise.setSuccess(streamChannel);
+            } else if (f.isCancelled()) {
+                promise.cancel(false);
+            } else {
+                streamChannel.close();
+                promise.setFailure(f.cause());
             }
         });
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
@@ -168,12 +168,9 @@ public class DefaultHttp2ConnectionTest {
         client.forEachActiveStream(new Http2StreamVisitor() {
             @Override
             public boolean visit(Http2Stream stream) {
-                client.close(promise).addListener(new FutureListener<Void>() {
-                    @Override
-                    public void operationComplete(Future<Void> future) {
-                        assertTrue(promise.isDone());
-                        latch.countDown();
-                    }
+                client.close(promise).addListener(future -> {
+                    assertTrue(promise.isDone());
+                    latch.countDown();
                 });
                 return true;
             }
@@ -204,12 +201,9 @@ public class DefaultHttp2ConnectionTest {
                 }
             });
         } catch (Http2Exception ignored) {
-            client.close(promise).addListener(new FutureListener<Void>() {
-                @Override
-                public void operationComplete(Future<Void> future) {
-                    assertTrue(promise.isDone());
-                    latch.countDown();
-                }
+            client.close(promise).addListener(future -> {
+                assertTrue(promise.isDone());
+                latch.countDown();
             });
         }
         assertTrue(latch.await(5, TimeUnit.SECONDS));
@@ -683,12 +677,9 @@ public class DefaultHttp2ConnectionTest {
     private void testRemoveAllStreams() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         final Promise<Void> promise = group.next().newPromise();
-        client.close(promise).addListener(new FutureListener<Void>() {
-            @Override
-            public void operationComplete(Future<Void> future) {
-                assertTrue(promise.isDone());
-                latch.countDown();
-            }
+        client.close(promise).addListener(future -> {
+            assertTrue(promise.isDone());
+            latch.countDown();
         });
         assertTrue(latch.await(5, TimeUnit.SECONDS));
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2PushPromiseFrameTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2PushPromiseFrameTest.java
@@ -19,7 +19,6 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
@@ -120,30 +119,24 @@ public class DefaultHttp2PushPromiseFrameTest {
                 Http2PushPromiseFrame pushPromiseFrame = new DefaultHttp2PushPromiseFrame(pushRequestHeaders);
                 pushPromiseFrame.stream(receivedFrame.stream());
                 pushPromiseFrame.pushStream(newPushFrameStream);
-                ctx.writeAndFlush(pushPromiseFrame).addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) {
-                        contentMap.put(newPushFrameStream.id(), "Meow, I am Pushed via HTTP/2");
+                ctx.writeAndFlush(pushPromiseFrame).addListener(future -> {
+                    contentMap.put(newPushFrameStream.id(), "Meow, I am Pushed via HTTP/2");
 
-                        // Write headers for actual request
-                        Http2Headers http2Headers = new DefaultHttp2Headers();
-                        http2Headers.status("200");
-                        http2Headers.add("push", "false");
-                        Http2HeadersFrame headersFrame = new DefaultHttp2HeadersFrame(http2Headers, false);
-                        headersFrame.stream(receivedFrame.stream());
-                        ChannelFuture channelFuture = ctx.writeAndFlush(headersFrame);
+                    // Write headers for actual request
+                    Http2Headers http2Headers = new DefaultHttp2Headers();
+                    http2Headers.status("200");
+                    http2Headers.add("push", "false");
+                    Http2HeadersFrame headersFrame = new DefaultHttp2HeadersFrame(http2Headers, false);
+                    headersFrame.stream(receivedFrame.stream());
+                    ChannelFuture channelFuture = ctx.writeAndFlush(headersFrame);
 
-                        // Write Data of actual request
-                        channelFuture.addListener(new ChannelFutureListener() {
-                            @Override
-                            public void operationComplete(ChannelFuture future) {
-                                Http2DataFrame dataFrame = new DefaultHttp2DataFrame(
-                                        Unpooled.wrappedBuffer("Meow".getBytes()), true);
-                                dataFrame.stream(receivedFrame.stream());
-                                ctx.writeAndFlush(dataFrame);
-                            }
-                        });
-                    }
+                    // Write Data of actual request
+                    channelFuture.addListener(f -> {
+                        Http2DataFrame dataFrame = new DefaultHttp2DataFrame(
+                                Unpooled.wrappedBuffer("Meow".getBytes()), true);
+                        dataFrame.stream(receivedFrame.stream());
+                        ctx.writeAndFlush(dataFrame);
+                    });
                 });
             } else if (msg instanceof Http2PriorityFrame) {
                 Http2PriorityFrame priorityFrame = (Http2PriorityFrame) msg;

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -789,12 +789,7 @@ public class Http2ConnectionHandlerTest {
                 new DefaultChannelPromise(channel, ImmediateEventExecutor.INSTANCE);
         final ChannelPromise promise2 =
                 new DefaultChannelPromise(channel, ImmediateEventExecutor.INSTANCE);
-        promise.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                handler.resetStream(ctx, STREAM_ID, STREAM_CLOSED.code(), promise2);
-            }
-        });
+        promise.addListener(f -> handler.resetStream(ctx, STREAM_ID, STREAM_CLOSED.code(), promise2));
 
         handler.resetStream(ctx, STREAM_ID, CANCEL.code(), promise);
         verify(frameWriter).writeRstStream(eq(ctx), eq(STREAM_ID), anyLong(), any(ChannelPromise.class));

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -21,7 +21,6 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandler;
@@ -291,21 +290,13 @@ public class Http2ConnectionRoundtripTest {
             @Override
             public void run() throws Http2Exception {
                 http2Client.encoder().writeHeaders(ctx(), 3, headers, 0, false, newPromise())
-                        .addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) {
-                        clientHeadersWriteException.set(future.cause());
-                    }
-                });
+                        .addListener(future -> clientHeadersWriteException.set(future.cause()));
                 // It is expected that this write should fail locally and the remote peer will never see this.
                 http2Client.encoder().writeData(ctx(), 3, Unpooled.buffer(), 0, true, newPromise())
-                    .addListener(new ChannelFutureListener() {
-                        @Override
-                        public void operationComplete(ChannelFuture future) {
-                            clientDataWriteException.set(future.cause());
-                            clientDataWrite.countDown();
-                        }
-                });
+                    .addListener(future -> {
+                        clientDataWriteException.set(future.cause());
+                        clientDataWrite.countDown();
+                    });
                 http2Client.flush(ctx());
             }
         });
@@ -333,13 +324,10 @@ public class Http2ConnectionRoundtripTest {
             @Override
             public void run() throws Http2Exception {
                 http2Client.encoder().writeHeaders(ctx(), 5, headers, 0, true,
-                        newPromise()).addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) {
-                        clientHeadersWriteException2.set(future.cause());
-                        clientHeadersLatch.countDown();
-                    }
-                });
+                        newPromise()).addListener(future -> {
+                            clientHeadersWriteException2.set(future.cause());
+                            clientHeadersLatch.countDown();
+                        });
                 http2Client.flush(ctx());
             }
         });
@@ -557,12 +545,9 @@ public class Http2ConnectionRoundtripTest {
             @Override
             public void run() throws Http2Exception {
                 http2Server.encoder().writeHeaders(serverCtx(), streamId, headers, 0, true, serverNewPromise())
-                        .addListener(new ChannelFutureListener() {
-                            @Override
-                            public void operationComplete(ChannelFuture future) {
-                                serverWriteHeadersCauseRef.set(future.cause());
-                                serverWriteHeadersLatch.countDown();
-                            }
+                        .addListener(future -> {
+                            serverWriteHeadersCauseRef.set(future.cause());
+                            serverWriteHeadersLatch.countDown();
                         });
                 http2Server.flush(serverCtx());
             }
@@ -587,12 +572,7 @@ public class Http2ConnectionRoundtripTest {
 
         // Create a latch to track when the close occurs.
         final CountDownLatch closeLatch = new CountDownLatch(1);
-        clientChannel.closeFuture().addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                closeLatch.countDown();
-            }
-        });
+        clientChannel.closeFuture().addListener(future -> closeLatch.countDown());
 
         // Create a single stream by sending a HEADERS frame to the server.
         final Http2Headers headers = dummyHeaders();
@@ -633,12 +613,7 @@ public class Http2ConnectionRoundtripTest {
 
         // Create a latch to track when the close occurs.
         final CountDownLatch closeLatch = new CountDownLatch(1);
-        clientChannel.closeFuture().addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                closeLatch.countDown();
-            }
-        });
+        clientChannel.closeFuture().addListener(future -> closeLatch.countDown());
 
         // Create a single stream by sending a HEADERS frame to the server.
         runInChannel(clientChannel, new Http2Runnable() {
@@ -797,12 +772,7 @@ public class Http2ConnectionRoundtripTest {
 
         // Create a latch to track when the close occurs.
         final CountDownLatch closeLatch = new CountDownLatch(1);
-        clientChannel.closeFuture().addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                closeLatch.countDown();
-            }
-        });
+        clientChannel.closeFuture().addListener(future -> closeLatch.countDown());
 
         // Create a single stream by sending a HEADERS frame to the server.
         final Http2Headers headers = dummyHeaders();
@@ -924,12 +894,7 @@ public class Http2ConnectionRoundtripTest {
                         true, newPromise());
                 clientWriteAfterGoAwayFutureRef.set(f);
                 http2Client.flush(ctx());
-                f.addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) {
-                        clientWriteAfterGoAwayLatch.countDown();
-                    }
-                });
+                f.addListener(future -> clientWriteAfterGoAwayLatch.countDown());
             }
         });
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
@@ -18,7 +18,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelPromise;
@@ -44,6 +43,7 @@ import io.netty.util.concurrent.GlobalEventExecutor;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.ReflectionUtil;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -662,15 +662,11 @@ public class Http2FrameCodecTest {
         final Promise<Void> listenerExecuted = new DefaultPromise<Void>(GlobalEventExecutor.INSTANCE);
 
         channel.writeAndFlush(new DefaultHttp2HeadersFrame(new DefaultHttp2Headers(), false).stream(stream))
-               .addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) {
-                        assertTrue(future.isSuccess());
-                        assertTrue(isStreamIdValid(stream.id()));
-                        listenerExecuted.setSuccess(null);
-                    }
-                }
-        );
+               .addListener(future -> {
+                   assertTrue(future.isSuccess());
+                   assertTrue(isStreamIdValid(stream.id()));
+                   listenerExecuted.setSuccess(null);
+               });
         ByteBuf data = Unpooled.buffer().writeZero(100);
         ChannelFuture f = channel.writeAndFlush(new DefaultHttp2DataFrame(data).stream(stream));
         assertTrue(f.isSuccess());
@@ -903,13 +899,10 @@ public class Http2FrameCodecTest {
 
         final AtomicBoolean listenerExecuted = new AtomicBoolean();
         channel.writeAndFlush(new DefaultHttp2HeadersFrame(new DefaultHttp2Headers()).stream(stream2))
-                .addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) {
-                        assertTrue(future.isSuccess());
-                        assertEquals(State.OPEN, stream2.state());
-                        listenerExecuted.set(true);
-                    }
+                .addListener(future -> {
+                    assertTrue(future.isSuccess());
+                    assertEquals(State.OPEN, stream2.state());
+                    listenerExecuted.set(true);
                 });
 
         assertTrue(listenerExecuted.get());
@@ -940,15 +933,12 @@ public class Http2FrameCodecTest {
                     // Simulate consuming the frame and update the flow-controller.
                     Http2DataFrame data = (Http2DataFrame) msg;
                     ctx.writeAndFlush(new DefaultHttp2WindowUpdateFrame(data.initialFlowControlledBytes())
-                            .stream(data.stream())).addListener(new ChannelFutureListener() {
-                        @Override
-                        public void operationComplete(ChannelFuture future) {
-                            Throwable cause = future.cause();
-                            if (cause != null) {
-                                ctx.fireExceptionCaught(cause);
-                            }
-                        }
-                    });
+                            .stream(data.stream())).addListener(future -> {
+                                Throwable cause = future.cause();
+                                if (cause != null) {
+                                    ctx.fireExceptionCaught(cause);
+                                }
+                            });
                 }
                 ReferenceCountUtil.release(msg);
             }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
@@ -986,12 +986,9 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
         // Create a promise before actually doing the close, because otherwise we would be adding a listener to a future
         // that is already completed because we are using EmbeddedChannel which executes code in the JUnit thread.
         ChannelPromise p = childChannel.newPromise();
-        p.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                channelOpen.set(future.channel().isOpen());
-                channelActive.set(future.channel().isActive());
-            }
+        p.addListener((ChannelFutureListener) future -> {
+            channelOpen.set(future.channel().isOpen());
+            channelActive.set(future.channel().isActive());
         });
         childChannel.close(p).syncUninterruptibly();
 
@@ -1011,12 +1008,9 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
          final AtomicBoolean channelOpen = new AtomicBoolean(true);
          final AtomicBoolean channelActive = new AtomicBoolean(true);
 
-         childChannel.closeFuture().addListener(new ChannelFutureListener() {
-             @Override
-             public void operationComplete(ChannelFuture future) {
-                 channelOpen.set(future.channel().isOpen());
-                 channelActive.set(future.channel().isActive());
-             }
+         childChannel.closeFuture().addListener((ChannelFutureListener) future -> {
+             channelOpen.set(future.channel().isOpen());
+             channelActive.set(future.channel().isActive());
          });
          childChannel.close().syncUninterruptibly();
 
@@ -1052,12 +1046,9 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
 
         ChannelFuture f = childChannel.writeAndFlush(new DefaultHttp2HeadersFrame(headers));
         assertFalse(f.isDone());
-        f.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                channelOpen.set(future.channel().isOpen());
-                channelActive.set(future.channel().isActive());
-            }
+        f.addListener((ChannelFutureListener) future -> {
+            channelOpen.set(future.channel().isOpen());
+            channelActive.set(future.channel().isActive());
         });
 
         ChannelPromise first = writePromises.poll();

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTransportTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTransportTest.java
@@ -295,20 +295,18 @@ public class Http2MultiplexTransportTest {
                                     public void run() {
                                         ctx.writeAndFlush(new DefaultHttp2HeadersFrame(
                                                 new DefaultHttp2Headers(), false)).addListener(
-                                                        new ChannelFutureListener() {
-                                            @Override
-                                            public void operationComplete(ChannelFuture future) {
-                                                ctx.write(new DefaultHttp2DataFrame(
-                                                        Unpooled.copiedBuffer("Hello World", CharsetUtil.US_ASCII),
-                                                        true));
-                                                ctx.channel().executor().execute(new Runnable() {
-                                                    @Override
-                                                    public void run() {
-                                                        ctx.flush();
-                                                    }
+                                                (ChannelFutureListener) future -> {
+                                                    ctx.write(new DefaultHttp2DataFrame(
+                                                            Unpooled.copiedBuffer(
+                                                                    "Hello World", CharsetUtil.US_ASCII),
+                                                            true));
+                                                    ctx.channel().executor().execute(new Runnable() {
+                                                        @Override
+                                                        public void run() {
+                                                            ctx.flush();
+                                                        }
+                                                    });
                                                 });
-                                            }
-                                        });
                                     }
                                 }, 500, MILLISECONDS);
                             }
@@ -489,13 +487,10 @@ public class Http2MultiplexTransportTest {
                                         latch.countDown();
                                     }
                                 });
-                                h2Bootstrap.open().addListener(new FutureListener<Channel>() {
-                                    @Override
-                                    public void operationComplete(Future<Channel> future) {
-                                        if (future.isSuccess()) {
-                                            future.getNow().writeAndFlush(new DefaultHttp2HeadersFrame(
-                                                    new DefaultHttp2Headers(), false));
-                                        }
+                                h2Bootstrap.open().addListener((FutureListener<Channel>) future -> {
+                                    if (future.isSuccess()) {
+                                        future.getNow().writeAndFlush(new DefaultHttp2HeadersFrame(
+                                                new DefaultHttp2Headers(), false));
                                     }
                                 });
 
@@ -574,14 +569,10 @@ public class Http2MultiplexTransportTest {
                                 if (msg instanceof Http2HeadersFrame && ((Http2HeadersFrame) msg).isEndStream()) {
                                     ctx.writeAndFlush(new DefaultHttp2HeadersFrame(
                                                     new DefaultHttp2Headers(), false))
-                                            .addListener(new ChannelFutureListener() {
-                                                @Override
-                                                public void operationComplete(ChannelFuture future) {
+                                            .addListener((ChannelFutureListener) future ->
                                                     ctx.writeAndFlush(new DefaultHttp2DataFrame(
                                                             Unpooled.copiedBuffer("Hello World", CharsetUtil.US_ASCII),
-                                                            true));
-                                                }
-                                            });
+                                                            true)));
                                 }
                                 ReferenceCountUtil.release(msg);
                             }
@@ -632,13 +623,10 @@ public class Http2MultiplexTransportTest {
                                         ReferenceCountUtil.release(msg);
                                     }
                                 });
-                                h2Bootstrap.open().addListener(new FutureListener<Channel>() {
-                                    @Override
-                                    public void operationComplete(Future<Channel> future) {
-                                        if (future.isSuccess()) {
-                                            future.getNow().writeAndFlush(new DefaultHttp2HeadersFrame(
-                                                    new DefaultHttp2Headers(), true));
-                                        }
+                                h2Bootstrap.open().addListener((FutureListener<Channel>) future -> {
+                                    if (future.isSuccess()) {
+                                        future.getNow().writeAndFlush(new DefaultHttp2HeadersFrame(
+                                                new DefaultHttp2Headers(), true));
                                     }
                                 });
                             }

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicStreamShutdownTest.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicStreamShutdownTest.java
@@ -54,13 +54,10 @@ public class QuicStreamShutdownTest extends AbstractQuicTest {
                     new ChannelInboundHandler() {
                         @Override
                         public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-                            ChannelFutureListener futureListener = new ChannelFutureListener() {
-                                @Override
-                                public void operationComplete(ChannelFuture channelFuture) {
-                                    Throwable cause = channelFuture.cause();
-                                    if (cause instanceof ChannelOutputShutdownException) {
-                                        latch.countDown();
-                                    }
+                            ChannelFutureListener futureListener = channelFuture -> {
+                                Throwable cause = channelFuture.cause();
+                                if (cause instanceof ChannelOutputShutdownException) {
+                                    latch.countDown();
                                 }
                             };
                             ByteBuf buffer = (ByteBuf) msg;
@@ -105,27 +102,21 @@ public class QuicStreamShutdownTest extends AbstractQuicTest {
                         public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
                             QuicStreamChannel streamChannel = (QuicStreamChannel) ctx.channel();
                             streamChannel.shutdown(ChannelShutdownType.newInbound())
-                                    .addListener(new ChannelFutureListener() {
-                                @Override
-                                public void operationComplete(ChannelFuture f) {
-                                    ByteBuf buffer = (ByteBuf) msg;
-                                    if (!f.isSuccess()) {
-                                        errorRef.compareAndSet(null, f.cause());
-                                        latch.countDown();
-                                        buffer.release();
-                                    } else {
-                                        ctx.writeAndFlush(buffer).addListener(new ChannelFutureListener() {
-                                            @Override
-                                            public void operationComplete(ChannelFuture channelFuture) {
+                                    .addListener(f -> {
+                                        ByteBuf buffer = (ByteBuf) msg;
+                                        if (!f.isSuccess()) {
+                                            errorRef.compareAndSet(null, f.cause());
+                                            latch.countDown();
+                                            buffer.release();
+                                        } else {
+                                            ctx.writeAndFlush(buffer).addListener(channelFuture -> {
                                                 if (!channelFuture.isSuccess()) {
                                                     errorRef.compareAndSet(null, channelFuture.cause());
                                                 }
                                                 latch.countDown();
-                                            }
-                                        });
-                                    }
-                                }
-                            });
+                                            });
+                                        }
+                                    });
                         }
                     });
 
@@ -182,15 +173,12 @@ public class QuicStreamShutdownTest extends AbstractQuicTest {
                             ByteBuf buffer = (ByteBuf) msg;
                             buffer.release();
                             streamChannel.shutdown(ChannelShutdownType.newOutbound(100))
-                                    .addListener(new ChannelFutureListener() {
-                                @Override
-                                public void operationComplete(ChannelFuture f) {
-                                    if (!f.isSuccess()) {
-                                        errorRef.compareAndSet(null, f.cause());
-                                    }
-                                    latch.countDown();
-                                }
-                            });
+                                    .addListener(f -> {
+                                        if (!f.isSuccess()) {
+                                            errorRef.compareAndSet(null, f.cause());
+                                        }
+                                        latch.countDown();
+                                    });
                         }
                     });
 

--- a/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java
@@ -114,12 +114,9 @@ public abstract class MultithreadEventExecutorGroup extends AbstractEventExecuto
 
         chooser = chooserFactory.newChooser(children);
 
-        final FutureListener<Object> terminationListener = new FutureListener<Object>() {
-            @Override
-            public void operationComplete(Future<Object> future) {
-                if (terminatedChildren.incrementAndGet() == children.length) {
-                    terminationFuture.setSuccess(null);
-                }
+        final FutureListener<Object> terminationListener = future -> {
+            if (terminatedChildren.incrementAndGet() == children.length) {
+                terminationFuture.setSuccess(null);
             }
         };
 

--- a/common/src/main/java/io/netty/util/concurrent/PromiseNotifier.java
+++ b/common/src/main/java/io/netty/util/concurrent/PromiseNotifier.java
@@ -91,12 +91,9 @@ public class PromiseNotifier<V, F extends Future<V>> implements GenericFutureLis
     @SuppressWarnings({"unchecked", "rawtypes"})
     public static <V, F extends Future<V>> F cascade(boolean logNotifyFailure, final F future,
                                                      final Promise<? super V> promise) {
-        promise.addListener(new FutureListener() {
-            @Override
-            public void operationComplete(Future f) {
-                if (f.isCancelled()) {
-                    future.cancel(false);
-                }
+        promise.addListener((FutureListener) f -> {
+            if (f.isCancelled()) {
+                future.cancel(false);
             }
         });
         future.addListener(new PromiseNotifier(logNotifyFailure, promise) {

--- a/common/src/test/java/io/netty/util/concurrent/DefaultPromiseTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/DefaultPromiseTest.java
@@ -422,14 +422,11 @@ public class DefaultPromiseTest {
         for (int i = 0; i < p.length; i ++) {
             final int finalI = i;
             p[i] = new DefaultPromise<Void>(executor);
-            p[i].addListener(new FutureListener<Void>() {
-                @Override
-                public void operationComplete(Future<Void> future) {
-                    if (finalI + 1 < p.length) {
-                        p[finalI + 1].setSuccess(null);
-                    }
-                    latch.countDown();
+            p[i].addListener((FutureListener<Void>) future -> {
+                if (finalI + 1 < p.length) {
+                    p[finalI + 1].setSuccess(null);
                 }
+                latch.countDown();
             });
         }
 
@@ -464,20 +461,13 @@ public class DefaultPromiseTest {
         for (int i = 0; i < p.length; i ++) {
             final int finalI = i;
             p[i] = new DefaultPromise<Void>(executor);
-            p[i].addListener(new FutureListener<Void>() {
-                @Override
-                public void operationComplete(Future<Void> future) {
-                    future.addListener(new FutureListener<Void>() {
-                        @Override
-                        public void operationComplete(Future<Void> future) {
-                            if (finalI + 1 < p.length) {
-                                p[finalI + 1].setSuccess(null);
-                            }
-                            latch.countDown();
-                        }
-                    });
+            p[i].addListener((FutureListener<Void>) future -> future.addListener(
+                    (FutureListener<Void>) f -> {
+                if (finalI + 1 < p.length) {
+                    p[finalI + 1].setSuccess(null);
                 }
-            });
+                latch.countDown();
+            }));
         }
 
         p[0].setSuccess(null);
@@ -502,12 +492,7 @@ public class DefaultPromiseTest {
             final Promise<Void> promise = new DefaultPromise<Void>(executor);
 
             // Add a listener before completion so "lateListener" is used next time we add a listener.
-            promise.addListener(new FutureListener<Void>() {
-                @Override
-                public void operationComplete(Future<Void> future) {
-                    assertTrue(state.compareAndSet(0, 1));
-                }
-            });
+            promise.addListener((FutureListener<Void>) future -> assertTrue(state.compareAndSet(0, 1)));
 
             // Simulate write operation completing, which will execute listeners in another thread.
             if (cause == null) {
@@ -517,12 +502,9 @@ public class DefaultPromiseTest {
             }
 
             // Add a "late listener"
-            promise.addListener(new FutureListener<Void>() {
-                @Override
-                public void operationComplete(Future<Void> future) {
-                    assertTrue(state.compareAndSet(1, 2));
-                    latch1.countDown();
-                }
+            promise.addListener((FutureListener<Void>) future -> {
+                assertTrue(state.compareAndSet(1, 2));
+                latch1.countDown();
             });
 
             // Wait for the listeners and late listeners to be completed.
@@ -534,12 +516,9 @@ public class DefaultPromiseTest {
             executor.execute(new Runnable() {
                 @Override
                 public void run() {
-                    promise.addListener(new FutureListener<Void>() {
-                        @Override
-                        public void operationComplete(Future<Void> future) {
-                            assertTrue(state.compareAndSet(2, 3));
-                            latch2.countDown();
-                        }
+                    promise.addListener((FutureListener<Void>) future -> {
+                        assertTrue(state.compareAndSet(2, 3));
+                        latch2.countDown();
                     });
                 }
             });
@@ -563,17 +542,8 @@ public class DefaultPromiseTest {
     private static void testPromiseListenerAddWhenComplete(Throwable cause) throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         final Promise<Void> promise = new DefaultPromise<Void>(ImmediateEventExecutor.INSTANCE);
-        promise.addListener(new FutureListener<Void>() {
-            @Override
-            public void operationComplete(Future<Void> future) {
-                promise.addListener(new FutureListener<Void>() {
-                    @Override
-                    public void operationComplete(Future<Void> future) {
-                        latch.countDown();
-                    }
-                });
-            }
-        });
+        promise.addListener((FutureListener<Void>) future ->
+                promise.addListener((FutureListener<Void>) f -> latch.countDown()));
         if (cause == null) {
             promise.setSuccess(null);
         } else {
@@ -586,12 +556,7 @@ public class DefaultPromiseTest {
         EventExecutor executor = new TestEventExecutor();
         int expectedCount = numListenersBefore + 2;
         final CountDownLatch latch = new CountDownLatch(expectedCount);
-        final FutureListener<Void> listener = new FutureListener<Void>() {
-            @Override
-            public void operationComplete(Future<Void> future) {
-                latch.countDown();
-            }
-        };
+        final FutureListener<Void> listener = future -> latch.countDown();
         final Promise<Void> promise = new DefaultPromise<Void>(executor);
         executor.execute(new Runnable() {
             @Override

--- a/common/src/test/java/io/netty/util/concurrent/UnorderedThreadPoolEventExecutorTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/UnorderedThreadPoolEventExecutorTest.java
@@ -58,12 +58,7 @@ public class UnorderedThreadPoolEventExecutorTest {
                 public void run() {
                     latch.countDown();
                 }
-            }).addListener(new FutureListener<Object>() {
-                @Override
-                public void operationComplete(Future<Object> future) {
-                    latch.countDown();
-                }
-            });
+            }).addListener((FutureListener<Object>) f -> latch.countDown());
             exchanger.exchange(null);
             latch.await();
             future.syncUninterruptibly();

--- a/example/src/main/java/io/netty/example/discard/DiscardClientHandler.java
+++ b/example/src/main/java/io/netty/example/discard/DiscardClientHandler.java
@@ -16,7 +16,6 @@
 package io.netty.example.discard;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
@@ -65,15 +64,12 @@ public class DiscardClientHandler extends SimpleChannelInboundHandler<Object> {
         ctx.writeAndFlush(content.retainedDuplicate()).addListener(trafficGenerator);
     }
 
-    private final ChannelFutureListener trafficGenerator = new ChannelFutureListener() {
-        @Override
-        public void operationComplete(ChannelFuture future) {
-            if (future.isSuccess()) {
-                generateTraffic();
-            } else {
-                future.cause().printStackTrace();
-                future.channel().close();
-            }
+    private final ChannelFutureListener trafficGenerator = future -> {
+        if (future.isSuccess()) {
+            generateTraffic();
+        } else {
+            future.cause().printStackTrace();
+            future.channel().close();
         }
     };
 }

--- a/example/src/main/java/io/netty/example/factorial/FactorialClientHandler.java
+++ b/example/src/main/java/io/netty/example/factorial/FactorialClientHandler.java
@@ -66,12 +66,9 @@ public class FactorialClientHandler extends SimpleChannelInboundHandler<BigInteg
         receivedMessages ++;
         if (receivedMessages == FactorialClient.COUNT) {
             // Offer the answer after closing the connection.
-            ctx.channel().close().addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) {
-                    boolean offered = answer.offer(msg);
-                    assert offered;
-                }
+            ctx.channel().close().addListener(future -> {
+                boolean offered = answer.offer(msg);
+                assert offered;
             });
         }
     }
@@ -96,15 +93,12 @@ public class FactorialClientHandler extends SimpleChannelInboundHandler<BigInteg
         ctx.flush();
     }
 
-    private final ChannelFutureListener numberSender = new ChannelFutureListener() {
-        @Override
-        public void operationComplete(ChannelFuture future) {
-            if (future.isSuccess()) {
-                sendNumbers();
-            } else {
-                future.cause().printStackTrace();
-                future.channel().close();
-            }
+    private final ChannelFutureListener numberSender = future -> {
+        if (future.isSuccess()) {
+            sendNumbers();
+        } else {
+            future.cause().printStackTrace();
+            future.channel().close();
         }
     };
 }

--- a/example/src/main/java/io/netty/example/haproxy/HAProxyHandler.java
+++ b/example/src/main/java/io/netty/example/haproxy/HAProxyHandler.java
@@ -17,7 +17,6 @@
 package io.netty.example.haproxy;
 
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandler;
 import io.netty.channel.ChannelPromise;
@@ -35,15 +34,12 @@ public class HAProxyHandler implements ChannelOutboundHandler {
     public void write(final ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         ChannelFuture future = ctx.write(msg, promise);
         if (msg instanceof HAProxyMessage) {
-            future.addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) {
-                    if (future.isSuccess()) {
-                        ctx.pipeline().remove(HAProxyMessageEncoder.INSTANCE);
-                        ctx.pipeline().remove(HAProxyHandler.this);
-                    } else {
-                        ctx.close();
-                    }
+            future.addListener(future1 -> {
+                if (future1.isSuccess()) {
+                    ctx.pipeline().remove(HAProxyMessageEncoder.INSTANCE);
+                    ctx.pipeline().remove(HAProxyHandler.this);
+                } else {
+                    ctx.close();
                 }
             });
         }

--- a/example/src/main/java/io/netty/example/proxy/HexDumpProxyBackendHandler.java
+++ b/example/src/main/java/io/netty/example/proxy/HexDumpProxyBackendHandler.java
@@ -16,8 +16,6 @@
 package io.netty.example.proxy;
 
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandler;
 
@@ -40,14 +38,11 @@ public class HexDumpProxyBackendHandler implements ChannelInboundHandler {
 
     @Override
     public void channelRead(final ChannelHandlerContext ctx, Object msg) {
-        inboundChannel.writeAndFlush(msg).addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                if (future.isSuccess()) {
-                    ctx.channel().read();
-                } else {
-                    future.channel().close();
-                }
+        inboundChannel.writeAndFlush(msg).addListener(future -> {
+            if (future.isSuccess()) {
+                ctx.read();
+            } else {
+                ctx.close();
             }
         });
     }

--- a/example/src/main/java/io/netty/example/proxy/HexDumpProxyFrontendHandler.java
+++ b/example/src/main/java/io/netty/example/proxy/HexDumpProxyFrontendHandler.java
@@ -50,16 +50,13 @@ public class HexDumpProxyFrontendHandler implements ChannelInboundHandler {
          .option(ChannelOption.AUTO_READ, false);
         ChannelFuture f = b.connect(remoteHost, remotePort);
         outboundChannel = f.channel();
-        f.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                if (future.isSuccess()) {
-                    // connection complete start to read first data
-                    inboundChannel.read();
-                } else {
-                    // Close the connection if the connection attempt has failed.
-                    inboundChannel.close();
-                }
+        f.addListener(future -> {
+            if (future.isSuccess()) {
+                // connection complete start to read first data
+                inboundChannel.read();
+            } else {
+                // Close the connection if the connection attempt has failed.
+                inboundChannel.close();
             }
         });
     }
@@ -67,15 +64,12 @@ public class HexDumpProxyFrontendHandler implements ChannelInboundHandler {
     @Override
     public void channelRead(final ChannelHandlerContext ctx, Object msg) {
         if (outboundChannel.isActive()) {
-            outboundChannel.writeAndFlush(msg).addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) {
-                    if (future.isSuccess()) {
-                        // was able to flush out data, start to read the next chunk
-                        ctx.channel().read();
-                    } else {
-                        future.channel().close();
-                    }
+            outboundChannel.writeAndFlush(msg).addListener(future -> {
+                if (future.isSuccess()) {
+                    // was able to flush out data, start to read the next chunk
+                    ctx.read();
+                } else {
+                    ctx.close();
                 }
             });
         }

--- a/example/src/main/java/io/netty/example/redis/RedisClient.java
+++ b/example/src/main/java/io/netty/example/redis/RedisClient.java
@@ -29,7 +29,6 @@ import io.netty.handler.codec.redis.RedisArrayAggregator;
 import io.netty.handler.codec.redis.RedisBulkStringAggregator;
 import io.netty.handler.codec.redis.RedisDecoder;
 import io.netty.handler.codec.redis.RedisEncoder;
-import io.netty.util.concurrent.GenericFutureListener;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -77,13 +76,10 @@ public class RedisClient {
                 }
                 // Sends the received line to the server.
                 lastWriteFuture = ch.writeAndFlush(line);
-                lastWriteFuture.addListener(new GenericFutureListener<ChannelFuture>() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) {
-                        if (!future.isSuccess()) {
-                            System.err.print("write failed: ");
-                            future.cause().printStackTrace(System.err);
-                        }
+                lastWriteFuture.addListener(future -> {
+                    if (!future.isSuccess()) {
+                        System.err.print("write failed: ");
+                        future.cause().printStackTrace(System.err);
                     }
                 });
             }

--- a/example/src/main/java/io/netty/example/securechat/SecureChatServerHandler.java
+++ b/example/src/main/java/io/netty/example/securechat/SecureChatServerHandler.java
@@ -19,8 +19,6 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.ssl.SslHandler;
-import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.GenericFutureListener;
 
 import java.util.Collections;
 import java.util.Set;
@@ -37,20 +35,16 @@ public class SecureChatServerHandler extends SimpleChannelInboundHandler<String>
     public void channelActive(final ChannelHandlerContext ctx) throws Exception {
         // Once session is secured, send a greeting and register the channel to the global channel
         // list so the channel received the messages from others.
-        ctx.pipeline().get(SslHandler.class).handshakeFuture().addListener(
-                new GenericFutureListener<Future<Channel>>() {
-                    @Override
-                    public void operationComplete(Future<Channel> future) {
-                        ctx.writeAndFlush(
-                                "Welcome to secure chat service!\n");
-                        ctx.writeAndFlush(
-                                "Your session is protected by " +
-                                        ctx.pipeline().get(SslHandler.class).engine().getSession().getCipherSuite() +
-                                        " cipher suite.\n");
+        ctx.pipeline().get(SslHandler.class).handshakeFuture().addListener(future -> {
+                    ctx.writeAndFlush(
+                            "Welcome to secure chat service!\n");
+                    ctx.writeAndFlush(
+                            "Your session is protected by " +
+                                    ctx.pipeline().get(SslHandler.class).engine().getSession().getCipherSuite() +
+                                    " cipher suite.\n");
 
-                        channels.add(ctx.channel());
-                    }
-        });
+                    channels.add(ctx.channel());
+                });
     }
 
     @Override

--- a/example/src/main/java/io/netty/example/socksproxy/SocksServerConnectHandler.java
+++ b/example/src/main/java/io/netty/example/socksproxy/SocksServerConnectHandler.java
@@ -49,27 +49,21 @@ public final class SocksServerConnectHandler extends SimpleChannelInboundHandler
             final Socks4CommandRequest request = (Socks4CommandRequest) message;
             Promise<Channel> promise = ctx.executor().newPromise();
             promise.addListener(
-                    new FutureListener<Channel>() {
-                        @Override
-                        public void operationComplete(final Future<Channel> future) {
-                            final Channel outboundChannel = future.getNow();
-                            if (future.isSuccess()) {
-                                ChannelFuture responseFuture = ctx.channel().writeAndFlush(
-                                        new DefaultSocks4CommandResponse(Socks4CommandStatus.SUCCESS));
+                    (FutureListener<Channel>) future -> {
+                        final Channel outboundChannel = future.getNow();
+                        if (future.isSuccess()) {
+                            ChannelFuture responseFuture = ctx.channel().writeAndFlush(
+                                    new DefaultSocks4CommandResponse(Socks4CommandStatus.SUCCESS));
 
-                                responseFuture.addListener(new ChannelFutureListener() {
-                                    @Override
-                                    public void operationComplete(ChannelFuture channelFuture) {
-                                        ctx.pipeline().remove(SocksServerConnectHandler.this);
-                                        outboundChannel.pipeline().addLast(new RelayHandler(ctx.channel()));
-                                        ctx.pipeline().addLast(new RelayHandler(outboundChannel));
-                                    }
-                                });
-                            } else {
-                                ctx.channel().writeAndFlush(
-                                        new DefaultSocks4CommandResponse(Socks4CommandStatus.REJECTED_OR_FAILED));
-                                SocksServerUtils.closeOnFlush(ctx.channel());
-                            }
+                            responseFuture.addListener(channelFuture -> {
+                                ctx.pipeline().remove(SocksServerConnectHandler.this);
+                                outboundChannel.pipeline().addLast(new RelayHandler(ctx.channel()));
+                                ctx.pipeline().addLast(new RelayHandler(outboundChannel));
+                            });
+                        } else {
+                            ctx.channel().writeAndFlush(
+                                    new DefaultSocks4CommandResponse(Socks4CommandStatus.REJECTED_OR_FAILED));
+                            SocksServerUtils.closeOnFlush(ctx.channel());
                         }
                     });
 
@@ -80,49 +74,40 @@ public final class SocksServerConnectHandler extends SimpleChannelInboundHandler
                     .option(ChannelOption.SO_KEEPALIVE, true)
                     .handler(new DirectClientHandler(promise));
 
-            b.connect(request.dstAddr(), request.dstPort()).addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) {
-                    if (future.isSuccess()) {
-                        // Connection established use handler provided results
-                    } else {
-                        // Close the connection if the connection attempt has failed.
-                        ctx.channel().writeAndFlush(
-                                new DefaultSocks4CommandResponse(Socks4CommandStatus.REJECTED_OR_FAILED)
-                        );
-                        SocksServerUtils.closeOnFlush(ctx.channel());
-                    }
+            b.connect(request.dstAddr(), request.dstPort()).addListener(future -> {
+                if (future.isSuccess()) {
+                    // Connection established use handler provided results
+                } else {
+                    // Close the connection if the connection attempt has failed.
+                    ctx.channel().writeAndFlush(
+                            new DefaultSocks4CommandResponse(Socks4CommandStatus.REJECTED_OR_FAILED)
+                    );
+                    SocksServerUtils.closeOnFlush(ctx.channel());
                 }
             });
         } else if (message instanceof Socks5CommandRequest) {
             final Socks5CommandRequest request = (Socks5CommandRequest) message;
             Promise<Channel> promise = ctx.executor().newPromise();
             promise.addListener(
-                    new FutureListener<Channel>() {
-                        @Override
-                        public void operationComplete(final Future<Channel> future) {
-                            final Channel outboundChannel = future.getNow();
-                            if (future.isSuccess()) {
-                                ChannelFuture responseFuture =
-                                        ctx.channel().writeAndFlush(new DefaultSocks5CommandResponse(
-                                                Socks5CommandStatus.SUCCESS,
-                                                request.dstAddrType(),
-                                                request.dstAddr(),
-                                                request.dstPort()));
+                    (FutureListener<Channel>) future -> {
+                        final Channel outboundChannel = future.getNow();
+                        if (future.isSuccess()) {
+                            ChannelFuture responseFuture =
+                                    ctx.channel().writeAndFlush(new DefaultSocks5CommandResponse(
+                                            Socks5CommandStatus.SUCCESS,
+                                            request.dstAddrType(),
+                                            request.dstAddr(),
+                                            request.dstPort()));
 
-                                responseFuture.addListener(new ChannelFutureListener() {
-                                    @Override
-                                    public void operationComplete(ChannelFuture channelFuture) {
-                                        ctx.pipeline().remove(SocksServerConnectHandler.this);
-                                        outboundChannel.pipeline().addLast(new RelayHandler(ctx.channel()));
-                                        ctx.pipeline().addLast(new RelayHandler(outboundChannel));
-                                    }
-                                });
-                            } else {
-                                ctx.channel().writeAndFlush(new DefaultSocks5CommandResponse(
-                                        Socks5CommandStatus.FAILURE, request.dstAddrType()));
-                                SocksServerUtils.closeOnFlush(ctx.channel());
-                            }
+                            responseFuture.addListener(f -> {
+                                ctx.pipeline().remove(SocksServerConnectHandler.this);
+                                outboundChannel.pipeline().addLast(new RelayHandler(ctx.channel()));
+                                ctx.pipeline().addLast(new RelayHandler(outboundChannel));
+                            });
+                        } else {
+                            ctx.channel().writeAndFlush(new DefaultSocks5CommandResponse(
+                                    Socks5CommandStatus.FAILURE, request.dstAddrType()));
+                            SocksServerUtils.closeOnFlush(ctx.channel());
                         }
                     });
 
@@ -133,17 +118,14 @@ public final class SocksServerConnectHandler extends SimpleChannelInboundHandler
                     .option(ChannelOption.SO_KEEPALIVE, true)
                     .handler(new DirectClientHandler(promise));
 
-            b.connect(request.dstAddr(), request.dstPort()).addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) {
-                    if (future.isSuccess()) {
-                        // Connection established use handler provided results
-                    } else {
-                        // Close the connection if the connection attempt has failed.
-                        ctx.channel().writeAndFlush(
-                                new DefaultSocks5CommandResponse(Socks5CommandStatus.FAILURE, request.dstAddrType()));
-                        SocksServerUtils.closeOnFlush(ctx.channel());
-                    }
+            b.connect(request.dstAddr(), request.dstPort()).addListener(future -> {
+                if (future.isSuccess()) {
+                    // Connection established use handler provided results
+                } else {
+                    // Close the connection if the connection attempt has failed.
+                    ctx.channel().writeAndFlush(
+                            new DefaultSocks5CommandResponse(Socks5CommandStatus.FAILURE, request.dstAddrType()));
+                    SocksServerUtils.closeOnFlush(ctx.channel());
                 }
             });
         } else {

--- a/example/src/main/java/io/netty/example/stomp/websocket/StompChatHandler.java
+++ b/example/src/main/java/io/netty/example/stomp/websocket/StompChatHandler.java
@@ -102,12 +102,8 @@ public class StompChatHandler extends SimpleChannelInboundHandler<StompFrame> {
         }
 
         subscriptions.add(subscription);
-        ctx.channel().closeFuture().addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                chatDestinations.get(subscription.destination()).remove(subscription);
-            }
-        });
+        ctx.channel().closeFuture().addListener(f ->
+                chatDestinations.get(subscription.destination()).remove(subscription));
 
         String receiptId = inboundFrame.headers().getAsString(RECEIPT);
         if (receiptId != null) {

--- a/example/src/main/java/io/netty/example/stomp/websocket/StompWebSocketChatServer.java
+++ b/example/src/main/java/io/netty/example/stomp/websocket/StompWebSocketChatServer.java
@@ -34,14 +34,11 @@ public class StompWebSocketChatServer {
                     .group(group)
                     .channel(NioServerSocketChannel.class)
                     .childHandler(new StompWebSocketChatServerInitializer("/chat"));
-            bootstrap.bind(port).addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) {
-                    if (future.isSuccess()) {
-                        System.out.println("Open your web browser and navigate to http://127.0.0.1:" + PORT + '/');
-                    } else {
-                        System.out.println("Cannot start server, follows exception " + future.cause());
-                    }
+            bootstrap.bind(port).addListener(future -> {
+                if (future.isSuccess()) {
+                    System.out.println("Open your web browser and navigate to http://127.0.0.1:" + PORT + '/');
+                } else {
+                    System.out.println("Cannot start server, follows exception " + future.cause());
                 }
             }).channel().closeFuture().sync();
         } finally {

--- a/example/src/main/java/io/netty/example/uptime/UptimeClient.java
+++ b/example/src/main/java/io/netty/example/uptime/UptimeClient.java
@@ -16,8 +16,6 @@
 package io.netty.example.uptime;
 
 import io.netty.bootstrap.Bootstrap;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
@@ -59,13 +57,10 @@ public final class UptimeClient {
     }
 
     static void connect() {
-        bs.connect().addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                if (future.cause() != null) {
-                    handler.startTime = -1;
-                    handler.println("Failed to connect: " + future.cause());
-                }
+        bs.connect().addListener(future -> {
+            if (future.cause() != null) {
+                handler.startTime = -1;
+                handler.println("Failed to connect: " + future.cause());
             }
         });
     }

--- a/handler-proxy/src/main/java/io/netty/handler/proxy/ProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/handler/proxy/ProxyHandler.java
@@ -64,12 +64,9 @@ public abstract class ProxyHandler implements ChannelInboundHandler, ChannelOutb
     private boolean flushedPrematurely;
     private final LazyChannelPromise connectPromise = new LazyChannelPromise();
     private Future<?> connectTimeoutFuture;
-    private final ChannelFutureListener writeListener = new ChannelFutureListener() {
-        @Override
-        public void operationComplete(ChannelFuture future) {
-            if (!future.isSuccess()) {
-                setConnectFailure(future.cause());
-            }
+    private final ChannelFutureListener writeListener = future -> {
+        if (!future.isSuccess()) {
+            setConnectFailure(future.cause());
         }
     };
 

--- a/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyHandlerTest.java
+++ b/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyHandlerTest.java
@@ -573,14 +573,11 @@ public class ProxyHandlerTest {
         @Override
         public void channelActive(ChannelHandlerContext ctx) throws Exception {
             ctx.writeAndFlush(Unpooled.copiedBuffer("A\n", CharsetUtil.US_ASCII)).addListener(
-                    new ChannelFutureListener() {
-                        @Override
-                        public void operationComplete(ChannelFuture future) {
-                            latch.countDown();
-                            if (!(future.cause() instanceof ProxyConnectException)) {
-                                exceptions.add(new AssertionError(
-                                        "Unexpected failure cause for initial write: " + future.cause()));
-                            }
+                    future -> {
+                        latch.countDown();
+                        if (!(future.cause() instanceof ProxyConnectException)) {
+                            exceptions.add(new AssertionError(
+                                    "Unexpected failure cause for initial write: " + future.cause()));
                         }
                     });
         }

--- a/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyServer.java
+++ b/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyServer.java
@@ -169,16 +169,13 @@ abstract class ProxyServer {
             if (finished) {
                 this.finished = true;
                 ChannelFuture f = connectToDestination(ctx.channel().executor(), new BackendHandler(ctx));
-                f.addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) {
-                        if (!future.isSuccess()) {
-                            recordException(future.cause());
-                            ctx.close();
-                        } else {
-                            backend = future.channel();
-                            flush();
-                        }
+                f.addListener((ChannelFutureListener) future -> {
+                    if (!future.isSuccess()) {
+                        recordException(future.cause());
+                        ctx.close();
+                    } else {
+                        backend = future.channel();
+                        flush();
                     }
                 });
             }

--- a/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspClient.java
+++ b/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspClient.java
@@ -143,21 +143,18 @@ final class OcspClient {
                             uri.getHost(), port, path, ioTransport, dnsNameResolver);
 
                     // Validate OCSP response
-                    ocspResponsePromise.addListener(new GenericFutureListener<Future<OCSPResp>>() {
-                        @Override
-                        public void operationComplete(Future<OCSPResp> future) {
-                            // If Future was successful then we have received OCSP response
-                            // We will now validate it.
-                            if (future.isSuccess()) {
-                                try {
-                                    BasicOCSPResp resp = (BasicOCSPResp) future.getNow().getResponseObject();
-                                    validateResponse(responsePromise, resp, derNonce, issuer, validateResponseNonce);
-                                } catch (Throwable t) {
-                                    responsePromise.tryFailure(t);
-                                }
-                            } else {
-                                responsePromise.tryFailure(future.cause());
+                    ocspResponsePromise.addListener((GenericFutureListener<Future<OCSPResp>>) future -> {
+                        // If Future was successful then we have received OCSP response
+                        // We will now validate it.
+                        if (future.isSuccess()) {
+                            try {
+                                BasicOCSPResp resp = (BasicOCSPResp) future.getNow().getResponseObject();
+                                validateResponse(responsePromise, resp, derNonce, issuer, validateResponseNonce);
+                            } catch (Throwable t) {
+                                responsePromise.tryFailure(t);
                             }
+                        } else {
+                            responsePromise.tryFailure(future.cause());
                         }
                     });
 
@@ -193,41 +190,35 @@ final class OcspClient {
                     .attr(OcspServerCertificateValidator.OCSP_PIPELINE_ATTRIBUTE, Boolean.TRUE)
                     .handler(new Initializer(responsePromise));
 
-            dnsNameResolver.resolve(host).addListener(new FutureListener<InetAddress>() {
-                @Override
-                public void operationComplete(Future<InetAddress> future) {
+            dnsNameResolver.resolve(host).addListener((FutureListener<InetAddress>) future -> {
 
-                    // If Future was successful then we have successfully resolved OCSP server address.
-                    // If not, mark 'responsePromise' as failure.
-                    if (future.isSuccess()) {
-                        // Get the resolved InetAddress
-                        InetAddress hostAddress = future.getNow();
-                        final ChannelFuture channelFuture = bootstrap.connect(hostAddress, port);
-                        channelFuture.addListener(new ChannelFutureListener() {
-                            @Override
-                            public void operationComplete(ChannelFuture future) {
-                                // If Future was successful then connection to OCSP responder was successful.
-                                // We will send a OCSP request now
-                                if (future.isSuccess()) {
-                                    FullHttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, POST, path,
-                                            ocspRequest);
-                                    request.headers().add(HttpHeaderNames.HOST, host);
-                                    request.headers().add(HttpHeaderNames.USER_AGENT, "Netty OCSP Client");
-                                    request.headers().add(HttpHeaderNames.CONTENT_TYPE, OCSP_REQUEST_TYPE);
-                                    request.headers().add(HttpHeaderNames.ACCEPT_ENCODING, OCSP_RESPONSE_TYPE);
-                                    request.headers().add(HttpHeaderNames.CONTENT_LENGTH, ocspRequest.readableBytes());
+                // If Future was successful then we have successfully resolved OCSP server address.
+                // If not, mark 'responsePromise' as failure.
+                if (future.isSuccess()) {
+                    // Get the resolved InetAddress
+                    InetAddress hostAddress = future.getNow();
+                    final ChannelFuture channelFuture = bootstrap.connect(hostAddress, port);
+                    channelFuture.addListener(f -> {
+                        // If Future was successful then connection to OCSP responder was successful.
+                        // We will send a OCSP request now
+                        if (f.isSuccess()) {
+                            FullHttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, POST, path,
+                                    ocspRequest);
+                            request.headers().add(HttpHeaderNames.HOST, host);
+                            request.headers().add(HttpHeaderNames.USER_AGENT, "Netty OCSP Client");
+                            request.headers().add(HttpHeaderNames.CONTENT_TYPE, OCSP_REQUEST_TYPE);
+                            request.headers().add(HttpHeaderNames.ACCEPT_ENCODING, OCSP_RESPONSE_TYPE);
+                            request.headers().add(HttpHeaderNames.CONTENT_LENGTH, ocspRequest.readableBytes());
 
-                                    // Send the OCSP HTTP Request
-                                    channelFuture.channel().writeAndFlush(request);
-                                } else {
-                                    responsePromise.tryFailure(new IllegalStateException(
-                                            "Connection to OCSP Responder Failed", future.cause()));
-                                }
-                            }
-                        });
-                    } else {
-                        responsePromise.tryFailure(future.cause());
-                    }
+                            // Send the OCSP HTTP Request
+                            channelFuture.channel().writeAndFlush(request);
+                        } else {
+                            responsePromise.tryFailure(new IllegalStateException(
+                                    "Connection to OCSP Responder Failed", f.cause()));
+                        }
+                    });
+                } else {
+                    responsePromise.tryFailure(future.cause());
                 }
             });
         } catch (Exception ex) {

--- a/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspServerCertificateValidator.java
+++ b/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspServerCertificateValidator.java
@@ -147,44 +147,41 @@ public class OcspServerCertificateValidator implements ChannelInboundHandler {
                 Promise<BasicOCSPResp> ocspRespPromise = OcspClient.query((X509Certificate) certificates[0],
                         (X509Certificate) certificates[1], validateNonce, ioTransport, dnsNameResolver);
 
-                ocspRespPromise.addListener(new GenericFutureListener<Future<BasicOCSPResp>>() {
-                    @Override
-                    public void operationComplete(Future<BasicOCSPResp> future) {
-                        // If Future is success then we have successfully received OCSP response
-                        // from OCSP responder. We will validate it now and process.
-                        if (future.isSuccess()) {
-                            SingleResp response = future.getNow().getResponses()[0];
+                ocspRespPromise.addListener((GenericFutureListener<Future<BasicOCSPResp>>) future -> {
+                    // If Future is success then we have successfully received OCSP response
+                    // from OCSP responder. We will validate it now and process.
+                    if (future.isSuccess()) {
+                        SingleResp response = future.getNow().getResponses()[0];
 
-                            Date current = new Date();
-                            if (!(current.after(response.getThisUpdate()) &&
-                                    current.before(response.getNextUpdate()))) {
-                                ctx.fireExceptionCaught(new IllegalStateException("OCSP Response is out-of-date"));
-                            }
-
-                            OcspResponse.Status status;
-                            if (response.getCertStatus() == null) {
-                                // 'null' means certificate is valid
-                                status = OcspResponse.Status.VALID;
-                            } else if (response.getCertStatus() instanceof RevokedStatus) {
-                                status = OcspResponse.Status.REVOKED;
-                            } else {
-                                status = OcspResponse.Status.UNKNOWN;
-                            }
-
-                            ctx.fireUserEventTriggered(new OcspValidationEvent(
-                                    new OcspResponse(status, response.getThisUpdate(), response.getNextUpdate())));
-
-                            // If Certificate is not VALID and 'closeAndThrowIfNotValid' is set
-                            // to 'true' then close the channel and throw an exception.
-                            if (status != OcspResponse.Status.VALID && closeAndThrowIfNotValid) {
-                                ctx.channel().close();
-                                // Certificate is not valid. Throw
-                                ctx.fireExceptionCaught(new OCSPException(
-                                        "Certificate not valid. Status: " + status));
-                            }
-                        } else {
-                            ctx.fireExceptionCaught(future.cause());
+                        Date current = new Date();
+                        if (!(current.after(response.getThisUpdate()) &&
+                                current.before(response.getNextUpdate()))) {
+                            ctx.fireExceptionCaught(new IllegalStateException("OCSP Response is out-of-date"));
                         }
+
+                        OcspResponse.Status status;
+                        if (response.getCertStatus() == null) {
+                            // 'null' means certificate is valid
+                            status = OcspResponse.Status.VALID;
+                        } else if (response.getCertStatus() instanceof RevokedStatus) {
+                            status = OcspResponse.Status.REVOKED;
+                        } else {
+                            status = OcspResponse.Status.UNKNOWN;
+                        }
+
+                        ctx.fireUserEventTriggered(new OcspValidationEvent(
+                                new OcspResponse(status, response.getThisUpdate(), response.getNextUpdate())));
+
+                        // If Certificate is not VALID and 'closeAndThrowIfNotValid' is set
+                        // to 'true' then close the channel and throw an exception.
+                        if (status != OcspResponse.Status.VALID && closeAndThrowIfNotValid) {
+                            ctx.channel().close();
+                            // Certificate is not valid. Throw
+                            ctx.fireExceptionCaught(new OCSPException(
+                                    "Certificate not valid. Status: " + status));
+                        }
+                    } else {
+                        ctx.fireExceptionCaught(future.cause());
                     }
                 });
             }

--- a/handler/src/main/java/io/netty/handler/address/DynamicAddressConnectHandler.java
+++ b/handler/src/main/java/io/netty/handler/address/DynamicAddressConnectHandler.java
@@ -15,8 +15,6 @@
  */
 package io.netty.handler.address;
 
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandler;
 import io.netty.channel.ChannelPromise;
@@ -45,14 +43,11 @@ public abstract class DynamicAddressConnectHandler implements ChannelOutboundHan
             promise.setFailure(e);
             return;
         }
-        ctx.connect(remote, local, promise).addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                if (future.isSuccess()) {
-                    // We only remove this handler from the pipeline once the connect was successful as otherwise
-                    // the user may try to connect again.
-                    future.channel().pipeline().remove(DynamicAddressConnectHandler.this);
-                }
+        ctx.connect(remote, local, promise).addListener(future -> {
+            if (future.isSuccess()) {
+                // We only remove this handler from the pipeline once the connect was successful as otherwise
+                // the user may try to connect again.
+                ctx.pipeline().remove(DynamicAddressConnectHandler.this);
             }
         });
     }

--- a/handler/src/main/java/io/netty/handler/address/ResolveAddressHandler.java
+++ b/handler/src/main/java/io/netty/handler/address/ResolveAddressHandler.java
@@ -49,17 +49,14 @@ public class ResolveAddressHandler implements ChannelOutboundHandler {
                         final SocketAddress localAddress, final ChannelPromise promise) {
         AddressResolver<? extends SocketAddress> resolver = resolverGroup.getResolver(ctx.executor());
         if (resolver.isSupported(remoteAddress) && !resolver.isResolved(remoteAddress)) {
-            resolver.resolve(remoteAddress).addListener(new FutureListener<SocketAddress>() {
-                @Override
-                public void operationComplete(Future<SocketAddress> future) {
-                    Throwable cause = future.cause();
-                    if (cause != null) {
-                        promise.setFailure(cause);
-                    } else {
-                        ctx.connect(future.getNow(), localAddress, promise);
-                    }
-                    ctx.pipeline().remove(ResolveAddressHandler.this);
+            resolver.resolve(remoteAddress).addListener((FutureListener<SocketAddress>) future -> {
+                Throwable cause = future.cause();
+                if (cause != null) {
+                    promise.setFailure(cause);
+                } else {
+                    ctx.connect(future.getNow(), localAddress, promise);
                 }
+                ctx.pipeline().remove(ResolveAddressHandler.this);
             });
         } else {
             ctx.connect(remoteAddress, localAddress, promise);

--- a/handler/src/main/java/io/netty/handler/ipfilter/UniqueIpFilter.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/UniqueIpFilter.java
@@ -44,12 +44,7 @@ public class UniqueIpFilter extends AbstractRemoteAddressFilter<InetSocketAddres
         if (!connected.add(remoteIp)) {
             return false;
         } else {
-            ctx.channel().closeFuture().addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) {
-                    connected.remove(remoteIp);
-                }
-            });
+            ctx.channel().closeFuture().addListener(future -> connected.remove(remoteIp));
             return true;
         }
     }

--- a/handler/src/main/java/io/netty/handler/ssl/SslClientHelloHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslClientHelloHandler.java
@@ -224,26 +224,23 @@ public abstract class SslClientHelloHandler<T> extends ByteToMessageDecoder impl
             } else {
                 suppressRead = true;
                 final ByteBuf finalClientHello = clientHello;
-                future.addListener(new FutureListener<T>() {
-                    @Override
-                    public void operationComplete(Future<T> future) {
-                        releaseIfNotNull(finalClientHello);
+                future.addListener((FutureListener<T>) future1 -> {
+                    releaseIfNotNull(finalClientHello);
+                    try {
+                        suppressRead = false;
                         try {
-                            suppressRead = false;
-                            try {
-                                onLookupComplete(ctx, future);
-                            } catch (DecoderException err) {
-                                ctx.fireExceptionCaught(err);
-                            } catch (Exception cause) {
-                                ctx.fireExceptionCaught(new DecoderException(cause));
-                            } catch (Throwable cause) {
-                                ctx.fireExceptionCaught(cause);
-                            }
-                        } finally {
-                            if (readPending) {
-                                readPending = false;
-                                ctx.read();
-                            }
+                            onLookupComplete(ctx, future1);
+                        } catch (DecoderException err) {
+                            ctx.fireExceptionCaught(err);
+                        } catch (Exception cause) {
+                            ctx.fireExceptionCaught(new DecoderException(cause));
+                        } catch (Throwable cause) {
+                            ctx.fireExceptionCaught(cause);
+                        }
+                    } finally {
+                        if (readPending) {
+                            readPending = false;
+                            ctx.read();
                         }
                     }
                 });

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -24,7 +24,6 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelOption;
@@ -41,7 +40,6 @@ import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.DefaultPromise;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.ImmediateExecutor;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.PromiseNotifier;
@@ -1015,13 +1013,10 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                 }
                 SSLEngineResult result = wrap(alloc, engine, Unpooled.EMPTY_BUFFER, out);
                 if (result.bytesProduced() > 0) {
-                    ctx.write(out).addListener(new ChannelFutureListener() {
-                        @Override
-                        public void operationComplete(ChannelFuture future) {
-                            Throwable cause = future.cause();
-                            if (cause != null) {
-                                setHandshakeFailureTransportFailure(ctx, cause);
-                            }
+                    ctx.write(out).addListener(future -> {
+                        Throwable cause = future.cause();
+                        if (cause != null) {
+                            setHandshakeFailureTransportFailure(ctx, cause);
                         }
                     });
                     if (inUnwrap) {
@@ -2142,12 +2137,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                 safeClose(ctx, closeNotifyPromise, PromiseNotifier.cascade(false, ctx.newPromise(), promise));
             } else {
                 /// We already handling the close_notify so just attach the promise to the sslClosePromise.
-                sslClosePromise.addListener(new FutureListener<Channel>() {
-                    @Override
-                    public void operationComplete(Future<Channel> future) {
-                        promise.setSuccess();
-                    }
-                });
+                sslClosePromise.addListener(f -> promise.setSuccess());
             }
         }
     }
@@ -2318,12 +2308,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         }, handshakeTimeoutMillis, TimeUnit.MILLISECONDS);
 
         // Cancel the handshake timeout when handshake is finished.
-        localHandshakePromise.addListener(new FutureListener<Channel>() {
-            @Override
-            public void operationComplete(Future<Channel> f) {
-                timeoutFuture.cancel(false);
-            }
-        });
+        localHandshakePromise.addListener(f -> timeoutFuture.cancel(false));
     }
 
     private void forceFlush(ChannelHandlerContext ctx) {
@@ -2381,49 +2366,43 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         }
 
         // Close the connection if close_notify is sent in time.
-        flushFuture.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture f) {
-                if (timeoutFuture != null) {
-                    timeoutFuture.cancel(false);
-                }
-                final long closeNotifyReadTimeout = closeNotifyReadTimeoutMillis;
-                if (closeNotifyReadTimeout <= 0) {
-                    // Trigger the close in all cases to make sure the promise is notified
-                    // See https://github.com/netty/netty/issues/2358
-                    addCloseListener(ctx.close(ctx.newPromise()), promise);
-                } else {
-                    final Future<?> closeNotifyReadTimeoutFuture;
+        flushFuture.addListener(f -> {
+            if (timeoutFuture != null) {
+                timeoutFuture.cancel(false);
+            }
+            final long closeNotifyReadTimeout = closeNotifyReadTimeoutMillis;
+            if (closeNotifyReadTimeout <= 0) {
+                // Trigger the close in all cases to make sure the promise is notified
+                // See https://github.com/netty/netty/issues/2358
+                addCloseListener(ctx.close(ctx.newPromise()), promise);
+            } else {
+                final Future<?> closeNotifyReadTimeoutFuture;
 
-                    if (!sslClosePromise.isDone()) {
-                        closeNotifyReadTimeoutFuture = ctx.executor().schedule(new Runnable() {
-                            @Override
-                            public void run() {
-                                if (!sslClosePromise.isDone()) {
-                                    logger.debug(
-                                            "{} did not receive close_notify in {}ms; force-closing the connection.",
-                                            ctx.channel(), closeNotifyReadTimeout);
-
-                                    // Do the close now...
-                                    addCloseListener(ctx.close(ctx.newPromise()), promise);
-                                }
-                            }
-                        }, closeNotifyReadTimeout, TimeUnit.MILLISECONDS);
-                    } else {
-                        closeNotifyReadTimeoutFuture = null;
-                    }
-
-                    // Do the close once the we received the close_notify.
-                    sslClosePromise.addListener(new FutureListener<Channel>() {
+                if (!sslClosePromise.isDone()) {
+                    closeNotifyReadTimeoutFuture = ctx.executor().schedule(new Runnable() {
                         @Override
-                        public void operationComplete(Future<Channel> future) {
-                            if (closeNotifyReadTimeoutFuture != null) {
-                                closeNotifyReadTimeoutFuture.cancel(false);
+                        public void run() {
+                            if (!sslClosePromise.isDone()) {
+                                logger.debug(
+                                        "{} did not receive close_notify in {}ms; force-closing the connection.",
+                                        ctx.channel(), closeNotifyReadTimeout);
+
+                                // Do the close now...
+                                addCloseListener(ctx.close(ctx.newPromise()), promise);
                             }
-                            addCloseListener(ctx.close(ctx.newPromise()), promise);
                         }
-                    });
+                    }, closeNotifyReadTimeout, TimeUnit.MILLISECONDS);
+                } else {
+                    closeNotifyReadTimeoutFuture = null;
                 }
+
+                // Do the close once the we received the close_notify.
+                sslClosePromise.addListener(future -> {
+                    if (closeNotifyReadTimeoutFuture != null) {
+                        closeNotifyReadTimeoutFuture.cancel(false);
+                    }
+                    addCloseListener(ctx.close(ctx.newPromise()), promise);
+                });
             }
         });
     }

--- a/handler/src/main/java/io/netty/handler/stream/ChunkedWriteHandler.java
+++ b/handler/src/main/java/io/netty/handler/stream/ChunkedWriteHandler.java
@@ -297,24 +297,16 @@ public class ChunkedWriteHandler implements ChannelInboundHandler, ChannelOutbou
                         // be closed before it's not written.
                         //
                         // See https://github.com/netty/netty/issues/303
-                        f.addListener(new ChannelFutureListener() {
-                            @Override
-                            public void operationComplete(ChannelFuture future) {
-                                handleEndOfInputFuture(future, chunks, currentWrite);
-                            }
-                        });
+                        f.addListener((ChannelFutureListener) future ->
+                                handleEndOfInputFuture(future, chunks, currentWrite));
                     }
                 } else {
                     final boolean resume = !channel.isWritable();
                     if (f.isDone()) {
                         handleFuture(f, chunks, currentWrite, resume);
                     } else {
-                        f.addListener(new ChannelFutureListener() {
-                            @Override
-                            public void operationComplete(ChannelFuture future) {
-                                handleFuture(future, chunks, currentWrite, resume);
-                            }
-                        });
+                        f.addListener((ChannelFutureListener) future ->
+                                handleFuture(future, chunks, currentWrite, resume));
                     }
                 }
                 requiresFlush = false;

--- a/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
+++ b/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
@@ -17,7 +17,6 @@ package io.netty.handler.timeout;
 
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandler;
@@ -99,15 +98,6 @@ import java.util.concurrent.TimeUnit;
 public class IdleStateHandler implements ChannelInboundHandler, ChannelOutboundHandler {
     private static final long MIN_TIMEOUT_NANOS = TimeUnit.MILLISECONDS.toNanos(1);
 
-    // Not create a new ChannelFutureListener per write operation to reduce GC pressure.
-    private final ChannelFutureListener writeListener = new ChannelFutureListener() {
-        @Override
-        public void operationComplete(ChannelFuture future) {
-            lastWriteTime = ticker.nanoTime();
-            firstWriterIdleEvent = firstAllIdleEvent = true;
-        }
-    };
-
     private final long readerIdleTimeNanos;
     private final long writerIdleTimeNanos;
     private final long allIdleTimeNanos;
@@ -130,6 +120,12 @@ public class IdleStateHandler implements ChannelInboundHandler, ChannelOutboundH
     private static final byte ST_DESTROYED = 2;
 
     private boolean reading;
+
+    // Not create a new ChannelFutureListener per write operation to reduce GC pressure.
+    private final ChannelFutureListener writeListener = future -> {
+        lastWriteTime = ticker.nanoTime();
+        firstWriterIdleEvent = firstAllIdleEvent = true;
+    };
 
     /**
      * Creates a new instance firing {@link IdleStateEvent}s.

--- a/handler/src/test/java/io/netty/handler/flush/FlushConsolidationHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/flush/FlushConsolidationHandlerTest.java
@@ -19,8 +19,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelOutboundHandler;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.GenericFutureListener;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
@@ -172,12 +170,7 @@ public class FlushConsolidationHandlerTest {
     public void testResend() throws Exception {
         final AtomicInteger flushCount = new AtomicInteger();
         final EmbeddedChannel channel = newChannel(flushCount, true);
-        channel.writeAndFlush(1L).addListener(new GenericFutureListener<Future<? super Void>>() {
-            @Override
-            public void operationComplete(Future<? super Void> future) {
-                channel.writeAndFlush(1L);
-            }
-        });
+        channel.writeAndFlush(1L).addListener(future -> channel.writeAndFlush(1L));
         channel.flushOutbound();
         assertEquals(1L, (Long) channel.readOutbound());
         assertEquals(1L, (Long) channel.readOutbound());

--- a/handler/src/test/java/io/netty/handler/ssl/ParameterizedSslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ParameterizedSslHandlerTest.java
@@ -20,8 +20,6 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelInitializer;
@@ -43,7 +41,6 @@ import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.handler.ssl.util.SimpleTrustManagerFactory;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.PromiseNotifier;
@@ -184,13 +181,10 @@ public class ParameterizedSslHandlerTest {
                                                 buf.writerIndex(buf.writerIndex() + singleComponentSize);
                                                 content.addComponent(true, buf);
                                             }
-                                            ctx.writeAndFlush(content).addListener(new ChannelFutureListener() {
-                                                @Override
-                                                public void operationComplete(ChannelFuture future) {
-                                                    writeCause = future.cause();
-                                                    if (writeCause == null) {
-                                                        sentData = true;
-                                                    }
+                                            ctx.writeAndFlush(content).addListener(future -> {
+                                                writeCause = future.cause();
+                                                if (writeCause == null) {
+                                                    sentData = true;
                                                 }
                                             });
                                         } else {
@@ -439,13 +433,10 @@ public class ParameterizedSslHandlerTest {
                             SslHandler handler = sslServerCtx.newHandler(ch.alloc());
                             handler.setCloseNotifyReadTimeoutMillis(closeNotifyReadTimeout);
                             PromiseNotifier.cascade(handler.sslCloseFuture(), serverPromise);
-                            handler.handshakeFuture().addListener(new FutureListener<Channel>() {
-                                @Override
-                                public void operationComplete(Future<Channel> future) {
-                                    if (!future.isSuccess()) {
-                                        // Something bad happened during handshake fail the promise!
-                                        serverPromise.tryFailure(future.cause());
-                                    }
+                            handler.handshakeFuture().addListener((FutureListener<Channel>) future -> {
+                                if (!future.isSuccess()) {
+                                    // Something bad happened during handshake fail the promise!
+                                    serverPromise.tryFailure(future.cause());
                                 }
                             });
                             ch.pipeline().addLast(handler);
@@ -477,16 +468,13 @@ public class ParameterizedSslHandlerTest {
                             SslHandler handler = sslClientCtx.newHandler(ch.alloc());
                             handler.setCloseNotifyReadTimeoutMillis(closeNotifyReadTimeout);
                             PromiseNotifier.cascade(handler.sslCloseFuture(), clientPromise);
-                            handler.handshakeFuture().addListener(new FutureListener<Channel>() {
-                                @Override
-                                public void operationComplete(Future<Channel> future) {
-                                    if (future.isSuccess()) {
-                                        closeSent.compareAndSet(false, true);
-                                        future.getNow().close();
-                                    } else {
-                                        // Something bad happened during handshake fail the promise!
-                                        clientPromise.tryFailure(future.cause());
-                                    }
+                            handler.handshakeFuture().addListener((FutureListener<Channel>) future -> {
+                                if (future.isSuccess()) {
+                                    closeSent.compareAndSet(false, true);
+                                    future.getNow().close();
+                                } else {
+                                    // Something bad happened during handshake fail the promise!
+                                    clientPromise.tryFailure(future.cause());
                                 }
                             });
                             ch.pipeline().addLast(handler);

--- a/handler/src/test/java/io/netty/handler/ssl/RenegotiateTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/RenegotiateTest.java
@@ -81,15 +81,12 @@ public abstract class RenegotiateTest {
                                             final SslHandler handler = ctx.pipeline().get(SslHandler.class);
 
                                             renegotiate = true;
-                                            handler.renegotiate().addListener(new FutureListener<Channel>() {
-                                                @Override
-                                                public void operationComplete(Future<Channel> future) {
-                                                    if (!future.isSuccess()) {
-                                                        error.compareAndSet(null, future.cause());
-                                                        ctx.close();
-                                                    }
-                                                    latch.countDown();
+                                            handler.renegotiate().addListener(future -> {
+                                                if (!future.isSuccess()) {
+                                                    error.compareAndSet(null, future.cause());
+                                                    ctx.close();
                                                 }
+                                                latch.countDown();
                                             });
                                         } else {
                                             error.compareAndSet(null, event.cause());

--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -56,7 +56,6 @@ import io.netty.util.AbstractReferenceCounted;
 import io.netty.util.IllegalReferenceCountException;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ReferenceCounted;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.ImmediateExecutor;
@@ -144,12 +143,9 @@ public class SslHandlerTest {
         try {
             final CountDownLatch writeCauseLatch = new CountDownLatch(1);
             final AtomicReference<Throwable> failureRef = new AtomicReference<Throwable>();
-            ch.write(Unpooled.wrappedBuffer(new byte[]{1})).addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) {
-                    failureRef.compareAndSet(null, future.cause());
-                    writeCauseLatch.countDown();
-                }
+            ch.write(Unpooled.wrappedBuffer(new byte[]{1})).addListener(future -> {
+                failureRef.compareAndSet(null, future.cause());
+                writeCauseLatch.countDown();
             });
             writeLatch.await();
 
@@ -513,19 +509,16 @@ public class SslHandlerTest {
                 final SslHandler sslHandler = sslCtx.newHandler(ch.alloc());
                 sslHandler.setHandshakeTimeoutMillis(1000);
                 ch.pipeline().addFirst(sslHandler);
-                sslHandler.handshakeFuture().addListener(new FutureListener<Channel>() {
-                    @Override
-                    public void operationComplete(final Future<Channel> future) {
-                        ch.pipeline().remove(sslHandler);
+                sslHandler.handshakeFuture().addListener(future -> {
+                    ch.pipeline().remove(sslHandler);
 
-                        // Schedule the close so removal has time to propagate exception if any.
-                        ch.executor().execute(new Runnable() {
-                            @Override
-                            public void run() {
-                                ch.close();
-                            }
-                        });
-                    }
+                    // Schedule the close so removal has time to propagate exception if any.
+                    ch.executor().execute(new Runnable() {
+                        @Override
+                        public void run() {
+                            ch.close();
+                        }
+                    });
                 });
 
                 ch.pipeline().addLast(new ChannelInboundHandler() {
@@ -618,12 +611,9 @@ public class SslHandlerTest {
                           public void channelActive(ChannelHandlerContext ctx) {
                               ByteBuf buf = ctx.alloc().buffer(10);
                               buf.writeZero(buf.capacity());
-                              ctx.writeAndFlush(buf).addListener(new ChannelFutureListener() {
-                                  @Override
-                                  public void operationComplete(ChannelFuture future) {
-                                      events.add(future);
-                                      latch.countDown();
-                                  }
+                              ctx.writeAndFlush(buf).addListener(future -> {
+                                  events.add(future);
+                                  latch.countDown();
                               });
                           }
 
@@ -884,12 +874,9 @@ public class SslHandlerTest {
                                 }
                             });
                         }
-                    }).connect(sc.localAddress()).addListener(new ChannelFutureListener() {
-                        @Override
-                        public void operationComplete(ChannelFuture future) {
-                            // Write something to trigger the handshake before fireChannelActive is called.
-                            future.channel().writeAndFlush(wrappedBuffer(new byte [] { 1, 2, 3, 4 }));
-                        }
+                    }).connect(sc.localAddress()).addListener((ChannelFutureListener) future -> {
+                        // Write something to trigger the handshake before fireChannelActive is called.
+                        future.channel().writeAndFlush(wrappedBuffer(new byte [] { 1, 2, 3, 4 }));
                     }).syncUninterruptibly().channel();
 
             // Ensure there is no AssertionError thrown by having the handshake failed by the writeAndFlush(...) before
@@ -963,12 +950,9 @@ public class SslHandlerTest {
                         }
                     }).connect(sc.localAddress());
             if (!startTls) {
-                future.addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) {
-                        // Write something to trigger the handshake before fireChannelActive is called.
-                        future.channel().writeAndFlush(wrappedBuffer(new byte [] { 1, 2, 3, 4 }));
-                    }
+                future.addListener((ChannelFutureListener) future1 -> {
+                    // Write something to trigger the handshake before fireChannelActive is called.
+                    future1.channel().writeAndFlush(wrappedBuffer(new byte [] { 1, 2, 3, 4 }));
                 });
             }
             cc = future.syncUninterruptibly().channel();
@@ -1546,12 +1530,7 @@ public class SslHandlerTest {
                         }
                     }).connect(sc.localAddress());
             future.syncUninterruptibly();
-            clientSslHandler.handshakeFuture().addListener(new FutureListener<Channel>() {
-                @Override
-                public void operationComplete(Future<Channel> f) {
-                    future.channel().close();
-                }
-            });
+            clientSslHandler.handshakeFuture().addListener((FutureListener<Channel>) f -> future.channel().close());
             assertFalse(clientSslHandler.handshakeFuture().await().isSuccess());
             assertFalse(serverSslHandler.handshakeFuture().await().isSuccess());
 

--- a/handler/src/test/java/io/netty/handler/stream/ChunkedWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/stream/ChunkedWriteHandlerTest.java
@@ -197,13 +197,7 @@ public class ChunkedWriteHandlerTest {
         };
 
         final AtomicBoolean listenerNotified = new AtomicBoolean(false);
-        final ChannelFutureListener listener = new ChannelFutureListener() {
-
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                listenerNotified.set(true);
-            }
-        };
+        final ChannelFutureListener listener = future -> listenerNotified.set(true);
 
         EmbeddedChannel ch = new EmbeddedChannel(new ChunkedWriteHandler());
         ch.writeAndFlush(input).addListener(listener).syncUninterruptibly();
@@ -521,12 +515,9 @@ public class ChunkedWriteHandlerTest {
         final CountDownLatch listenerInvoked = new CountDownLatch(1);
 
         ChannelFuture writeFuture = ch.write(input);
-        writeFuture.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                inputClosedWhenListenerInvoked.set(input.isClosed());
-                listenerInvoked.countDown();
-            }
+        writeFuture.addListener(future -> {
+            inputClosedWhenListenerInvoked.set(input.isClosed());
+            listenerInvoked.countDown();
         });
         ch.flush();
 
@@ -545,12 +536,9 @@ public class ChunkedWriteHandlerTest {
         final CountDownLatch listenerInvoked = new CountDownLatch(1);
 
         ChannelFuture writeFuture = ch.write(input);
-        writeFuture.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                inputClosedWhenListenerInvoked.set(input.isClosed());
-                listenerInvoked.countDown();
-            }
+        writeFuture.addListener(future -> {
+            inputClosedWhenListenerInvoked.set(input.isClosed());
+            listenerInvoked.countDown();
         });
         ch.flush();
 
@@ -570,12 +558,9 @@ public class ChunkedWriteHandlerTest {
         final CountDownLatch listenerInvoked = new CountDownLatch(1);
 
         ChannelFuture writeFuture = ch.write(input);
-        writeFuture.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                inputClosedWhenListenerInvoked.set(input.isClosed());
-                listenerInvoked.countDown();
-            }
+        writeFuture.addListener(future -> {
+            inputClosedWhenListenerInvoked.set(input.isClosed());
+            listenerInvoked.countDown();
         });
         ch.close(); // close channel to make handler discard the input on subsequent flush
         ch.flush();
@@ -645,12 +630,9 @@ public class ChunkedWriteHandlerTest {
         final CountDownLatch listenerInvoked = new CountDownLatch(1);
 
         ChannelFuture writeFuture = ch.write(input);
-        writeFuture.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                inputClosedWhenListenerInvoked.set(input.isClosed());
-                listenerInvoked.countDown();
-            }
+        writeFuture.addListener(future -> {
+            inputClosedWhenListenerInvoked.set(input.isClosed());
+            listenerInvoked.countDown();
         });
         ch.close(); // close channel to make handler discard the input on subsequent flush
         ch.flush();

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -910,12 +910,7 @@ public class DnsNameResolver extends InetNameResolver {
         if (f.isDone()) {
             resolveAllNow(f, hostname, question, additionals, promise);
         } else {
-            f.addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture f) {
-                    resolveAllNow(f, hostname, question, additionals, promise);
-                }
-            });
+            f.addListener((ChannelFutureListener) f1 -> resolveAllNow(f1, hostname, question, additionals, promise));
         }
         return promise;
     }
@@ -1025,12 +1020,8 @@ public class DnsNameResolver extends InetNameResolver {
             if (f.isDone()) {
                 doResolveNow(f, hostname, additionals, promise, resolveCache);
             } else {
-                f.addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture f) {
-                        doResolveNow(f, hostname, additionals, promise, resolveCache);
-                    }
-                });
+                f.addListener((ChannelFutureListener) f1 ->
+                        doResolveNow(f1, hostname, additionals, promise, resolveCache));
             }
         }
     }
@@ -1116,14 +1107,11 @@ public class DnsNameResolver extends InetNameResolver {
         final Promise<List<InetAddress>> allPromise = executor().newPromise();
         doResolveAllUncached(channel, hostname, additionals, promise, allPromise,
                 resolveCache, completeEarlyIfPossible);
-        allPromise.addListener(new FutureListener<List<InetAddress>>() {
-            @Override
-            public void operationComplete(Future<List<InetAddress>> future) {
-                if (future.isSuccess()) {
-                    trySuccess(promise, future.getNow().get(0));
-                } else {
-                    tryFailure(promise, future.cause());
-                }
+        allPromise.addListener((FutureListener<List<InetAddress>>) future -> {
+            if (future.isSuccess()) {
+                trySuccess(promise, future.getNow().get(0));
+            } else {
+                tryFailure(promise, future.cause());
             }
         });
     }
@@ -1167,12 +1155,8 @@ public class DnsNameResolver extends InetNameResolver {
             if (f.isDone()) {
                 doResolveAllNow(f, hostname, additionals, promise, resolveCache);
             } else {
-                f.addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture f) {
-                        doResolveAllNow(f, hostname, additionals, promise, resolveCache);
-                    }
-                });
+                f.addListener((ChannelFutureListener) f1 ->
+                        doResolveAllNow(f1, hostname, additionals, promise, resolveCache));
             }
         }
     }
@@ -1367,19 +1351,16 @@ public class DnsNameResolver extends InetNameResolver {
             }
         } else {
             final Promise<AddressedEnvelope<DnsResponse, InetSocketAddress>> p = executor().newPromise();
-            f.addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture f) {
-                    if (f.isSuccess()) {
-                        Future<AddressedEnvelope<DnsResponse, InetSocketAddress>> qf = doQuery(
-                                f.channel(), nameServerAddr, question, NoopDnsQueryLifecycleObserver.INSTANCE,
-                                additionalsArray, true, promise);
-                        PromiseNotifier.cascade(qf, p);
-                    } else {
-                        UnknownHostException e = toException(f, question.name(), question, additionalsArray);
-                        promise.setFailure(e);
-                        p.setFailure(e);
-                    }
+            f.addListener((ChannelFutureListener) f1 -> {
+                if (f1.isSuccess()) {
+                    Future<AddressedEnvelope<DnsResponse, InetSocketAddress>> qf = doQuery(
+                            f1.channel(), nameServerAddr, question, NoopDnsQueryLifecycleObserver.INSTANCE,
+                            additionalsArray, true, promise);
+                    PromiseNotifier.cascade(qf, p);
+                } else {
+                    UnknownHostException e = toException(f1, question.name(), question, additionalsArray);
+                    promise.setFailure(e);
+                    p.setFailure(e);
                 }
             });
             return p;
@@ -1611,12 +1592,9 @@ public class DnsNameResolver extends InetNameResolver {
         @Override
         public <T> ChannelFuture nextResolveChannel(Future<T> resolutionFuture) {
             final ChannelFuture f = registerOrBind(bootstrap, localAddress);
-            resolutionFuture.addListener(new FutureListener<T>() {
-                @Override
-                public void operationComplete(Future<T> future) {
-                    // Always just close the Channel once the resolution is considered complete.
-                    f.channel().close();
-                }
+            resolutionFuture.addListener((FutureListener<T>) future -> {
+                // Always just close the Channel once the resolution is considered complete.
+                f.channel().close();
             });
             return f;
         }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
@@ -181,32 +181,29 @@ abstract class DnsQueryContext {
         }
 
         // Ensure we remove the id from the QueryContextManager once the query completes.
-        promise.addListener(new FutureListener<AddressedEnvelope<DnsResponse, InetSocketAddress>>() {
-            @Override
-            public void operationComplete(Future<AddressedEnvelope<DnsResponse, InetSocketAddress>> future) {
-                // Cancel the timeout task.
-                Future<?> timeoutFuture = DnsQueryContext.this.timeoutFuture;
-                if (timeoutFuture != null) {
-                    DnsQueryContext.this.timeoutFuture = null;
-                    timeoutFuture.cancel(false);
-                }
+        promise.addListener((FutureListener<AddressedEnvelope<DnsResponse, InetSocketAddress>>) future -> {
+            // Cancel the timeout task.
+            Future<?> timeoutFuture = DnsQueryContext.this.timeoutFuture;
+            if (timeoutFuture != null) {
+                DnsQueryContext.this.timeoutFuture = null;
+                timeoutFuture.cancel(false);
+            }
 
-                Throwable cause = future.cause();
-                if (cause instanceof DnsNameResolverTimeoutException || cause instanceof CancellationException) {
-                    // This query was failed due a timeout or cancellation. Let's delay the removal of the id to reduce
-                    // the risk of reusing the same id again while the remote nameserver might send the response after
-                    // the timeout.
-                    channel.executor().schedule(new Runnable() {
-                        @Override
-                        public void run() {
-                            removeFromContextManager(nameServerAddr);
-                        }
-                    }, ID_REUSE_ON_TIMEOUT_DELAY_MILLIS, TimeUnit.MILLISECONDS);
-                } else {
-                    // Remove the id from the manager as soon as the query completes. This may be because of success,
-                    // failure or cancellation
-                    removeFromContextManager(nameServerAddr);
-                }
+            Throwable cause = future.cause();
+            if (cause instanceof DnsNameResolverTimeoutException || cause instanceof CancellationException) {
+                // This query was failed due a timeout or cancellation. Let's delay the removal of the id to reduce
+                // the risk of reusing the same id again while the remote nameserver might send the response after
+                // the timeout.
+                channel.executor().schedule(new Runnable() {
+                    @Override
+                    public void run() {
+                        removeFromContextManager(nameServerAddr);
+                    }
+                }, ID_REUSE_ON_TIMEOUT_DELAY_MILLIS, TimeUnit.MILLISECONDS);
+            } else {
+                // Remove the id from the manager as soon as the query completes. This may be because of success,
+                // failure or cancellation
+                removeFromContextManager(nameServerAddr);
             }
         });
         final DnsQuestion question = question();
@@ -252,12 +249,8 @@ abstract class DnsQueryContext {
         if (writeFuture.isDone()) {
             onQueryWriteCompletion(queryTimeoutMillis, writeFuture);
         } else {
-            writeFuture.addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) {
-                    onQueryWriteCompletion(queryTimeoutMillis, writeFuture);
-                }
-            });
+            writeFuture.addListener((ChannelFutureListener) future ->
+                    onQueryWriteCompletion(queryTimeoutMillis, future));
         }
     }
 
@@ -358,86 +351,79 @@ abstract class DnsQueryContext {
             return false;
         }
 
-        socketBootstrap.connect(nameServerAddr).addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                if (!future.isSuccess()) {
-                    logger.debug("{} Unable to fallback to TCP [{}: {}]",
-                            future.channel(), id, nameServerAddr, future.cause());
+        socketBootstrap.connect(nameServerAddr).addListener((ChannelFutureListener) future -> {
+            if (!future.isSuccess()) {
+                logger.debug("{} Unable to fallback to TCP [{}: {}]",
+                        future.channel(), id, nameServerAddr, future.cause());
 
-                    // TCP fallback failed, just use the truncated response or error.
-                    finishOriginal(originalResult, future);
-                    return;
-                }
-                final Channel tcpCh = future.channel();
-                Promise<AddressedEnvelope<DnsResponse, InetSocketAddress>> promise =
-                        tcpCh.executor().newPromise();
-                final TcpDnsQueryContext tcpCtx = new TcpDnsQueryContext(tcpCh,
-                        (InetSocketAddress) tcpCh.remoteAddress(), queryContextManager, queryLifecycleObserver, 0,
-                        recursionDesired, queryTimeoutMillis, question(), additionals, promise);
-                tcpCh.pipeline().addLast(TCP_ENCODER);
-                tcpCh.pipeline().addLast(new TcpDnsResponseDecoder());
-                tcpCh.pipeline().addLast(new ChannelInboundHandler() {
-                    @Override
-                    public void channelRead(ChannelHandlerContext ctx, Object msg) {
-                        Channel tcpCh = ctx.channel();
-                        DnsResponse response = (DnsResponse) msg;
-                        int queryId = response.id();
-
-                        if (logger.isDebugEnabled()) {
-                            logger.debug("{} RECEIVED: TCP [{}: {}], {}", tcpCh, queryId,
-                                    tcpCh.remoteAddress(), response);
-                        }
-
-                        DnsQueryContext foundCtx = queryContextManager.get(nameServerAddr, queryId);
-                        if (foundCtx != null && foundCtx.isDone()) {
-                            logger.debug("{} Received a DNS response for a query that was timed out or cancelled " +
-                                    ": TCP [{}: {}]", tcpCh, queryId, nameServerAddr);
-                            response.release();
-                        } else if (foundCtx == tcpCtx) {
-                            tcpCtx.finishSuccess(new AddressedEnvelopeAdapter(
-                                    (InetSocketAddress) ctx.channel().remoteAddress(),
-                                    (InetSocketAddress) ctx.channel().localAddress(),
-                                    response), false);
-                        } else {
-                            response.release();
-                            tcpCtx.finishFailure("Received TCP DNS response with unexpected ID", null, false);
-                            if (logger.isDebugEnabled()) {
-                                logger.debug("{} Received a DNS response with an unexpected ID: TCP [{}: {}]",
-                                        tcpCh, queryId, tcpCh.remoteAddress());
-                            }
-                        }
-                    }
-
-                    @Override
-                    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-                        if (tcpCtx.finishFailure(
-                                "TCP fallback error", cause, false) && logger.isDebugEnabled()) {
-                            logger.debug("{} Error during processing response: TCP [{}: {}]",
-                                    ctx.channel(), id,
-                                    ctx.channel().remoteAddress(), cause);
-                        }
-                    }
-                });
-
-                promise.addListener(
-                        new FutureListener<AddressedEnvelope<DnsResponse, InetSocketAddress>>() {
-                            @Override
-                            public void operationComplete(
-                                    Future<AddressedEnvelope<DnsResponse, InetSocketAddress>> future) {
-                                if (future.isSuccess()) {
-                                    finishSuccess(future.getNow(), false);
-                                    // Release the original result.
-                                    ReferenceCountUtil.release(originalResult);
-                                } else {
-                                    // TCP fallback failed, just use the truncated response or error.
-                                    finishOriginal(originalResult, future);
-                                }
-                                tcpCh.close();
-                            }
-                        });
-                tcpCtx.writeQuery(true);
+                // TCP fallback failed, just use the truncated response or error.
+                finishOriginal(originalResult, future);
+                return;
             }
+            final Channel tcpCh = future.channel();
+            Promise<AddressedEnvelope<DnsResponse, InetSocketAddress>> promise =
+                    tcpCh.executor().newPromise();
+            final TcpDnsQueryContext tcpCtx = new TcpDnsQueryContext(tcpCh,
+                    (InetSocketAddress) tcpCh.remoteAddress(), queryContextManager, queryLifecycleObserver, 0,
+                    recursionDesired, queryTimeoutMillis, question(), additionals, promise);
+            tcpCh.pipeline().addLast(TCP_ENCODER);
+            tcpCh.pipeline().addLast(new TcpDnsResponseDecoder());
+            tcpCh.pipeline().addLast(new ChannelInboundHandler() {
+                @Override
+                public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                    Channel tcpCh = ctx.channel();
+                    DnsResponse response = (DnsResponse) msg;
+                    int queryId = response.id();
+
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("{} RECEIVED: TCP [{}: {}], {}", tcpCh, queryId,
+                                tcpCh.remoteAddress(), response);
+                    }
+
+                    DnsQueryContext foundCtx = queryContextManager.get(nameServerAddr, queryId);
+                    if (foundCtx != null && foundCtx.isDone()) {
+                        logger.debug("{} Received a DNS response for a query that was timed out or cancelled " +
+                                ": TCP [{}: {}]", tcpCh, queryId, nameServerAddr);
+                        response.release();
+                    } else if (foundCtx == tcpCtx) {
+                        tcpCtx.finishSuccess(new AddressedEnvelopeAdapter(
+                                (InetSocketAddress) ctx.channel().remoteAddress(),
+                                (InetSocketAddress) ctx.channel().localAddress(),
+                                response), false);
+                    } else {
+                        response.release();
+                        tcpCtx.finishFailure("Received TCP DNS response with unexpected ID", null, false);
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("{} Received a DNS response with an unexpected ID: TCP [{}: {}]",
+                                    tcpCh, queryId, tcpCh.remoteAddress());
+                        }
+                    }
+                }
+
+                @Override
+                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                    if (tcpCtx.finishFailure(
+                            "TCP fallback error", cause, false) && logger.isDebugEnabled()) {
+                        logger.debug("{} Error during processing response: TCP [{}: {}]",
+                                ctx.channel(), id,
+                                ctx.channel().remoteAddress(), cause);
+                    }
+                }
+            });
+
+            promise.addListener(
+                    (FutureListener<AddressedEnvelope<DnsResponse, InetSocketAddress>>) future1 -> {
+                        if (future1.isSuccess()) {
+                            finishSuccess(future1.getNow(), false);
+                            // Release the original result.
+                            ReferenceCountUtil.release(originalResult);
+                        } else {
+                            // TCP fallback failed, just use the truncated response or error.
+                            finishOriginal(originalResult, future1);
+                        }
+                        tcpCh.close();
+                    });
+            tcpCtx.writeQuery(true);
         });
         return true;
     }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -471,53 +471,50 @@ abstract class DnsResolveContext<T> {
 
         queriesInProgress.add(f);
 
-        f.addListener(new FutureListener<AddressedEnvelope<DnsResponse, InetSocketAddress>>() {
-            @Override
-            public void operationComplete(Future<AddressedEnvelope<DnsResponse, InetSocketAddress>> future) {
-                queriesInProgress.remove(future);
+        f.addListener((FutureListener<AddressedEnvelope<DnsResponse, InetSocketAddress>>) future -> {
+            queriesInProgress.remove(future);
 
-                if (promise.isDone() || future.isCancelled()) {
-                    queryLifecycleObserver.queryCancelled(allowedQueries);
+            if (promise.isDone() || future.isCancelled()) {
+                queryLifecycleObserver.queryCancelled(allowedQueries);
 
-                    // Check if we need to release the envelope itself. If the query was cancelled the getNow() will
-                    // return null as well as the Future will be failed with a CancellationException.
-                    AddressedEnvelope<DnsResponse, InetSocketAddress> result = future.getNow();
-                    if (result != null) {
-                        result.release();
-                    }
-                    return;
+                // Check if we need to release the envelope itself. If the query was cancelled the getNow() will
+                // return null as well as the Future will be failed with a CancellationException.
+                AddressedEnvelope<DnsResponse, InetSocketAddress> result = future.getNow();
+                if (result != null) {
+                    result.release();
                 }
+                return;
+            }
 
-                final Throwable queryCause = future.cause();
-                try {
-                    if (queryCause == null) {
-                        if (isFeedbackAddressStream) {
-                            final DnsServerResponseFeedbackAddressStream feedbackNameServerAddrStream =
-                                    (DnsServerResponseFeedbackAddressStream) nameServerAddrStream;
-                            feedbackNameServerAddrStream.feedbackSuccess(nameServerAddr,
-                                    System.nanoTime() - queryStartTimeNanos);
-                        }
-                        onResponse(nameServerAddrStream, nameServerAddrStreamIndex, question, future.getNow(),
-                                   queryLifecycleObserver, promise);
-                    } else {
-                        // Server did not respond or I/O error occurred; try again.
-                        if (isFeedbackAddressStream) {
-                            final DnsServerResponseFeedbackAddressStream feedbackNameServerAddrStream =
-                                    (DnsServerResponseFeedbackAddressStream) nameServerAddrStream;
-                            feedbackNameServerAddrStream.feedbackFailure(nameServerAddr, queryCause,
-                                    System.nanoTime() - queryStartTimeNanos);
-                        }
-                        queryLifecycleObserver.queryFailed(queryCause);
-                        query(nameServerAddrStream, nameServerAddrStreamIndex + 1, question,
-                              newDnsQueryLifecycleObserver(question), true, promise, queryCause);
+            final Throwable queryCause = future.cause();
+            try {
+                if (queryCause == null) {
+                    if (isFeedbackAddressStream) {
+                        final DnsServerResponseFeedbackAddressStream feedbackNameServerAddrStream =
+                                (DnsServerResponseFeedbackAddressStream) nameServerAddrStream;
+                        feedbackNameServerAddrStream.feedbackSuccess(nameServerAddr,
+                                System.nanoTime() - queryStartTimeNanos);
                     }
-                } finally {
-                    tryToFinishResolve(nameServerAddrStream, nameServerAddrStreamIndex, question,
-                                       // queryLifecycleObserver has already been terminated at this point so we must
-                                       // not allow it to be terminated again by tryToFinishResolve.
-                                       NoopDnsQueryLifecycleObserver.INSTANCE,
-                                       promise, queryCause);
+                    onResponse(nameServerAddrStream, nameServerAddrStreamIndex, question, future.getNow(),
+                               queryLifecycleObserver, promise);
+                } else {
+                    // Server did not respond or I/O error occurred; try again.
+                    if (isFeedbackAddressStream) {
+                        final DnsServerResponseFeedbackAddressStream feedbackNameServerAddrStream =
+                                (DnsServerResponseFeedbackAddressStream) nameServerAddrStream;
+                        feedbackNameServerAddrStream.feedbackFailure(nameServerAddr, queryCause,
+                                System.nanoTime() - queryStartTimeNanos);
+                    }
+                    queryLifecycleObserver.queryFailed(queryCause);
+                    query(nameServerAddrStream, nameServerAddrStreamIndex + 1, question,
+                          newDnsQueryLifecycleObserver(question), true, promise, queryCause);
                 }
+            } finally {
+                tryToFinishResolve(nameServerAddrStream, nameServerAddrStreamIndex, question,
+                                   // queryLifecycleObserver has already been terminated at this point so we must
+                                   // not allow it to be terminated again by tryToFinishResolve.
+                                   NoopDnsQueryLifecycleObserver.INSTANCE,
+                                   promise, queryCause);
             }
         });
     }
@@ -538,23 +535,20 @@ abstract class DnsResolveContext<T> {
         queriesInProgress.add(resolveFuture);
 
         Promise<List<InetAddress>> resolverPromise = parent.executor().newPromise();
-        resolverPromise.addListener(new FutureListener<List<InetAddress>>() {
-            @Override
-            public void operationComplete(final Future<List<InetAddress>> future) {
-                // Remove placeholder.
-                queriesInProgress.remove(resolveFuture);
+        resolverPromise.addListener((FutureListener<List<InetAddress>>) future -> {
+            // Remove placeholder.
+            queriesInProgress.remove(resolveFuture);
 
-                if (future.isSuccess()) {
-                    List<InetAddress> resolvedAddresses = future.getNow();
-                    DnsServerAddressStream addressStream = new CombinedDnsServerAddressStream(
-                            nameServerAddr, resolvedAddresses, nameServerAddrStream);
-                    query(addressStream, nameServerAddrStreamIndex, question,
-                          queryLifecycleObserver, true, promise, cause);
-                } else {
-                    // Ignore the server and try the next one...
-                    query(nameServerAddrStream, nameServerAddrStreamIndex + 1,
-                          question, queryLifecycleObserver, true, promise, cause);
-                }
+            if (future.isSuccess()) {
+                List<InetAddress> resolvedAddresses = future.getNow();
+                DnsServerAddressStream addressStream = new CombinedDnsServerAddressStream(
+                        nameServerAddr, resolvedAddresses, nameServerAddrStream);
+                query(addressStream, nameServerAddrStreamIndex, question,
+                      queryLifecycleObserver, true, promise, cause);
+            } else {
+                // Ignore the server and try the next one...
+                query(nameServerAddrStream, nameServerAddrStreamIndex + 1,
+                      question, queryLifecycleObserver, true, promise, cause);
             }
         });
         DnsCache resolveCache = resolveCache();

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/InflightNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/InflightNameResolver.java
@@ -81,12 +81,7 @@ final class InflightNameResolver<T> implements NameResolver<T> {
             if (earlyPromise.isDone()) {
                 transferResult(earlyPromise, promise);
             } else {
-                earlyPromise.addListener(new FutureListener<U>() {
-                    @Override
-                    public void operationComplete(Future<U> f) {
-                        transferResult(f, promise);
-                    }
-                });
+                earlyPromise.addListener((FutureListener<U>) f -> transferResult(f, promise));
             }
         } else {
             try {
@@ -103,12 +98,7 @@ final class InflightNameResolver<T> implements NameResolver<T> {
                 if (promise.isDone()) {
                     resolveMap.remove(inetHost);
                 } else {
-                    promise.addListener(new FutureListener<U>() {
-                        @Override
-                        public void operationComplete(Future<U> f) {
-                            resolveMap.remove(inetHost);
-                        }
-                    });
+                    promise.addListener((FutureListener<U>) f -> resolveMap.remove(inetHost));
                 }
             }
         }

--- a/resolver-dns/src/main/resources/META-INF/native-image/io.netty/netty5-resolver-dns/generated/handlers/reflect-config.json
+++ b/resolver-dns/src/main/resources/META-INF/native-image/io.netty/netty5-resolver-dns/generated/handlers/reflect-config.json
@@ -28,9 +28,9 @@
     "queryAllPublicMethods": true
   },
   {
-    "name": "io.netty.resolver.dns.DnsQueryContext$5$1",
+    "name": "io.netty.resolver.dns.DnsQueryContext$4",
     "condition": {
-      "typeReachable": "io.netty.resolver.dns.DnsQueryContext$5$1"
+      "typeReachable": "io.netty.resolver.dns.DnsQueryContext$4"
     },
     "queryAllPublicMethods": true
   }

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsAddressResolverGroupTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsAddressResolverGroupTest.java
@@ -53,16 +53,13 @@ public class DnsAddressResolverGroupTest {
             AddressResolver<?> resolver = resolverGroup.getResolver(defaultEventLoopGroup.next());
             resolver.resolve(new SocketAddress() {
                 private static final long serialVersionUID = 3169703458729818468L;
-            }).addListener(new FutureListener<Object>() {
-                @Override
-                public void operationComplete(Future<Object> future) {
-                    try {
-                        assertInstanceOf(UnsupportedAddressTypeException.class, future.cause());
-                        assertTrue(loop.inEventLoop());
-                        promise.setSuccess(null);
-                    } catch (Throwable cause) {
-                        promise.setFailure(cause);
-                    }
+            }).addListener((FutureListener<Object>) future -> {
+                try {
+                    assertInstanceOf(UnsupportedAddressTypeException.class, future.cause());
+                    assertTrue(loop.inEventLoop());
+                    promise.setSuccess(null);
+                } catch (Throwable cause) {
+                    promise.setFailure(cause);
                 }
             }).await();
             promise.sync();
@@ -104,14 +101,11 @@ public class DnsAddressResolverGroupTest {
                                 final Promise<InetSocketAddress> promise)
             throws InterruptedException, ExecutionException {
         resolver.resolve(socketAddress)
-                .addListener(new FutureListener<InetSocketAddress>() {
-                    @Override
-                    public void operationComplete(Future<InetSocketAddress> future) {
-                        try {
-                            promise.setSuccess(future.get());
-                        } catch (Throwable cause) {
-                            promise.setFailure(cause);
-                        }
+                .addListener((FutureListener<InetSocketAddress>) future -> {
+                    try {
+                        promise.setSuccess(future.get());
+                    } catch (Throwable cause) {
+                        promise.setFailure(cause);
                     }
                 }).await();
         promise.sync();

--- a/resolver/src/main/java/io/netty/resolver/AddressResolverGroup.java
+++ b/resolver/src/main/java/io/netty/resolver/AddressResolverGroup.java
@@ -74,15 +74,12 @@ public abstract class AddressResolverGroup<T extends SocketAddress> implements C
 
                 resolvers.put(executor, newResolver);
 
-                final FutureListener<Object> terminationListener = new FutureListener<Object>() {
-                    @Override
-                    public void operationComplete(Future<Object> future) {
-                        synchronized (resolvers) {
-                            resolvers.remove(executor);
-                            executorTerminationListeners.remove(executor);
-                        }
-                        newResolver.close();
+                final FutureListener<Object> terminationListener = future -> {
+                    synchronized (resolvers) {
+                        resolvers.remove(executor);
+                        executorTerminationListeners.remove(executor);
                     }
+                    newResolver.close();
                 };
 
                 executorTerminationListeners.put(executor, terminationListener);

--- a/resolver/src/main/java/io/netty/resolver/CompositeNameResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/CompositeNameResolver.java
@@ -66,14 +66,11 @@ public final class CompositeNameResolver<T> extends SimpleNameResolver<T> {
             promise.setFailure(lastFailure);
         } else {
             NameResolver<T> resolver = resolvers[resolverIndex];
-            resolver.resolve(inetHost).addListener(new FutureListener<T>() {
-                @Override
-                public void operationComplete(Future<T> future) {
-                    if (future.isSuccess()) {
-                        promise.setSuccess(future.getNow());
-                    } else {
-                        doResolveRec(inetHost, promise, resolverIndex + 1, future.cause());
-                    }
+            resolver.resolve(inetHost).addListener((FutureListener<T>) future -> {
+                if (future.isSuccess()) {
+                    promise.setSuccess(future.getNow());
+                } else {
+                    doResolveRec(inetHost, promise, resolverIndex + 1, future.cause());
                 }
             });
         }
@@ -92,14 +89,11 @@ public final class CompositeNameResolver<T> extends SimpleNameResolver<T> {
             promise.setFailure(lastFailure);
         } else {
             NameResolver<T> resolver = resolvers[resolverIndex];
-            resolver.resolveAll(inetHost).addListener(new FutureListener<List<T>>() {
-                @Override
-                public void operationComplete(Future<List<T>> future) {
-                    if (future.isSuccess()) {
-                        promise.setSuccess(future.getNow());
-                    } else {
-                        doResolveAllRec(inetHost, promise, resolverIndex + 1, future.cause());
-                    }
+            resolver.resolveAll(inetHost).addListener((FutureListener<List<T>>) future -> {
+                if (future.isSuccess()) {
+                    promise.setSuccess(future.getNow());
+                } else {
+                    doResolveAllRec(inetHost, promise, resolverIndex + 1, future.cause());
                 }
             });
         }

--- a/resolver/src/main/java/io/netty/resolver/InetSocketAddressResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/InetSocketAddressResolver.java
@@ -53,14 +53,11 @@ public class InetSocketAddressResolver extends AbstractAddressResolver<InetSocke
         // Note that InetSocketAddress.getHostName() will never incur a reverse lookup here,
         // because an unresolved address always has a host name.
         nameResolver.resolve(unresolvedAddress.getHostName())
-                .addListener(new FutureListener<InetAddress>() {
-                    @Override
-                    public void operationComplete(Future<InetAddress> future) {
-                        if (future.isSuccess()) {
-                            promise.setSuccess(new InetSocketAddress(future.getNow(), unresolvedAddress.getPort()));
-                        } else {
-                            promise.setFailure(future.cause());
-                        }
+                .addListener((FutureListener<InetAddress>) future -> {
+                    if (future.isSuccess()) {
+                        promise.setSuccess(new InetSocketAddress(future.getNow(), unresolvedAddress.getPort()));
+                    } else {
+                        promise.setFailure(future.cause());
                     }
                 });
     }
@@ -71,20 +68,17 @@ public class InetSocketAddressResolver extends AbstractAddressResolver<InetSocke
         // Note that InetSocketAddress.getHostName() will never incur a reverse lookup here,
         // because an unresolved address always has a host name.
         nameResolver.resolveAll(unresolvedAddress.getHostName())
-                .addListener(new FutureListener<List<InetAddress>>() {
-                    @Override
-                    public void operationComplete(Future<List<InetAddress>> future) {
-                        if (future.isSuccess()) {
-                            List<InetAddress> inetAddresses = future.getNow();
-                            List<InetSocketAddress> socketAddresses =
-                                    new ArrayList<InetSocketAddress>(inetAddresses.size());
-                            for (InetAddress inetAddress : inetAddresses) {
-                                socketAddresses.add(new InetSocketAddress(inetAddress, unresolvedAddress.getPort()));
-                            }
-                            promise.setSuccess(socketAddresses);
-                        } else {
-                            promise.setFailure(future.cause());
+                .addListener((FutureListener<List<InetAddress>>) future -> {
+                    if (future.isSuccess()) {
+                        List<InetAddress> inetAddresses = future.getNow();
+                        List<InetSocketAddress> socketAddresses =
+                                new ArrayList<InetSocketAddress>(inetAddresses.size());
+                        for (InetAddress inetAddress : inetAddresses) {
+                            socketAddresses.add(new InetSocketAddress(inetAddress, unresolvedAddress.getPort()));
                         }
+                        promise.setSuccess(socketAddresses);
+                    } else {
+                        promise.setFailure(future.cause());
                     }
                 });
     }

--- a/resolver/src/main/java/io/netty/resolver/RoundRobinInetAddressResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/RoundRobinInetAddressResolver.java
@@ -52,45 +52,39 @@ public class RoundRobinInetAddressResolver extends InetNameResolver {
         // hijack the doResolve request, but do a doResolveAll request under the hood.
         // Note that InetSocketAddress.getHostName() will never incur a reverse lookup here,
         // because an unresolved address always has a host name.
-        nameResolver.resolveAll(inetHost).addListener(new FutureListener<List<InetAddress>>() {
-            @Override
-            public void operationComplete(Future<List<InetAddress>> future) {
-                if (future.isSuccess()) {
-                    List<InetAddress> inetAddresses = future.getNow();
-                    int numAddresses = inetAddresses.size();
-                    if (numAddresses > 0) {
-                        // if there are multiple addresses: we shall pick one by one
-                        // to support the round robin distribution
-                        promise.setSuccess(inetAddresses.get(randomIndex(numAddresses)));
-                    } else {
-                        promise.setFailure(new UnknownHostException(inetHost));
-                    }
+        nameResolver.resolveAll(inetHost).addListener((FutureListener<List<InetAddress>>) future -> {
+            if (future.isSuccess()) {
+                List<InetAddress> inetAddresses = future.getNow();
+                int numAddresses = inetAddresses.size();
+                if (numAddresses > 0) {
+                    // if there are multiple addresses: we shall pick one by one
+                    // to support the round robin distribution
+                    promise.setSuccess(inetAddresses.get(randomIndex(numAddresses)));
                 } else {
-                    promise.setFailure(future.cause());
+                    promise.setFailure(new UnknownHostException(inetHost));
                 }
+            } else {
+                promise.setFailure(future.cause());
             }
         });
     }
 
     @Override
     protected void doResolveAll(String inetHost, final Promise<List<InetAddress>> promise) throws Exception {
-        nameResolver.resolveAll(inetHost).addListener(new FutureListener<List<InetAddress>>() {
-            @Override
-            public void operationComplete(Future<List<InetAddress>> future) {
-                if (future.isSuccess()) {
-                    List<InetAddress> inetAddresses = future.getNow();
-                    if (!inetAddresses.isEmpty()) {
-                        // create a copy to make sure that it's modifiable random access collection
-                        List<InetAddress> result = new ArrayList<InetAddress>(inetAddresses);
-                        // rotate by different distance each time to force round robin distribution
-                        Collections.rotate(result, randomIndex(inetAddresses.size()));
-                        promise.setSuccess(result);
-                    } else {
-                        promise.setSuccess(inetAddresses);
-                    }
+        nameResolver.resolveAll(inetHost).addListener((FutureListener<List<InetAddress>>) future -> {
+            if (future.isSuccess()) {
+                List<InetAddress> inetAddresses = future.getNow();
+                if (!inetAddresses.isEmpty()) {
+                    // create a copy to make sure that it's modifiable random access collection
+                    List<InetAddress> result = new ArrayList<InetAddress>(inetAddresses);
+                    // rotate by different distance each time to force round robin distribution
+                    Collections.rotate(result, randomIndex(inetAddresses.size()));
+                    promise.setSuccess(result);
                 } else {
-                    promise.setFailure(future.cause());
+                    promise.setSuccess(inetAddresses);
                 }
+            } else {
+                promise.setFailure(future.cause());
             }
         });
     }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractSocketReuseFdTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractSocketReuseFdTest.java
@@ -96,12 +96,9 @@ public abstract class AbstractSocketReuseFdTest extends AbstractSocketTest {
             }
         });
 
-        ChannelFutureListener listener = new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                if (!future.isSuccess()) {
-                    clientDonePromise.tryFailure(future.cause());
-                }
+        ChannelFutureListener listener = future -> {
+            if (!future.isSuccess()) {
+                clientDonePromise.tryFailure(future.cause());
             }
         };
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketBufReleaseTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketBufReleaseTest.java
@@ -96,12 +96,7 @@ public class SocketBufReleaseTest extends AbstractSocketTest {
             // call retain on it so it can't be put back on the pool
             buf.writeBytes(data).retain();
 
-            ctx.channel().writeAndFlush(buf).addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) {
-                    latch.countDown();
-                }
-            });
+            ctx.channel().writeAndFlush(buf).addListener(future -> latch.countDown());
         }
 
         @Override

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -366,12 +366,8 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                         public void channelActive(ChannelHandlerContext ctx) throws Exception {
                             ByteBuf buf = ctx.alloc().buffer(totalServerBytesWritten);
                             buf.writerIndex(buf.capacity());
-                            ctx.writeAndFlush(buf).addListener(new ChannelFutureListener() {
-                                @Override
-                                public void operationComplete(ChannelFuture future) {
-                                    future.channel().shutdown(ChannelShutdownType.newOutbound());
-                                }
-                            });
+                            ctx.writeAndFlush(buf).addListener((ChannelFutureListener) future ->
+                                    future.channel().shutdown(ChannelShutdownType.newOutbound()));
                             serverInitializedLatch.countDown();
                         }
 
@@ -559,27 +555,20 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
                 // We write a reply and immediately close our end of the socket.
                 ByteBuf buf = ctx.alloc().buffer(expectedBytes);
                 buf.writerIndex(buf.writerIndex() + expectedBytes);
-                ctx.writeAndFlush(buf).addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) {
-                        future.channel().close().addListener(new ChannelFutureListener() {
-                            @Override
-                            public void operationComplete(final ChannelFuture future) {
-                                // This is a bit racy but there is no better way how to handle this in Java11.
-                                // The problem is that on close() the underlying FD will not actually be closed directly
-                                // but the close will be done after the Selector did process all events. Because of
-                                // this we will need to give it a bit time to ensure the FD is actual closed before we
-                                // count down the latch and try to write.
-                                future.channel().executor().schedule(new Runnable() {
-                                    @Override
-                                    public void run() {
-                                        followerCloseLatch.countDown();
-                                    }
-                                }, 200, TimeUnit.MILLISECONDS);
-                            }
-                        });
-                    }
-                });
+                ctx.writeAndFlush(buf).addListener(future ->
+                        ctx.close().addListener(f -> {
+                            // This is a bit racy but there is no better way how to handle this in Java11.
+                            // The problem is that on close() the underlying FD will not actually be closed directly
+                            // but the close will be done after the Selector did process all events. Because of
+                            // this we will need to give it a bit time to ensure the FD is actual closed before we
+                            // count down the latch and try to write.
+                            ctx.executor().schedule(new Runnable() {
+                                @Override
+                                public void run() {
+                                    followerCloseLatch.countDown();
+                                }
+                            }, 200, MILLISECONDS);
+                        }));
             }
         }
 
@@ -618,13 +607,10 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
             followerCloseLatch.await();
 
             // This write should fail, but we should still be allowed to read the peer's data
-            ctx.writeAndFlush(buf).addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) {
-                    if (future.cause() == null) {
-                        causeRef.set(new IllegalStateException("second write should have failed!"));
-                        doneLatch.countDown();
-                    }
+            ctx.writeAndFlush(buf).addListener(future -> {
+                if (future.cause() == null) {
+                    causeRef.set(new IllegalStateException("second write should have failed!"));
+                    doneLatch.countDown();
                 }
             });
         }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
@@ -38,7 +38,6 @@ import io.netty.pkitesting.CertificateBuilder;
 import io.netty.pkitesting.X509Bundle;
 import io.netty.testsuite.util.TestUtils;
 import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.junit.jupiter.api.AfterAll;
@@ -518,13 +517,7 @@ public class SocketSslEchoTest extends AbstractSocketTest {
         @Override
         public void handlerAdded(final ChannelHandlerContext ctx) {
             if (!autoRead) {
-                ctx.pipeline().get(SslHandler.class).handshakeFuture().addListener(
-                        new GenericFutureListener<Future<? super Channel>>() {
-                            @Override
-                            public void operationComplete(Future<? super Channel> future) {
-                                ctx.read();
-                            }
-                        });
+                ctx.pipeline().get(SslHandler.class).handshakeFuture().addListener(future -> ctx.read());
             }
         }
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslLargeCertificateTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslLargeCertificateTest.java
@@ -209,12 +209,7 @@ public class SocketSslLargeCertificateTest {
                                 if (receivedRead) {
                                     receivedRead = false;
                                     ctx.writeAndFlush(Unpooled.buffer()).addListener(ChannelFutureListener.CLOSE);
-                                    ctx.channel().closeFuture().addListener(new ChannelFutureListener() {
-                                        @Override
-                                        public void operationComplete(ChannelFuture future) {
-                                            completion.setSuccess(null);
-                                        }
-                                    });
+                                    ctx.channel().closeFuture().addListener(future -> completion.setSuccess(null));
                                 }
                             }
 

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketFdTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketFdTest.java
@@ -72,13 +72,10 @@ public class EpollDomainSocketFdTest extends AbstractSocketTest {
                 final EpollSocketChannel ch = new EpollSocketChannel(
                         ctx.channel().executor(), SocketProtocolFamily.UNIX);
 
-                ctx.writeAndFlush(ch.fd()).addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) {
-                        if (!future.isSuccess()) {
-                            Throwable cause = future.cause();
-                            queue.offer(cause);
-                        }
+                ctx.writeAndFlush(ch.fd()).addListener(future -> {
+                    if (!future.isSuccess()) {
+                        Throwable cause = future.cause();
+                        queue.offer(cause);
                     }
                 });
             }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketFdTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketFdTest.java
@@ -20,8 +20,6 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.socket.SocketProtocolFamily;
@@ -80,25 +78,19 @@ public class IoUringDomainSocketFdTest extends AbstractSocketTest {
                 final IoUringSocketChannel ch = new IoUringSocketChannel(
                         ctx.channel().executor(), SocketProtocolFamily.UNIX);
 
-                ctx.writeAndFlush(ch.fd()).addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) {
-                        if (!future.isSuccess()) {
-                            Throwable cause = future.cause();
-                            recvFdFuture.completeExceptionally(cause);
-                        } else {
-                            ByteBuf sendBuffer = ctx.alloc().directBuffer(expected.length());
-                            sendBuffer.writeBytes(expected.getBytes());
-                            ctx.writeAndFlush(sendBuffer).addListener(new ChannelFutureListener() {
-                                @Override
-                                public void operationComplete(ChannelFuture future) {
-                                    if (!future.isSuccess()) {
-                                        Throwable cause = future.cause();
-                                        recvByteBufFuture.completeExceptionally(cause);
-                                    }
-                                }
-                            });
-                        }
+                ctx.writeAndFlush(ch.fd()).addListener(future -> {
+                    if (!future.isSuccess()) {
+                        Throwable cause = future.cause();
+                        recvFdFuture.completeExceptionally(cause);
+                    } else {
+                        ByteBuf sendBuffer = ctx.alloc().directBuffer(expected.length());
+                        sendBuffer.writeBytes(expected.getBytes());
+                        ctx.writeAndFlush(sendBuffer).addListener(f -> {
+                            if (!f.isSuccess()) {
+                                Throwable cause = f.cause();
+                                recvByteBufFuture.completeExceptionally(cause);
+                            }
+                        });
                     }
                 });
             }

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainSocketFdTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainSocketFdTest.java
@@ -72,13 +72,10 @@ public class KQueueDomainSocketFdTest extends AbstractSocketTest {
                 final KQueueSocketChannel ch = new KQueueSocketChannel(
                         ctx.channel().executor(), SocketProtocolFamily.UNIX);
 
-                ctx.writeAndFlush(ch.fd()).addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) {
-                        if (!future.isSuccess()) {
-                            Throwable cause = future.cause();
-                            queue.offer(cause);
-                        }
+                ctx.writeAndFlush(ch.fd()).addListener(future -> {
+                    if (!future.isSuccess()) {
+                        Throwable cause = future.cause();
+                        queue.offer(cause);
                     }
                 });
             }

--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -259,21 +259,18 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
         } else {
             // Registration future is almost always fulfilled already, but just in case it's not.
             final PendingRegistrationPromise promise = new PendingRegistrationPromise(channel);
-            regFuture.addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) {
-                    Throwable cause = future.cause();
-                    if (cause != null) {
-                        // Registration on the EventLoop failed so fail the ChannelPromise directly to not cause an
-                        // IllegalStateException once we try to access the EventLoop of the Channel.
-                        promise.setFailure(cause);
-                    } else {
-                        // Registration was successful, so set the correct executor to use.
-                        // See https://github.com/netty/netty/issues/2586
-                        promise.registered();
+            regFuture.addListener(future -> {
+                Throwable cause = future.cause();
+                if (cause != null) {
+                    // Registration on the EventLoop failed so fail the ChannelPromise directly to not cause an
+                    // IllegalStateException once we try to access the EventLoop of the Channel.
+                    promise.setFailure(cause);
+                } else {
+                    // Registration was successful, so set the correct executor to use.
+                    // See https://github.com/netty/netty/issues/2586
+                    promise.registered();
 
-                        doBind0(regFuture, channel, localAddress, promise);
-                    }
+                    doBind0(regFuture, channel, localAddress, promise);
                 }
             });
             return promise;

--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -203,22 +203,19 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
         } else {
             // Registration future is almost always fulfilled already, but just in case it's not.
             final PendingRegistrationPromise promise = new PendingRegistrationPromise(channel);
-            regFuture.addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) {
-                    // Directly obtain the cause and do a null check so we only need one volatile read in case of a
-                    // failure.
-                    Throwable cause = future.cause();
-                    if (cause != null) {
-                        // Registration on the EventLoop failed so fail the ChannelPromise directly to not cause an
-                        // IllegalStateException once we try to access the EventLoop of the Channel.
-                        promise.setFailure(cause);
-                    } else {
-                        // Registration was successful, so set the correct executor to use.
-                        // See https://github.com/netty/netty/issues/2586
-                        promise.registered();
-                        doResolveAndConnect0(channel, remoteAddress, localAddress, promise);
-                    }
+            regFuture.addListener(future -> {
+                // Directly obtain the cause and do a null check so we only need one volatile read in case of a
+                // failure.
+                Throwable cause = future.cause();
+                if (cause != null) {
+                    // Registration on the EventLoop failed so fail the ChannelPromise directly to not cause an
+                    // IllegalStateException once we try to access the EventLoop of the Channel.
+                    promise.setFailure(cause);
+                } else {
+                    // Registration was successful, so set the correct executor to use.
+                    // See https://github.com/netty/netty/issues/2586
+                    promise.registered();
+                    doResolveAndConnect0(channel, remoteAddress, localAddress, promise);
                 }
             });
             return promise;
@@ -265,15 +262,12 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
             }
 
             // Wait until the name resolution is finished.
-            resolveFuture.addListener(new FutureListener<SocketAddress>() {
-                @Override
-                public void operationComplete(Future<SocketAddress> future) {
-                    if (future.cause() != null) {
-                        channel.close();
-                        promise.setFailure(future.cause());
-                    } else {
-                        doConnect(future.getNow(), localAddress, promise);
-                    }
+            resolveFuture.addListener((FutureListener<SocketAddress>) future -> {
+                if (future.cause() != null) {
+                    channel.close();
+                    promise.setFailure(future.cause());
+                } else {
+                    doConnect(future.getNow(), localAddress, promise);
                 }
             });
         } catch (Throwable cause) {

--- a/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
@@ -294,12 +294,9 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
             }
 
             try {
-                child.register().addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) {
-                        if (!future.isSuccess()) {
-                            forceClose(child, future.cause());
-                        }
+                child.register().addListener(future -> {
+                    if (!future.isSuccess()) {
+                        forceClose(child, future.cause());
                     }
                 });
             } catch (Throwable t) {

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -420,34 +420,31 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
 
             ChannelPromise registerPromise = newPromise();
             boolean firstRegistration = neverRegistered;
-            registerPromise.addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) {
-                    if (future.isSuccess()) {
-                        neverRegistered = false;
-                        registered = true;
+            registerPromise.addListener(future -> {
+                if (future.isSuccess()) {
+                    neverRegistered = false;
+                    registered = true;
 
-                        safeSetSuccess(promise);
-                        pipeline.fireChannelRegistered();
-                        // Only fire a channelActive if the channel has never been registered. This prevents firing
-                        // multiple channel actives if the channel is deregistered and re-registered.
-                        if (isActive()) {
-                            if (firstRegistration) {
-                                pipeline.fireChannelActive();
-                            } else if (config().isAutoRead()) {
-                                // This channel was registered before and autoRead() is set. This means we need to
-                                // begin read again so that we process inbound data.
-                                //
-                                // See https://github.com/netty/netty/issues/4805
-                                read();
-                            }
+                    safeSetSuccess(promise);
+                    pipeline.fireChannelRegistered();
+                    // Only fire a channelActive if the channel has never been registered. This prevents firing
+                    // multiple channel actives if the channel is deregistered and re-registered.
+                    if (isActive()) {
+                        if (firstRegistration) {
+                            pipeline.fireChannelActive();
+                        } else if (config().isAutoRead()) {
+                            // This channel was registered before and autoRead() is set. This means we need to
+                            // begin read again so that we process inbound data.
+                            //
+                            // See https://github.com/netty/netty/issues/4805
+                            read();
                         }
-                    } else {
-                        // Close the channel directly to avoid FD leak.
-                        close(newPromise());
-                        closeFuture.setClosed();
-                        safeSetFailure(promise, future.cause());
                     }
+                } else {
+                    // Close the channel directly to avoid FD leak.
+                    close(newPromise());
+                    closeFuture.setClosed();
+                    safeSetFailure(promise, future.cause());
                 }
             });
             doRegister(registerPromise);
@@ -634,12 +631,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                     safeSetSuccess(promise);
                 } else {
                     // This means close() was called before so we just register a listener and return
-                    closeFuture.addListener(new ChannelFutureListener() {
-                        @Override
-                        public void operationComplete(ChannelFuture future) {
-                            promise.setSuccess();
-                        }
-                    });
+                    closeFuture.addListener(future -> promise.setSuccess());
                 }
                 return;
             }

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
@@ -64,12 +64,7 @@ public class EmbeddedChannel extends AbstractChannel {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(EmbeddedChannel.class);
 
-    private final ChannelFutureListener recordExceptionListener = new ChannelFutureListener() {
-        @Override
-        public void operationComplete(ChannelFuture future) {
-            recordException(future);
-        }
-    };
+    private final ChannelFutureListener recordExceptionListener = this::recordException;
 
     private final ChannelConfig config;
     private Queue<Object> inboundMessages;

--- a/transport/src/main/java/io/netty/channel/pool/AbstractChannelPoolMap.java
+++ b/transport/src/main/java/io/netty/channel/pool/AbstractChannelPoolMap.java
@@ -16,7 +16,6 @@
 package io.netty.channel.pool;
 
 import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.ReadOnlyIterator;
@@ -80,14 +79,11 @@ public abstract class AbstractChannelPoolMap<K, P extends ChannelPool>
         P pool =  map.remove(checkNotNull(key, "key"));
         if (pool != null) {
             final Promise<Boolean> removePromise = GlobalEventExecutor.INSTANCE.newPromise();
-            poolCloseAsyncIfSupported(pool).addListener(new GenericFutureListener<Future<? super Void>>() {
-                @Override
-                public void operationComplete(Future<? super Void> future) {
-                    if (future.isSuccess()) {
-                        removePromise.setSuccess(Boolean.TRUE);
-                    } else {
-                        removePromise.setFailure(future.cause());
-                    }
+            poolCloseAsyncIfSupported(pool).addListener(future -> {
+                if (future.isSuccess()) {
+                    removePromise.setSuccess(Boolean.TRUE);
+                } else {
+                    removePromise.setFailure(future.cause());
                 }
             });
             return removePromise;

--- a/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
@@ -291,34 +291,30 @@ public class FixedChannelPool extends SimpleChannelPool {
     public Future<Void> release(final Channel channel, final Promise<Void> promise) {
         ObjectUtil.checkNotNull(promise, "promise");
         final Promise<Void> p = executor.newPromise();
-        super.release(channel, p.addListener(new FutureListener<Void>() {
+        super.release(channel, p.addListener((FutureListener<Void>) future -> {
+            try {
+                assert executor.inEventLoop();
 
-            @Override
-            public void operationComplete(Future<Void> future) {
-                try {
-                    assert executor.inEventLoop();
-
-                    if (closed) {
-                        // Since the pool is closed, we have no choice but to close the channel
-                        channel.close();
-                        promise.setFailure(new IllegalStateException("FixedChannelPool was closed"));
-                        return;
-                    }
-
-                    if (future.isSuccess()) {
-                        decrementAndRunTaskQueue();
-                        promise.setSuccess(null);
-                    } else {
-                        Throwable cause = future.cause();
-                        // Check if the exception was not because of we passed the Channel to the wrong pool.
-                        if (!(cause instanceof IllegalArgumentException)) {
-                            decrementAndRunTaskQueue();
-                        }
-                        promise.setFailure(future.cause());
-                    }
-                } catch (Throwable cause) {
-                    promise.tryFailure(cause);
+                if (closed) {
+                    // Since the pool is closed, we have no choice but to close the channel
+                    channel.close();
+                    promise.setFailure(new IllegalStateException("FixedChannelPool was closed"));
+                    return;
                 }
+
+                if (future.isSuccess()) {
+                    decrementAndRunTaskQueue();
+                    promise.setSuccess(null);
+                } else {
+                    Throwable cause = future.cause();
+                    // Check if the exception was not because of we passed the Channel to the wrong pool.
+                    if (!(cause instanceof IllegalArgumentException)) {
+                        decrementAndRunTaskQueue();
+                    }
+                    promise.setFailure(future.cause());
+                }
+            } catch (Throwable cause) {
+                promise.tryFailure(cause);
             }
         }));
         return promise;
@@ -469,14 +465,11 @@ public class FixedChannelPool extends SimpleChannelPool {
             executor.execute(new Runnable() {
                 @Override
                 public void run() {
-                    close0().addListener(new FutureListener<Void>() {
-                        @Override
-                        public void operationComplete(Future<Void> f) {
-                            if (f.isSuccess()) {
-                                closeComplete.setSuccess(null);
-                            } else {
-                                closeComplete.setFailure(f.cause());
-                            }
+                    close0().addListener((FutureListener<Void>) f -> {
+                        if (f.isSuccess()) {
+                            closeComplete.setSuccess(null);
+                        } else {
+                            closeComplete.setFailure(f.cause());
                         }
                     });
                 }

--- a/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
@@ -178,12 +178,7 @@ public class SimpleChannelPool implements ChannelPool {
                 if (f.isDone()) {
                     notifyConnect(f, promise);
                 } else {
-                    f.addListener(new ChannelFutureListener() {
-                        @Override
-                        public void operationComplete(ChannelFuture future) {
-                            notifyConnect(future, promise);
-                        }
-                    });
+                    f.addListener((ChannelFutureListener) future -> notifyConnect(future, promise));
                 }
             } else {
                 EventLoop loop = ch.executor();
@@ -229,12 +224,7 @@ public class SimpleChannelPool implements ChannelPool {
             if (f.isDone()) {
                 notifyHealthCheck(f, channel, promise);
             } else {
-                f.addListener(new FutureListener<Boolean>() {
-                    @Override
-                    public void operationComplete(Future<Boolean> future) {
-                        notifyHealthCheck(future, channel, promise);
-                    }
-                });
+                f.addListener((FutureListener<Boolean>) future -> notifyHealthCheck(future, channel, promise));
             }
         } catch (Throwable cause) {
             closeAndFail(channel, cause, promise);
@@ -321,12 +311,7 @@ public class SimpleChannelPool implements ChannelPool {
         if (f.isDone()) {
             releaseAndOfferIfHealthy(channel, promise, f);
         } else {
-            f.addListener(new FutureListener<Boolean>() {
-                @Override
-                public void operationComplete(Future<Boolean> future) {
-                    releaseAndOfferIfHealthy(channel, promise, f);
-                }
-            });
+            f.addListener((FutureListener<Boolean>) future -> releaseAndOfferIfHealthy(channel, promise, f));
         }
     }
 

--- a/transport/src/main/resources/META-INF/native-image/io.netty/netty5-transport/generated/handlers/reflect-config.json
+++ b/transport/src/main/resources/META-INF/native-image/io.netty/netty5-transport/generated/handlers/reflect-config.json
@@ -63,9 +63,9 @@
     "queryAllPublicMethods": true
   },
   {
-    "name": "io.netty.channel.embedded.EmbeddedChannel$2",
+    "name": "io.netty.channel.embedded.EmbeddedChannel$1",
     "condition": {
-      "typeReachable": "io.netty.channel.embedded.EmbeddedChannel$2"
+      "typeReachable": "io.netty.channel.embedded.EmbeddedChannel$1"
     },
     "queryAllPublicMethods": true
   },

--- a/transport/src/test/java/io/netty/channel/AbstractCoalescingBufferQueueTest.java
+++ b/transport/src/test/java/io/netty/channel/AbstractCoalescingBufferQueueTest.java
@@ -67,12 +67,9 @@ public class AbstractCoalescingBufferQueueTest {
         };
 
         final byte[] bytes = new byte[128];
-        queue.add(Unpooled.wrappedBuffer(bytes), new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                queue.add(Unpooled.wrappedBuffer(bytes));
-                assertEquals(bytes.length, queue.readableBytes());
-            }
+        queue.add(Unpooled.wrappedBuffer(bytes), future -> {
+            queue.add(Unpooled.wrappedBuffer(bytes));
+            assertEquals(bytes.length, queue.readableBytes());
         });
 
         assertEquals(bytes.length, queue.readableBytes());

--- a/transport/src/test/java/io/netty/channel/CoalescingBufferQueueTest.java
+++ b/transport/src/test/java/io/netty/channel/CoalescingBufferQueueTest.java
@@ -52,12 +52,9 @@ public class CoalescingBufferQueueTest {
         channel = new EmbeddedChannel();
         writeQueue = new CoalescingBufferQueue(channel, 16, true);
         catPromise = newPromise();
-        mouseListener = new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                mouseDone = true;
-                mouseSuccess = future.isSuccess();
-            }
+        mouseListener = future -> {
+            mouseDone = true;
+            mouseSuccess = future.isSuccess();
         };
         emptyPromise = newPromise();
 

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
@@ -1016,34 +1016,31 @@ public class DefaultChannelPipelineTest {
         try {
             final Object event = new Object();
             final Promise<Object> promise = ImmediateEventExecutor.INSTANCE.newPromise();
-            pipeline1.channel().register().addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) {
-                    ChannelPipeline pipeline = future.channel().pipeline();
-                    final AtomicBoolean handlerAddedCalled = new AtomicBoolean();
-                    pipeline.addLast(new ChannelInboundHandler() {
-                        @Override
-                        public void handlerAdded(ChannelHandlerContext ctx) {
-                            handlerAddedCalled.set(true);
-                        }
-
-                        @Override
-                        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
-                            promise.setSuccess(event);
-                        }
-
-                        @Override
-                        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-                            promise.setFailure(cause);
-                        }
-                    });
-                    if (!handlerAddedCalled.get()) {
-                        promise.setFailure(new AssertionError("handlerAdded(...) should have been called"));
-                        return;
+            pipeline1.channel().register().addListener(future -> {
+                ChannelPipeline pipeline = channel.pipeline();
+                final AtomicBoolean handlerAddedCalled = new AtomicBoolean();
+                pipeline.addLast(new ChannelInboundHandler() {
+                    @Override
+                    public void handlerAdded(ChannelHandlerContext ctx) {
+                        handlerAddedCalled.set(true);
                     }
-                    // This event must be captured by the added handler.
-                    pipeline.fireUserEventTriggered(event);
+
+                    @Override
+                    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                        promise.setSuccess(event);
+                    }
+
+                    @Override
+                    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                        promise.setFailure(cause);
+                    }
+                });
+                if (!handlerAddedCalled.get()) {
+                    promise.setFailure(new AssertionError("handlerAdded(...) should have been called"));
+                    return;
                 }
+                // This event must be captured by the added handler.
+                pipeline.fireUserEventTriggered(event);
             });
             assertSame(event, promise.syncUninterruptibly().getNow());
         } finally {

--- a/transport/src/test/java/io/netty/channel/PendingWriteQueueTest.java
+++ b/transport/src/test/java/io/netty/channel/PendingWriteQueueTest.java
@@ -46,12 +46,7 @@ public class PendingWriteQueueTest {
                 assertFalse(ctx.channel().isWritable(), "Should not be writable anymore");
 
                 ChannelFuture future = queue.removeAndWrite();
-                future.addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) {
-                        assertQueueEmpty(queue);
-                    }
-                });
+                future.addListener(f -> assertQueueEmpty(queue));
                 super.flush(ctx);
             }
         }, 1);
@@ -65,12 +60,7 @@ public class PendingWriteQueueTest {
                 assertFalse(ctx.channel().isWritable(), "Should not be writable anymore");
 
                 ChannelFuture future = queue.removeAndWriteAll();
-                future.addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) {
-                        assertQueueEmpty(queue);
-                    }
-                });
+                future.addListener(f -> assertQueueEmpty(queue));
                 super.flush(ctx);
             }
         }, 3);
@@ -213,12 +203,7 @@ public class PendingWriteQueueTest {
         final PendingWriteQueue queue = new PendingWriteQueue(channel.pipeline().firstContext());
 
         ChannelPromise promise = channel.newPromise();
-        promise.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                queue.removeAndFailAll(new IllegalStateException());
-            }
-        });
+        promise.addListener(future -> queue.removeAndFailAll(new IllegalStateException()));
         queue.add(1L, promise);
 
         ChannelPromise promise2 = channel.newPromise();
@@ -245,12 +230,7 @@ public class PendingWriteQueueTest {
 
         ChannelPromise promise = channel.newPromise();
         final ChannelPromise promise3 = channel.newPromise();
-        promise.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                queue.add(3L, promise3);
-            }
-        });
+        promise.addListener(future -> queue.add(3L, promise3));
         queue.add(1L, promise);
         ChannelPromise promise2 = channel.newPromise();
         queue.add(2L, promise2);
@@ -276,28 +256,15 @@ public class PendingWriteQueueTest {
 
         ChannelPromise promise = channel.newPromise();
         final ChannelPromise promise3 = channel.newPromise();
-        promise3.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                failOrder.add(3);
-            }
-        });
-        promise.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                failOrder.add(1);
-                queue.add(3L, promise3);
-            }
+        promise3.addListener(future -> failOrder.add(3));
+        promise.addListener(future -> {
+            failOrder.add(1);
+            queue.add(3L, promise3);
         });
         queue.add(1L, promise);
 
         ChannelPromise promise2 = channel.newPromise();
-        promise2.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                failOrder.add(2);
-            }
-        });
+        promise2.addListener(future -> failOrder.add(2));
         queue.add(2L, promise2);
         queue.removeAndFailAll(new Exception());
         assertTrue(promise.isDone());
@@ -318,12 +285,7 @@ public class PendingWriteQueueTest {
         final PendingWriteQueue queue = new PendingWriteQueue(channel.pipeline().firstContext());
 
         ChannelPromise promise = channel.newPromise();
-        promise.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                queue.removeAndWriteAll();
-            }
-        });
+        promise.addListener(future -> queue.removeAndWriteAll());
         queue.add(1L, promise);
 
         ChannelPromise promise2 = channel.newPromise();

--- a/transport/src/test/java/io/netty/channel/ReentrantChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/ReentrantChannelTest.java
@@ -24,8 +24,6 @@ import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalChannel;
 import io.netty.channel.local.LocalIoHandler;
 import io.netty.channel.local.LocalServerChannel;
-import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.GenericFutureListener;
 import org.junit.jupiter.api.Test;
 
 import java.nio.channels.ClosedChannelException;
@@ -237,12 +235,7 @@ public class ReentrantChannelTest extends BaseChannelTest {
 
             @Override
             public void write(final ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
-                promise.addListener(new GenericFutureListener<Future<? super Void>>() {
-                    @Override
-                    public void operationComplete(Future<? super Void> future) {
-                        ctx.channel().close();
-                    }
-                });
+                promise.addListener(future -> ctx.channel().close());
                 ctx.write(msg, promise);
                 ctx.channel().flush();
             }

--- a/transport/src/test/java/io/netty/channel/SingleThreadEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/SingleThreadEventLoopTest.java
@@ -410,12 +410,7 @@ public class SingleThreadEventLoopTest {
         final CountDownLatch latch = new CountDownLatch(1);
         Channel ch = new LocalChannel(loopA);
         ChannelPromise promise = ch.newPromise();
-        promise.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                latch.countDown();
-            }
-        });
+        promise.addListener(future -> latch.countDown());
 
         // Disable logging temporarily.
         Logger root = (Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);

--- a/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
@@ -93,12 +93,7 @@ public class EmbeddedChannelTest {
     @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
     public void promiseDoesNotInfiniteLoop() throws InterruptedException {
         EmbeddedChannel channel = new EmbeddedChannel();
-        channel.closeFuture().addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                future.channel().close();
-            }
-        });
+        channel.closeFuture().addListener((ChannelFutureListener) future -> future.channel().close());
 
         channel.close().syncUninterruptibly();
     }
@@ -141,12 +136,7 @@ public class EmbeddedChannelTest {
                 latch.countDown();
             }
         }, 1, TimeUnit.SECONDS);
-        future.addListener(new FutureListener() {
-            @Override
-            public void operationComplete(Future future) {
-                latch.countDown();
-            }
-        });
+        future.addListener((FutureListener) future1 -> latch.countDown());
         long next = ch.runScheduledPendingTasks();
         assertTrue(next > 0);
         // Sleep for the nanoseconds but also give extra 50ms as the clock my not be very precise and so fail the test
@@ -627,12 +617,7 @@ public class EmbeddedChannelTest {
         });
 
         final EmbeddedEventLoop embeddedEventLoop = new EmbeddedEventLoop(new EmbeddedEventLoop.FreezableTicker());
-        channel.deregister().addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                channel.register();
-            }
-        });
+        channel.deregister().addListener(f -> channel.register());
 
         if (!unregisteredLatch.await(5, TimeUnit.SECONDS)) {
             fail("Channel was not unregistered in time.");

--- a/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
@@ -371,12 +371,7 @@ public class LocalChannelTest {
                     @Override
                     public void run() {
                         ChannelPromise promise = ccCpy.newPromise();
-                        promise.addListener(new ChannelFutureListener() {
-                            @Override
-                            public void operationComplete(ChannelFuture future) {
-                                ccCpy.pipeline().lastContext().close();
-                            }
-                        });
+                        promise.addListener(future -> ccCpy.pipeline().lastContext().close());
                         ccCpy.writeAndFlush(data.retainedDuplicate(), promise);
                     }
                 });
@@ -514,12 +509,8 @@ public class LocalChannelTest {
                     @Override
                     public void run() {
                         ChannelPromise promise = ccCpy.newPromise();
-                        promise.addListener(new ChannelFutureListener() {
-                            @Override
-                            public void operationComplete(ChannelFuture future) {
-                                ccCpy.writeAndFlush(data2.retainedDuplicate(), ccCpy.newPromise());
-                            }
-                        });
+                        promise.addListener(future ->
+                                ccCpy.writeAndFlush(data2.retainedDuplicate(), ccCpy.newPromise()));
                         ccCpy.writeAndFlush(data.retainedDuplicate(), promise);
                     }
                 });
@@ -596,12 +587,9 @@ public class LocalChannelTest {
                 @Override
                 public void run() {
                     ChannelPromise promise = ccCpy.newPromise();
-                    promise.addListener(new ChannelFutureListener() {
-                        @Override
-                        public void operationComplete(ChannelFuture future) {
-                            Channel serverChannelCpy = serverChannelRef.get();
-                            serverChannelCpy.writeAndFlush(data2.retainedDuplicate(), serverChannelCpy.newPromise());
-                        }
+                    promise.addListener(future -> {
+                        Channel serverChannelCpy = serverChannelRef.get();
+                        serverChannelCpy.writeAndFlush(data2.retainedDuplicate(), serverChannelCpy.newPromise());
                     });
                     ccCpy.writeAndFlush(data.retainedDuplicate(), promise);
                 }
@@ -678,13 +666,10 @@ public class LocalChannelTest {
                     @Override
                     public void run() {
                         ChannelPromise promise = ccCpy.newPromise();
-                        promise.addListener(new ChannelFutureListener() {
-                            @Override
-                            public void operationComplete(ChannelFuture future) {
-                                Channel serverChannelCpy = serverChannelRef.get();
-                                serverChannelCpy.writeAndFlush(
-                                        data2.retainedDuplicate(), serverChannelCpy.newPromise());
-                            }
+                        promise.addListener(future -> {
+                            Channel serverChannelCpy = serverChannelRef.get();
+                            serverChannelCpy.writeAndFlush(
+                                    data2.retainedDuplicate(), serverChannelCpy.newPromise());
                         });
                         ccCpy.writeAndFlush(data.retainedDuplicate(), promise);
                     }
@@ -760,40 +745,34 @@ public class LocalChannelTest {
                     @Override
                     public void run() {
                         ccCpy.writeAndFlush(data.retainedDuplicate(), ccCpy.newPromise())
-                        .addListener(new ChannelFutureListener() {
-                            @Override
-                            public void operationComplete(ChannelFuture future) {
-                                serverChannelCpy.executor().execute(new Runnable() {
-                                    @Override
-                                    public void run() {
-                                        // The point of this test is to write while the peer is closed, so we should
-                                        // ensure the peer is actually closed before we write.
-                                        int waitCount = 0;
-                                        while (ccCpy.isOpen()) {
-                                            try {
-                                                Thread.sleep(50);
-                                            } catch (InterruptedException ignored) {
-                                                // ignored
-                                            }
-                                            if (++waitCount > 5) {
-                                                fail();
-                                            }
+                        .addListener(future -> {
+                            serverChannelCpy.executor().execute(new Runnable() {
+                                @Override
+                                public void run() {
+                                    // The point of this test is to write while the peer is closed, so we should
+                                    // ensure the peer is actually closed before we write.
+                                    int waitCount = 0;
+                                    while (ccCpy.isOpen()) {
+                                        try {
+                                            Thread.sleep(50);
+                                        } catch (InterruptedException ignored) {
+                                            // ignored
                                         }
-                                        serverChannelCpy.writeAndFlush(data2.retainedDuplicate(),
-                                                                       serverChannelCpy.newPromise())
-                                            .addListener(new ChannelFutureListener() {
-                                            @Override
-                                            public void operationComplete(ChannelFuture future) {
-                                                if (!future.isSuccess() &&
-                                                    future.cause() instanceof ClosedChannelException) {
-                                                    writeFailLatch.countDown();
-                                                }
+                                        if (++waitCount > 5) {
+                                            fail();
+                                        }
+                                    }
+                                    serverChannelCpy.writeAndFlush(data2.retainedDuplicate(),
+                                                                   serverChannelCpy.newPromise())
+                                        .addListener(f -> {
+                                            if (!f.isSuccess() &&
+                                                f.cause() instanceof ClosedChannelException) {
+                                                writeFailLatch.countDown();
                                             }
                                         });
-                                    }
-                                });
-                                ccCpy.close();
-                            }
+                                }
+                            });
+                            ccCpy.close();
                         });
                     }
                 });
@@ -967,12 +946,9 @@ public class LocalChannelTest {
     }
 
     private static void writeAndFlushReadOnSuccess(final ChannelHandlerContext ctx, Object msg) {
-        ctx.writeAndFlush(msg).addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                if (future.isSuccess()) {
-                    ctx.read();
-                }
+        ctx.writeAndFlush(msg).addListener(future -> {
+            if (future.isSuccess()) {
+                ctx.read();
             }
         });
     }

--- a/transport/src/test/java/io/netty/channel/pool/AbstractChannelPoolMapTest.java
+++ b/transport/src/test/java/io/netty/channel/pool/AbstractChannelPoolMapTest.java
@@ -25,7 +25,6 @@ import io.netty.channel.local.LocalChannel;
 import io.netty.channel.local.LocalIoHandler;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.Promise;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -158,14 +157,11 @@ public class AbstractChannelPoolMapTest {
         @Override
         public Future<Void> closeAsync() {
             Future<Void> poolClose = super.closeAsync();
-            poolClose.addListener(new GenericFutureListener<Future<? super Void>>() {
-                @Override
-                public void operationComplete(Future<? super Void> future) {
-                    if (future.isSuccess()) {
-                        closeFuture.setSuccess(null);
-                    } else {
-                        closeFuture.setFailure(future.cause());
-                    }
+            poolClose.addListener(future -> {
+                if (future.isSuccess()) {
+                    closeFuture.setSuccess(null);
+                } else {
+                    closeFuture.setFailure(future.cause());
                 }
             });
             return poolClose;

--- a/transport/src/test/java/io/netty/channel/pool/FixedChannelPoolTest.java
+++ b/transport/src/test/java/io/netty/channel/pool/FixedChannelPoolTest.java
@@ -29,7 +29,6 @@ import io.netty.channel.local.LocalIoHandler;
 import io.netty.channel.local.LocalServerChannel;
 import io.netty.channel.pool.FixedChannelPool.AcquireTimeoutAction;
 import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.GenericFutureListener;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -279,12 +278,9 @@ public class FixedChannelPoolTest {
         pool.acquire().get();
 
         final ChannelPromise closePromise = sc.newPromise();
-        pool.closeAsync().addListener(new GenericFutureListener<Future<? super Void>>() {
-            @Override
-            public void operationComplete(Future<? super Void> future) {
-                assertEquals(0, pool.acquiredChannelCount());
-                sc.close(closePromise).syncUninterruptibly();
-            }
+        pool.closeAsync().addListener(future -> {
+            assertEquals(0, pool.acquiredChannelCount());
+            sc.close(closePromise).syncUninterruptibly();
         }).awaitUninterruptibly();
         closePromise.awaitUninterruptibly();
     }

--- a/transport/src/test/java/io/netty/channel/socket/nio/NioSocketChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/nio/NioSocketChannelTest.java
@@ -136,12 +136,9 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
                     // Trigger a gathering write by writing two buffers.
                     ctx.write(Unpooled.wrappedBuffer(new byte[] { 'a' }));
                     ChannelFuture f = ctx.write(Unpooled.wrappedBuffer(new byte[] { 'b' }));
-                    f.addListener(new ChannelFutureListener() {
-                        @Override
-                        public void operationComplete(ChannelFuture future) {
-                            // This message must be flushed
-                            ctx.writeAndFlush(Unpooled.wrappedBuffer(new byte[]{'c'}));
-                        }
+                    f.addListener(future -> {
+                        // This message must be flushed
+                        ctx.writeAndFlush(Unpooled.wrappedBuffer(new byte[]{'c'}));
                     });
                     ctx.flush();
                 }
@@ -201,12 +198,9 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
                              // As soon as the channel becomes active re-register it to another
                              // EventLoop. After this is done we should still receive the data that
                              // was written to the channel.
-                             ctx.deregister().addListener(new ChannelFutureListener() {
-                                 @Override
-                                 public void operationComplete(ChannelFuture cf) {
-                                     Channel channel = cf.channel();
-                                     channel.register();
-                                 }
+                             ctx.deregister().addListener((ChannelFutureListener) cf -> {
+                                 Channel channel = cf.channel();
+                                 channel.register();
                              });
                          }
                      });


### PR DESCRIPTION
Motivation:

We should just use lambdas when possible.

Modifications:

Use lambdas when possible for listeners

Result:

Cleanup
