### PR TITLE
Ensure ChannelPromise that are used by ChannelOutboundHandler will al…

### DIFF
--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -24,6 +24,7 @@ import io.netty.util.ResourceLeakHint;
 import io.netty.util.concurrent.AbstractEventExecutor;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.OrderedEventExecutor;
+import io.netty.util.concurrent.PromiseNotifier;
 import io.netty.util.internal.ObjectPool.Handle;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PromiseNotificationUtil;
@@ -457,8 +458,26 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         return deregister(newPromise());
     }
 
+    /**
+     * If possible check if the given {@link ChannelPromise} is using the same {@link EventExecutor} as this
+     * {@link ChannelHandlerContext} and if not return a new {@link ChannelPromise} that runs on the same
+     * {@link EventExecutor} as this {@link ChannelHandlerContext}. The result of the new {@link ChannelPromise} is
+     * cascaded to the old {@link ChannelPromise}.
+     *
+     * This is done to ensure that {@link ChannelFutureListener}s that are added to the {@link ChannelPromise} by an
+     * {@link ChannelOutboundHandler} are executed in the same thread as the handler itself. By doing so we can
+     * ensure that there are not issues even if fields etc that are stored in the handler are modified by the listener.
+     */
+    private ChannelPromise ensurePromiseUseCorrectExecutor(ChannelPromise promise) {
+        if (promise instanceof DefaultChannelPromise && !((DefaultChannelPromise) promise).executor().inEventLoop()) {
+            ChannelPromise newPromise = newPromise();
+            PromiseNotifier.cascade(newPromise, promise);
+            return newPromise;
+        }
+        return promise;
+    }
     @Override
