### PR TITLE
allow LocalChannel queue to be overridden by descendants - use SpscChunked*ArrayQueue as the default

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -22,14 +22,14 @@ import org.jctools.queues.MpmcArrayQueue;
 import org.jctools.queues.MpscArrayQueue;
 import org.jctools.queues.MpscChunkedArrayQueue;
 import org.jctools.queues.MpscUnboundedArrayQueue;
-import org.jctools.queues.SpscChunkedArrayQueue;
 import org.jctools.queues.SpscLinkedQueue;
+import org.jctools.queues.SpscUnboundedArrayQueue;
 import org.jctools.queues.atomic.MpmcAtomicArrayQueue;
 import org.jctools.queues.atomic.MpscAtomicArrayQueue;
 import org.jctools.queues.atomic.MpscChunkedAtomicArrayQueue;
 import org.jctools.queues.atomic.MpscUnboundedAtomicArrayQueue;
 import org.jctools.queues.atomic.SpscLinkedAtomicQueue;
-import org.jctools.queues.atomic.SpscChunkedAtomicArrayQueue;
+import org.jctools.queues.atomic.SpscUnboundedAtomicArrayQueue;
 import org.jctools.queues.atomic.unpadded.MpscAtomicUnpaddedArrayQueue;
 import org.jctools.queues.unpadded.MpscUnpaddedArrayQueue;
 import org.jctools.util.Pow2;
@@ -1109,9 +1109,9 @@ public final class PlatformDependent {
      * Create a new {@link Queue} which is safe to use for single producer (one thread!) and a single
      * consumer (one thread!).
      */
-    public static <T> Queue<T> newChunkedSpscQueue(final int chunkSize, final int capacity) {
-        return hasUnsafe() ? new SpscChunkedArrayQueue<T>(chunkSize, capacity)
-                : new SpscChunkedAtomicArrayQueue<T>(chunkSize, capacity);
+    public static <T> Queue<T> newChunkedSpscQueue(final int chunkSize) {
+        return hasUnsafe() ? new SpscUnboundedArrayQueue<T>(chunkSize)
+                : new SpscUnboundedAtomicArrayQueue<T>(chunkSize);
     }
 
     /**

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -22,12 +22,14 @@ import org.jctools.queues.MpmcArrayQueue;
 import org.jctools.queues.MpscArrayQueue;
 import org.jctools.queues.MpscChunkedArrayQueue;
 import org.jctools.queues.MpscUnboundedArrayQueue;
+import org.jctools.queues.SpscChunkedArrayQueue;
 import org.jctools.queues.SpscLinkedQueue;
 import org.jctools.queues.atomic.MpmcAtomicArrayQueue;
 import org.jctools.queues.atomic.MpscAtomicArrayQueue;
 import org.jctools.queues.atomic.MpscChunkedAtomicArrayQueue;
 import org.jctools.queues.atomic.MpscUnboundedAtomicArrayQueue;
 import org.jctools.queues.atomic.SpscLinkedAtomicQueue;
+import org.jctools.queues.atomic.SpscChunkedAtomicArrayQueue;
 import org.jctools.queues.atomic.unpadded.MpscAtomicUnpaddedArrayQueue;
 import org.jctools.queues.unpadded.MpscUnpaddedArrayQueue;
 import org.jctools.util.Pow2;
@@ -1101,6 +1103,15 @@ public final class PlatformDependent {
      */
     public static <T> Queue<T> newSpscQueue() {
         return hasUnsafe() ? new SpscLinkedQueue<T>() : new SpscLinkedAtomicQueue<T>();
+    }
+
+    /**
+     * Create a new {@link Queue} which is safe to use for single producer (one thread!) and a single
+     * consumer (one thread!).
+     */
+    public static <T> Queue<T> newChunkedSpscQueue(final int chunkSize, final int capacity) {
+        return hasUnsafe() ? new SpscChunkedArrayQueue<T>(chunkSize, capacity)
+                : new SpscChunkedAtomicArrayQueue<T>(chunkSize, capacity);
     }
 
     /**

--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -57,7 +57,6 @@ public class LocalChannel extends AbstractChannel {
     private static final ChannelMetadata METADATA = new ChannelMetadata(false);
     private static final int MAX_READER_STACK_DEPTH = 8;
     private static final int CHUNK_SIZE = SystemPropertyUtil.getInt("io.netty.local.channel.chunkSize", 4 * 1024);
-    private static final int MAX_CAPACITY = SystemPropertyUtil.getInt("io.netty.local.channel.maxCapacity", 64 * 1024);
 
     private enum State { OPEN, BOUND, CONNECTED, CLOSED }
 
@@ -145,7 +144,7 @@ public class LocalChannel extends AbstractChannel {
     }
 
     protected Queue<Object> newQueue() {
-        return PlatformDependent.newChunkedSpscQueue(CHUNK_SIZE, MAX_CAPACITY);
+        return PlatformDependent.newChunkedSpscQueue(CHUNK_SIZE);
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -33,6 +33,7 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.SingleThreadEventExecutor;
 import io.netty.util.internal.InternalThreadLocalMap;
 import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -55,12 +56,13 @@ public class LocalChannel extends AbstractChannel {
             AtomicReferenceFieldUpdater.newUpdater(LocalChannel.class, Future.class, "finishReadFuture");
     private static final ChannelMetadata METADATA = new ChannelMetadata(false);
     private static final int MAX_READER_STACK_DEPTH = 8;
+    private static final int CHUNK_SIZE = SystemPropertyUtil.getInt("io.netty.local.channel.chunkSize", 4 * 1024);
+    private static final int MAX_CAPACITY = SystemPropertyUtil.getInt("io.netty.local.channel.maxCapacity", 64 * 1024);
 
     private enum State { OPEN, BOUND, CONNECTED, CLOSED }
 
     private final ChannelConfig config = new DefaultChannelConfig(this);
-    // To further optimize this we could write our own SPSC queue.
-    final Queue<Object> inboundBuffer = PlatformDependent.newSpscQueue();
+    final Queue<Object> inboundBuffer = newQueue();
     private final Runnable readTask = new Runnable() {
         @Override
         public void run() {
@@ -140,6 +142,10 @@ public class LocalChannel extends AbstractChannel {
     @Override
     public boolean isActive() {
         return state == State.CONNECTED;
+    }
+
+    protected Queue<Object> newQueue() {
+        return PlatformDependent.newChunkedSpscQueue(CHUNK_SIZE, MAX_CAPACITY);
     }
 
     @Override


### PR DESCRIPTION
Motivation:

To reduce the allocations generated by LocalChannel's Queue.

Modifications:

Modify code to allow users to provide their own Queue impl. Use a default Queue impl that allocates less.

Result:

Less GC. Fixes some parts of https://github.com/netty/netty/issues/15994
