### PR TITLE
Avoid non-portable malloc-of-zero behavior

### DIFF
--- a/common/src/main/java/io/netty/util/internal/CleanerJava24Linker.java
+++ b/common/src/main/java/io/netty/util/internal/CleanerJava24Linker.java
@@ -206,7 +206,9 @@ public class CleanerJava24Linker implements Cleaner {
     static long malloc(int capacity) {
         final long addr;
         try {
-            addr = (long) INVOKE_MALLOC.invokeExact((long) capacity);
+            // Always allocate at least 1 byte, to avoid relying on non-portable behavior
+            // of malloc(3) for zero size allocations.
+            addr = (long) INVOKE_MALLOC.invokeExact(Math.max(capacity, 1L));
         } catch (Throwable e) {
             throw new Error(e); // Should not happen.
         }


### PR DESCRIPTION
Motivation:
POSIX permits malloc with a zero size parameter to either return NULL or a unique pointer. To avoid relying on non-portable behavior, we should always allocate at least one byte. This will always give us a unique pointer, which we can pass to free later.

Modification:
When linking directly to malloc, always allocate at least one byte.

Result:
Fixes https://github.com/netty/netty/issues/16054