### PR TITLE
API: Change method signature to return void when promise is given

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicChannel.java
@@ -143,7 +143,9 @@ public interface QuicChannel extends Channel {
      * @return          the {@link Future} that will be notified once the operation completes.
      */
     default Future<QuicStreamChannel> createStream(QuicStreamType type, @Nullable ChannelHandler handler) {
-        return createStream(type, handler, executor().newPromise());
+        Promise<QuicStreamChannel> promise = executor().newPromise();
+        createStream(type, handler, promise);
+        return promise;
     }
 
     /**
@@ -151,14 +153,13 @@ public interface QuicChannel extends Channel {
      * The {@link ChannelHandler} (if not {@code null}) is added to the {@link io.netty.channel.ChannelPipeline} of the
      * {@link QuicStreamChannel} automatically.
      *
-     * @param type      the {@link QuicStreamType} of the {@link QuicStreamChannel}.
-     * @param handler   the {@link ChannelHandler} that will be added to the {@link QuicStreamChannel}s
-     *                  {@link io.netty.channel.ChannelPipeline} during the stream creation.
-     * @param promise   the {@link Promise} that will be notified once the operation completes.
-     * @return          the {@link Future} that will be notified once the operation completes.
+     * @param type    the {@link QuicStreamType} of the {@link QuicStreamChannel}.
+     * @param handler the {@link ChannelHandler} that will be added to the {@link QuicStreamChannel}s
+     *                {@link io.netty.channel.ChannelPipeline} during the stream creation.
+     * @param promise the {@link Promise} that will be notified once the operation completes.
      */
-    Future<QuicStreamChannel> createStream(QuicStreamType type, @Nullable ChannelHandler handler,
-                                           Promise<QuicStreamChannel> promise);
+    void createStream(QuicStreamType type, @Nullable ChannelHandler handler,
+                      Promise<QuicStreamChannel> promise);
 
     /**
      * Returns a new {@link QuicStreamChannelBootstrap} which makes it easy to bootstrap new {@link QuicStreamChannel}s
@@ -182,20 +183,21 @@ public interface QuicChannel extends Channel {
      * @return                  the future that is notified.
      */
     default Future<Void> close(boolean applicationClose, int error, ByteBuf reason) {
-        return close(applicationClose, error, reason, newPromise());
+        Promise<Void> promise = newPromise();
+        close(applicationClose, error, reason, promise);
+        return promise;
     }
 
     /**
      * Close the {@link QuicChannel}
      *
-     * @param applicationClose  {@code true} if an application close should be used,
-     *                          {@code false} if a normal close should be used.
-     * @param error             the application error number, or {@code 0} if no special error should be signaled.
-     * @param reason            the reason for the closure (which may be an empty {@link ByteBuf}.
-     * @param promise           the {@link Promise} that will be notified.
-     * @return                  the future that is notified.
+     * @param applicationClose {@code true} if an application close should be used,
+     *                         {@code false} if a normal close should be used.
+     * @param error            the application error number, or {@code 0} if no special error should be signaled.
+     * @param reason           the reason for the closure (which may be an empty {@link ByteBuf}.
+     * @param promise          the {@link Promise} that will be notified.
      */
-    Future<Void> close(boolean applicationClose, int error, ByteBuf reason, Promise<Void> promise);
+    void close(boolean applicationClose, int error, ByteBuf reason, Promise<Void> promise);
 
     /**
      * Collects statistics about the connection and notifies the {@link Future} once done.
@@ -203,16 +205,17 @@ public interface QuicChannel extends Channel {
      * @return the {@link Future} that is notified once the stats were collected.
      */
     default Future<QuicConnectionStats> collectStats() {
-        return collectStats(executor().newPromise());
+        Promise<QuicConnectionStats> promise = executor().newPromise();
+        collectStats(promise);
+        return promise;
     }
 
     /**
      * Collects statistics about the connection and notifies the {@link Promise} once done.
      *
-     * @param   promise the {@link Promise} that is notified once the stats were collected.
-     * @return          the {@link Future} that is notified once the stats were collected.
+     * @param promise the {@link Promise} that is notified once the stats were collected.
      */
-    Future<QuicConnectionStats> collectStats(Promise<QuicConnectionStats> promise);
+    void collectStats(Promise<QuicConnectionStats> promise);
 
     /**
      * Collects statistics about the path of the connection and notifies the {@link Future} once done.
@@ -220,16 +223,17 @@ public interface QuicChannel extends Channel {
      * @return the {@link Future} that is notified once the stats were collected.
      */
     default Future<QuicConnectionPathStats> collectPathStats(int pathIdx) {
-        return collectPathStats(pathIdx, executor().newPromise());
+        Promise<QuicConnectionPathStats> promise = executor().newPromise();
+        collectPathStats(pathIdx, promise);
+        return promise;
     }
 
     /**
      * Collects statistics about the path of the connection and notifies the {@link Promise} once done.
      *
-     * @param   promise the {@link Promise} that is notified once the stats were collected.
-     * @return          the {@link Future} that is notified once the stats were collected.
+     * @param promise the {@link Promise} that is notified once the stats were collected.
      */
-    Future<QuicConnectionPathStats> collectPathStats(int pathIdx, Promise<QuicConnectionPathStats> promise);
+    void collectPathStats(int pathIdx, Promise<QuicConnectionPathStats> promise);
 
     /**
      * Creates a new {@link QuicChannelBootstrap} that can be used to create and connect new {@link QuicChannel}s to

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicChannelBootstrap.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicChannelBootstrap.java
@@ -188,17 +188,17 @@ public final class QuicChannelBootstrap {
      * @return {@link Future} which is notified once the operation completes.
      */
     public Future<QuicChannel> connect() {
-        return connect(parent.executor().newPromise());
+        Promise<QuicChannel> promise = parent.executor().newPromise();
+        connect(promise);
+        return promise;
     }
 
     /**
      * Connects a {@link QuicChannel} to the remote peer and notifies the promise once done.
      *
-     * @param promise   the {@link Promise} which is notified once the operations completes.
-     * @return          {@link Future} which is notified once the operation completes.
-
+     * @param promise the {@link Promise} which is notified once the operations completes.
      */
-    public Future<QuicChannel> connect(Promise<QuicChannel> promise) {
+    public void connect(Promise<QuicChannel> promise) {
         if (handler == null && streamHandler == null) {
             throw new IllegalStateException("handler and streamHandler not set");
         }
@@ -239,6 +239,5 @@ public final class QuicChannelBootstrap {
                 });
             }
         });
