### PR TITLE
NioDatagramChannel.block(...) does not early return on failure (#16044)

### DIFF
--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
@@ -552,7 +552,7 @@ public final class NioDatagramChannel
                         try {
                             key.block(sourceToBlock);
                         } catch (IOException e) {
-                            promise.setFailure(e);
+                            return promise.setFailure(e);
                         }
                     }
                 }


### PR DESCRIPTION
Motivation:

The block(...) method missed to return when the promise is failed and so will throw an IllegalStateException leater when we try to call setSuccess(...)

Modifications:

Add missing return

Result:

Correctly report failure in block(...) method