### PR TITLE
Channel: Add correct overrides for methods that return itself

### DIFF
--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/EmbeddedQuicChannel.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/EmbeddedQuicChannel.java
@@ -125,13 +125,13 @@ final class EmbeddedQuicChannel extends EmbeddedChannel implements QuicChannel {
     }
 
     @Override
-    public QuicChannel flush() {
+    public EmbeddedQuicChannel flush() {
         super.flush();
         return this;
     }
 
     @Override
-    public QuicChannel read() {
+    public EmbeddedQuicChannel read() {
         super.read();
         return this;
     }

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/EmbeddedQuicStreamChannel.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/EmbeddedQuicStreamChannel.java
@@ -92,13 +92,13 @@ final class EmbeddedQuicStreamChannel extends EmbeddedChannel implements QuicStr
     }
 
     @Override
-    public QuicStreamChannel flush() {
+    public EmbeddedQuicStreamChannel flush() {
         super.flush();
         return this;
     }
 
     @Override
-    public QuicStreamChannel read() {
+    public EmbeddedQuicStreamChannel read() {
         super.read();
         return this;
     }

--- a/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
@@ -1349,6 +1349,18 @@ public class PcapWriteHandlerTest {
         }
 
         @Override
+        public EmbeddedDatagramChannel flush() {
+            super.flush();
+            return this;
+        }
+
+        @Override
+        public EmbeddedDatagramChannel read() {
+            super.read();
+            return this;
+        }
+
+        @Override
         public boolean isConnected() {
             return true;
         }

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -18,6 +18,7 @@ package io.netty.channel.epoll;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelOutboundBuffer;
@@ -501,8 +502,20 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
     }
 
     @Override
-    public EpollDatagramChannelConfig config() {
+    public ChannelConfig config() {
         return config;
+    }
+
+    @Override
+    public DatagramChannel read() {
+        super.read();
+        return this;
+    }
+
+    @Override
+    public DatagramChannel flush() {
+        super.flush();
+        return this;
     }
 
     @Override
@@ -542,7 +555,6 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
     @Override
     void epollInReady() {
         assert executor().inEventLoop();
-        EpollDatagramChannelConfig config = config();
         if (shouldBreakEpollInReady(config)) {
             clearEpollIn0();
             return;
@@ -561,7 +573,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
                 } else {
                     do {
                         final boolean read;
-                        int datagramSize = config().getMaxDatagramPayloadSize();
+                        int datagramSize = config.getMaxDatagramPayloadSize();
 
                         ByteBuf byteBuf = allocHandle.allocate(allocator);
                         // Only try to use recvmmsg if its really supported by the running system.

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
@@ -218,6 +218,18 @@ public final class EpollServerSocketChannel extends AbstractEpollChannel impleme
         return config;
     }
 
+    @Override
+    public ServerSocketChannel read() {
+        super.read();
+        return this;
+    }
+
+    @Override
+    public ServerSocketChannel flush() {
+        super.flush();
+        return this;
+    }
+
     private Channel newChildChannel(EventLoop eventLoop, int fd, byte[] address, int offset, int len) {
         if (socket.protocolFamily() ==  SocketProtocolFamily.UNIX) {
             return new EpollSocketChannel(eventLoop, this, new LinuxSocket(fd, SocketProtocolFamily.UNIX));

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannel.java
@@ -133,6 +133,18 @@ public final class EpollSocketChannel extends AbstractEpollChannel implements So
     }
 
     @Override
+    public SocketChannel read() {
+        super.read();
+        return this;
+    }
+
+    @Override
+    public SocketChannel flush() {
+        super.flush();
+        return this;
+    }
+
+    @Override
     protected boolean isAllowHalfClosure() {
         return this.config.isAllowHalfClosure();
     }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
@@ -337,6 +337,18 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
     }
 
     @Override
+    public DatagramChannel read() {
+        super.read();
+        return this;
+    }
+
+    @Override
+    public DatagramChannel flush() {
+        super.flush();
+        return this;
+    }
+
+    @Override
     protected void doDisconnect(ChannelPromise promise) {
         try {
             // TODO: use io_uring for this too...

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringServerSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringServerSocketChannel.java
@@ -318,6 +318,18 @@ public final class IoUringServerSocketChannel extends AbstractIoUringChannel imp
         return config;
     }
 
+    @Override
+    public ServerSocketChannel read() {
+        super.read();
+        return this;
+    }
+
+    @Override
+    public ServerSocketChannel flush() {
+        super.flush();
+        return this;
+    }
+
     private Channel newChildChannel(EventLoop eventLoop, int fd, ByteBuffer acceptedAddressMemory) {
         IoUringIoHandler handler = registration().attachment();
         LinuxSocket socket = new LinuxSocket(fd, this.socket.protocolFamily());

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
@@ -91,6 +91,18 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
     }
 
     @Override
+    public SocketChannel read() {
+        super.read();
+        return this;
+    }
+
+    @Override
+    public SocketChannel flush() {
+        super.flush();
+        return this;
+    }
+
+    @Override
     public ServerSocketChannel parent() {
         return (ServerSocketChannel) super.parent();
     }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
@@ -328,6 +328,18 @@ public final class KQueueDatagramChannel extends AbstractKQueueChannel implement
         }
     }
 
+    @Override
+    public DatagramChannel read() {
+        super.read();
+        return this;
+    }
+
+    @Override
+    public DatagramChannel flush() {
+        super.flush();
+        return this;
+    }
+
     private boolean doWriteMessage(Object msg) throws Exception {
         final ByteBuf data;
         SocketAddress remoteAddress;

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerSocketChannel.java
@@ -193,6 +193,18 @@ public final class KQueueServerSocketChannel extends AbstractKQueueChannel imple
         return config;
     }
 
+    @Override
+    public ServerSocketChannel read() {
+        super.read();
+        return this;
+    }
+
+    @Override
+    public ServerSocketChannel flush() {
+        super.flush();
+        return this;
+    }
+
     private Channel newChildChannel(EventLoop eventLoop, int fd, byte[] address, int offset, int len) {
         if (socket.protocolFamily() == SocketProtocolFamily.UNIX) {
             return new KQueueSocketChannel(eventLoop, this, new BsdSocket(fd, SocketProtocolFamily.UNIX), true);

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannel.java
@@ -100,6 +100,18 @@ public final class KQueueSocketChannel extends AbstractKQueueChannel implements 
     }
 
     @Override
+    public SocketChannel read() {
+        super.read();
+        return this;
+    }
+
+    @Override
+    public SocketChannel flush() {
+        super.flush();
+        return this;
+    }
+
+    @Override
     protected boolean isAllowHalfClosure() {
         return config.isAllowHalfClosure();
     }

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/SctpChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/SctpChannel.java
@@ -123,4 +123,10 @@ public interface SctpChannel extends Channel {
      * Will notify the given {@link ChannelPromise} and return a {@link ChannelFuture}
      */
     ChannelFuture unbindAddress(InetAddress localAddress, ChannelPromise promise);
+
+    @Override
+    SctpChannel read();
+
+    @Override
+    SctpChannel flush();
 }

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
@@ -129,6 +129,18 @@ public class NioSctpChannel extends AbstractNioMessageChannel implements io.nett
     }
 
     @Override
+    public io.netty.channel.sctp.SctpChannel read() {
+        super.read();
+        return this;
+    }
+
+    @Override
+    public io.netty.channel.sctp.SctpChannel flush() {
+        super.flush();
+        return this;
+    }
+
+    @Override
     protected void doShutdown(ChannelShutdownType type, ChannelPromise promise) {
         promise.setFailure(new UnsupportedOperationException());
     }

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpServerChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpServerChannel.java
@@ -28,6 +28,7 @@ import io.netty.channel.ChannelShutdownType;
 import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.ServerChannel;
 import io.netty.channel.ServerChannelRecvByteBufAllocator;
 import io.netty.channel.nio.AbstractNioMessageChannel;
 import io.netty.channel.nio.NioIoHandle;
@@ -78,6 +79,18 @@ public class NioSctpServerChannel extends AbstractNioMessageChannel
         this.childEventLoopGroup =
                 validateEventLoopGroup(childEventLoopGroup, "childEventLoopGroup", NioIoHandle.class);
         config = new NioSctpServerChannelConfig(this, javaChannel());
+    }
+
+    @Override
+    public ServerChannel read() {
+        super.read();
+        return this;
+    }
+
+    @Override
+    public ServerChannel flush() {
+        super.flush();
+        return this;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/AbstractServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractServerChannel.java
@@ -43,6 +43,18 @@ public abstract class AbstractServerChannel extends AbstractChannel implements S
     }
 
     @Override
+    public ServerChannel read() {
+        super.read();
+        return this;
+    }
+
+    @Override
+    public ServerChannel flush() {
+        super.flush();
+        return this;
+    }
+
+    @Override
     public EventLoopGroup childEventExecutorGroup() {
         return childEventLoopGroup;
     }

--- a/transport/src/main/java/io/netty/channel/ServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/ServerChannel.java
@@ -26,4 +26,10 @@ public interface ServerChannel extends Channel {
      * @return  the used child group.
      */
     EventLoopGroup childEventExecutorGroup();
+
+    @Override
+    ServerChannel read();
+
+    @Override
+    ServerChannel flush();
 }

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
@@ -695,14 +695,15 @@ public class EmbeddedChannel extends AbstractChannel {
     }
 
     @Override
-    public Channel flush() {
+    public EmbeddedChannel flush() {
         executingStackCnt++;
         try {
-            return super.flush();
+            super.flush();
         } finally {
             executingStackCnt--;
             maybeRunPendingTasks();
         }
+        return this;
     }
 
     @Override
@@ -753,11 +754,12 @@ public class EmbeddedChannel extends AbstractChannel {
     public Channel read() {
         executingStackCnt++;
         try {
-            return super.read();
+            super.read();
         } finally {
             executingStackCnt--;
             maybeRunPendingTasks();
         }
+        return this;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/socket/DatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/DatagramChannel.java
@@ -187,4 +187,10 @@ public interface DatagramChannel extends Channel {
      */
     ChannelFuture block(
             InetAddress multicastAddress, InetAddress sourceToBlock, ChannelPromise future);
+
+    @Override
+    DatagramChannel read();
+
+    @Override
+    DatagramChannel flush();
 }

--- a/transport/src/main/java/io/netty/channel/socket/ServerSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/ServerSocketChannel.java
@@ -15,10 +15,7 @@
  */
 package io.netty.channel.socket;
 
-import io.netty.channel.ChannelConfig;
 import io.netty.channel.ServerChannel;
-
-import java.net.InetSocketAddress;
 
 /**
  * A {@link ServerChannel} which accepts incoming connections.
@@ -43,4 +40,9 @@ import java.net.InetSocketAddress;
  */
 public interface ServerSocketChannel extends ServerChannel {
 
+    @Override
+    ServerSocketChannel read();
+
+    @Override
+    ServerSocketChannel flush();
 }

--- a/transport/src/main/java/io/netty/channel/socket/SocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/SocketChannel.java
@@ -16,6 +16,7 @@
 package io.netty.channel.socket;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelShutdownDirection;
 
 /**
  * A socket {@link Channel}.
@@ -49,4 +50,13 @@ import io.netty.channel.Channel;
 public interface SocketChannel extends Channel {
     @Override
     ServerSocketChannel parent();
+
+    @Override
+    boolean isShutdown(ChannelShutdownDirection direction);
+
+    @Override
+    SocketChannel read();
+
+    @Override
+    SocketChannel flush();
 }

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
@@ -23,7 +23,6 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPromise;
-import io.netty.channel.ChannelShutdownDirection;
 import io.netty.channel.ChannelShutdownType;
 import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.EventLoop;
@@ -587,6 +586,18 @@ public final class NioDatagramChannel
             promise.setFailure(e);
         }
         return promise;
+    }
+
+    @Override
+    public io.netty.channel.socket.DatagramChannel read() {
+        super.read();
+        return this;
+    }
+
+    @Override
+    public io.netty.channel.socket.DatagramChannel flush() {
+        super.flush();
+        return this;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioServerSocketChannel.java
@@ -250,6 +250,18 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public io.netty.channel.socket.ServerSocketChannel read() {
+        super.read();
+        return this;
+    }
+
+    @Override
+    public io.netty.channel.socket.ServerSocketChannel flush() {
+        super.flush();
+        return this;
+    }
+
     private static final class NioServerSocketChannelConfig extends DefaultChannelConfig {
 
         final NetworkChannel jdkChannel;

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
@@ -127,6 +127,18 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
         config = new NioSocketChannelConfig(this, channel);
     }
 
+    @Override
+    public io.netty.channel.socket.SocketChannel read() {
+        super.read();
+        return this;
+    }
+
+    @Override
+    public io.netty.channel.socket.SocketChannel flush() {
+        super.flush();
+        return this;
+    }
+
     protected boolean isAllowHalfClosure() {
         return config.isAllowHalfClosure();
     }

--- a/transport/src/test/java/io/netty/bootstrap/ServerBootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/ServerBootstrapTest.java
@@ -277,6 +277,18 @@ public class ServerBootstrapTest {
         }
 
         @Override
+        public ServerChannel read() {
+            super.read();
+            return this;
+        }
+
+        @Override
+        public ServerChannel flush() {
+            super.flush();
+            return this;
+        }
+
+        @Override
         protected void doBind(SocketAddress localAddress, ChannelPromise promise) {
             active = true;
             promise.setSuccess();


### PR DESCRIPTION
Motivation:

We should add the correct overrides for the various Channel implementations for methods that return itself

Modifications:

Add overriddes

Result:

Correct method chaining possible