-        return promise;
     }
 }

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicStreamChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicStreamChannel.java
@@ -83,18 +83,19 @@ public interface QuicStreamChannel extends Channel {
      * @return          future that is notified once the operation completes.
      */
     default Future<Void> updatePriority(QuicStreamPriority priority) {
-        return updatePriority(priority, newPromise());
+        Promise<Void> promise = newPromise();
+        updatePriority(priority, promise);
+        return promise;
     }
 
     /**
      * Update the priority of the stream. A stream's priority determines the order in which stream data is sent
      * on the wire (streams with lower priority are sent first).
      *
-     * @param priority  the priority.
-     * @param promise   notified once operations completes.
-     * @return          future that is notified once the operation completes.
+     * @param priority the priority.
+     * @param promise  notified once operations completes.
      */
-    Future<Void> updatePriority(QuicStreamPriority priority, Promise<Void> promise);
+    void updatePriority(QuicStreamPriority priority, Promise<Void> promise);
 
     @Override
     QuicChannel parent();

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicStreamChannelBootstrap.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicStreamChannelBootstrap.java
@@ -111,21 +111,22 @@ public final class QuicStreamChannelBootstrap {
      * @return  the {@link Future} that is notified once the operation completes.
      */
     public Future<QuicStreamChannel> create() {
-        return create(parent.executor().newPromise());
+        Promise<QuicStreamChannel> promise = parent.executor().newPromise();
+        create(promise);
+        return promise;
     }
 
     /**
      * Creates a new {@link QuicStreamChannel} and notifies the {@link Future}.
      *
-     * @param promise   the {@link Promise} that is notified once the operation completes.
-     * @return          the {@link Future} that is notified once the operation completes.
+     * @param promise the {@link Promise} that is notified once the operation completes.
      */
-    public Future<QuicStreamChannel> create(Promise<QuicStreamChannel> promise) {
+    public void create(Promise<QuicStreamChannel> promise) {
         if (handler == null) {
             throw new IllegalStateException("streamHandler not set");
         }
 
-        return parent.createStream(type, new QuicStreamChannelBootstrapHandler(handler,
+        parent.createStream(type, new QuicStreamChannelBootstrapHandler(handler,
                 Quic.toOptionsArray(options), Quic.toAttributesArray(attrs)), promise);
     }
 

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicChannel.java
@@ -457,24 +457,22 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     }
 
     @Override
-    public Future<QuicStreamChannel> createStream(QuicStreamType type, @Nullable ChannelHandler handler,
-                                                  Promise<QuicStreamChannel> promise) {
+    public void createStream(QuicStreamType type, @Nullable ChannelHandler handler,
+                             Promise<QuicStreamChannel> promise) {
         if (executor().inEventLoop()) {
             connectStream(type, handler, promise);
         } else {
             executor().execute(() -> connectStream(type, handler, promise));
         }
-        return promise;
     }
 
     @Override
-    public Future<Void> close(boolean applicationClose, int error, ByteBuf reason, Promise<Void> promise) {
+    public void close(boolean applicationClose, int error, ByteBuf reason, Promise<Void> promise) {
         if (executor().inEventLoop()) {
             close0(applicationClose, error, reason, promise);
         } else {
             executor().execute(() -> close0(applicationClose, error, reason, promise));
         }
-        return promise;
     }
 
     private void close0(boolean applicationClose, int error, ByteBuf reason, Promise<Void> promise) {
@@ -2032,13 +2030,12 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     }
 
     @Override
-    public Future<QuicConnectionStats> collectStats(Promise<QuicConnectionStats> promise) {
+    public void collectStats(Promise<QuicConnectionStats> promise) {
         if (executor().inEventLoop()) {
             collectStats0(promise);
         } else {
             executor().execute(() -> collectStats0(promise));
         }
-        return promise;
     }
 
     private void collectStats0(Promise<QuicConnectionStats> promise) {
@@ -2066,13 +2063,12 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     }
 
     @Override
-    public Future<QuicConnectionPathStats> collectPathStats(int pathIdx, Promise<QuicConnectionPathStats> promise) {
+    public void collectPathStats(int pathIdx, Promise<QuicConnectionPathStats> promise) {
         if (executor().inEventLoop()) {
             collectPathStats0(pathIdx, promise);
         } else {
             executor().execute(() -> collectPathStats0(pathIdx, promise));
         }
-        return promise;
     }
 
     private void collectPathStats0(int pathIdx, Promise<QuicConnectionPathStats> promise) {

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicStreamChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicStreamChannel.java
@@ -130,13 +130,12 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
     }
 
     @Override
-    public Future<Void> updatePriority(QuicStreamPriority priority, Promise<Void> promise) {
+    public void updatePriority(QuicStreamPriority priority, Promise<Void> promise) {
         if (executor().inEventLoop()) {
             updatePriority0(priority, promise);
         } else {
             executor().execute(() -> updatePriority0(priority, promise));
         }
-        return promise;
     }
 
     private void updatePriority0(QuicStreamPriority priority, Promise<Void> promise) {

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/BrotliEncoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/BrotliEncoder.java
@@ -24,7 +24,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToByteEncoder;
 import io.netty.util.AttributeKey;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.ObjectUtil;
 
@@ -155,7 +154,7 @@ public final class BrotliEncoder extends MessageToByteEncoder<ByteBuf> {
         finishEncode(ctx, ctx.newPromise());
     }
 
-    private Future<Void> finishEncode(ChannelHandlerContext ctx, Promise<Void> promise) {
+    private void finishEncode(ChannelHandlerContext ctx, Promise<Void> promise) {
         Writer writer;
 
         if (isSharable) {
@@ -168,13 +167,13 @@ public final class BrotliEncoder extends MessageToByteEncoder<ByteBuf> {
             writer.close();
             this.writer = null;
         }
-        return promise;
     }
 
     @Override
     public void close(final ChannelHandlerContext ctx, final Promise<Void> promise) {
-        Future<Void> f = finishEncode(ctx, ctx.newPromise());
-        EncoderUtil.closeAfterFinishEncode(ctx, f, promise);
+        Promise<Void> p = ctx.newPromise();
+        finishEncode(ctx, p);
+        EncoderUtil.closeAfterFinishEncode(ctx, p, promise);
     }
 
     /**

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/Bzip2Encoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/Bzip2Encoder.java
@@ -22,7 +22,6 @@ import io.netty.handler.codec.MessageToByteEncoder;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
-import io.netty.util.concurrent.PromiseNotifier;
 
 import static io.netty.handler.codec.compression.Bzip2Constants.BASE_BLOCK_SIZE;
 import static io.netty.handler.codec.compression.Bzip2Constants.END_OF_STREAM_MAGIC_1;
@@ -173,7 +172,9 @@ public class Bzip2Encoder extends MessageToByteEncoder<ByteBuf> {
      * The returned {@link Future} will be notified once the operation completes.
      */
     public Future<Void> close() {
-        return close(ctx().newPromise());
+        Promise<Void> promise = ctx().newPromise();
+        close(promise);
+        return promise;
     }
 
     /**
@@ -181,33 +182,32 @@ public class Bzip2Encoder extends MessageToByteEncoder<ByteBuf> {
      * The given {@link Future} will be notified once the operation
      * completes and will also be returned.
      */
-    public Future<Void> close(final Promise<Void> promise) {
+    public void close(final Promise<Void> promise) {
         ChannelHandlerContext ctx = ctx();
         EventExecutor executor = ctx.executor();
         if (executor.inEventLoop()) {
-            return finishEncode(ctx, promise);
+            finishEncode(ctx, promise);
         } else {
             executor.execute(new Runnable() {
                 @Override
                 public void run() {
-                    Future<Void> f = finishEncode(ctx(), promise);
-                    PromiseNotifier.cascade(f, promise);
+                    finishEncode(ctx(), promise);
                 }
             });
-            return promise;
         }
     }
 
     @Override
     public void close(final ChannelHandlerContext ctx, final Promise<Void> promise) {
-        Future<Void> f = finishEncode(ctx, ctx.newPromise());
-        EncoderUtil.closeAfterFinishEncode(ctx, f, promise);
+        Promise<Void> p = ctx().newPromise();
+        finishEncode(ctx, p);
+        EncoderUtil.closeAfterFinishEncode(ctx, p, promise);
     }
 
-    private Future<Void> finishEncode(final ChannelHandlerContext ctx, Promise<Void> promise) {
+    private void finishEncode(final ChannelHandlerContext ctx, Promise<Void> promise) {
         if (finished) {
             promise.setSuccess(null);
-            return promise;
+            return;
         }
         finished = true;
 
@@ -224,7 +224,7 @@ public class Bzip2Encoder extends MessageToByteEncoder<ByteBuf> {
         } finally {
             blockCompressor = null;
         }
-        return ctx.writeAndFlush(footer, promise);
+        ctx.writeAndFlush(footer, promise);
     }
 
     private ChannelHandlerContext ctx() {

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/JZlibEncoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/JZlibEncoder.java
@@ -23,7 +23,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
-import io.netty.util.concurrent.PromiseNotifier;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.ObjectUtil;
 
@@ -222,25 +221,24 @@ public class JZlibEncoder extends ZlibEncoder {
 
     @Override
     public Future<Void> close() {
-        return close(ctx().channel().newPromise());
+        Promise<Void> promise = ctx().channel().newPromise();
+        close(promise);
+        return promise;
     }
 
     @Override
-    public Future<Void> close(final Promise<Void> promise) {
+    public void close(final Promise<Void> promise) {
         ChannelHandlerContext ctx = ctx();
         EventExecutor executor = ctx.executor();
         if (executor.inEventLoop()) {
-            return finishEncode(ctx, promise);
+            finishEncode(ctx, promise);
         } else {
-            final Promise<Void> p = ctx.newPromise();
             executor.execute(new Runnable() {
                 @Override
                 public void run() {
-                    Future<Void> f = finishEncode(ctx(), p);
-                    PromiseNotifier.cascade(f, promise);
+                    finishEncode(ctx(), promise);
                 }
             });
-            return p;
         }
     }
 
@@ -322,9 +320,10 @@ public class JZlibEncoder extends ZlibEncoder {
     public void close(
             final ChannelHandlerContext ctx,
             final Promise<Void> promise) {
-        Future<Void> f = finishEncode(ctx, ctx.newPromise());
+        Promise<Void> p = ctx.newPromise();
+        finishEncode(ctx, p);
 
-        if (!f.isDone()) {
+        if (!p.isDone()) {
             // Ensure the channel is closed even if the write operation completes in time.
             final Future<?> future = ctx.executor().schedule(new Runnable() {
                 @Override
@@ -335,7 +334,7 @@ public class JZlibEncoder extends ZlibEncoder {
                 }
             }, THREAD_POOL_DELAY_SECONDS, TimeUnit.SECONDS);
 
-            f.addListener(f1 -> {
+            p.addListener(f1 -> {
                 // Cancel the scheduled timeout.
                 future.cancel(true);
                 if (!promise.isDone()) {
@@ -347,10 +346,10 @@ public class JZlibEncoder extends ZlibEncoder {
         }
     }
 
-    private Future<Void> finishEncode(ChannelHandlerContext ctx, Promise<Void> promise) {
+    private void finishEncode(ChannelHandlerContext ctx, Promise<Void> promise) {
         if (finished) {
             promise.setSuccess(null);
-            return promise;
+            return;
         }
         finished = true;
 
@@ -371,7 +370,7 @@ public class JZlibEncoder extends ZlibEncoder {
             int resultCode = z.deflate(JZlib.Z_FINISH);
             if (resultCode != JZlib.Z_OK && resultCode != JZlib.Z_STREAM_END) {
                 promise.setFailure(ZlibUtil.deflaterException(z, "compression failure", resultCode));
-                return promise;
+                return;
             } else if (z.next_out_index != 0) {
                 // Suppressed a warning above to be on the safe side
                 // even if z.next_out_index seems to be always 0 here
@@ -389,7 +388,7 @@ public class JZlibEncoder extends ZlibEncoder {
             z.next_in = null;
             z.next_out = null;
         }
-        return ctx.writeAndFlush(footer, promise);
+        ctx.writeAndFlush(footer, promise);
     }
 
     @Override

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
@@ -20,7 +20,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
-import io.netty.util.concurrent.PromiseNotifier;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.SystemPropertyUtil;
@@ -178,22 +177,21 @@ public class JdkZlibEncoder extends ZlibEncoder {
 
     @Override
     public Future<Void> close() {
-        return close(ctx().newPromise());
+        Promise<Void> promise = ctx().channel().newPromise();
+        close(promise);
+        return promise;
     }
 
     @Override
-    public Future<Void> close(final Promise<Void> promise) {
+    public void close(final Promise<Void> promise) {
         ChannelHandlerContext ctx = ctx();
         EventExecutor executor = ctx.executor();
         if (executor.inEventLoop()) {
-            return finishEncode(ctx, promise);
+            finishEncode(ctx, promise);
         } else {
-            final Promise<Void> p = ctx.newPromise();
             executor.execute(() -> {
-                Future<Void> f = finishEncode(ctx(), p);
-                PromiseNotifier.cascade(f, promise);
+                finishEncode(ctx(), promise);
             });
-            return p;
         }
     }
 
@@ -301,14 +299,15 @@ public class JdkZlibEncoder extends ZlibEncoder {
 
     @Override
     public void close(final ChannelHandlerContext ctx, final Promise<Void> promise) {
-        Future<Void> f = finishEncode(ctx, ctx.newPromise());
-        EncoderUtil.closeAfterFinishEncode(ctx, f, promise);
+        Promise<Void> p = ctx().newPromise();
+        finishEncode(ctx, p);
+        EncoderUtil.closeAfterFinishEncode(ctx, p, promise);
     }
 
-    private Future<Void> finishEncode(final ChannelHandlerContext ctx, Promise<Void> promise) {
+    private void finishEncode(final ChannelHandlerContext ctx, Promise<Void> promise) {
         if (finished) {
             promise.setSuccess(null);
-            return promise;
+            return;
         }
 
         finished = true;
@@ -336,7 +335,7 @@ public class JdkZlibEncoder extends ZlibEncoder {
             footer.writeIntLE(uncBytes);
         }
         deflater.end();
-        return ctx.writeAndFlush(footer, promise);
+        ctx.writeAndFlush(footer, promise);
     }
 
     private void deflate(ByteBuf out) {

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/Lz4FrameEncoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/Lz4FrameEncoder.java
@@ -25,7 +25,6 @@ import io.netty.handler.codec.MessageToByteEncoder;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
-import io.netty.util.concurrent.PromiseNotifier;
 import io.netty.util.internal.ObjectUtil;
 import net.jpountz.lz4.LZ4Compressor;
 import net.jpountz.lz4.LZ4Exception;
@@ -303,10 +302,10 @@ public class Lz4FrameEncoder extends MessageToByteEncoder<ByteBuf> {
         ctx.flush();
     }
 
-    private Future<Void> finishEncode(final ChannelHandlerContext ctx, Promise<Void> promise) {
+    private void finishEncode(final ChannelHandlerContext ctx, Promise<Void> promise) {
         if (finished) {
             promise.setSuccess(null);
-            return promise;
+            return;
         }
         finished = true;
 
@@ -324,7 +323,7 @@ public class Lz4FrameEncoder extends MessageToByteEncoder<ByteBuf> {
 
         footer.writerIndex(idx + HEADER_LENGTH);
 
-        return ctx.writeAndFlush(footer, promise);
+        ctx.writeAndFlush(footer, promise);
     }
 
     /**
@@ -340,7 +339,9 @@ public class Lz4FrameEncoder extends MessageToByteEncoder<ByteBuf> {
      * The returned {@link Future} will be notified once the operation completes.
      */
     public Future<Void> close() {
-        return close(ctx().newPromise());
+        Promise<Void> promise = ctx.newPromise();
+        close(promise);
+        return promise;
     }
 
     /**
@@ -348,28 +349,27 @@ public class Lz4FrameEncoder extends MessageToByteEncoder<ByteBuf> {
      * The given {@link Promise} will be notified once the operation
      * completes and will also be returned.
      */
-    public Future<Void> close(final Promise<Void> promise) {
+    public void close(final Promise<Void> promise) {
         ChannelHandlerContext ctx = ctx();
         EventExecutor executor = ctx.executor();
         if (executor.inEventLoop()) {
-            return finishEncode(ctx, promise);
+            finishEncode(ctx, promise);
         } else {
             executor.execute(new Runnable() {
                 @Override
                 public void run() {
-                    Future<Void> f = finishEncode(ctx(), promise);
-                    PromiseNotifier.cascade(f, promise);
+                    finishEncode(ctx(), promise);
                 }
             });
-            return promise;
         }
     }
 
     @Override
     public void close(final ChannelHandlerContext ctx, final Promise<Void> promise) {
-        Future<Void> f = finishEncode(ctx, ctx.newPromise());
+        Promise<Void> p = ctx.newPromise();
+        finishEncode(ctx, p);
 
-        EncoderUtil.closeAfterFinishEncode(ctx, f, promise);
+        EncoderUtil.closeAfterFinishEncode(ctx, p, promise);
     }
 
     private ChannelHandlerContext ctx() {

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/ZlibEncoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/ZlibEncoder.java
@@ -48,6 +48,6 @@ public abstract class ZlibEncoder extends MessageToByteEncoder<ByteBuf> {
      * The given {@link Promise} will be notified once the operation
      * completes and will also be returned.
      */
-    public abstract Future<Void> close(Promise<Void> promise);
+    public abstract void close(Promise<Void> promise);
 
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker.java
@@ -273,18 +273,18 @@ public abstract class WebSocketClientHandshaker {
      */
     public Future<Void> handshake(Channel channel) {
         ObjectUtil.checkNotNull(channel, "channel");
-        return handshake(channel, channel.newPromise());
+        Promise<Void> promise = channel.newPromise();
+        handshake(channel, promise);
+        return promise;
     }
 
     /**
      * Begins the opening handshake
      *
-     * @param channel
-     *            Channel
-     * @param promise
-     *            the {@link Promise} to be notified when the opening handshake is sent
+     * @param channel Channel
+     * @param promise the {@link Promise} to be notified when the opening handshake is sent
      */
-    public final Future<Void> handshake(Channel channel, final Promise<Void> promise) {
+    public final void handshake(Channel channel, final Promise<Void> promise) {
         final ChannelPipeline pipeline = channel.pipeline();
         HttpResponseDecoder decoder = pipeline.get(HttpResponseDecoder.class);
         if (decoder == null) {
@@ -292,7 +292,7 @@ public abstract class WebSocketClientHandshaker {
             if (codec == null) {
                promise.setFailure(new IllegalStateException("ChannelPipeline does not contain " +
                        "an HttpResponseDecoder or HttpClientCodec"));
-               return promise;
+               return;
             }
         }
 
@@ -300,7 +300,7 @@ public abstract class WebSocketClientHandshaker {
             if (customHeaders == null || !customHeaders.contains(HttpHeaderNames.HOST)) {
                 promise.setFailure(new IllegalArgumentException("Cannot generate the 'host' header value," +
                         " webSocketURI should contain host or passed through customHeaders"));
-                return promise;
+                return;
             }
 
             if (generateOriginHeader && !customHeaders.contains(HttpHeaderNames.ORIGIN)) {
@@ -314,7 +314,7 @@ public abstract class WebSocketClientHandshaker {
                 promise.setFailure(new IllegalArgumentException("Cannot generate the '" + originName + "' header" +
                         " value, webSocketURI should contain host or disable generateOriginHeader or pass value" +
                         " through customHeaders"));
-                return promise;
+                return;
             }
         }
 
@@ -338,7 +338,6 @@ public abstract class WebSocketClientHandshaker {
                 promise.setFailure(future.cause());
             }
         });
-        return promise;
     }
 
     /**
@@ -453,23 +452,20 @@ public abstract class WebSocketClientHandshaker {
      *            the {@link Future} which is notified once the handshake completes.
      */
     public final Future<Void> processHandshake(final Channel channel, HttpResponse response) {
-        return processHandshake(channel, response, channel.newPromise());
+        Promise<Void> promise = channel.newPromise();
+        processHandshake(channel, response, promise);
+        return promise;
     }
 
     /**
      * Process the opening handshake initiated by {@link #handshake}}.
      *
-     * @param channel
-     *            Channel
-     * @param response
-     *            HTTP response containing the closing handshake details
-     * @param promise
-     *            the {@link Promise} to notify once the handshake completes.
-     * @return future
-     *            the {@link Future} which is notified once the handshake completes.
+     * @param channel  Channel
+     * @param response HTTP response containing the closing handshake details
+     * @param promise  the {@link Promise} to notify once the handshake completes.
      */
-    public final Future<Void> processHandshake(final Channel channel, HttpResponse response,
-                                                final Promise<Void> promise) {
+    public final void processHandshake(final Channel channel, HttpResponse response,
+                                       final Promise<Void> promise) {
         if (response instanceof FullHttpResponse) {
             try {
                 finishHandshake(channel, (FullHttpResponse) response);
@@ -483,8 +479,9 @@ public abstract class WebSocketClientHandshaker {
             if (ctx == null) {
                 ctx = p.context(HttpClientCodec.class);
                 if (ctx == null) {
-                    return promise.setFailure(new IllegalStateException("ChannelPipeline does not contain " +
+                    promise.setFailure(new IllegalStateException("ChannelPipeline does not contain " +
                             "an HttpResponseDecoder or HttpClientCodec"));
+                    return;
                 }
             }
 
@@ -592,7 +589,6 @@ public abstract class WebSocketClientHandshaker {
                 promise.setFailure(cause);
             }
         }
-        return promise;
     }
 
     /**
@@ -623,25 +619,24 @@ public abstract class WebSocketClientHandshaker {
      */
     public Future<Void> close(Channel channel, CloseWebSocketFrame frame) {
         ObjectUtil.checkNotNull(channel, "channel");
-        return close(channel, frame, channel.newPromise());
+        Promise<Void> promise = channel.newPromise();
+        close(channel, frame, promise);
+        return promise;
     }
 
     /**
      * Performs the closing handshake
-     *
+     * <p>
      * When called from within a {@link ChannelHandler} you most likely want to use
      * {@link #close(ChannelHandlerContext, CloseWebSocketFrame, Promise)}.
      *
-     * @param channel
-     *            Channel
-     * @param frame
-     *            Closing Frame that was received
-     * @param promise
-     *            the {@link Promise} to be notified when the closing handshake is done
+     * @param channel Channel
+     * @param frame   Closing Frame that was received
+     * @param promise the {@link Promise} to be notified when the closing handshake is done
      */
-    public Future<Void> close(Channel channel, CloseWebSocketFrame frame, Promise<Void> promise) {
+    public void close(Channel channel, CloseWebSocketFrame frame, Promise<Void> promise) {
         ObjectUtil.checkNotNull(channel, "channel");
-        return close0(channel, channel, frame, promise);
+        close0(channel, channel, frame, promise);
     }
 
     /**
@@ -654,31 +649,30 @@ public abstract class WebSocketClientHandshaker {
      */
     public Future<Void> close(ChannelHandlerContext ctx, CloseWebSocketFrame frame) {
         ObjectUtil.checkNotNull(ctx, "ctx");
-        return close(ctx, frame, ctx.newPromise());
+        Promise<Void> promise = ctx.newPromise();
+        close(ctx, frame, promise);
+        return promise;
     }
 
     /**
      * Performs the closing handshake
      *
-     * @param ctx
-     *            the {@link ChannelHandlerContext} to use.
-     * @param frame
-     *            Closing Frame that was received
-     * @param promise
-     *            the {@link Promise} to be notified when the closing handshake is done
+     * @param ctx     the {@link ChannelHandlerContext} to use.
+     * @param frame   Closing Frame that was received
+     * @param promise the {@link Promise} to be notified when the closing handshake is done
      */
-    public Future<Void> close(ChannelHandlerContext ctx, CloseWebSocketFrame frame, Promise<Void> promise) {
+    public void close(ChannelHandlerContext ctx, CloseWebSocketFrame frame, Promise<Void> promise) {
         ObjectUtil.checkNotNull(ctx, "ctx");
-        return close0(ctx, ctx.channel(), frame, promise);
+        close0(ctx, ctx.channel(), frame, promise);
     }
 
-    private Future<Void> close0(final ChannelOutboundInvoker invoker, final Channel channel,
-                                 CloseWebSocketFrame frame, Promise<Void> promise) {
+    private void close0(final ChannelOutboundInvoker invoker, final Channel channel,
+                        CloseWebSocketFrame frame, Promise<Void> promise) {
         invoker.writeAndFlush(frame, promise);
         final long forceCloseTimeoutMillis = this.forceCloseTimeoutMillis;
         final WebSocketClientHandshaker handshaker = this;
         if (forceCloseTimeoutMillis <= 0 || !channel.isActive() || forceCloseInit != 0) {
-            return promise;
+            return;
         }
 
         promise.addListener(future -> {
@@ -701,7 +695,6 @@ public abstract class WebSocketClientHandshaker {
                 channel.closeFuture().addListener(f -> forceCloseFuture.cancel(false));
             }
         });
-        return promise;
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
@@ -456,7 +456,9 @@ public abstract class WebSocketServerHandshaker {
     }
 
     private Future<Void> close0(ChannelOutboundInvoker invoker, CloseWebSocketFrame frame, Promise<Void> promise) {
-        return invoker.writeAndFlush(frame, promise).addListener(f -> invoker.close());
+        invoker.writeAndFlush(frame, promise);
+        promise.addListener(f -> invoker.close());
+        return promise;
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker00.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker00.java
@@ -214,7 +214,8 @@ public class WebSocketServerHandshaker00 extends WebSocketServerHandshaker {
      */
     @Override
     public Future<Void> close(Channel channel, CloseWebSocketFrame frame, Promise<Void> promise) {
-        return channel.writeAndFlush(frame, promise);
+        channel.writeAndFlush(frame, promise);
+        return promise;
     }
 
     /**
@@ -230,7 +231,8 @@ public class WebSocketServerHandshaker00 extends WebSocketServerHandshaker {
     @Override
     public Future<Void> close(ChannelHandlerContext ctx, CloseWebSocketFrame frame,
                                Promise<Void> promise) {
-        return ctx.writeAndFlush(frame, promise);
+        ctx.writeAndFlush(frame, promise);
+        return promise;
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshakerFactory.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshakerFactory.java
@@ -206,6 +206,7 @@ public class WebSocketServerHandshakerFactory {
                 HttpResponseStatus.UPGRADE_REQUIRED, channel.alloc().buffer(0));
         res.headers().set(HttpHeaderNames.SEC_WEBSOCKET_VERSION, WebSocketVersion.V13.toHttpHeaderValue());
         HttpUtil.setContentLength(res, 0);
-        return channel.writeAndFlush(res, promise);
+        channel.writeAndFlush(res, promise);
+        return promise;
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySessionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySessionHandler.java
@@ -788,6 +788,7 @@ public class SpdySessionHandler implements ChannelInboundHandler, ChannelOutboun
                     halfCloseStream(writeStreamId, false, pendingWrite.promise);
                 }
 
+                ctx.writeAndFlush(spdyDataFrame, pendingWrite.promise);
                 // The transfer window size is pre-decremented when sending a data frame downstream.
                 // Close the session on write failures that leave the transfer window in a corrupt state.
                 pendingWrite.promise.addListener(future -> {
@@ -795,7 +796,6 @@ public class SpdySessionHandler implements ChannelInboundHandler, ChannelOutboun
                         issueSessionError(ctx, SpdySessionStatus.INTERNAL_ERROR);
                     }
                 });
-                ctx.writeAndFlush(spdyDataFrame, pendingWrite.promise);
             }
         }
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySessionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySessionHandler.java
@@ -790,11 +790,12 @@ public class SpdySessionHandler implements ChannelInboundHandler, ChannelOutboun
 
                 // The transfer window size is pre-decremented when sending a data frame downstream.
                 // Close the session on write failures that leave the transfer window in a corrupt state.
-                ctx.writeAndFlush(spdyDataFrame, pendingWrite.promise).addListener(future -> {
+                pendingWrite.promise.addListener(future -> {
                     if (!future.isSuccess()) {
                         issueSessionError(ctx, SpdySessionStatus.INTERNAL_ERROR);
                     }
                 });
+                ctx.writeAndFlush(spdyDataFrame, pendingWrite.promise);
             }
         }
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
@@ -500,33 +500,33 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
     }
 
     @Override
-    public Future<Void> bind(SocketAddress localAddress, Promise<Void> promise) {
-        return pipeline().bind(localAddress, promise);
+    public void bind(SocketAddress localAddress, Promise<Void> promise) {
+        pipeline().bind(localAddress, promise);
     }
 
     @Override
-    public Future<Void> connect(SocketAddress remoteAddress, Promise<Void> promise) {
-        return pipeline().connect(remoteAddress, promise);
+    public void connect(SocketAddress remoteAddress, Promise<Void> promise) {
+        pipeline().connect(remoteAddress, promise);
     }
 
     @Override
-    public Future<Void> connect(SocketAddress remoteAddress, SocketAddress localAddress, Promise<Void> promise) {
-        return pipeline().connect(remoteAddress, localAddress, promise);
+    public void connect(SocketAddress remoteAddress, SocketAddress localAddress, Promise<Void> promise) {
+        pipeline().connect(remoteAddress, localAddress, promise);
     }
 
     @Override
-    public Future<Void> disconnect(Promise<Void> promise) {
-        return pipeline().disconnect(promise);
+    public void disconnect(Promise<Void> promise) {
+        pipeline().disconnect(promise);
     }
 
     @Override
-    public Future<Void> close(Promise<Void> promise) {
-        return pipeline().close(promise);
+    public void close(Promise<Void> promise) {
+        pipeline().close(promise);
     }
 
     @Override
-    public Future<Void> deregister(Promise<Void> promise) {
-        return pipeline().deregister(promise);
+    public void deregister(Promise<Void> promise) {
+        pipeline().deregister(promise);
     }
 
     @Override
@@ -535,13 +535,13 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
     }
 
     @Override
-    public Future<Void> write(Object msg, Promise<Void> promise) {
-        return pipeline().write(msg, promise);
+    public void write(Object msg, Promise<Void> promise) {
+        pipeline().write(msg, promise);
     }
 
     @Override
-    public Future<Void> writeAndFlush(Object msg, Promise<Void> promise) {
-        return pipeline().writeAndFlush(msg, promise);
+    public void writeAndFlush(Object msg, Promise<Void> promise) {
+        pipeline().writeAndFlush(msg, promise);
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
@@ -34,7 +34,6 @@ import io.netty.handler.codec.compression.ZstdEncoder;
 import io.netty.handler.codec.compression.ZstdOptions;
 import io.netty.handler.codec.compression.SnappyFrameEncoder;
 import io.netty.handler.codec.compression.SnappyOptions;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.PromiseCombiner;
 import io.netty.util.internal.ObjectUtil;
@@ -171,13 +170,14 @@ public class CompressorHttp2ConnectionEncoder extends DecoratingHttp2ConnectionE
     }
 
     @Override
-    public Future<Void> writeData(final ChannelHandlerContext ctx, final int streamId, ByteBuf data, int padding,
-                                  final boolean endOfStream, Promise<Void> promise) {
+    public void writeData(final ChannelHandlerContext ctx, final int streamId, ByteBuf data, int padding,
+                          final boolean endOfStream, Promise<Void> promise) {
         final Http2Stream stream = connection().stream(streamId);
         final EmbeddedChannel channel = stream == null ? null : (EmbeddedChannel) stream.getProperty(propertyKey);
         if (channel == null) {
             // The compressor may be null if no compatible encoding type was found in this stream's headers
-            return super.writeData(ctx, streamId, data, padding, endOfStream, promise);
+            super.writeData(ctx, streamId, data, padding, endOfStream, promise);
+            return;
         }
 
         try {
@@ -189,12 +189,13 @@ public class CompressorHttp2ConnectionEncoder extends DecoratingHttp2ConnectionE
                     if (channel.finish()) {
                         buf = nextReadableBuf(channel);
                     }
-                    return super.writeData(ctx, streamId, buf == null ? Unpooled.EMPTY_BUFFER : buf, padding,
+                    super.writeData(ctx, streamId, buf == null ? Unpooled.EMPTY_BUFFER : buf, padding,
                             true, promise);
+                } else {
+                    // END_STREAM is not set and the assumption is data is still forthcoming.
+                    promise.setSuccess(null);
                 }
-                // END_STREAM is not set and the assumption is data is still forthcoming.
-                promise.setSuccess(null);
-                return promise;
+                return;
             }
 
             PromiseCombiner combiner = new PromiseCombiner(ctx.executor());
@@ -224,49 +225,42 @@ public class CompressorHttp2ConnectionEncoder extends DecoratingHttp2ConnectionE
                 cleanup(stream, channel);
             }
         }
-        return promise;
     }
 
     @Override
-    public Future<Void> writeHeaders(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int padding,
-            boolean endStream, Promise<Void> promise) {
+    public void writeHeaders(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int padding,
+                             boolean endStream, Promise<Void> promise) {
         try {
             // Determine if compression is required and sanitize the headers.
             EmbeddedChannel compressor = newCompressor(ctx, headers, endStream);
 
             // Write the headers and create the stream object.
-            Future<Void> future = super.writeHeaders(ctx, streamId, headers, padding, endStream, promise);
+            super.writeHeaders(ctx, streamId, headers, padding, endStream, promise);
 
             // After the stream object has been created, then attach the compressor as a property for data compression.
             bindCompressorToStream(compressor, streamId);
-
-            return future;
         } catch (Throwable e) {
             promise.tryFailure(e);
         }
-        return promise;
     }
 
     @Override
-    public Future<Void> writeHeaders(final ChannelHandlerContext ctx, final int streamId, final Http2Headers headers,
-            final int streamDependency, final short weight, final boolean exclusive, final int padding,
-            final boolean endOfStream, final Promise<Void> promise) {
+    public void writeHeaders(final ChannelHandlerContext ctx, final int streamId, final Http2Headers headers,
+                             final int streamDependency, final short weight, final boolean exclusive, final int padding,
+                             final boolean endOfStream, final Promise<Void> promise) {
         try {
             // Determine if compression is required and sanitize the headers.
             EmbeddedChannel compressor = newCompressor(ctx, headers, endOfStream);
 
             // Write the headers and create the stream object.
-            Future<Void> future = super.writeHeaders(ctx, streamId, headers, streamDependency, weight, exclusive,
+            super.writeHeaders(ctx, streamId, headers, streamDependency, weight, exclusive,
                                                       padding, endOfStream, promise);
 
             // After the stream object has been created, then attach the compressor as a property for data compression.
             bindCompressorToStream(compressor, streamId);
-
-            return future;
         } catch (Throwable e) {
             promise.tryFailure(e);
         }
-        return promise;
     }
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DecoratingHttp2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DecoratingHttp2FrameWriter.java
@@ -16,7 +16,6 @@ package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
@@ -32,74 +31,73 @@ public class DecoratingHttp2FrameWriter implements Http2FrameWriter {
     }
 
     @Override
-    public Future<Void> writeData(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
-                                  boolean endStream, Promise<Void> promise) {
-        return delegate.writeData(ctx, streamId, data, padding, endStream, promise);
+    public void writeData(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
+                          boolean endStream, Promise<Void> promise) {
+        delegate.writeData(ctx, streamId, data, padding, endStream, promise);
     }
 
     @Override
-    public Future<Void> writeHeaders(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int padding,
-                                      boolean endStream, Promise<Void> promise) {
-        return delegate.writeHeaders(ctx, streamId, headers, padding, endStream, promise);
+    public void writeHeaders(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int padding,
+                             boolean endStream, Promise<Void> promise) {
+        delegate.writeHeaders(ctx, streamId, headers, padding, endStream, promise);
     }
 
     @Override
-    public Future<Void> writeHeaders(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
-                                      int streamDependency, short weight, boolean exclusive, int padding,
-                                      boolean endStream, Promise<Void> promise) {
-        return delegate
-                .writeHeaders(ctx, streamId, headers, streamDependency, weight, exclusive, padding, endStream, promise);
+    public void writeHeaders(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
+                             int streamDependency, short weight, boolean exclusive, int padding,
+                             boolean endStream, Promise<Void> promise) {
+        delegate.writeHeaders(ctx, streamId, headers, streamDependency, weight, exclusive, padding, endStream, promise);
     }
 
     @Override
-    public Future<Void> writePriority(ChannelHandlerContext ctx, int streamId, int streamDependency, short weight,
-                                       boolean exclusive, Promise<Void> promise) {
-        return delegate.writePriority(ctx, streamId, streamDependency, weight, exclusive, promise);
+    public void writePriority(ChannelHandlerContext ctx, int streamId, int streamDependency, short weight,
+                              boolean exclusive, Promise<Void> promise) {
+        delegate.writePriority(ctx, streamId, streamDependency, weight, exclusive, promise);
     }
 
     @Override
-    public Future<Void> writeRstStream(ChannelHandlerContext ctx, int streamId, long errorCode,
-                                        Promise<Void> promise) {
-        return delegate.writeRstStream(ctx, streamId, errorCode, promise);
+    public void writeRstStream(ChannelHandlerContext ctx, int streamId, long errorCode,
+                               Promise<Void> promise) {
+        delegate.writeRstStream(ctx, streamId, errorCode, promise);
     }
 
     @Override
-    public Future<Void> writeSettings(ChannelHandlerContext ctx, Http2Settings settings, Promise<Void> promise) {
-        return delegate.writeSettings(ctx, settings, promise);
+    public void writeSettings(ChannelHandlerContext ctx, Http2Settings settings, Promise<Void> promise) {
+        delegate.writeSettings(ctx, settings, promise);
     }
 
     @Override
-    public Future<Void> writeSettingsAck(ChannelHandlerContext ctx, Promise<Void> promise) {
-        return delegate.writeSettingsAck(ctx, promise);
+    public void writeSettingsAck(ChannelHandlerContext ctx, Promise<Void> promise) {
+        delegate.writeSettingsAck(ctx, promise);
     }
 
     @Override
-    public Future<Void> writePing(ChannelHandlerContext ctx, boolean ack, long data, Promise<Void> promise) {
-        return delegate.writePing(ctx, ack, data, promise);
+    public void writePing(ChannelHandlerContext ctx, boolean ack, long data, Promise<Void> promise) {
+        delegate.writePing(ctx, ack, data, promise);
     }
 
     @Override
-    public Future<Void> writePushPromise(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
-                                          Http2Headers headers, int padding, Promise<Void> promise) {
-        return delegate.writePushPromise(ctx, streamId, promisedStreamId, headers, padding, promise);
+    public void writePushPromise(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
+                                 Http2Headers headers, int padding, Promise<Void> promise) {
+        delegate.writePushPromise(ctx, streamId, promisedStreamId, headers, padding, promise);
     }
 
     @Override
-    public Future<Void> writeGoAway(ChannelHandlerContext ctx, int lastStreamId, long errorCode, ByteBuf debugData,
-                                     Promise<Void> promise) {
-        return delegate.writeGoAway(ctx, lastStreamId, errorCode, debugData, promise);
+    public void writeGoAway(ChannelHandlerContext ctx, int lastStreamId, long errorCode, ByteBuf debugData,
+                            Promise<Void> promise) {
+        delegate.writeGoAway(ctx, lastStreamId, errorCode, debugData, promise);
     }
 
     @Override
-    public Future<Void> writeWindowUpdate(ChannelHandlerContext ctx, int streamId, int windowSizeIncrement,
-                                           Promise<Void> promise) {
-        return delegate.writeWindowUpdate(ctx, streamId, windowSizeIncrement, promise);
+    public void writeWindowUpdate(ChannelHandlerContext ctx, int streamId, int windowSizeIncrement,
+                                  Promise<Void> promise) {
+        delegate.writeWindowUpdate(ctx, streamId, windowSizeIncrement, promise);
     }
 
     @Override
-    public Future<Void> writeFrame(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags,
-                                    ByteBuf payload, Promise<Void> promise) {
-        return delegate.writeFrame(ctx, frameType, streamId, flags, payload, promise);
+    public void writeFrame(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags,
+                           ByteBuf payload, Promise<Void> promise) {
+        delegate.writeFrame(ctx, frameType, streamId, flags, payload, promise);
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
@@ -117,8 +117,8 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder, Ht
     }
 
     @Override
-    public Future<Void> writeData(final ChannelHandlerContext ctx, final int streamId, ByteBuf data, int padding,
-            final boolean endOfStream, Promise<Void> promise) {
+    public void writeData(final ChannelHandlerContext ctx, final int streamId, ByteBuf data, int padding,
+                          final boolean endOfStream, Promise<Void> promise) {
         final Http2Stream stream;
         try {
             stream = requireStream(streamId);
@@ -134,19 +134,19 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder, Ht
             }
         } catch (Throwable e) {
             data.release();
-            return promise.setFailure(e);
+            promise.setFailure(e);
+            return;
         }
 
         // Hand control of the frame to the flow controller.
         flowController().addFlowControlled(stream,
                 new FlowControlledData(ctx.channel(), stream, data, padding, endOfStream, promise));
-        return promise;
     }
 
     @Override
-    public Future<Void> writeHeaders(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int padding,
-            boolean endStream, Promise<Void> promise) {
-        return writeHeaders0(ctx, streamId, headers, false, 0, (short) 0, false, padding, endStream, promise);
+    public void writeHeaders(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int padding,
+                             boolean endStream, Promise<Void> promise) {
+        writeHeaders0(ctx, streamId, headers, false, 0, (short) 0, false, padding, endStream, promise);
     }
 
     private static boolean validateHeadersSentState(Http2Stream stream, Http2Headers headers, boolean isServer,
@@ -159,30 +159,31 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder, Ht
     }
 
     @Override
-    public Future<Void> writeHeaders(final ChannelHandlerContext ctx, final int streamId,
-            final Http2Headers headers, final int streamDependency, final short weight,
-            final boolean exclusive, final int padding, final boolean endOfStream, Promise<Void> promise) {
-        return writeHeaders0(ctx, streamId, headers, true, streamDependency,
-                weight, exclusive, padding, endOfStream, promise);
+    public void writeHeaders(final ChannelHandlerContext ctx, final int streamId,
+                             final Http2Headers headers, final int streamDependency, final short weight,
+                             final boolean exclusive, final int padding, final boolean endOfStream,
+                             Promise<Void> promise) {
+        writeHeaders0(ctx, streamId, headers, true, streamDependency, weight, exclusive, padding, endOfStream, promise);
     }
 
     /**
      * Write headers via {@link Http2FrameWriter}. If {@code hasPriority} is {@code false} it will ignore the
      * {@code streamDependency}, {@code weight} and {@code exclusive} parameters.
      */
-    private static Future<Void> sendHeaders(Http2FrameWriter frameWriter, ChannelHandlerContext ctx, int streamId,
+    private static void sendHeaders(Http2FrameWriter frameWriter, ChannelHandlerContext ctx, int streamId,
                                        Http2Headers headers, final boolean hasPriority,
                                        int streamDependency, final short weight,
                                        boolean exclusive, final int padding,
                                        boolean endOfStream, Promise<Void> promise) {
         if (hasPriority) {
-            return frameWriter.writeHeaders(ctx, streamId, headers, streamDependency,
+            frameWriter.writeHeaders(ctx, streamId, headers, streamDependency,
                     weight, exclusive, padding, endOfStream, promise);
+        } else {
+            frameWriter.writeHeaders(ctx, streamId, headers, padding, endOfStream, promise);
         }
-        return frameWriter.writeHeaders(ctx, streamId, headers, padding, endOfStream, promise);
     }
 
-    private Future<Void> writeHeaders0(final ChannelHandlerContext ctx, final int streamId,
+    private void writeHeaders0(final ChannelHandlerContext ctx, final int streamId,
                                         final Http2Headers headers, final boolean hasPriority,
                                         final int streamDependency, final short weight,
                                         final boolean exclusive, final int padding,
@@ -200,7 +201,7 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder, Ht
                 } catch (Http2Exception cause) {
                     if (connection.remote().mayHaveCreatedStream(streamId)) {
                         promise.tryFailure(new IllegalStateException("Stream no longer exists: " + streamId, cause));
-                        return promise;
+                        return;
                     }
                     throw cause;
                 }
@@ -227,11 +228,11 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder, Ht
 
                 boolean isInformational = validateHeadersSentState(stream, headers, connection.isServer(), endOfStream);
 
-                Future<Void> future = sendHeaders(frameWriter, ctx, streamId, headers, hasPriority, streamDependency,
+                sendHeaders(frameWriter, ctx, streamId, headers, hasPriority, streamDependency,
                         weight, exclusive, padding, endOfStream, promise);
 
                 // Writing headers may fail during the encode state if they violate HPACK limits.
-                Throwable failureCause = future.cause();
+                Throwable failureCause = promise.cause();
                 if (failureCause == null) {
                     // Synchronously set the headersSent flag to ensure that we do not subsequently write
                     // other headers containing pseudo-header fields.
@@ -240,9 +241,9 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder, Ht
                     // necessarily mean the write will complete successfully.
                     stream.headersSent(isInformational);
 
-                    if (!future.isSuccess()) {
+                    if (!promise.isSuccess()) {
                         // Either the future is not done or failed in the meantime.
-                        notifyLifecycleManagerOnError(future, ctx);
+                        notifyLifecycleManagerOnError(promise, ctx);
                     }
                 } else {
                     lifecycleManager.onError(ctx, true, failureCause);
@@ -252,40 +253,36 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder, Ht
                     // Must handle calling onError before calling closeStreamLocal, otherwise the error handler will
                     // incorrectly think the stream no longer exists and so may not send RST_STREAM or perform similar
                     // appropriate action.
-                    lifecycleManager.closeStreamLocal(stream, future);
+                    lifecycleManager.closeStreamLocal(stream, promise);
                 }
-
-                return future;
             } else {
                 // Pass headers to the flow-controller so it can maintain their sequence relative to DATA frames.
                 flowController.addFlowControlled(stream,
                         new FlowControlledHeaders(stream, headers, hasPriority, streamDependency,
                                 weight, exclusive, padding, true, promise));
-                return promise;
             }
         } catch (Throwable t) {
             lifecycleManager.onError(ctx, true, t);
             promise.tryFailure(t);
-            return promise;
         }
     }
 
     @Override
-    public Future<Void> writePriority(ChannelHandlerContext ctx, int streamId, int streamDependency, short weight,
-            boolean exclusive, Promise<Void> promise) {
-        return frameWriter.writePriority(ctx, streamId, streamDependency, weight, exclusive, promise);
+    public void writePriority(ChannelHandlerContext ctx, int streamId, int streamDependency, short weight,
+                              boolean exclusive, Promise<Void> promise) {
+        frameWriter.writePriority(ctx, streamId, streamDependency, weight, exclusive, promise);
     }
 
     @Override
-    public Future<Void> writeRstStream(ChannelHandlerContext ctx, int streamId, long errorCode,
-            Promise<Void> promise) {
+    public void writeRstStream(ChannelHandlerContext ctx, int streamId, long errorCode,
+                               Promise<Void> promise) {
         // Delegate to the lifecycle manager for proper updating of connection state.
-        return lifecycleManager.resetStream(ctx, streamId, errorCode, promise);
+        lifecycleManager.resetStream(ctx, streamId, errorCode, promise);
     }
 
     @Override
-    public Future<Void> writeSettings(ChannelHandlerContext ctx, Http2Settings settings,
-            Promise<Void> promise) {
+    public void writeSettings(ChannelHandlerContext ctx, Http2Settings settings,
+                              Promise<Void> promise) {
         outstandingLocalSettingsQueue.add(settings);
         try {
             Boolean pushEnabled = settings.pushEnabled();
@@ -293,21 +290,24 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder, Ht
                 throw connectionError(PROTOCOL_ERROR, "Server sending SETTINGS frame with ENABLE_PUSH specified");
             }
         } catch (Throwable e) {
-            return promise.setFailure(e);
+            promise.setFailure(e);
+            return;
         }
 
-        return frameWriter.writeSettings(ctx, settings, promise);
+        frameWriter.writeSettings(ctx, settings, promise);
     }
 
     @Override
-    public Future<Void> writeSettingsAck(ChannelHandlerContext ctx, Promise<Void> promise) {
+    public void writeSettingsAck(ChannelHandlerContext ctx, Promise<Void> promise) {
         if (outstandingRemoteSettingsQueue == null) {
-            return frameWriter.writeSettingsAck(ctx, promise);
+            frameWriter.writeSettingsAck(ctx, promise);
+            return;
         }
         Http2Settings settings = outstandingRemoteSettingsQueue.poll();
         if (settings == null) {
-            return promise.setFailure(new Http2Exception(INTERNAL_ERROR, "attempted to write a SETTINGS ACK with no " +
+            promise.setFailure(new Http2Exception(INTERNAL_ERROR, "attempted to write a SETTINGS ACK with no " +
                     " pending SETTINGS"));
+            return;
         }
         SimpleChannelPromiseAggregator aggregator = new SimpleChannelPromiseAggregator(promise, ctx.channel(),
                 ctx.executor());
@@ -326,17 +326,17 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder, Ht
             applySettingsPromise.setFailure(e);
             lifecycleManager.onError(ctx, true, e);
         }
-        return aggregator.doneAllocatingPromises();
+        aggregator.doneAllocatingPromises();
     }
 
     @Override
-    public Future<Void> writePing(ChannelHandlerContext ctx, boolean ack, long data, Promise<Void> promise) {
-        return frameWriter.writePing(ctx, ack, data, promise);
+    public void writePing(ChannelHandlerContext ctx, boolean ack, long data, Promise<Void> promise) {
+        frameWriter.writePing(ctx, ack, data, promise);
     }
 
     @Override
-    public Future<Void> writePushPromise(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
-            Http2Headers headers, int padding, Promise<Void> promise) {
+    public void writePushPromise(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
+                                 Http2Headers headers, int padding, Promise<Void> promise) {
         try {
             if (connection.goAwayReceived()) {
                 throw connectionError(PROTOCOL_ERROR, "Sending PUSH_PROMISE after GO_AWAY received.");
@@ -346,47 +346,45 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder, Ht
             // Reserve the promised stream.
             connection.local().reservePushStream(promisedStreamId, stream);
 
-            Future<Void> future = frameWriter.writePushPromise(ctx, streamId, promisedStreamId, headers, padding,
-                                                                promise);
+            frameWriter.writePushPromise(ctx, streamId, promisedStreamId, headers, padding,
+                    promise);
             // Writing headers may fail during the encode state if they violate HPACK limits.
-            Throwable failureCause = future.cause();
+            Throwable failureCause = promise.cause();
             if (failureCause == null) {
                 // This just sets internal stream state which is used elsewhere in the codec and doesn't
                 // necessarily mean the write will complete successfully.
                 stream.pushPromiseSent();
 
-                if (!future.isSuccess()) {
+                if (!promise.isSuccess()) {
                     // Either the future is not done or failed in the meantime.
-                    notifyLifecycleManagerOnError(future, ctx);
+                    notifyLifecycleManagerOnError(promise, ctx);
                 }
             } else {
                 lifecycleManager.onError(ctx, true, failureCause);
             }
-            return future;
         } catch (Throwable t) {
             lifecycleManager.onError(ctx, true, t);
             promise.tryFailure(t);
-            return promise;
         }
     }
 
     @Override
-    public Future<Void> writeGoAway(ChannelHandlerContext ctx, int lastStreamId, long errorCode, ByteBuf debugData,
-                                    Promise<Void> promise) {
-        return lifecycleManager.goAway(ctx, lastStreamId, errorCode, debugData, promise);
+    public void writeGoAway(ChannelHandlerContext ctx, int lastStreamId, long errorCode, ByteBuf debugData,
+                            Promise<Void> promise) {
+        lifecycleManager.goAway(ctx, lastStreamId, errorCode, debugData, promise);
     }
 
     @Override
-    public Future<Void> writeWindowUpdate(ChannelHandlerContext ctx, int streamId, int windowSizeIncrement,
-            Promise<Void> promise) {
-        return promise.setFailure(new UnsupportedOperationException("Use the Http2[Inbound|Outbound]FlowController" +
+    public void writeWindowUpdate(ChannelHandlerContext ctx, int streamId, int windowSizeIncrement,
+                                  Promise<Void> promise) {
+        promise.setFailure(new UnsupportedOperationException("Use the Http2[Inbound|Outbound]FlowController" +
                 " objects to control window sizes"));
     }
 
     @Override
-    public Future<Void> writeFrame(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags,
-            ByteBuf payload, Promise<Void> promise) {
-        return frameWriter.writeFrame(ctx, frameType, streamId, flags, payload, promise);
+    public void writeFrame(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags,
+                           ByteBuf payload, Promise<Void> promise) {
+        frameWriter.writeFrame(ctx, frameType, streamId, flags, payload, promise);
     }
 
     @Override
@@ -574,10 +572,10 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder, Ht
             // closeStreamLocal().
             promise.addListener(this);
 
-            Future<Void> f = sendHeaders(frameWriter, ctx, stream.id(), headers, hasPriority, streamDependency,
+            sendHeaders(frameWriter, ctx, stream.id(), headers, hasPriority, streamDependency,
                     weight, exclusive, padding, endOfStream, promise);
             // Writing headers may fail during the encode state if they violate HPACK limits.
-            Throwable failureCause = f.cause();
+            Throwable failureCause = promise.cause();
             if (failureCause == null) {
                 // This just sets internal stream state which is used elsewhere in the codec and doesn't
                 // necessarily mean the write will complete successfully.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
@@ -145,8 +145,8 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
     }
 
     @Override
-    public Future<Void> writeData(ChannelHandlerContext ctx, int streamId, ByteBuf data,
-                                  int padding, boolean endStream, Promise<Void> promise) {
+    public void writeData(ChannelHandlerContext ctx, int streamId, ByteBuf data,
+                          int padding, boolean endStream, Promise<Void> promise) {
         final SimpleChannelPromiseAggregator promiseAggregator =
                 new SimpleChannelPromiseAggregator(promise, ctx.channel(), ctx.executor());
         ByteBuf frameHeader = null;
@@ -261,29 +261,29 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
                 promiseAggregator.setFailure(cause);
                 promiseAggregator.doneAllocatingPromises();
             }
-            return promiseAggregator;
+            return;
         }
-        return promiseAggregator.doneAllocatingPromises();
+        promiseAggregator.doneAllocatingPromises();
     }
 
     @Override
-    public Future<Void> writeHeaders(ChannelHandlerContext ctx, int streamId,
-            Http2Headers headers, int padding, boolean endStream, Promise<Void> promise) {
-        return writeHeadersInternal(ctx, streamId, headers, padding, endStream,
+    public void writeHeaders(ChannelHandlerContext ctx, int streamId,
+                             Http2Headers headers, int padding, boolean endStream, Promise<Void> promise) {
+        writeHeadersInternal(ctx, streamId, headers, padding, endStream,
                 false, 0, (short) 0, false, promise);
     }
 
     @Override
-    public Future<Void> writeHeaders(ChannelHandlerContext ctx, int streamId,
-            Http2Headers headers, int streamDependency, short weight, boolean exclusive,
-            int padding, boolean endStream, Promise<Void> promise) {
-        return writeHeadersInternal(ctx, streamId, headers, padding, endStream,
+    public void writeHeaders(ChannelHandlerContext ctx, int streamId,
+                             Http2Headers headers, int streamDependency, short weight, boolean exclusive,
+                             int padding, boolean endStream, Promise<Void> promise) {
+        writeHeadersInternal(ctx, streamId, headers, padding, endStream,
                 true, streamDependency, weight, exclusive, promise);
     }
 
     @Override
-    public Future<Void> writePriority(ChannelHandlerContext ctx, int streamId,
-            int streamDependency, short weight, boolean exclusive, Promise<Void> promise) {
+    public void writePriority(ChannelHandlerContext ctx, int streamId,
+                              int streamDependency, short weight, boolean exclusive, Promise<Void> promise) {
         try {
             verifyStreamId(streamId, STREAM_ID);
             verifyStreamOrConnectionId(streamDependency, STREAM_DEPENDENCY);
@@ -294,15 +294,15 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
             buf.writeInt(exclusive ? (int) (0x80000000L | streamDependency) : streamDependency);
             // Adjust the weight so that it fits into a single byte on the wire.
             buf.writeByte(weight - 1);
-            return ctx.write(buf, promise);
+            ctx.write(buf, promise);
         } catch (Throwable t) {
-            return promise.setFailure(t);
+            promise.setFailure(t);
         }
     }
 
     @Override
-    public Future<Void> writeRstStream(ChannelHandlerContext ctx, int streamId, long errorCode,
-            Promise<Void> promise) {
+    public void writeRstStream(ChannelHandlerContext ctx, int streamId, long errorCode,
+                               Promise<Void> promise) {
         try {
             verifyStreamId(streamId, STREAM_ID);
             verifyErrorCode(errorCode);
@@ -310,15 +310,15 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
             ByteBuf buf = ctx.alloc().buffer(RST_STREAM_FRAME_LENGTH);
             writeFrameHeaderInternal(buf, INT_FIELD_LENGTH, RST_STREAM, new Http2Flags(), streamId);
             buf.writeInt((int) errorCode);
-            return ctx.write(buf, promise);
+            ctx.write(buf, promise);
         } catch (Throwable t) {
-            return promise.setFailure(t);
+            promise.setFailure(t);
         }
     }
 
     @Override
-    public Future<Void> writeSettings(ChannelHandlerContext ctx, Http2Settings settings,
-            Promise<Void> promise) {
+    public void writeSettings(ChannelHandlerContext ctx, Http2Settings settings,
+                              Promise<Void> promise) {
         try {
             checkNotNull(settings, "settings");
             int payloadLength = SETTING_ENTRY_LENGTH * settings.size();
@@ -328,37 +328,37 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
                 buf.writeChar(entry.key());
                 buf.writeInt(entry.value().intValue());
             }
-            return ctx.write(buf, promise);
+            ctx.write(buf, promise);
         } catch (Throwable t) {
-            return promise.setFailure(t);
+            promise.setFailure(t);
         }
     }
 
     @Override
-    public Future<Void> writeSettingsAck(ChannelHandlerContext ctx, Promise<Void> promise) {
+    public void writeSettingsAck(ChannelHandlerContext ctx, Promise<Void> promise) {
         try {
             ByteBuf buf = ctx.alloc().buffer(FRAME_HEADER_LENGTH);
             writeFrameHeaderInternal(buf, 0, SETTINGS, new Http2Flags().ack(true), 0);
-            return ctx.write(buf, promise);
+            ctx.write(buf, promise);
         } catch (Throwable t) {
-            return promise.setFailure(t);
+            promise.setFailure(t);
         }
     }
 
     @Override
-    public Future<Void> writePing(ChannelHandlerContext ctx, boolean ack, long data, Promise<Void> promise) {
+    public void writePing(ChannelHandlerContext ctx, boolean ack, long data, Promise<Void> promise) {
         Http2Flags flags = ack ? new Http2Flags().ack(true) : new Http2Flags();
         ByteBuf buf = ctx.alloc().buffer(FRAME_HEADER_LENGTH + PING_FRAME_PAYLOAD_LENGTH);
         // Assume nothing below will throw until buf is written. That way we don't have to take care of ownership
         // in the catch block.
         writeFrameHeaderInternal(buf, PING_FRAME_PAYLOAD_LENGTH, PING, flags, 0);
         buf.writeLong(data);
-        return ctx.write(buf, promise);
+        ctx.write(buf, promise);
     }
 
     @Override
-    public Future<Void> writePushPromise(ChannelHandlerContext ctx, int streamId,
-            int promisedStreamId, Http2Headers headers, int padding, Promise<Void> promise) {
+    public void writePushPromise(ChannelHandlerContext ctx, int streamId,
+                                 int promisedStreamId, Http2Headers headers, int padding, Promise<Void> promise) {
         ByteBuf headerBlock = null;
         SimpleChannelPromiseAggregator promiseAggregator =
                 new SimpleChannelPromiseAggregator(promise, ctx.channel(), ctx.executor());
@@ -411,12 +411,12 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
                 headerBlock.release();
             }
         }
-        return promiseAggregator.doneAllocatingPromises();
+        promiseAggregator.doneAllocatingPromises();
     }
 
     @Override
-    public Future<Void> writeGoAway(ChannelHandlerContext ctx, int lastStreamId, long errorCode,
-            ByteBuf debugData, Promise<Void> promise) {
+    public void writeGoAway(ChannelHandlerContext ctx, int lastStreamId, long errorCode,
+                            ByteBuf debugData, Promise<Void> promise) {
         SimpleChannelPromiseAggregator promiseAggregator =
                 new SimpleChannelPromiseAggregator(promise, ctx.channel(), ctx.executor());
         try {
@@ -438,7 +438,7 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
                 promiseAggregator.setFailure(t);
                 promiseAggregator.doneAllocatingPromises();
             }
-            return promiseAggregator;
+            return;
         }
 
         try {
@@ -446,12 +446,12 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
         } catch (Throwable t) {
             promiseAggregator.setFailure(t);
         }
-        return promiseAggregator.doneAllocatingPromises();
+        promiseAggregator.doneAllocatingPromises();
     }
 
     @Override
-    public Future<Void> writeWindowUpdate(ChannelHandlerContext ctx, int streamId,
-            int windowSizeIncrement, Promise<Void> promise) {
+    public void writeWindowUpdate(ChannelHandlerContext ctx, int streamId,
+                                  int windowSizeIncrement, Promise<Void> promise) {
         try {
             verifyStreamOrConnectionId(streamId, STREAM_ID);
             verifyWindowSizeIncrement(windowSizeIncrement);
@@ -459,15 +459,15 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
             ByteBuf buf = ctx.alloc().buffer(WINDOW_UPDATE_FRAME_LENGTH);
             writeFrameHeaderInternal(buf, INT_FIELD_LENGTH, WINDOW_UPDATE, new Http2Flags(), streamId);
             buf.writeInt(windowSizeIncrement);
-            return ctx.write(buf, promise);
+            ctx.write(buf, promise);
         } catch (Throwable t) {
-            return promise.setFailure(t);
+            promise.setFailure(t);
         }
     }
 
     @Override
-    public Future<Void> writeFrame(ChannelHandlerContext ctx, byte frameType, int streamId,
-            Http2Flags flags, ByteBuf payload, Promise<Void> promise) {
+    public void writeFrame(ChannelHandlerContext ctx, byte frameType, int streamId,
+                           Http2Flags flags, ByteBuf payload, Promise<Void> promise) {
         SimpleChannelPromiseAggregator promiseAggregator =
                 new SimpleChannelPromiseAggregator(promise, ctx.channel(), ctx.executor());
         try {
@@ -484,14 +484,14 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
                 promiseAggregator.setFailure(t);
                 promiseAggregator.doneAllocatingPromises();
             }
-            return promiseAggregator;
+            return;
         }
         try {
             ctx.write(payload, promiseAggregator.newPromise());
         } catch (Throwable t) {
             promiseAggregator.setFailure(t);
         }
-        return promiseAggregator.doneAllocatingPromises();
+        promiseAggregator.doneAllocatingPromises();
     }
 
     private Future<Void> writeHeadersInternal(ChannelHandlerContext ctx,

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionEncoder.java
@@ -16,7 +16,6 @@ package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 
 
@@ -61,6 +60,6 @@ public interface Http2ConnectionEncoder extends Http2FrameWriter {
      * state checks on the connection/stream.
      */
     @Override
-    Future<Void> writeFrame(ChannelHandlerContext ctx, byte frameType, int streamId,
+    void writeFrame(ChannelHandlerContext ctx, byte frameType, int streamId,
                             Http2Flags flags, ByteBuf payload, Promise<Void> promise);
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -376,11 +376,13 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
             }
 
             // Both client and server must send their initial settings.
-            encoder.writeSettings(ctx, initialSettings, ctx.<Void>newPromise().addListener(f -> {
+            Promise<Void> settingsPromise = ctx.newPromise();
+            encoder.writeSettings(ctx, initialSettings, settingsPromise);
+            settingsPromise.addListener(f -> {
                 if (!f.isSuccess()) {
                     ctx.close();
                 }
-            }));
+            });
 
             if (isClient) {
                 // If this handler is extended by the user and we directly fire the userEvent from this context then

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -376,11 +376,11 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
             }
 
             // Both client and server must send their initial settings.
-            encoder.writeSettings(ctx, initialSettings, ctx.newPromise()).addListener(f -> {
+            encoder.writeSettings(ctx, initialSettings, ctx.<Void>newPromise().addListener(f -> {
                 if (!f.isSuccess()) {
                     ctx.close();
                 }
-            });
+            }));
 
             if (isClient) {
                 // If this handler is extended by the user and we directly fire the userEvent from this context then
@@ -496,9 +496,14 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         // a GO_AWAY has been sent we send a empty buffer just so we can wait to close until all other data has been
         // flushed to the OS.
         // https://github.com/netty/netty/issues/5307
-        Future<Void> f = connection().goAwaySent() ? ctx.write(EMPTY_BUFFER) : goAway(ctx, null, ctx.newPromise());
+        Promise<Void> p = ctx.newPromise();
+        if (connection().goAwaySent()) {
+            ctx.write(EMPTY_BUFFER, p);
+        } else {
+            goAway(ctx, null, p);
+        }
         ctx.flush();
-        doGracefulShutdown(ctx, f, promise);
+        doGracefulShutdown(ctx, p, promise);
     }
 
     private FutureListener<Void> newClosingChannelFutureListener(
@@ -689,11 +694,12 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         }
 
         Promise<Void> promise = ctx.newPromise();
-        Future<Void> future = goAway(ctx, http2Ex, ctx.newPromise());
+        Promise<Void> goawayPromise = ctx.newPromise();
+        goAway(ctx, http2Ex, goawayPromise);
         if (http2Ex.shutdownHint() == Http2Exception.ShutdownHint.GRACEFUL_SHUTDOWN) {
-            doGracefulShutdown(ctx, future, promise);
+            doGracefulShutdown(ctx, goawayPromise, promise);
         } else {
-            future.addListener(newClosingChannelFutureListener(ctx, promise));
+            goawayPromise.addListener(newClosingChannelFutureListener(ctx, promise));
         }
     }
 
@@ -770,33 +776,33 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
      * triggered by the first frame of a stream being invalid. That is, there was an error reading the frame before
      * we could create a new stream.
      */
-    private Future<Void> resetUnknownStream(final ChannelHandlerContext ctx, int streamId, long errorCode,
+    private void resetUnknownStream(final ChannelHandlerContext ctx, int streamId, long errorCode,
                                              Promise<Void> promise) {
-        Future<Void> future = frameWriter().writeRstStream(ctx, streamId, errorCode, promise);
-        if (future.isDone()) {
-            closeConnectionOnError(ctx, future);
+        frameWriter().writeRstStream(ctx, streamId, errorCode, promise);
+        if (promise.isDone()) {
+            closeConnectionOnError(ctx, promise);
         } else {
-            future.addListener(f -> closeConnectionOnError(ctx, f));
+            promise.addListener(f -> closeConnectionOnError(ctx, f));
         }
-        return future;
     }
 
     @Override
-    public Future<Void> resetStream(final ChannelHandlerContext ctx, int streamId, long errorCode,
-                                     Promise<Void> promise) {
+    public void resetStream(final ChannelHandlerContext ctx, int streamId, long errorCode,
+                            Promise<Void> promise) {
         final Http2Stream stream = connection().stream(streamId);
         if (stream == null) {
-            return resetUnknownStream(ctx, streamId, errorCode, promise);
+            resetUnknownStream(ctx, streamId, errorCode, promise);
+        } else {
+            resetStream(ctx, stream, errorCode, promise);
         }
-
-       return resetStream(ctx, stream, errorCode, promise);
     }
 
-    private Future<Void> resetStream(final ChannelHandlerContext ctx, final Http2Stream stream,
+    private void resetStream(final ChannelHandlerContext ctx, final Http2Stream stream,
                                       long errorCode, Promise<Void> promise) {
         if (stream.isResetSent()) {
             // Don't write a RST_STREAM frame if we have already written one.
-            return promise.setSuccess(null);
+            promise.setSuccess(null);
+            return;
         }
         // Synchronously set the resetSent flag to prevent any subsequent calls
         // from resulting in multiple reset frames being sent.
@@ -805,53 +811,48 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         // call resetStream(...) again.
         stream.resetSent();
 
-        final Future<Void> future;
         // If the remote peer is not aware of the steam, then we are not allowed to send a RST_STREAM
         // https://tools.ietf.org/html/rfc7540#section-6.4.
         if (stream.state() == IDLE ||
             connection().local().created(stream) && !stream.isHeadersSent() && !stream.isPushPromiseSent()) {
-            future = promise.setSuccess(null);
+            promise.setSuccess(null);
         } else {
-            future = frameWriter().writeRstStream(ctx, stream.id(), errorCode, promise);
+            frameWriter().writeRstStream(ctx, stream.id(), errorCode, promise);
         }
-        if (future.isDone()) {
-            processRstStreamWriteResult(ctx, stream, future);
+        if (promise.isDone()) {
+            processRstStreamWriteResult(ctx, stream, promise);
         } else {
-            future.addListener(f -> processRstStreamWriteResult(ctx, stream, f));
+            promise.addListener(f -> processRstStreamWriteResult(ctx, stream, f));
         }
-
-        return future;
     }
 
     @Override
-    public Future<Void> goAway(final ChannelHandlerContext ctx, final int lastStreamId, final long errorCode,
-                                final ByteBuf debugData, Promise<Void> promise) {
+    public void goAway(final ChannelHandlerContext ctx, final int lastStreamId, final long errorCode,
+                       final ByteBuf debugData, Promise<Void> promise) {
         final Http2Connection connection = connection();
         try {
             if (!connection.goAwaySent(lastStreamId, errorCode, debugData)) {
                 debugData.release();
                 promise.trySuccess(null);
-                return promise;
+                return;
             }
         } catch (Throwable cause) {
             debugData.release();
             promise.tryFailure(cause);
-            return promise;
+            return;
         }
 
         // Need to retain before we write the buffer because if we do it after the refCnt could already be 0 and
         // result in an IllegalRefCountException.
         debugData.retain();
-        Future<Void> future = frameWriter().writeGoAway(ctx, lastStreamId, errorCode, debugData, promise);
+        frameWriter().writeGoAway(ctx, lastStreamId, errorCode, debugData, promise);
 
-        if (future.isDone()) {
-            processGoAwayWriteResult(ctx, lastStreamId, errorCode, debugData, future);
+        if (promise.isDone()) {
+            processGoAwayWriteResult(ctx, lastStreamId, errorCode, debugData, promise);
         } else {
-            future.addListener(f ->
+            promise.addListener(f ->
                     processGoAwayWriteResult(ctx, lastStreamId, errorCode, debugData, (Future<Void>) f));
         }
-
-        return future;
     }
 
     /**
@@ -878,7 +879,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
      * Close the remote endpoint with a {@code GO_AWAY} frame. Does <strong>not</strong> flush
      * immediately, this is the responsibility of the caller.
      */
-    private Future<Void> goAway(ChannelHandlerContext ctx, Http2Exception cause, Promise<Void> promise) {
+    private void goAway(ChannelHandlerContext ctx, Http2Exception cause, Promise<Void> promise) {
         long errorCode = cause != null ? cause.error().code() : NO_ERROR.code();
         int lastKnownStream;
         if (cause != null && cause.shutdownHint() == Http2Exception.ShutdownHint.HARD_SHUTDOWN) {
@@ -890,7 +891,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         } else {
             lastKnownStream = connection().remote().lastStreamCreated();
         }
-        return goAway(ctx, lastKnownStream, errorCode, Http2CodecUtil.toByteBuf(ctx, cause), promise);
+        goAway(ctx, lastKnownStream, errorCode, Http2CodecUtil.toByteBuf(ctx, cause), promise);
     }
 
     private void processRstStreamWriteResult(ChannelHandlerContext ctx,

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ControlFrameLimitEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ControlFrameLimitEncoder.java
@@ -15,7 +15,6 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.ObjectUtil;
@@ -49,35 +48,36 @@ final class Http2ControlFrameLimitEncoder extends DecoratingHttp2ConnectionEncod
     }
 
     @Override
-    public Future<Void> writeSettingsAck(ChannelHandlerContext ctx, Promise<Void> promise) {
+    public void writeSettingsAck(ChannelHandlerContext ctx, Promise<Void> promise) {
         Promise<Void> newPromise = handleOutstandingControlFrames(ctx, promise);
         if (newPromise == null) {
-            return promise;
+            return;
         }
-        return super.writeSettingsAck(ctx, newPromise);
+        super.writeSettingsAck(ctx, newPromise);
     }
 
     @Override
-    public Future<Void> writePing(ChannelHandlerContext ctx, boolean ack, long data, Promise<Void> promise) {
+    public void writePing(ChannelHandlerContext ctx, boolean ack, long data, Promise<Void> promise) {
         // Only apply the limit to ping acks.
         if (ack) {
             Promise<Void> newPromise = handleOutstandingControlFrames(ctx, promise);
             if (newPromise == null) {
-                return promise;
+                return;
             }
-            return super.writePing(ctx, ack, data, newPromise);
+            super.writePing(ctx, ack, data, newPromise);
+            return;
         }
-        return super.writePing(ctx, ack, data, promise);
+        super.writePing(ctx, ack, data, promise);
     }
 
     @Override
-    public Future<Void> writeRstStream(
+    public void writeRstStream(
             ChannelHandlerContext ctx, int streamId, long errorCode, Promise<Void> promise) {
         Promise<Void> newPromise = handleOutstandingControlFrames(ctx, promise);
         if (newPromise == null) {
-            return promise;
+            return;
         }
-        return super.writeRstStream(ctx, streamId, errorCode, newPromise);
+        super.writeRstStream(ctx, streamId, errorCode, newPromise);
     }
 
     private Promise<Void> handleOutstandingControlFrames(ChannelHandlerContext ctx, Promise<Void> promise) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2DataWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2DataWriter.java
@@ -16,7 +16,6 @@ package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 
 /**
@@ -27,17 +26,16 @@ public interface Http2DataWriter {
      * Writes a {@code DATA} frame to the remote endpoint. This will result in one or more
      * frames being written to the context.
      *
-     * @param ctx the context to use for writing.
-     * @param streamId the stream for which to send the frame.
-     * @param data the payload of the frame. This will be released by this method.
-     * @param padding additional bytes that should be added to obscure the true content size. Must be between 0 and
-     *                256 (inclusive). A 1 byte padding is encoded as just the pad length field with value 0.
-     *                A 256 byte padding is encoded as the pad length field with value 255 and 255 padding bytes
-     *                appended to the end of the frame.
+     * @param ctx       the context to use for writing.
+     * @param streamId  the stream for which to send the frame.
+     * @param data      the payload of the frame. This will be released by this method.
+     * @param padding   additional bytes that should be added to obscure the true content size. Must be between 0 and
+     *                  256 (inclusive). A 1 byte padding is encoded as just the pad length field with value 0.
+     *                  A 256 byte padding is encoded as the pad length field with value 255 and 255 padding bytes
+     *                  appended to the end of the frame.
      * @param endStream indicates if this is the last frame to be sent for the stream.
-     * @param promise the promise for the write.
-     * @return the future for the write.
+     * @param promise   the promise for the write.
      */
-    Future<Void> writeData(ChannelHandlerContext ctx, int streamId,
-                           ByteBuf data, int padding, boolean endStream, Promise<Void> promise);
+    void writeData(ChannelHandlerContext ctx, int streamId,
+                   ByteBuf data, int padding, boolean endStream, Promise<Void> promise);
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameWriter.java
@@ -17,7 +17,6 @@ package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 
 import java.io.Closeable;
@@ -46,173 +45,141 @@ public interface Http2FrameWriter extends Http2DataWriter, Closeable {
     /**
      * Writes a HEADERS frame to the remote endpoint.
      *
-     * @param ctx the context to use for writing.
-     * @param streamId the stream for which to send the frame.
-     * @param headers the headers to be sent.
-     * @param padding additional bytes that should be added to obscure the true content size. Must be between 0 and
-     *                256 (inclusive).
+     * @param ctx       the context to use for writing.
+     * @param streamId  the stream for which to send the frame.
+     * @param headers   the headers to be sent.
+     * @param padding   additional bytes that should be added to obscure the true content size. Must be between 0 and
+     *                  256 (inclusive).
      * @param endStream indicates if this is the last frame to be sent for the stream.
-     * @param promise the promise for the write.
-     * @return the future for the write.
-     * <a href="https://tools.ietf.org/html/rfc7540#section-10.5.1">Section 10.5.1</a> states the following:
-     * <pre>
-     * The header block MUST be processed to ensure a consistent connection state, unless the connection is closed.
-     * </pre>
-     * If this call has modified the HPACK header state you <strong>MUST</strong> throw a connection error.
-     * <p>
-     * If this call has <strong>NOT</strong> modified the HPACK header state you are free to throw a stream error.
+     * @param promise   the promise for the write.
      */
-    Future<Void> writeHeaders(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
-                               int padding, boolean endStream, Promise<Void> promise);
+    void writeHeaders(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
+                      int padding, boolean endStream, Promise<Void> promise);
 
     /**
      * Writes a HEADERS frame with priority specified to the remote endpoint.
      *
-     * @param ctx the context to use for writing.
-     * @param streamId the stream for which to send the frame.
-     * @param headers the headers to be sent.
+     * @param ctx              the context to use for writing.
+     * @param streamId         the stream for which to send the frame.
+     * @param headers          the headers to be sent.
      * @param streamDependency the stream on which this stream should depend, or 0 if it should
-     *            depend on the connection.
-     * @param weight the weight for this stream.
-     * @param exclusive whether this stream should be the exclusive dependant of its parent.
-     * @param padding additional bytes that should be added to obscure the true content size. Must be between 0 and
-     *                256 (inclusive).
-     * @param endStream indicates if this is the last frame to be sent for the stream.
-     * @param promise the promise for the write.
-     * @return the future for the write.
-     * <a href="https://tools.ietf.org/html/rfc7540#section-10.5.1">Section 10.5.1</a> states the following:
-     * <pre>
-     * The header block MUST be processed to ensure a consistent connection state, unless the connection is closed.
-     * </pre>
-     * If this call has modified the HPACK header state you <strong>MUST</strong> throw a connection error.
-     * <p>
-     * If this call has <strong>NOT</strong> modified the HPACK header state you are free to throw a stream error.
+     *                         depend on the connection.
+     * @param weight           the weight for this stream.
+     * @param exclusive        whether this stream should be the exclusive dependant of its parent.
+     * @param padding          additional bytes that should be added to obscure the true content size.
+     *                         Must be between 0 and 256 (inclusive).
+     * @param endStream        indicates if this is the last frame to be sent for the stream.
+     * @param promise          the promise for the write.
      */
-    Future<Void> writeHeaders(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
-                               int streamDependency, short weight, boolean exclusive, int padding, boolean endStream,
-                               Promise<Void> promise);
+    void writeHeaders(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
+                      int streamDependency, short weight, boolean exclusive, int padding, boolean endStream,
+                      Promise<Void> promise);
 
     /**
      * Writes a PRIORITY frame to the remote endpoint.
      *
-     * @param ctx the context to use for writing.
-     * @param streamId the stream for which to send the frame.
+     * @param ctx              the context to use for writing.
+     * @param streamId         the stream for which to send the frame.
      * @param streamDependency the stream on which this stream should depend, or 0 if it should
-     *            depend on the connection.
-     * @param weight the weight for this stream.
-     * @param exclusive whether this stream should be the exclusive dependant of its parent.
-     * @param promise the promise for the write.
-     * @return the future for the write.
+     *                         depend on the connection.
+     * @param weight           the weight for this stream.
+     * @param exclusive        whether this stream should be the exclusive dependant of its parent.
+     * @param promise          the promise for the write.
      */
-    Future<Void> writePriority(ChannelHandlerContext ctx, int streamId, int streamDependency,
-            short weight, boolean exclusive, Promise<Void> promise);
+    void writePriority(ChannelHandlerContext ctx, int streamId, int streamDependency,
+                       short weight, boolean exclusive, Promise<Void> promise);
 
     /**
      * Writes a RST_STREAM frame to the remote endpoint.
      *
-     * @param ctx the context to use for writing.
-     * @param streamId the stream for which to send the frame.
+     * @param ctx       the context to use for writing.
+     * @param streamId  the stream for which to send the frame.
      * @param errorCode the error code indicating the nature of the failure.
-     * @param promise the promise for the write.
-     * @return the future for the write.
+     * @param promise   the promise for the write.
      */
-    Future<Void> writeRstStream(ChannelHandlerContext ctx, int streamId, long errorCode,
-            Promise<Void> promise);
+    void writeRstStream(ChannelHandlerContext ctx, int streamId, long errorCode,
+                        Promise<Void> promise);
 
     /**
      * Writes a SETTINGS frame to the remote endpoint.
      *
-     * @param ctx the context to use for writing.
+     * @param ctx      the context to use for writing.
      * @param settings the settings to be sent.
-     * @param promise the promise for the write.
-     * @return the future for the write.
+     * @param promise  the promise for the write.
      */
-    Future<Void> writeSettings(ChannelHandlerContext ctx, Http2Settings settings,
-                               Promise<Void> promise);
+    void writeSettings(ChannelHandlerContext ctx, Http2Settings settings,
+                       Promise<Void> promise);
 
     /**
      * Writes a SETTINGS acknowledgment to the remote endpoint.
      *
-     * @param ctx the context to use for writing.
+     * @param ctx     the context to use for writing.
      * @param promise the promise for the write.
-     * @return the future for the write.
      */
-    Future<Void> writeSettingsAck(ChannelHandlerContext ctx, Promise<Void> promise);
+    void writeSettingsAck(ChannelHandlerContext ctx, Promise<Void> promise);
 
     /**
      * Writes a PING frame to the remote endpoint.
      *
-     * @param ctx the context to use for writing.
-     * @param ack indicates whether this is an ack of a PING frame previously received from the
-     *            remote endpoint.
-     * @param data the payload of the frame.
+     * @param ctx     the context to use for writing.
+     * @param ack     indicates whether this is an ack of a PING frame previously received from the
+     *                remote endpoint.
+     * @param data    the payload of the frame.
      * @param promise the promise for the write.
-     * @return the future for the write.
      */
-    Future<Void> writePing(ChannelHandlerContext ctx, boolean ack, long data,
-            Promise<Void> promise);
+    void writePing(ChannelHandlerContext ctx, boolean ack, long data,
+                   Promise<Void> promise);
 
     /**
      * Writes a PUSH_PROMISE frame to the remote endpoint.
      *
-     * @param ctx the context to use for writing.
-     * @param streamId the stream for which to send the frame.
+     * @param ctx              the context to use for writing.
+     * @param streamId         the stream for which to send the frame.
      * @param promisedStreamId the ID of the promised stream.
-     * @param headers the headers to be sent.
-     * @param padding additional bytes that should be added to obscure the true content size. Must be between 0 and
-     *                256 (inclusive).
-     * @param promise the promise for the write.
-     * @return the future for the write.
-     * <a href="https://tools.ietf.org/html/rfc7540#section-10.5.1">Section 10.5.1</a> states the following:
-     * <pre>
-     * The header block MUST be processed to ensure a consistent connection state, unless the connection is closed.
-     * </pre>
-     * If this call has modified the HPACK header state you <strong>MUST</strong> throw a connection error.
-     * <p>
-     * If this call has <strong>NOT</strong> modified the HPACK header state you are free to throw a stream error.
+     * @param headers          the headers to be sent.
+     * @param padding          additional bytes that should be added to obscure the true content size.
+     *                         Must be between 0 and 256 (inclusive).
+     * @param promise          the promise for the write.
      */
-    Future<Void> writePushPromise(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
-                                   Http2Headers headers, int padding, Promise<Void> promise);
+    void writePushPromise(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
+                          Http2Headers headers, int padding, Promise<Void> promise);
 
     /**
      * Writes a GO_AWAY frame to the remote endpoint.
      *
-     * @param ctx the context to use for writing.
+     * @param ctx          the context to use for writing.
      * @param lastStreamId the last known stream of this endpoint.
-     * @param errorCode the error code, if the connection was abnormally terminated.
-     * @param debugData application-defined debug data. This will be released by this method.
-     * @param promise the promise for the write.
-     * @return the future for the write.
+     * @param errorCode    the error code, if the connection was abnormally terminated.
+     * @param debugData    application-defined debug data. This will be released by this method.
+     * @param promise      the promise for the write.
      */
-    Future<Void> writeGoAway(ChannelHandlerContext ctx, int lastStreamId, long errorCode,
-            ByteBuf debugData, Promise<Void> promise);
+    void writeGoAway(ChannelHandlerContext ctx, int lastStreamId, long errorCode,
+                     ByteBuf debugData, Promise<Void> promise);
 
     /**
      * Writes a WINDOW_UPDATE frame to the remote endpoint.
      *
-     * @param ctx the context to use for writing.
-     * @param streamId the stream for which to send the frame.
+     * @param ctx                 the context to use for writing.
+     * @param streamId            the stream for which to send the frame.
      * @param windowSizeIncrement the number of bytes by which the local inbound flow control window
-     *            is increasing.
-     * @param promise the promise for the write.
-     * @return the future for the write.
+     *                            is increasing.
+     * @param promise             the promise for the write.
      */
-    Future<Void> writeWindowUpdate(ChannelHandlerContext ctx, int streamId,
-            int windowSizeIncrement, Promise<Void> promise);
+    void writeWindowUpdate(ChannelHandlerContext ctx, int streamId,
+                           int windowSizeIncrement, Promise<Void> promise);
 
     /**
      * Generic write method for any HTTP/2 frame. This allows writing of non-standard frames.
      *
-     * @param ctx the context to use for writing.
+     * @param ctx       the context to use for writing.
      * @param frameType the frame type identifier.
-     * @param streamId the stream for which to send the frame.
-     * @param flags the flags to write for this frame.
-     * @param payload the payload to write for this frame. This will be released by this method.
-     * @param promise the promise for the write.
-     * @return the future for the write.
+     * @param streamId  the stream for which to send the frame.
+     * @param flags     the flags to write for this frame.
+     * @param payload   the payload to write for this frame. This will be released by this method.
+     * @param promise   the promise for the write.
      */
-    Future<Void> writeFrame(ChannelHandlerContext ctx, byte frameType, int streamId,
-            Http2Flags flags, ByteBuf payload, Promise<Void> promise);
+    void writeFrame(ChannelHandlerContext ctx, byte frameType, int streamId,
+                    Http2Flags flags, ByteBuf payload, Promise<Void> promise);
 
     /**
      * Get the configuration related elements for this {@link Http2FrameWriter}

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2LifecycleManager.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2LifecycleManager.java
@@ -54,16 +54,14 @@ public interface Http2LifecycleManager {
      * Ensure the stream identified by {@code streamId} is reset. If our local state does not indicate the stream has
      * been reset yet then a {@code RST_STREAM} will be sent to the peer. If our local state indicates the stream
      * has already been reset then the return status will indicate success without sending anything to the peer.
-     * @param ctx The context used for communication and buffer allocation if necessary.
-     * @param streamId The identifier of the stream to reset.
+     *
+     * @param ctx       The context used for communication and buffer allocation if necessary.
+     * @param streamId  The identifier of the stream to reset.
      * @param errorCode Justification as to why this stream is being reset. See {@link Http2Error}.
-     * @param promise Used to indicate the return status of this operation.
-     * @return Will be considered successful when the connection and stream state has been updated, and a
-     * {@code RST_STREAM} frame has been sent to the peer. If the stream state has already been updated and a
-     * {@code RST_STREAM} frame has been sent then the return status may indicate success immediately.
+     * @param promise   Used to indicate the return status of this operation.
      */
-    Future<Void> resetStream(ChannelHandlerContext ctx, int streamId, long errorCode,
-            Promise<Void> promise);
+    void resetStream(ChannelHandlerContext ctx, int streamId, long errorCode,
+                     Promise<Void> promise);
 
     /**
      * Prevents the peer from creating streams and close the connection if {@code errorCode} is not
@@ -72,17 +70,15 @@ public interface Http2LifecycleManager {
      * sending a {@code GO_AWAY} frame (assuming we have not already sent one with
      * {@code Last-Stream-ID <= lastStreamId}), or may just return success if a {@code GO_AWAY} has previously been
      * sent.
-     * @param ctx The context used for communication and buffer allocation if necessary.
+     *
+     * @param ctx          The context used for communication and buffer allocation if necessary.
      * @param lastStreamId The last stream that the local endpoint is claiming it will accept.
-     * @param errorCode The rational as to why the connection is being closed. See {@link Http2Error}.
-     * @param debugData For diagnostic purposes (carries no semantic value).
-     * @param promise Used to indicate the return status of this operation.
-     * @return Will be considered successful when the connection and stream state has been updated, and a
-     * {@code GO_AWAY} frame has been sent to the peer. If the stream state has already been updated and a
-     * {@code GO_AWAY} frame has been sent then the return status may indicate success immediately.
+     * @param errorCode    The rational as to why the connection is being closed. See {@link Http2Error}.
+     * @param debugData    For diagnostic purposes (carries no semantic value).
+     * @param promise      Used to indicate the return status of this operation.
      */
-    Future<Void> goAway(ChannelHandlerContext ctx, int lastStreamId, long errorCode,
-            ByteBuf debugData, Promise<Void> promise);
+    void goAway(ChannelHandlerContext ctx, int lastStreamId, long errorCode,
+                ByteBuf debugData, Promise<Void> promise);
 
     /**
      * Processes the given error.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MaxRstFrameLimitEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MaxRstFrameLimitEncoder.java
@@ -15,7 +15,6 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.Ticker;
 import io.netty.util.internal.logging.InternalLogger;
@@ -58,9 +57,9 @@ final class Http2MaxRstFrameLimitEncoder extends DecoratingHttp2ConnectionEncode
     }
 
     @Override
-    public Future<Void> writeRstStream(ChannelHandlerContext ctx, int streamId, long errorCode,
-                                       Promise<Void> promise) {
-        Future<Void> future = super.writeRstStream(ctx, streamId, errorCode, promise);
+    public void writeRstStream(ChannelHandlerContext ctx, int streamId, long errorCode,
+                               Promise<Void> promise) {
+        super.writeRstStream(ctx, streamId, errorCode, promise);
         if (countRstFrameErrorCode(errorCode)) {
             long currentNano = ticker.nanoTime();
             if (currentNano - lastRstFrameNano >= nanosPerWindow) {
@@ -83,8 +82,6 @@ final class Http2MaxRstFrameLimitEncoder extends DecoratingHttp2ConnectionEncode
                 }
             }
         }
-
-        return future;
     }
 
     private boolean countRstFrameErrorCode(long errorCode) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2OutboundFrameLogger.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2OutboundFrameLogger.java
@@ -19,7 +19,6 @@ import static io.netty.handler.codec.http2.Http2FrameLogger.Direction.OUTBOUND;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 
 /**
@@ -36,93 +35,93 @@ public class Http2OutboundFrameLogger implements Http2FrameWriter {
     }
 
     @Override
-    public Future<Void> writeData(ChannelHandlerContext ctx, int streamId, ByteBuf data,
-            int padding, boolean endStream, Promise<Void> promise) {
+    public void writeData(ChannelHandlerContext ctx, int streamId, ByteBuf data,
+                          int padding, boolean endStream, Promise<Void> promise) {
         logger.logData(OUTBOUND, ctx, streamId, data, padding, endStream);
-        return writer.writeData(ctx, streamId, data, padding, endStream, promise);
+        writer.writeData(ctx, streamId, data, padding, endStream, promise);
     }
 
     @Override
-    public Future<Void> writeHeaders(ChannelHandlerContext ctx, int streamId,
-                                     Http2Headers headers, int padding, boolean endStream, Promise<Void> promise) {
+    public void writeHeaders(ChannelHandlerContext ctx, int streamId,
+                             Http2Headers headers, int padding, boolean endStream, Promise<Void> promise) {
         logger.logHeaders(OUTBOUND, ctx, streamId, headers, padding, endStream);
-        return writer.writeHeaders(ctx, streamId, headers, padding, endStream, promise);
+        writer.writeHeaders(ctx, streamId, headers, padding, endStream, promise);
     }
 
     @Override
-    public Future<Void> writeHeaders(ChannelHandlerContext ctx, int streamId,
-            Http2Headers headers, int streamDependency, short weight, boolean exclusive,
-            int padding, boolean endStream, Promise<Void> promise) {
+    public void writeHeaders(ChannelHandlerContext ctx, int streamId,
+                             Http2Headers headers, int streamDependency, short weight, boolean exclusive,
+                             int padding, boolean endStream, Promise<Void> promise) {
         logger.logHeaders(OUTBOUND, ctx, streamId, headers, streamDependency, weight, exclusive,
                 padding, endStream);
-        return writer.writeHeaders(ctx, streamId, headers, streamDependency, weight,
+        writer.writeHeaders(ctx, streamId, headers, streamDependency, weight,
                 exclusive, padding, endStream, promise);
     }
 
     @Override
-    public Future<Void> writePriority(ChannelHandlerContext ctx, int streamId,
-            int streamDependency, short weight, boolean exclusive, Promise<Void> promise) {
+    public void writePriority(ChannelHandlerContext ctx, int streamId,
+                              int streamDependency, short weight, boolean exclusive, Promise<Void> promise) {
         logger.logPriority(OUTBOUND, ctx, streamId, streamDependency, weight, exclusive);
-        return writer.writePriority(ctx, streamId, streamDependency, weight, exclusive, promise);
+        writer.writePriority(ctx, streamId, streamDependency, weight, exclusive, promise);
     }
 
     @Override
-    public Future<Void> writeRstStream(ChannelHandlerContext ctx,
-            int streamId, long errorCode, Promise<Void> promise) {
+    public void writeRstStream(ChannelHandlerContext ctx,
+                               int streamId, long errorCode, Promise<Void> promise) {
         logger.logRstStream(OUTBOUND, ctx, streamId, errorCode);
-        return writer.writeRstStream(ctx, streamId, errorCode, promise);
+        writer.writeRstStream(ctx, streamId, errorCode, promise);
     }
 
     @Override
-    public Future<Void> writeSettings(ChannelHandlerContext ctx,
-            Http2Settings settings, Promise<Void> promise) {
+    public void writeSettings(ChannelHandlerContext ctx,
+                              Http2Settings settings, Promise<Void> promise) {
         logger.logSettings(OUTBOUND, ctx, settings);
-        return writer.writeSettings(ctx, settings, promise);
+        writer.writeSettings(ctx, settings, promise);
     }
 
     @Override
-    public Future<Void> writeSettingsAck(ChannelHandlerContext ctx, Promise<Void> promise) {
+    public void writeSettingsAck(ChannelHandlerContext ctx, Promise<Void> promise) {
         logger.logSettingsAck(OUTBOUND, ctx);
-        return writer.writeSettingsAck(ctx, promise);
+        writer.writeSettingsAck(ctx, promise);
     }
 
     @Override
-    public Future<Void> writePing(ChannelHandlerContext ctx, boolean ack,
-            long data, Promise<Void> promise) {
+    public void writePing(ChannelHandlerContext ctx, boolean ack,
+                          long data, Promise<Void> promise) {
         if (ack) {
             logger.logPingAck(OUTBOUND, ctx, data);
         } else {
             logger.logPing(OUTBOUND, ctx, data);
         }
-        return writer.writePing(ctx, ack, data, promise);
+        writer.writePing(ctx, ack, data, promise);
     }
 
     @Override
-    public Future<Void> writePushPromise(ChannelHandlerContext ctx, int streamId,
-            int promisedStreamId, Http2Headers headers, int padding, Promise<Void> promise) {
+    public void writePushPromise(ChannelHandlerContext ctx, int streamId,
+                                 int promisedStreamId, Http2Headers headers, int padding, Promise<Void> promise) {
         logger.logPushPromise(OUTBOUND, ctx, streamId, promisedStreamId, headers, padding);
-        return writer.writePushPromise(ctx, streamId, promisedStreamId, headers, padding, promise);
+        writer.writePushPromise(ctx, streamId, promisedStreamId, headers, padding, promise);
     }
 
     @Override
-    public Future<Void> writeGoAway(ChannelHandlerContext ctx, int lastStreamId, long errorCode,
-            ByteBuf debugData, Promise<Void> promise) {
+    public void writeGoAway(ChannelHandlerContext ctx, int lastStreamId, long errorCode,
+                            ByteBuf debugData, Promise<Void> promise) {
         logger.logGoAway(OUTBOUND, ctx, lastStreamId, errorCode, debugData);
-        return writer.writeGoAway(ctx, lastStreamId, errorCode, debugData, promise);
+        writer.writeGoAway(ctx, lastStreamId, errorCode, debugData, promise);
     }
 
     @Override
-    public Future<Void> writeWindowUpdate(ChannelHandlerContext ctx,
-            int streamId, int windowSizeIncrement, Promise<Void> promise) {
+    public void writeWindowUpdate(ChannelHandlerContext ctx,
+                                  int streamId, int windowSizeIncrement, Promise<Void> promise) {
         logger.logWindowsUpdate(OUTBOUND, ctx, streamId, windowSizeIncrement);
-        return writer.writeWindowUpdate(ctx, streamId, windowSizeIncrement, promise);
+        writer.writeWindowUpdate(ctx, streamId, windowSizeIncrement, promise);
     }
 
     @Override
-    public Future<Void> writeFrame(ChannelHandlerContext ctx, byte frameType, int streamId,
-            Http2Flags flags, ByteBuf payload, Promise<Void> promise) {
+    public void writeFrame(ChannelHandlerContext ctx, byte frameType, int streamId,
+                           Http2Flags flags, ByteBuf payload, Promise<Void> promise) {
         logger.logUnknownFrame(OUTBOUND, ctx, frameType, streamId, flags, payload);
-        return writer.writeFrame(ctx, frameType, streamId, flags, payload, promise);
+        writer.writeFrame(ctx, frameType, streamId, flags, payload, promise);
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/StreamBufferingEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/StreamBufferingEncoder.java
@@ -19,7 +19,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 
 import java.util.ArrayDeque;
@@ -151,35 +150,39 @@ public class StreamBufferingEncoder extends DecoratingHttp2ConnectionEncoder {
     }
 
     @Override
-    public Future<Void> writeHeaders(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int padding,
-                                      boolean endStream, Promise<Void> promise) {
-        return writeHeaders0(ctx, streamId, headers, false, 0, (short) 0,
+    public void writeHeaders(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int padding,
+                             boolean endStream, Promise<Void> promise) {
+        writeHeaders0(ctx, streamId, headers, false, 0, (short) 0,
                              false, padding, endStream, promise);
     }
 
     @Override
-    public Future<Void> writeHeaders(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
-                                      int streamDependency, short weight, boolean exclusive, int padding,
-                                      boolean endOfStream, Promise<Void> promise) {
-        return writeHeaders0(ctx, streamId, headers, true, streamDependency, weight, exclusive, padding,
+    public void writeHeaders(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
+                             int streamDependency, short weight, boolean exclusive, int padding,
+                             boolean endOfStream, Promise<Void> promise) {
+        writeHeaders0(ctx, streamId, headers, true, streamDependency, weight, exclusive, padding,
                              endOfStream, promise);
     }
 
-    private Future<Void> writeHeaders0(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
+    private void writeHeaders0(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
                                        boolean hasPriority, int streamDependency, short weight, boolean exclusive,
                                        int padding, boolean endOfStream, Promise<Void> promise) {
         if (closed) {
-            return promise.setFailure(new Http2ChannelClosedException());
+            promise.setFailure(new Http2ChannelClosedException());
+            return;
         }
         if (isExistingStream(streamId) || canCreateStream()) {
             if (hasPriority) {
-                return super.writeHeaders(ctx, streamId, headers, streamDependency, weight,
+                super.writeHeaders(ctx, streamId, headers, streamDependency, weight,
                                           exclusive, padding, endOfStream, promise);
+            } else {
+                super.writeHeaders(ctx, streamId, headers, padding, endOfStream, promise);
             }
-            return super.writeHeaders(ctx, streamId, headers, padding, endOfStream, promise);
+            return;
         }
         if (goAwayDetail != null) {
-            return promise.setFailure(new Http2GoAwayException(goAwayDetail));
+            promise.setFailure(new Http2GoAwayException(goAwayDetail));
+            return;
         }
         PendingStream pendingStream = pendingStreams.get(streamId);
         if (pendingStream == null) {
@@ -188,14 +191,14 @@ public class StreamBufferingEncoder extends DecoratingHttp2ConnectionEncoder {
         }
         pendingStream.frames.add(new HeadersFrame(headers, hasPriority, streamDependency, weight, exclusive,
                 padding, endOfStream, promise));
-        return promise;
     }
 
     @Override
-    public Future<Void> writeRstStream(ChannelHandlerContext ctx, int streamId, long errorCode,
-                                        Promise<Void> promise) {
+    public void writeRstStream(ChannelHandlerContext ctx, int streamId, long errorCode,
+                               Promise<Void> promise) {
         if (isExistingStream(streamId)) {
-            return super.writeRstStream(ctx, streamId, errorCode, promise);
+            super.writeRstStream(ctx, streamId, errorCode, promise);
+            return;
         }
         // Since the delegate doesn't know about any buffered streams we have to handle cancellation
         // of the promises and releasing of the ByteBufs here.
@@ -210,14 +213,14 @@ public class StreamBufferingEncoder extends DecoratingHttp2ConnectionEncoder {
         } else {
             promise.setFailure(connectionError(PROTOCOL_ERROR, "Stream does not exist %d", streamId));
         }
-        return promise;
     }
 
     @Override
-    public Future<Void> writeData(ChannelHandlerContext ctx, int streamId, ByteBuf data,
-                                   int padding, boolean endOfStream, Promise<Void> promise) {
+    public void writeData(ChannelHandlerContext ctx, int streamId, ByteBuf data,
+                          int padding, boolean endOfStream, Promise<Void> promise) {
         if (isExistingStream(streamId)) {
-            return super.writeData(ctx, streamId, data, padding, endOfStream, promise);
+            super.writeData(ctx, streamId, data, padding, endOfStream, promise);
+            return;
         }
         PendingStream pendingStream = pendingStreams.get(streamId);
         if (pendingStream != null) {
@@ -226,17 +229,18 @@ public class StreamBufferingEncoder extends DecoratingHttp2ConnectionEncoder {
             ReferenceCountUtil.safeRelease(data);
             promise.setFailure(connectionError(PROTOCOL_ERROR, "Stream does not exist %d", streamId));
         }
-        return promise;
     }
 
     @Override
-    public Future<Void> writeSettingsAck(ChannelHandlerContext ctx, Promise<Void> promise) {
-        final Future<Void> future = super.writeSettingsAck(ctx, promise);
-        // In case autoAckSettings was set to false, decorated DefaultHttp2ConnectionEncoder will dequeue pending
-        // settings and call remoteSettings on its own instance. Therefore, we need to consume potentially updated value
-        // after this method returns.
-        updateMaxConcurrentStreams();
-        return future;
+    public void writeSettingsAck(ChannelHandlerContext ctx, Promise<Void> promise) {
+        try {
+            super.writeSettingsAck(ctx, promise);
+        } finally {
+            // In case autoAckSettings was set to false, decorated DefaultHttp2ConnectionEncoder will dequeue pending
+            // settings and call remoteSettings on its own instance. Therefore, we need to consume potentially
+            // updated value after this method returns.
+            updateMaxConcurrentStreams();
+        }
     }
 
     @Override

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
@@ -141,55 +141,47 @@ public class DefaultHttp2ConnectionEncoderTest {
         }).when(writer).writeGoAway(eq(ctx), anyInt(), anyInt(), any(ByteBuf.class), any(Promise.class));
         writtenData = new ArrayList<String>();
         writtenPadding = new ArrayList<Integer>();
-        when(writer.writeData(eq(ctx), anyInt(), any(ByteBuf.class), anyInt(), anyBoolean(),
-                any(Promise.class))).then(new Answer<Future<Void>>() {
-                    @Override
-                    public Future<Void> answer(InvocationOnMock in) throws Throwable {
-                        // Make sure we only receive stream closure on the last frame and that void promises
-                        // are used for all writes except the last one.
-                        Promise<Void> promise = (Promise<Void>) in.getArguments()[5];
-                        if (streamClosed) {
-                            fail("Stream already closed");
-                        } else {
-                            streamClosed = (Boolean) in.getArguments()[4];
-                        }
-                        writtenPadding.add((Integer) in.getArguments()[3]);
-                        ByteBuf data = (ByteBuf) in.getArguments()[2];
-                        writtenData.add(data.toString(UTF_8));
-                        // Release the buffer just as DefaultHttp2FrameWriter does
-                        data.release();
-                        // Let the promise succeed to trigger listeners.
-                        return promise.setSuccess(null);
-                    }
-                });
-        when(writer.writeHeaders(eq(ctx), anyInt(), any(Http2Headers.class), anyInt(), anyShort(), anyBoolean(),
-                anyInt(), anyBoolean(), any(Promise.class)))
-                .then(new Answer<Future>() {
-                    @Override
-                    public Future<Void> answer(InvocationOnMock invocationOnMock) {
-                        Promise<Void> promise = invocationOnMock.getArgument(8);
-                        if (streamClosed) {
-                            fail("Stream already closed");
-                        } else {
-                            streamClosed = invocationOnMock.getArgument(5);
-                        }
-                        return promise.setSuccess(null);
-                    }
-                });
-        when(writer.writeHeaders(eq(ctx), anyInt(), any(Http2Headers.class),
-                anyInt(), anyBoolean(), any(Promise.class)))
-                .then(new Answer<Future<Void>>() {
-                    @Override
-                    public Future<Void> answer(InvocationOnMock invocationOnMock) {
-                        Promise<Void> promise = invocationOnMock.getArgument(5);
-                        if (streamClosed) {
-                            fail("Stream already closed");
-                        } else {
-                            streamClosed = invocationOnMock.getArgument(4);
-                        }
-                        return promise.setSuccess(null);
-                    }
-                });
+        doAnswer(in -> {
+            // Make sure we only receive stream closure on the last frame and that void promises
+            // are used for all writes except the last one.
+            Promise<Void> promise = (Promise<Void>) in.getArguments()[5];
+            if (streamClosed) {
+                fail("Stream already closed");
+            } else {
+                streamClosed = (Boolean) in.getArguments()[4];
+            }
+            writtenPadding.add((Integer) in.getArguments()[3]);
+            ByteBuf data = (ByteBuf) in.getArguments()[2];
+            writtenData.add(data.toString(UTF_8));
+            // Release the buffer just as DefaultHttp2FrameWriter does
+            data.release();
+            // Let the promise succeed to trigger listeners.
+            promise.setSuccess(null);
+            return null;
+        }).when(writer).writeData(eq(ctx), anyInt(), any(ByteBuf.class), anyInt(), anyBoolean(),
+                any(Promise.class));
+        doAnswer(invocationOnMock -> {
+            Promise<Void> promise = invocationOnMock.getArgument(8);
+            if (streamClosed) {
+                fail("Stream already closed");
+            } else {
+                streamClosed = invocationOnMock.getArgument(5);
+            }
+            promise.setSuccess(null);
+            return null;
+        }).when(writer).writeHeaders(eq(ctx), anyInt(), any(Http2Headers.class), anyInt(), anyShort(), anyBoolean(),
+                anyInt(), anyBoolean(), any(Promise.class));
+        doAnswer(invocationOnMock -> {
+            Promise<Void> promise = invocationOnMock.getArgument(5);
+            if (streamClosed) {
+                fail("Stream already closed");
+            } else {
+                streamClosed = invocationOnMock.getArgument(4);
+            }
+            promise.setSuccess(null);
+            return null;
+        }).when(writer).writeHeaders(eq(ctx), anyInt(), any(Http2Headers.class),
+                anyInt(), anyBoolean(), any(Promise.class));
         payloadCaptor = ArgumentCaptor.forClass(Http2RemoteFlowController.FlowControlled.class);
         doNothing().when(remoteFlow).addFlowControlled(any(Http2Stream.class), payloadCaptor.capture());
         when(ctx.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
@@ -361,9 +353,9 @@ public class DefaultHttp2ConnectionEncoderTest {
         encoder.writeHeaders(ctx, streamId, EmptyHttp2Headers.INSTANCE, 0, false, promise);
 
         Promise<Void> promise2 = newPromise();
-        Future<Void> future = encoder.writeHeaders(ctx, streamId, EmptyHttp2Headers.INSTANCE, 0, false, promise2);
-        assertTrue(future.isDone());
-        assertFalse(future.isSuccess());
+        encoder.writeHeaders(ctx, streamId, EmptyHttp2Headers.INSTANCE, 0, false, promise2);
+        assertTrue(promise2.isDone());
+        assertFalse(promise2.isSuccess());
 
         verify(writer, times(1)).writeHeaders(eq(ctx), eq(streamId), eq(EmptyHttp2Headers.INSTANCE),
                 eq(0), eq(false), eq(promise));
@@ -380,9 +372,9 @@ public class DefaultHttp2ConnectionEncoderTest {
         when(remoteFlow.hasFlowControlled(eq(stream))).thenReturn(true);
 
         Promise<Void> promise2 = newPromise();
-        Future<Void> future = encoder.writeHeaders(ctx, streamId, EmptyHttp2Headers.INSTANCE, 0, false, promise2);
-        assertTrue(future.isDone());
-        assertFalse(future.isSuccess());
+        encoder.writeHeaders(ctx, streamId, EmptyHttp2Headers.INSTANCE, 0, false, promise2);
+        assertTrue(promise2.isDone());
+        assertFalse(promise2.isSuccess());
 
         verify(writer, times(1)).writeHeaders(eq(ctx), eq(streamId), eq(EmptyHttp2Headers.INSTANCE),
                 eq(0), eq(false), eq(promise));
@@ -407,9 +399,9 @@ public class DefaultHttp2ConnectionEncoderTest {
         encoder.writeHeaders(ctx, streamId, EmptyHttp2Headers.INSTANCE, 0, true, promise2);
 
         Promise<Void> promise3 = newPromise();
-        Future<Void> future = encoder.writeHeaders(ctx, streamId, EmptyHttp2Headers.INSTANCE, 0, eos, promise3);
-        assertTrue(future.isDone());
-        assertFalse(future.isSuccess());
+        encoder.writeHeaders(ctx, streamId, EmptyHttp2Headers.INSTANCE, 0, eos, promise3);
+        assertTrue(promise3.isDone());
+        assertFalse(promise3.isSuccess());
 
         verify(writer, times(1)).writeHeaders(eq(ctx), eq(streamId), eq(EmptyHttp2Headers.INSTANCE),
                 eq(0), eq(false), eq(promise));
@@ -448,9 +440,9 @@ public class DefaultHttp2ConnectionEncoderTest {
         encoder.writeHeaders(ctx, streamId, EmptyHttp2Headers.INSTANCE, 0, false, promise2);
 
         Promise<Void> promise3 = newPromise();
-        Future<Void> future = encoder.writeHeaders(ctx, streamId, EmptyHttp2Headers.INSTANCE, 0, eos, promise3);
-        assertTrue(future.isDone());
-        assertEquals(eos, future.isSuccess());
+        encoder.writeHeaders(ctx, streamId, EmptyHttp2Headers.INSTANCE, 0, eos, promise3);
+        assertTrue(promise3.isDone());
+        assertEquals(eos, promise3.isSuccess());
 
         verify(writer, times(infoHeaderCount)).writeHeaders(eq(ctx), eq(streamId), eq(infoHeaders),
                 eq(0), eq(false), any(Promise.class));
@@ -491,9 +483,9 @@ public class DefaultHttp2ConnectionEncoderTest {
         encoder.writeHeaders(ctx, streamId, EmptyHttp2Headers.INSTANCE, 0, true, promise2);
 
         Promise<Void> promise3 = newPromise();
-        Future<Void> future = encoder.writeHeaders(ctx, streamId, EmptyHttp2Headers.INSTANCE, 0, eos, promise3);
-        assertTrue(future.isDone());
-        assertFalse(future.isSuccess());
+        encoder.writeHeaders(ctx, streamId, EmptyHttp2Headers.INSTANCE, 0, eos, promise3);
+        assertTrue(promise3.isDone());
+        assertFalse(promise3.isSuccess());
 
         verify(writer, times(1)).writeHeaders(eq(ctx), eq(streamId), eq(EmptyHttp2Headers.INSTANCE),
                 eq(0), eq(false), eq(promise));
@@ -536,9 +528,9 @@ public class DefaultHttp2ConnectionEncoderTest {
         encoder.writeHeaders(ctx, streamId, EmptyHttp2Headers.INSTANCE, 0, false, promise2);
 
         Promise<Void> promise3 = newPromise();
-        Future<Void> future = encoder.writeHeaders(ctx, streamId, EmptyHttp2Headers.INSTANCE, 0, eos, promise3);
-        assertTrue(future.isDone());
-        assertEquals(eos, future.isSuccess());
+        encoder.writeHeaders(ctx, streamId, EmptyHttp2Headers.INSTANCE, 0, eos, promise3);
+        assertTrue(promise3.isDone());
+        assertEquals(eos, promise3.isSuccess());
 
         verify(writer, times(infoHeaderCount)).writeHeaders(eq(ctx), eq(streamId), eq(infoHeaders),
                 eq(0), eq(false), any(Promise.class));
@@ -554,10 +546,11 @@ public class DefaultHttp2ConnectionEncoderTest {
     public void pushPromiseWriteAfterGoAwayReceivedShouldFail() throws Exception {
         createStream(STREAM_ID, false);
         goAwayReceived(0);
-        Future<Void> future = encoder.writePushPromise(ctx, STREAM_ID, PUSH_STREAM_ID, EmptyHttp2Headers.INSTANCE, 0,
-                newPromise());
-        assertTrue(future.isDone());
-        assertFalse(future.isSuccess());
+        Promise<Void> promise = newPromise();
+        encoder.writePushPromise(ctx, STREAM_ID, PUSH_STREAM_ID, EmptyHttp2Headers.INSTANCE, 0,
+                promise);
+        assertTrue(promise.isDone());
+        assertFalse(promise.isSuccess());
     }
 
     @Test
@@ -711,14 +704,11 @@ public class DefaultHttp2ConnectionEncoderTest {
         final Promise<Void> promise = newPromise();
         final Throwable ex = new RuntimeException();
         // Fake an encoding error, like HPACK's HeaderListSizeException
-        when(writer.writeHeaders(eq(ctx), eq(STREAM_ID), eq(EmptyHttp2Headers.INSTANCE), eq(0), eq(true), eq(promise)))
-            .thenAnswer(new Answer<Future<Void>>() {
-                @Override
-                public Future<Void> answer(InvocationOnMock invocation) {
-                    promise.setFailure(ex);
-                    return promise;
-                }
-            });
+        doAnswer(invocation -> {
+            promise.setFailure(ex);
+            return null;
+        }).when(writer).writeHeaders(eq(ctx), eq(STREAM_ID),
+                eq(EmptyHttp2Headers.INSTANCE), eq(0), eq(true), eq(promise));
 
         writeAllFlowControlledFrames();
         Http2Stream stream = createStream(STREAM_ID, false);
@@ -737,14 +727,11 @@ public class DefaultHttp2ConnectionEncoderTest {
         final Promise<Void> promise = newPromise();
         final Throwable ex = new RuntimeException();
         // Fake an encoding error, like HPACK's HeaderListSizeException
-        when(writer.writeHeaders(eq(ctx), eq(STREAM_ID), eq(EmptyHttp2Headers.INSTANCE), eq(0), eq(true), eq(promise)))
-            .thenAnswer(new Answer<Future<Void>>() {
-                @Override
-                public Future<Void> answer(InvocationOnMock invocation) {
-                    promise.setFailure(ex);
-                    return promise;
-                }
-            });
+        doAnswer(invocation -> {
+            promise.setFailure(ex);
+            return null;
+        }).when(writer).writeHeaders(eq(ctx), eq(STREAM_ID), eq(EmptyHttp2Headers.INSTANCE),
+                eq(0), eq(true), eq(promise));
 
         writeAllFlowControlledFrames();
         encoder.writeHeaders(ctx, STREAM_ID, EmptyHttp2Headers.INSTANCE, 0, true, promise);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriterTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriterTest.java
@@ -85,11 +85,11 @@ public class DefaultHttp2FrameWriterTest {
                     outbound.writeBytes((ByteBuf) msg);
                 }
                 ReferenceCountUtil.release(msg);
-                return future;
+                return null;
             }
         };
         when(ctx.write(any())).then(answer);
-        when(ctx.write(any(), any(Promise.class))).then(answer);
+        doAnswer(answer).when(ctx).write(any(), any(Promise.class));
         when(ctx.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
         when(ctx.channel()).thenReturn(channel);
         when(ctx.executor()).thenReturn(ImmediateEventExecutor.INSTANCE);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -25,8 +25,6 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http2.Http2Exception.ShutdownHint;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.EventExecutor;
-import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
 import org.junit.jupiter.api.AfterEach;
@@ -83,7 +81,6 @@ public class Http2ConnectionHandlerTest {
     private static final int NON_EXISTANT_STREAM_ID = 13;
 
     private Http2ConnectionHandler handler;
-    private Promise promise;
 
     @Mock
     private Http2Connection connection;
@@ -119,9 +116,6 @@ public class Http2ConnectionHandlerTest {
     private ChannelPipeline pipeline;
 
     @Mock
-    private Future future;
-
-    @Mock
     private Http2Stream stream;
 
     @Mock
@@ -140,8 +134,6 @@ public class Http2ConnectionHandlerTest {
     public void setup() throws Exception {
         MockitoAnnotations.initMocks(this);
 
-        promise = ImmediateEventExecutor.INSTANCE.newPromise();
-
         DefaultChannelConfig config = new DefaultChannelConfig(channel);
         when(channel.config()).thenReturn(config);
 
@@ -151,54 +143,42 @@ public class Http2ConnectionHandlerTest {
         when(encoder.frameWriter()).thenReturn(frameWriter);
         when(encoder.flowController()).thenReturn(remoteFlow);
         when(decoder.flowController()).thenReturn(localFlow);
-        doAnswer(new Answer<Future<Void>>() {
-            @Override
-            public Future<Void> answer(InvocationOnMock invocation) throws Throwable {
-                ByteBuf buf = invocation.getArgument(3);
-                goAwayDebugCap = buf.toString(UTF_8);
-                buf.release();
-                return future;
-            }
+        doAnswer(invocation -> {
+            ByteBuf buf = invocation.getArgument(3);
+            goAwayDebugCap = buf.toString(UTF_8);
+            buf.release();
+            ((Promise<Void>) invocation.getArgument(4)).setSuccess(null);
+            return null;
         }).when(frameWriter).writeGoAway(
                 any(ChannelHandlerContext.class), anyInt(), anyLong(), any(ByteBuf.class), any(Promise.class));
-        doAnswer(new Answer<Future<Void>>() {
-            @Override
-            public Future<Void> answer(InvocationOnMock invocation) throws Throwable {
-                Object o = invocation.getArguments()[0];
-                if (o instanceof FutureListener<?>) {
-                    ((FutureListener<Void>) o).operationComplete(future);
-                }
-                return future;
-            }
-        }).when(future).addListener(any(FutureListener.class));
-        when(future.cause()).thenReturn(fakeException);
         when(channel.isActive()).thenReturn(true);
         when(channel.pipeline()).thenReturn(pipeline);
         when(connection.remote()).thenReturn(remote);
         when(remote.flowController()).thenReturn(remoteFlowController);
         when(connection.local()).thenReturn(local);
         when(local.flowController()).thenReturn(localFlowController);
-        doAnswer(new Answer<Http2Stream>() {
-            @Override
-            public Http2Stream answer(InvocationOnMock in) throws Throwable {
-                Http2StreamVisitor visitor = in.getArgument(0);
-                if (!visitor.visit(stream)) {
-                    return stream;
-                }
-                return null;
+        doAnswer((Answer<Http2Stream>) in -> {
+            Http2StreamVisitor visitor = in.getArgument(0);
+            if (!visitor.visit(stream)) {
+                return stream;
             }
+            return null;
         }).when(connection).forEachActiveStream(any(Http2StreamVisitor.class));
         when(connection.stream(NON_EXISTANT_STREAM_ID)).thenReturn(null);
         when(connection.numActiveStreams()).thenReturn(1);
         when(connection.stream(STREAM_ID)).thenReturn(stream);
         when(connection.goAwaySent(anyInt(), anyLong(), any(ByteBuf.class))).thenReturn(true);
         when(stream.open(anyBoolean())).thenReturn(stream);
-        when(encoder.writeSettings(eq(ctx), any(Http2Settings.class), eq(promise))).thenReturn(future);
+        doAnswer(invocationOnMock -> {
+            ((Promise<Void>) invocationOnMock.getArgument(2)).setSuccess(null);
+            return null;
+        }).when(encoder).writeSettings(eq(ctx), any(Http2Settings.class), any(Promise.class));
         when(ctx.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
         when(ctx.channel()).thenReturn(channel);
-        when(ctx.newSucceededFuture(eq(null))).thenReturn(future);
-        when(ctx.newPromise()).thenReturn(promise);
-        when(ctx.write(any())).thenReturn(future);
+        when(ctx.newSucceededFuture(eq(null))).thenReturn(
+                ImmediateEventExecutor.INSTANCE.newSucceededFuture(null));
+        doAnswer(invocationOnMock -> ImmediateEventExecutor.INSTANCE.newPromise()).when(ctx).newPromise();
+        when(ctx.write(any())).thenReturn(ImmediateEventExecutor.INSTANCE.newPromise());
         when(ctx.executor()).thenReturn(executor);
         doAnswer(new Answer<Object>() {
             @Override
@@ -314,7 +294,7 @@ public class Http2ConnectionHandlerTest {
         handler.channelRead(ctx, copiedBuffer("BAD_PREFACE", UTF_8));
         ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
         verify(frameWriter).writeGoAway(eq(ctx), eq(Integer.MAX_VALUE), eq(PROTOCOL_ERROR.code()),
-                captor.capture(), eq(promise));
+                captor.capture(), any(Promise.class));
         assertEquals(0, captor.getValue().refCnt());
     }
 
@@ -325,7 +305,7 @@ public class Http2ConnectionHandlerTest {
         handler.channelRead(ctx, copiedBuffer("GET /path HTTP/1.1", US_ASCII));
         ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
         verify(frameWriter).writeGoAway(eq(ctx), eq(Integer.MAX_VALUE), eq(PROTOCOL_ERROR.code()),
-            captor.capture(), eq(promise));
+            captor.capture(), any(Promise.class));
         assertEquals(0, captor.getValue().refCnt());
         assertTrue(goAwayDebugCap.contains("/path"));
     }
@@ -341,7 +321,7 @@ public class Http2ConnectionHandlerTest {
         handler.channelRead(ctx, buf);
         ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
         verify(frameWriter, atLeastOnce()).writeGoAway(eq(ctx), eq(Integer.MAX_VALUE), eq(PROTOCOL_ERROR.code()),
-                captor.capture(), eq(promise));
+                captor.capture(), any(Promise.class));
         assertEquals(0, captor.getValue().refCnt());
     }
 
@@ -395,7 +375,7 @@ public class Http2ConnectionHandlerTest {
         handler.exceptionCaught(ctx, e);
         ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
         verify(frameWriter).writeGoAway(eq(ctx), eq(Integer.MAX_VALUE), eq(PROTOCOL_ERROR.code()),
-                captor.capture(), eq(promise));
+                captor.capture(), any(Promise.class));
         captor.getValue().release();
     }
 
@@ -410,17 +390,21 @@ public class Http2ConnectionHandlerTest {
         when(connection.isServer()).thenReturn(true);
         when(stream.isHeadersSent()).thenReturn(false);
         when(remote.lastStreamCreated()).thenReturn(STREAM_ID);
-        when(encoder.writeRstStream(eq(ctx), eq(STREAM_ID),
-                eq(PROTOCOL_ERROR.code()), eq(promise))).thenReturn(future);
+        doAnswer(invocationOnMock -> {
+            ((Promise<Void>) invocationOnMock.getArgument(3)).setFailure(e);
+            return null;
+        }).when(encoder).writeRstStream(eq(ctx), eq(STREAM_ID),
+                eq(PROTOCOL_ERROR.code()), any(Promise.class));
 
         handler.exceptionCaught(ctx, e);
 
         ArgumentCaptor<Http2Headers> captor = ArgumentCaptor.forClass(Http2Headers.class);
         verify(encoder).writeHeaders(eq(ctx), eq(STREAM_ID),
-                captor.capture(), eq(padding), eq(true), eq(promise));
+                captor.capture(), eq(padding), eq(true), any(Promise.class));
         Http2Headers headers = captor.getValue();
         assertEquals(HttpResponseStatus.REQUEST_HEADER_FIELDS_TOO_LARGE.codeAsText(), headers.status());
-        verify(encoder).writeRstStream(ctx, STREAM_ID, PROTOCOL_ERROR.code(), promise);
+        verify(encoder).writeRstStream(eq(ctx), eq(STREAM_ID), eq(PROTOCOL_ERROR.code()),
+                any(Promise.class));
     }
 
     @Test
@@ -434,14 +418,17 @@ public class Http2ConnectionHandlerTest {
         when(connection.isServer()).thenReturn(true);
         when(stream.isHeadersSent()).thenReturn(false);
         when(remote.lastStreamCreated()).thenReturn(STREAM_ID);
-        when(encoder.writeRstStream(eq(ctx), eq(STREAM_ID),
-            eq(PROTOCOL_ERROR.code()), eq(promise))).thenReturn(future);
+        doAnswer(invocationOnMock -> {
+            ((Promise<Void>) invocationOnMock.getArgument(3)).setSuccess(null);
+            return null;
+        }).when(encoder).writeRstStream(eq(ctx), eq(STREAM_ID),
+            eq(PROTOCOL_ERROR.code()), any(Promise.class));
 
         handler.exceptionCaught(ctx, e);
 
         verify(encoder, never()).writeHeaders(eq(ctx), eq(STREAM_ID),
-            any(Http2Headers.class), eq(padding), eq(true), eq(promise));
-        verify(encoder).writeRstStream(ctx, STREAM_ID, PROTOCOL_ERROR.code(), promise);
+            any(Http2Headers.class), eq(padding), eq(true), any(Promise.class));
+        verify(encoder).writeRstStream(eq(ctx), eq(STREAM_ID), eq(PROTOCOL_ERROR.code()), any(Promise.class));
     }
 
     @Test
@@ -455,14 +442,17 @@ public class Http2ConnectionHandlerTest {
         when(connection.isServer()).thenReturn(false);
         when(stream.isHeadersSent()).thenReturn(false);
         when(remote.lastStreamCreated()).thenReturn(STREAM_ID);
-        when(encoder.writeRstStream(eq(ctx), eq(STREAM_ID),
-                eq(PROTOCOL_ERROR.code()), eq(promise))).thenReturn(future);
+        doAnswer(invocationOnMock -> {
+            ((Promise<Void>) invocationOnMock.getArgument(3)).setSuccess(null);
+            return null;
+        }).when(encoder).writeRstStream(eq(ctx), eq(STREAM_ID),
+                eq(PROTOCOL_ERROR.code()), any(Promise.class));
 
         handler.exceptionCaught(ctx, e);
 
         verify(encoder, never()).writeHeaders(eq(ctx), eq(STREAM_ID),
-                any(Http2Headers.class), eq(padding), eq(true), eq(promise));
-        verify(encoder).writeRstStream(ctx, STREAM_ID, PROTOCOL_ERROR.code(), promise);
+                any(Http2Headers.class), eq(padding), eq(true), any(Promise.class));
+        verify(encoder).writeRstStream(eq(ctx), eq(STREAM_ID), eq(PROTOCOL_ERROR.code()), any(Promise.class));
     }
 
     @Test
@@ -491,14 +481,17 @@ public class Http2ConnectionHandlerTest {
         when(connection.isServer()).thenReturn(true);
         when(stream.isHeadersSent()).thenReturn(true);
         when(remote.lastStreamCreated()).thenReturn(STREAM_ID);
-        when(encoder.writeRstStream(eq(ctx), eq(STREAM_ID),
-            eq(PROTOCOL_ERROR.code()), eq(promise))).thenReturn(future);
+        doAnswer(invocationOnMock -> {
+            ((Promise<Void>) invocationOnMock.getArgument(3)).setSuccess(null);
+            return null;
+        }).when(encoder).writeRstStream(eq(ctx), eq(STREAM_ID), eq(PROTOCOL_ERROR.code()), any(Promise.class));
         handler.exceptionCaught(ctx, e);
 
         verify(encoder, never()).writeHeaders(eq(ctx), eq(STREAM_ID),
-            any(Http2Headers.class), eq(padding), eq(true), eq(promise));
+            any(Http2Headers.class), eq(padding), eq(true), any(Promise.class));
 
-        verify(encoder).writeRstStream(ctx, STREAM_ID, PROTOCOL_ERROR.code(), promise);
+        verify(encoder).writeRstStream(eq(ctx), eq(STREAM_ID), eq(PROTOCOL_ERROR.code()),
+                any(Promise.class));
     }
 
     @Test
@@ -515,15 +508,18 @@ public class Http2ConnectionHandlerTest {
         when(connection.isServer()).thenReturn(true);
         when(stream.isHeadersSent()).thenReturn(false);
         when(remote.lastStreamCreated()).thenReturn(STREAM_ID);
-        when(encoder.writeRstStream(eq(ctx), eq(STREAM_ID),
-            eq(PROTOCOL_ERROR.code()), eq(promise))).thenReturn(future);
+        doAnswer(invocationOnMock -> {
+            ((Promise<Void>) invocationOnMock.getArgument(3)).setSuccess(null);
+            return null;
+        }).when(encoder).writeRstStream(eq(ctx), eq(STREAM_ID), eq(PROTOCOL_ERROR.code()), any(Promise.class));
         handler.exceptionCaught(ctx, e);
 
         verify(remote).createStream(STREAM_ID, true);
         verify(encoder).writeHeaders(eq(ctx), eq(STREAM_ID),
-            any(Http2Headers.class), eq(padding), eq(true), eq(promise));
+            any(Http2Headers.class), eq(padding), eq(true), any(Promise.class));
 
-        verify(encoder).writeRstStream(ctx, STREAM_ID, PROTOCOL_ERROR.code(), promise);
+        verify(encoder).writeRstStream(eq(ctx), eq(STREAM_ID), eq(PROTOCOL_ERROR.code()),
+                any(Promise.class));
     }
 
     @Test
@@ -539,23 +535,31 @@ public class Http2ConnectionHandlerTest {
     @Test
     public void writeRstOnNonExistantStreamShouldSucceed() throws Exception {
         handler = newHandler();
-        when(frameWriter.writeRstStream(eq(ctx), eq(NON_EXISTANT_STREAM_ID),
-                                        eq(STREAM_CLOSED.code()), eq(promise))).thenReturn(future);
-        handler.resetStream(ctx, NON_EXISTANT_STREAM_ID, STREAM_CLOSED.code(), promise);
-        verify(frameWriter).writeRstStream(eq(ctx), eq(NON_EXISTANT_STREAM_ID), eq(STREAM_CLOSED.code()), eq(promise));
+        doAnswer(invocationOnMock -> {
+            ((Promise<Void>) invocationOnMock.getArgument(3)).setSuccess(null);
+            return null;
+        }).when(frameWriter).writeRstStream(eq(ctx), eq(NON_EXISTANT_STREAM_ID),
+                eq(STREAM_CLOSED.code()), any(Promise.class));
+        handler.resetStream(ctx, NON_EXISTANT_STREAM_ID, STREAM_CLOSED.code(),
+                ImmediateEventExecutor.INSTANCE.newPromise());
+        verify(frameWriter).writeRstStream(eq(ctx), eq(NON_EXISTANT_STREAM_ID), eq(STREAM_CLOSED.code()),
+                any(Promise.class));
     }
 
     @Test
     public void writeRstOnClosedStreamShouldSucceed() throws Exception {
         handler = newHandler();
         when(stream.id()).thenReturn(STREAM_ID);
-        when(frameWriter.writeRstStream(eq(ctx), eq(STREAM_ID),
-                anyLong(), any(Promise.class))).thenReturn(future);
+        doAnswer(invocationOnMock -> {
+            ((Promise<Void>) invocationOnMock.getArgument(3)).setSuccess(null);
+            return null;
+        }).when(frameWriter).writeRstStream(eq(ctx), eq(STREAM_ID), eq(PROTOCOL_ERROR.code()), any(Promise.class));
+
         when(stream.state()).thenReturn(CLOSED);
         when(stream.isHeadersSent()).thenReturn(true);
         // The stream is "closed" but is still known about by the connection (connection().stream(..)
         // will return the stream). We should still write a RST_STREAM frame in this scenario.
-        handler.resetStream(ctx, STREAM_ID, STREAM_CLOSED.code(), promise);
+        handler.resetStream(ctx, STREAM_ID, STREAM_CLOSED.code(), ImmediateEventExecutor.INSTANCE.newPromise());
         verify(frameWriter).writeRstStream(eq(ctx), eq(STREAM_ID), anyLong(), any(Promise.class));
     }
 
@@ -563,7 +567,7 @@ public class Http2ConnectionHandlerTest {
     public void writeRstOnIdleStreamShouldNotWriteButStillSucceed() throws Exception {
         handler = newHandler();
         when(stream.state()).thenReturn(IDLE);
-        handler.resetStream(ctx, STREAM_ID, STREAM_CLOSED.code(), promise);
+        handler.resetStream(ctx, STREAM_ID, STREAM_CLOSED.code(), ImmediateEventExecutor.INSTANCE.newPromise());
         verify(frameWriter, never()).writeRstStream(eq(ctx), eq(STREAM_ID), anyLong(), any(Promise.class));
         verify(stream).close();
     }
@@ -572,33 +576,21 @@ public class Http2ConnectionHandlerTest {
     @Test
     public void closeListenerShouldBeNotifiedOnlyOneTime() throws Exception {
         handler = newHandler();
-        when(future.isDone()).thenReturn(true);
-        when(future.isSuccess()).thenReturn(true);
-        doAnswer(new Answer<Future<Void>>() {
+        handler.close(ctx, ImmediateEventExecutor.INSTANCE.newPromise());
+        when(connection.numActiveStreams()).thenReturn(0);
+
+        // Simulate that all streams have become inactive by the time the future completes.
+        doAnswer(new Answer<Http2Stream>() {
             @Override
-            public Future<Void> answer(InvocationOnMock invocation) throws Throwable {
-                Object[] args = invocation.getArguments();
-                FutureListener<Void> listener = (FutureListener<Void>) args[0];
-                // Simulate that all streams have become inactive by the time the future completes.
-                doAnswer(new Answer<Http2Stream>() {
-                    @Override
-                    public Http2Stream answer(InvocationOnMock in) throws Throwable {
-                        return null;
-                    }
-                }).when(connection).forEachActiveStream(any(Http2StreamVisitor.class));
-                when(connection.numActiveStreams()).thenReturn(0);
-                // Simulate the future being completed.
-                listener.operationComplete(future);
-                return future;
+            public Http2Stream answer(InvocationOnMock in) throws Throwable {
+                return null;
             }
-        }).when(future).addListener(any(FutureListener.class));
-        handler.close(ctx, promise);
-        if (future.isDone()) {
-            when(connection.numActiveStreams()).thenReturn(0);
-        }
-        handler.closeStream(stream, future);
+        }).when(connection).forEachActiveStream(any(Http2StreamVisitor.class));
+        when(connection.numActiveStreams()).thenReturn(0);
+
+        handler.closeStream(stream, ImmediateEventExecutor.INSTANCE.newSucceededFuture(null));
         // Simulate another stream close call being made after the context should already be closed.
-        handler.closeStream(stream, future);
+        handler.closeStream(stream, ImmediateEventExecutor.INSTANCE.newSucceededFuture(null));
         verify(ctx, times(1)).close(any(Promise.class));
     }
 
@@ -607,21 +599,12 @@ public class Http2ConnectionHandlerTest {
     public void canSendGoAwayFrame() throws Exception {
         ByteBuf data = dummyData();
         long errorCode = Http2Error.INTERNAL_ERROR.code();
-        when(future.isDone()).thenReturn(true);
-        when(future.isSuccess()).thenReturn(true);
-        doAnswer(new Answer<Void>() {
-            @Override
-            public Void answer(InvocationOnMock invocation) throws Throwable {
-                ((FutureListener<Void>) invocation.getArgument(0)).operationComplete(future);
-                return null;
-            }
-        }).when(future).addListener(any(FutureListener.class));
         handler = newHandler();
-        handler.goAway(ctx, STREAM_ID, errorCode, data, promise);
+        handler.goAway(ctx, STREAM_ID, errorCode, data, ImmediateEventExecutor.INSTANCE.newPromise());
 
         verify(connection).goAwaySent(eq(STREAM_ID), eq(errorCode), eq(data));
         verify(frameWriter).writeGoAway(eq(ctx), eq(STREAM_ID), eq(errorCode), eq(data),
-                eq(promise));
+                any(Promise.class));
         verify(ctx).close();
         assertEquals(0, data.refCnt());
     }
@@ -632,13 +615,13 @@ public class Http2ConnectionHandlerTest {
         ByteBuf data = dummyData();
         long errorCode = Http2Error.INTERNAL_ERROR.code();
 
-        handler.goAway(ctx, STREAM_ID + 2, errorCode, data.retain(), promise);
+        handler.goAway(ctx, STREAM_ID + 2, errorCode, data.retain(),
+                ImmediateEventExecutor.INSTANCE.newPromise());
         verify(frameWriter).writeGoAway(eq(ctx), eq(STREAM_ID + 2), eq(errorCode), eq(data),
-                eq(promise));
+                any(Promise.class));
         verify(connection).goAwaySent(eq(STREAM_ID + 2), eq(errorCode), eq(data));
-        promise = ImmediateEventExecutor.INSTANCE.newPromise();
-        handler.goAway(ctx, STREAM_ID, errorCode, data, promise);
-        verify(frameWriter).writeGoAway(eq(ctx), eq(STREAM_ID), eq(errorCode), eq(data), eq(promise));
+        handler.goAway(ctx, STREAM_ID, errorCode, data, ImmediateEventExecutor.INSTANCE.newPromise());
+        verify(frameWriter).writeGoAway(eq(ctx), eq(STREAM_ID), eq(errorCode), eq(data), any(Promise.class));
         verify(connection).goAwaySent(eq(STREAM_ID), eq(errorCode), eq(data));
         assertEquals(0, data.refCnt());
     }
@@ -649,9 +632,10 @@ public class Http2ConnectionHandlerTest {
         ByteBuf data = dummyData();
         long errorCode = Http2Error.INTERNAL_ERROR.code();
 
-        handler.goAway(ctx, STREAM_ID, errorCode, data.retain(), promise);
+        Promise<Void> promise = ImmediateEventExecutor.INSTANCE.newPromise();
+        handler.goAway(ctx, STREAM_ID, errorCode, data.retain(), ImmediateEventExecutor.INSTANCE.newPromise());
         verify(connection).goAwaySent(eq(STREAM_ID), eq(errorCode), eq(data));
-        verify(frameWriter).writeGoAway(eq(ctx), eq(STREAM_ID), eq(errorCode), eq(data), eq(promise));
+        verify(frameWriter).writeGoAway(eq(ctx), eq(STREAM_ID), eq(errorCode), eq(data), any(Promise.class));
         // The frameWriter is only mocked, so it should not have interacted with the promise.
         assertFalse(promise.isDone());
 
@@ -703,7 +687,7 @@ public class Http2ConnectionHandlerTest {
         when(channel.isActive()).thenReturn(false);
         handler = newHandler();
         when(channel.isActive()).thenReturn(true);
-        handler.close(ctx, promise);
+        handler.close(ctx, ImmediateEventExecutor.INSTANCE.newPromise());
         verifyZeroInteractions(frameWriter);
     }
 
@@ -731,7 +715,7 @@ public class Http2ConnectionHandlerTest {
         handler = newHandler();
         final long expectedMillis = 1234;
         handler.gracefulShutdownTimeoutMillis(expectedMillis);
-        handler.close(ctx, promise);
+        handler.close(ctx, ImmediateEventExecutor.INSTANCE.newPromise());
         verify(executor, atLeastOnce()).schedule(any(Runnable.class), eq(expectedMillis), eq(TimeUnit.MILLISECONDS));
     }
 
@@ -741,7 +725,7 @@ public class Http2ConnectionHandlerTest {
         when(connection.numActiveStreams()).thenReturn(0);
         final long expectedMillis = 1234;
         handler.gracefulShutdownTimeoutMillis(expectedMillis);
-        handler.close(ctx, promise);
+        handler.close(ctx, ImmediateEventExecutor.INSTANCE.newPromise());
         verify(executor, atLeastOnce()).schedule(any(Runnable.class), eq(expectedMillis), eq(TimeUnit.MILLISECONDS));
     }
 
@@ -749,7 +733,7 @@ public class Http2ConnectionHandlerTest {
     public void gracefulShutdownIndefiniteTimeoutTest() throws Exception {
         handler = newHandler();
         handler.gracefulShutdownTimeoutMillis(-1);
-        handler.close(ctx, promise);
+        handler.close(ctx, ImmediateEventExecutor.INSTANCE.newPromise());
         verify(executor, never()).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
     }
 
@@ -772,14 +756,11 @@ public class Http2ConnectionHandlerTest {
                 return resetSent.get();
             }
         });
-        when(frameWriter.writeRstStream(eq(ctx), eq(STREAM_ID), anyLong(), any(Promise.class)))
-                .then(new Answer<Future<Void>>() {
-                    @Override
-                    public Future<Void> answer(InvocationOnMock invocationOnMock) throws Throwable {
-                        Promise<Void> promise = invocationOnMock.getArgument(3);
-                        return promise.setSuccess(null);
-                    }
-                });
+        doAnswer(invocationOnMock -> {
+            Promise<Void> promise = invocationOnMock.getArgument(3);
+            promise.setSuccess(null);
+            return null;
+        }).when(frameWriter).writeRstStream(eq(ctx), eq(STREAM_ID), anyLong(), any(Promise.class));
 
         Promise<Void> promise = ImmediateEventExecutor.INSTANCE.newPromise();
         final Promise<Void> promise2 = ImmediateEventExecutor.INSTANCE.newPromise();

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -288,14 +288,14 @@ public class Http2ConnectionRoundtripTest {
         runInChannel(clientChannel, new Http2Runnable() {
             @Override
             public void run() throws Http2Exception {
-                http2Client.encoder().writeHeaders(ctx(), 3, headers, 0, false, newPromise())
-                        .addListener(future -> clientHeadersWriteException.set(future.cause()));
+                http2Client.encoder().writeHeaders(ctx(), 3, headers, 0, false,
+                        newPromise().addListener(future -> clientHeadersWriteException.set(future.cause())));
                 // It is expected that this write should fail locally and the remote peer will never see this.
-                http2Client.encoder().writeData(ctx(), 3, Unpooled.buffer(), 0, true, newPromise())
-                    .addListener(future -> {
+                http2Client.encoder().writeData(ctx(), 3, Unpooled.buffer(), 0, true,
+                        newPromise().addListener(future -> {
                         clientDataWriteException.set(future.cause());
                         clientDataWrite.countDown();
-                    });
+                    }));
                 http2Client.flush(ctx());
             }
         });
@@ -323,10 +323,10 @@ public class Http2ConnectionRoundtripTest {
             @Override
             public void run() throws Http2Exception {
                 http2Client.encoder().writeHeaders(ctx(), 5, headers, 0, true,
-                        newPromise()).addListener(future -> {
+                        newPromise().addListener(future -> {
                             clientHeadersWriteException2.set(future.cause());
                             clientHeadersLatch.countDown();
-                        });
+                        }));
                 http2Client.flush(ctx());
             }
         });
@@ -543,11 +543,11 @@ public class Http2ConnectionRoundtripTest {
         runInChannel(serverConnectedChannel, new Http2Runnable() {
             @Override
             public void run() throws Http2Exception {
-                http2Server.encoder().writeHeaders(serverCtx(), streamId, headers, 0, true, serverNewPromise())
-                        .addListener(future -> {
+                http2Server.encoder().writeHeaders(serverCtx(), streamId, headers, 0, true,
+                        serverNewPromise().addListener(future -> {
                             serverWriteHeadersCauseRef.set(future.cause());
                             serverWriteHeadersLatch.countDown();
-                        });
+                        }));
                 http2Server.flush(serverCtx());
             }
         });
@@ -889,11 +889,12 @@ public class Http2ConnectionRoundtripTest {
         runInChannel(clientChannel, new Http2Runnable() {
             @Override
             public void run() throws Http2Exception {
-                Future<Void> f = http2Client.encoder().writeHeaders(ctx(), 5, headers, 0, (short) 16, false, 0,
-                        true, newPromise());
-                clientWriteAfterGoAwayFutureRef.set(f);
+                Promise<Void> promise = newPromise();
+                http2Client.encoder().writeHeaders(ctx(), 5, headers, 0, (short) 16, false, 0,
+                        true, promise);
+                clientWriteAfterGoAwayFutureRef.set(promise);
                 http2Client.flush(ctx());
-                f.addListener(future -> clientWriteAfterGoAwayLatch.countDown());
+                promise.addListener(future -> clientWriteAfterGoAwayLatch.countDown());
             }
         });
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -288,14 +288,16 @@ public class Http2ConnectionRoundtripTest {
         runInChannel(clientChannel, new Http2Runnable() {
             @Override
             public void run() throws Http2Exception {
-                http2Client.encoder().writeHeaders(ctx(), 3, headers, 0, false,
-                        newPromise().addListener(future -> clientHeadersWriteException.set(future.cause())));
+                Promise<Void> headersPromise = newPromise();
+                http2Client.encoder().writeHeaders(ctx(), 3, headers, 0, false, headersPromise);
+                headersPromise.addListener(future -> clientHeadersWriteException.set(future.cause()));
                 // It is expected that this write should fail locally and the remote peer will never see this.
-                http2Client.encoder().writeData(ctx(), 3, Unpooled.buffer(), 0, true,
-                        newPromise().addListener(future -> {
-                        clientDataWriteException.set(future.cause());
-                        clientDataWrite.countDown();
-                    }));
+                Promise<Void> dataPromise = newPromise();
+                http2Client.encoder().writeData(ctx(), 3, Unpooled.buffer(), 0, true, dataPromise);
+                dataPromise.addListener(future -> {
+                    clientDataWriteException.set(future.cause());
+                    clientDataWrite.countDown();
+                });
                 http2Client.flush(ctx());
             }
         });
@@ -322,11 +324,12 @@ public class Http2ConnectionRoundtripTest {
         runInChannel(clientChannel, new Http2Runnable() {
             @Override
             public void run() throws Http2Exception {
-                http2Client.encoder().writeHeaders(ctx(), 5, headers, 0, true,
-                        newPromise().addListener(future -> {
-                            clientHeadersWriteException2.set(future.cause());
-                            clientHeadersLatch.countDown();
-                        }));
+                Promise<Void> headersPromise = newPromise();
+                http2Client.encoder().writeHeaders(ctx(), 5, headers, 0, true, headersPromise);
+                headersPromise.addListener(future -> {
+                    clientHeadersWriteException2.set(future.cause());
+                    clientHeadersLatch.countDown();
+                });
                 http2Client.flush(ctx());
             }
         });
@@ -543,11 +546,12 @@ public class Http2ConnectionRoundtripTest {
         runInChannel(serverConnectedChannel, new Http2Runnable() {
             @Override
             public void run() throws Http2Exception {
-                http2Server.encoder().writeHeaders(serverCtx(), streamId, headers, 0, true,
-                        serverNewPromise().addListener(future -> {
-                            serverWriteHeadersCauseRef.set(future.cause());
-                            serverWriteHeadersLatch.countDown();
-                        }));
+                Promise<Void> headersPromise = serverNewPromise();
+                http2Server.encoder().writeHeaders(serverCtx(), streamId, headers, 0, true, headersPromise);
+                headersPromise.addListener(future -> {
+                    serverWriteHeadersCauseRef.set(future.cause());
+                    serverWriteHeadersLatch.countDown();
+                });
                 http2Server.flush(serverCtx());
             }
         });

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ControlFrameLimitEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ControlFrameLimitEncoderTest.java
@@ -24,7 +24,6 @@ import io.netty.channel.DefaultMessageSizeEstimator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.EventExecutor;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
 import org.junit.jupiter.api.AfterEach;
@@ -87,41 +86,28 @@ public class Http2ControlFrameLimitEncoderTest {
         when(configuration.frameSizePolicy()).thenReturn(frameSizePolicy);
         when(frameSizePolicy.maxFrameSize()).thenReturn(DEFAULT_MAX_FRAME_SIZE);
 
-        when(writer.writeRstStream(eq(ctx), anyInt(), anyLong(), any(Promise.class)))
-                .thenAnswer(new Answer<Future<Void>>() {
-                    @Override
-                    public Future<Void> answer(InvocationOnMock invocationOnMock) {
-                        return handlePromise(invocationOnMock, 3);
-                    }
-                });
-        when(writer.writeSettingsAck(any(ChannelHandlerContext.class), any(Promise.class)))
-                .thenAnswer(new Answer<>() {
-                    @Override
-                    public Future<Void> answer(InvocationOnMock invocationOnMock) {
-                        return handlePromise(invocationOnMock, 1);
-                    }
-        });
-        when(writer.writePing(any(ChannelHandlerContext.class), anyBoolean(), anyLong(), any(Promise.class)))
-                .thenAnswer(new Answer<>() {
-                    @Override
-                    public Future<Void> answer(InvocationOnMock invocationOnMock) {
-                        Promise<Void> promise = handlePromise(invocationOnMock, 3);
-                        if (invocationOnMock.getArgument(1) == Boolean.FALSE) {
-                            promise.trySuccess(null);
-                        }
-                        return promise;
-                    }
-                });
-        when(writer.writeGoAway(any(ChannelHandlerContext.class), anyInt(), anyLong(), any(ByteBuf.class),
-                any(Promise.class))).thenAnswer(new Answer<>() {
-            @Override
-            public Future<Void> answer(InvocationOnMock invocationOnMock) {
-                ReferenceCountUtil.release(invocationOnMock.getArgument(3));
-                Promise<Void> promise = invocationOnMock.getArgument(4);
-                goAwayPromises.offer(promise);
-                return promise;
+        doAnswer(invocationOnMock -> {
+            handlePromise(invocationOnMock, 3);
+            return null;
+        }).when(writer).writeRstStream(eq(ctx), anyInt(), anyLong(), any(Promise.class));
+        doAnswer(invocationOnMock -> {
+            handlePromise(invocationOnMock, 1);
+            return null;
+        }).when(writer).writeSettingsAck(any(ChannelHandlerContext.class), any(Promise.class));
+        doAnswer(invocationOnMock -> {
+            Promise<Void> promise = handlePromise(invocationOnMock, 3);
+            if (invocationOnMock.getArgument(1) == Boolean.FALSE) {
+                promise.trySuccess(null);
             }
-        });
+            return null;
+        }).when(writer).writePing(any(ChannelHandlerContext.class), anyBoolean(), anyLong(), any(Promise.class));
+        doAnswer(invocationOnMock -> {
+            ReferenceCountUtil.release(invocationOnMock.getArgument(3));
+            Promise<Void> promise = invocationOnMock.getArgument(4);
+            goAwayPromises.offer(promise);
+            return null;
+        }).when(writer).writeGoAway(any(ChannelHandlerContext.class), anyInt(), anyLong(), any(ByteBuf.class),
+                any(Promise.class));
         Http2Connection connection = new DefaultHttp2Connection(false);
         connection.remote().flowController(new DefaultHttp2RemoteFlowController(connection));
         connection.local().flowController(new DefaultHttp2LocalFlowController(connection).frameWriter(writer));
@@ -182,75 +168,134 @@ public class Http2ControlFrameLimitEncoderTest {
 
     @Test
     public void testLimitSettingsAck() {
-        assertFalse(encoder.writeSettingsAck(ctx, newPromise()).isDone());
+        Promise<Void> promise = newPromise();
+        encoder.writeSettingsAck(ctx, promise);
+        assertFalse(promise.isDone());
         // The second write is always marked as success by our mock, which means it will also not be queued and so
         // not count to the number of queued frames.
-        assertTrue(encoder.writeSettingsAck(ctx, newPromise()).isSuccess());
-        assertFalse(encoder.writeSettingsAck(ctx, newPromise()).isDone());
+        promise = newPromise();
+        encoder.writeSettingsAck(ctx, promise);
+        assertTrue(promise.isSuccess());
+
+        promise = newPromise();
+        encoder.writeSettingsAck(ctx, promise);
+        assertFalse(promise.isDone());
 
         verifyFlushAndClose(0, false);
 
-        assertFalse(encoder.writeSettingsAck(ctx, newPromise()).isDone());
-        assertFalse(encoder.writeSettingsAck(ctx, newPromise()).isDone());
+        promise = newPromise();
+        encoder.writeSettingsAck(ctx, promise);
+        assertFalse(promise.isDone());
+        promise = newPromise();
+        encoder.writeSettingsAck(ctx, promise);
+        assertFalse(promise.isDone());
 
         verifyFlushAndClose(1, true);
     }
 
     @Test
     public void testLimitPingAck() {
-        assertFalse(encoder.writePing(ctx, true, 8, newPromise()).isDone());
+        Promise<Void> promise = newPromise();
+        encoder.writePing(ctx, true, 8, promise);
+        assertFalse(promise.isDone());
         // The second write is always marked as success by our mock, which means it will also not be queued and so
         // not count to the number of queued frames.
-        assertTrue(encoder.writePing(ctx, true, 8, newPromise()).isSuccess());
-        assertFalse(encoder.writePing(ctx, true, 8, newPromise()).isDone());
+        promise = newPromise();
+        encoder.writePing(ctx, true, 8, promise);
+        assertTrue(promise.isSuccess());
+        promise = newPromise();
+        encoder.writePing(ctx, true, 8, promise);
+        assertFalse(promise.isDone());
 
         verifyFlushAndClose(0, false);
 
-        assertFalse(encoder.writePing(ctx, true, 8, newPromise()).isDone());
-        assertFalse(encoder.writePing(ctx, true, 8, newPromise()).isDone());
+        promise = newPromise();
+        encoder.writePing(ctx, true, 8, promise);
+        assertFalse(promise.isDone());
+        promise = newPromise();
+        encoder.writePing(ctx, true, 8, promise);
+        assertFalse(promise.isDone());
 
         verifyFlushAndClose(1, true);
     }
 
     @Test
     public void testNotLimitPing() {
-        assertTrue(encoder.writePing(ctx, false, 8, newPromise()).isSuccess());
-        assertTrue(encoder.writePing(ctx, false, 8, newPromise()).isSuccess());
-        assertTrue(encoder.writePing(ctx, false, 8, newPromise()).isSuccess());
-        assertTrue(encoder.writePing(ctx, false, 8, newPromise()).isSuccess());
+        Promise<Void> promise = newPromise();
+        encoder.writePing(ctx, false, 8, promise);
+        assertTrue(promise.isSuccess());
+
+        promise = newPromise();
+        encoder.writePing(ctx, false, 8, promise);
+        assertTrue(promise.isSuccess());
+
+        promise = newPromise();
+        encoder.writePing(ctx, false, 8, promise);
+        assertTrue(promise.isSuccess());
+
+        promise = newPromise();
+        encoder.writePing(ctx, false, 8, promise);
+        assertTrue(promise.isSuccess());
 
         verifyFlushAndClose(0, false);
     }
 
     @Test
     public void testLimitRst() {
-        assertFalse(encoder.writeRstStream(ctx, 1, CANCEL.code(), newPromise()).isDone());
+        Promise<Void> promise = newPromise();
+        encoder.writeRstStream(ctx, 1, CANCEL.code(), newPromise());
+        assertFalse(promise.isDone());
+
+        promise = newPromise();
         // The second write is always marked as success by our mock, which means it will also not be queued and so
         // not count to the number of queued frames.
-        assertTrue(encoder.writeRstStream(ctx, 1, CANCEL.code(), newPromise()).isSuccess());
-        assertFalse(encoder.writeRstStream(ctx, 1, CANCEL.code(), newPromise()).isDone());
+        encoder.writeRstStream(ctx, 1, CANCEL.code(), promise);
+        assertTrue(promise.isSuccess());
+
+        promise = newPromise();
+        encoder.writeRstStream(ctx, 1, CANCEL.code(), promise);
+        assertFalse(promise.isDone());
 
         verifyFlushAndClose(0, false);
 
-        assertFalse(encoder.writeRstStream(ctx, 1, CANCEL.code(), newPromise()).isDone());
-        assertFalse(encoder.writeRstStream(ctx, 1, CANCEL.code(), newPromise()).isDone());
+        promise = newPromise();
+        encoder.writeRstStream(ctx, 1, CANCEL.code(), promise);
+        assertFalse(promise.isDone());
+
+        promise = newPromise();
+        encoder.writeRstStream(ctx, 1, CANCEL.code(), promise);
+        assertFalse(promise.isDone());
 
         verifyFlushAndClose(1, true);
     }
 
     @Test
     public void testLimit() {
-        assertFalse(encoder.writeRstStream(ctx, 1, CANCEL.code(), newPromise()).isDone());
+        Promise<Void> promise = newPromise();
+        encoder.writeRstStream(ctx, 1, CANCEL.code(), promise);
+        assertFalse(promise.isDone());
+
         // The second write is always marked as success by our mock, which means it will also not be queued and so
         // not count to the number of queued frames.
-        assertTrue(encoder.writePing(ctx, false, 8, newPromise()).isSuccess());
-        assertFalse(encoder.writePing(ctx, true, 8, newPromise()).isSuccess());
+        promise = newPromise();
+        encoder.writePing(ctx, false, 8, promise);
+        assertTrue(promise.isSuccess());
+
+        promise = newPromise();
+        encoder.writePing(ctx, true, 8, promise);
+        assertFalse(promise.isSuccess());
 
         verifyFlushAndClose(0, false);
 
-        assertFalse(encoder.writeSettingsAck(ctx, newPromise()).isDone());
-        assertFalse(encoder.writeRstStream(ctx, 1, CANCEL.code(), newPromise()).isDone());
-        assertFalse(encoder.writePing(ctx, true, 8, newPromise()).isSuccess());
+        promise = newPromise();
+        encoder.writeSettingsAck(ctx, promise);
+        assertFalse(promise.isDone());
+        promise = newPromise();
+        encoder.writeRstStream(ctx, 1, CANCEL.code(), promise);
+        assertFalse(promise.isDone());
+        promise = newPromise();
+        encoder.writePing(ctx, true, 8, promise);
+        assertFalse(promise.isSuccess());
 
         verifyFlushAndClose(1, true);
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameInboundWriter.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameInboundWriter.java
@@ -49,59 +49,83 @@ final class Http2FrameInboundWriter {
     }
 
     void writeInboundData(int streamId, ByteBuf data, int padding, boolean endStream) {
-        writer.writeData(ctx, streamId, data, padding, endStream, ctx.newPromise()).syncUninterruptibly();
+        Promise<Void> promise = ctx.newPromise();
+        writer.writeData(ctx, streamId, data, padding, endStream, promise);
+        promise.syncUninterruptibly();
     }
 
     void writeInboundHeaders(int streamId, Http2Headers headers,
                          int padding, boolean endStream) {
-        writer.writeHeaders(ctx, streamId, headers, padding, endStream, ctx.newPromise()).syncUninterruptibly();
+        Promise<Void> promise = ctx.newPromise();
+        writer.writeHeaders(ctx, streamId, headers, padding, endStream, promise);
+        promise.syncUninterruptibly();
     }
 
     void writeInboundHeaders(int streamId, Http2Headers headers,
                                int streamDependency, short weight, boolean exclusive, int padding, boolean endStream) {
+        Promise<Void> promise = ctx.newPromise();
         writer.writeHeaders(ctx, streamId, headers, streamDependency,
-                weight, exclusive, padding, endStream, ctx.newPromise()).syncUninterruptibly();
+                weight, exclusive, padding, endStream, promise);
+        promise.syncUninterruptibly();
     }
 
     void writeInboundPriority(int streamId, int streamDependency,
                                 short weight, boolean exclusive) {
+        Promise<Void> promise = ctx.newPromise();
         writer.writePriority(ctx, streamId, streamDependency, weight,
-                exclusive, ctx.newPromise()).syncUninterruptibly();
+                exclusive, promise);
+        promise.syncUninterruptibly();
     }
 
     void writeInboundRstStream(int streamId, long errorCode) {
-        writer.writeRstStream(ctx, streamId, errorCode, ctx.newPromise()).syncUninterruptibly();
+        Promise<Void> promise = ctx.newPromise();
+        writer.writeRstStream(ctx, streamId, errorCode, promise);
+        promise.syncUninterruptibly();
     }
 
     void writeInboundSettings(Http2Settings settings) {
-        writer.writeSettings(ctx, settings, ctx.newPromise()).syncUninterruptibly();
+        Promise<Void> promise = ctx.newPromise();
+        writer.writeSettings(ctx, settings, promise);
+        promise.syncUninterruptibly();
     }
 
     void writeInboundSettingsAck() {
-        writer.writeSettingsAck(ctx, ctx.newPromise()).syncUninterruptibly();
+        Promise<Void> promise = ctx.newPromise();
+        writer.writeSettingsAck(ctx, promise);
+        promise.syncUninterruptibly();
     }
 
     void writeInboundPing(boolean ack, long data) {
-        writer.writePing(ctx, ack, data, ctx.newPromise()).syncUninterruptibly();
+        Promise<Void> promise = ctx.newPromise();
+        writer.writePing(ctx, ack, data, promise);
+        promise.syncUninterruptibly();
     }
 
     void writePushPromise(int streamId, int promisedStreamId,
                                    Http2Headers headers, int padding) {
-           writer.writePushPromise(ctx, streamId, promisedStreamId,
-                   headers, padding, ctx.newPromise()).syncUninterruptibly();
+        Promise<Void> promise = ctx.newPromise();
+        writer.writePushPromise(ctx, streamId, promisedStreamId,
+                   headers, padding, promise);
+        promise.syncUninterruptibly();
     }
 
     void writeInboundGoAway(int lastStreamId, long errorCode, ByteBuf debugData) {
-        writer.writeGoAway(ctx, lastStreamId, errorCode, debugData, ctx.newPromise()).syncUninterruptibly();
+        Promise<Void> promise = ctx.newPromise();
+        writer.writeGoAway(ctx, lastStreamId, errorCode, debugData, promise);
+        promise.syncUninterruptibly();
     }
 
     void writeInboundWindowUpdate(int streamId, int windowSizeIncrement) {
-        writer.writeWindowUpdate(ctx, streamId, windowSizeIncrement, ctx.newPromise()).syncUninterruptibly();
+        Promise<Void> promise = ctx.newPromise();
+        writer.writeWindowUpdate(ctx, streamId, windowSizeIncrement, promise);
+        promise.syncUninterruptibly();
     }
 
     void writeInboundFrame(byte frameType, int streamId,
                              Http2Flags flags, ByteBuf payload) {
-        writer.writeFrame(ctx, frameType, streamId, flags, payload, ctx.newPromise()).syncUninterruptibly();
+        Promise<Void> promise = ctx.newPromise();
+        writer.writeFrame(ctx, frameType, streamId, flags, payload, promise);
+        promise.syncUninterruptibly();
     }
 
     private static final class WriteInboundChannelHandlerContext
@@ -198,8 +222,8 @@ final class Http2FrameInboundWriter {
         }
 
         @Override
-        public Future<Void> shutdown(ChannelShutdownType type, Promise<Void> promise) {
-            return channel.shutdown(type, promise);
+        public void shutdown(ChannelShutdownType type, Promise<Void> promise) {
+            channel.shutdown(type, promise);
         }
 
         @Override
@@ -225,8 +249,8 @@ final class Http2FrameInboundWriter {
         }
 
         @Override
-        public Future<Void> register(Promise<Void> promise) {
-            return channel.register(promise);
+        public void register(Promise<Void> promise) {
+            channel.register(promise);
         }
 
         @Override
@@ -265,47 +289,49 @@ final class Http2FrameInboundWriter {
         }
 
         @Override
-        public Future<Void> bind(SocketAddress localAddress, Promise<Void> promise) {
-            return channel.bind(localAddress, promise);
+        public void bind(SocketAddress localAddress, Promise<Void> promise) {
+            channel.bind(localAddress, promise);
         }
 
         @Override
-        public Future<Void> connect(SocketAddress remoteAddress, Promise<Void> promise) {
-            return channel.connect(remoteAddress, promise);
+        public void connect(SocketAddress remoteAddress, Promise<Void> promise) {
+            channel.connect(remoteAddress, promise);
         }
 
         @Override
-        public Future<Void> connect(SocketAddress remoteAddress, SocketAddress localAddress, Promise<Void> promise) {
-            return channel.connect(remoteAddress, localAddress, promise);
+        public void connect(SocketAddress remoteAddress, SocketAddress localAddress, Promise<Void> promise) {
+            channel.connect(remoteAddress, localAddress, promise);
         }
 
         @Override
-        public Future<Void> disconnect(Promise<Void> promise) {
-            return channel.disconnect(promise);
+        public void disconnect(Promise<Void> promise) {
+            channel.disconnect(promise);
         }
 
         @Override
-        public Future<Void> close(Promise<Void> promise) {
-            return channel.close(promise);
+        public void close(Promise<Void> promise) {
+            channel.close(promise);
         }
 
         @Override
-        public Future<Void> deregister(Promise<Void> promise) {
-            return channel.deregister(promise);
+        public void deregister(Promise<Void> promise) {
+            channel.deregister(promise);
         }
 
         @Override
         public Future<Void> write(Object msg) {
-            return write(msg, newPromise());
+            Promise<Void> promise = newPromise();
+            write(msg, promise);
+            return promise;
         }
 
         @Override
-        public Future<Void> write(Object msg, Promise<Void> promise) {
-            return writeAndFlush(msg, promise);
+        public void write(Object msg, Promise<Void> promise) {
+            writeAndFlush(msg, promise);
         }
 
         @Override
-        public Future<Void> writeAndFlush(Object msg, Promise<Void> promise) {
+        public void writeAndFlush(Object msg, Promise<Void> promise) {
             try {
                 channel.writeInbound(msg);
                 channel.runPendingTasks();
@@ -313,12 +339,13 @@ final class Http2FrameInboundWriter {
             } catch (Throwable cause) {
                 promise.setFailure(cause);
             }
-            return promise;
         }
 
         @Override
         public Future<Void> writeAndFlush(Object msg) {
-            return writeAndFlush(msg, newPromise());
+            Promise<Void> promise = newPromise();
+            writeAndFlush(msg, promise);
+            return promise;
         }
 
         @Override

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MaxRstFrameLimitEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MaxRstFrameLimitEncoderTest.java
@@ -46,6 +46,7 @@ import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_MAX_FRAME_SIZE
 import static io.netty.handler.codec.http2.Http2Error.CANCEL;
 import static io.netty.handler.codec.http2.Http2Error.ENHANCE_YOUR_CALM;
 import static io.netty.handler.codec.http2.Http2Error.NO_ERROR;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
@@ -96,23 +97,17 @@ public class Http2MaxRstFrameLimitEncoderTest {
         when(configuration.frameSizePolicy()).thenReturn(frameSizePolicy);
         when(frameSizePolicy.maxFrameSize()).thenReturn(DEFAULT_MAX_FRAME_SIZE);
 
-        when(writer.writeRstStream(eq(ctx), anyInt(), anyLong(), any(Promise.class)))
-                .thenAnswer(new Answer<>() {
-                    @Override
-                    public Future<Void> answer(InvocationOnMock invocationOnMock) {
-                        return handlePromise(invocationOnMock, 3);
-                    }
-                });
-        when(writer.writeGoAway(any(ChannelHandlerContext.class), anyInt(), anyLong(), any(ByteBuf.class),
-                any(Promise.class))).thenAnswer(new Answer<>() {
-            @Override
-            public Future<Void> answer(InvocationOnMock invocationOnMock) {
-                ReferenceCountUtil.release(invocationOnMock.getArgument(3));
-                Promise<Void> promise = invocationOnMock.getArgument(4);
-                goAwayPromises.offer(promise);
-                return promise;
-            }
-        });
+        doAnswer(invocationOnMock -> {
+            handlePromise(invocationOnMock, 3);
+            return null;
+        }).when(writer).writeRstStream(eq(ctx), anyInt(), anyLong(), any(Promise.class));
+        doAnswer(invocationOnMock -> {
+            ReferenceCountUtil.release(invocationOnMock.getArgument(3));
+            Promise<Void> promise = invocationOnMock.getArgument(4);
+            goAwayPromises.offer(promise);
+            return null;
+        }).when(writer).writeGoAway(any(ChannelHandlerContext.class), anyInt(), anyLong(), any(ByteBuf.class),
+                any(Promise.class));
         Http2Connection connection = new DefaultHttp2Connection(false);
         connection.remote().flowController(new DefaultHttp2RemoteFlowController(connection));
         connection.local().flowController(new DefaultHttp2LocalFlowController(connection).frameWriter(writer));
@@ -171,10 +166,16 @@ public class Http2MaxRstFrameLimitEncoderTest {
     @ParameterizedTest
     @EnumSource(Http2Error.class)
     public void testLimitRst(Http2Error error) {
-        assertTrue(encoder.writeRstStream(ctx, 1, error.code(), newPromise()).isSuccess());
-        assertTrue(encoder.writeRstStream(ctx, 1, error.code(), newPromise()).isSuccess());
+        Promise<Void> promise = newPromise();
+        encoder.writeRstStream(ctx, 1, error.code(), promise);
+        assertTrue(promise.isSuccess());
+        promise = newPromise();
+        encoder.writeRstStream(ctx, 1, error.code(), promise);
+        assertTrue(promise.isSuccess());
         verifyFlushAndClose(0, false);
-        assertTrue(encoder.writeRstStream(ctx, 1, error.code(), newPromise()).isSuccess());
+        promise = newPromise();
+        encoder.writeRstStream(ctx, 1, error.code(), promise);
+        assertTrue(promise.isSuccess());
         if (error == CANCEL || error == NO_ERROR) {
             // CANCEL and NO_ERROR are ignored as these will not be caused by a stream error.
             verifyFlushAndClose(0, false);
@@ -186,11 +187,17 @@ public class Http2MaxRstFrameLimitEncoderTest {
     @ParameterizedTest
     @EnumSource(Http2Error.class)
     public void testLimitRstReset(Http2Error error) throws Exception {
-        assertTrue(encoder.writeRstStream(ctx, 1, error.code(), newPromise()).isSuccess());
-        assertTrue(encoder.writeRstStream(ctx, 1, error.code(), newPromise()).isSuccess());
+        Promise<Void> promise = newPromise();
+        encoder.writeRstStream(ctx, 1, error.code(), promise);
+        assertTrue(promise.isSuccess());
+        promise = newPromise();
+        encoder.writeRstStream(ctx, 1, error.code(), promise);
+        assertTrue(promise.isSuccess());
         verifyFlushAndClose(0, false);
         ticker.advance(1, TimeUnit.SECONDS);
-        assertTrue(encoder.writeRstStream(ctx, 1, error.code(), newPromise()).isSuccess());
+        promise = newPromise();
+        encoder.writeRstStream(ctx, 1, error.code(), promise);
+        assertTrue(promise.isSuccess());
         verifyFlushAndClose(0, false);
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
@@ -79,9 +79,9 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     private final Http2Headers request = new DefaultHttp2Headers()
@@ -802,22 +802,24 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
 
     @Test
     public void outboundStreamShouldNotWriteResetFrameOnClose_IfStreamDidntExist() throws Exception {
-        when(frameWriter.writeHeaders(eqCodecCtx(), anyInt(),
-                any(Http2Headers.class), anyInt(), anyBoolean(),
-                any(Promise.class))).thenAnswer(new Answer<>() {
+        doAnswer(new Answer<>() {
 
             private boolean headersWritten;
             @Override
-            public Future<Void> answer(InvocationOnMock invocationOnMock) {
+            public Void answer(InvocationOnMock invocationOnMock) {
                 // We want to fail to write the first headers frame. This is what happens if the connection
                 // refuses to allocate a new stream due to having received a GOAWAY.
                 if (!headersWritten) {
                     headersWritten = true;
-                    return ((Promise<Void>) invocationOnMock.getArgument(5)).setFailure(new Exception("boom"));
+                    ((Promise<Void>) invocationOnMock.getArgument(5)).setFailure(new Exception("boom"));
+                    return null;
                 }
-                return ((Promise<Void>) invocationOnMock.getArgument(5)).setSuccess(null);
+                ((Promise<Void>) invocationOnMock.getArgument(5)).setSuccess(null);
+                return null;
             }
-        });
+        }).when(frameWriter).writeHeaders(eqCodecCtx(), anyInt(),
+                any(Http2Headers.class), anyInt(), anyBoolean(),
+                any(Promise.class));
 
         Http2StreamChannel childChannel = newOutboundStream(new ChannelInboundHandler() {
             @Override
@@ -878,15 +880,13 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
         assertTrue(childChannel.isActive());
 
         Http2Headers headers = new DefaultHttp2Headers();
-        when(frameWriter.writeHeaders(eqCodecCtx(), anyInt(),
+        doAnswer(invocationOnMock -> {
+            ((Promise<Void>) invocationOnMock.getArgument(5)).setFailure(
+                    new StreamException(childChannel.stream().id(), Http2Error.STREAM_CLOSED, "Stream Closed"));
+            return null;
+        }).when(frameWriter).writeHeaders(eqCodecCtx(), anyInt(),
                 eq(headers), anyInt(), anyBoolean(),
-                any(Promise.class))).thenAnswer(new Answer<>() {
-            @Override
-            public Future<Void> answer(InvocationOnMock invocationOnMock) {
-                return ((Promise<Void>) invocationOnMock.getArgument(5)).setFailure(
-                        new StreamException(childChannel.stream().id(), Http2Error.STREAM_CLOSED, "Stream Closed"));
-            }
-        });
+                any(Promise.class));
         final Future<Void> future = childChannel.writeAndFlush(
                 new DefaultHttp2HeadersFrame(new DefaultHttp2Headers()));
 
@@ -946,15 +946,13 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
         assertTrue(childChannel.isActive());
 
         Http2Headers headers = new DefaultHttp2Headers();
-        when(frameWriter.writeHeaders(eqCodecCtx(), anyInt(),
+        doAnswer(invocationOnMock -> {
+            ((Promise<Void>) invocationOnMock.getArgument(5)).setFailure(
+                    new Http2NoMoreStreamIdsException());
+            return null;
+        }).when(frameWriter).writeHeaders(eqCodecCtx(), anyInt(),
                eq(headers), anyInt(), anyBoolean(),
-               any(Promise.class))).thenAnswer(new Answer<>() {
-           @Override
-           public Future<Void> answer(InvocationOnMock invocationOnMock) {
-               return ((Promise<Void>) invocationOnMock.getArgument(5)).setFailure(
-                       new Http2NoMoreStreamIdsException());
-            }
-        });
+               any(Promise.class));
 
         final Future<Void> future = childChannel.writeAndFlush(new DefaultHttp2HeadersFrame(headers));
         parentChannel.flush();
@@ -990,7 +988,8 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
             channelOpen.set(childChannel.isOpen());
             channelActive.set(childChannel.isActive());
         });
-        childChannel.close(p).syncUninterruptibly();
+        childChannel.close(p);
+        p.syncUninterruptibly();
 
         assertFalse(channelOpen.get());
         assertFalse(channelActive.get());
@@ -1033,16 +1032,13 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
         final AtomicBoolean channelActive = new AtomicBoolean(true);
 
         Http2Headers headers = new DefaultHttp2Headers();
-        when(frameWriter.writeHeaders(eqCodecCtx(), anyInt(),
+        doAnswer(invocationOnMock -> {
+            Promise<Void> promise = invocationOnMock.getArgument(5);
+            writePromises.offer(promise);
+            return null;
+        }).when(frameWriter).writeHeaders(eqCodecCtx(), anyInt(),
                 eq(headers), anyInt(), anyBoolean(),
-                any(Promise.class))).thenAnswer(new Answer<>() {
-            @Override
-            public Future<Void> answer(InvocationOnMock invocationOnMock) {
-                Promise<Void> promise = invocationOnMock.getArgument(5);
-                writePromises.offer(promise);
-                return promise;
-            }
-        });
+                any(Promise.class));
 
         Future<Void> f = childChannel.writeAndFlush(new DefaultHttp2HeadersFrame(headers));
         assertFalse(f.isDone());

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
@@ -22,7 +22,6 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.AsciiString;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -366,88 +365,68 @@ public final class Http2TestUtil {
         }).when(frameWriter).close();
 
         when(frameWriter.configuration()).thenReturn(configuration);
-        when(frameWriter.writeSettings(any(ChannelHandlerContext.class), any(Http2Settings.class),
-                any(Promise.class))).thenAnswer(new Answer<>() {
-            @Override
-            public Future<Void> answer(InvocationOnMock invocationOnMock) {
-                return ((Promise<Void>) invocationOnMock.getArgument(2)).setSuccess(null);
-            }
-        });
+        doAnswer(invocationOnMock -> {
+            ((Promise<Void>) invocationOnMock.getArgument(2)).setSuccess(null);
+            return null;
+        }).when(frameWriter).writeSettings(any(ChannelHandlerContext.class), any(Http2Settings.class),
+                any(Promise.class));
 
-        when(frameWriter.writeSettingsAck(any(ChannelHandlerContext.class), any(Promise.class)))
-                .thenAnswer(new Answer<>() {
-            @Override
-            public Future<Void> answer(InvocationOnMock invocationOnMock) {
-                return ((Promise<Void>) invocationOnMock.getArgument(1)).setSuccess(null);
-            }
-        });
+        doAnswer(invocationOnMock ->  {
+            ((Promise<Void>) invocationOnMock.getArgument(1)).setSuccess(null);
+            return null;
+        }).when(frameWriter).writeSettingsAck(any(ChannelHandlerContext.class), any(Promise.class));
 
-        when(frameWriter.writeGoAway(any(ChannelHandlerContext.class), anyInt(),
-                anyLong(), any(ByteBuf.class), any(Promise.class))).thenAnswer(new Answer<>() {
-            @Override
-            public Future<Void> answer(InvocationOnMock invocationOnMock) {
-                buffers.offer((ByteBuf) invocationOnMock.getArgument(3));
-                return ((Promise<Void>) invocationOnMock.getArgument(4)).setSuccess(null);
-            }
-        });
-        when(frameWriter.writeHeaders(any(ChannelHandlerContext.class), anyInt(), any(Http2Headers.class), anyInt(),
-                anyBoolean(), any(Promise.class))).thenAnswer(new Answer<>() {
-            @Override
-            public Future<Void> answer(InvocationOnMock invocationOnMock) {
-                return ((Promise<Void>) invocationOnMock.getArgument(5)).setSuccess(null);
-            }
-        });
+        doAnswer(invocationOnMock -> {
+            buffers.offer((ByteBuf) invocationOnMock.getArgument(3));
+            ((Promise<Void>) invocationOnMock.getArgument(4)).setSuccess(null);
+            return null;
+        }).when(frameWriter).writeGoAway(any(ChannelHandlerContext.class), anyInt(),
+                anyLong(), any(ByteBuf.class), any(Promise.class));
+        doAnswer(invocationOnMock -> {
+            ((Promise<Void>) invocationOnMock.getArgument(5)).setSuccess(null);
+            return null;
+        }).when(frameWriter).writeHeaders(any(ChannelHandlerContext.class), anyInt(), any(Http2Headers.class), anyInt(),
+                anyBoolean(), any(Promise.class));
 
-        when(frameWriter.writeHeaders(any(ChannelHandlerContext.class), anyInt(),
+        doAnswer(invocationOnMock -> {
+            ((Promise<Void>) invocationOnMock.getArgument(8)).setSuccess(null);
+            return null;
+        }).when(frameWriter).writeHeaders(any(ChannelHandlerContext.class), anyInt(),
                 any(Http2Headers.class), anyInt(), anyShort(), anyBoolean(), anyInt(), anyBoolean(),
-                any(Promise.class))).thenAnswer(new Answer<>() {
-            @Override
-            public Future<Void> answer(InvocationOnMock invocationOnMock) {
-                return ((Promise<Void>) invocationOnMock.getArgument(8)).setSuccess(null);
-            }
-        });
+                any(Promise.class));
 
-        when(frameWriter.writeData(any(ChannelHandlerContext.class), anyInt(), any(ByteBuf.class), anyInt(),
-                anyBoolean(), any(Promise.class))).thenAnswer(new Answer<>() {
-            @Override
-            public Future<Void> answer(InvocationOnMock invocationOnMock) {
-                buffers.offer((ByteBuf) invocationOnMock.getArgument(2));
-                return ((Promise<Void>) invocationOnMock.getArgument(5)).setSuccess(null);
-            }
-        });
+        doAnswer(invocationOnMock -> {
+            buffers.offer((ByteBuf) invocationOnMock.getArgument(2));
+            ((Promise<Void>) invocationOnMock.getArgument(5)).setSuccess(null);
+            return null;
+        }).when(frameWriter).writeData(any(ChannelHandlerContext.class), anyInt(), any(ByteBuf.class), anyInt(),
+                anyBoolean(), any(Promise.class));
 
-        when(frameWriter.writeRstStream(any(ChannelHandlerContext.class), anyInt(),
-                anyLong(), any(Promise.class))).thenAnswer(new Answer<>() {
-            @Override
-            public Future<Void> answer(InvocationOnMock invocationOnMock) {
-                return ((Promise<Void>) invocationOnMock.getArgument(3)).setSuccess(null);
-            }
-        });
+        doAnswer(invocationOnMock -> {
+            ((Promise<Void>) invocationOnMock.getArgument(3)).setSuccess(null);
+            return null;
+        }).when(frameWriter).writeRstStream(any(ChannelHandlerContext.class), anyInt(),
+                anyLong(), any(Promise.class));
 
-        when(frameWriter.writeWindowUpdate(any(ChannelHandlerContext.class), anyInt(), anyInt(),
-                any(Promise.class))).then(new Answer<>() {
-            @Override
-            public Future<Void> answer(InvocationOnMock invocationOnMock) {
-                return ((Promise<Void>) invocationOnMock.getArgument(3)).setSuccess(null);
-            }
-        });
+        doAnswer(invocationOnMock -> {
+            ((Promise<Void>) invocationOnMock.getArgument(3)).setSuccess(null);
+            return null;
+        }).when(frameWriter).writeWindowUpdate(any(ChannelHandlerContext.class), anyInt(), anyInt(),
+                any(Promise.class));
 
-        when(frameWriter.writePushPromise(any(ChannelHandlerContext.class), anyInt(), anyInt(), any(Http2Headers.class),
-                anyInt(), anyChannelPromise())).thenAnswer(new Answer<>() {
-            @Override
-            public Future<Void> answer(InvocationOnMock invocationOnMock) {
-                return ((Promise<Void>) invocationOnMock.getArgument(5)).setSuccess(null);
-            }
-        });
+        doAnswer(invocationOnMock -> {
+            ((Promise<Void>) invocationOnMock.getArgument(5)).setSuccess(null);
+            return null;
+        }).when(frameWriter).writePushPromise(any(ChannelHandlerContext.class),
+                anyInt(), anyInt(), any(Http2Headers.class),
+                anyInt(), anyChannelPromise());
 
-        when(frameWriter.writeFrame(any(ChannelHandlerContext.class), anyByte(), anyInt(), any(Http2Flags.class),
-                any(ByteBuf.class), anyChannelPromise())).thenAnswer(new Answer<>() {
-            @Override
-            public Future<Void> answer(InvocationOnMock invocationOnMock) {
-                buffers.offer((ByteBuf) invocationOnMock.getArgument(4));
-                return ((Promise<Void>) invocationOnMock.getArgument(5)).setSuccess(null);
-            }
-        });
+        doAnswer(invocationOnMock -> {
+            buffers.offer((ByteBuf) invocationOnMock.getArgument(4));
+            ((Promise<Void>) invocationOnMock.getArgument(5)).setSuccess(null);
+            return null;
+        }).when(frameWriter).writeFrame(any(ChannelHandlerContext.class), anyByte(), anyInt(), any(Http2Flags.class),
+                any(ByteBuf.class), anyChannelPromise());
         return frameWriter;
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
@@ -146,7 +146,8 @@ public class HttpToHttp2ConnectionHandlerTest {
                 .add(new AsciiString("foo2"), new AsciiString("goo2"));
 
         Promise<Void> writePromise = newPromise();
-        verifyHeadersOnly(http2Headers, writePromise, clientChannel.writeAndFlush(request, writePromise));
+        clientChannel.writeAndFlush(request, writePromise);
+        verifyHeadersOnly(http2Headers, writePromise);
     }
 
     @Test
@@ -169,7 +170,8 @@ public class HttpToHttp2ConnectionHandlerTest {
                         .add(new AsciiString("foo2"), new AsciiString("goo2"));
 
         Promise<Void> writePromise = newPromise();
-        verifyHeadersOnly(http2Headers, writePromise, clientChannel.writeAndFlush(request, writePromise));
+        clientChannel.writeAndFlush(request, writePromise);
+        verifyHeadersOnly(http2Headers, writePromise);
     }
 
     @Test
@@ -190,7 +192,8 @@ public class HttpToHttp2ConnectionHandlerTest {
                 .add(HttpHeaderNames.COOKIE, "e=f");
 
         Promise<Void> writePromise = newPromise();
-        verifyHeadersOnly(http2Headers, writePromise, clientChannel.writeAndFlush(request, writePromise));
+        clientChannel.writeAndFlush(request, writePromise);
+        verifyHeadersOnly(http2Headers, writePromise);
     }
 
     @Test
@@ -206,7 +209,8 @@ public class HttpToHttp2ConnectionHandlerTest {
                 .scheme(new AsciiString("http"));
 
         Promise<Void> writePromise = newPromise();
-        verifyHeadersOnly(http2Headers, writePromise, clientChannel.writeAndFlush(request, writePromise));
+        clientChannel.writeAndFlush(request, writePromise);
+        verifyHeadersOnly(http2Headers, writePromise);
     }
 
     @Test
@@ -223,7 +227,8 @@ public class HttpToHttp2ConnectionHandlerTest {
                                          .scheme(new AsciiString("http"));
 
         Promise<Void> writePromise = newPromise();
-        verifyHeadersOnly(http2Headers, writePromise, clientChannel.writeAndFlush(request, writePromise));
+        clientChannel.writeAndFlush(request, writePromise);
+        verifyHeadersOnly(http2Headers, writePromise);
     }
 
     @Test
@@ -241,7 +246,8 @@ public class HttpToHttp2ConnectionHandlerTest {
                 .authority(new AsciiString("www.example.org:5555")).scheme(new AsciiString("https"));
 
         Promise<Void> writePromise = newPromise();
-        verifyHeadersOnly(http2Headers, writePromise, clientChannel.writeAndFlush(request, writePromise));
+        clientChannel.writeAndFlush(request, writePromise);
+        verifyHeadersOnly(http2Headers, writePromise);
     }
 
     @Test
@@ -257,7 +263,8 @@ public class HttpToHttp2ConnectionHandlerTest {
                 .authority(new AsciiString("www.example.org:5555")).scheme(new AsciiString("http"));
 
         Promise<Void> writePromise = newPromise();
-        verifyHeadersOnly(http2Headers, writePromise, clientChannel.writeAndFlush(request, writePromise));
+        clientChannel.writeAndFlush(request, writePromise);
+        verifyHeadersOnly(http2Headers, writePromise);
     }
 
     @Test
@@ -271,7 +278,8 @@ public class HttpToHttp2ConnectionHandlerTest {
                 .scheme(new AsciiString("http")).authority(new AsciiString("www.example.com:80"));
 
         Promise<Void> writePromise = newPromise();
-        verifyHeadersOnly(http2Headers, writePromise, clientChannel.writeAndFlush(request, writePromise));
+        clientChannel.writeAndFlush(request, writePromise);
+        verifyHeadersOnly(http2Headers, writePromise);
     }
 
     @Test
@@ -287,7 +295,8 @@ public class HttpToHttp2ConnectionHandlerTest {
                 .scheme(new AsciiString("http")).authority(new AsciiString("www.example.com:80"));
 
         Promise<Void> writePromise = newPromise();
-        verifyHeadersOnly(http2Headers, writePromise, clientChannel.writeAndFlush(request, writePromise));
+        clientChannel.writeAndFlush(request, writePromise);
+        verifyHeadersOnly(http2Headers, writePromise);
     }
 
     @Test
@@ -305,7 +314,8 @@ public class HttpToHttp2ConnectionHandlerTest {
                 .scheme(new AsciiString("http")).authority(new AsciiString("[::1]:80"));
 
         Promise<Void> writePromise = newPromise();
-        verifyHeadersOnly(http2Headers, writePromise, clientChannel.writeAndFlush(request, writePromise));
+        clientChannel.writeAndFlush(request, writePromise);
+        verifyHeadersOnly(http2Headers, writePromise);
     }
 
     @Test
@@ -321,7 +331,8 @@ public class HttpToHttp2ConnectionHandlerTest {
                 .scheme(new AsciiString("http")).authority(new AsciiString("localhost:80"));
 
         Promise<Void> writePromise = newPromise();
-        verifyHeadersOnly(http2Headers, writePromise, clientChannel.writeAndFlush(request, writePromise));
+        clientChannel.writeAndFlush(request, writePromise);
+        verifyHeadersOnly(http2Headers, writePromise);
     }
 
     @Test
@@ -337,7 +348,8 @@ public class HttpToHttp2ConnectionHandlerTest {
                 .scheme(new AsciiString("http")).authority(new AsciiString("1.2.3.4:80"));
 
         Promise<Void> writePromise = newPromise();
-        verifyHeadersOnly(http2Headers, writePromise, clientChannel.writeAndFlush(request, writePromise));
+        clientChannel.writeAndFlush(request, writePromise);
+        verifyHeadersOnly(http2Headers, writePromise);
     }
 
     @Test
@@ -348,13 +360,11 @@ public class HttpToHttp2ConnectionHandlerTest {
         httpHeaders.setInt(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), 5);
         httpHeaders.set(HttpHeaderNames.HOST, "localhost");
         Promise<Void> writePromise = newPromise();
-        Future<Void> writeFuture = clientChannel.writeAndFlush(request, writePromise);
+        clientChannel.writeAndFlush(request, writePromise);
 
         assertTrue(writePromise.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
         assertTrue(writePromise.isDone());
         assertFalse(writePromise.isSuccess());
-        assertTrue(writeFuture.isDone());
-        assertFalse(writeFuture.isSuccess());
     }
 
     @Test
@@ -367,17 +377,12 @@ public class HttpToHttp2ConnectionHandlerTest {
         httpHeaders.set(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), "http");
         httpHeaders.set(HttpHeaderNames.HOST, "localhost");
         Promise<Void> writePromise = newPromise();
-        Future<Void> writeFuture = clientChannel.writeAndFlush(request, writePromise);
+        clientChannel.writeAndFlush(request, writePromise);
 
         assertTrue(writePromise.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
         assertTrue(writePromise.isDone());
         assertFalse(writePromise.isSuccess());
         Throwable cause = writePromise.cause();
-        assertInstanceOf(Http2NoMoreStreamIdsException.class, cause);
-
-        assertTrue(writeFuture.isDone());
-        assertFalse(writeFuture.isSuccess());
-        cause = writeFuture.cause();
         assertInstanceOf(Http2NoMoreStreamIdsException.class, cause);
     }
 
@@ -409,12 +414,10 @@ public class HttpToHttp2ConnectionHandlerTest {
                 .add(new AsciiString("foo"), new AsciiString("goo2"))
                 .add(new AsciiString("foo2"), new AsciiString("goo2"));
         Promise<Void> writePromise = newPromise();
-        Future<Void> writeFuture = clientChannel.writeAndFlush(request, writePromise);
+        clientChannel.writeAndFlush(request, writePromise);
 
         assertTrue(writePromise.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
         assertTrue(writePromise.isSuccess());
-        assertTrue(writeFuture.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
-        assertTrue(writeFuture.isSuccess());
         awaitRequests();
         verify(serverListener).onHeadersRead(any(ChannelHandlerContext.class), eq(3), eq(http2Headers), eq(0),
                 anyShort(), anyBoolean(), eq(0), eq(false));
@@ -458,12 +461,10 @@ public class HttpToHttp2ConnectionHandlerTest {
                 .add(new AsciiString("trailing"), new AsciiString("bar"));
 
         Promise<Void> writePromise = newPromise();
-        Future<Void> writeFuture = clientChannel.writeAndFlush(request, writePromise);
+        clientChannel.writeAndFlush(request, writePromise);
 
         assertTrue(writePromise.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
         assertTrue(writePromise.isSuccess());
-        assertTrue(writeFuture.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
-        assertTrue(writeFuture.isSuccess());
         awaitRequests();
         verify(serverListener).onHeadersRead(any(ChannelHandlerContext.class), eq(3), eq(http2Headers), eq(0),
                 anyShort(), anyBoolean(), eq(0), eq(false));
@@ -513,28 +514,22 @@ public class HttpToHttp2ConnectionHandlerTest {
                 .add(new AsciiString("trailing"), new AsciiString("bar"));
 
         Promise<Void> writePromise = newPromise();
-        Future<Void> writeFuture = clientChannel.write(request, writePromise);
+        clientChannel.write(request, writePromise);
         Promise<Void> contentPromise = newPromise();
-        Future<Void> contentFuture = clientChannel.write(httpContent, contentPromise);
+        clientChannel.write(httpContent, contentPromise);
         Promise<Void> lastContentPromise = newPromise();
-        Future<Void> lastContentFuture = clientChannel.write(lastHttpContent, lastContentPromise);
+        clientChannel.write(lastHttpContent, lastContentPromise);
 
         clientChannel.flush();
 
         assertTrue(writePromise.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
         assertTrue(writePromise.isSuccess());
-        assertTrue(writeFuture.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
-        assertTrue(writeFuture.isSuccess());
 
         assertTrue(contentPromise.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
         assertTrue(contentPromise.isSuccess());
-        assertTrue(contentFuture.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
-        assertTrue(contentFuture.isSuccess());
 
         assertTrue(lastContentPromise.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
         assertTrue(lastContentPromise.isSuccess());
-        assertTrue(lastContentFuture.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
-        assertTrue(lastContentFuture.isSuccess());
 
         awaitRequests();
         verify(serverListener).onHeadersRead(any(ChannelHandlerContext.class), eq(3), eq(http2Headers), eq(0),
@@ -608,12 +603,10 @@ public class HttpToHttp2ConnectionHandlerTest {
         assertTrue(serverChannelLatch.await(WAIT_TIME_SECONDS, SECONDS));
     }
 
-    private void verifyHeadersOnly(Http2Headers expected, Promise<Void> writePromise, Future<Void> writeFuture)
+    private void verifyHeadersOnly(Http2Headers expected, Promise<Void> writePromise)
             throws Exception {
         assertTrue(writePromise.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
         assertTrue(writePromise.isSuccess());
-        assertTrue(writeFuture.awaitUninterruptibly(WAIT_TIME_SECONDS, SECONDS));
-        assertTrue(writeFuture.isSuccess());
         awaitRequests();
         verify(serverListener).onHeadersRead(any(ChannelHandlerContext.class), eq(5),
                 eq(expected), eq(0), anyShort(), anyBoolean(), eq(0), eq(true));

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
@@ -106,18 +106,17 @@ public class StreamBufferingEncoderTest {
         when(writer.configuration()).thenReturn(configuration);
         when(configuration.frameSizePolicy()).thenReturn(frameSizePolicy);
         when(frameSizePolicy.maxFrameSize()).thenReturn(DEFAULT_MAX_FRAME_SIZE);
-        when(writer.writeData(any(ChannelHandlerContext.class), anyInt(), any(ByteBuf.class), anyInt(), anyBoolean(),
-                any(Promise.class))).thenAnswer(successAnswer());
-        when(writer.writeRstStream(eq(ctx), anyInt(), anyLong(), any(Promise.class))).thenAnswer(
-                successAnswer());
-        when(writer.writeGoAway(any(ChannelHandlerContext.class), anyInt(), anyLong(), any(ByteBuf.class),
-                any(Promise.class)))
-                .thenAnswer(successAnswer());
-        when(writer.writeHeaders(any(ChannelHandlerContext.class), anyInt(), any(Http2Headers.class),
-            anyInt(), anyBoolean(), any(Promise.class))).thenAnswer(noopAnswer());
-        when(writer.writeHeaders(any(ChannelHandlerContext.class), anyInt(), any(Http2Headers.class),
-            anyInt(), anyShort(), anyBoolean(), anyInt(), anyBoolean(), any(Promise.class)))
-            .thenAnswer(noopAnswer());
+        doAnswer(successAnswer()).when(writer).writeData(
+                any(ChannelHandlerContext.class), anyInt(), any(ByteBuf.class), anyInt(),
+                anyBoolean(), any(Promise.class));
+        doAnswer(successAnswer()).when(writer).writeRstStream(eq(ctx), anyInt(), anyLong(), any(Promise.class));
+        doAnswer(successAnswer()).when(writer).writeGoAway(any(ChannelHandlerContext.class),
+                anyInt(), anyLong(), any(ByteBuf.class), any(Promise.class));
+        doAnswer(noopAnswer()).when(writer).writeHeaders(any(ChannelHandlerContext.class),
+                anyInt(), any(Http2Headers.class), anyInt(), anyBoolean(), any(Promise.class));
+        doAnswer(noopAnswer()).when(writer).writeHeaders(any(ChannelHandlerContext.class), anyInt(),
+                any(Http2Headers.class), anyInt(), anyShort(), anyBoolean(), anyInt(),
+                anyBoolean(), any(Promise.class));
 
         connection = new DefaultHttp2Connection(false);
         connection.remote().flowController(new DefaultHttp2RemoteFlowController(connection));
@@ -278,12 +277,14 @@ public class StreamBufferingEncoderTest {
     public void sendingGoAwayShouldNotFailStreams() {
         setMaxConcurrentStreams(1);
 
-        when(writer.writeHeaders(any(ChannelHandlerContext.class), anyInt(), any(Http2Headers.class), anyInt(),
-              anyBoolean(), any(Promise.class))).thenAnswer(successAnswer());
-        when(writer.writeHeaders(any(ChannelHandlerContext.class), anyInt(), any(Http2Headers.class), anyInt(),
-              anyShort(), anyBoolean(), anyInt(), anyBoolean(), any(Promise.class))).thenAnswer(successAnswer());
+        doAnswer(successAnswer()).when(writer).writeHeaders(any(ChannelHandlerContext.class), anyInt(),
+                any(Http2Headers.class), anyInt(), anyBoolean(), any(Promise.class));
+        doAnswer(successAnswer()).when(writer).writeHeaders(any(ChannelHandlerContext.class), anyInt(),
+                any(Http2Headers.class), anyInt(), anyShort(), anyBoolean(), anyInt(), anyBoolean(),
+                any(Promise.class));
 
         Future<Void> f1 = encoderWriteHeaders(3, newPromise());
+        assertTrue(f1.isSuccess());
         assertEquals(0, encoder.numBufferedStreams());
         Future<Void> f2 = encoderWriteHeaders(5, newPromise());
         assertEquals(1, encoder.numBufferedStreams());
@@ -295,7 +296,6 @@ public class StreamBufferingEncoderTest {
 
         assertEquals(1, connection.numActiveStreams());
         assertEquals(2, encoder.numBufferedStreams());
-        assertFalse(f1.isDone());
         assertFalse(f2.isDone());
         assertFalse(f3.isDone());
     }
@@ -465,7 +465,8 @@ public class StreamBufferingEncoderTest {
         ByteBuf data = mock(ByteBuf.class);
         Future<Void> f1 = encoderWriteHeaders(3, newPromise());
         assertEquals(1, encoder.numBufferedStreams());
-        Future<Void> f2 = encoder.writeData(ctx, 3, data, 0, false, newPromise());
+        Promise<Void> p2 = newPromise();
+        encoder.writeData(ctx, 3, data, 0, false, p2);
 
         Promise<Void> rstPromise = mock(Promise.class);
         encoder.writeRstStream(ctx, 3, CANCEL.code(), rstPromise);
@@ -473,7 +474,7 @@ public class StreamBufferingEncoderTest {
         assertEquals(0, encoder.numBufferedStreams());
         verify(rstPromise).setSuccess(null);
         assertTrue(f1.isSuccess());
-        assertTrue(f2.isSuccess());
+        assertTrue(p2.isSuccess());
         verify(data).release();
     }
 
@@ -509,8 +510,9 @@ public class StreamBufferingEncoderTest {
 
     private void testStreamId(int nextStreamId) throws Http2Exception {
         connection.local().createStream(nextStreamId, false);
-        Future<Void> channelFuture = encoder.writeData(ctx, nextStreamId, EMPTY_BUFFER, 0, false, newPromise());
-        assertNull(channelFuture.cause());
+        Promise<Void> promise = newPromise();
+        encoder.writeData(ctx, nextStreamId, EMPTY_BUFFER, 0, false, promise);
+        assertNull(promise.cause());
     }
 
     private void setMaxConcurrentStreams(int newValue) {
@@ -569,31 +571,26 @@ public class StreamBufferingEncoderTest {
         }
     }
 
-    private Answer<Future<Void>> successAnswer() {
+    private Answer<Void> successAnswer() {
         return new Answer<>() {
             @Override
-            public Future<Void> answer(InvocationOnMock invocation) throws Throwable {
+            public Void answer(InvocationOnMock invocation) throws Throwable {
                 for (Object a : invocation.getArguments()) {
+                    if (a instanceof Promise) {
+                        ((Promise<?>) a).setSuccess(null);
+                    }
                     ReferenceCountUtil.safeRelease(a);
                 }
-
-                Promise<Void> future = newPromise();
-                future.setSuccess(null);
-                return future;
+                return null;
             }
         };
     }
 
-    private Answer<Future<Void>> noopAnswer() {
+    private Answer<Void> noopAnswer() {
         return new Answer<>() {
             @Override
-            public Future<Void> answer(InvocationOnMock invocation) throws Throwable {
-                for (Object a : invocation.getArguments()) {
-                    if (a instanceof Future<?>) {
-                        return (Future<Void>) a;
-                    }
-                }
-                return newPromise();
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                return null;
             }
         };
     }

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/EmbeddedQuicChannel.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/EmbeddedQuicChannel.java
@@ -35,7 +35,6 @@ import io.netty.handler.codec.quic.QuicStreamChannel;
 import io.netty.handler.codec.quic.QuicStreamType;
 import io.netty.handler.codec.quic.QuicTransportParameters;
 import io.netty.util.AttributeKey;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import org.jetbrains.annotations.Nullable;
 
@@ -144,33 +143,33 @@ final class EmbeddedQuicChannel extends EmbeddedChannel implements QuicChannel {
     }
 
     @Override
-    public Future<QuicStreamChannel> createStream(QuicStreamType type, ChannelHandler handler,
-                                                  Promise<QuicStreamChannel> promise) {
+    public void createStream(QuicStreamType type, ChannelHandler handler,
+                             Promise<QuicStreamChannel> promise) {
         final AtomicLong streamIdGenerator = attr(streamIdGeneratorKey).get();
-        return promise.setSuccess(new EmbeddedQuicStreamChannel(this, true, type,
+        promise.setSuccess(new EmbeddedQuicStreamChannel(this, true, type,
                 streamIdGenerator.getAndAdd(2), handler));
     }
 
     @Override
-    public Future<Void> close(boolean applicationClose, int error, ByteBuf reason, Promise<Void> promise) {
+    public void close(boolean applicationClose, int error, ByteBuf reason, Promise<Void> promise) {
         closeErrorCodes.add(error);
         if (closed.compareAndSet(false, true)) {
             promise.addListener(__ -> reason.release());
         } else {
             reason.release();
         }
-        return close(promise);
+        close(promise);
     }
 
     @Override
-    public Future<QuicConnectionStats> collectStats(Promise<QuicConnectionStats> promise) {
-        return promise.setFailure(
+    public void collectStats(Promise<QuicConnectionStats> promise) {
+        promise.setFailure(
                 new UnsupportedOperationException("Collect stats not supported for embedded channel."));
     }
 
     @Override
-    public Future<QuicConnectionPathStats> collectPathStats(int i, Promise<QuicConnectionPathStats> promise) {
-        return promise.setFailure(
+    public void collectPathStats(int i, Promise<QuicConnectionPathStats> promise) {
+        promise.setFailure(
                 new UnsupportedOperationException("Collect path stats not supported for embedded channel."));
     }
 

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/EmbeddedQuicStreamChannel.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/EmbeddedQuicStreamChannel.java
@@ -34,7 +34,6 @@ import io.netty.handler.codec.quic.QuicStreamFrame;
 import io.netty.handler.codec.quic.QuicStreamPriority;
 import io.netty.handler.codec.quic.QuicStreamType;
 import io.netty.util.AttributeKey;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import org.jetbrains.annotations.Nullable;
 
@@ -110,8 +109,8 @@ final class EmbeddedQuicStreamChannel extends EmbeddedChannel implements QuicStr
     }
 
     @Override
-    public Future<Void> updatePriority(QuicStreamPriority priority, Promise<Void> promise) {
-        return promise.setFailure(new UnsupportedOperationException());
+    public void updatePriority(QuicStreamPriority priority, Promise<Void> promise) {
+        promise.setFailure(new UnsupportedOperationException());
     }
 
     @Override

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3FrameToHttpObjectCodecTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3FrameToHttpObjectCodecTest.java
@@ -765,7 +765,7 @@ public class Http3FrameToHttpObjectCodecTest {
                 new Http3FrameToHttpObjectCodec(false)
         );
 
-        Future<Void> fullPromise = ch.writeOneOutbound(msg, ch.newPromise());
+        Future<Void> fullPromise = ch.writeOneOutbound(msg);
         ch.flushOutbound();
 
         if (headers) {

--- a/example/src/main/java/io/netty/example/haproxy/HAProxyHandler.java
+++ b/example/src/main/java/io/netty/example/haproxy/HAProxyHandler.java
@@ -20,7 +20,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandler;
 import io.netty.handler.codec.haproxy.HAProxyMessage;
 import io.netty.handler.codec.haproxy.HAProxyMessageEncoder;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 
 public class HAProxyHandler implements ChannelOutboundHandler {
@@ -32,9 +31,9 @@ public class HAProxyHandler implements ChannelOutboundHandler {
 
     @Override
     public void write(final ChannelHandlerContext ctx, Object msg, Promise<Void> promise) {
-        Future<Void> future = ctx.write(msg, promise);
+        ctx.write(msg, promise);
         if (msg instanceof HAProxyMessage) {
-            future.addListener(future1 -> {
+            promise.addListener(future1 -> {
                 if (future1.isSuccess()) {
                     ctx.pipeline().remove(HAProxyMessageEncoder.INSTANCE);
                     ctx.pipeline().remove(HAProxyHandler.this);

--- a/handler-proxy/src/test/java/io/netty/handler/proxy/HttpProxyHandlerTest.java
+++ b/handler-proxy/src/test/java/io/netty/handler/proxy/HttpProxyHandlerTest.java
@@ -247,7 +247,7 @@ public class HttpProxyHandlerTest {
         verifyNoMoreInteractions(promise);
 
         ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
-        when(ctx.connect(same(proxyAddress), isNull(InetSocketAddress.class), same(promise))).thenReturn(promise);
+        ctx.connect(same(proxyAddress), isNull(InetSocketAddress.class), same(promise));
 
         HttpProxyHandler handler = new HttpProxyHandler(
                 new InetSocketAddress(NetUtil.LOCALHOST, 8080),

--- a/handler/src/main/java/io/netty/handler/address/DynamicAddressConnectHandler.java
+++ b/handler/src/main/java/io/netty/handler/address/DynamicAddressConnectHandler.java
@@ -43,7 +43,8 @@ public abstract class DynamicAddressConnectHandler implements ChannelOutboundHan
             promise.setFailure(e);
             return;
         }
-        ctx.connect(remote, local, promise).addListener(future -> {
+        ctx.connect(remote, local, promise);
+        promise.addListener(future -> {
             if (future.isSuccess()) {
                 // We only remove this handler from the pipeline once the connect was successful as otherwise
                 // the user may try to connect again.

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -645,29 +645,15 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
     }
 
     /**
-     * Use {@link #closeOutbound()}
-     */
-    @Deprecated
-    public Future<Void> close() {
-        return closeOutbound();
-    }
-
-    /**
-     * Use {@link #closeOutbound(Promise)}
-     */
-    @Deprecated
-    public Future<Void> close(Promise<Void> promise) {
-        return closeOutbound(promise);
-    }
-
-    /**
      * Sends an SSL {@code close_notify} message to the specified channel and
      * destroys the underlying {@link SSLEngine}. This will <strong>not</strong> close the underlying
      * {@link Channel}. If you want to also close the {@link Channel} use {@link Channel#close()} or
      * {@link ChannelHandlerContext#close()}
      */
     public Future<Void> closeOutbound() {
-        return closeOutbound(ctx.newPromise());
+        Promise<Void> promise = ctx.newPromise();
+        closeOutbound(promise);
+        return promise;
     }
 
     /**
@@ -676,7 +662,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
      * {@link Channel}. If you want to also close the {@link Channel} use {@link Channel#close()} or
      * {@link ChannelHandlerContext#close()}
      */
-    public Future<Void> closeOutbound(final Promise<Void> promise) {
+    public void closeOutbound(final Promise<Void> promise) {
         final ChannelHandlerContext ctx = this.ctx;
         if (ctx.executor().inEventLoop()) {
             closeOutbound0(promise);
@@ -688,7 +674,6 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                 }
             });
         }
-        return promise;
     }
 
     private void closeOutbound0(Promise<Void> promise) {
@@ -2352,7 +2337,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                         if (!flushFuture.isDone()) {
                             logger.warn("{} Last write attempt timed out; force-closing the connection.",
                                     ctx.channel());
-                            addCloseListener(ctx.close(ctx.newPromise()), promise);
+                            addCloseListener(ctx.close(), promise);
                         }
                     }
                 }, closeNotifyTimeout, TimeUnit.MILLISECONDS);
@@ -2372,7 +2357,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
             if (closeNotifyReadTimeout <= 0) {
                 // Trigger the close in all cases to make sure the promise is notified
                 // See https://github.com/netty/netty/issues/2358
-                addCloseListener(ctx.close(ctx.newPromise()), promise);
+                addCloseListener(ctx.close(), promise);
             } else {
                 final Future<?> closeNotifyReadTimeoutFuture;
 
@@ -2386,7 +2371,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                                         ctx.channel(), closeNotifyReadTimeout);
 
                                 // Do the close now...
-                                addCloseListener(ctx.close(ctx.newPromise()), promise);
+                                addCloseListener(ctx.close(), promise);
                             }
                         }
                     }, closeNotifyReadTimeout, TimeUnit.MILLISECONDS);
@@ -2399,7 +2384,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                     if (closeNotifyReadTimeoutFuture != null) {
                         closeNotifyReadTimeoutFuture.cancel(false);
                     }
-                    addCloseListener(ctx.close(ctx.newPromise()), promise);
+                    addCloseListener(ctx.close(), promise);
                 });
             }
         });

--- a/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
+++ b/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
@@ -280,10 +280,9 @@ public class IdleStateHandler implements ChannelInboundHandler, ChannelOutboundH
     public void write(ChannelHandlerContext ctx, Object msg, Promise<Void> promise) {
         // Allow writing with void promise if handler is only configured for read timeout events.
         if (writerIdleTimeNanos > 0 || allIdleTimeNanos > 0) {
-            ctx.write(msg, promise).addListener(writeListener);
-        } else {
-            ctx.write(msg, promise);
+            promise.addListener(writeListener);
         }
+        ctx.write(msg, promise);
     }
 
     /**

--- a/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
+++ b/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
@@ -278,11 +278,11 @@ public class IdleStateHandler implements ChannelInboundHandler, ChannelOutboundH
 
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, Promise<Void> promise) {
+        ctx.write(msg, promise);
         // Allow writing with void promise if handler is only configured for read timeout events.
         if (writerIdleTimeNanos > 0 || allIdleTimeNanos > 0) {
             promise.addListener(writeListener);
         }
-        ctx.write(msg, promise);
     }
 
     /**

--- a/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
@@ -1390,7 +1390,7 @@ public class PcapWriteHandlerTest {
         }
 
         @Override
-        public Future<Void> joinGroup(InetAddress multicastAddress, Promise<Void> future) {
+        public void joinGroup(InetAddress multicastAddress, Promise<Void> future) {
             throw new UnsupportedOperationException();
         }
 
@@ -1400,7 +1400,7 @@ public class PcapWriteHandlerTest {
         }
 
         @Override
-        public Future<Void> joinGroup(
+        public void joinGroup(
                 InetSocketAddress multicastAddress,
                 NetworkInterface networkInterface,
                 Promise<Void> future) {
@@ -1416,7 +1416,7 @@ public class PcapWriteHandlerTest {
         }
 
         @Override
-        public Future<Void> joinGroup(
+        public void joinGroup(
                 InetAddress multicastAddress,
                 NetworkInterface networkInterface,
                 InetAddress source,
@@ -1430,7 +1430,7 @@ public class PcapWriteHandlerTest {
         }
 
         @Override
-        public Future<Void> leaveGroup(InetAddress multicastAddress, Promise<Void> future) {
+        public void leaveGroup(InetAddress multicastAddress, Promise<Void> future) {
             throw new UnsupportedOperationException();
         }
 
@@ -1440,7 +1440,7 @@ public class PcapWriteHandlerTest {
         }
 
         @Override
-        public Future<Void> leaveGroup(
+        public void leaveGroup(
                 InetSocketAddress multicastAddress,
                 NetworkInterface networkInterface,
                 Promise<Void> future) {
@@ -1456,7 +1456,7 @@ public class PcapWriteHandlerTest {
         }
 
         @Override
-        public Future<Void> leaveGroup(
+        public void leaveGroup(
                 InetAddress multicastAddress,
                 NetworkInterface networkInterface,
                 InetAddress source,
@@ -1473,7 +1473,7 @@ public class PcapWriteHandlerTest {
         }
 
         @Override
-        public Future<Void> block(
+        public void block(
                 InetAddress multicastAddress,
                 NetworkInterface networkInterface,
                 InetAddress sourceToBlock,
@@ -1487,7 +1487,7 @@ public class PcapWriteHandlerTest {
         }
 
         @Override
-        public Future<Void> block(InetAddress multicastAddress, InetAddress sourceToBlock, Promise<Void> future) {
+        public void block(InetAddress multicastAddress, InetAddress sourceToBlock, Promise<Void> future) {
             throw new UnsupportedOperationException();
         }
     }

--- a/microbench/src/main/java/io/netty/handler/codec/http2/Http2FrameWriterDataBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http2/Http2FrameWriterDataBenchmark.java
@@ -23,7 +23,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandler;
 import io.netty.microbench.channel.EmbeddedChannelWriteReleaseHandlerContext;
 import io.netty.microbench.util.AbstractMicrobenchmark;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -118,8 +117,8 @@ public class Http2FrameWriterDataBenchmark extends AbstractMicrobenchmark {
                 unreleasableBuffer(directBuffer(MAX_UNSIGNED_BYTE).writeZero(MAX_UNSIGNED_BYTE)).asReadOnly();
         private final int maxFrameSize = DEFAULT_MAX_FRAME_SIZE;
         @Override
-        public Future<Void> writeData(ChannelHandlerContext ctx, int streamId, ByteBuf data,
-                                      int padding, boolean endStream, Promise<Void> promise) {
+        public void writeData(ChannelHandlerContext ctx, int streamId, ByteBuf data,
+                              int padding, boolean endStream, Promise<Void> promise) {
             final Http2CodecUtil.SimpleChannelPromiseAggregator promiseAggregator =
                     new Http2CodecUtil.SimpleChannelPromiseAggregator(promise, ctx.channel(), ctx.executor());
             final DataFrameHeader header = new DataFrameHeader(ctx, streamId);
@@ -172,9 +171,9 @@ public class Http2FrameWriterDataBenchmark extends AbstractMicrobenchmark {
                     promiseAggregator.setFailure(t);
                     promiseAggregator.doneAllocatingPromises();
                 }
-                return promiseAggregator;
+                return;
             }
-            return promiseAggregator.doneAllocatingPromises();
+            promiseAggregator.doneAllocatingPromises();
         }
 
         private static int paddingBytes(int padding) {

--- a/microbench/src/main/java/io/netty/microbench/channel/DefaultChannelPipelineBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/channel/DefaultChannelPipelineBenchmark.java
@@ -358,10 +358,10 @@ public class DefaultChannelPipelineBenchmark extends AbstractMicrobenchmark {
         hole.consume(pipeline.fireChannelActive());             // 1
         hole.consume(pipeline.fireChannelRead(MESSAGE));        // 2
         hole.consume(pipeline.fireChannelRead(MESSAGE));        // 3
-        hole.consume(pipeline.write(MESSAGE, promises[index])); // 4
+        pipeline.write(MESSAGE, promises[index]);               // 4
         hole.consume(pipeline.fireChannelRead(MESSAGE));        // 5
         hole.consume(pipeline.fireChannelRead(MESSAGE));        // 6
-        hole.consume(pipeline.write(MESSAGE, promises[index])); // 7
+        pipeline.write(MESSAGE, promises[index]);               // 7
         hole.consume(pipeline.fireChannelReadComplete());       // 8
         hole.consume(pipeline.fireUserEventTriggered(MESSAGE)); // 9
         hole.consume(pipeline.fireChannelWritabilityChanged()); // 10

--- a/microbench/src/main/java/io/netty/microbench/channel/EmbeddedChannelHandlerContext.java
+++ b/microbench/src/main/java/io/netty/microbench/channel/EmbeddedChannelHandlerContext.java
@@ -129,38 +129,8 @@ public abstract class EmbeddedChannelHandlerContext implements ChannelHandlerCon
     }
 
     @Override
-    public final Future<Void> bind(SocketAddress localAddress) {
-        return bind(localAddress, newPromise());
-    }
-
-    @Override
-    public final Future<Void> connect(SocketAddress remoteAddress) {
-        return connect(remoteAddress, newPromise());
-    }
-
-    @Override
-    public final Future<Void> connect(SocketAddress remoteAddress, SocketAddress localAddress) {
-        return connect(remoteAddress, localAddress, newPromise());
-    }
-
-    @Override
-    public final Future<Void> disconnect() {
-        return disconnect(newPromise());
-    }
-
-    @Override
-    public final Future<Void> close() {
-        return close(newPromise());
-    }
-
-    @Override
-    public final Future<Void> deregister() {
-        return deregister(newPromise());
-    }
-
-    @Override
-    public Future<Void> register(Promise<Void> promise) {
-        return channel.register(promise);
+    public void register(Promise<Void> promise) {
+        channel.register(promise);
     }
 
     @Override
@@ -169,7 +139,7 @@ public abstract class EmbeddedChannelHandlerContext implements ChannelHandlerCon
     }
 
     @Override
-    public final Future<Void> bind(SocketAddress localAddress, Promise<Void> promise) {
+    public final void bind(SocketAddress localAddress, Promise<Void> promise) {
         try {
             channel().bind(localAddress, promise);
             this.localAddress = localAddress;
@@ -177,63 +147,57 @@ public abstract class EmbeddedChannelHandlerContext implements ChannelHandlerCon
             promise.setFailure(e);
             handleException(e);
         }
-        return promise;
     }
 
     @Override
-    public final Future<Void> connect(SocketAddress remoteAddress, Promise<Void> promise) {
+    public final void connect(SocketAddress remoteAddress, Promise<Void> promise) {
         try {
             channel().connect(remoteAddress, localAddress, promise);
         } catch (Exception e) {
             promise.setFailure(e);
             handleException(e);
         }
-        return promise;
     }
 
     @Override
-    public final Future<Void> connect(SocketAddress remoteAddress, SocketAddress localAddress,
-                                      Promise<Void> promise) {
+    public final void connect(SocketAddress remoteAddress, SocketAddress localAddress,
+                              Promise<Void> promise) {
         try {
             channel().connect(remoteAddress, localAddress, promise);
         } catch (Exception e) {
             promise.setFailure(e);
             handleException(e);
         }
-        return promise;
     }
 
     @Override
-    public final Future<Void> disconnect(Promise<Void> promise) {
+    public final void disconnect(Promise<Void> promise) {
         try {
             channel().disconnect(promise);
         } catch (Exception e) {
             promise.setFailure(e);
             handleException(e);
         }
-        return promise;
     }
 
     @Override
-    public final Future<Void> close(Promise<Void> promise) {
+    public final void close(Promise<Void> promise) {
         try {
             channel().close(promise);
         } catch (Exception e) {
             promise.setFailure(e);
             handleException(e);
         }
-        return promise;
     }
 
     @Override
-    public final Future<Void> deregister(Promise<Void> promise) {
+    public final void deregister(Promise<Void> promise) {
         try {
             channel().deregister(promise);
         } catch (Exception e) {
             promise.setFailure(e);
             handleException(e);
         }
-        return promise;
     }
 
     @Override
@@ -252,8 +216,8 @@ public abstract class EmbeddedChannelHandlerContext implements ChannelHandlerCon
     }
 
     @Override
-    public Future<Void> write(Object msg, Promise<Void> promise) {
-        return channel().write(msg, promise);
+    public void write(Object msg, Promise<Void> promise) {
+        channel().write(msg, promise);
     }
 
     @Override
@@ -263,13 +227,13 @@ public abstract class EmbeddedChannelHandlerContext implements ChannelHandlerCon
     }
 
     @Override
-    public Future<Void> writeAndFlush(Object msg, Promise<Void> promise) {
-        return channel().writeAndFlush(msg, promise);
+    public void writeAndFlush(Object msg, Promise<Void> promise) {
+        channel().writeAndFlush(msg, promise);
     }
 
     @Override
     public Future<Void> writeAndFlush(Object msg) {
-        return writeAndFlush(msg, newPromise());
+        return channel().writeAndFlush(msg);
     }
 
     @Override
@@ -303,7 +267,7 @@ public abstract class EmbeddedChannelHandlerContext implements ChannelHandlerCon
     }
 
     @Override
-    public Future<Void> shutdown(ChannelShutdownType type, Promise<Void> promise) {
-        return channel().shutdown(type, promise);
+    public void shutdown(ChannelShutdownType type, Promise<Void> promise) {
+        channel().shutdown(type, promise);
     }
 }

--- a/microbench/src/main/java/io/netty/microbench/channel/EmbeddedChannelWriteAccumulatingHandlerContext.java
+++ b/microbench/src/main/java/io/netty/microbench/channel/EmbeddedChannelWriteAccumulatingHandlerContext.java
@@ -52,11 +52,13 @@ public abstract class EmbeddedChannelWriteAccumulatingHandlerContext extends Emb
 
     @Override
     public final Future<Void> write(Object msg) {
-        return write(msg, newPromise());
+        Promise<Void> promise = newPromise();
+        write(msg, promise);
+        return promise;
     }
 
     @Override
-    public final Future<Void> write(Object msg, Promise<Void> promise) {
+    public final void write(Object msg, Promise<Void> promise) {
         try {
             if (msg instanceof ByteBuf) {
                 if (cumulation == null) {
@@ -72,11 +74,10 @@ public abstract class EmbeddedChannelWriteAccumulatingHandlerContext extends Emb
             promise.setFailure(e);
             handleException(e);
         }
-        return promise;
     }
 
     @Override
-    public final Future<Void> writeAndFlush(Object msg, Promise<Void> promise) {
+    public final void writeAndFlush(Object msg, Promise<Void> promise) {
         try {
             if (msg instanceof ByteBuf) {
                 ByteBuf buf = (ByteBuf) msg;
@@ -93,11 +94,12 @@ public abstract class EmbeddedChannelWriteAccumulatingHandlerContext extends Emb
             promise.setFailure(e);
             handleException(e);
         }
-        return promise;
     }
 
     @Override
     public final Future<Void> writeAndFlush(Object msg) {
-        return writeAndFlush(msg, newPromise());
+        Promise<Void> promise = newPromise();
+        writeAndFlush(msg, promise);
+        return promise;
     }
 }

--- a/microbench/src/main/java/io/netty/microbench/channel/EmbeddedChannelWriteReleaseHandlerContext.java
+++ b/microbench/src/main/java/io/netty/microbench/channel/EmbeddedChannelWriteReleaseHandlerContext.java
@@ -36,11 +36,13 @@ public abstract class EmbeddedChannelWriteReleaseHandlerContext extends Embedded
 
     @Override
     public final Future<Void> write(Object msg) {
-        return write(msg, newPromise());
+        Promise<Void> promise = newPromise();
+        write(msg, promise);
+        return promise;
     }
 
     @Override
-    public final Future<Void> write(Object msg, Promise<Void> promise) {
+    public final void write(Object msg, Promise<Void> promise) {
         try {
             if (msg instanceof ReferenceCounted) {
                 ((ReferenceCounted) msg).release();
@@ -52,11 +54,10 @@ public abstract class EmbeddedChannelWriteReleaseHandlerContext extends Embedded
             promise.setFailure(e);
             handleException(e);
         }
-        return promise;
     }
 
     @Override
-    public final Future<Void> writeAndFlush(Object msg, Promise<Void> promise) {
+    public final void writeAndFlush(Object msg, Promise<Void> promise) {
         try {
             if (msg instanceof ReferenceCounted) {
                 ((ReferenceCounted) msg).release();
@@ -68,11 +69,12 @@ public abstract class EmbeddedChannelWriteReleaseHandlerContext extends Embedded
             promise.setFailure(e);
             handleException(e);
         }
-        return promise;
     }
 
     @Override
     public final Future<Void> writeAndFlush(Object msg) {
-        return writeAndFlush(msg, newPromise());
+        Promise<Void> promise = newPromise();
+        writeAndFlush(msg, promise);
+        return promise;
     }
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
@@ -241,12 +241,15 @@ abstract class DnsQueryContext {
 
     private void writeQuery(final DnsQuery query,
                             final boolean flush, Promise<Void> promise) {
-        final Future<Void> writeFuture = flush ? channel.writeAndFlush(query, promise) :
-                channel.write(query, promise);
-        if (writeFuture.isDone()) {
-            onQueryWriteCompletion(queryTimeoutMillis, writeFuture);
+        if (flush) {
+            channel.writeAndFlush(query, promise);
         } else {
-            writeFuture.addListener(future ->
+            channel.write(query, promise);
+        }
+        if (promise.isDone()) {
+            onQueryWriteCompletion(queryTimeoutMillis, promise);
+        } else {
+            promise.addListener(future ->
                     onQueryWriteCompletion(queryTimeoutMillis, future));
         }
     }

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -33,7 +33,6 @@ import io.netty.channel.unix.Errors.NativeIoException;
 import io.netty.channel.unix.UnixChannelUtil;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.UncheckedBooleanSupplier;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.RecyclableArrayList;
@@ -142,12 +141,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
     }
 
     @Override
-    public Future<Void> joinGroup(InetAddress multicastAddress) {
-        return joinGroup(multicastAddress, newPromise());
-    }
-
-    @Override
-    public Future<Void> joinGroup(InetAddress multicastAddress, Promise<Void> promise) {
+    public void joinGroup(InetAddress multicastAddress, Promise<Void> promise) {
         SocketProtocolFamily family = socket.protocolFamily();
         switch (family) {
             case INET6:
@@ -157,38 +151,26 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
                     if (iface == null) {
                         iface = NetworkInterface.getByInetAddress(((InetSocketAddress) localAddress()).getAddress());
                     }
-                    return joinGroup(multicastAddress, iface, null, promise);
+                    joinGroup(multicastAddress, iface, null, promise);
                 } catch (SocketException e) {
                     promise.setFailure(e);
                 }
-                return promise;
+                return;
             default:
-                return promise.setFailure(
+                promise.setFailure(
                         new UnsupportedOperationException("Not supported for SocketProtocolFamily: " + family));
         }
     }
 
     @Override
-    public Future<Void> joinGroup(
-            InetSocketAddress multicastAddress, NetworkInterface networkInterface) {
-        return joinGroup(multicastAddress, networkInterface, newPromise());
-    }
-
-    @Override
-    public Future<Void> joinGroup(
+    public void joinGroup(
             InetSocketAddress multicastAddress, NetworkInterface networkInterface,
             Promise<Void> promise) {
-        return joinGroup(multicastAddress.getAddress(), networkInterface, null, promise);
+        joinGroup(multicastAddress.getAddress(), networkInterface, null, promise);
     }
 
     @Override
-    public Future<Void> joinGroup(
-            InetAddress multicastAddress, NetworkInterface networkInterface, InetAddress source) {
-        return joinGroup(multicastAddress, networkInterface, source, newPromise());
-    }
-
-    @Override
-    public Future<Void> joinGroup(
+    public void joinGroup(
             final InetAddress multicastAddress, final NetworkInterface networkInterface,
             final InetAddress source, final Promise<Void> promise) {
 
@@ -209,9 +191,9 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
                         }
                     });
                 }
-                return promise;
+                return;
             default:
-                return promise.setFailure(
+                promise.setFailure(
                         new UnsupportedOperationException("Not supported for SocketProtocolFamily: " + family));
         }
     }
@@ -230,43 +212,25 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
     }
 
     @Override
-    public Future<Void> leaveGroup(InetAddress multicastAddress) {
-        return leaveGroup(multicastAddress, newPromise());
-    }
-
-    @Override
-    public Future<Void> leaveGroup(InetAddress multicastAddress, Promise<Void> promise) {
+    public void leaveGroup(InetAddress multicastAddress, Promise<Void> promise) {
         try {
-            return leaveGroup(
+            leaveGroup(
                     multicastAddress, NetworkInterface.getByInetAddress(
                             ((InetSocketAddress) localAddress()).getAddress()), null, promise);
         } catch (IOException e) {
             promise.setFailure(e);
         }
-        return promise;
     }
 
     @Override
-    public Future<Void> leaveGroup(
-            InetSocketAddress multicastAddress, NetworkInterface networkInterface) {
-        return leaveGroup(multicastAddress, networkInterface, newPromise());
-    }
-
-    @Override
-    public Future<Void> leaveGroup(
+    public void leaveGroup(
             InetSocketAddress multicastAddress,
             NetworkInterface networkInterface, Promise<Void> promise) {
-        return leaveGroup(multicastAddress.getAddress(), networkInterface, null, promise);
+        leaveGroup(multicastAddress.getAddress(), networkInterface, null, promise);
     }
 
     @Override
-    public Future<Void> leaveGroup(
-            InetAddress multicastAddress, NetworkInterface networkInterface, InetAddress source) {
-        return leaveGroup(multicastAddress, networkInterface, source, newPromise());
-    }
-
-    @Override
-    public Future<Void> leaveGroup(
+    public void leaveGroup(
             final InetAddress multicastAddress, final NetworkInterface networkInterface, final InetAddress source,
             final Promise<Void> promise) {
         ObjectUtil.checkNotNull(multicastAddress, "multicastAddress");
@@ -287,9 +251,9 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
                         }
                     });
                 }
-                return promise;
+                return;
             default:
-                return promise.setFailure(
+                promise.setFailure(
                         new UnsupportedOperationException("Not supported for SocketProtocolFamily: " + family));
         }
     }
@@ -308,14 +272,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
     }
 
     @Override
-    public Future<Void> block(
-            InetAddress multicastAddress, NetworkInterface networkInterface,
-            InetAddress sourceToBlock) {
-        return block(multicastAddress, networkInterface, sourceToBlock, newPromise());
-    }
-
-    @Override
-    public Future<Void> block(
+    public void block(
             final InetAddress multicastAddress, final NetworkInterface networkInterface,
             final InetAddress sourceToBlock, final Promise<Void> promise) {
         ObjectUtil.checkNotNull(multicastAddress, "multicastAddress");
@@ -323,16 +280,10 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
         ObjectUtil.checkNotNull(networkInterface, "networkInterface");
 
         promise.setFailure(new UnsupportedOperationException("Multicast block not supported"));
-        return promise;
     }
 
     @Override
-    public Future<Void> block(InetAddress multicastAddress, InetAddress sourceToBlock) {
-        return block(multicastAddress, sourceToBlock, newPromise());
-    }
-
-    @Override
-    public Future<Void> block(
+    public void block(
             InetAddress multicastAddress, InetAddress sourceToBlock, Promise<Void> promise) {
 
         SocketProtocolFamily family = socket.protocolFamily();
@@ -340,16 +291,15 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
             case INET6:
             case INET:
                 try {
-                    return block(
-                            multicastAddress,
+                    block(multicastAddress,
                             NetworkInterface.getByInetAddress(((InetSocketAddress) localAddress()).getAddress()),
                             sourceToBlock, promise);
                 } catch (Throwable e) {
                     promise.setFailure(e);
                 }
-                return promise;
+                return;
             default:
-                return promise.setFailure(
+                promise.setFailure(
                         new UnsupportedOperationException("Not supported for SocketProtocolFamily: " + family));
         }
     }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
@@ -30,7 +30,6 @@ import io.netty.channel.unix.Errors.NativeIoException;
 import io.netty.channel.unix.SegmentedDatagramPacket;
 import io.netty.channel.unix.Socket;
 import io.netty.util.UncheckedBooleanSupplier;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
@@ -141,44 +140,26 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
     }
 
     @Override
-    public Future<Void> joinGroup(InetAddress multicastAddress) {
-        return joinGroup(multicastAddress, newPromise());
-    }
-
-    @Override
-    public Future<Void> joinGroup(InetAddress multicastAddress, Promise<Void> promise) {
+    public void joinGroup(InetAddress multicastAddress, Promise<Void> promise) {
         try {
-            return joinGroup(
+            joinGroup(
                     multicastAddress,
                     NetworkInterface.getByInetAddress(
                             ((InetSocketAddress) localAddress()).getAddress()), null, promise);
         } catch (IOException e) {
             promise.setFailure(e);
         }
-        return promise;
     }
 
     @Override
-    public Future<Void> joinGroup(
-            InetSocketAddress multicastAddress, NetworkInterface networkInterface) {
-        return joinGroup(multicastAddress, networkInterface, newPromise());
-    }
-
-    @Override
-    public Future<Void> joinGroup(
+    public void joinGroup(
             InetSocketAddress multicastAddress, NetworkInterface networkInterface,
             Promise<Void> promise) {
-        return joinGroup(multicastAddress.getAddress(), networkInterface, null, promise);
+        joinGroup(multicastAddress.getAddress(), networkInterface, null, promise);
     }
 
     @Override
-    public Future<Void> joinGroup(
-            InetAddress multicastAddress, NetworkInterface networkInterface, InetAddress source) {
-        return joinGroup(multicastAddress, networkInterface, source, newPromise());
-    }
-
-    @Override
-    public Future<Void> joinGroup(
+    public void joinGroup(
             final InetAddress multicastAddress, final NetworkInterface networkInterface,
             final InetAddress source, final Promise<Void> promise) {
 
@@ -191,47 +172,28 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
         } catch (IOException e) {
             promise.setFailure(e);
         }
-        return promise;
     }
 
     @Override
-    public Future<Void> leaveGroup(InetAddress multicastAddress) {
-        return leaveGroup(multicastAddress, newPromise());
-    }
-
-    @Override
-    public Future<Void> leaveGroup(InetAddress multicastAddress, Promise<Void> promise) {
+    public void leaveGroup(InetAddress multicastAddress, Promise<Void> promise) {
         try {
-            return leaveGroup(
+            leaveGroup(
                     multicastAddress, NetworkInterface.getByInetAddress(
                             ((InetSocketAddress) localAddress()).getAddress()), null, promise);
         } catch (IOException e) {
             promise.setFailure(e);
         }
-        return promise;
     }
 
     @Override
-    public Future<Void> leaveGroup(
-            InetSocketAddress multicastAddress, NetworkInterface networkInterface) {
-        return leaveGroup(multicastAddress, networkInterface, newPromise());
-    }
-
-    @Override
-    public Future<Void> leaveGroup(
+    public void leaveGroup(
             InetSocketAddress multicastAddress,
             NetworkInterface networkInterface, Promise<Void> promise) {
-        return leaveGroup(multicastAddress.getAddress(), networkInterface, null, promise);
+        leaveGroup(multicastAddress.getAddress(), networkInterface, null, promise);
     }
 
     @Override
-    public Future<Void> leaveGroup(
-            InetAddress multicastAddress, NetworkInterface networkInterface, InetAddress source) {
-        return leaveGroup(multicastAddress, networkInterface, source, newPromise());
-    }
-
-    @Override
-    public Future<Void> leaveGroup(
+    public void leaveGroup(
             final InetAddress multicastAddress, final NetworkInterface networkInterface, final InetAddress source,
             final Promise<Void> promise) {
         ObjectUtil.checkNotNull(multicastAddress, "multicastAddress");
@@ -243,18 +205,10 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
         } catch (IOException e) {
             promise.setFailure(e);
         }
-        return promise;
     }
 
     @Override
-    public Future<Void> block(
-            InetAddress multicastAddress, NetworkInterface networkInterface,
-            InetAddress sourceToBlock) {
-        return block(multicastAddress, networkInterface, sourceToBlock, newPromise());
-    }
-
-    @Override
-    public Future<Void> block(
+    public void block(
             final InetAddress multicastAddress, final NetworkInterface networkInterface,
             final InetAddress sourceToBlock, final Promise<Void> promise) {
         ObjectUtil.checkNotNull(multicastAddress, "multicastAddress");
@@ -262,26 +216,18 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
         ObjectUtil.checkNotNull(networkInterface, "networkInterface");
 
         promise.setFailure(new UnsupportedOperationException("Multicast not supported"));
-        return promise;
     }
 
     @Override
-    public Future<Void> block(InetAddress multicastAddress, InetAddress sourceToBlock) {
-        return block(multicastAddress, sourceToBlock, newPromise());
-    }
-
-    @Override
-    public Future<Void> block(
+    public void block(
             InetAddress multicastAddress, InetAddress sourceToBlock, Promise<Void> promise) {
         try {
-            return block(
-                    multicastAddress,
+            block(multicastAddress,
                     NetworkInterface.getByInetAddress(((InetSocketAddress) localAddress()).getAddress()),
                     sourceToBlock, promise);
         } catch (Throwable e) {
             promise.setFailure(e);
         }
-        return promise;
     }
 
     @Override

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
@@ -33,7 +33,6 @@ import io.netty.channel.unix.IovArray;
 import io.netty.channel.unix.UnixChannelUtil;
 import io.netty.util.CharsetUtil;
 import io.netty.util.UncheckedBooleanSupplier;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
@@ -175,12 +174,7 @@ public final class KQueueDatagramChannel extends AbstractKQueueChannel implement
     }
 
     @Override
-    public Future<Void> joinGroup(InetAddress multicastAddress) {
-        return joinGroup(multicastAddress, newPromise());
-    }
-
-    @Override
-    public Future<Void> joinGroup(InetAddress multicastAddress, Promise<Void> promise) {
+    public void joinGroup(InetAddress multicastAddress, Promise<Void> promise) {
         SocketProtocolFamily family = socket.protocolFamily();
         switch (family) {
             case INET6:
@@ -190,38 +184,26 @@ public final class KQueueDatagramChannel extends AbstractKQueueChannel implement
                     if (iface == null) {
                         iface = NetworkInterface.getByInetAddress(((InetSocketAddress) localAddress()).getAddress());
                     }
-                    return joinGroup(multicastAddress, iface, null, promise);
+                    joinGroup(multicastAddress, iface, null, promise);
                 } catch (SocketException e) {
                     promise.setFailure(e);
                 }
-                return promise;
+                return;
             default:
-                return promise.setFailure(
+                promise.setFailure(
                         new UnsupportedOperationException("Not supported for SocketProtocolFamily: " + family));
         }
     }
 
     @Override
-    public Future<Void> joinGroup(
-            InetSocketAddress multicastAddress, NetworkInterface networkInterface) {
-        return joinGroup(multicastAddress, networkInterface, newPromise());
-    }
-
-    @Override
-    public Future<Void> joinGroup(
+    public void joinGroup(
             InetSocketAddress multicastAddress, NetworkInterface networkInterface,
             Promise<Void> promise) {
-        return joinGroup(multicastAddress.getAddress(), networkInterface, null, promise);
+        joinGroup(multicastAddress.getAddress(), networkInterface, null, promise);
     }
 
     @Override
-    public Future<Void> joinGroup(
-            InetAddress multicastAddress, NetworkInterface networkInterface, InetAddress source) {
-        return joinGroup(multicastAddress, networkInterface, source, newPromise());
-    }
-
-    @Override
-    public Future<Void> joinGroup(
+    public void joinGroup(
             final InetAddress multicastAddress, final NetworkInterface networkInterface,
             final InetAddress source, final Promise<Void> promise) {
 
@@ -231,47 +213,27 @@ public final class KQueueDatagramChannel extends AbstractKQueueChannel implement
         promise.setFailure(
                 new UnsupportedOperationException("Not supported for SocketProtocolFamily: " +
                         socket.protocolFamily()));
-        return promise;
     }
 
     @Override
-    public Future<Void> leaveGroup(InetAddress multicastAddress) {
-        return leaveGroup(multicastAddress, newPromise());
-    }
-
-    @Override
-    public Future<Void> leaveGroup(InetAddress multicastAddress, Promise<Void> promise) {
+    public void leaveGroup(InetAddress multicastAddress, Promise<Void> promise) {
         try {
-            return leaveGroup(
+            leaveGroup(
                     multicastAddress, NetworkInterface.getByInetAddress(
                             ((InetSocketAddress) localAddress()).getAddress()), null, promise);
         } catch (SocketException e) {
             promise.setFailure(e);
         }
-        return promise;
     }
-
     @Override
-    public Future<Void> leaveGroup(
-            InetSocketAddress multicastAddress, NetworkInterface networkInterface) {
-        return leaveGroup(multicastAddress, networkInterface, newPromise());
-    }
-
-    @Override
-    public Future<Void> leaveGroup(
+    public void leaveGroup(
             InetSocketAddress multicastAddress,
             NetworkInterface networkInterface, Promise<Void> promise) {
-        return leaveGroup(multicastAddress.getAddress(), networkInterface, null, promise);
+        leaveGroup(multicastAddress.getAddress(), networkInterface, null, promise);
     }
 
     @Override
-    public Future<Void> leaveGroup(
-            InetAddress multicastAddress, NetworkInterface networkInterface, InetAddress source) {
-        return leaveGroup(multicastAddress, networkInterface, source, newPromise());
-    }
-
-    @Override
-    public Future<Void> leaveGroup(
+    public void leaveGroup(
             final InetAddress multicastAddress, final NetworkInterface networkInterface, final InetAddress source,
             final Promise<Void> promise) {
         ObjectUtil.checkNotNull(multicastAddress, "multicastAddress");
@@ -279,18 +241,10 @@ public final class KQueueDatagramChannel extends AbstractKQueueChannel implement
 
         promise.setFailure(new UnsupportedOperationException("Not supported for SocketProtocolFamily: " +
                 socket.protocolFamily()));
-        return promise;
     }
 
     @Override
-    public Future<Void> block(
-            InetAddress multicastAddress, NetworkInterface networkInterface,
-            InetAddress sourceToBlock) {
-        return block(multicastAddress, networkInterface, sourceToBlock, newPromise());
-    }
-
-    @Override
-    public Future<Void> block(
+    public void block(
             final InetAddress multicastAddress, final NetworkInterface networkInterface,
             final InetAddress sourceToBlock, final Promise<Void> promise) {
         ObjectUtil.checkNotNull(multicastAddress, "multicastAddress");
@@ -298,32 +252,25 @@ public final class KQueueDatagramChannel extends AbstractKQueueChannel implement
         ObjectUtil.checkNotNull(networkInterface, "networkInterface");
         promise.setFailure(new UnsupportedOperationException("Not supported for SocketProtocolFamily: " +
                 socket.protocolFamily()));
-        return promise;
     }
 
     @Override
-    public Future<Void> block(InetAddress multicastAddress, InetAddress sourceToBlock) {
-        return block(multicastAddress, sourceToBlock, newPromise());
-    }
-
-    @Override
-    public Future<Void> block(
+    public void block(
             InetAddress multicastAddress, InetAddress sourceToBlock, Promise<Void> promise) {
         SocketProtocolFamily family = socket.protocolFamily();
         switch (family) {
             case INET6:
             case INET:
                 try {
-                    return block(
-                            multicastAddress,
+                    block(multicastAddress,
                             NetworkInterface.getByInetAddress(((InetSocketAddress) localAddress()).getAddress()),
                             sourceToBlock, promise);
                 } catch (SocketException e) {
                     promise.setFailure(e);
                 }
-                return promise;
+                return;
             default:
-                return promise.setFailure(
+                promise.setFailure(
                     new UnsupportedOperationException("Not supported for SocketProtocolFamily: " + family));
         }
     }

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/SctpChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/SctpChannel.java
@@ -101,7 +101,9 @@ public interface SctpChannel extends Channel {
      * The Channel bust be bound and yet to be connected.
      */
     default Future<Void> bindAddress(InetAddress localAddress) {
-        return bindAddress(localAddress, newPromise());
+        Promise<Void> promise = newPromise();
+        bindAddress(localAddress, promise);
+        return promise;
     }
 
     /**
@@ -110,14 +112,16 @@ public interface SctpChannel extends Channel {
      * <p>
      * Will notify the given {@link Promise} and return a {@link Future}
      */
-    Future<Void> bindAddress(InetAddress localAddress, Promise<Void> promise);
+    void bindAddress(InetAddress localAddress, Promise<Void> promise);
 
     /**
      * Unbind the address from channel's multi-homing address list.
      * The address should be added already in multi-homing address list.
      */
     default Future<Void> unbindAddress(InetAddress localAddress) {
-        return unbindAddress(localAddress, newPromise());
+        Promise<Void> promise = newPromise();
+        unbindAddress(localAddress, promise);
+        return promise;
     }
 
     /**
@@ -126,7 +130,7 @@ public interface SctpChannel extends Channel {
      * <p>
      * Will notify the given {@link Promise} and return a {@link Future}
      */
-    Future<Void> unbindAddress(InetAddress localAddress, Promise<Void> promise);
+    void unbindAddress(InetAddress localAddress, Promise<Void> promise);
 
     @Override
     SctpChannel read();

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/SctpServerChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/SctpServerChannel.java
@@ -76,7 +76,9 @@ public interface SctpServerChannel extends ServerChannel {
      * The Channel must be bound and yet to be connected.
      */
     default Future<Void> bindAddress(InetAddress localAddress) {
-        return bindAddress(localAddress, newPromise());
+        Promise<Void> promise = newPromise();
+        bindAddress(localAddress, promise);
+        return promise;
     }
 
     /**
@@ -85,14 +87,16 @@ public interface SctpServerChannel extends ServerChannel {
      * <p>
      * Will notify the given {@link Promise} and return a {@link Future}
      */
-    Future<Void> bindAddress(InetAddress localAddress, Promise<Void> promise);
+    void bindAddress(InetAddress localAddress, Promise<Void> promise);
 
     /**
      * Unbind the address from channel's multi-homing address list.
      * The address should be added already in multi-homing address list.
      */
     default Future<Void> unbindAddress(InetAddress localAddress) {
-        return  unbindAddress(localAddress, newPromise());
+        Promise<Void> promise = newPromise();
+        unbindAddress(localAddress, promise);
+        return promise;
     }
 
     /**
@@ -101,5 +105,5 @@ public interface SctpServerChannel extends ServerChannel {
      * <p>
      * Will notify the given {@link Promise} and return a {@link Future}
      */
-    Future<Void> unbindAddress(InetAddress localAddress, Promise<Void> promise);
+    void unbindAddress(InetAddress localAddress, Promise<Void> promise);
 }

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
@@ -35,7 +35,6 @@ import io.netty.channel.nio.NioIoOps;
 import io.netty.channel.sctp.SctpMessage;
 import io.netty.channel.sctp.SctpNotificationHandler;
 import io.netty.channel.sctp.SctpServerChannel;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
@@ -397,12 +396,7 @@ public class NioSctpChannel extends AbstractNioMessageChannel implements io.nett
     }
 
     @Override
-    public Future<Void> bindAddress(InetAddress localAddress) {
-        return bindAddress(localAddress, newPromise());
-    }
-
-    @Override
-    public Future<Void> bindAddress(final InetAddress localAddress, final Promise<Void> promise) {
+    public void bindAddress(final InetAddress localAddress, final Promise<Void> promise) {
         if (executor().inEventLoop()) {
             try {
                 javaChannel().bindAddress(localAddress);
@@ -418,16 +412,10 @@ public class NioSctpChannel extends AbstractNioMessageChannel implements io.nett
                 }
             });
         }
-        return promise;
     }
 
     @Override
-    public Future<Void> unbindAddress(InetAddress localAddress) {
-        return unbindAddress(localAddress, newPromise());
-    }
-
-    @Override
-    public Future<Void> unbindAddress(final InetAddress localAddress, final Promise<Void> promise) {
+    public void unbindAddress(final InetAddress localAddress, final Promise<Void> promise) {
         if (executor().inEventLoop()) {
             try {
                 javaChannel().unbindAddress(localAddress);
@@ -443,7 +431,6 @@ public class NioSctpChannel extends AbstractNioMessageChannel implements io.nett
                 }
             });
         }
-        return promise;
     }
 
     private final class NioSctpChannelConfig extends DefaultChannelConfig {

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpServerChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpServerChannel.java
@@ -33,7 +33,6 @@ import io.netty.channel.nio.NioIoHandle;
 import io.netty.channel.nio.NioIoOps;
 import io.netty.channel.sctp.SctpChannelOption;
 import io.netty.util.NetUtil;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.ObjectUtil;
 
@@ -188,12 +187,7 @@ public class NioSctpServerChannel extends AbstractNioMessageChannel
     }
 
     @Override
-    public Future<Void> bindAddress(InetAddress localAddress) {
-        return bindAddress(localAddress, newPromise());
-    }
-
-    @Override
-    public Future<Void> bindAddress(final InetAddress localAddress, final Promise<Void> promise) {
+    public void bindAddress(final InetAddress localAddress, final Promise<Void> promise) {
         if (executor().inEventLoop()) {
             try {
                 javaChannel().bindAddress(localAddress);
@@ -209,16 +203,10 @@ public class NioSctpServerChannel extends AbstractNioMessageChannel
                 }
             });
         }
-        return promise;
     }
 
     @Override
-    public Future<Void> unbindAddress(InetAddress localAddress) {
-        return unbindAddress(localAddress, newPromise());
-    }
-
-    @Override
-    public Future<Void> unbindAddress(final InetAddress localAddress, final Promise<Void> promise) {
+    public void unbindAddress(final InetAddress localAddress, final Promise<Void> promise) {
         if (executor().inEventLoop()) {
             try {
                 javaChannel().unbindAddress(localAddress);
@@ -234,7 +222,6 @@ public class NioSctpServerChannel extends AbstractNioMessageChannel
                 }
             });
         }
-        return promise;
     }
 
     // Unnecessary stuff

--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -377,45 +377,10 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
     }
 
     @Override
-    public Future<Void> register() {
-        return register(newPromise());
-    }
-
-    @Override
-    public Future<Void> bind(SocketAddress localAddress) {
-        return bind(localAddress, newPromise());
-    }
-
-    @Override
-    public Future<Void> connect(SocketAddress remoteAddress) {
-        return connect(remoteAddress, newPromise());
-    }
-
-    @Override
-    public Future<Void> connect(SocketAddress remoteAddress, SocketAddress localAddress) {
-        return connect(remoteAddress, localAddress, newPromise());
-    }
-
-    @Override
-    public Future<Void> disconnect() {
-        return disconnect(newPromise());
-    }
-
-    @Override
-    public Future<Void> close() {
-        return close(newPromise());
-    }
-
-    @Override
-    public Future<Void> deregister() {
-        return deregister(newPromise());
-    }
-
-    @Override
-    public Future<Void> register(final Promise<Void> promise) {
+    public void register(final Promise<Void> promise) {
         if (isNotValidPromise(promise)) {
             // cancelled
-            return promise;
+            return;
         }
 
         final AbstractChannelHandlerContext next = findContextOutbound(MASK_REGISTER);
@@ -436,16 +401,14 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         } else {
             safeExecute(executor, () -> register(promise), promise, null, false);
         }
-
-        return promise;
     }
 
     @Override
-    public Future<Void> bind(final SocketAddress localAddress, final Promise<Void> promise) {
+    public void bind(final SocketAddress localAddress, final Promise<Void> promise) {
         ObjectUtil.checkNotNull(localAddress, "localAddress");
         if (isNotValidPromise(promise)) {
             // cancelled
-            return promise;
+            return;
         }
 
         final AbstractChannelHandlerContext next = findContextOutbound(MASK_BIND);
@@ -466,22 +429,21 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         } else {
             safeExecute(executor, () -> bind(localAddress, promise), promise, null, false);
         }
-        return promise;
     }
 
     @Override
-    public Future<Void> connect(SocketAddress remoteAddress, Promise<Void> promise) {
-        return connect(remoteAddress, null, promise);
+    public void connect(SocketAddress remoteAddress, Promise<Void> promise) {
+        connect(remoteAddress, null, promise);
     }
 
     @Override
-    public Future<Void> connect(
+    public void connect(
             final SocketAddress remoteAddress, final SocketAddress localAddress, final Promise<Void> promise) {
         ObjectUtil.checkNotNull(remoteAddress, "remoteAddress");
 
         if (isNotValidPromise(promise)) {
             // cancelled
-            return promise;
+            return;
         }
 
         final AbstractChannelHandlerContext next = findContextOutbound(MASK_CONNECT);
@@ -502,19 +464,19 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         } else {
             safeExecute(executor, () -> connect(remoteAddress, localAddress, promise), promise, null, false);
         }
-        return promise;
     }
 
     @Override
-    public Future<Void> disconnect(final Promise<Void> promise) {
+    public void disconnect(final Promise<Void> promise) {
         if (!pipeline.hasDisconnect) {
             // Translate disconnect to close if the channel has no notion of disconnect-reconnect.
             // So far, UDP/IP is the only transport that has such behavior.
-            return close(promise);
+            close(promise);
+            return;
         }
         if (isNotValidPromise(promise)) {
             // cancelled
-            return promise;
+            return;
         }
 
         final AbstractChannelHandlerContext next = findContextOutbound(MASK_DISCONNECT);
@@ -535,14 +497,13 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         } else {
             safeExecute(executor, () -> disconnect(promise), promise, null, false);
         }
-        return promise;
     }
 
     @Override
-    public Future<Void> close(final Promise<Void> promise) {
+    public void close(final Promise<Void> promise) {
         if (isNotValidPromise(promise)) {
             // cancelled
-            return promise;
+            return;
         }
 
         final AbstractChannelHandlerContext next = findContextOutbound(MASK_CLOSE);
@@ -563,15 +524,13 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         } else {
             safeExecute(executor, () -> close(promise), promise, null, false);
         }
-
-        return promise;
     }
 
     @Override
-    public Future<Void> deregister(final Promise<Void> promise) {
+    public void deregister(final Promise<Void> promise) {
         if (isNotValidPromise(promise)) {
             // cancelled
-            return promise;
+            return;
         }
 
         final AbstractChannelHandlerContext next = findContextOutbound(MASK_DEREGISTER);
@@ -592,17 +551,15 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         } else {
             safeExecute(executor, () -> deregister(promise), promise, null, false);
         }
-
-        return promise;
     }
 
     @Override
-    public Future<Void> shutdown(ChannelShutdownType type, Promise<Void> promise) {
+    public void shutdown(ChannelShutdownType type, Promise<Void> promise) {
         ObjectUtil.checkNotNull(type, "type");
 
         if (isNotValidPromise(promise)) {
             // cancelled
-            return promise;
+            return;
         }
 
         final AbstractChannelHandlerContext next = findContextOutbound(MASK_SHUTDOWN);
@@ -623,8 +580,6 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         } else {
             safeExecute(executor, () -> shutdown(type, promise), promise, null, false);
         }
-
-        return promise;
     }
 
     @Override
@@ -657,9 +612,8 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
     }
 
     @Override
-    public Future<Void> write(final Object msg, final Promise<Void> promise) {
+    public void write(final Object msg, final Promise<Void> promise) {
         write(msg, false, promise);
-        return promise;
     }
 
     @Override
@@ -687,9 +641,8 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
     }
 
     @Override
-    public Future<Void> writeAndFlush(Object msg, Promise<Void> promise) {
+    public void writeAndFlush(Object msg, Promise<Void> promise) {
         write(msg, true, promise);
-        return promise;
     }
 
     void write(Object msg, boolean flush, Promise<Void> promise) {
@@ -748,11 +701,6 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
             throw e;
         }
         return true;
-    }
-
-    @Override
-    public Future<Void> writeAndFlush(Object msg) {
-        return writeAndFlush(msg, newPromise());
     }
 
     private static void notifyOutboundHandlerException(Throwable cause, Promise<Void> promise) {

--- a/transport/src/main/java/io/netty/channel/Channel.java
+++ b/transport/src/main/java/io/netty/channel/Channel.java
@@ -254,13 +254,13 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparabl
     }
 
     @Override
-    default Future<Void> writeAndFlush(Object msg, Promise<Void> promise) {
-        return pipeline().writeAndFlush(msg, promise);
+    default void writeAndFlush(Object msg, Promise<Void> promise) {
+        pipeline().writeAndFlush(msg, promise);
     }
 
     @Override
-    default Future<Void> write(Object msg, Promise<Void> promise) {
-        return pipeline().write(msg, promise);
+    default void write(Object msg, Promise<Void> promise) {
+        pipeline().write(msg, promise);
     }
 
     @Override
@@ -269,33 +269,33 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparabl
     }
 
     @Override
-    default Future<Void> deregister(Promise<Void> promise) {
-        return pipeline().deregister(promise);
+    default void deregister(Promise<Void> promise) {
+        pipeline().deregister(promise);
     }
 
     @Override
-    default Future<Void> close(Promise<Void> promise) {
-        return pipeline().close(promise);
+    default void close(Promise<Void> promise) {
+        pipeline().close(promise);
     }
 
     @Override
-    default Future<Void> disconnect(Promise<Void> promise) {
-        return pipeline().disconnect(promise);
+    default void disconnect(Promise<Void> promise) {
+        pipeline().disconnect(promise);
     }
 
     @Override
-    default Future<Void> connect(SocketAddress remoteAddress, SocketAddress localAddress, Promise<Void> promise) {
-        return pipeline().connect(remoteAddress, localAddress, promise);
+    default void connect(SocketAddress remoteAddress, SocketAddress localAddress, Promise<Void> promise) {
+        pipeline().connect(remoteAddress, localAddress, promise);
     }
 
     @Override
-    default Future<Void> connect(SocketAddress remoteAddress, Promise<Void> promise) {
-        return pipeline().connect(remoteAddress, promise);
+    default void connect(SocketAddress remoteAddress, Promise<Void> promise) {
+        pipeline().connect(remoteAddress, promise);
     }
 
     @Override
-    default Future<Void> bind(SocketAddress localAddress, Promise<Void> promise) {
-        return pipeline().bind(localAddress, promise);
+    default void bind(SocketAddress localAddress, Promise<Void> promise) {
+        pipeline().bind(localAddress, promise);
     }
 
     @Override
@@ -349,13 +349,13 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparabl
     }
 
     @Override
-    default Future<Void> register(Promise<Void> promise) {
-        return pipeline().register(promise);
+    default void register(Promise<Void> promise) {
+        pipeline().register(promise);
     }
 
     @Override
-    default Future<Void> shutdown(ChannelShutdownType type, Promise<Void> promise) {
-        return pipeline().shutdown(type, promise);
+    default void shutdown(ChannelShutdownType type, Promise<Void> promise) {
+        pipeline().shutdown(type, promise);
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/ChannelOutboundInvoker.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundInvoker.java
@@ -37,7 +37,7 @@ public interface ChannelOutboundInvoker {
      * method called of the next {@link ChannelOutboundHandler} contained in the {@link ChannelPipeline} of the
      * {@link Channel}.
      */
-    Future<Void> register(Promise<Void> promise);
+    void register(Promise<Void> promise);
 
     /**
      * Request to bind to the given {@link SocketAddress} and notify the {@link Future} once the operation
@@ -49,7 +49,9 @@ public interface ChannelOutboundInvoker {
      * {@link Channel}.
      */
     default Future<Void> bind(SocketAddress localAddress) {
-        return bind(localAddress, newPromise());
+        Promise<Void> promise = newPromise();
+        bind(localAddress, promise);
+        return promise;
     }
 
     /**
@@ -66,7 +68,9 @@ public interface ChannelOutboundInvoker {
      * {@link Channel}.
      */
     default Future<Void> connect(SocketAddress remoteAddress) {
-        return connect(remoteAddress, newPromise());
+        Promise<Void> promise = newPromise();
+        connect(remoteAddress, promise);
+        return promise;
     }
 
     /**
@@ -80,7 +84,9 @@ public interface ChannelOutboundInvoker {
      * {@link Channel}.
      */
     default Future<Void> connect(SocketAddress remoteAddress, SocketAddress localAddress) {
-        return connect(remoteAddress, localAddress, newPromise());
+        Promise<Void> promise = newPromise();
+        connect(remoteAddress, localAddress, promise);
+        return promise;
     }
 
     /**
@@ -93,7 +99,9 @@ public interface ChannelOutboundInvoker {
      * {@link Channel}.
      */
     default Future<Void> disconnect() {
-        return disconnect(newPromise());
+        Promise<Void> promise = newPromise();
+        disconnect(promise);
+        return promise;
     }
 
     /**
@@ -109,7 +117,9 @@ public interface ChannelOutboundInvoker {
      * {@link Channel}.
      */
     default Future<Void> close() {
-        return close(newPromise());
+        Promise<Void> promise = newPromise();
+        close(promise);
+        return promise;
     }
 
     /**
@@ -124,7 +134,9 @@ public interface ChannelOutboundInvoker {
      *
      */
     default Future<Void> deregister() {
-        return deregister(newPromise());
+        Promise<Void> promise = newPromise();
+        deregister(promise);
+        return promise;
     }
 
     /**
@@ -140,7 +152,9 @@ public interface ChannelOutboundInvoker {
      * {@link Channel}.
      */
     default Future<Void> register() {
-        return register(newPromise());
+        Promise<Void> promise = newPromise();
+        register(promise);
+        return promise;
     }
 
     /**
@@ -154,7 +168,7 @@ public interface ChannelOutboundInvoker {
      * called of the next {@link ChannelOutboundHandler} contained in the {@link ChannelPipeline} of the
      * {@link Channel}.
      */
-    Future<Void> bind(SocketAddress localAddress, Promise<Void> promise);
+    void bind(SocketAddress localAddress, Promise<Void> promise);
 
     /**
      * Request to connect to the given {@link SocketAddress} and notify the {@link Future} once the operation
@@ -172,7 +186,7 @@ public interface ChannelOutboundInvoker {
      * method called of the next {@link ChannelOutboundHandler} contained in the {@link ChannelPipeline} of the
      * {@link Channel}.
      */
-    Future<Void> connect(SocketAddress remoteAddress, Promise<Void> promise);
+    void connect(SocketAddress remoteAddress, Promise<Void> promise);
 
     /**
      * Request to connect to the given {@link SocketAddress} while bind to the localAddress and notify the
@@ -186,7 +200,7 @@ public interface ChannelOutboundInvoker {
      * method called of the next {@link ChannelOutboundHandler} contained in the {@link ChannelPipeline} of the
      * {@link Channel}.
      */
-    Future<Void> connect(SocketAddress remoteAddress, SocketAddress localAddress, Promise<Void> promise);
+    void connect(SocketAddress remoteAddress, SocketAddress localAddress, Promise<Void> promise);
 
     /**
      * Request to disconnect from the remote peer and notify the {@link Future} once the operation completes,
@@ -199,7 +213,7 @@ public interface ChannelOutboundInvoker {
      * method called of the next {@link ChannelOutboundHandler} contained in the {@link ChannelPipeline} of the
      * {@link Channel}.
      */
-    Future<Void> disconnect(Promise<Void> promise);
+    void disconnect(Promise<Void> promise);
 
     /**
      * Request to close the {@link Channel} and notify the {@link Future} once the operation completes,
@@ -214,7 +228,7 @@ public interface ChannelOutboundInvoker {
      * method called of the next {@link ChannelOutboundHandler} contained in the {@link ChannelPipeline} of the
      * {@link Channel}.
      */
-    Future<Void> close(Promise<Void> promise);
+    void close(Promise<Void> promise);
 
     /**
      * Request to deregister from the previous assigned {@link EventExecutor} and notify the
@@ -228,7 +242,7 @@ public interface ChannelOutboundInvoker {
      * method called of the next {@link ChannelOutboundHandler} contained in the {@link ChannelPipeline} of the
      * {@link Channel}.
      */
-    Future<Void> deregister(Promise<Void> promise);
+    void deregister(Promise<Void> promise);
 
     /**
      * Request to Read data from the {@link Channel} into the first inbound buffer, triggers an
@@ -250,7 +264,9 @@ public interface ChannelOutboundInvoker {
      * once you want to request to flush all pending data to the actual transport.
      */
     default Future<Void> write(Object msg) {
-        return write(msg, newPromise());
+        Promise<Void> promise = newPromise();
+        write(msg, promise);
+        return promise;
     }
 
     /**
@@ -258,7 +274,7 @@ public interface ChannelOutboundInvoker {
      * This method will not request to actual flush, so be sure to call {@link #flush()}
      * once you want to request to flush all pending data to the actual transport.
      */
-    Future<Void> write(Object msg, Promise<Void> promise);
+    void write(Object msg, Promise<Void> promise);
 
     /**
      * Request to flush all pending messages via this ChannelOutboundInvoker.
@@ -268,13 +284,15 @@ public interface ChannelOutboundInvoker {
     /**
      * Shortcut for call {@link #write(Object, Promise)} and {@link #flush()}.
      */
-    Future<Void> writeAndFlush(Object msg, Promise<Void> promise);
+    void writeAndFlush(Object msg, Promise<Void> promise);
 
     /**
      * Shortcut for call {@link #write(Object)} and {@link #flush()}.
      */
     default Future<Void> writeAndFlush(Object msg) {
-        return writeAndFlush(msg, newPromise());
+        Promise<Void> promise = newPromise();
+        writeAndFlush(msg, promise);
+        return promise;
     }
 
     /**
@@ -295,7 +313,9 @@ public interface ChannelOutboundInvoker {
      * {@link Channel}.
      */
     default Future<Void> shutdown(ChannelShutdownType type) {
-        return shutdown(type, newPromise());
+        Promise<Void> promise = newPromise();
+        shutdown(type, promise);
+        return promise;
     }
 
     /**
@@ -315,7 +335,7 @@ public interface ChannelOutboundInvoker {
      * method called of the next {@link ChannelOutboundHandler} contained in the {@link ChannelPipeline} of the
      * {@link Channel}.
      */
-    Future<Void> shutdown(ChannelShutdownType type, Promise<Void> promise);
+    void shutdown(ChannelShutdownType type, Promise<Void> promise);
 
     /**
      * Return a new {@link Promise}.

--- a/transport/src/main/java/io/netty/channel/CombinedChannelDuplexHandler.java
+++ b/transport/src/main/java/io/netty/channel/CombinedChannelDuplexHandler.java
@@ -502,39 +502,39 @@ public class CombinedChannelDuplexHandler<I extends ChannelInboundHandler, O ext
         }
 
         @Override
-        public Future<Void> register(Promise<Void> promise) {
-            return ctx.register(promise);
+        public void register(Promise<Void> promise) {
+            ctx.register(promise);
         }
 
         @Override
-        public Future<Void> bind(SocketAddress localAddress, Promise<Void> promise) {
-            return ctx.bind(localAddress, promise);
+        public void bind(SocketAddress localAddress, Promise<Void> promise) {
+            ctx.bind(localAddress, promise);
         }
 
         @Override
-        public Future<Void> connect(SocketAddress remoteAddress, Promise<Void> promise) {
-            return ctx.connect(remoteAddress, promise);
+        public void connect(SocketAddress remoteAddress, Promise<Void> promise) {
+            ctx.connect(remoteAddress, promise);
         }
 
         @Override
-        public Future<Void> connect(
+        public void connect(
                 SocketAddress remoteAddress, SocketAddress localAddress, Promise<Void> promise) {
-            return ctx.connect(remoteAddress, localAddress, promise);
+            ctx.connect(remoteAddress, localAddress, promise);
         }
 
         @Override
-        public Future<Void> disconnect(Promise<Void> promise) {
-            return ctx.disconnect(promise);
+        public void disconnect(Promise<Void> promise) {
+            ctx.disconnect(promise);
         }
 
         @Override
-        public Future<Void> close(Promise<Void> promise) {
-            return ctx.close(promise);
+        public void close(Promise<Void> promise) {
+            ctx.close(promise);
         }
 
         @Override
-        public Future<Void> deregister(Promise<Void> promise) {
-            return ctx.deregister(promise);
+        public void deregister(Promise<Void> promise) {
+            ctx.deregister(promise);
         }
 
         @Override
@@ -549,8 +549,8 @@ public class CombinedChannelDuplexHandler<I extends ChannelInboundHandler, O ext
         }
 
         @Override
-        public Future<Void> write(Object msg, Promise<Void> promise) {
-            return ctx.write(msg, promise);
+        public void write(Object msg, Promise<Void> promise) {
+            ctx.write(msg, promise);
         }
 
         @Override
@@ -560,8 +560,8 @@ public class CombinedChannelDuplexHandler<I extends ChannelInboundHandler, O ext
         }
 
         @Override
-        public Future<Void> writeAndFlush(Object msg, Promise<Void> promise) {
-            return ctx.writeAndFlush(msg, promise);
+        public void writeAndFlush(Object msg, Promise<Void> promise) {
+            ctx.writeAndFlush(msg, promise);
         }
 
         @Override
@@ -570,8 +570,8 @@ public class CombinedChannelDuplexHandler<I extends ChannelInboundHandler, O ext
         }
 
         @Override
-        public Future<Void> shutdown(ChannelShutdownType type, Promise<Void> promise) {
-            return ctx.shutdown(type, promise);
+        public void shutdown(ChannelShutdownType type, Promise<Void> promise) {
+            ctx.shutdown(type, promise);
         }
 
         @Override

--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -967,39 +967,39 @@ public class DefaultChannelPipeline implements ChannelPipeline {
     }
 
     @Override
-    public final Future<Void> register(Promise<Void> promise) {
-        return tail.register(promise);
+    public final void register(Promise<Void> promise) {
+        tail.register(promise);
     }
 
     @Override
-    public final Future<Void> bind(SocketAddress localAddress, Promise<Void> promise) {
-        return tail.bind(localAddress, promise);
+    public final void bind(SocketAddress localAddress, Promise<Void> promise) {
+        tail.bind(localAddress, promise);
     }
 
     @Override
-    public final Future<Void> connect(SocketAddress remoteAddress, Promise<Void> promise) {
-        return tail.connect(remoteAddress, promise);
+    public final void connect(SocketAddress remoteAddress, Promise<Void> promise) {
+        tail.connect(remoteAddress, promise);
     }
 
     @Override
-    public final Future<Void> connect(
+    public final void connect(
             SocketAddress remoteAddress, SocketAddress localAddress, Promise<Void> promise) {
-        return tail.connect(remoteAddress, localAddress, promise);
+        tail.connect(remoteAddress, localAddress, promise);
     }
 
     @Override
-    public final Future<Void> disconnect(Promise<Void> promise) {
-        return tail.disconnect(promise);
+    public final void disconnect(Promise<Void> promise) {
+        tail.disconnect(promise);
     }
 
     @Override
-    public final Future<Void> close(Promise<Void> promise) {
-        return tail.close(promise);
+    public final void close(Promise<Void> promise) {
+        tail.close(promise);
     }
 
     @Override
-    public final Future<Void> deregister(final Promise<Void> promise) {
-        return tail.deregister(promise);
+    public final void deregister(final Promise<Void> promise) {
+        tail.deregister(promise);
     }
 
     @Override
@@ -1014,13 +1014,13 @@ public class DefaultChannelPipeline implements ChannelPipeline {
     }
 
     @Override
-    public final Future<Void> write(Object msg, Promise<Void> promise) {
-        return tail.write(msg, promise);
+    public final void write(Object msg, Promise<Void> promise) {
+        tail.write(msg, promise);
     }
 
     @Override
-    public final Future<Void> writeAndFlush(Object msg, Promise<Void> promise) {
-        return tail.writeAndFlush(msg, promise);
+    public final void writeAndFlush(Object msg, Promise<Void> promise) {
+        tail.writeAndFlush(msg, promise);
     }
 
     @Override
@@ -1029,8 +1029,8 @@ public class DefaultChannelPipeline implements ChannelPipeline {
     }
 
     @Override
-    public final Future<Void> shutdown(ChannelShutdownType type, Promise<Void> promise) {
-        return tail.shutdown(type, promise);
+    public final void shutdown(ChannelShutdownType type, Promise<Void> promise) {
+        tail.shutdown(type, promise);
     }
 
     private void checkDuplicateName(String name) {

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
@@ -366,7 +366,7 @@ public class EmbeddedChannel extends AbstractChannel {
                 p.fireChannelRead(m);
             }
 
-            flushInbound(false, newPromise()).syncUninterruptibly();
+            flushInbound(false);
         } finally {
             executingStackCnt--;
             maybeRunPendingTasks();
@@ -381,7 +381,9 @@ public class EmbeddedChannel extends AbstractChannel {
      * @see #writeOneOutbound(Object)
      */
     public Future<Void> writeOneInbound(Object msg) {
-        return writeOneInbound(msg, newPromise());
+        Promise<Void> promise = newPromise();
+        writeOneInbound(msg, promise);
+        return promise;
     }
 
     /**
@@ -390,7 +392,7 @@ public class EmbeddedChannel extends AbstractChannel {
      *
      * @see #writeOneOutbound(Object, Promise)
      */
-    public Future<Void> writeOneInbound(Object msg, Promise<Void> promise) {
+    public void writeOneInbound(Object msg, Promise<Void> promise) {
         executingStackCnt++;
         try {
             if (checkOpen(true)) {
@@ -400,7 +402,7 @@ public class EmbeddedChannel extends AbstractChannel {
             executingStackCnt--;
             maybeRunPendingTasks();
         }
-        return checkException(promise);
+        checkException(promise);
     }
 
     /**
@@ -409,11 +411,11 @@ public class EmbeddedChannel extends AbstractChannel {
      * @see #flushOutbound()
      */
     public EmbeddedChannel flushInbound() {
-        flushInbound(true, newPromise());
+        flushInbound(true);
         return this;
     }
 
-    private Future<Void> flushInbound(boolean recordException, Promise<Void> promise) {
+    private void flushInbound(boolean recordException) {
         executingStackCnt++;
         try {
             if (checkOpen(recordException)) {
@@ -424,8 +426,7 @@ public class EmbeddedChannel extends AbstractChannel {
             executingStackCnt--;
             maybeRunPendingTasks();
         }
-
-      return checkException(promise);
+        checkException();
     }
 
     /**
@@ -481,7 +482,9 @@ public class EmbeddedChannel extends AbstractChannel {
      * @see #writeOneInbound(Object)
      */
     public Future<Void> writeOneOutbound(Object msg) {
-        return writeOneOutbound(msg, newPromise());
+        Promise<Void> promise = newPromise();
+        writeOneOutbound(msg, promise);
+        return promise;
     }
 
     /**
@@ -490,18 +493,19 @@ public class EmbeddedChannel extends AbstractChannel {
      *
      * @see #writeOneInbound(Object, Promise)
      */
-    public Future<Void> writeOneOutbound(Object msg, Promise<Void> promise) {
+    public void writeOneOutbound(Object msg, Promise<Void> promise) {
         executingStackCnt++;
         try {
             if (checkOpen(true)) {
-                return write(msg, promise);
+                write(msg, promise);
+                return;
             }
         } finally {
             executingStackCnt--;
             maybeRunPendingTasks();
         }
 
-        return checkException(promise);
+        checkException(promise);
     }
 
     /**
@@ -519,7 +523,7 @@ public class EmbeddedChannel extends AbstractChannel {
             executingStackCnt--;
             maybeRunPendingTasks();
         }
-        checkException(newPromise()).syncUninterruptibly();
+        checkException();
         return this;
     }
 
@@ -607,38 +611,39 @@ public class EmbeddedChannel extends AbstractChannel {
 
     @Override
     public final Future<Void> close() {
-        return close(newPromise());
+        Promise<Void> promise = newPromise();
+        close(promise);
+        return promise;
     }
 
     @Override
     public final Future<Void> disconnect() {
-        return disconnect(newPromise());
+        Promise<Void> promise = newPromise();
+        disconnect(promise);
+        return promise;
     }
 
     @Override
-    public final Future<Void> close(Promise<Void> promise) {
+    public final void close(Promise<Void> promise) {
         // We need to call runPendingTasks() before calling super.close() as there may be something in the queue
         // that needs to be run before the actual close takes place.
         executingStackCnt++;
-        Future<Void> future;
         try {
             runPendingTasks();
-            future = super.close(promise);
+            super.close(promise);
 
             cancelRemainingScheduledTasks = true;
         } finally {
             executingStackCnt--;
             maybeRunPendingTasks();
         }
-        return future;
     }
 
     @Override
-    public final Future<Void> disconnect(Promise<Void> promise) {
+    public final void disconnect(Promise<Void> promise) {
         executingStackCnt++;
-        Future<Void> future;
         try {
-            future = super.disconnect(promise);
+            super.disconnect(promise);
 
             if (!hasDisconnect) {
                 cancelRemainingScheduledTasks = true;
@@ -647,7 +652,6 @@ public class EmbeddedChannel extends AbstractChannel {
             executingStackCnt--;
             maybeRunPendingTasks();
         }
-        return future;
     }
 
     @Override
@@ -707,10 +711,10 @@ public class EmbeddedChannel extends AbstractChannel {
     }
 
     @Override
-    public Future<Void> bind(SocketAddress localAddress, Promise<Void> promise) {
+    public void bind(SocketAddress localAddress, Promise<Void> promise) {
         executingStackCnt++;
         try {
-            return super.bind(localAddress, promise);
+            super.bind(localAddress, promise);
         } finally {
             executingStackCnt--;
             maybeRunPendingTasks();
@@ -718,10 +722,10 @@ public class EmbeddedChannel extends AbstractChannel {
     }
 
     @Override
-    public Future<Void> connect(SocketAddress remoteAddress, Promise<Void> promise) {
+    public void connect(SocketAddress remoteAddress, Promise<Void> promise) {
         executingStackCnt++;
         try {
-            return super.connect(remoteAddress, promise);
+            super.connect(remoteAddress, promise);
         } finally {
             executingStackCnt--;
             maybeRunPendingTasks();
@@ -729,10 +733,10 @@ public class EmbeddedChannel extends AbstractChannel {
     }
 
     @Override
-    public Future<Void> connect(SocketAddress remoteAddress, SocketAddress localAddress, Promise<Void> promise) {
+    public void connect(SocketAddress remoteAddress, SocketAddress localAddress, Promise<Void> promise) {
         executingStackCnt++;
         try {
-            return super.connect(remoteAddress, localAddress, promise);
+            super.connect(remoteAddress, localAddress, promise);
         } finally {
             executingStackCnt--;
             maybeRunPendingTasks();
@@ -740,10 +744,10 @@ public class EmbeddedChannel extends AbstractChannel {
     }
 
     @Override
-    public Future<Void> deregister(Promise<Void> promise) {
+    public void deregister(Promise<Void> promise) {
         executingStackCnt++;
         try {
-            return super.deregister(promise);
+            super.deregister(promise);
         } finally {
             executingStackCnt--;
             maybeRunPendingTasks();
@@ -774,10 +778,10 @@ public class EmbeddedChannel extends AbstractChannel {
     }
 
     @Override
-    public Future<Void> write(Object msg, Promise<Void> promise) {
+    public void write(Object msg, Promise<Void> promise) {
         executingStackCnt++;
         try {
-            return super.write(msg, promise);
+            super.write(msg, promise);
         } finally {
             executingStackCnt--;
             maybeRunPendingTasks();
@@ -796,10 +800,10 @@ public class EmbeddedChannel extends AbstractChannel {
     }
 
     @Override
-    public Future<Void> writeAndFlush(Object msg, Promise<Void> promise) {
+    public void writeAndFlush(Object msg, Promise<Void> promise) {
         executingStackCnt++;
         try {
-            return super.writeAndFlush(msg, promise);
+            super.writeAndFlush(msg, promise);
         } finally {
             executingStackCnt--;
             maybeRunPendingTasks();
@@ -926,21 +930,24 @@ public class EmbeddedChannel extends AbstractChannel {
     /**
      * Checks for the presence of an {@link Exception}.
      */
-    private Future<Void> checkException(Promise<Void> promise) {
+    private void checkException(Promise<Void> promise) {
       Throwable t = lastException;
       if (t != null) {
           lastException = null;
-          return promise.setFailure(t);
+          promise.setFailure(t);
+          return;
       }
 
-      return promise.setSuccess(null);
+      promise.setSuccess(null);
     }
 
     /**
      * Check if there was any {@link Throwable} received and if so rethrow it.
      */
     public void checkException() {
-      checkException(newPromise()).syncUninterruptibly();
+        Promise<Void> promise = newPromise();
+        checkException(promise);
+        promise.syncUninterruptibly();
     }
 
     /**

--- a/transport/src/main/java/io/netty/channel/pool/ChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/ChannelPool.java
@@ -42,7 +42,7 @@ public interface ChannelPool extends Closeable {
      * <strong>Its important that an acquired is always released to the pool again, even if the {@link Channel}
      * is explicitly closed..</strong>
      */
-    Future<Channel> acquire(Promise<Channel> promise);
+    void acquire(Promise<Channel> promise);
 
     /**
      * Release a {@link Channel} back to this {@link ChannelPool}. The returned {@link Future} is notified once
@@ -54,7 +54,7 @@ public interface ChannelPool extends Closeable {
      * Release a {@link Channel} back to this {@link ChannelPool}. The given {@link Promise} is notified once
      * the release is successful and failed otherwise. When failed the {@link Channel} will automatically closed.
      */
-    Future<Void> release(Channel channel, Promise<Void> promise);
+    void release(Channel channel, Promise<Void> promise);
 
     @Override
     void close();

--- a/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
@@ -223,7 +223,7 @@ public class FixedChannelPool extends SimpleChannelPool {
     }
 
     @Override
-    public Future<Channel> acquire(final Promise<Channel> promise) {
+    public void acquire(final Promise<Channel> promise) {
         try {
             if (executor.inEventLoop()) {
                 acquire0(promise);
@@ -238,7 +238,6 @@ public class FixedChannelPool extends SimpleChannelPool {
         } catch (Throwable cause) {
             promise.tryFailure(cause);
         }
-        return promise;
     }
 
     private void acquire0(final Promise<Channel> promise) {
@@ -288,7 +287,7 @@ public class FixedChannelPool extends SimpleChannelPool {
     }
 
     @Override
-    public Future<Void> release(final Channel channel, final Promise<Void> promise) {
+    public void release(final Channel channel, final Promise<Void> promise) {
         ObjectUtil.checkNotNull(promise, "promise");
         final Promise<Void> p = executor.newPromise();
         super.release(channel, p.addListener((FutureListener<Void>) future -> {
@@ -317,7 +316,6 @@ public class FixedChannelPool extends SimpleChannelPool {
                 promise.tryFailure(cause);
             }
         }));
-        return promise;
     }
 
     private void decrementAndRunTaskQueue() {

--- a/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
@@ -152,12 +152,14 @@ public class SimpleChannelPool implements ChannelPool {
 
     @Override
     public final Future<Channel> acquire() {
-        return acquire(bootstrap.config().group().next().<Channel>newPromise());
+        Promise<Channel> promise = bootstrap.config().group().next().<Channel>newPromise();
+        acquire(promise);
+        return promise;
     }
 
     @Override
-    public Future<Channel> acquire(final Promise<Channel> promise) {
-        return acquireHealthyFromPoolOrNew(checkNotNull(promise, "promise"));
+    public void acquire(final Promise<Channel> promise) {
+        acquireHealthyFromPoolOrNew(checkNotNull(promise, "promise"));
     }
 
     /**
@@ -257,11 +259,13 @@ public class SimpleChannelPool implements ChannelPool {
 
     @Override
     public final Future<Void> release(Channel channel) {
-        return release(channel, channel.executor().<Void>newPromise());
+        Promise<Void> promise = channel.newPromise();
+        release(channel, promise);
+        return promise;
     }
 
     @Override
-    public Future<Void> release(final Channel channel, final Promise<Void> promise) {
+    public void release(final Channel channel, final Promise<Void> promise) {
         try {
             checkNotNull(channel, "channel");
             checkNotNull(promise, "promise");
@@ -279,7 +283,6 @@ public class SimpleChannelPool implements ChannelPool {
         } catch (Throwable cause) {
             closeAndFail(channel, cause, promise);
         }
-        return promise;
     }
 
     private void doReleaseChannel(Channel channel, Promise<Void> promise) {

--- a/transport/src/main/java/io/netty/channel/socket/DatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/DatagramChannel.java
@@ -68,7 +68,9 @@ public interface DatagramChannel extends Channel {
      * Joins a multicast group and notifies the {@link Future} once the operation completes.
      */
     default Future<Void> joinGroup(InetAddress multicastAddress) {
-        return joinGroup(multicastAddress, newPromise());
+        Promise<Void> promise = newPromise();
+        joinGroup(multicastAddress, promise);
+        return promise;
     }
 
     /**
@@ -76,14 +78,16 @@ public interface DatagramChannel extends Channel {
      * <p>
      * The given {@link Future} will be notified and also returned.
      */
-    Future<Void> joinGroup(InetAddress multicastAddress, Promise<Void> future);
+    void joinGroup(InetAddress multicastAddress, Promise<Void> future);
 
     /**
      * Joins the specified multicast group at the specified interface and notifies the {@link Future}
      * once the operation completes.
      */
     default Future<Void> joinGroup(InetSocketAddress multicastAddress, NetworkInterface networkInterface) {
-        return joinGroup(multicastAddress, networkInterface, newPromise());
+        Promise<Void> promise = newPromise();
+        joinGroup(multicastAddress, networkInterface, promise);
+        return promise;
     }
 
     /**
@@ -92,7 +96,7 @@ public interface DatagramChannel extends Channel {
      * <p>
      * The given {@link Future} will be notified and also returned.
      */
-    Future<Void> joinGroup(
+    void joinGroup(
             InetSocketAddress multicastAddress, NetworkInterface networkInterface, Promise<Void> future);
 
     /**
@@ -101,7 +105,9 @@ public interface DatagramChannel extends Channel {
      */
     default Future<Void> joinGroup(InetAddress multicastAddress,
                                    NetworkInterface networkInterface, InetAddress source) {
-        return  joinGroup(multicastAddress, networkInterface, source, newPromise());
+        Promise<Void> promise = newPromise();
+        joinGroup(multicastAddress, networkInterface, source, promise);
+        return promise;
     }
 
     /**
@@ -110,14 +116,16 @@ public interface DatagramChannel extends Channel {
      * <p>
      * The given {@link Future} will be notified and also returned.
      */
-    Future<Void> joinGroup(
+    void joinGroup(
             InetAddress multicastAddress, NetworkInterface networkInterface, InetAddress source, Promise<Void> future);
 
     /**
      * Leaves a multicast group and notifies the {@link Future} once the operation completes.
      */
     default Future<Void> leaveGroup(InetAddress multicastAddress) {
-        return leaveGroup(multicastAddress, newPromise());
+        Promise<Void> promise = newPromise();
+        leaveGroup(multicastAddress, promise);
+        return promise;
     }
 
     /**
@@ -125,14 +133,16 @@ public interface DatagramChannel extends Channel {
      * <p>
      * The given {@link Future} will be notified and also returned.
      */
-    Future<Void> leaveGroup(InetAddress multicastAddress, Promise<Void> future);
+    void leaveGroup(InetAddress multicastAddress, Promise<Void> future);
 
     /**
      * Leaves a multicast group on a specified local interface and notifies the {@link Future} once the
      * operation completes.
      */
     default Future<Void> leaveGroup(InetSocketAddress multicastAddress, NetworkInterface networkInterface) {
-        return leaveGroup(multicastAddress, networkInterface, newPromise());
+        Promise<Void> promise = newPromise();
+        leaveGroup(multicastAddress, networkInterface, promise);
+        return promise;
     }
 
     /**
@@ -141,7 +151,7 @@ public interface DatagramChannel extends Channel {
      * <p>
      * The given {@link Future} will be notified and also returned.
      */
-    Future<Void> leaveGroup(
+    void leaveGroup(
             InetSocketAddress multicastAddress, NetworkInterface networkInterface, Promise<Void> future);
 
     /**
@@ -151,7 +161,9 @@ public interface DatagramChannel extends Channel {
      */
     default Future<Void> leaveGroup(
             InetAddress multicastAddress, NetworkInterface networkInterface, InetAddress source) {
-        return leaveGroup(multicastAddress, networkInterface, source, newPromise());
+        Promise<Void> promise = newPromise();
+        leaveGroup(multicastAddress, networkInterface, source, promise);
+        return promise;
     }
 
     /**
@@ -160,7 +172,7 @@ public interface DatagramChannel extends Channel {
      * <p>
      * The given {@link Future} will be notified and also returned.
      */
-    Future<Void> leaveGroup(
+    void leaveGroup(
             InetAddress multicastAddress, NetworkInterface networkInterface, InetAddress source,
             Promise<Void> future);
 
@@ -173,7 +185,9 @@ public interface DatagramChannel extends Channel {
     default Future<Void> block(
             InetAddress multicastAddress, NetworkInterface networkInterface,
             InetAddress sourceToBlock) {
-        return block(multicastAddress, networkInterface, sourceToBlock, newPromise());
+        Promise<Void> promise = newPromise();
+        block(multicastAddress, networkInterface, sourceToBlock, promise);
+        return promise;
     }
 
     /**
@@ -182,7 +196,7 @@ public interface DatagramChannel extends Channel {
      * <p>
      * The given {@link Future} will be notified and also returned.
      */
-    Future<Void> block(
+    void block(
             InetAddress multicastAddress, NetworkInterface networkInterface,
             InetAddress sourceToBlock, Promise<Void> future);
 
@@ -193,7 +207,9 @@ public interface DatagramChannel extends Channel {
      * The given {@link Future} will be notified and also returned.
      */
     default Future<Void> block(InetAddress multicastAddress, InetAddress sourceToBlock) {
-        return block(multicastAddress, sourceToBlock, newPromise());
+        Promise<Void> promise = newPromise();
+        block(multicastAddress, sourceToBlock, promise);
+        return promise;
     }
 
     /**
@@ -202,8 +218,7 @@ public interface DatagramChannel extends Channel {
      * <p>
      * The given {@link Future} will be notified and also returned.
      */
-    Future<Void> block(
-                    InetAddress multicastAddress, InetAddress sourceToBlock, Promise<Void> future);
+    void block(InetAddress multicastAddress, InetAddress sourceToBlock, Promise<Void> future);
 
     @Override
     DatagramChannel read();

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
@@ -31,7 +31,6 @@ import io.netty.channel.nio.NioIoOps;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.socket.SocketProtocolFamily;
 import io.netty.util.UncheckedBooleanSupplier;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
@@ -374,29 +373,27 @@ public final class NioDatagramChannel
     }
 
     @Override
-    public Future<Void> joinGroup(InetAddress multicastAddress, Promise<Void> promise) {
+    public void joinGroup(InetAddress multicastAddress, Promise<Void> promise) {
         try {
             NetworkInterface iface = config.getNetworkInterface();
             if (iface == null) {
                 iface = NetworkInterface.getByInetAddress(((InetSocketAddress) localAddress()).getAddress());
             }
-            return joinGroup(
-                    multicastAddress, iface, null, promise);
+            joinGroup(multicastAddress, iface, null, promise);
         } catch (SocketException e) {
             promise.setFailure(e);
         }
-        return promise;
     }
 
     @Override
-    public Future<Void> joinGroup(
+    public void joinGroup(
             InetSocketAddress multicastAddress, NetworkInterface networkInterface,
             Promise<Void> promise) {
-        return joinGroup(multicastAddress.getAddress(), networkInterface, null, promise);
+        joinGroup(multicastAddress.getAddress(), networkInterface, null, promise);
     }
 
     @Override
-    public Future<Void> joinGroup(
+    public void joinGroup(
             InetAddress multicastAddress, NetworkInterface networkInterface,
             InetAddress source, Promise<Void> promise) {
 
@@ -429,31 +426,28 @@ public final class NioDatagramChannel
         } catch (Throwable e) {
             promise.setFailure(e);
         }
-
-        return promise;
     }
 
     @Override
-    public Future<Void> leaveGroup(InetAddress multicastAddress, Promise<Void> promise) {
+    public void leaveGroup(InetAddress multicastAddress, Promise<Void> promise) {
         try {
-            return leaveGroup(
+            leaveGroup(
                     multicastAddress, NetworkInterface.getByInetAddress(
                             ((InetSocketAddress) localAddress()).getAddress()), null, promise);
         } catch (SocketException e) {
             promise.setFailure(e);
         }
-        return promise;
     }
 
     @Override
-    public Future<Void> leaveGroup(
+    public void leaveGroup(
             InetSocketAddress multicastAddress,
             NetworkInterface networkInterface, Promise<Void> promise) {
-        return leaveGroup(multicastAddress.getAddress(), networkInterface, null, promise);
+        leaveGroup(multicastAddress.getAddress(), networkInterface, null, promise);
     }
 
     @Override
-    public Future<Void> leaveGroup(
+    public void leaveGroup(
             InetAddress multicastAddress, NetworkInterface networkInterface, InetAddress source,
             Promise<Void> promise) {
 
@@ -484,14 +478,13 @@ public final class NioDatagramChannel
         }
 
         promise.setSuccess(null);
-        return promise;
     }
 
     /**
      * Block the given sourceToBlock address for the given multicastAddress on the given networkInterface
      */
     @Override
-    public Future<Void> block(
+    public void block(
             InetAddress multicastAddress, NetworkInterface networkInterface,
             InetAddress sourceToBlock, Promise<Void> promise) {
 
@@ -507,14 +500,14 @@ public final class NioDatagramChannel
                         try {
                             key.block(sourceToBlock);
                         } catch (IOException e) {
-                            return promise.setFailure(e);
+                            promise.setFailure(e);
+                            return;
                         }
                     }
                 }
             }
         }
         promise.setSuccess(null);
-        return promise;
     }
 
     /**
@@ -522,26 +515,15 @@ public final class NioDatagramChannel
      *
      */
     @Override
-    public Future<Void> block(InetAddress multicastAddress, InetAddress sourceToBlock) {
-        return block(multicastAddress, sourceToBlock, newPromise());
-    }
-
-    /**
-     * Block the given sourceToBlock address for the given multicastAddress
-     *
-     */
-    @Override
-    public Future<Void> block(
+    public void block(
             InetAddress multicastAddress, InetAddress sourceToBlock, Promise<Void> promise) {
         try {
-            return block(
-                    multicastAddress,
+            block(multicastAddress,
                     NetworkInterface.getByInetAddress(((InetSocketAddress) localAddress()).getAddress()),
                     sourceToBlock, promise);
         } catch (SocketException e) {
             promise.setFailure(e);
         }
-        return promise;
     }
 
     @Override

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
@@ -909,8 +909,8 @@ public class DefaultChannelPipelineTest {
 
         Promise<Void> promise = pipeline.channel().newPromise();
         assertTrue(promise.cancel(false));
-        Future<Void> future = pipeline.bind(new LocalAddress("test"), promise);
-        assertTrue(future.isCancelled());
+        pipeline.bind(new LocalAddress("test"), promise);
+        assertTrue(promise.isCancelled());
     }
 
     @Test
@@ -920,8 +920,8 @@ public class DefaultChannelPipelineTest {
 
         Promise<Void> promise = pipeline.channel().newPromise();
         assertTrue(promise.cancel(false));
-        Future<Void> future = pipeline.connect(new LocalAddress("test"), promise);
-        assertTrue(future.isCancelled());
+        pipeline.connect(new LocalAddress("test"), promise);
+        assertTrue(promise.isCancelled());
     }
 
     @Test
@@ -931,8 +931,8 @@ public class DefaultChannelPipelineTest {
 
         Promise<Void> promise = pipeline.channel().newPromise();
         assertTrue(promise.cancel(false));
-        Future<Void> future = pipeline.disconnect(promise);
-        assertTrue(future.isCancelled());
+        pipeline.disconnect(promise);
+        assertTrue(promise.isCancelled());
     }
 
     @Test
@@ -942,8 +942,8 @@ public class DefaultChannelPipelineTest {
 
         Promise<Void> promise = pipeline.channel().newPromise();
         assertTrue(promise.cancel(false));
-        Future<Void> future = pipeline.close(promise);
-        assertTrue(future.isCancelled());
+        pipeline.close(promise);
+        assertTrue(promise.isCancelled());
     }
 
     @Test
@@ -971,8 +971,8 @@ public class DefaultChannelPipelineTest {
 
         Promise<Void> promise = pipeline.channel().newPromise();
         assertTrue(promise.cancel(false));
-        Future<Void> future = pipeline.deregister(promise);
-        assertTrue(future.isCancelled());
+        pipeline.deregister(promise);
+        assertTrue(promise.isCancelled());
     }
 
     @Test
@@ -984,8 +984,8 @@ public class DefaultChannelPipelineTest {
         assertTrue(promise.cancel(false));
         ByteBuf buffer = Unpooled.buffer();
         assertEquals(1, buffer.refCnt());
-        Future<Void> future = pipeline.write(buffer, promise);
-        assertTrue(future.isCancelled());
+        pipeline.write(buffer, promise);
+        assertTrue(promise.isCancelled());
         assertEquals(0, buffer.refCnt());
     }
 
@@ -998,8 +998,8 @@ public class DefaultChannelPipelineTest {
         assertTrue(promise.cancel(false));
         ByteBuf buffer = Unpooled.buffer();
         assertEquals(1, buffer.refCnt());
-        Future<Void> future = pipeline.writeAndFlush(buffer, promise);
-        assertTrue(future.isCancelled());
+        pipeline.writeAndFlush(buffer, promise);
+        assertTrue(promise.isCancelled());
         assertEquals(0, buffer.refCnt());
     }
 

--- a/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
@@ -213,7 +213,9 @@ public class EmbeddedChannelTest {
         testFireChannelInactiveAndUnregistered(new Action() {
             @Override
             public Future<Void> doRun(Channel channel) {
-                return channel.close(channel.newPromise());
+                Promise<Void> promise = channel.newPromise();
+                channel.close(promise);
+                return promise;
             }
         });
     }
@@ -231,7 +233,9 @@ public class EmbeddedChannelTest {
         testFireChannelInactiveAndUnregistered(new Action() {
             @Override
             public Future<Void> doRun(Channel channel) {
-                return channel.disconnect(channel.newPromise());
+                Promise<Void> promise = channel.newPromise();
+                channel.disconnect(promise);
+                return promise;
             }
         });
     }

--- a/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
@@ -742,7 +742,7 @@ public class LocalChannelTest {
                 cc.pipeline().lastContext().executor().execute(new Runnable() {
                     @Override
                     public void run() {
-                        ccCpy.writeAndFlush(data.retainedDuplicate(), ccCpy.<Void>newPromise()
+                        ccCpy.writeAndFlush(data.retainedDuplicate())
                         .addListener(future -> {
                             serverChannelCpy.executor().execute(new Runnable() {
                                 @Override
@@ -760,18 +760,17 @@ public class LocalChannelTest {
                                             fail();
                                         }
                                     }
-                                    serverChannelCpy.writeAndFlush(data2.retainedDuplicate(),
-                                                                   serverChannelCpy.<Void>newPromise()
+                                    serverChannelCpy.writeAndFlush(data2.retainedDuplicate())
                                         .addListener(f -> {
                                             if (!f.isSuccess() &&
                                                 f.cause() instanceof ClosedChannelException) {
                                                 writeFailLatch.countDown();
                                             }
-                                        }));
+                                        });
                                 }
                             });
                             ccCpy.close();
-                        }));
+                        });
                     }
                 });
 

--- a/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
@@ -742,7 +742,7 @@ public class LocalChannelTest {
                 cc.pipeline().lastContext().executor().execute(new Runnable() {
                     @Override
                     public void run() {
-                        ccCpy.writeAndFlush(data.retainedDuplicate(), ccCpy.newPromise())
+                        ccCpy.writeAndFlush(data.retainedDuplicate(), ccCpy.<Void>newPromise()
                         .addListener(future -> {
                             serverChannelCpy.executor().execute(new Runnable() {
                                 @Override
@@ -761,17 +761,17 @@ public class LocalChannelTest {
                                         }
                                     }
                                     serverChannelCpy.writeAndFlush(data2.retainedDuplicate(),
-                                                                   serverChannelCpy.newPromise())
+                                                                   serverChannelCpy.<Void>newPromise()
                                         .addListener(f -> {
                                             if (!f.isSuccess() &&
                                                 f.cause() instanceof ClosedChannelException) {
                                                 writeFailLatch.countDown();
                                             }
-                                        });
+                                        }));
                                 }
                             });
                             ccCpy.close();
-                        });
+                        }));
                     }
                 });
 
@@ -833,7 +833,8 @@ public class LocalChannelTest {
                 }
             });
             // Connect to the server
-            cc.connect(sc.localAddress(), promise).sync();
+            cc.connect(sc.localAddress(), promise);
+            promise.sync();
 
             assertPromise.syncUninterruptibly();
             assertTrue(promise.isSuccess());

--- a/transport/src/test/java/io/netty/channel/pool/FixedChannelPoolTest.java
+++ b/transport/src/test/java/io/netty/channel/pool/FixedChannelPoolTest.java
@@ -280,7 +280,8 @@ public class FixedChannelPoolTest {
         final Promise<Void> closePromise = sc.newPromise();
         pool.closeAsync().addListener(future -> {
             assertEquals(0, pool.acquiredChannelCount());
-            sc.close(closePromise).syncUninterruptibly();
+            sc.close(closePromise);
+            closePromise.syncUninterruptibly();
         }).awaitUninterruptibly();
         closePromise.awaitUninterruptibly();
     }

--- a/transport/src/test/java/io/netty/channel/pool/SimpleChannelPoolTest.java
+++ b/transport/src/test/java/io/netty/channel/pool/SimpleChannelPoolTest.java
@@ -232,7 +232,7 @@ public class SimpleChannelPoolTest {
         Channel channel1 = pool.acquire().get();
         channel1.close().syncUninterruptibly();
         Future<Void> releaseFuture =
-                pool.release(channel1, channel1.executor().<Void>newPromise()).syncUninterruptibly();
+                pool.release(channel1).syncUninterruptibly();
         assertTrue(releaseFuture.isSuccess());
 
         Channel channel2 = pool.acquire().get();


### PR DESCRIPTION
Motivation:

We usually provided two variants for methods. One that just returns a Future<...> and one that takes a Promise<...> and returns a Future<...>. While the first is ok the other one is kind of odd and confusing in the sense that its not really clear if a listener is better added to the promse or the future. Let's make the API a bit cleaner and just change the return type to void if a Promise<...> is provided.

Modifications:

- Change all method signatures from `Future method(..., Promise)` to `void method(..., Promise)` and so make things more clear and consistent.

Result:

API cleanup