### PR TITLE
codec-dns: Decompress MX RDATA exchange domain names during DNS record decoding

### DIFF
--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordDecoder.java
@@ -16,6 +16,8 @@
 package io.netty.handler.codec.dns;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.CorruptedFrameException;
 
 /**
  * The default {@link DnsRecordDecoder} implementation.
@@ -99,6 +101,30 @@ public class DefaultDnsRecordDecoder implements DnsRecordDecoder {
                                            DnsCodecUtil.decompressDomainName(
                                                    in.duplicate().setIndex(offset, offset + length)));
         }
+        if (type ==  DnsRecordType.MX) {
+            // MX RDATA: 16-bit preference + exchange (domain name, possibly compressed)
+            if (length < 3) {
+                throw new CorruptedFrameException("MX record RDATA is too short: " + length);
+            }
+            final int pref = in.getUnsignedShort(offset);
+            ByteBuf exchange = null;
+            try {
+                exchange = DnsCodecUtil.decompressDomainName(
+                        in.duplicate().setIndex(offset + 2, offset + length));
+
+                // Build decompressed RDATA = [preference][expanded exchange name]
+                final ByteBuf out = Unpooled.buffer(2 + exchange.readableBytes());
+                out.writeShort(pref);
+                out.writeBytes(exchange);
+
+                return new DefaultDnsRawRecord(name, type, dnsClass, timeToLive, out);
+            } finally {
+                if (exchange != null) {
+                    exchange.release();
+                }
+            }
+        }
+
         return new DefaultDnsRawRecord(
                 name, type, dnsClass, timeToLive, in.retainedDuplicate().setIndex(offset, offset + length));
     }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordDecoder.java
@@ -113,7 +113,7 @@ public class DefaultDnsRecordDecoder implements DnsRecordDecoder {
                         in.duplicate().setIndex(offset + 2, offset + length));
 
                 // Build decompressed RDATA = [preference][expanded exchange name]
-                final ByteBuf out = Unpooled.buffer(2 + exchange.readableBytes());
+                final ByteBuf out = in.alloc().buffer(2 + exchange.readableBytes());
                 out.writeShort(pref);
                 out.writeBytes(exchange);
 


### PR DESCRIPTION
### Motivation:

MX RDATA contains a domain name (the mail exchanger) which may be encoded using DNS compression pointers. At present, MX RDATA is left compressed, while other record types such as CNAME and NS are decompressed in advance. This difference in behaviour can make handling MX records less consistent when inspecting or processing decoded DNS records.

Refs #16003

### Modifications:

Added MX-specific handling in DefaultDnsRecordDecoder

Preserved the 16-bit preference field while decompressing the exchange domain name

Returned decompressed MX RDATA in the same form as other name-containing record types

Added unit tests covering MX RDATA with compression pointers

### Result:

MX records with compressed exchange names are now decoded into fully decompressed RDATA, aligning their behaviour with CNAME and NS records and improving consistency when working with DNS data.