### PR TITLE
Replace *FutureListener* usage with Lambda where possible (#16032)

### DIFF
--- a/codec-base/src/main/java/io/netty/handler/codec/MessageAggregator.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/MessageAggregator.java
@@ -223,12 +223,9 @@ public abstract class MessageAggregator<I, S, C extends ByteBufHolder, O extends
                 // Cache the write listener for reuse.
                 ChannelFutureListener listener = continueResponseWriteListener;
                 if (listener == null) {
-                    continueResponseWriteListener = listener = new ChannelFutureListener() {
-                        @Override
-                        public void operationComplete(ChannelFuture future) throws Exception {
-                            if (!future.isSuccess()) {
-                                ctx.fireExceptionCaught(future.cause());
-                            }
+                    continueResponseWriteListener = listener = future -> {
+                        if (!future.isSuccess()) {
+                            ctx.fireExceptionCaught(future.cause());
                         }
                     };
                 }

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/EncoderUtil.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/EncoderUtil.java
@@ -16,7 +16,6 @@
 package io.netty.handler.codec.compression;
 
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.util.concurrent.Future;
@@ -37,14 +36,11 @@ final class EncoderUtil {
                 }
             }, THREAD_POOL_DELAY_SECONDS, TimeUnit.SECONDS);
 
-            finishFuture.addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture f)  {
-                    // Cancel the scheduled timeout.
-                    future.cancel(true);
-                    if (!promise.isDone()) {
-                        ctx.close(promise);
-                    }
+            finishFuture.addListener(f -> {
+                // Cancel the scheduled timeout.
+                future.cancel(true);
+                if (!promise.isDone()) {
+                    ctx.close(promise);
                 }
             });
         } else {

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/JZlibEncoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/JZlibEncoder.java
@@ -337,14 +337,11 @@ public class JZlibEncoder extends ZlibEncoder {
                 }
             }, THREAD_POOL_DELAY_SECONDS, TimeUnit.SECONDS);
 
-            f.addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture f) {
-                    // Cancel the scheduled timeout.
-                    future.cancel(true);
-                    if (!promise.isDone()) {
-                        ctx.close(promise);
-                    }
+            f.addListener(f1 -> {
+                // Cancel the scheduled timeout.
+                future.cancel(true);
+                if (!promise.isDone()) {
+                    ctx.close(promise);
                 }
             });
         } else {

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/Lz4FrameEncoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/Lz4FrameEncoderTest.java
@@ -22,8 +22,6 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.EventLoopGroup;
@@ -280,16 +278,13 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
                     final int size = 27;
                     ByteBuf buf = ByteBufAllocator.DEFAULT.buffer(size, size);
                     finalClientChannel.writeAndFlush(buf.writerIndex(buf.writerIndex() + size))
-                            .addListener(new ChannelFutureListener() {
-                        @Override
-                        public void operationComplete(ChannelFuture future) throws Exception {
-                            try {
-                                writeFailCauseRef.set(future.cause());
-                            } finally {
-                                latch.countDown();
-                            }
-                        }
-                    });
+                            .addListener(future -> {
+                                try {
+                                    writeFailCauseRef.set(future.cause());
+                                } finally {
+                                    latch.countDown();
+                                }
+                            });
                 }
             });
             latch.await();

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketProtocolHandler.java
@@ -98,12 +98,7 @@ abstract class WebSocketProtocolHandler extends MessageToMessageDecoder<WebSocke
             }
             flush(ctx);
             applyCloseSentTimeout(ctx);
-            closeSent.addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) {
-                    ctx.close(promise);
-                }
-            });
+            closeSent.addListener(future -> ctx.close(promise));
         }
     }
 
@@ -138,12 +133,7 @@ abstract class WebSocketProtocolHandler extends MessageToMessageDecoder<WebSocke
             }
         }, forceCloseTimeoutMillis, TimeUnit.MILLISECONDS);
 
-        closeSent.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                timeoutTask.cancel(false);
-            }
-        });
+        closeSent.addListener(future -> timeoutTask.cancel(false));
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
@@ -228,16 +228,13 @@ public abstract class WebSocketServerHandshaker {
             encoderName = p.context(HttpResponseEncoder.class).name();
             p.addBefore(encoderName, "wsencoder", newWebSocketEncoder());
         }
-        channel.writeAndFlush(response).addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
-                if (future.isSuccess()) {
-                    ChannelPipeline p = future.channel().pipeline();
-                    p.remove(encoderName);
-                    promise.setSuccess();
-                } else {
-                    promise.setFailure(future.cause());
-                }
+        channel.writeAndFlush(response).addListener(future -> {
+            if (future.isSuccess()) {
+                ChannelPipeline p1 = channel.pipeline();
+                p1.remove(encoderName);
+                promise.setSuccess();
+            } else {
+                promise.setFailure(future.cause());
             }
         });
         return promise;

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameCodec.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameCodec.java
@@ -16,8 +16,6 @@
 package io.netty.handler.codec.spdy;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandler;
@@ -149,12 +147,9 @@ public class SpdyFrameCodec extends ByteToMessageDecoder
     public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
         super.handlerAdded(ctx);
         this.ctx = ctx;
-        ctx.channel().closeFuture().addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
-                spdyHeaderBlockDecoder.end();
-                spdyHeaderBlockEncoder.end();
-            }
+        ctx.channel().closeFuture().addListener(future -> {
+            spdyHeaderBlockDecoder.end();
+            spdyHeaderBlockEncoder.end();
         });
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySessionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySessionHandler.java
@@ -500,12 +500,9 @@ public class SpdySessionHandler extends ChannelDuplexHandler {
                 // The transfer window size is pre-decremented when sending a data frame downstream.
                 // Close the session on write failures that leave the transfer window in a corrupt state.
                 final ChannelHandlerContext context = ctx;
-                ctx.write(partialDataFrame).addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
-                        if (!future.isSuccess()) {
-                            issueSessionError(context, SpdySessionStatus.INTERNAL_ERROR);
-                        }
+                ctx.write(partialDataFrame).addListener(future -> {
+                    if (!future.isSuccess()) {
+                        issueSessionError(context, SpdySessionStatus.INTERNAL_ERROR);
                     }
                 });
                 return;
@@ -517,12 +514,9 @@ public class SpdySessionHandler extends ChannelDuplexHandler {
                 // The transfer window size is pre-decremented when sending a data frame downstream.
                 // Close the session on write failures that leave the transfer window in a corrupt state.
                 final ChannelHandlerContext context = ctx;
-                promise.addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
-                        if (!future.isSuccess()) {
-                            issueSessionError(context, SpdySessionStatus.INTERNAL_ERROR);
-                        }
+                promise.addListener(future -> {
+                    if (!future.isSuccess()) {
+                        issueSessionError(context, SpdySessionStatus.INTERNAL_ERROR);
                     }
                 });
             }
@@ -776,13 +770,9 @@ public class SpdySessionHandler extends ChannelDuplexHandler {
                         writeStreamId, spdyDataFrame.content().readRetainedSlice(sendWindowSize));
 
                 // The transfer window size is pre-decremented when sending a data frame downstream.
-                // Close the session on write failures that leave the transfer window in a corrupt state.
-                ctx.writeAndFlush(partialDataFrame).addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
-                        if (!future.isSuccess()) {
-                            issueSessionError(ctx, SpdySessionStatus.INTERNAL_ERROR);
-                        }
+                ctx.writeAndFlush(partialDataFrame).addListener(future -> {
+                    if (!future.isSuccess()) {
+                        issueSessionError(ctx, SpdySessionStatus.INTERNAL_ERROR);
                     }
                 });
             } else {
@@ -798,12 +788,9 @@ public class SpdySessionHandler extends ChannelDuplexHandler {
 
                 // The transfer window size is pre-decremented when sending a data frame downstream.
                 // Close the session on write failures that leave the transfer window in a corrupt state.
-                ctx.writeAndFlush(spdyDataFrame, pendingWrite.promise).addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
-                        if (!future.isSuccess()) {
-                            issueSessionError(ctx, SpdySessionStatus.INTERNAL_ERROR);
-                        }
+                ctx.writeAndFlush(spdyDataFrame, pendingWrite.promise).addListener(future -> {
+                    if (!future.isSuccess()) {
+                        issueSessionError(ctx, SpdySessionStatus.INTERNAL_ERROR);
                     }
                 });
             }

--- a/codec-http/src/main/resources/META-INF/native-image/io.netty/netty-codec-http/generated/handlers/reflect-config.json
+++ b/codec-http/src/main/resources/META-INF/native-image/io.netty/netty-codec-http/generated/handlers/reflect-config.json
@@ -308,9 +308,9 @@
     "queryAllPublicMethods": true
   },
   {
-    "name": "io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker$4",
+    "name": "io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker$3",
     "condition": {
-      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker$4"
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker$3"
     },
     "queryAllPublicMethods": true
   },
@@ -357,9 +357,9 @@
     "queryAllPublicMethods": true
   },
   {
-    "name": "io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker$2",
+    "name": "io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker$1",
     "condition": {
-      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker$2"
+      "typeReachable": "io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker$1"
     },
     "queryAllPublicMethods": true
   },

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerUpgradeHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerUpgradeHandlerTest.java
@@ -21,8 +21,6 @@ import java.util.Collections;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelDuplexHandler;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -116,12 +114,7 @@ public class HttpServerUpgradeHandlerTest {
                         ctx.write(msg, promise);
                     }
                 });
-                promise.addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) {
-                        writeFlushed = true;
-                    }
-                });
+                promise.addListener(future -> writeFlushed = true);
             }
         };
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
@@ -17,8 +17,6 @@ package io.netty.handler.codec.http.websocketx;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
@@ -249,12 +247,7 @@ public class WebSocketHandshakeHandOverTest {
             @Override
             public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
                 if (evt == ClientHandshakeStateEvent.HANDSHAKE_COMPLETE) {
-                    ctx.channel().closeFuture().addListener(new ChannelFutureListener() {
-                        @Override
-                        public void operationComplete(ChannelFuture future) throws Exception {
-                            clientForceClosed = true;
-                        }
-                    });
+                    ctx.channel().closeFuture().addListener(future -> clientForceClosed = true);
                     handshaker.close(ctx.channel(), new CloseWebSocketFrame());
                 }
             }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
@@ -525,13 +525,10 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder, Ht
     }
 
     private void notifyLifecycleManagerOnError(ChannelFuture future, final ChannelHandlerContext ctx) {
-        future.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
-                Throwable cause = future.cause();
-                if (cause != null) {
-                    lifecycleManager.onError(ctx, true, cause);
-                }
+        future.addListener(future1 -> {
+            Throwable cause = future1.cause();
+            if (cause != null) {
+                lifecycleManager.onError(ctx, true, cause);
             }
         });
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ControlFrameLimitEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ControlFrameLimitEncoder.java
@@ -29,16 +29,11 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
  */
 final class Http2ControlFrameLimitEncoder extends DecoratingHttp2ConnectionEncoder {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(Http2ControlFrameLimitEncoder.class);
+    private int outstandingControlFrames;
 
     private final int maxOutstandingControlFrames;
-    private final ChannelFutureListener outstandingControlFramesListener = new ChannelFutureListener() {
-        @Override
-        public void operationComplete(ChannelFuture future) {
-            outstandingControlFrames--;
-        }
-    };
+    private final ChannelFutureListener outstandingControlFramesListener = f-> outstandingControlFrames--;
     private Http2LifecycleManager lifecycleManager;
-    private int outstandingControlFrames;
     private boolean limitReached;
 
     Http2ControlFrameLimitEncoder(Http2ConnectionEncoder delegate, int maxOutstandingControlFrames) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
@@ -416,12 +416,9 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
                 numBufferedStreams++;
                 // Clean up the stream being initialized if writing the headers fails and also
                 // decrement the number of buffered streams.
-                promise.addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture channelFuture) {
-                        numBufferedStreams--;
-                        handleHeaderFuture(channelFuture, streamId);
-                    }
+                promise.addListener((ChannelFutureListener) channelFuture -> {
+                    numBufferedStreams--;
+                    handleHeaderFuture(channelFuture, streamId);
                 });
             } else {
                 handleHeaderFuture(promise, streamId);
@@ -445,12 +442,9 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
                 numBufferedStreams++;
                 // Clean up the stream being initialized if writing the headers fails and also
                 // decrement the number of buffered streams.
-                promise.addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture channelFuture) {
-                        numBufferedStreams--;
-                        handleHeaderFuture(channelFuture, streamId);
-                    }
+                promise.addListener((ChannelFutureListener) channelFuture -> {
+                    numBufferedStreams--;
+                    handleHeaderFuture(channelFuture, streamId);
                 });
             }
         }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexHandler.java
