### PR TITLE
Buddy allocation for large buffers in adaptive allocator

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -1254,9 +1254,8 @@ final class AdaptivePoolingAllocator {
             // Called by allocating thread when draining freeList.
             int size = MIN_BUDDY_SIZE << (packed >> 16);
             int offset = (packed & 0xFFFF) * MIN_BUDDY_SIZE;
-            int index = unreserveMatchingBuddy(1, size, offset, 0);
+            unreserveMatchingBuddy(1, size, offset, 0);
             allocatedBytes -= size;
-            assert index != -1;
         }
 
         @Override
@@ -1301,12 +1300,12 @@ final class AdaptivePoolingAllocator {
         }
 
         /**
-         * Un-reserve the matching buddy and return its corresponding buddy index, or -1 on corrupt state.
+         * Un-reserve the matching buddy and return whether there are any other child or sibling reservations.
          */
-        private int unreserveMatchingBuddy(int index, int size, int offset, int currOffset) {
+        private boolean unreserveMatchingBuddy(int index, int size, int offset, int currOffset) {
             byte[] buddies = this.buddies;
             if (buddies.length <= index) {
-                return -1;
+                return false;
             }
             byte buddy = buddies[index];
             int currSize = MIN_BUDDY_SIZE << (buddy & SHIFT_MASK);
@@ -1315,33 +1314,35 @@ final class AdaptivePoolingAllocator {
                 // We're at the right size level.
                 if (currOffset == offset) {
                     buddies[index] &= SHIFT_MASK;
-                    return index;
+                    return false;
                 } else {
-                    return -1;
+                    throw new IllegalStateException("The intended segment was not found at index " +
+                            index + ", for size " + size + " and offset " + offset);
                 }
             }
 
             // We're at a parent size level. Use the target offset to guide our drill-down path.
-            int found;
+            boolean claims;
             int siblingIndex;
             if (offset < currOffset + (currSize >> 1)) {
                 // Must be down the left path.
-                found = unreserveMatchingBuddy(index << 1, size, offset, currOffset);
+                claims = unreserveMatchingBuddy(index << 1, size, offset, currOffset);
                 siblingIndex = (index << 1) + 1;
             } else {
                 // Must be down the rigth path.
-                found = unreserveMatchingBuddy((index << 1) + 1, size, offset, currOffset + (currSize >> 1));
+                claims = unreserveMatchingBuddy((index << 1) + 1, size, offset, currOffset + (currSize >> 1));
                 siblingIndex = index << 1;
             }
-            if (found != -1) {
+            if (!claims) {
+                // No other claims down the path we took. Check if the sibling has claims.
                 byte sibling = buddies[siblingIndex];
                 if ((sibling & SHIFT_MASK) == sibling) {
                     // No claims in the sibling. We can clear this level as well.
                     buddies[index] &= SHIFT_MASK;
+                    return false;
                 }
-                return found;
             }
-            return -1;
+            return true;
         }
 
         private String dot() {

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -1305,29 +1305,79 @@ final class AdaptivePoolingAllocator {
          */
         private int unreserveMatchingBuddy(int index, int size, int offset, int currOffset) {
             byte[] buddies = this.buddies;
-            while (index < buddies.length) {
-                byte buddy = buddies[index];
-                int currValue = MIN_BUDDY_SIZE << (buddy & SHIFT_MASK);
-                if (currValue < size) {
-                    return -1;
-                }
-                if (currValue == size && currOffset == offset) {
+            if (buddies.length <= index) {
+                return -1;
+            }
+            byte buddy = buddies[index];
+            int currSize = MIN_BUDDY_SIZE << (buddy & SHIFT_MASK);
+
+            if (currSize == size) {
+                // We're at the right size level.
+                if (currOffset == offset) {
                     buddies[index] &= SHIFT_MASK;
                     return index;
+                } else {
+                    return -1;
                 }
-                int found = unreserveMatchingBuddy(index << 1, size, offset, currOffset);
-                if (found != -1) {
-                    byte sibling = (index & 1) == 1 ? buddies[index << 1] : buddies[(index << 1) + 1];
-                    if ((sibling & SHIFT_MASK) == sibling) {
-                        // No claims in the sibling. We can clear this level as well.
-                        buddies[index] &= SHIFT_MASK;
-                    }
-                    return found;
+            }
+
+            // We're at a parent size level. Use the target offset to guide our drill-down path.
+            int found;
+            int siblingIndex;
+            if (offset < currOffset + (currSize >> 1)) {
+                // Must be down the left path.
+                found = unreserveMatchingBuddy(index << 1, size, offset, currOffset);
+                siblingIndex = (index << 1) + 1;
+            } else {
+                // Must be down the rigth path.
+                found = unreserveMatchingBuddy((index << 1) + 1, size, offset, currOffset + (currSize >> 1));
+                siblingIndex = index << 1;
+            }
+            if (found != -1) {
+                byte sibling = buddies[siblingIndex];
+                if ((sibling & SHIFT_MASK) == sibling) {
+                    // No claims in the sibling. We can clear this level as well.
+                    buddies[index] &= SHIFT_MASK;
                 }
-                index++;
-                currOffset += currValue;
+                return found;
             }
             return -1;
+        }
+
+        private String dot() {
+            StringBuilder sb = new StringBuilder("digraph { node [shape=box] ; ");
+            dot(sb, 1, 0);
+            sb.append('}');
+            return sb.toString();
+        }
+
+        private void dot(StringBuilder sb, int index, int currOffset) {
+            byte[] buddies = this.buddies;
+            if (buddies.length <= index) {
+                return;
+            }
+            byte buddy = buddies[index];
+            int currSize = MIN_BUDDY_SIZE << (buddy & SHIFT_MASK);
+            boolean hasClaimedChildren = (buddy & HAS_CLAIMED_CHILDREN) == HAS_CLAIMED_CHILDREN;
+            boolean isClaimed = (buddy & IS_CLAIMED) == IS_CLAIMED;
+            sb.append('"').append(index).append("\" [label=\"")
+                    .append(index).append(" - ")
+                    .append(currSize / MIN_BUDDY_SIZE).append(':')
+                    .append(currOffset / MIN_BUDDY_SIZE);
+            if (isClaimed) {
+                sb.append(" C");
+            }
+            if (hasClaimedChildren) {
+                sb.append(" CC");
+            }
+            sb.append("\"] ; ");
+            int childIndex = index << 1;
+            if (childIndex < buddies.length) {
+                sb.append('"').append(index).append("\" -> \"").append(childIndex).append("\" ; ");
+                sb.append('"').append(index).append("\" -> \"").append(childIndex + 1).append("\" ; ");
+            }
+            dot(sb, childIndex, currOffset);
+            dot(sb, childIndex + 1, currOffset + (currSize >> 1));
         }
     }
 

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -1295,10 +1295,13 @@ final class AdaptivePoolingAllocator {
         private static final byte IS_CLAIMED = (byte) (1 << 7);
         private static final byte HAS_CLAIMED_CHILDREN = 1 << 6;
         private static final byte SHIFT_MASK = ~(IS_CLAIMED | HAS_CLAIMED_CHILDREN);
+        private static final int PACK_OFFSET_MASK = 0xFFFF;
+        private static final int PACK_SIZE_SHIFT = Integer.SIZE - Integer.numberOfLeadingZeros(PACK_OFFSET_MASK);
 
         private final MpscIntQueue freeList;
         // The bits of each buddy: [1: is claimed][1: has claimed children][30: MIN_BUDDY_SIZE shift to get size]
         private final byte[] buddies;
+        private final int freeListCapacity;
 
         BuddyChunk(AbstractByteBuf delegate, Magazine magazine, ChunkReleasePredicate chunkReleasePredicate) {
             super(delegate, magazine, true, chunkReleasePredicate);
@@ -1307,7 +1310,8 @@ final class AdaptivePoolingAllocator {
             int tree = (capFactor << 1) - 1;
             int maxShift = Integer.numberOfTrailingZeros(capFactor);
             assert maxShift <= 30; // The top 2 bits are used for marking.
-            freeList = MpscIntQueue.create(tree >> 1, -1); // At most half of tree (all leaf nodes) can be freed.
+            freeListCapacity = tree >> 1;
+            freeList = MpscIntQueue.create(freeListCapacity, -1); // At most half of tree (all leaf nodes) can be freed.
             buddies = new byte[1 + tree];
 
             // Generate the buddies entries.
@@ -1327,7 +1331,7 @@ final class AdaptivePoolingAllocator {
         @Override
         public boolean readInitInto(AdaptiveByteBuf buf, int size, int startingCapacity, int maxCapacity) {
             if (!freeList.isEmpty()) {
-                freeList.drain(256, this);
+                freeList.drain(freeListCapacity, this);
             }
             int startIndex = chooseFirstFreeBuddy(1, startingCapacity, 0);
             if (startIndex == -1) {
@@ -1352,15 +1356,17 @@ final class AdaptivePoolingAllocator {
         @Override
         public void accept(int packed) {
             // Called by allocating thread when draining freeList.
-            int size = MIN_BUDDY_SIZE << (packed >> 16);
-            int offset = (packed & 0xFFFF) * MIN_BUDDY_SIZE;
+            int size = MIN_BUDDY_SIZE << (packed >> PACK_SIZE_SHIFT);
+            int offset = (packed & PACK_OFFSET_MASK) * MIN_BUDDY_SIZE;
             unreserveMatchingBuddy(1, size, offset, 0);
             allocatedBytes -= size;
         }
 
         @Override
         void releaseSegment(int startingIndex, int size) {
-            int packed = startingIndex / MIN_BUDDY_SIZE | Integer.numberOfTrailingZeros(size / MIN_BUDDY_SIZE) << 16;
+            int packedOffset = startingIndex / MIN_BUDDY_SIZE;
+            int packedSize = Integer.numberOfTrailingZeros(size / MIN_BUDDY_SIZE) << PACK_SIZE_SHIFT;
+            int packed = packedOffset | packedSize;
             freeList.offer(packed);
             release();
         }
@@ -1368,7 +1374,7 @@ final class AdaptivePoolingAllocator {
         @Override
         public int remainingCapacity() {
             if (!freeList.isEmpty()) {
-                freeList.drain(256, this);
+                freeList.drain(freeListCapacity, this);
             }
             return super.remainingCapacity();
         }
@@ -1415,10 +1421,9 @@ final class AdaptivePoolingAllocator {
                 if (currOffset == offset) {
                     buddies[index] &= SHIFT_MASK;
                     return false;
-                } else {
-                    throw new IllegalStateException("The intended segment was not found at index " +
-                            index + ", for size " + size + " and offset " + offset);
                 }
+                throw new IllegalStateException("The intended segment was not found at index " +
+                        index + ", for size " + size + " and offset " + offset);
             }
 
             // We're at a parent size level. Use the target offset to guide our drill-down path.

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -1344,42 +1344,6 @@ final class AdaptivePoolingAllocator {
             }
             return true;
         }
-
-        private String dot() {
-            StringBuilder sb = new StringBuilder("digraph { node [shape=box] ; ");
-            dot(sb, 1, 0);
-            sb.append('}');
-            return sb.toString();
-        }
-
-        private void dot(StringBuilder sb, int index, int currOffset) {
-            byte[] buddies = this.buddies;
-            if (buddies.length <= index) {
-                return;
-            }
-            byte buddy = buddies[index];
-            int currSize = MIN_BUDDY_SIZE << (buddy & SHIFT_MASK);
-            boolean hasClaimedChildren = (buddy & HAS_CLAIMED_CHILDREN) == HAS_CLAIMED_CHILDREN;
-            boolean isClaimed = (buddy & IS_CLAIMED) == IS_CLAIMED;
-            sb.append('"').append(index).append("\" [label=\"")
-                    .append(index).append(" - ")
-                    .append(currSize / MIN_BUDDY_SIZE).append(':')
-                    .append(currOffset / MIN_BUDDY_SIZE);
-            if (isClaimed) {
-                sb.append(" C");
-            }
-            if (hasClaimedChildren) {
-                sb.append(" CC");
-            }
-            sb.append("\"] ; ");
-            int childIndex = index << 1;
-            if (childIndex < buddies.length) {
-                sb.append('"').append(index).append("\" -> \"").append(childIndex).append("\" ; ");
-                sb.append('"').append(index).append("\" -> \"").append(childIndex + 1).append("\" ; ");
-            }
-            dot(sb, childIndex, currOffset);
-            dot(sb, childIndex + 1, currOffset + (currSize >> 1));
-        }
     }
 
     static final class AdaptiveByteBuf extends AbstractReferenceCountedByteBuf {

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -190,8 +190,7 @@ final class AdaptivePoolingAllocator {
         chunkRegistry = new ChunkRegistry();
         sizeClassedMagazineGroups = createMagazineGroupSizeClasses(this, false);
         largeBufferMagazineGroup = new MagazineGroup(
-                this, chunkAllocator, new BuddyChunkControllerFactory(true), false);
-//                this, chunkAllocator, new HistogramChunkControllerFactory(true), false);
+                this, chunkAllocator, new BuddyChunkControllerFactory(), false);
 
         boolean disableThreadLocalGroups = IS_LOW_MEM && DISABLE_THREAD_LOCAL_MAGAZINES_ON_LOW_MEM;
         threadLocalGroup = disableThreadLocalGroups ? null : new FastThreadLocal<MagazineGroup[]>() {
@@ -589,15 +588,9 @@ final class AdaptivePoolingAllocator {
     }
 
     private static final class BuddyChunkControllerFactory implements ChunkControllerFactory {
-        private final boolean shareable;
-
-        private BuddyChunkControllerFactory(boolean shareable) {
-            this.shareable = shareable;
-        }
-
         @Override
         public ChunkController create(MagazineGroup group) {
-            return new BuddyChunkController(group, shareable);
+            return new BuddyChunkController(group);
         }
     }
 
@@ -605,7 +598,7 @@ final class AdaptivePoolingAllocator {
         private final ChunkAllocator chunkAllocator;
         private final ChunkRegistry chunkRegistry;
 
-        BuddyChunkController(MagazineGroup group, boolean shareable) {
+        BuddyChunkController(MagazineGroup group) {
             chunkAllocator = group.chunkAllocator;
             chunkRegistry = group.allocator.chunkRegistry;
         }
@@ -1033,7 +1026,6 @@ final class AdaptivePoolingAllocator {
             } else {
                 RefCnt.resetRefCnt(refCnt);
                 delegate.setIndex(0, 0);
-                allocatedBytes = 0;
                 if (!mag.trySetNextInLine(this)) {
                     // As this Chunk does not belong to the mag anymore we need to decrease the used memory .
                     detachFromMagazine();
@@ -1269,10 +1261,9 @@ final class AdaptivePoolingAllocator {
 
         @Override
         boolean releaseSegment(int startingIndex, int size) {
-            boolean released = release();
             int packed = startingIndex / MIN_BUDDY_SIZE | Integer.numberOfTrailingZeros(size / MIN_BUDDY_SIZE) << 16;
             freeList.offer(packed);
-            return released;
+            return release();
         }
 
         /**
@@ -1325,7 +1316,7 @@ final class AdaptivePoolingAllocator {
                     }
                     return found;
                 }
-                index = (index << 1) + 1;
+                index++;
                 currOffset += currValue;
             }
             return -1;

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -1296,7 +1296,7 @@ final class AdaptivePoolingAllocator {
                     return found;
                 }
                 index = (index << 1) + 1;
-                currOffset += currValue;
+                currOffset += currValue >> 1; // Bump offset to skip first half of this layer.
             }
             return -1;
         }

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -24,6 +24,7 @@ import io.netty.util.Recycler.EnhancedHandle;
 import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.concurrent.FastThreadLocalThread;
 import io.netty.util.concurrent.MpscIntQueue;
+import io.netty.util.internal.MathUtil;
 import io.netty.util.internal.ObjectPool;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
@@ -49,6 +50,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.StampedLock;
+import java.util.function.IntConsumer;
 import java.util.function.IntSupplier;
 
 /**
@@ -157,8 +159,6 @@ final class AdaptivePoolingAllocator {
             8704, // 8192 + 512
             16384,
             16896, // 16384 + 512
-            32768,
-            65536,
     };
 
     private static final int SIZE_CLASSES_COUNT = SIZE_CLASSES.length;
@@ -191,7 +191,8 @@ final class AdaptivePoolingAllocator {
         chunkRegistry = new ChunkRegistry();
         sizeClassedMagazineGroups = createMagazineGroupSizeClasses(this, false);
         largeBufferMagazineGroup = new MagazineGroup(
-                this, chunkAllocator, new HistogramChunkControllerFactory(true), false);
+                this, chunkAllocator, new BuddyChunkControllerFactory(true), false);
+//                this, chunkAllocator, new HistogramChunkControllerFactory(true), false);
 
         boolean disableThreadLocalGroups = IS_LOW_MEM && DISABLE_THREAD_LOCAL_MAGAZINES_ON_LOW_MEM;
         threadLocalGroup = disableThreadLocalGroups ? null : new FastThreadLocal<MagazineGroup[]>() {
@@ -592,6 +593,48 @@ final class AdaptivePoolingAllocator {
         }
     }
 
+    private static final class BuddyChunkControllerFactory implements ChunkControllerFactory {
+        private final boolean shareable;
+
+        private BuddyChunkControllerFactory(boolean shareable) {
+            this.shareable = shareable;
+        }
+
+        @Override
+        public ChunkController create(MagazineGroup group) {
+            return new BuddyChunkController(group, shareable);
+        }
+    }
+
+    private static final class BuddyChunkController implements ChunkController {
+        private final ChunkAllocator chunkAllocator;
+        private final ChunkRegistry chunkRegistry;
+
+        BuddyChunkController(MagazineGroup group, boolean shareable) {
+            chunkAllocator = group.chunkAllocator;
+            chunkRegistry = group.allocator.chunkRegistry;
+        }
+
+        @Override
+        public int computeBufferCapacity(int requestedSize, int maxCapacity, boolean isReallocation) {
+            return MathUtil.safeFindNextPositivePowerOfTwo(requestedSize);
+        }
+
+        @Override
+        public void initializeSharedStateIn(ChunkController chunkController) {
+            // NOOP
+        }
+
+        @Override
+        public Chunk newChunkAllocation(int promptingSize, Magazine magazine) {
+            int chunkSize = Math.min(MAX_CHUNK_SIZE,
+                    MathUtil.safeFindNextPositivePowerOfTwo(BUFS_PER_CHUNK * promptingSize));
+            BuddyChunk chunk = new BuddyChunk(chunkAllocator.allocate(chunkSize, chunkSize), magazine, size -> false);
+            chunkRegistry.add(chunk);
+            return chunk;
+        }
+    }
+
     private static final class HistogramChunkControllerFactory implements ChunkControllerFactory {
         private final boolean shareable;
 
@@ -913,8 +956,8 @@ final class AdaptivePoolingAllocator {
             if (curr != null) {
                 // We have a Chunk that has some space left.
                 int remainingCapacity = curr.remainingCapacity();
-                if (remainingCapacity > startingCapacity) {
-                    curr.readInitInto(buf, size, startingCapacity, maxCapacity);
+                if (remainingCapacity > startingCapacity &&
+                        curr.readInitInto(buf, size, startingCapacity, maxCapacity)) {
                     // We still have some bytes left that we can use for the next allocation, just early return.
                     return true;
                 }
@@ -923,11 +966,9 @@ final class AdaptivePoolingAllocator {
                 // null and release it once we are done.
                 current = null;
                 if (remainingCapacity >= size) {
-                    try {
-                        curr.readInitInto(buf, size, remainingCapacity, maxCapacity);
-                        return true;
-                    } finally {
+                    if (curr.readInitInto(buf, size, remainingCapacity, maxCapacity)) {
                         curr.releaseFromMagazine();
+                        return true;
                     }
                 }
 
@@ -959,9 +1000,9 @@ final class AdaptivePoolingAllocator {
                 }
 
                 int remainingCapacity = curr.remainingCapacity();
-                if (remainingCapacity > startingCapacity) {
+                if (remainingCapacity > startingCapacity &&
+                        curr.readInitInto(buf, size, startingCapacity, maxCapacity)) {
                     // We have a Chunk that has some space left.
-                    curr.readInitInto(buf, size, startingCapacity, maxCapacity);
                     current = curr;
                     return true;
                 }
@@ -970,8 +1011,7 @@ final class AdaptivePoolingAllocator {
                     // At this point we know that this will be the last time curr will be used, so directly set it to
                     // null and release it once we are done.
                     try {
-                        curr.readInitInto(buf, size, remainingCapacity, maxCapacity);
-                        return true;
+                        return curr.readInitInto(buf, size, remainingCapacity, maxCapacity);
                     } finally {
                         // Release in a finally block so even if readInitInto(...) would throw we would still correctly
                         // release the current chunk before null it out.
@@ -1005,14 +1045,15 @@ final class AdaptivePoolingAllocator {
             }
 
             current = curr;
+            boolean success;
             try {
                 int remainingCapacity = curr.remainingCapacity();
                 assert remainingCapacity >= size;
                 if (remainingCapacity > startingCapacity) {
-                    curr.readInitInto(buf, size, startingCapacity, maxCapacity);
+                    success = curr.readInitInto(buf, size, startingCapacity, maxCapacity);
                     curr = null;
                 } else {
-                    curr.readInitInto(buf, size, remainingCapacity, maxCapacity);
+                    success = curr.readInitInto(buf, size, remainingCapacity, maxCapacity);
                 }
             } finally {
                 if (curr != null) {
@@ -1022,7 +1063,7 @@ final class AdaptivePoolingAllocator {
                     current = null;
                 }
             }
-            return true;
+            return success;
         }
 
         private void restoreMagazineFreed() {
@@ -1183,7 +1224,7 @@ final class AdaptivePoolingAllocator {
         /**
          * Called when a ByteBuf is done using its allocation in this chunk.
          */
-        boolean releaseSegment(int ignoredSegmentId) {
+        boolean releaseSegment(int ignoredSegmentId, int size) {
             return release();
         }
 
@@ -1255,7 +1296,7 @@ final class AdaptivePoolingAllocator {
             }
         }
 
-        public void readInitInto(AdaptiveByteBuf buf, int size, int startingCapacity, int maxCapacity) {
+        public boolean readInitInto(AdaptiveByteBuf buf, int size, int startingCapacity, int maxCapacity) {
             int startIndex = allocatedBytes;
             allocatedBytes = startIndex + startingCapacity;
             Chunk chunk = this;
@@ -1272,6 +1313,7 @@ final class AdaptivePoolingAllocator {
                     chunk.release();
                 }
             }
+            return true;
         }
 
         public int remainingCapacity() {
@@ -1317,10 +1359,10 @@ final class AdaptivePoolingAllocator {
         }
 
         @Override
-        public void readInitInto(AdaptiveByteBuf buf, int size, int startingCapacity, int maxCapacity) {
+        public boolean readInitInto(AdaptiveByteBuf buf, int size, int startingCapacity, int maxCapacity) {
             int startIndex = freeList.poll();
             if (startIndex == FREE_LIST_EMPTY) {
-                throw new IllegalStateException("Free list is empty");
+                 return false;
             }
             allocatedBytes += segmentSize;
             Chunk chunk = this;
@@ -1334,9 +1376,10 @@ final class AdaptivePoolingAllocator {
                     // the chunk again as we retained it before calling buf.init(...). Beside this we also need to
                     // restore the old allocatedBytes value.
                     allocatedBytes -= segmentSize;
-                    chunk.releaseSegment(startIndex);
+                    chunk.releaseSegment(startIndex, startingCapacity);
                 }
             }
+            return true;
         }
 
         @Override
@@ -1367,11 +1410,145 @@ final class AdaptivePoolingAllocator {
         }
 
         @Override
-        boolean releaseSegment(int startIndex) {
+        boolean releaseSegment(int startIndex, int size) {
             boolean released = release();
             boolean segmentReturned = freeList.offer(startIndex);
             assert segmentReturned: "Unable to return segment " + startIndex + " to free list";
             return released;
+        }
+    }
+
+    private static final class BuddyChunk extends Chunk implements IntConsumer {
+        private static final int MIN_BUDDY_SIZE = 32768;
+        private static final byte IS_CLAIMED = (byte) (1 << 7);
+        private static final byte HAS_CLAIMED_CHILDREN = 1 << 6;
+        private static final byte SHIFT_MASK = ~(IS_CLAIMED | HAS_CLAIMED_CHILDREN);
+
+        private final MpscIntQueue freeList;
+        // The bits of each buddy: [1: is claimed][1: has claimed children][30: MIN_BUDDY_SIZE shift to get size]
+        private final byte[] buddies;
+
+        BuddyChunk(AbstractByteBuf delegate, Magazine magazine, ChunkReleasePredicate chunkReleasePredicate) {
+            super(delegate, magazine, true, chunkReleasePredicate);
+            int capacity = delegate.capacity();
+            int capFactor = capacity / MIN_BUDDY_SIZE;
+            int tree = (capFactor << 1) - 1;
+            int maxShift = Integer.numberOfTrailingZeros(capFactor);
+            assert maxShift <= 30; // The top 2 bits are used for marking.
+            freeList = MpscIntQueue.create(tree >> 1, -1); // At most half of tree (all leaf nodes) can be freed.
+            buddies = new byte[1 + tree];
+
+            // Generate the buddies entries.
+            int index = 1;
+            int runLength = 1;
+            int currentRun = 0;
+            while (maxShift > 0) {
+                buddies[index++] = (byte) maxShift;
+                if (++currentRun == runLength) {
+                    currentRun = 0;
+                    runLength <<= 1;
+                    maxShift--;
+                }
+            }
+        }
+
+        @Override
+        public boolean readInitInto(AdaptiveByteBuf buf, int size, int startingCapacity, int maxCapacity) {
+            if (!freeList.isEmpty()) {
+                freeList.drain(256, this);
+            }
+            int startIndex = chooseFirstFreeBuddy(1, startingCapacity, 0);
+            if (startIndex == -1) {
+                return false;
+            }
+            Chunk chunk = this;
+            chunk.retain();
+            try {
+                buf.init(delegate, this, 0, 0, startIndex, size, startingCapacity, maxCapacity);
+                allocatedBytes += startingCapacity;
+                chunk = null;
+            } finally {
+                if (chunk != null) {
+                    // If chunk is not null we know that buf.init(...) failed and so we need to manually release
+                    // the chunk again as we retained it before calling buf.init(...).
+                    chunk.release();
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public void accept(int packed) {
+            // Called by allocating thread when draining freeList.
+            int size = MIN_BUDDY_SIZE << (packed >> 16);
+            int offset = (packed & 0xFFFF) * MIN_BUDDY_SIZE;
+            int index = unreserveMatchingBuddy(1, size, offset, 0);
+            allocatedBytes -= size;
+            assert index != -1;
+        }
+
+        @Override
+        boolean releaseSegment(int startingIndex, int size) {
+            boolean released = release();
+            int packed = startingIndex / MIN_BUDDY_SIZE | Integer.numberOfTrailingZeros(size / MIN_BUDDY_SIZE) << 16;
+            freeList.offer(packed);
+            return released;
+        }
+
+        /**
+         * Claim a suitable buddy and return its start offset into the delegate chunk, or return -1 if nothing claimed.
+         */
+        private int chooseFirstFreeBuddy(int index, int size, int currOffset) {
+            byte[] buddies = this.buddies;
+            while (index < buddies.length) {
+                byte buddy = buddies[index];
+                int currValue = MIN_BUDDY_SIZE << (buddy & SHIFT_MASK);
+                if (currValue < size || (buddy & IS_CLAIMED) == IS_CLAIMED) {
+                    return -1;
+                }
+                if (currValue == size && (buddy & HAS_CLAIMED_CHILDREN) == 0) {
+                    buddies[index] |= IS_CLAIMED;
+                    return currOffset;
+                }
+                int found = chooseFirstFreeBuddy(index << 1, size, currOffset);
+                if (found != -1) {
+                    buddies[index] |= HAS_CLAIMED_CHILDREN;
+                    return found;
+                }
+                index = (index << 1) + 1;
+                currOffset += currValue;
+            }
+            return -1;
+        }
+
+        /**
+         * Un-reserve the matching buddy and return its corresponding buddy index, or -1 on corrupt state.
+         */
+        private int unreserveMatchingBuddy(int index, int size, int offset, int currOffset) {
+            byte[] buddies = this.buddies;
+            while (index < buddies.length) {
+                byte buddy = buddies[index];
+                int currValue = MIN_BUDDY_SIZE << (buddy & SHIFT_MASK);
+                if (currValue < size) {
+                    return -1;
+                }
+                if (currValue == size && currOffset == offset) {
+                    buddies[index] &= SHIFT_MASK;
+                    return index;
+                }
+                int found = unreserveMatchingBuddy(index << 1, size, offset, currOffset);
+                if (found != -1) {
+                    byte sibling = (index & 1) == 1 ? buddies[index << 1] : buddies[(index << 1) + 1];
+                    if ((sibling & SHIFT_MASK) == sibling) {
+                        // No claims in the sibling. We can clear this level as well.
+                        buddies[index] &= SHIFT_MASK;
+                    }
+                    return found;
+                }
+                index = (index << 1) + 1;
+                currOffset += currValue;
+            }
+            return -1;
         }
     }
 
@@ -1466,11 +1643,12 @@ final class AdaptivePoolingAllocator {
             int readerIndex = this.readerIndex;
             int writerIndex = this.writerIndex;
             int baseOldRootIndex = startIndex;
-            int oldCapacity = length;
+            int oldLength = length;
+            int oldCapacity = maxFastCapacity;
             AbstractByteBuf oldRoot = rootParent();
             allocator.reallocate(newCapacity, maxCapacity(), this);
-            oldRoot.getBytes(baseOldRootIndex, this, 0, oldCapacity);
-            chunk.releaseSegment(baseOldRootIndex);
+            oldRoot.getBytes(baseOldRootIndex, this, 0, oldLength);
+            chunk.releaseSegment(baseOldRootIndex, oldCapacity);
             this.readerIndex = readerIndex;
             this.writerIndex = writerIndex;
             return this;
@@ -1879,7 +2057,7 @@ final class AdaptivePoolingAllocator {
             }
 
             if (chunk != null) {
-                chunk.releaseSegment(startIndex);
+                chunk.releaseSegment(startIndex, maxFastCapacity);
             }
             tmpNioBuf = null;
             chunk = null;

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -1266,6 +1266,14 @@ final class AdaptivePoolingAllocator {
             return release();
         }
 
+        @Override
+        public int remainingCapacity() {
+            if (!freeList.isEmpty()) {
+                freeList.drain(256, this);
+            }
+            return super.remainingCapacity();
+        }
+
         /**
          * Claim a suitable buddy and return its start offset into the delegate chunk, or return -1 if nothing claimed.
          */

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -158,6 +158,8 @@ final class AdaptivePoolingAllocator {
             8704, // 8192 + 512
             16384,
             16896, // 16384 + 512
+            32768, // TODO: Remove the 32k and 64k size classes once we're smarter about choosing chunks
+            65536,
     };
 
     private static final int SIZE_CLASSES_COUNT = SIZE_CLASSES.length;

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -1379,6 +1379,18 @@ final class AdaptivePoolingAllocator {
             return super.remainingCapacity();
         }
 
+        @Override
+        boolean releaseFromMagazine() {
+            // Buddy chunks can be reused before they become empty.
+            // We can therefor put them in the shared queue as soon as the magazine is done with this chunk.
+            Magazine mag = magazine;
+            detachFromMagazine();
+            if (!mag.offerToQueue(this)) {
+                return super.releaseFromMagazine();
+            }
+            return false;
+        }
+
         /**
          * Claim a suitable buddy and return its start offset into the delegate chunk, or return -1 if nothing claimed.
          */

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -46,7 +46,6 @@ import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.StampedLock;
@@ -162,7 +161,7 @@ final class AdaptivePoolingAllocator {
     };
 
     private static final int SIZE_CLASSES_COUNT = SIZE_CLASSES.length;
-    private static final byte[] SIZE_INDEXES = new byte[(SIZE_CLASSES[SIZE_CLASSES_COUNT - 1] / 32) + 1];
+    private static final byte[] SIZE_INDEXES = new byte[SIZE_CLASSES[SIZE_CLASSES_COUNT - 1] / 32 + 1];
 
     static {
         if (MAGAZINE_BUFFER_QUEUE_CAPACITY < 2) {
@@ -353,10 +352,6 @@ final class AdaptivePoolingAllocator {
 
     private void free() {
         largeBufferMagazineGroup.free();
-    }
-
-    static int sizeToBucket(int size) {
-        return HistogramChunkController.sizeToBucket(size);
     }
 
     private static final class MagazineGroup {
@@ -632,221 +627,6 @@ final class AdaptivePoolingAllocator {
             BuddyChunk chunk = new BuddyChunk(chunkAllocator.allocate(chunkSize, chunkSize), magazine, size -> false);
             chunkRegistry.add(chunk);
             return chunk;
-        }
-    }
-
-    private static final class HistogramChunkControllerFactory implements ChunkControllerFactory {
-        private final boolean shareable;
-
-        private HistogramChunkControllerFactory(boolean shareable) {
-            this.shareable = shareable;
-        }
-
-        @Override
-        public ChunkController create(MagazineGroup group) {
-            return new HistogramChunkController(group, shareable);
-        }
-    }
-
-    private static final class HistogramChunkController implements ChunkController, ChunkReleasePredicate {
-        private static final int MIN_DATUM_TARGET = 1024;
-        private static final int MAX_DATUM_TARGET = 65534;
-        private static final int INIT_DATUM_TARGET = 9;
-        private static final int HISTO_BUCKET_COUNT = 16;
-        private static final int[] HISTO_BUCKETS = {
-                16 * 1024,
-                24 * 1024,
-                32 * 1024,
-                48 * 1024,
-                64 * 1024,
-                96 * 1024,
-                128 * 1024,
-                192 * 1024,
-                256 * 1024,
-                384 * 1024,
-                512 * 1024,
-                768 * 1024,
-                1024 * 1024,
-                1792 * 1024,
-                2048 * 1024,
-                3072 * 1024
-        };
-
-        private final MagazineGroup group;
-        private final boolean shareable;
-        private final short[][] histos = {
-                new short[HISTO_BUCKET_COUNT], new short[HISTO_BUCKET_COUNT],
-                new short[HISTO_BUCKET_COUNT], new short[HISTO_BUCKET_COUNT],
-        };
-        private final ChunkRegistry chunkRegistry;
-        private short[] histo = histos[0];
-        private final int[] sums = new int[HISTO_BUCKET_COUNT];
-
-        private int histoIndex;
-        private int datumCount;
-        private int datumTarget = INIT_DATUM_TARGET;
-        private boolean hasHadRotation;
-        private volatile int sharedPrefChunkSize = MIN_CHUNK_SIZE;
-        private volatile int localPrefChunkSize = MIN_CHUNK_SIZE;
-        private volatile int localUpperBufSize;
-
-        private HistogramChunkController(MagazineGroup group, boolean shareable) {
-            this.group = group;
-            this.shareable = shareable;
-            chunkRegistry = group.allocator.chunkRegistry;
-        }
-
-        @Override
-        public int computeBufferCapacity(
-                int requestedSize, int maxCapacity, boolean isReallocation) {
-            if (!isReallocation) {
-                // Only record allocation size if it's not caused by a reallocation that was triggered by capacity
-                // change of the buffer.
-                recordAllocationSize(requestedSize);
-            }
-
-            // Predict starting capacity from localUpperBufSize, but place limits on the max starting capacity
-            // based on the requested size, because localUpperBufSize can potentially be quite large.
-            int startCapLimits;
-            if (requestedSize <= 32768) { // Less than or equal to 32 KiB.
-                startCapLimits = 65536; // Use at most 64 KiB, which is also the AdaptiveRecvByteBufAllocator max.
-            } else {
-                startCapLimits = requestedSize * 2; // Otherwise use at most twice the requested memory.
-            }
-            int startingCapacity = Math.min(startCapLimits, localUpperBufSize);
-            startingCapacity = Math.max(requestedSize, Math.min(maxCapacity, startingCapacity));
-            return startingCapacity;
-        }
-
-        private void recordAllocationSize(int bufferSizeToRecord) {
-            // Use the preserved size from the reused AdaptiveByteBuf, if available.
-            // Otherwise, use the requested buffer size.
-            // This way, we better take into account
-            if (bufferSizeToRecord == 0) {
-                return;
-            }
-            int bucket = sizeToBucket(bufferSizeToRecord);
-            histo[bucket]++;
-            if (datumCount++ == datumTarget) {
-                rotateHistograms();
-            }
-        }
-
-        static int sizeToBucket(int size) {
-            int index = binarySearchInsertionPoint(Arrays.binarySearch(HISTO_BUCKETS, size));
-            return index >= HISTO_BUCKETS.length ? HISTO_BUCKETS.length - 1 : index;
-        }
-
-        private static int binarySearchInsertionPoint(int index) {
-            if (index < 0) {
-                index = -(index + 1);
-            }
-            return index;
-        }
-
-        static int bucketToSize(int sizeBucket) {
-            return HISTO_BUCKETS[sizeBucket];
-        }
-
-        private void rotateHistograms() {
-            short[][] hs = histos;
-            for (int i = 0; i < HISTO_BUCKET_COUNT; i++) {
-                sums[i] = (hs[0][i] & 0xFFFF) + (hs[1][i] & 0xFFFF) + (hs[2][i] & 0xFFFF) + (hs[3][i] & 0xFFFF);
-            }
-            int sum = 0;
-            for (int count : sums) {
-                sum  += count;
-            }
-            int targetPercentile = (int) (sum * 0.99);
-            int sizeBucket = 0;
-            for (; sizeBucket < sums.length; sizeBucket++) {
-                if (sums[sizeBucket] > targetPercentile) {
-                    break;
-                }
-                targetPercentile -= sums[sizeBucket];
-            }
-            hasHadRotation = true;
-            int percentileSize = bucketToSize(sizeBucket);
-            int prefChunkSize = Math.max(percentileSize * BUFS_PER_CHUNK, MIN_CHUNK_SIZE);
-            localUpperBufSize = percentileSize;
-            localPrefChunkSize = prefChunkSize;
-            if (shareable) {
-                for (Magazine mag : group.magazines) {
-                    HistogramChunkController statistics = (HistogramChunkController) mag.chunkController;
-                    prefChunkSize = Math.max(prefChunkSize, statistics.localPrefChunkSize);
-                }
-            }
-            if (sharedPrefChunkSize != prefChunkSize) {
-                // Preferred chunk size changed. Increase check frequency.
-                datumTarget = Math.max(datumTarget >> 1, MIN_DATUM_TARGET);
-                sharedPrefChunkSize = prefChunkSize;
-            } else {
-                // Preferred chunk size did not change. Check less often.
-                datumTarget = Math.min(datumTarget << 1, MAX_DATUM_TARGET);
-            }
-
-            histoIndex = histoIndex + 1 & 3;
-            histo = histos[histoIndex];
-            datumCount = 0;
-            Arrays.fill(histo, (short) 0);
-        }
-
-        /**
-         * Get the preferred chunk size, based on statistics from the {@linkplain #recordAllocationSize(int) recorded}
-         * allocation sizes.
-         * <p>
-         * This method must be thread-safe.
-         *
-         * @return The currently preferred chunk allocation size.
-         */
-        int preferredChunkSize() {
-            return sharedPrefChunkSize;
-        }
-
-        @Override
-        public void initializeSharedStateIn(ChunkController chunkController) {
-            HistogramChunkController statistics = (HistogramChunkController) chunkController;
-            int sharedPrefChunkSize = this.sharedPrefChunkSize;
-            statistics.localPrefChunkSize = sharedPrefChunkSize;
-            statistics.sharedPrefChunkSize = sharedPrefChunkSize;
-        }
-
-        @Override
-        public Chunk newChunkAllocation(int promptingSize, Magazine magazine) {
-            int size = Math.max(promptingSize * BUFS_PER_CHUNK, preferredChunkSize());
-            int minChunks = size / MIN_CHUNK_SIZE;
-            if (MIN_CHUNK_SIZE * minChunks < size) {
-                // Round up to nearest whole MIN_CHUNK_SIZE unit. The MIN_CHUNK_SIZE is an even multiple of many
-                // popular small page sizes, like 4k, 16k, and 64k, which makes it easier for the system allocator
-                // to manage the memory in terms of whole pages. This reduces memory fragmentation,
-                // but without the potentially high overhead that power-of-2 chunk sizes would bring.
-                size = MIN_CHUNK_SIZE * (1 + minChunks);
-            }
-
-            // Limit chunks to the max size, even if the histogram suggests to go above it.
-            size = Math.min(size, MAX_CHUNK_SIZE);
-
-            // If we haven't rotated the histogram yet, optimisticly record this chunk size as our preferred.
-            if (!hasHadRotation && sharedPrefChunkSize == MIN_CHUNK_SIZE) {
-                sharedPrefChunkSize = size;
-            }
-
-            ChunkAllocator chunkAllocator = group.chunkAllocator;
-            Chunk chunk = new Chunk(chunkAllocator.allocate(size, size), magazine, true, this);
-            chunkRegistry.add(chunk);
-            return chunk;
-        }
-
-        @Override
-        public boolean shouldReleaseChunk(int chunkSize) {
-            int preferredSize = preferredChunkSize();
-            int givenChunks = chunkSize / MIN_CHUNK_SIZE;
-            int preferredChunks = preferredSize / MIN_CHUNK_SIZE;
-            int deviation = Math.abs(givenChunks - preferredChunks);
-
-            // Retire chunks with a 5% probability per unit of MIN_CHUNK_SIZE deviation from preference.
-            return deviation != 0 &&
-                    ThreadLocalRandom.current().nextDouble() * 20.0 < deviation;
         }
     }
 

--- a/buffer/src/test/java/io/netty/buffer/AdaptivePoolingAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptivePoolingAllocatorTest.java
@@ -15,52 +15,11 @@
  */
 package io.netty.buffer;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class AdaptivePoolingAllocatorTest implements Supplier<String> {
-    private int i;
-
-    @BeforeEach
-    void setUp() {
-        i = 0;
-    }
-
-    @Override
-    public String get() {
-        return "i = " + i;
-    }
-
-    @Test
-    void sizeBucketComputations() throws Exception {
-        assertSizeBucket(0, 16 * 1024);
-        assertSizeBucket(1, 24 * 1024);
-        assertSizeBucket(2, 32 * 1024);
-        assertSizeBucket(3, 48 * 1024);
-        assertSizeBucket(4, 64 * 1024);
-        assertSizeBucket(5, 96 * 1024);
-        assertSizeBucket(6, 128 * 1024);
-        assertSizeBucket(7, 192 * 1024);
-        assertSizeBucket(8, 256 * 1024);
-        assertSizeBucket(9, 384 * 1024);
-        assertSizeBucket(10, 512 * 1024);
-        assertSizeBucket(11, 768 * 1024);
-        assertSizeBucket(12, 1024 * 1024);
-        assertSizeBucket(13, 1792 * 1024);
-        assertSizeBucket(14, 2048 * 1024);
-        assertSizeBucket(15, 3072 * 1024);
-        // The sizeBucket function will be used for sizes up to 8 MiB
-        assertSizeBucket(15, 4 * 1024 * 1024);
-        assertSizeBucket(15, 5 * 1024 * 1024);
-        assertSizeBucket(15, 6 * 1024 * 1024);
-        assertSizeBucket(15, 7 * 1024 * 1024);
-        assertSizeBucket(15, 8 * 1024 * 1024);
-    }
-
+class AdaptivePoolingAllocatorTest {
     @Test
     void sizeClassComputations() throws Exception {
         final int[] sizeClasses = AdaptivePoolingAllocator.getSizeClasses();
@@ -78,12 +37,6 @@ class AdaptivePoolingAllocatorTest implements Supplier<String> {
             int sizeToTest = size;
             assertEquals(expectedSizeClass, AdaptivePoolingAllocator.sizeClassIndexOf(size),
                          () -> "size = " + sizeToTest);
-        }
-    }
-
-    private void assertSizeBucket(int expectedSizeBucket, int maxSizeIncluded) {
-        for (; i <= maxSizeIncluded; i++) {
-            assertEquals(expectedSizeBucket, AdaptivePoolingAllocator.sizeToBucket(i), this);
         }
     }
 }


### PR DESCRIPTION
Motivation:

The histogram bump allocating chunks have poor chunk and memory reuse in practice, which leads to higher memory usage than the pooled allocator whenever an application performs enough allocations of buffers that don't fit in our size-classed chunks.

Buddy allocation should in theory reduce memory consumption by allowing memory reuse within a chunk, similar to the size-classed chunks, but for variable power-of-two sized allocations.

We've found that beyond 16k-20k buffer sizes, allocations predominantly comes in power-of-two sizes, hence buddy allocation should be a good fit for this size regime.

Modification:

* Implement a new chunk type that does buddy allocation, based on an array-embedded binary search tree.
* The tree is encoded as a dense byte array, with two bits marking node or child-node usage, and six bits to encode the node size.
* The histogram pointer-bump allocating chunk implementation is removed, which unlocks potential simplifications and optimizations that will benefit both buddy and size-classed chunks.
* The 32k and 64k size classes are kept for the time being, to keep chunk churn under control, but they are planned to be removed in a follow-up PR.

Result:

We generally get improvements to memory usage, because the buddy allocator is able to reuse its chunks before they are fully deallocated.
If the 32k and 64k size-classes are removed, then the improvements continue to hold up, but we see an increase in allocation churn for buddy chunks.
This needs to be investigated and solved before we can remove the 32k and 64k size-classes.
Presumably, it comes down to making better decisions about the size of the buddy chunks, and in picking which chunks to allocate from next once a magazine has exhausted its current chunk.