-    public ChannelFuture bind(final SocketAddress localAddress, final ChannelPromise promise) {
+    public ChannelFuture bind(final SocketAddress localAddress, ChannelPromise promise) {
         ObjectUtil.checkNotNull(localAddress, "localAddress");
         if (isNotValidPromise(promise, false)) {
             // cancelled
@@ -469,6 +488,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         EventExecutor executor = next.executor();
         if (executor.inEventLoop()) {
             if (next.invokeHandler()) {
+                promise = ensurePromiseUseCorrectExecutor(promise);
                 try {
                     // DON'T CHANGE
                     // Duplex handlers implements both out/in interfaces causing a scalability issue
@@ -491,12 +511,8 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
                 next.bind(localAddress, promise);
             }
         } else {
-            safeExecute(executor, new Runnable() {
-                @Override
-                public void run() {
-                    bind(localAddress, promise);
-                }
-            }, promise, null, false);
+            final ChannelPromise p = promise;
+            safeExecute(executor, () -> bind(localAddress, p), promise, null, false);
         }
         return promise;
     }
@@ -508,7 +524,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
 
     @Override
     public ChannelFuture connect(
-            final SocketAddress remoteAddress, final SocketAddress localAddress, final ChannelPromise promise) {
+            final SocketAddress remoteAddress, final SocketAddress localAddress, ChannelPromise promise) {
         ObjectUtil.checkNotNull(remoteAddress, "remoteAddress");
 
         if (isNotValidPromise(promise, false)) {
@@ -520,6 +536,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         EventExecutor executor = next.executor();
         if (executor.inEventLoop()) {
             if (next.invokeHandler()) {
+                promise = ensurePromiseUseCorrectExecutor(promise);
                 try {
                     // DON'T CHANGE
                     // Duplex handlers implements both out/in interfaces causing a scalability issue
@@ -542,18 +559,14 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
                 next.connect(remoteAddress, localAddress, promise);
             }
         } else {
-            safeExecute(executor, new Runnable() {
-                @Override
-                public void run() {
-                    connect(remoteAddress, localAddress, promise);
-                }
-            }, promise, null, false);
+            final ChannelPromise p = promise;
+            safeExecute(executor, () -> connect(remoteAddress, localAddress, p), promise, null, false);
         }
         return promise;
     }
 
     @Override
-    public ChannelFuture disconnect(final ChannelPromise promise) {
+    public ChannelFuture disconnect(ChannelPromise promise) {
         if (!channel().metadata().hasDisconnect()) {
             // Translate disconnect to close if the channel has no notion of disconnect-reconnect.
             // So far, UDP/IP is the only transport that has such behavior.
@@ -568,6 +581,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         EventExecutor executor = next.executor();
         if (executor.inEventLoop()) {
             if (next.invokeHandler()) {
+                promise = ensurePromiseUseCorrectExecutor(promise);
                 try {
                     // DON'T CHANGE
                     // Duplex handlers implements both out/in interfaces causing a scalability issue
@@ -590,18 +604,14 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
                 next.disconnect(promise);
             }
         } else {
-            safeExecute(executor, new Runnable() {
-                @Override
-                public void run() {
-                    disconnect(promise);
-                }
-            }, promise, null, false);
+            final ChannelPromise p = promise;
+            safeExecute(executor, () -> disconnect(p), promise, null, false);
         }
         return promise;
     }
 
     @Override
-    public ChannelFuture close(final ChannelPromise promise) {
+    public ChannelFuture close(ChannelPromise promise) {
         if (isNotValidPromise(promise, false)) {
             // cancelled
             return promise;
@@ -611,6 +621,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         EventExecutor executor = next.executor();
         if (executor.inEventLoop()) {
             if (next.invokeHandler()) {
+                promise = ensurePromiseUseCorrectExecutor(promise);
                 try {
                     // DON'T CHANGE
                     // Duplex handlers implements both out/in interfaces causing a scalability issue
@@ -633,19 +644,15 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
                 next.close(promise);
             }
         } else {
-            safeExecute(executor, new Runnable() {
-                @Override
-                public void run() {
-                    close(promise);
-                }
-            }, promise, null, false);
+            final ChannelPromise p = promise;
+            safeExecute(executor, () -> close(p), promise, null, false);
         }
 
         return promise;
     }
 
     @Override
-    public ChannelFuture deregister(final ChannelPromise promise) {
+    public ChannelFuture deregister(ChannelPromise promise) {
         if (isNotValidPromise(promise, false)) {
             // cancelled
             return promise;
@@ -655,6 +662,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         EventExecutor executor = next.executor();
         if (executor.inEventLoop()) {
             if (next.invokeHandler()) {
+                promise = ensurePromiseUseCorrectExecutor(promise);
                 try {
                     // DON'T CHANGE
                     // Duplex handlers implements both out/in interfaces causing a scalability issue
@@ -677,12 +685,8 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
                 deregister(promise);
             }
         } else {
-            safeExecute(executor, new Runnable() {
-                @Override
-                public void run() {
-                    deregister(promise);
-                }
-            }, promise, null, false);
+            final ChannelPromise p = promise;
+            safeExecute(executor, () -> deregister(p), promise, null, false);
         }
 
         return promise;
@@ -780,6 +784,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
             EventExecutor executor = next.executor();
             if (executor.inEventLoop()) {
                 if (next.invokeHandler()) {
+                    promise = ensurePromiseUseCorrectExecutor(promise);
                     try {
                         // DON'T CHANGE
                         // Duplex handlers implements both out/in interfaces causing a scalability issue

--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -476,6 +476,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         }
         return promise;
     }
+
     @Override
     public ChannelFuture bind(final SocketAddress localAddress, ChannelPromise promise) {
         ObjectUtil.checkNotNull(localAddress, "localAddress");


### PR DESCRIPTION
…ways complete in the assumed thread.

Motivation:

At the moment we often make the assumption that the ChannelFutureListener attached by an ChannelOutboundHandler will execute in the same thread as the ChannelOutboundHandler by itself. This is not really safe to assume as the user can pass in a ChannelPromise that is tight to another EventExecutor or the previous ChannelOutboundHandler might use a different EventExecutor as the current one and might have created the ChannelPromise.

Modifications:

- If the ChannelPromise is not using the "correct" EventExecutor just create a new one, cascade its result to the original ChannelPromise and pass the new ChannelPromise to the ChannelOutboundHandler. This ensures we execute stuff in the assumed thread.
- Add unit test

Result:

More safe behaviour when executing ChannelOutboundHandler