@@ -99,12 +99,7 @@ import static io.netty.handler.codec.http2.Http2Exception.connectionError;
  */
 public final class Http2MultiplexHandler extends Http2ChannelDuplexHandler {
 
-    static final ChannelFutureListener CHILD_CHANNEL_REGISTRATION_LISTENER = new ChannelFutureListener() {
-        @Override
-        public void operationComplete(ChannelFuture future) {
-            registerDone(future);
-        }
-    };
+    static final ChannelFutureListener CHILD_CHANNEL_REGISTRATION_LISTENER = Http2MultiplexHandler::registerDone;
 
     private final ChannelHandler inboundStreamHandler;
     private final ChannelHandler upgradeStreamHandler;

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
@@ -22,8 +22,6 @@ import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.local.LocalIoHandler;
 import io.netty.handler.codec.http2.Http2Connection.Endpoint;
 import io.netty.handler.codec.http2.Http2Stream.State;
-import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -168,12 +166,9 @@ public class DefaultHttp2ConnectionTest {
         client.forEachActiveStream(new Http2StreamVisitor() {
             @Override
             public boolean visit(Http2Stream stream) {
-                client.close(promise).addListener(new FutureListener<Void>() {
-                    @Override
-                    public void operationComplete(Future<Void> future) throws Exception {
-                        assertTrue(promise.isDone());
-                        latch.countDown();
-                    }
+                client.close(promise).addListener(future -> {
+                    assertTrue(promise.isDone());
+                    latch.countDown();
                 });
                 return true;
             }
@@ -204,12 +199,9 @@ public class DefaultHttp2ConnectionTest {
                 }
             });
         } catch (Http2Exception ignored) {
-            client.close(promise).addListener(new FutureListener<Void>() {
-                @Override
-                public void operationComplete(Future<Void> future) throws Exception {
-                    assertTrue(promise.isDone());
-                    latch.countDown();
-                }
+            client.close(promise).addListener(future -> {
+                assertTrue(promise.isDone());
+                latch.countDown();
             });
         }
         assertTrue(latch.await(5, TimeUnit.SECONDS));
@@ -683,12 +675,9 @@ public class DefaultHttp2ConnectionTest {
     private void testRemoveAllStreams() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         final Promise<Void> promise = group.next().newPromise();
-        client.close(promise).addListener(new FutureListener<Void>() {
-            @Override
-            public void operationComplete(Future<Void> future) throws Exception {
-                assertTrue(promise.isDone());
-                latch.countDown();
-            }
+        client.close(promise).addListener(future -> {
+            assertTrue(promise.isDone());
+            latch.countDown();
         });
         assertTrue(latch.await(5, TimeUnit.SECONDS));
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -839,12 +839,7 @@ public class Http2ConnectionHandlerTest {
                 new DefaultChannelPromise(channel, ImmediateEventExecutor.INSTANCE);
         final ChannelPromise promise2 =
                 new DefaultChannelPromise(channel, ImmediateEventExecutor.INSTANCE);
-        promise.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                handler.resetStream(ctx, STREAM_ID, STREAM_CLOSED.code(), promise2);
-            }
-        });
+        promise.addListener(f -> handler.resetStream(ctx, STREAM_ID, STREAM_CLOSED.code(), promise2));
 
         handler.resetStream(ctx, STREAM_ID, CANCEL.code(), promise);
         verify(frameWriter).writeRstStream(eq(ctx), eq(STREAM_ID), anyLong(), any(ChannelPromise.class));

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
@@ -988,12 +988,9 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
         // Create a promise before actually doing the close, because otherwise we would be adding a listener to a future
         // that is already completed because we are using EmbeddedChannel which executes code in the JUnit thread.
         ChannelPromise p = childChannel.newPromise();
-        p.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                channelOpen.set(future.channel().isOpen());
-                channelActive.set(future.channel().isActive());
-            }
+        p.addListener((ChannelFutureListener) future -> {
+            channelOpen.set(future.channel().isOpen());
+            channelActive.set(future.channel().isActive());
         });
         childChannel.close(p).syncUninterruptibly();
 
@@ -1013,12 +1010,9 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
          final AtomicBoolean channelOpen = new AtomicBoolean(true);
          final AtomicBoolean channelActive = new AtomicBoolean(true);
 
-         childChannel.closeFuture().addListener(new ChannelFutureListener() {
-             @Override
-             public void operationComplete(ChannelFuture future) {
-                 channelOpen.set(future.channel().isOpen());
-                 channelActive.set(future.channel().isActive());
-             }
+         childChannel.closeFuture().addListener((ChannelFutureListener) future -> {
+             channelOpen.set(future.channel().isOpen());
+             channelActive.set(future.channel().isActive());
          });
          childChannel.close().syncUninterruptibly();
 
@@ -1054,12 +1048,9 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
 
         ChannelFuture f = childChannel.writeAndFlush(new DefaultHttp2HeadersFrame(headers));
         assertFalse(f.isDone());
-        f.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
-                channelOpen.set(future.channel().isOpen());
-                channelActive.set(future.channel().isActive());
-            }
+        f.addListener((ChannelFutureListener) future -> {
+            channelOpen.set(future.channel().isOpen());
+            channelActive.set(future.channel().isActive());
         });
 
         ChannelPromise first = writePromises.poll();

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTransportTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTransportTest.java
@@ -62,7 +62,6 @@ import io.netty.pkitesting.X509Bundle;
 import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -295,20 +294,18 @@ public class Http2MultiplexTransportTest {
                                     public void run() {
                                         ctx.writeAndFlush(new DefaultHttp2HeadersFrame(
                                                 new DefaultHttp2Headers(), false)).addListener(
-                                                        new ChannelFutureListener() {
-                                            @Override
-                                            public void operationComplete(ChannelFuture future) {
-                                                ctx.write(new DefaultHttp2DataFrame(
-                                                        Unpooled.copiedBuffer("Hello World", CharsetUtil.US_ASCII),
-                                                        true));
-                                                ctx.channel().eventLoop().execute(new Runnable() {
-                                                    @Override
-                                                    public void run() {
-                                                        ctx.flush();
-                                                    }
+                                                (ChannelFutureListener) future -> {
+                                                    ctx.write(new DefaultHttp2DataFrame(
+                                                            Unpooled.copiedBuffer(
+                                                                    "Hello World", CharsetUtil.US_ASCII),
+                                                            true));
+                                                    ctx.channel().eventLoop().execute(new Runnable() {
+                                                        @Override
+                                                        public void run() {
+                                                            ctx.flush();
+                                                        }
+                                                    });
                                                 });
-                                            }
-                                        });
                                     }
                                 }, 500, MILLISECONDS);
                             }
@@ -489,13 +486,10 @@ public class Http2MultiplexTransportTest {
                                         latch.countDown();
                                     }
                                 });
-                                h2Bootstrap.open().addListener(new FutureListener<Channel>() {
-                                    @Override
-                                    public void operationComplete(Future<Channel> future) {
-                                        if (future.isSuccess()) {
-                                            future.getNow().writeAndFlush(new DefaultHttp2HeadersFrame(
-                                                    new DefaultHttp2Headers(), false));
-                                        }
+                                h2Bootstrap.open().addListener((FutureListener<Channel>) future -> {
+                                    if (future.isSuccess()) {
+                                        future.getNow().writeAndFlush(new DefaultHttp2HeadersFrame(
+                                                new DefaultHttp2Headers(), false));
                                     }
                                 });
 
@@ -574,14 +568,10 @@ public class Http2MultiplexTransportTest {
                                 if (msg instanceof Http2HeadersFrame && ((Http2HeadersFrame) msg).isEndStream()) {
                                     ctx.writeAndFlush(new DefaultHttp2HeadersFrame(
                                                     new DefaultHttp2Headers(), false))
-                                            .addListener(new ChannelFutureListener() {
-                                                @Override
-                                                public void operationComplete(ChannelFuture future) {
+                                            .addListener((ChannelFutureListener) future ->
                                                     ctx.writeAndFlush(new DefaultHttp2DataFrame(
                                                             Unpooled.copiedBuffer("Hello World", CharsetUtil.US_ASCII),
-                                                            true));
-                                                }
-                                            });
+                                                            true)));
                                 }
                                 ReferenceCountUtil.release(msg);
                             }
@@ -632,13 +622,10 @@ public class Http2MultiplexTransportTest {
                                         ReferenceCountUtil.release(msg);
                                     }
                                 });
-                                h2Bootstrap.open().addListener(new FutureListener<Channel>() {
-                                    @Override
-                                    public void operationComplete(Future<Channel> future) {
-                                        if (future.isSuccess()) {
-                                            future.getNow().writeAndFlush(new DefaultHttp2HeadersFrame(
-                                                    new DefaultHttp2Headers(), true));
-                                        }
+                                h2Bootstrap.open().addListener((FutureListener<Channel>) future -> {
+                                    if (future.isSuccess()) {
+                                        future.getNow().writeAndFlush(new DefaultHttp2HeadersFrame(
+                                                new DefaultHttp2Headers(), true));
                                     }
                                 });
                             }

--- a/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java
@@ -114,12 +114,9 @@ public abstract class MultithreadEventExecutorGroup extends AbstractEventExecuto
 
         chooser = chooserFactory.newChooser(children);
 
-        final FutureListener<Object> terminationListener = new FutureListener<Object>() {
-            @Override
-            public void operationComplete(Future<Object> future) throws Exception {
-                if (terminatedChildren.incrementAndGet() == children.length) {
-                    terminationFuture.setSuccess(null);
-                }
+        final FutureListener<Object> terminationListener = future -> {
+            if (terminatedChildren.incrementAndGet() == children.length) {
+                terminationFuture.setSuccess(null);
             }
         };
 

--- a/common/src/main/java/io/netty/util/concurrent/PromiseNotifier.java
+++ b/common/src/main/java/io/netty/util/concurrent/PromiseNotifier.java
@@ -91,12 +91,9 @@ public class PromiseNotifier<V, F extends Future<V>> implements GenericFutureLis
     @SuppressWarnings({"unchecked", "rawtypes"})
     public static <V, F extends Future<V>> F cascade(boolean logNotifyFailure, final F future,
                                                      final Promise<? super V> promise) {
-        promise.addListener(new FutureListener() {
-            @Override
-            public void operationComplete(Future f) {
-                if (f.isCancelled()) {
-                    future.cancel(false);
-                }
+        promise.addListener((FutureListener) f -> {
+            if (f.isCancelled()) {
+                future.cancel(false);
             }
         });
         future.addListener(new PromiseNotifier(logNotifyFailure, promise) {

--- a/common/src/test/java/io/netty/util/concurrent/UnorderedThreadPoolEventExecutorTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/UnorderedThreadPoolEventExecutorTest.java
@@ -58,12 +58,7 @@ public class UnorderedThreadPoolEventExecutorTest {
                 public void run() {
                     latch.countDown();
                 }
-            }).addListener(new FutureListener<Object>() {
-                @Override
-                public void operationComplete(Future<Object> future) throws Exception {
-                    latch.countDown();
-                }
-            });
+            }).addListener((FutureListener<Object>) f -> latch.countDown());
             exchanger.exchange(null);
             latch.await();
             future.syncUninterruptibly();

--- a/example/src/main/java/io/netty/example/discard/DiscardClientHandler.java
+++ b/example/src/main/java/io/netty/example/discard/DiscardClientHandler.java
@@ -16,7 +16,6 @@
 package io.netty.example.discard;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
@@ -65,15 +64,12 @@ public class DiscardClientHandler extends SimpleChannelInboundHandler<Object> {
         ctx.writeAndFlush(content.retainedDuplicate()).addListener(trafficGenerator);
     }
 
-    private final ChannelFutureListener trafficGenerator = new ChannelFutureListener() {
-        @Override
-        public void operationComplete(ChannelFuture future) {
-            if (future.isSuccess()) {
-                generateTraffic();
-            } else {
-                future.cause().printStackTrace();
-                future.channel().close();
-            }
+    private final ChannelFutureListener trafficGenerator = future -> {
+        if (future.isSuccess()) {
+            generateTraffic();
+        } else {
+            future.cause().printStackTrace();
+            future.channel().close();
         }
     };
 }

--- a/example/src/main/java/io/netty/example/factorial/FactorialClientHandler.java
+++ b/example/src/main/java/io/netty/example/factorial/FactorialClientHandler.java
@@ -66,12 +66,9 @@ public class FactorialClientHandler extends SimpleChannelInboundHandler<BigInteg
         receivedMessages ++;
         if (receivedMessages == FactorialClient.COUNT) {
             // Offer the answer after closing the connection.
-            ctx.channel().close().addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) {
-                    boolean offered = answer.offer(msg);
-                    assert offered;
-                }
+            ctx.channel().close().addListener(future -> {
+                boolean offered = answer.offer(msg);
+                assert offered;
             });
         }
     }
@@ -96,15 +93,12 @@ public class FactorialClientHandler extends SimpleChannelInboundHandler<BigInteg
         ctx.flush();
     }
 
-    private final ChannelFutureListener numberSender = new ChannelFutureListener() {
-        @Override
-        public void operationComplete(ChannelFuture future) throws Exception {
-            if (future.isSuccess()) {
-                sendNumbers();
-            } else {
-                future.cause().printStackTrace();
-                future.channel().close();
-            }
+    private final ChannelFutureListener numberSender = future -> {
+        if (future.isSuccess()) {
+            sendNumbers();
+        } else {
+            future.cause().printStackTrace();
+            future.channel().close();
         }
     };
 }

--- a/example/src/main/java/io/netty/example/haproxy/HAProxyHandler.java
+++ b/example/src/main/java/io/netty/example/haproxy/HAProxyHandler.java
@@ -17,7 +17,6 @@
 package io.netty.example.haproxy;
 
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
@@ -36,15 +35,12 @@ public class HAProxyHandler extends ChannelOutboundHandlerAdapter {
     public void write(final ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
         ChannelFuture future = ctx.write(msg, promise);
         if (msg instanceof HAProxyMessage) {
-            future.addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) throws Exception {
-                    if (future.isSuccess()) {
-                        ctx.pipeline().remove(HAProxyMessageEncoder.INSTANCE);
-                        ctx.pipeline().remove(HAProxyHandler.this);
-                    } else {
-                        ctx.close();
-                    }
+            future.addListener(future1 -> {
+                if (future1.isSuccess()) {
+                    ctx.pipeline().remove(HAProxyMessageEncoder.INSTANCE);
+                    ctx.pipeline().remove(HAProxyHandler.this);
+                } else {
+                    ctx.close();
                 }
             });
         }

--- a/example/src/main/java/io/netty/example/proxy/HexDumpProxyBackendHandler.java
+++ b/example/src/main/java/io/netty/example/proxy/HexDumpProxyBackendHandler.java
@@ -16,8 +16,6 @@
 package io.netty.example.proxy;
 
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 
@@ -40,14 +38,11 @@ public class HexDumpProxyBackendHandler extends ChannelInboundHandlerAdapter {
 
     @Override
     public void channelRead(final ChannelHandlerContext ctx, Object msg) {
-        inboundChannel.writeAndFlush(msg).addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                if (future.isSuccess()) {
-                    ctx.channel().read();
-                } else {
-                    future.channel().close();
-                }
+        inboundChannel.writeAndFlush(msg).addListener(future -> {
+            if (future.isSuccess()) {
+                ctx.read();
+            } else {
+                ctx.close();
             }
         });
     }

--- a/example/src/main/java/io/netty/example/proxy/HexDumpProxyFrontendHandler.java
+++ b/example/src/main/java/io/netty/example/proxy/HexDumpProxyFrontendHandler.java
@@ -50,16 +50,13 @@ public class HexDumpProxyFrontendHandler extends ChannelInboundHandlerAdapter {
          .option(ChannelOption.AUTO_READ, false);
         ChannelFuture f = b.connect(remoteHost, remotePort);
         outboundChannel = f.channel();
-        f.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                if (future.isSuccess()) {
-                    // connection complete start to read first data
-                    inboundChannel.read();
-                } else {
-                    // Close the connection if the connection attempt has failed.
-                    inboundChannel.close();
-                }
+        f.addListener(future -> {
+            if (future.isSuccess()) {
+                // connection complete start to read first data
+                inboundChannel.read();
+            } else {
+                // Close the connection if the connection attempt has failed.
+                inboundChannel.close();
             }
         });
     }
@@ -67,15 +64,12 @@ public class HexDumpProxyFrontendHandler extends ChannelInboundHandlerAdapter {
     @Override
     public void channelRead(final ChannelHandlerContext ctx, Object msg) {
         if (outboundChannel.isActive()) {
-            outboundChannel.writeAndFlush(msg).addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) {
-                    if (future.isSuccess()) {
-                        // was able to flush out data, start to read the next chunk
-                        ctx.channel().read();
-                    } else {
-                        future.channel().close();
-                    }
+            outboundChannel.writeAndFlush(msg).addListener(future -> {
+                if (future.isSuccess()) {
+                    // was able to flush out data, start to read the next chunk
+                    ctx.read();
+                } else {
+                    ctx.close();
                 }
             });
         }

--- a/example/src/main/java/io/netty/example/redis/RedisClient.java
+++ b/example/src/main/java/io/netty/example/redis/RedisClient.java
@@ -29,7 +29,6 @@ import io.netty.handler.codec.redis.RedisArrayAggregator;
 import io.netty.handler.codec.redis.RedisBulkStringAggregator;
 import io.netty.handler.codec.redis.RedisDecoder;
 import io.netty.handler.codec.redis.RedisEncoder;
-import io.netty.util.concurrent.GenericFutureListener;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -77,13 +76,10 @@ public class RedisClient {
                 }
                 // Sends the received line to the server.
                 lastWriteFuture = ch.writeAndFlush(line);
-                lastWriteFuture.addListener(new GenericFutureListener<ChannelFuture>() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
-                        if (!future.isSuccess()) {
-                            System.err.print("write failed: ");
-                            future.cause().printStackTrace(System.err);
-                        }
+                lastWriteFuture.addListener(future -> {
+                    if (!future.isSuccess()) {
+                        System.err.print("write failed: ");
+                        future.cause().printStackTrace(System.err);
                     }
                 });
             }

--- a/example/src/main/java/io/netty/example/securechat/SecureChatServerHandler.java
+++ b/example/src/main/java/io/netty/example/securechat/SecureChatServerHandler.java
@@ -21,11 +21,9 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.group.ChannelGroup;
 import io.netty.channel.group.DefaultChannelGroup;
 import io.netty.handler.ssl.SslHandler;
-import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.GenericFutureListener;
+
 import io.netty.util.concurrent.GlobalEventExecutor;
 
-import java.net.InetAddress;
 
 /**
  * Handles a server-side channel.
@@ -38,20 +36,16 @@ public class SecureChatServerHandler extends SimpleChannelInboundHandler<String>
     public void channelActive(final ChannelHandlerContext ctx) {
         // Once session is secured, send a greeting and register the channel to the global channel
         // list so the channel received the messages from others.
-        ctx.pipeline().get(SslHandler.class).handshakeFuture().addListener(
-                new GenericFutureListener<Future<Channel>>() {
-                    @Override
-                    public void operationComplete(Future<Channel> future) throws Exception {
-                        ctx.writeAndFlush(
-                                "Welcome to " + InetAddress.getLocalHost().getHostName() + " secure chat service!\n");
-                        ctx.writeAndFlush(
-                                "Your session is protected by " +
-                                        ctx.pipeline().get(SslHandler.class).engine().getSession().getCipherSuite() +
-                                        " cipher suite.\n");
+        ctx.pipeline().get(SslHandler.class).handshakeFuture().addListener(future -> {
+                    ctx.writeAndFlush(
+                            "Welcome to secure chat service!\n");
+                    ctx.writeAndFlush(
+                            "Your session is protected by " +
+                                    ctx.pipeline().get(SslHandler.class).engine().getSession().getCipherSuite() +
+                                    " cipher suite.\n");
 
-                        channels.add(ctx.channel());
-                    }
-        });
+                    channels.add(ctx.channel());
+                });
     }
 
     @Override

--- a/example/src/main/java/io/netty/example/socksproxy/SocksServerConnectHandler.java
+++ b/example/src/main/java/io/netty/example/socksproxy/SocksServerConnectHandler.java
@@ -18,7 +18,6 @@ package io.netty.example.socksproxy;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOption;
@@ -31,7 +30,6 @@ import io.netty.handler.codec.socksx.v4.Socks4CommandStatus;
 import io.netty.handler.codec.socksx.v5.DefaultSocks5CommandResponse;
 import io.netty.handler.codec.socksx.v5.Socks5CommandRequest;
 import io.netty.handler.codec.socksx.v5.Socks5CommandStatus;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;
 
@@ -46,27 +44,21 @@ public final class SocksServerConnectHandler extends SimpleChannelInboundHandler
             final Socks4CommandRequest request = (Socks4CommandRequest) message;
             Promise<Channel> promise = ctx.executor().newPromise();
             promise.addListener(
-                    new FutureListener<Channel>() {
-                        @Override
-                        public void operationComplete(final Future<Channel> future) throws Exception {
-                            final Channel outboundChannel = future.getNow();
-                            if (future.isSuccess()) {
-                                ChannelFuture responseFuture = ctx.channel().writeAndFlush(
-                                        new DefaultSocks4CommandResponse(Socks4CommandStatus.SUCCESS));
+                    (FutureListener<Channel>) future -> {
+                        final Channel outboundChannel = future.getNow();
+                        if (future.isSuccess()) {
+                            ChannelFuture responseFuture = ctx.channel().writeAndFlush(
+                                    new DefaultSocks4CommandResponse(Socks4CommandStatus.SUCCESS));
 
-                                responseFuture.addListener(new ChannelFutureListener() {
-                                    @Override
-                                    public void operationComplete(ChannelFuture channelFuture) {
-                                        ctx.pipeline().remove(SocksServerConnectHandler.this);
-                                        outboundChannel.pipeline().addLast(new RelayHandler(ctx.channel()));
-                                        ctx.pipeline().addLast(new RelayHandler(outboundChannel));
-                                    }
-                                });
-                            } else {
-                                ctx.channel().writeAndFlush(
-                                        new DefaultSocks4CommandResponse(Socks4CommandStatus.REJECTED_OR_FAILED));
-                                SocksServerUtils.closeOnFlush(ctx.channel());
-                            }
+                            responseFuture.addListener(channelFuture -> {
+                                ctx.pipeline().remove(SocksServerConnectHandler.this);
+                                outboundChannel.pipeline().addLast(new RelayHandler(ctx.channel()));
+                                ctx.pipeline().addLast(new RelayHandler(outboundChannel));
+                            });
+                        } else {
+                            ctx.channel().writeAndFlush(
+                                    new DefaultSocks4CommandResponse(Socks4CommandStatus.REJECTED_OR_FAILED));
+                            SocksServerUtils.closeOnFlush(ctx.channel());
                         }
                     });
 
@@ -77,49 +69,40 @@ public final class SocksServerConnectHandler extends SimpleChannelInboundHandler
                     .option(ChannelOption.SO_KEEPALIVE, true)
                     .handler(new DirectClientHandler(promise));
 
-            b.connect(request.dstAddr(), request.dstPort()).addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) throws Exception {
-                    if (future.isSuccess()) {
-                        // Connection established use handler provided results
-                    } else {
-                        // Close the connection if the connection attempt has failed.
-                        ctx.channel().writeAndFlush(
-                                new DefaultSocks4CommandResponse(Socks4CommandStatus.REJECTED_OR_FAILED)
-                        );
-                        SocksServerUtils.closeOnFlush(ctx.channel());
-                    }
+            b.connect(request.dstAddr(), request.dstPort()).addListener(future -> {
+                if (future.isSuccess()) {
+                    // Connection established use handler provided results
+                } else {
+                    // Close the connection if the connection attempt has failed.
+                    ctx.channel().writeAndFlush(
+                            new DefaultSocks4CommandResponse(Socks4CommandStatus.REJECTED_OR_FAILED)
+                    );
+                    SocksServerUtils.closeOnFlush(ctx.channel());
                 }
             });
         } else if (message instanceof Socks5CommandRequest) {
             final Socks5CommandRequest request = (Socks5CommandRequest) message;
             Promise<Channel> promise = ctx.executor().newPromise();
             promise.addListener(
-                    new FutureListener<Channel>() {
-                        @Override
-                        public void operationComplete(final Future<Channel> future) throws Exception {
-                            final Channel outboundChannel = future.getNow();
-                            if (future.isSuccess()) {
-                                ChannelFuture responseFuture =
-                                        ctx.channel().writeAndFlush(new DefaultSocks5CommandResponse(
-                                                Socks5CommandStatus.SUCCESS,
-                                                request.dstAddrType(),
-                                                request.dstAddr(),
-                                                request.dstPort()));
+                    (FutureListener<Channel>) future -> {
+                        final Channel outboundChannel = future.getNow();
+                        if (future.isSuccess()) {
+                            ChannelFuture responseFuture =
+                                    ctx.channel().writeAndFlush(new DefaultSocks5CommandResponse(
+                                            Socks5CommandStatus.SUCCESS,
+                                            request.dstAddrType(),
+                                            request.dstAddr(),
+                                            request.dstPort()));
 
-                                responseFuture.addListener(new ChannelFutureListener() {
-                                    @Override
-                                    public void operationComplete(ChannelFuture channelFuture) {
-                                        ctx.pipeline().remove(SocksServerConnectHandler.this);
-                                        outboundChannel.pipeline().addLast(new RelayHandler(ctx.channel()));
-                                        ctx.pipeline().addLast(new RelayHandler(outboundChannel));
-                                    }
-                                });
-                            } else {
-                                ctx.channel().writeAndFlush(new DefaultSocks5CommandResponse(
-                                        Socks5CommandStatus.FAILURE, request.dstAddrType()));
-                                SocksServerUtils.closeOnFlush(ctx.channel());
-                            }
+                            responseFuture.addListener(f -> {
+                                ctx.pipeline().remove(SocksServerConnectHandler.this);
+                                outboundChannel.pipeline().addLast(new RelayHandler(ctx.channel()));
+                                ctx.pipeline().addLast(new RelayHandler(outboundChannel));
+                            });
+                        } else {
+                            ctx.channel().writeAndFlush(new DefaultSocks5CommandResponse(
+                                    Socks5CommandStatus.FAILURE, request.dstAddrType()));
+                            SocksServerUtils.closeOnFlush(ctx.channel());
                         }
                     });
 
@@ -130,17 +113,14 @@ public final class SocksServerConnectHandler extends SimpleChannelInboundHandler
                     .option(ChannelOption.SO_KEEPALIVE, true)
                     .handler(new DirectClientHandler(promise));
 
-            b.connect(request.dstAddr(), request.dstPort()).addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) throws Exception {
-                    if (future.isSuccess()) {
-                        // Connection established use handler provided results
-                    } else {
-                        // Close the connection if the connection attempt has failed.
-                        ctx.channel().writeAndFlush(
-                                new DefaultSocks5CommandResponse(Socks5CommandStatus.FAILURE, request.dstAddrType()));
-                        SocksServerUtils.closeOnFlush(ctx.channel());
-                    }
+            b.connect(request.dstAddr(), request.dstPort()).addListener(future -> {
+                if (future.isSuccess()) {
+                    // Connection established use handler provided results
+                } else {
+                    // Close the connection if the connection attempt has failed.
+                    ctx.channel().writeAndFlush(
+                            new DefaultSocks5CommandResponse(Socks5CommandStatus.FAILURE, request.dstAddrType()));
+                    SocksServerUtils.closeOnFlush(ctx.channel());
                 }
             });
         } else {

--- a/example/src/main/java/io/netty/example/stomp/websocket/StompChatHandler.java
+++ b/example/src/main/java/io/netty/example/stomp/websocket/StompChatHandler.java
@@ -99,12 +99,8 @@ public class StompChatHandler extends SimpleChannelInboundHandler<StompFrame> {
         }
 
         subscriptions.add(subscription);
-        ctx.channel().closeFuture().addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                chatDestinations.get(subscription.destination()).remove(subscription);
-            }
-        });
+        ctx.channel().closeFuture().addListener(f ->
+                chatDestinations.get(subscription.destination()).remove(subscription));
 
         String receiptId = inboundFrame.headers().getAsString(RECEIPT);
         if (receiptId != null) {

--- a/example/src/main/java/io/netty/example/stomp/websocket/StompWebSocketChatServer.java
+++ b/example/src/main/java/io/netty/example/stomp/websocket/StompWebSocketChatServer.java
@@ -34,14 +34,11 @@ public class StompWebSocketChatServer {
                     .group(group)
                     .channel(NioServerSocketChannel.class)
                     .childHandler(new StompWebSocketChatServerInitializer("/chat"));
-            bootstrap.bind(port).addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) {
-                    if (future.isSuccess()) {
-                        System.out.println("Open your web browser and navigate to http://127.0.0.1:" + PORT + '/');
-                    } else {
-                        System.out.println("Cannot start server, follows exception " + future.cause());
-                    }
+            bootstrap.bind(port).addListener(future -> {
+                if (future.isSuccess()) {
+                    System.out.println("Open your web browser and navigate to http://127.0.0.1:" + PORT + '/');
+                } else {
+                    System.out.println("Cannot start server, follows exception " + future.cause());
                 }
             }).channel().closeFuture().sync();
         } finally {

--- a/example/src/main/java/io/netty/example/uptime/UptimeClient.java
+++ b/example/src/main/java/io/netty/example/uptime/UptimeClient.java
@@ -16,8 +16,6 @@
 package io.netty.example.uptime;
 
 import io.netty.bootstrap.Bootstrap;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
@@ -59,13 +57,10 @@ public final class UptimeClient {
     }
 
     static void connect() {
-        bs.connect().addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
-                if (future.cause() != null) {
-                    handler.startTime = -1;
-                    handler.println("Failed to connect: " + future.cause());
-                }
+        bs.connect().addListener(future -> {
+            if (future.cause() != null) {
+                handler.startTime = -1;
+                handler.println("Failed to connect: " + future.cause());
             }
         });
     }

--- a/handler-proxy/src/main/java/io/netty/handler/proxy/ProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/handler/proxy/ProxyHandler.java
@@ -18,7 +18,6 @@ package io.netty.handler.proxy;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelDuplexHandler;
-import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
@@ -63,12 +62,9 @@ public abstract class ProxyHandler extends ChannelDuplexHandler {
     private boolean flushedPrematurely;
     private final LazyChannelPromise connectPromise = new LazyChannelPromise();
     private Future<?> connectTimeoutFuture;
-    private final ChannelFutureListener writeListener = new ChannelFutureListener() {
-        @Override
-        public void operationComplete(ChannelFuture future) throws Exception {
-            if (!future.isSuccess()) {
-                setConnectFailure(future.cause());
-            }
+    private final ChannelFutureListener writeListener = future -> {
+        if (!future.isSuccess()) {
+            setConnectFailure(future.cause());
         }
     };
 

--- a/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyHandlerTest.java
+++ b/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyHandlerTest.java
@@ -22,7 +22,6 @@ import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
@@ -573,14 +572,11 @@ public class ProxyHandlerTest {
         @Override
         public void channelActive(ChannelHandlerContext ctx) throws Exception {
             ctx.writeAndFlush(Unpooled.copiedBuffer("A\n", CharsetUtil.US_ASCII)).addListener(
-                    new ChannelFutureListener() {
-                        @Override
-                        public void operationComplete(ChannelFuture future) throws Exception {
-                            latch.countDown();
-                            if (!(future.cause() instanceof ProxyConnectException)) {
-                                exceptions.add(new AssertionError(
-                                        "Unexpected failure cause for initial write: " + future.cause()));
-                            }
+                    future -> {
+                        latch.countDown();
+                        if (!(future.cause() instanceof ProxyConnectException)) {
+                            exceptions.add(new AssertionError(
+                                    "Unexpected failure cause for initial write: " + future.cause()));
                         }
                     });
         }

--- a/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyServer.java
+++ b/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyServer.java
@@ -169,16 +169,13 @@ abstract class ProxyServer {
             if (finished) {
                 this.finished = true;
                 ChannelFuture f = connectToDestination(ctx.channel().eventLoop(), new BackendHandler(ctx));
-                f.addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
-                        if (!future.isSuccess()) {
-                            recordException(future.cause());
-                            ctx.close();
-                        } else {
-                            backend = future.channel();
-                            flush();
-                        }
+                f.addListener((ChannelFutureListener) future -> {
+                    if (!future.isSuccess()) {
+                        recordException(future.cause());
+                        ctx.close();
+                    } else {
+                        backend = future.channel();
+                        flush();
                     }
                 });
             }

--- a/handler/src/main/java/io/netty/handler/address/DynamicAddressConnectHandler.java
+++ b/handler/src/main/java/io/netty/handler/address/DynamicAddressConnectHandler.java
@@ -15,8 +15,6 @@
  */
 package io.netty.handler.address;
 
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandler;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
@@ -46,14 +44,11 @@ public abstract class DynamicAddressConnectHandler extends ChannelOutboundHandle
             promise.setFailure(e);
             return;
         }
-        ctx.connect(remote, local, promise).addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                if (future.isSuccess()) {
-                    // We only remove this handler from the pipeline once the connect was successful as otherwise
-                    // the user may try to connect again.
-                    future.channel().pipeline().remove(DynamicAddressConnectHandler.this);
-                }
+        ctx.connect(remote, local, promise).addListener(future -> {
+            if (future.isSuccess()) {
+                // We only remove this handler from the pipeline once the connect was successful as otherwise
+                // the user may try to connect again.
+                ctx.pipeline().remove(DynamicAddressConnectHandler.this);
             }
         });
     }

--- a/handler/src/main/java/io/netty/handler/address/ResolveAddressHandler.java
+++ b/handler/src/main/java/io/netty/handler/address/ResolveAddressHandler.java
@@ -46,17 +46,14 @@ public class ResolveAddressHandler extends ChannelOutboundHandlerAdapter {
                         final SocketAddress localAddress, final ChannelPromise promise)  {
         AddressResolver<? extends SocketAddress> resolver = resolverGroup.getResolver(ctx.executor());
         if (resolver.isSupported(remoteAddress) && !resolver.isResolved(remoteAddress)) {
-            resolver.resolve(remoteAddress).addListener(new FutureListener<SocketAddress>() {
-                @Override
-                public void operationComplete(Future<SocketAddress> future) {
-                    Throwable cause = future.cause();
-                    if (cause != null) {
-                        promise.setFailure(cause);
-                    } else {
-                        ctx.connect(future.getNow(), localAddress, promise);
-                    }
-                    ctx.pipeline().remove(ResolveAddressHandler.this);
+            resolver.resolve(remoteAddress).addListener((FutureListener<SocketAddress>) future -> {
+                Throwable cause = future.cause();
+                if (cause != null) {
+                    promise.setFailure(cause);
+                } else {
+                    ctx.connect(future.getNow(), localAddress, promise);
                 }
+                ctx.pipeline().remove(ResolveAddressHandler.this);
             });
         } else {
             ctx.connect(remoteAddress, localAddress, promise);

--- a/handler/src/main/java/io/netty/handler/ipfilter/UniqueIpFilter.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/UniqueIpFilter.java
@@ -16,8 +16,6 @@
 package io.netty.handler.ipfilter;
 
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 
@@ -41,12 +39,7 @@ public class UniqueIpFilter extends AbstractRemoteAddressFilter<InetSocketAddres
         if (!connected.add(remoteIp)) {
             return false;
         } else {
-            ctx.channel().closeFuture().addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) throws Exception {
-                    connected.remove(remoteIp);
-                }
-            });
+            ctx.channel().closeFuture().addListener(future -> connected.remove(remoteIp));
             return true;
         }
     }

--- a/handler/src/main/java/io/netty/handler/ssl/SslClientHelloHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslClientHelloHandler.java
@@ -223,26 +223,23 @@ public abstract class SslClientHelloHandler<T> extends ByteToMessageDecoder impl
             } else {
                 suppressRead = true;
                 final ByteBuf finalClientHello = clientHello;
-                future.addListener(new FutureListener<T>() {
-                    @Override
-                    public void operationComplete(Future<T> future) {
-                        releaseIfNotNull(finalClientHello);
+                future.addListener((FutureListener<T>) future1 -> {
+                    releaseIfNotNull(finalClientHello);
+                    try {
+                        suppressRead = false;
                         try {
-                            suppressRead = false;
-                            try {
-                                onLookupComplete(ctx, future);
-                            } catch (DecoderException err) {
-                                ctx.fireExceptionCaught(err);
-                            } catch (Exception cause) {
-                                ctx.fireExceptionCaught(new DecoderException(cause));
-                            } catch (Throwable cause) {
-                                ctx.fireExceptionCaught(cause);
-                            }
-                        } finally {
-                            if (readPending) {
-                                readPending = false;
-                                ctx.read();
-                            }
+                            onLookupComplete(ctx, future1);
+                        } catch (DecoderException err) {
+                            ctx.fireExceptionCaught(err);
+                        } catch (Exception cause) {
+                            ctx.fireExceptionCaught(new DecoderException(cause));
+                        } catch (Throwable cause) {
+                            ctx.fireExceptionCaught(cause);
+                        }
+                    } finally {
+                        if (readPending) {
+                            readPending = false;
+                            ctx.read();
                         }
                     }
                 });

--- a/handler/src/main/java/io/netty/handler/stream/ChunkedWriteHandler.java
+++ b/handler/src/main/java/io/netty/handler/stream/ChunkedWriteHandler.java
@@ -297,24 +297,16 @@ public class ChunkedWriteHandler extends ChannelDuplexHandler {
                         // be closed before it's not written.
                         //
                         // See https://github.com/netty/netty/issues/303
-                        f.addListener(new ChannelFutureListener() {
-                            @Override
-                            public void operationComplete(ChannelFuture future) {
-                                handleEndOfInputFuture(future, chunks, currentWrite);
-                            }
-                        });
+                        f.addListener((ChannelFutureListener) future ->
+                                handleEndOfInputFuture(future, chunks, currentWrite));
                     }
                 } else {
                     final boolean resume = !channel.isWritable();
                     if (f.isDone()) {
                         handleFuture(f, chunks, currentWrite, resume);
                     } else {
-                        f.addListener(new ChannelFutureListener() {
-                            @Override
-                            public void operationComplete(ChannelFuture future) {
-                                handleFuture(future, chunks, currentWrite, resume);
-                            }
-                        });
+                        f.addListener((ChannelFutureListener) future ->
+                                handleFuture(future, chunks, currentWrite, resume));
                     }
                 }
                 requiresFlush = false;

--- a/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
+++ b/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
@@ -19,7 +19,6 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.Channel.Unsafe;
 import io.netty.channel.ChannelDuplexHandler;
-import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
@@ -100,15 +99,6 @@ import java.util.concurrent.TimeUnit;
 public class IdleStateHandler extends ChannelDuplexHandler {
     private static final long MIN_TIMEOUT_NANOS = TimeUnit.MILLISECONDS.toNanos(1);
 
-    // Not create a new ChannelFutureListener per write operation to reduce GC pressure.
-    private final ChannelFutureListener writeListener = new ChannelFutureListener() {
-        @Override
-        public void operationComplete(ChannelFuture future) throws Exception {
-            lastWriteTime = ticker.nanoTime();
-            firstWriterIdleEvent = firstAllIdleEvent = true;
-        }
-    };
-
     private final boolean observeOutput;
     private final long readerIdleTimeNanos;
     private final long writerIdleTimeNanos;
@@ -137,6 +127,11 @@ public class IdleStateHandler extends ChannelDuplexHandler {
     private int lastMessageHashCode;
     private long lastPendingWriteBytes;
     private long lastFlushProgress;
+    // Not create a new ChannelFutureListener per write operation to reduce GC pressure.
+    private final ChannelFutureListener writeListener = future -> {
+        lastWriteTime = ticker.nanoTime();
+        firstWriterIdleEvent = firstAllIdleEvent = true;
+    };
 
     /**
      * Creates a new instance firing {@link IdleStateEvent}s.

--- a/handler/src/test/java/io/netty/handler/flush/FlushConsolidationHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/flush/FlushConsolidationHandlerTest.java
@@ -19,8 +19,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.GenericFutureListener;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
@@ -172,12 +170,7 @@ public class FlushConsolidationHandlerTest {
     public void testResend() throws Exception {
         final AtomicInteger flushCount = new AtomicInteger();
         final EmbeddedChannel channel = newChannel(flushCount, true);
-        channel.writeAndFlush(1L).addListener(new GenericFutureListener<Future<? super Void>>() {
-            @Override
-            public void operationComplete(Future<? super Void> future) throws Exception {
-                channel.writeAndFlush(1L);
-            }
-        });
+        channel.writeAndFlush(1L).addListener(future -> channel.writeAndFlush(1L));
         channel.flushOutbound();
         assertEquals(1L, (Long) channel.readOutbound());
         assertEquals(1L, (Long) channel.readOutbound());

--- a/handler/src/test/java/io/netty/handler/ssl/RenegotiateTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/RenegotiateTest.java
@@ -31,8 +31,6 @@ import io.netty.handler.ssl.util.CachedSelfSignedCertificate;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.FutureListener;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -81,15 +79,12 @@ public abstract class RenegotiateTest {
                                             final SslHandler handler = ctx.pipeline().get(SslHandler.class);
 
                                             renegotiate = true;
-                                            handler.renegotiate().addListener(new FutureListener<Channel>() {
-                                                @Override
-                                                public void operationComplete(Future<Channel> future) throws Exception {
-                                                    if (!future.isSuccess()) {
-                                                        error.compareAndSet(null, future.cause());
-                                                        ctx.close();
-                                                    }
-                                                    latch.countDown();
+                                            handler.renegotiate().addListener(future -> {
+                                                if (!future.isSuccess()) {
+                                                    error.compareAndSet(null, future.cause());
+                                                    ctx.close();
                                                 }
+                                                latch.countDown();
                                             });
                                         } else {
                                             error.compareAndSet(null, event.cause());

--- a/handler/src/test/java/io/netty/handler/stream/ChunkedWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/stream/ChunkedWriteHandlerTest.java
@@ -197,13 +197,7 @@ public class ChunkedWriteHandlerTest {
         };
 
         final AtomicBoolean listenerNotified = new AtomicBoolean(false);
-        final ChannelFutureListener listener = new ChannelFutureListener() {
-
-            @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
-                listenerNotified.set(true);
-            }
-        };
+        final ChannelFutureListener listener = future -> listenerNotified.set(true);
 
         EmbeddedChannel ch = new EmbeddedChannel(new ChunkedWriteHandler());
         ch.writeAndFlush(input).addListener(listener).syncUninterruptibly();
@@ -521,12 +515,9 @@ public class ChunkedWriteHandlerTest {
         final CountDownLatch listenerInvoked = new CountDownLatch(1);
 
         ChannelFuture writeFuture = ch.write(input);
-        writeFuture.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                inputClosedWhenListenerInvoked.set(input.isClosed());
-                listenerInvoked.countDown();
-            }
+        writeFuture.addListener(future -> {
+            inputClosedWhenListenerInvoked.set(input.isClosed());
+            listenerInvoked.countDown();
         });
         ch.flush();
 
@@ -545,12 +536,9 @@ public class ChunkedWriteHandlerTest {
         final CountDownLatch listenerInvoked = new CountDownLatch(1);
 
         ChannelFuture writeFuture = ch.write(input);
-        writeFuture.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                inputClosedWhenListenerInvoked.set(input.isClosed());
-                listenerInvoked.countDown();
-            }
+        writeFuture.addListener(future -> {
+            inputClosedWhenListenerInvoked.set(input.isClosed());
+            listenerInvoked.countDown();
         });
         ch.flush();
 
@@ -570,12 +558,9 @@ public class ChunkedWriteHandlerTest {
         final CountDownLatch listenerInvoked = new CountDownLatch(1);
 
         ChannelFuture writeFuture = ch.write(input);
-        writeFuture.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                inputClosedWhenListenerInvoked.set(input.isClosed());
-                listenerInvoked.countDown();
-            }
+        writeFuture.addListener(future -> {
+            inputClosedWhenListenerInvoked.set(input.isClosed());
+            listenerInvoked.countDown();
         });
         ch.close(); // close channel to make handler discard the input on subsequent flush
         ch.flush();
@@ -645,12 +630,9 @@ public class ChunkedWriteHandlerTest {
         final CountDownLatch listenerInvoked = new CountDownLatch(1);
 
         ChannelFuture writeFuture = ch.write(input);
-        writeFuture.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                inputClosedWhenListenerInvoked.set(input.isClosed());
-                listenerInvoked.countDown();
-            }
+        writeFuture.addListener(future -> {
+            inputClosedWhenListenerInvoked.set(input.isClosed());
+            listenerInvoked.countDown();
         });
         ch.close(); // close channel to make handler discard the input on subsequent flush
         ch.flush();

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/InflightNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/InflightNameResolver.java
@@ -81,12 +81,7 @@ final class InflightNameResolver<T> implements NameResolver<T> {
             if (earlyPromise.isDone()) {
                 transferResult(earlyPromise, promise);
             } else {
-                earlyPromise.addListener(new FutureListener<U>() {
-                    @Override
-                    public void operationComplete(Future<U> f) throws Exception {
-                        transferResult(f, promise);
-                    }
-                });
+                earlyPromise.addListener((FutureListener<U>) f -> transferResult(f, promise));
             }
         } else {
             try {
@@ -103,12 +98,7 @@ final class InflightNameResolver<T> implements NameResolver<T> {
                 if (promise.isDone()) {
                     resolveMap.remove(inetHost);
                 } else {
-                    promise.addListener(new FutureListener<U>() {
-                        @Override
-                        public void operationComplete(Future<U> f) throws Exception {
-                            resolveMap.remove(inetHost);
-                        }
-                    });
+                    promise.addListener((FutureListener<U>) f -> resolveMap.remove(inetHost));
                 }
             }
         }

--- a/resolver-dns/src/main/resources/META-INF/native-image/io.netty/netty-resolver-dns/generated/handlers/reflect-config.json
+++ b/resolver-dns/src/main/resources/META-INF/native-image/io.netty/netty-resolver-dns/generated/handlers/reflect-config.json
@@ -28,9 +28,9 @@
     "queryAllPublicMethods": true
   },
   {
-    "name": "io.netty.resolver.dns.DnsQueryContext$5$1",
+    "name": "io.netty.resolver.dns.DnsQueryContext$4",
     "condition": {
-      "typeReachable": "io.netty.resolver.dns.DnsQueryContext$5$1"
+      "typeReachable": "io.netty.resolver.dns.DnsQueryContext$4"
     },
     "queryAllPublicMethods": true
   }

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsAddressResolverGroupTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsAddressResolverGroupTest.java
@@ -53,16 +53,13 @@ public class DnsAddressResolverGroupTest {
             AddressResolver<?> resolver = resolverGroup.getResolver(defaultEventLoopGroup.next());
             resolver.resolve(new SocketAddress() {
                 private static final long serialVersionUID = 3169703458729818468L;
-            }).addListener(new FutureListener<Object>() {
-                @Override
-                public void operationComplete(Future<Object> future) {
-                    try {
-                        assertInstanceOf(UnsupportedAddressTypeException.class, future.cause());
-                        assertTrue(loop.inEventLoop());
-                        promise.setSuccess(null);
-                    } catch (Throwable cause) {
-                        promise.setFailure(cause);
-                    }
+            }).addListener((FutureListener<Object>) future -> {
+                try {
+                    assertInstanceOf(UnsupportedAddressTypeException.class, future.cause());
+                    assertTrue(loop.inEventLoop());
+                    promise.setSuccess(null);
+                } catch (Throwable cause) {
+                    promise.setFailure(cause);
                 }
             }).await();
             promise.sync();
@@ -104,14 +101,11 @@ public class DnsAddressResolverGroupTest {
                                 final Promise<InetSocketAddress> promise)
             throws InterruptedException, ExecutionException {
         resolver.resolve(socketAddress)
-                .addListener(new FutureListener<InetSocketAddress>() {
-                    @Override
-                    public void operationComplete(Future<InetSocketAddress> future) {
-                        try {
-                            promise.setSuccess(future.get());
-                        } catch (Throwable cause) {
-                            promise.setFailure(cause);
-                        }
+                .addListener((FutureListener<InetSocketAddress>) future -> {
+                    try {
+                        promise.setSuccess(future.get());
+                    } catch (Throwable cause) {
+                        promise.setFailure(cause);
                     }
                 }).await();
         promise.sync();

--- a/resolver/src/main/java/io/netty/resolver/AddressResolverGroup.java
+++ b/resolver/src/main/java/io/netty/resolver/AddressResolverGroup.java
@@ -74,15 +74,12 @@ public abstract class AddressResolverGroup<T extends SocketAddress> implements C
 
                 resolvers.put(executor, newResolver);
 
-                final FutureListener<Object> terminationListener = new FutureListener<Object>() {
-                    @Override
-                    public void operationComplete(Future<Object> future) {
-                        synchronized (resolvers) {
-                            resolvers.remove(executor);
-                            executorTerminationListeners.remove(executor);
-                        }
-                        newResolver.close();
+                final FutureListener<Object> terminationListener = future -> {
+                    synchronized (resolvers) {
+                        resolvers.remove(executor);
+                        executorTerminationListeners.remove(executor);
                     }
+                    newResolver.close();
                 };
 
                 executorTerminationListeners.put(executor, terminationListener);

--- a/resolver/src/main/java/io/netty/resolver/CompositeNameResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/CompositeNameResolver.java
@@ -66,14 +66,11 @@ public final class CompositeNameResolver<T> extends SimpleNameResolver<T> {
             promise.setFailure(lastFailure);
         } else {
             NameResolver<T> resolver = resolvers[resolverIndex];
-            resolver.resolve(inetHost).addListener(new FutureListener<T>() {
-                @Override
-                public void operationComplete(Future<T> future) throws Exception {
-                    if (future.isSuccess()) {
-                        promise.setSuccess(future.getNow());
-                    } else {
-                        doResolveRec(inetHost, promise, resolverIndex + 1, future.cause());
-                    }
+            resolver.resolve(inetHost).addListener((FutureListener<T>) future -> {
+                if (future.isSuccess()) {
+                    promise.setSuccess(future.getNow());
+                } else {
+                    doResolveRec(inetHost, promise, resolverIndex + 1, future.cause());
                 }
             });
         }
@@ -92,14 +89,11 @@ public final class CompositeNameResolver<T> extends SimpleNameResolver<T> {
             promise.setFailure(lastFailure);
         } else {
             NameResolver<T> resolver = resolvers[resolverIndex];
-            resolver.resolveAll(inetHost).addListener(new FutureListener<List<T>>() {
-                @Override
-                public void operationComplete(Future<List<T>> future) throws Exception {
-                    if (future.isSuccess()) {
-                        promise.setSuccess(future.getNow());
-                    } else {
-                        doResolveAllRec(inetHost, promise, resolverIndex + 1, future.cause());
-                    }
+            resolver.resolveAll(inetHost).addListener((FutureListener<List<T>>) future -> {
+                if (future.isSuccess()) {
+                    promise.setSuccess(future.getNow());
+                } else {
+                    doResolveAllRec(inetHost, promise, resolverIndex + 1, future.cause());
                 }
             });
         }

--- a/resolver/src/main/java/io/netty/resolver/InetSocketAddressResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/InetSocketAddressResolver.java
@@ -53,14 +53,11 @@ public class InetSocketAddressResolver extends AbstractAddressResolver<InetSocke
         // Note that InetSocketAddress.getHostName() will never incur a reverse lookup here,
         // because an unresolved address always has a host name.
         nameResolver.resolve(unresolvedAddress.getHostName())
-                .addListener(new FutureListener<InetAddress>() {
-                    @Override
-                    public void operationComplete(Future<InetAddress> future) throws Exception {
-                        if (future.isSuccess()) {
-                            promise.setSuccess(new InetSocketAddress(future.getNow(), unresolvedAddress.getPort()));
-                        } else {
-                            promise.setFailure(future.cause());
-                        }
+                .addListener((FutureListener<InetAddress>) future -> {
+                    if (future.isSuccess()) {
+                        promise.setSuccess(new InetSocketAddress(future.getNow(), unresolvedAddress.getPort()));
+                    } else {
+                        promise.setFailure(future.cause());
                     }
                 });
     }
@@ -71,20 +68,17 @@ public class InetSocketAddressResolver extends AbstractAddressResolver<InetSocke
         // Note that InetSocketAddress.getHostName() will never incur a reverse lookup here,
         // because an unresolved address always has a host name.
         nameResolver.resolveAll(unresolvedAddress.getHostName())
-                .addListener(new FutureListener<List<InetAddress>>() {
-                    @Override
-                    public void operationComplete(Future<List<InetAddress>> future) throws Exception {
-                        if (future.isSuccess()) {
-                            List<InetAddress> inetAddresses = future.getNow();
-                            List<InetSocketAddress> socketAddresses =
-                                    new ArrayList<InetSocketAddress>(inetAddresses.size());
-                            for (InetAddress inetAddress : inetAddresses) {
-                                socketAddresses.add(new InetSocketAddress(inetAddress, unresolvedAddress.getPort()));
-                            }
-                            promise.setSuccess(socketAddresses);
-                        } else {
-                            promise.setFailure(future.cause());
+                .addListener((FutureListener<List<InetAddress>>) future -> {
+                    if (future.isSuccess()) {
+                        List<InetAddress> inetAddresses = future.getNow();
+                        List<InetSocketAddress> socketAddresses =
+                                new ArrayList<InetSocketAddress>(inetAddresses.size());
+                        for (InetAddress inetAddress : inetAddresses) {
+                            socketAddresses.add(new InetSocketAddress(inetAddress, unresolvedAddress.getPort()));
                         }
+                        promise.setSuccess(socketAddresses);
+                    } else {
+                        promise.setFailure(future.cause());
                     }
                 });
     }

--- a/resolver/src/main/java/io/netty/resolver/RoundRobinInetAddressResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/RoundRobinInetAddressResolver.java
@@ -52,45 +52,39 @@ public class RoundRobinInetAddressResolver extends InetNameResolver {
         // hijack the doResolve request, but do a doResolveAll request under the hood.
         // Note that InetSocketAddress.getHostName() will never incur a reverse lookup here,
         // because an unresolved address always has a host name.
-        nameResolver.resolveAll(inetHost).addListener(new FutureListener<List<InetAddress>>() {
-            @Override
-            public void operationComplete(Future<List<InetAddress>> future) throws Exception {
-                if (future.isSuccess()) {
-                    List<InetAddress> inetAddresses = future.getNow();
-                    int numAddresses = inetAddresses.size();
-                    if (numAddresses > 0) {
-                        // if there are multiple addresses: we shall pick one by one
-                        // to support the round robin distribution
-                        promise.setSuccess(inetAddresses.get(randomIndex(numAddresses)));
-                    } else {
-                        promise.setFailure(new UnknownHostException(inetHost));
-                    }
+        nameResolver.resolveAll(inetHost).addListener((FutureListener<List<InetAddress>>) future -> {
+            if (future.isSuccess()) {
+                List<InetAddress> inetAddresses = future.getNow();
+                int numAddresses = inetAddresses.size();
+                if (numAddresses > 0) {
+                    // if there are multiple addresses: we shall pick one by one
+                    // to support the round robin distribution
+                    promise.setSuccess(inetAddresses.get(randomIndex(numAddresses)));
                 } else {
-                    promise.setFailure(future.cause());
+                    promise.setFailure(new UnknownHostException(inetHost));
                 }
+            } else {
+                promise.setFailure(future.cause());
             }
         });
     }
 
     @Override
     protected void doResolveAll(String inetHost, final Promise<List<InetAddress>> promise) throws Exception {
-        nameResolver.resolveAll(inetHost).addListener(new FutureListener<List<InetAddress>>() {
-            @Override
-            public void operationComplete(Future<List<InetAddress>> future) throws Exception {
-                if (future.isSuccess()) {
-                    List<InetAddress> inetAddresses = future.getNow();
-                    if (!inetAddresses.isEmpty()) {
-                        // create a copy to make sure that it's modifiable random access collection
-                        List<InetAddress> result = new ArrayList<InetAddress>(inetAddresses);
-                        // rotate by different distance each time to force round robin distribution
-                        Collections.rotate(result, randomIndex(inetAddresses.size()));
-                        promise.setSuccess(result);
-                    } else {
-                        promise.setSuccess(inetAddresses);
-                    }
+        nameResolver.resolveAll(inetHost).addListener((FutureListener<List<InetAddress>>) future -> {
+            if (future.isSuccess()) {
+                List<InetAddress> inetAddresses = future.getNow();
+                if (!inetAddresses.isEmpty()) {
+                    // create a copy to make sure that it's modifiable random access collection
+                    List<InetAddress> result = new ArrayList<InetAddress>(inetAddresses);
+                    // rotate by different distance each time to force round robin distribution
+                    Collections.rotate(result, randomIndex(inetAddresses.size()));
+                    promise.setSuccess(result);
                 } else {
-                    promise.setFailure(future.cause());
+                    promise.setSuccess(inetAddresses);
                 }
+            } else {
+                promise.setFailure(future.cause());
             }
         });
     }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractSocketReuseFdTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractSocketReuseFdTest.java
@@ -96,12 +96,9 @@ public abstract class AbstractSocketReuseFdTest extends AbstractSocketTest {
             }
         });
 
-        ChannelFutureListener listener = new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                if (!future.isSuccess()) {
-                    clientDonePromise.tryFailure(future.cause());
-                }
+        ChannelFutureListener listener = future -> {
+            if (!future.isSuccess()) {
+                clientDonePromise.tryFailure(future.cause());
             }
         };
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketBufReleaseTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketBufReleaseTest.java
@@ -19,8 +19,6 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.util.concurrent.DefaultEventExecutorGroup;
@@ -96,12 +94,7 @@ public class SocketBufReleaseTest extends AbstractSocketTest {
             // call retain on it so it can't be put back on the pool
             buf.writeBytes(data).retain();
 
-            ctx.channel().writeAndFlush(buf).addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) throws Exception {
-                    latch.countDown();
-                }
-            });
+            ctx.channel().writeAndFlush(buf).addListener(future -> latch.countDown());
         }
 
         @Override

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
@@ -39,7 +39,6 @@ import io.netty.pkitesting.CertificateBuilder;
 import io.netty.pkitesting.X509Bundle;
 import io.netty.testsuite.util.TestUtils;
 import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.junit.jupiter.api.AfterAll;
@@ -515,13 +514,7 @@ public class SocketSslEchoTest extends AbstractSocketTest {
         @Override
         public void handlerAdded(final ChannelHandlerContext ctx) {
             if (!autoRead) {
-                ctx.pipeline().get(SslHandler.class).handshakeFuture().addListener(
-                        new GenericFutureListener<Future<? super Channel>>() {
-                            @Override
-                            public void operationComplete(Future<? super Channel> future) {
-                                ctx.read();
-                            }
-                        });
+                ctx.pipeline().get(SslHandler.class).handshakeFuture().addListener(future -> ctx.read());
             }
         }
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslLargeCertificateTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslLargeCertificateTest.java
@@ -53,7 +53,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
-import java.security.Provider;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
@@ -210,12 +209,7 @@ public class SocketSslLargeCertificateTest {
                                 if (receivedRead) {
                                     receivedRead = false;
                                     ctx.writeAndFlush(Unpooled.buffer()).addListener(ChannelFutureListener.CLOSE);
-                                    ctx.channel().closeFuture().addListener(new ChannelFutureListener() {
-                                        @Override
-                                        public void operationComplete(ChannelFuture future) throws Exception {
-                                            completion.setSuccess(null);
-                                        }
-                                    });
+                                    ctx.channel().closeFuture().addListener(future -> completion.setSuccess(null));
                                 }
                             }
 

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketFdTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketFdTest.java
@@ -18,8 +18,6 @@ package io.netty.channel.epoll;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.unix.DomainSocketReadMode;
@@ -70,13 +68,10 @@ public class EpollDomainSocketFdTest extends AbstractSocketTest {
                 // Create new channel and obtain a file descriptor from it.
                 final EpollDomainSocketChannel ch = new EpollDomainSocketChannel();
 
-                ctx.writeAndFlush(ch.fd()).addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
-                        if (!future.isSuccess()) {
-                            Throwable cause = future.cause();
-                            queue.offer(cause);
-                        }
+                ctx.writeAndFlush(ch.fd()).addListener(future -> {
+                    if (!future.isSuccess()) {
+                        Throwable cause = future.cause();
+                        queue.offer(cause);
                     }
                 });
             }

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainSocketFdTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainSocketFdTest.java
@@ -18,8 +18,6 @@ package io.netty.channel.kqueue;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.unix.DomainSocketReadMode;
@@ -70,13 +68,10 @@ public class KQueueDomainSocketFdTest extends AbstractSocketTest {
                 // Create new channel and obtain a file descriptor from it.
                 final KQueueDomainSocketChannel ch = new KQueueDomainSocketChannel();
 
-                ctx.writeAndFlush(ch.fd()).addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
-                        if (!future.isSuccess()) {
-                            Throwable cause = future.cause();
-                            queue.offer(cause);
-                        }
+                ctx.writeAndFlush(ch.fd()).addListener(future -> {
+                    if (!future.isSuccess()) {
+                        Throwable cause = future.cause();
+                        queue.offer(cause);
                     }
                 });
             }

--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -303,21 +303,18 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
         } else {
             // Registration future is almost always fulfilled already, but just in case it's not.
             final PendingRegistrationPromise promise = new PendingRegistrationPromise(channel);
-            regFuture.addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) throws Exception {
-                    Throwable cause = future.cause();
-                    if (cause != null) {
-                        // Registration on the EventLoop failed so fail the ChannelPromise directly to not cause an
-                        // IllegalStateException once we try to access the EventLoop of the Channel.
-                        promise.setFailure(cause);
-                    } else {
-                        // Registration was successful, so set the correct executor to use.
-                        // See https://github.com/netty/netty/issues/2586
-                        promise.registered();
+            regFuture.addListener(future -> {
+                Throwable cause = future.cause();
+                if (cause != null) {
+                    // Registration on the EventLoop failed so fail the ChannelPromise directly to not cause an
+                    // IllegalStateException once we try to access the EventLoop of the Channel.
+                    promise.setFailure(cause);
+                } else {
+                    // Registration was successful, so set the correct executor to use.
+                    // See https://github.com/netty/netty/issues/2586
+                    promise.registered();
 
-                        doBind0(regFuture, channel, localAddress, promise);
-                    }
+                    doBind0(regFuture, channel, localAddress, promise);
                 }
             });
             return promise;

--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -172,22 +172,19 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
         } else {
             // Registration future is almost always fulfilled already, but just in case it's not.
             final PendingRegistrationPromise promise = new PendingRegistrationPromise(channel);
-            regFuture.addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) throws Exception {
-                    // Directly obtain the cause and do a null check so we only need one volatile read in case of a
-                    // failure.
-                    Throwable cause = future.cause();
-                    if (cause != null) {
-                        // Registration on the EventLoop failed so fail the ChannelPromise directly to not cause an
-                        // IllegalStateException once we try to access the EventLoop of the Channel.
-                        promise.setFailure(cause);
-                    } else {
-                        // Registration was successful, so set the correct executor to use.
-                        // See https://github.com/netty/netty/issues/2586
-                        promise.registered();
-                        doResolveAndConnect0(channel, remoteAddress, localAddress, promise);
-                    }
+            regFuture.addListener(future -> {
+                // Directly obtain the cause and do a null check so we only need one volatile read in case of a
+                // failure.
+                Throwable cause = future.cause();
+                if (cause != null) {
+                    // Registration on the EventLoop failed so fail the ChannelPromise directly to not cause an
+                    // IllegalStateException once we try to access the EventLoop of the Channel.
+                    promise.setFailure(cause);
+                } else {
+                    // Registration was successful, so set the correct executor to use.
+                    // See https://github.com/netty/netty/issues/2586
+                    promise.registered();
+                    doResolveAndConnect0(channel, remoteAddress, localAddress, promise);
                 }
             });
             return promise;
@@ -234,15 +231,12 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
             }
 
             // Wait until the name resolution is finished.
-            resolveFuture.addListener(new FutureListener<SocketAddress>() {
-                @Override
-                public void operationComplete(Future<SocketAddress> future) throws Exception {
-                    if (future.cause() != null) {
-                        channel.close();
-                        promise.setFailure(future.cause());
-                    } else {
-                        doConnect(future.getNow(), localAddress, promise);
-                    }
+            resolveFuture.addListener((FutureListener<SocketAddress>) future -> {
+                if (future.cause() != null) {
+                    channel.close();
+                    promise.setFailure(future.cause());
+                } else {
+                    doConnect(future.getNow(), localAddress, promise);
                 }
             });
         } catch (Throwable cause) {

--- a/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
@@ -17,8 +17,6 @@ package io.netty.bootstrap;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -246,12 +244,9 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
             }
 
             try {
-                childGroup.register(child).addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
-                        if (!future.isSuccess()) {
-                            forceClose(child, future.cause());
-                        }
+                childGroup.register(child).addListener(future -> {
+                    if (!future.isSuccess()) {
+                        forceClose(child, future.cause());
                     }
                 });
             } catch (Throwable t) {

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -376,6 +376,10 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                     neverRegistered = false;
                     registered = true;
 
+                    // Ensure we call handlerAdded(...) before we actually notify the promise. This is needed as the
+                    // user may already fire events through the pipeline in the ChannelFutureListener.
+                    pipeline.invokeHandlerAddedIfNeeded();
+
                     safeSetSuccess(promise);
                     pipeline.fireChannelRegistered();
                     // Only fire a channelActive if the channel has never been registered. This prevents firing

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -371,38 +371,31 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             }
             ChannelPromise registerPromise = newPromise();
             boolean firstRegistration = neverRegistered;
-            registerPromise.addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) throws Exception {
-                    if (future.isSuccess()) {
-                        neverRegistered = false;
-                        registered = true;
+            registerPromise.addListener(future -> {
+                if (future.isSuccess()) {
+                    neverRegistered = false;
+                    registered = true;
 
-                        // Ensure we call handlerAdded(...) before we actually notify the promise. This is needed as the
-                        // user may already fire events through the pipeline in the ChannelFutureListener.
-                        pipeline.invokeHandlerAddedIfNeeded();
-
-                        safeSetSuccess(promise);
-                        pipeline.fireChannelRegistered();
-                        // Only fire a channelActive if the channel has never been registered. This prevents firing
-                        // multiple channel actives if the channel is deregistered and re-registered.
-                        if (isActive()) {
-                            if (firstRegistration) {
-                                pipeline.fireChannelActive();
-                            } else if (config().isAutoRead()) {
-                                // This channel was registered before and autoRead() is set. This means we need to
-                                // begin read again so that we process inbound data.
-                                //
-                                // See https://github.com/netty/netty/issues/4805
-                                beginRead();
-                            }
+                    safeSetSuccess(promise);
+                    pipeline.fireChannelRegistered();
+                    // Only fire a channelActive if the channel has never been registered. This prevents firing
+                    // multiple channel actives if the channel is deregistered and re-registered.
+                    if (isActive()) {
+                        if (firstRegistration) {
+                            pipeline.fireChannelActive();
+                        } else if (config().isAutoRead()) {
+                            // This channel was registered before and autoRead() is set. This means we need to
+                            // begin read again so that we process inbound data.
+                            //
+                            // See https://github.com/netty/netty/issues/4805
+                            beginRead();
                         }
-                    } else {
-                        // Close the channel directly to avoid FD leak.
-                        closeForcibly();
-                        closeFuture.setClosed();
-                        safeSetFailure(promise, future.cause());
                     }
+                } else {
+                    // Close the channel directly to avoid FD leak.
+                    close(newPromise());
+                    closeFuture.setClosed();
+                    safeSetFailure(promise, future.cause());
                 }
             });
             doRegister(registerPromise);
@@ -557,12 +550,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                     safeSetSuccess(promise);
                 } else if (!(promise instanceof VoidChannelPromise)) { // Only needed if no VoidChannelPromise.
                     // This means close() was called before so we just register a listener and return
-                    closeFuture.addListener(new ChannelFutureListener() {
-                        @Override
-                        public void operationComplete(ChannelFuture future) throws Exception {
-                            promise.setSuccess();
-                        }
-                    });
+                    closeFuture.addListener(future -> promise.setSuccess());
                 }
                 return;
             }

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
@@ -63,12 +63,7 @@ public class EmbeddedChannel extends AbstractChannel {
     private static final ChannelMetadata METADATA_DISCONNECT = new ChannelMetadata(true);
 
     private final EmbeddedEventLoop loop;
-    private final ChannelFutureListener recordExceptionListener = new ChannelFutureListener() {
-        @Override
-        public void operationComplete(ChannelFuture future) throws Exception {
-            recordException(future);
-        }
-    };
+    private final ChannelFutureListener recordExceptionListener = this::recordException;
 
     private final ChannelMetadata metadata;
     private final ChannelConfig config;

--- a/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
@@ -178,12 +178,7 @@ public class SimpleChannelPool implements ChannelPool {
                 if (f.isDone()) {
                     notifyConnect(f, promise);
                 } else {
-                    f.addListener(new ChannelFutureListener() {
-                        @Override
-                        public void operationComplete(ChannelFuture future) throws Exception {
-                            notifyConnect(future, promise);
-                        }
-                    });
+                    f.addListener((ChannelFutureListener) future -> notifyConnect(future, promise));
                 }
             } else {
                 EventLoop loop = ch.eventLoop();
@@ -229,12 +224,7 @@ public class SimpleChannelPool implements ChannelPool {
             if (f.isDone()) {
                 notifyHealthCheck(f, channel, promise);
             } else {
-                f.addListener(new FutureListener<Boolean>() {
-                    @Override
-                    public void operationComplete(Future<Boolean> future) {
-                        notifyHealthCheck(future, channel, promise);
-                    }
-                });
+                f.addListener((FutureListener<Boolean>) future -> notifyHealthCheck(future, channel, promise));
             }
         } catch (Throwable cause) {
             closeAndFail(channel, cause, promise);
@@ -321,12 +311,7 @@ public class SimpleChannelPool implements ChannelPool {
         if (f.isDone()) {
             releaseAndOfferIfHealthy(channel, promise, f);
         } else {
-            f.addListener(new FutureListener<Boolean>() {
-                @Override
-                public void operationComplete(Future<Boolean> future) throws Exception {
-                    releaseAndOfferIfHealthy(channel, promise, f);
-                }
-            });
+            f.addListener((FutureListener<Boolean>) future -> releaseAndOfferIfHealthy(channel, promise, f));
         }
     }
 

--- a/transport/src/main/resources/META-INF/native-image/io.netty/netty-transport/generated/handlers/reflect-config.json
+++ b/transport/src/main/resources/META-INF/native-image/io.netty/netty-transport/generated/handlers/reflect-config.json
@@ -91,9 +91,9 @@
     "queryAllPublicMethods": true
   },
   {
-    "name": "io.netty.channel.embedded.EmbeddedChannel$2",
+    "name": "io.netty.channel.embedded.EmbeddedChannel$1",
     "condition": {
-      "typeReachable": "io.netty.channel.embedded.EmbeddedChannel$2"
+      "typeReachable": "io.netty.channel.embedded.EmbeddedChannel$1"
     },
     "queryAllPublicMethods": true
   },

--- a/transport/src/test/java/io/netty/channel/AbstractCoalescingBufferQueueTest.java
+++ b/transport/src/test/java/io/netty/channel/AbstractCoalescingBufferQueueTest.java
@@ -67,12 +67,9 @@ public class AbstractCoalescingBufferQueueTest {
         };
 
         final byte[] bytes = new byte[128];
-        queue.add(Unpooled.wrappedBuffer(bytes), new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                queue.add(Unpooled.wrappedBuffer(bytes));
-                assertEquals(bytes.length, queue.readableBytes());
-            }
+        queue.add(Unpooled.wrappedBuffer(bytes), future -> {
+            queue.add(Unpooled.wrappedBuffer(bytes));
+            assertEquals(bytes.length, queue.readableBytes());
         });
 
         assertEquals(bytes.length, queue.readableBytes());

--- a/transport/src/test/java/io/netty/channel/CoalescingBufferQueueTest.java
+++ b/transport/src/test/java/io/netty/channel/CoalescingBufferQueueTest.java
@@ -53,12 +53,9 @@ public class CoalescingBufferQueueTest {
         channel = new EmbeddedChannel();
         writeQueue = new CoalescingBufferQueue(channel, 16, true);
         catPromise = newPromise();
-        mouseListener = new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
-                mouseDone = true;
-                mouseSuccess = future.isSuccess();
-            }
+        mouseListener = future -> {
+            mouseDone = true;
+            mouseSuccess = future.isSuccess();
         };
         emptyPromise = newPromise();
         voidPromise = channel.voidPromise();

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
@@ -1204,34 +1204,31 @@ public class DefaultChannelPipelineTest {
         try {
             final Object event = new Object();
             final Promise<Object> promise = ImmediateEventExecutor.INSTANCE.newPromise();
-            group.register(pipeline1.channel()).addListener(new ChannelFutureListener() {
-                @Override
-                public void operationComplete(ChannelFuture future) {
-                    ChannelPipeline pipeline = future.channel().pipeline();
-                    final AtomicBoolean handlerAddedCalled = new AtomicBoolean();
-                    pipeline.addLast(new ChannelInboundHandlerAdapter() {
-                        @Override
-                        public void handlerAdded(ChannelHandlerContext ctx) {
-                            handlerAddedCalled.set(true);
-                        }
-
-                        @Override
-                        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
-                            promise.setSuccess(event);
-                        }
-
-                        @Override
-                        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-                            promise.setFailure(cause);
-                        }
-                    });
-                    if (!handlerAddedCalled.get()) {
-                        promise.setFailure(new AssertionError("handlerAdded(...) should have been called"));
-                        return;
+            group.register(pipeline1.channel()).addListener(future -> {
+                ChannelPipeline pipeline = channel.pipeline();
+                final AtomicBoolean handlerAddedCalled = new AtomicBoolean();
+                pipeline.addLast(new ChannelInboundHandlerAdapter() {
+                    @Override
+                    public void handlerAdded(ChannelHandlerContext ctx) {
+                        handlerAddedCalled.set(true);
                     }
-                    // This event must be captured by the added handler.
-                    pipeline.fireUserEventTriggered(event);
+
+                    @Override
+                    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                        promise.setSuccess(event);
+                    }
+
+                    @Override
+                    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                        promise.setFailure(cause);
+                    }
+                });
+                if (!handlerAddedCalled.get()) {
+                    promise.setFailure(new AssertionError("handlerAdded(...) should have been called"));
+                    return;
                 }
+                // This event must be captured by the added handler.
+                pipeline.fireUserEventTriggered(event);
             });
             assertSame(event, promise.syncUninterruptibly().getNow());
         } finally {

--- a/transport/src/test/java/io/netty/channel/PendingWriteQueueTest.java
+++ b/transport/src/test/java/io/netty/channel/PendingWriteQueueTest.java
@@ -46,12 +46,7 @@ public class PendingWriteQueueTest {
                 assertFalse(ctx.channel().isWritable(), "Should not be writable anymore");
 
                 ChannelFuture future = queue.removeAndWrite();
-                future.addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) {
-                        assertQueueEmpty(queue);
-                    }
-                });
+                future.addListener(f -> assertQueueEmpty(queue));
                 super.flush(ctx);
             }
         }, 1);
@@ -65,12 +60,7 @@ public class PendingWriteQueueTest {
                 assertFalse(ctx.channel().isWritable(), "Should not be writable anymore");
 
                 ChannelFuture future = queue.removeAndWriteAll();
-                future.addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) {
-                        assertQueueEmpty(queue);
-                    }
-                });
+                future.addListener(f -> assertQueueEmpty(queue));
                 super.flush(ctx);
             }
         }, 3);
@@ -215,12 +205,7 @@ public class PendingWriteQueueTest {
         final PendingWriteQueue queue = new PendingWriteQueue(channel.pipeline().firstContext());
 
         ChannelPromise promise = channel.newPromise();
-        promise.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                queue.removeAndFailAll(new IllegalStateException());
-            }
-        });
+        promise.addListener(future -> queue.removeAndFailAll(new IllegalStateException()));
         queue.add(1L, promise);
 
         ChannelPromise promise2 = channel.newPromise();
@@ -247,12 +232,7 @@ public class PendingWriteQueueTest {
 
         ChannelPromise promise = channel.newPromise();
         final ChannelPromise promise3 = channel.newPromise();
-        promise.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                queue.add(3L, promise3);
-            }
-        });
+        promise.addListener(future -> queue.add(3L, promise3));
         queue.add(1L, promise);
         ChannelPromise promise2 = channel.newPromise();
         queue.add(2L, promise2);
@@ -302,28 +282,15 @@ public class PendingWriteQueueTest {
 
         ChannelPromise promise = channel.newPromise();
         final ChannelPromise promise3 = channel.newPromise();
-        promise3.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                failOrder.add(3);
-            }
-        });
-        promise.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                failOrder.add(1);
-                queue.add(3L, promise3);
-            }
+        promise3.addListener(future -> failOrder.add(3));
+        promise.addListener(future -> {
+            failOrder.add(1);
+            queue.add(3L, promise3);
         });
         queue.add(1L, promise);
 
         ChannelPromise promise2 = channel.newPromise();
-        promise2.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                failOrder.add(2);
-            }
-        });
+        promise2.addListener(future -> failOrder.add(2));
         queue.add(2L, promise2);
         queue.removeAndFailAll(new Exception());
         assertTrue(promise.isDone());
@@ -344,12 +311,7 @@ public class PendingWriteQueueTest {
         final PendingWriteQueue queue = new PendingWriteQueue(channel.pipeline().firstContext());
 
         ChannelPromise promise = channel.newPromise();
-        promise.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                queue.removeAndWriteAll();
-            }
-        });
+        promise.addListener(future -> queue.removeAndWriteAll());
         queue.add(1L, promise);
 
         ChannelPromise promise2 = channel.newPromise();

--- a/transport/src/test/java/io/netty/channel/ReentrantChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/ReentrantChannelTest.java
@@ -24,8 +24,6 @@ import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalChannel;
 import io.netty.channel.local.LocalIoHandler;
 import io.netty.channel.local.LocalServerChannel;
-import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.GenericFutureListener;
 import org.junit.jupiter.api.Test;
 
 import java.nio.channels.ClosedChannelException;
@@ -238,14 +236,9 @@ public class ReentrantChannelTest extends BaseChannelTest {
         clientChannel.pipeline().addLast(new ChannelOutboundHandlerAdapter() {
 
             @Override
-            public void write(final ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
-                promise.addListener(new GenericFutureListener<Future<? super Void>>() {
-                    @Override
-                    public void operationComplete(Future<? super Void> future) throws Exception {
-                        ctx.channel().close();
-                    }
-                });
-                super.write(ctx, msg, promise);
+            public void write(final ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+                promise.addListener(future -> ctx.channel().close());
+                ctx.write(msg, promise);
                 ctx.channel().flush();
             }
         });

--- a/transport/src/test/java/io/netty/channel/SingleThreadEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/SingleThreadEventLoopTest.java
@@ -406,12 +406,7 @@ public class SingleThreadEventLoopTest {
         final CountDownLatch latch = new CountDownLatch(1);
         Channel ch = new LocalChannel();
         ChannelPromise promise = ch.newPromise();
-        promise.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
-                latch.countDown();
-            }
-        });
+        promise.addListener(future -> latch.countDown());
 
         // Disable logging temporarily.
         Logger root = (Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);

--- a/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
@@ -94,13 +94,7 @@ public class EmbeddedChannelTest {
     @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
     public void promiseDoesNotInfiniteLoop() throws InterruptedException {
         EmbeddedChannel channel = new EmbeddedChannel();
-        channel.closeFuture().addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
-                future.channel().close();
-            }
-        });
-
+        channel.closeFuture().addListener((ChannelFutureListener) future -> future.channel().close());
         channel.close().syncUninterruptibly();
     }
 
@@ -142,12 +136,7 @@ public class EmbeddedChannelTest {
                 latch.countDown();
             }
         }, 1, TimeUnit.SECONDS);
-        future.addListener(new FutureListener() {
-            @Override
-            public void operationComplete(Future future) throws Exception {
-                latch.countDown();
-            }
-        });
+        future.addListener((FutureListener) future1 -> latch.countDown());
         long next = ch.runScheduledPendingTasks();
         assertTrue(next > 0);
         // Sleep for the nanoseconds but also give extra 50ms as the clock my not be very precise and so fail the test
@@ -630,12 +619,7 @@ public class EmbeddedChannelTest {
         });
 
         final EmbeddedEventLoop embeddedEventLoop = new EmbeddedEventLoop(new EmbeddedEventLoop.FreezableTicker());
-        channel.deregister().addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-                embeddedEventLoop.register(channel);
-            }
-        });
+        channel.deregister().addListener(f -> embeddedEventLoop.register(channel));
 
         if (!unregisteredLatch.await(5, TimeUnit.SECONDS)) {
             fail("Channel was not unregistered in time.");

--- a/transport/src/test/java/io/netty/channel/pool/AbstractChannelPoolMapTest.java
+++ b/transport/src/test/java/io/netty/channel/pool/AbstractChannelPoolMapTest.java
@@ -25,7 +25,6 @@ import io.netty.channel.local.LocalChannel;
 import io.netty.channel.local.LocalIoHandler;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.Promise;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
@@ -158,14 +157,11 @@ public class AbstractChannelPoolMapTest {
         @Override
         public Future<Void> closeAsync() {
             Future<Void> poolClose = super.closeAsync();
-            poolClose.addListener(new GenericFutureListener<Future<? super Void>>() {
-                @Override
-                public void operationComplete(Future<? super Void> future) throws Exception {
-                    if (future.isSuccess()) {
-                        closeFuture.setSuccess(null);
-                    } else {
-                        closeFuture.setFailure(future.cause());
-                    }
+            poolClose.addListener(future -> {
+                if (future.isSuccess()) {
+                    closeFuture.setSuccess(null);
+                } else {
+                    closeFuture.setFailure(future.cause());
                 }
             });
             return poolClose;

--- a/transport/src/test/java/io/netty/channel/pool/FixedChannelPoolTest.java
+++ b/transport/src/test/java/io/netty/channel/pool/FixedChannelPoolTest.java
@@ -29,7 +29,6 @@ import io.netty.channel.local.LocalIoHandler;
 import io.netty.channel.local.LocalServerChannel;
 import io.netty.channel.pool.FixedChannelPool.AcquireTimeoutAction;
 import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.GenericFutureListener;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -279,12 +278,9 @@ public class FixedChannelPoolTest {
         pool.acquire().get();
 
         final ChannelPromise closePromise = sc.newPromise();
-        pool.closeAsync().addListener(new GenericFutureListener<Future<? super Void>>() {
-            @Override
-            public void operationComplete(Future<? super Void> future) throws Exception {
-                assertEquals(0, pool.acquiredChannelCount());
-                sc.close(closePromise).syncUninterruptibly();
-            }
+        pool.closeAsync().addListener(future -> {
+            assertEquals(0, pool.acquiredChannelCount());
+            sc.close(closePromise).syncUninterruptibly();
         }).awaitUninterruptibly();
         closePromise.awaitUninterruptibly();
     }

--- a/transport/src/test/java/io/netty/channel/socket/nio/NioSocketChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/nio/NioSocketChannelTest.java
@@ -137,12 +137,9 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
                     // Trigger a gathering write by writing two buffers.
                     ctx.write(Unpooled.wrappedBuffer(new byte[] { 'a' }));
                     ChannelFuture f = ctx.write(Unpooled.wrappedBuffer(new byte[] { 'b' }));
-                    f.addListener(new ChannelFutureListener() {
-                        @Override
-                        public void operationComplete(ChannelFuture future) throws Exception {
-                            // This message must be flushed
-                            ctx.writeAndFlush(Unpooled.wrappedBuffer(new byte[]{'c'}));
-                        }
+                    f.addListener(future -> {
+                        // This message must be flushed
+                        ctx.writeAndFlush(Unpooled.wrappedBuffer(new byte[]{'c'}));
                     });
                     ctx.flush();
                 }
@@ -222,13 +219,10 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
                              // As soon as the channel becomes active re-register it to another
                              // EventLoop. After this is done we should still receive the data that
                              // was written to the channel.
-                             ctx.deregister().addListener(new ChannelFutureListener() {
-                                 @Override
-                                 public void operationComplete(ChannelFuture cf) {
-                                     Channel channel = cf.channel();
-                                     assertNotSame(loop, channel.eventLoop());
-                                     group.next().register(channel);
-                                 }
+                             ctx.deregister().addListener((ChannelFutureListener) cf -> {
+                                 Channel channel = cf.channel();
+                                 assertNotSame(loop, channel.eventLoop());
+                                 group.next().register(channel);
                              });
                          }
                      });


### PR DESCRIPTION
Motivation:

We should just use lambdas when possible.

Modifications:

Use lambdas when possible for listeners

Result:

Cleanup