### PR TITLE
Make AdaptiveByteBuf.setBytes faster (#15736)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -1496,4 +1496,8 @@ public abstract class AbstractByteBuf extends ByteBuf {
     long _memoryAddress() {
         return isAccessible() && hasMemoryAddress() ? memoryAddress() : 0L;
     }
+
+    ByteBuffer _internalNioBuffer() {
+        return internalNioBuffer(0, maxFastWritableBytes());
+    }
 }

--- a/buffer/src/main/java/io/netty/buffer/AdaptiveByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptiveByteBufAllocator.java
@@ -112,8 +112,8 @@ public final class AdaptiveByteBufAllocator extends AbstractByteBufAllocator
         @Override
         public AbstractByteBuf allocate(int initialCapacity, int maxCapacity) {
             return PlatformDependent.hasUnsafe() ?
-                    UnsafeByteBufUtil.newUnsafeDirectByteBuf(allocator, initialCapacity, maxCapacity, false) :
-                    new UnpooledDirectByteBuf(allocator, initialCapacity, maxCapacity, false);
+                    UnsafeByteBufUtil.newUnsafeDirectByteBuf(allocator, initialCapacity, maxCapacity) :
+                    new UnpooledDirectByteBuf(allocator, initialCapacity, maxCapacity);
         }
     }
 }

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -1687,16 +1687,33 @@ final class AdaptivePoolingAllocator {
         @Override
         public ByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length) {
             checkIndex(index, length);
-            ByteBuffer tmp = (ByteBuffer) internalNioBuffer().clear().position(index);
-            tmp.put(src.nioBuffer(srcIndex, length));
+            if (src instanceof AdaptiveByteBuf && PlatformDependent.javaVersion() >= 16) {
+                AdaptiveByteBuf srcBuf = (AdaptiveByteBuf) src;
+                srcBuf.checkIndex(srcIndex, length);
+                ByteBuffer dstBuffer = rootParent()._internalNioBuffer();
+                ByteBuffer srcBuffer = srcBuf.rootParent()._internalNioBuffer();
+                PlatformDependent.absolutePut(dstBuffer, idx(index), srcBuffer, srcBuf.idx(srcIndex), length);
+            } else {
+                ByteBuffer tmp = internalNioBuffer();
+                tmp.position(index);
+                tmp.put(src.nioBuffer(srcIndex, length));
+            }
             return this;
         }
 
         @Override
         public ByteBuf setBytes(int index, ByteBuffer src) {
-            checkIndex(index, src.remaining());
-            ByteBuffer tmp = (ByteBuffer) internalNioBuffer().clear().position(index);
-            tmp.put(src);
+            int length = src.remaining();
+            checkIndex(index, length);
+            ByteBuffer tmp = internalNioBuffer();
+            if (PlatformDependent.javaVersion() >= 16) {
+                int offset = src.position();
+                PlatformDependent.absolutePut(tmp, index, src, offset, length);
+                src.position(offset + length);
+            } else {
+                tmp.position(index);
+                tmp.put(src);
+            }
             return this;
         }
 
@@ -1705,7 +1722,8 @@ final class AdaptivePoolingAllocator {
                 throws IOException {
             checkIndex(index, length);
             if (length != 0) {
-                ByteBufUtil.readBytes(alloc(), internalNioBuffer().duplicate(), index, length, out);
+                ByteBuffer tmp = internalNioBuffer();
+                ByteBufUtil.readBytes(alloc(), tmp.hasArray() ? tmp : tmp.duplicate(), index, length, out);
             }
             return this;
         }

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -403,8 +403,8 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
             buf = directArena.allocate(cache, initialCapacity, maxCapacity);
         } else {
             buf = PlatformDependent.hasUnsafe() ?
-                    UnsafeByteBufUtil.newUnsafeDirectByteBuf(this, initialCapacity, maxCapacity, true) :
-                    new UnpooledDirectByteBuf(this, initialCapacity, maxCapacity, true);
+                    UnsafeByteBufUtil.newUnsafeDirectByteBuf(this, initialCapacity, maxCapacity) :
+                    new UnpooledDirectByteBuf(this, initialCapacity, maxCapacity);
             onAllocateBuffer(buf, false, false);
         }
         return toLeakAwareBuffer(buf);

--- a/buffer/src/main/java/io/netty/buffer/UnpooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledByteBufAllocator.java
@@ -179,7 +179,7 @@ public final class UnpooledByteBufAllocator extends AbstractByteBufAllocator imp
             extends UnpooledUnsafeNoCleanerDirectByteBuf {
         InstrumentedUnpooledUnsafeNoCleanerDirectByteBuf(
                 UnpooledByteBufAllocator alloc, int initialCapacity, int maxCapacity) {
-            super(alloc, initialCapacity, maxCapacity, true);
+            super(alloc, initialCapacity, maxCapacity);
         }
 
         @Override

--- a/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
@@ -213,7 +213,7 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
         ensureAccessible();
         ByteBuffer tmpBuf;
         if (internal) {
-            tmpBuf = internalNioBuffer();
+            tmpBuf = _internalNioBuffer();
         } else {
             tmpBuf = ByteBuffer.wrap(array);
         }
@@ -222,7 +222,7 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
 
     private int getBytes(int index, FileChannel out, long position, int length, boolean internal) throws IOException {
         ensureAccessible();
-        ByteBuffer tmpBuf = internal ? internalNioBuffer() : ByteBuffer.wrap(array);
+        ByteBuffer tmpBuf = internal ? _internalNioBuffer() : ByteBuffer.wrap(array);
         return out.write((ByteBuffer) tmpBuf.clear().position(index).limit(index + length), position);
     }
 
@@ -279,7 +279,7 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     public int setBytes(int index, ScatteringByteChannel in, int length) throws IOException {
         ensureAccessible();
         try {
-            return in.read((ByteBuffer) internalNioBuffer().clear().position(index).limit(index + length));
+            return in.read((ByteBuffer) _internalNioBuffer().clear().position(index).limit(index + length));
         } catch (ClosedChannelException ignored) {
             return -1;
         }
@@ -289,7 +289,7 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     public int setBytes(int index, FileChannel in, long position, int length) throws IOException {
         ensureAccessible();
         try {
-            return in.read((ByteBuffer) internalNioBuffer().clear().position(index).limit(index + length), position);
+            return in.read((ByteBuffer) _internalNioBuffer().clear().position(index).limit(index + length), position);
         } catch (ClosedChannelException ignored) {
             return -1;
         }
@@ -314,7 +314,7 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     public ByteBuffer internalNioBuffer(int index, int length) {
         checkIndex(index, length);
-        return (ByteBuffer) internalNioBuffer().clear().position(index).limit(index + length);
+        return (ByteBuffer) _internalNioBuffer().clear().position(index).limit(index + length);
     }
 
     @Override
@@ -535,7 +535,8 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
         return alloc().heapBuffer(length, maxCapacity()).writeBytes(array, index, length);
     }
 
-    private ByteBuffer internalNioBuffer() {
+    @Override
+    ByteBuffer _internalNioBuffer() {
         ByteBuffer tmpNioBuf = this.tmpNioBuf;
         if (tmpNioBuf == null) {
             this.tmpNioBuf = tmpNioBuf = ByteBuffer.wrap(array);

--- a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeDirectByteBuf.java
@@ -43,11 +43,6 @@ public class UnpooledUnsafeDirectByteBuf extends UnpooledDirectByteBuf {
         super(alloc, initialCapacity, maxCapacity);
     }
 
-    UnpooledUnsafeDirectByteBuf(ByteBufAllocator alloc, int initialCapacity, int maxCapacity,
-                                boolean allowSectionedInternalNioBufferAccess) {
-        super(alloc, initialCapacity, maxCapacity, allowSectionedInternalNioBufferAccess);
-    }
-
     /**
      * Creates a new direct buffer by wrapping the specified initial buffer.
      *

--- a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeNoCleanerDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeNoCleanerDirectByteBuf.java
@@ -21,9 +21,8 @@ import io.netty.util.internal.PlatformDependent;
 import java.nio.ByteBuffer;
 
 class UnpooledUnsafeNoCleanerDirectByteBuf extends UnpooledUnsafeDirectByteBuf {
-    UnpooledUnsafeNoCleanerDirectByteBuf(ByteBufAllocator alloc, int initialCapacity, int maxCapacity,
-                                         boolean allowSectionedInternalNioBufferAccess) {
-        super(alloc, initialCapacity, maxCapacity, allowSectionedInternalNioBufferAccess);
+    UnpooledUnsafeNoCleanerDirectByteBuf(ByteBufAllocator alloc, int initialCapacity, int maxCapacity) {
+        super(alloc, initialCapacity, maxCapacity);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/UnsafeByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/UnsafeByteBufUtil.java
@@ -689,14 +689,13 @@ final class UnsafeByteBufUtil {
     }
 
     static UnpooledUnsafeDirectByteBuf newUnsafeDirectByteBuf(
-            ByteBufAllocator alloc, int initialCapacity, int maxCapacity,
-            boolean allowSectionedInternalNioBufferAccess) {
+            ByteBufAllocator alloc, int initialCapacity, int maxCapacity) {
         if (PlatformDependent.useDirectBufferNoCleaner()) {
             return new UnpooledUnsafeNoCleanerDirectByteBuf(
-                    alloc, initialCapacity, maxCapacity, allowSectionedInternalNioBufferAccess);
+                    alloc, initialCapacity, maxCapacity);
         }
         return new UnpooledUnsafeDirectByteBuf(
-                alloc, initialCapacity, maxCapacity, allowSectionedInternalNioBufferAccess);
+                alloc, initialCapacity, maxCapacity);
     }
 
     private UnsafeByteBufUtil() { }

--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
@@ -2992,7 +2992,7 @@ public abstract class AbstractByteBufTest {
                     }
                     throw ex; // Propagate interrupted exceptions immediately.
                 } catch (ExecutionException ex) {
-                    if (e != null) {
+                    if (e == null) {
                         e = ex;
                     } else {
                         e.addSuppressed(ex);

--- a/buffer/src/test/java/io/netty/buffer/BigEndianUnsafeNoCleanerDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/BigEndianUnsafeNoCleanerDirectByteBufTest.java
@@ -31,6 +31,6 @@ public class BigEndianUnsafeNoCleanerDirectByteBufTest extends BigEndianDirectBy
 
     @Override
     protected ByteBuf newBuffer(int length, int maxCapacity) {
-        return new UnpooledUnsafeNoCleanerDirectByteBuf(UnpooledByteBufAllocator.DEFAULT, length, maxCapacity, true);
+        return new UnpooledUnsafeNoCleanerDirectByteBuf(UnpooledByteBufAllocator.DEFAULT, length, maxCapacity);
     }
 }

--- a/buffer/src/test/java/io/netty/buffer/LittleEndianUnsafeNoCleanerDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/LittleEndianUnsafeNoCleanerDirectByteBufTest.java
@@ -31,6 +31,6 @@ public class LittleEndianUnsafeNoCleanerDirectByteBufTest extends LittleEndianDi
 
     @Override
     protected ByteBuf newBuffer(int length, int maxCapacity) {
-        return new UnpooledUnsafeNoCleanerDirectByteBuf(UnpooledByteBufAllocator.DEFAULT, length, maxCapacity, true);
+        return new UnpooledUnsafeNoCleanerDirectByteBuf(UnpooledByteBufAllocator.DEFAULT, length, maxCapacity);
     }
 }

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -1064,6 +1064,17 @@ public final class PlatformDependent {
         }
     }
 
+    public static ByteBuffer absolutePut(ByteBuffer dst, int dstOffset, ByteBuffer src, int srcOffset, int length) {
+        if (PlatformDependent0.hasAbsolutePutMethod()) {
+            return PlatformDependent0.absolutePut(dst, dstOffset, src, srcOffset, length);
+        } else {
+            ByteBuffer a = (ByteBuffer) dst.duplicate().clear().position(dstOffset).limit(dstOffset + length);
+            ByteBuffer b = (ByteBuffer) src.duplicate().clear().position(srcOffset).limit(srcOffset + length);
+            a.put(b);
+            return dst;
+        }
+    }
+
     private static void incrementMemoryCounter(int capacity) {
         if (DIRECT_MEMORY_COUNTER != null) {
             long newUsedMemory = DIRECT_MEMORY_COUNTER.addAndGet(capacity);

--- a/microbench/src/main/java/io/netty/handler/codec/http2/Http2FrameWriterDataBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http2/Http2FrameWriterDataBenchmark.java
@@ -15,6 +15,7 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledByteBufAllocator;
@@ -76,7 +77,7 @@ public class Http2FrameWriterDataBenchmark extends AbstractMicrobenchmark {
     public void setup() {
         writer = new DefaultHttp2FrameWriter();
         oldWriter = new OldDefaultHttp2FrameWriter();
-        payload = pooled ? PooledByteBufAllocator.DEFAULT.buffer(payloadSize) : Unpooled.buffer(payloadSize);
+        payload = pooled ? ByteBufAllocator.DEFAULT.buffer(payloadSize) : Unpooled.buffer(payloadSize);
         payload.writeZero(payloadSize);
         ctx = new EmbeddedChannelWriteReleaseHandlerContext(
                 pooled ? PooledByteBufAllocator.DEFAULT : UnpooledByteBufAllocator.DEFAULT,

--- a/microbench/src/main/java/io/netty/microbench/buffer/ByteBufCopy2Benchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/ByteBufCopy2Benchmark.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.buffer;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.TearDown;
+
+public class ByteBufCopy2Benchmark extends AbstractMicrobenchmark {
+    static {
+        System.setProperty("io.netty.buffer.bytebuf.checkAccessible", "false");
+    }
+
+    @Param({
+            "7",
+            "36",
+            "128",
+            "512",
+    })
+    private int size;
+
+    @Param({
+            "true",
+            "false",
+    })
+    private boolean directByteBuf;
+
+    private ByteBuf buffer1;
+    private ByteBuf buffer2;
+
+    @Setup
+    public void setup() {
+        buffer1 = directByteBuf ?
+                ByteBufAllocator.DEFAULT.directBuffer(size, size) :
+                ByteBufAllocator.DEFAULT.heapBuffer(size, size);
+        buffer2 = directByteBuf ?
+                ByteBufAllocator.DEFAULT.directBuffer(size, size) :
+                ByteBufAllocator.DEFAULT.heapBuffer(size, size);
+        for (int i = 0; i < size; i++) {
+            buffer2.setByte(i, 0xA5);
+        }
+    }
+
+    @Benchmark
+    public ByteBuf setBytes() {
+        return buffer1.setBytes(0, buffer2, 0, size);
+    }
+
+    @TearDown
+    public void tearDown() {
+        buffer1.release();
+        buffer2.release();
+    }
+}

--- a/microbench/src/main/java/io/netty/microbench/buffer/ByteBufCopyBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/ByteBufCopyBenchmark.java
@@ -16,7 +16,7 @@
 package io.netty.microbench.buffer;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.microbench.util.AbstractMicrobenchmark;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -44,14 +44,18 @@ public class ByteBufCopyBenchmark extends AbstractMicrobenchmark {
             "true",
             "false",
     })
-    private boolean directByteBuff;
+    private boolean directByteBuf;
 
     @Param({
             "true",
             "false",
     })
     private boolean directByteBuffer;
-    @Param({"false", "true" })
+
+    @Param({
+            "false",
+            "true"
+    })
     private boolean readonlyByteBuffer;
 
     @Param({
@@ -90,11 +94,11 @@ public class ByteBufCopyBenchmark extends AbstractMicrobenchmark {
                 ByteBuffer.allocateDirect(requiredByteBufferSize) :
                 ByteBuffer.allocate(requiredByteBufferSize);
         if (pooledByteBuf) {
-            buffer = directByteBuff ?
-                    PooledByteBufAllocator.DEFAULT.directBuffer(requiredByteBufSize, requiredByteBufSize) :
-                    PooledByteBufAllocator.DEFAULT.heapBuffer(requiredByteBufSize, requiredByteBufSize);
+            buffer = directByteBuf ?
+                    ByteBufAllocator.DEFAULT.directBuffer(requiredByteBufSize, requiredByteBufSize) :
+                    ByteBufAllocator.DEFAULT.heapBuffer(requiredByteBufSize, requiredByteBufSize);
         } else {
-            buffer = directByteBuff ?
+            buffer = directByteBuf ?
                     Unpooled.directBuffer(requiredByteBufSize, requiredByteBufSize) :
                     Unpooled.buffer(requiredByteBufSize, requiredByteBufSize);
         }


### PR DESCRIPTION
Motivation:
The setBytes method was getting a sliced nioBuffer of its source, which typically causes allocation. On Java 16 onwards, we can instead copy using an absolutely offsetted `put` method, and forego allocating a duplicate ByteBuffer instance that is otherwise needed for isolating the position field.

Modification:
- Make use of the absolutely offsetted put method in setBytes, when its available.
- Use the underlying ByteBuffer of the shared chunk where possible to avoid multiple bounds checks.
- Add a benchmark targeting the setBytes method that takes a ByteBuf source.
- Change a few benchmarks to use the default allocator when pooling is enabled.

Result:
Faster setBytes in certain cases.