### PR TITLE
Improve exception message generated by `EnhancingX509ExtendedTrustManager`

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/EnhancingX509ExtendedTrustManager.java
+++ b/handler/src/main/java/io/netty/handler/ssl/EnhancingX509ExtendedTrustManager.java
@@ -36,6 +36,7 @@ final class EnhancingX509ExtendedTrustManager extends X509ExtendedTrustManager {
 
     // Constants for subject alt names of type DNS and IP. See X509Certificate#getSubjectAlternativeNames() javadocs.
     static final int ALTNAME_DNS = 2;
+    static final int ALTNAME_URI = 6;
     static final int ALTNAME_IP = 7;
     private static final String SEPARATOR = ", ";
 
@@ -106,7 +107,7 @@ final class EnhancingX509ExtendedTrustManager extends X509ExtendedTrustManager {
                 (message.startsWith("No subject alternative") || message.startsWith("No name matching"))) {
             StringBuilder sb = new StringBuilder(128);
             sb.append(message);
-            // Some exception messages from sun.security.util.HostnameChecker do not end witha dot.
+            // Some exception messages from sun.security.util.HostnameChecker do not end with a dot.
             if (message.charAt(message.length() - 1) != '.') {
                 sb.append('.');
             }
@@ -119,10 +120,20 @@ final class EnhancingX509ExtendedTrustManager extends X509ExtendedTrustManager {
                     boolean hasNames = false;
                     for (List<?> altNames : collection) {
                         final int nameType = ((Integer) altNames.get(0)).intValue();
-                        if (nameType == ALTNAME_DNS || nameType == ALTNAME_IP) {
-                            sb.append((String) altNames.get(1)).append(SEPARATOR);
-                            hasNames = true;
+                        if (nameType == ALTNAME_DNS) {
+                            sb.append("DNS");
+                        } else if (nameType == ALTNAME_IP) {
+                            sb.append("IP");
+                        } else if (nameType == ALTNAME_URI) {
+                            // URI names are common in some environments with gRPC services that use SPIFFEs.
+                            // Though the hostname matcher won't be looking at them, having them there can help
+                            // debugging cases where hostname verification was enabled when it shouldn't be.
+                            sb.append("URI");
+                        } else {
+                            continue;
                         }
+                        sb.append(':').append((String) altNames.get(1)).append(SEPARATOR);
+                        hasNames = true;
                     }
                     if (hasNames) {
                         // Strip of the last separator

--- a/handler/src/main/java/io/netty/handler/ssl/EnhancingX509ExtendedTrustManager.java
+++ b/handler/src/main/java/io/netty/handler/ssl/EnhancingX509ExtendedTrustManager.java
@@ -165,7 +165,7 @@ final class EnhancingX509ExtendedTrustManager extends X509ExtendedTrustManager {
         if (!(session instanceof ExtendedSSLSession)) {
             return null;
         }
-        List<SNIServerName> names = ((ExtendedSSLSession)session).getRequestedServerNames();
+        List<SNIServerName> names = ((ExtendedSSLSession) session).getRequestedServerNames();
         for (SNIServerName sni : names) {
             if (sni instanceof SNIHostName) {
                 SNIHostName hostName = (SNIHostName) sni;

--- a/handler/src/main/java/io/netty/handler/ssl/EnhancingX509ExtendedTrustManager.java
+++ b/handler/src/main/java/io/netty/handler/ssl/EnhancingX509ExtendedTrustManager.java
@@ -21,15 +21,24 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Collection;
 import java.util.List;
+import javax.naming.ldap.LdapName;
+import javax.naming.ldap.Rdn;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.X509ExtendedTrustManager;
 import javax.net.ssl.X509TrustManager;
+import javax.security.auth.x500.X500Principal;
 
 /**
  * Wraps an existing {@link X509ExtendedTrustManager} and enhances the {@link CertificateException} that is thrown
  * because of hostname validation.
  */
 final class EnhancingX509ExtendedTrustManager extends X509ExtendedTrustManager {
+
+    // Constants for subject alt names of type DNS and IP. See X509Certificate#getSubjectAlternativeNames() javadocs.
+    static final int ALTNAME_DNS = 2;
+    static final int ALTNAME_IP = 7;
+    private static final String SEPARATOR = ", ";
+
     private final X509ExtendedTrustManager wrapped;
 
     EnhancingX509ExtendedTrustManager(X509TrustManager wrapped) {
@@ -93,28 +102,55 @@ final class EnhancingX509ExtendedTrustManager extends X509ExtendedTrustManager {
             throws CertificateException {
         // Matching the message is the best we can do sadly.
         String message = e.getMessage();
-        if (message != null && e.getMessage().startsWith("No subject alternative DNS name matching")) {
-            StringBuilder names = new StringBuilder(64);
+        if (message != null &&
+                (message.startsWith("No subject alternative") || message.startsWith("No name matching"))) {
+            StringBuilder sb = new StringBuilder(128);
+            sb.append(message);
+            // Some exception messages from sun.security.util.HostnameChecker do not end witha dot.
+            if (message.charAt(message.length() - 1) != '.') {
+                sb.append('.');
+            }
+            sb.append(" Chain of ").append(chain.length).append(" certificate(s):");
             for (int i = 0; i < chain.length; i++) {
                 X509Certificate cert = chain[i];
                 Collection<List<?>> collection = cert.getSubjectAlternativeNames();
+                sb.append(' ').append(i + 1).append(". subjectAlternativeNames=[");
                 if (collection != null) {
+                    boolean hasNames = false;
                     for (List<?> altNames : collection) {
-                        // 2 is dNSName. See X509Certificate javadocs.
-                        if (altNames.size() >= 2 && ((Integer) altNames.get(0)).intValue() == 2) {
-                            names.append((String) altNames.get(1)).append(",");
+                        final int nameType = ((Integer) altNames.get(0)).intValue();
+                        if (nameType == ALTNAME_DNS || nameType == ALTNAME_IP) {
+                            sb.append((String) altNames.get(1)).append(SEPARATOR);
+                            hasNames = true;
                         }
                     }
+                    if (hasNames) {
+                        // Strip of the last separator
+                        sb.setLength(sb.length() - SEPARATOR.length());
+                    }
                 }
+                sb.append("], CN=").append(getCommonName(cert)).append('.');
             }
-            if (names.length() != 0) {
-                // Strip of ,
-                names.setLength(names.length() - 1);
-                throw new CertificateException(message +
-                        " Subject alternative DNS names in the certificate chain of " + chain.length +
-                        " certificate(s): " + names, e);
-            }
+            throw new CertificateException(sb.toString(), e);
         }
         throw e;
+    }
+
+    private static String getCommonName(X509Certificate cert) {
+        try {
+            // 1. Get the X500Principal (better than getSubjectDN which is implementation dependent and deprecated)
+            X500Principal principal = cert.getSubjectX500Principal();
+            // 2. Parse the DN using LdapName
+            LdapName ldapName = new LdapName(principal.getName());
+            // 3. Iterate over the Relative Distinguished Names (RDNs) to find CN
+            for (Rdn rdn : ldapName.getRdns()) {
+                if (rdn.getType().equalsIgnoreCase("CN")) {
+                    return rdn.getValue().toString();
+                }
+            }
+        } catch (Exception e) {
+            // ignore
+        }
+        return "null";
     }
 }

--- a/handler/src/main/java/io/netty/handler/ssl/EnhancingX509ExtendedTrustManager.java
+++ b/handler/src/main/java/io/netty/handler/ssl/EnhancingX509ExtendedTrustManager.java
@@ -23,7 +23,12 @@ import java.util.Collection;
 import java.util.List;
 import javax.naming.ldap.LdapName;
 import javax.naming.ldap.Rdn;
+import javax.net.ssl.ExtendedSSLSession;
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocket;
 import javax.net.ssl.X509ExtendedTrustManager;
 import javax.net.ssl.X509TrustManager;
 import javax.security.auth.x500.X500Principal;
@@ -58,7 +63,8 @@ final class EnhancingX509ExtendedTrustManager extends X509ExtendedTrustManager {
         try {
             wrapped.checkServerTrusted(chain, authType, socket);
         } catch (CertificateException e) {
-            throwEnhancedCertificateException(chain, e);
+            throwEnhancedCertificateException(e, chain,
+                    socket instanceof SSLSocket ? ((SSLSocket) socket).getHandshakeSession() : null);
         }
     }
 
@@ -74,7 +80,7 @@ final class EnhancingX509ExtendedTrustManager extends X509ExtendedTrustManager {
         try {
             wrapped.checkServerTrusted(chain, authType, engine);
         } catch (CertificateException e) {
-            throwEnhancedCertificateException(chain, e);
+            throwEnhancedCertificateException(e, chain, engine != null ? engine.getHandshakeSession() : null);
         }
     }
 
@@ -90,7 +96,7 @@ final class EnhancingX509ExtendedTrustManager extends X509ExtendedTrustManager {
         try {
             wrapped.checkServerTrusted(chain, authType);
         } catch (CertificateException e) {
-            throwEnhancedCertificateException(chain, e);
+            throwEnhancedCertificateException(e, chain, null);
         }
     }
 
@@ -99,19 +105,23 @@ final class EnhancingX509ExtendedTrustManager extends X509ExtendedTrustManager {
         return wrapped.getAcceptedIssuers();
     }
 
-    private static void throwEnhancedCertificateException(X509Certificate[] chain, CertificateException e)
-            throws CertificateException {
+    private static void throwEnhancedCertificateException(CertificateException e, X509Certificate[] chain,
+                                                          SSLSession session) throws CertificateException {
         // Matching the message is the best we can do sadly.
         String message = e.getMessage();
         if (message != null &&
                 (message.startsWith("No subject alternative") || message.startsWith("No name matching"))) {
             StringBuilder sb = new StringBuilder(128);
             sb.append(message);
-            // Some exception messages from sun.security.util.HostnameChecker do not end with a dot.
-            if (message.charAt(message.length() - 1) != '.') {
-                sb.append('.');
+            // Some exception messages from sun.security.util.HostnameChecker may end with a dot that we don't need
+            if (message.charAt(message.length() - 1) == '.') {
+                sb.setLength(sb.length() - 1);
             }
-            sb.append(" Chain of ").append(chain.length).append(" certificate(s):");
+            if (session != null) {
+                sb.append(" for SNIHostName=").append(getSNIHostName(session))
+                        .append(" and peerHost=").append(session.getPeerHost());
+            }
+            sb.append(" in the chain of ").append(chain.length).append(" certificate(s):");
             for (int i = 0; i < chain.length; i++) {
                 X509Certificate cert = chain[i];
                 Collection<List<?>> collection = cert.getSubjectAlternativeNames();
@@ -149,6 +159,20 @@ final class EnhancingX509ExtendedTrustManager extends X509ExtendedTrustManager {
             throw new CertificateException(sb.toString(), e);
         }
         throw e;
+    }
+
+    private static String getSNIHostName(SSLSession session) {
+        if (!(session instanceof ExtendedSSLSession)) {
+            return null;
+        }
+        List<SNIServerName> names = ((ExtendedSSLSession)session).getRequestedServerNames();
+        for (SNIServerName sni : names) {
+            if (sni instanceof SNIHostName) {
+                SNIHostName hostName = (SNIHostName) sni;
+                return hostName.getAsciiName();
+            }
+        }
+        return null;
     }
 
     private static String getCommonName(X509Certificate cert) {

--- a/handler/src/main/java/io/netty/handler/ssl/EnhancingX509ExtendedTrustManager.java
+++ b/handler/src/main/java/io/netty/handler/ssl/EnhancingX509ExtendedTrustManager.java
@@ -119,6 +119,10 @@ final class EnhancingX509ExtendedTrustManager extends X509ExtendedTrustManager {
                 if (collection != null) {
                     boolean hasNames = false;
                     for (List<?> altNames : collection) {
+                        if (altNames.size() < 2) {
+                            // We expect at least a pair of 'nameType:value' in that list.
+                            continue;
+                        }
                         final int nameType = ((Integer) altNames.get(0)).intValue();
                         if (nameType == ALTNAME_DNS) {
                             sb.append("DNS");

--- a/handler/src/main/java/io/netty/handler/ssl/EnhancingX509ExtendedTrustManager.java
+++ b/handler/src/main/java/io/netty/handler/ssl/EnhancingX509ExtendedTrustManager.java
@@ -148,7 +148,7 @@ final class EnhancingX509ExtendedTrustManager extends X509ExtendedTrustManager {
                     return rdn.getValue().toString();
                 }
             }
-        } catch (Exception e) {
+        } catch (Exception ignore) {
             // ignore
         }
         return "null";

--- a/handler/src/test/java/io/netty/handler/ssl/EnhancedX509ExtendedTrustManagerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/EnhancedX509ExtendedTrustManagerTest.java
@@ -19,11 +19,9 @@ package io.netty.handler.ssl;
 import io.netty.util.internal.EmptyArrays;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLSocket;
-import javax.net.ssl.X509ExtendedTrustManager;
 import java.math.BigInteger;
 import java.net.Socket;
 import java.security.Principal;
@@ -35,20 +33,38 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.X509ExtendedTrustManager;
+import javax.security.auth.x500.X500Principal;
 
+import static io.netty.handler.ssl.EnhancingX509ExtendedTrustManager.ALTNAME_DNS;
+import static io.netty.handler.ssl.EnhancingX509ExtendedTrustManager.ALTNAME_IP;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Named.named;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 public class EnhancedX509ExtendedTrustManagerTest {
+
+    private static final String SAN_ENTRY_DNS = "some.netty.io";
+    private static final String SAN_ENTRY_IP = "127.0.0.1";
+    private static final String COMMON_NAME = "leaf.netty.io";
 
     private static final X509Certificate TEST_CERT = new X509Certificate() {
 
         @Override
         public Collection<List<?>> getSubjectAlternativeNames() {
-            return Arrays.asList(Arrays.asList(1, new Object()), Arrays.asList(2, "some.netty.io"));
+            return Arrays.asList(Arrays.asList(1, new Object()),
+                    Arrays.asList(ALTNAME_DNS, "some.netty.io"), Arrays.asList(ALTNAME_IP, "127.0.0.1"));
+        }
+
+        @Override
+        public X500Principal getSubjectX500Principal() {
+            return new X500Principal("CN=" + COMMON_NAME + ", O=Netty");
         }
 
         @Override
@@ -223,23 +239,23 @@ public class EnhancedX509ExtendedTrustManagerTest {
         }
     });
 
-    static List<Executable> throwingMatchingExecutables() {
-        return Arrays.asList(new Executable() {
+    static List<Arguments> throwingMatchingExecutables() {
+        return Arrays.asList(arguments(named("checkServerTrusted", new Executable() {
             @Override
             public void execute() throws Throwable {
                 MATCHING_MANAGER.checkServerTrusted(new X509Certificate[] { TEST_CERT }, null);
             }
-        }, new Executable() {
+        })), arguments(named("checkServerTrusted with SSLEngine", new Executable() {
             @Override
             public void execute() throws Throwable {
                 MATCHING_MANAGER.checkServerTrusted(new X509Certificate[] { TEST_CERT }, null, (SSLEngine) null);
             }
-        }, new Executable() {
+        })), arguments(named("checkServerTrusted with SSLSocket", new Executable() {
             @Override
             public void execute() throws Throwable {
                 MATCHING_MANAGER.checkServerTrusted(new X509Certificate[] { TEST_CERT }, null, (SSLSocket) null);
             }
-        });
+        })));
     }
 
     private static final EnhancingX509ExtendedTrustManager NON_MATCHING_MANAGER =
@@ -286,23 +302,23 @@ public class EnhancedX509ExtendedTrustManagerTest {
                 }
             });
 
-    static List<Executable> throwingNonMatchingExecutables() {
-        return Arrays.asList(new Executable() {
+    static List<Arguments> throwingNonMatchingExecutables() {
+        return Arrays.asList(arguments(named("checkServerTrusted", new Executable() {
             @Override
             public void execute() throws Throwable {
                 NON_MATCHING_MANAGER.checkServerTrusted(new X509Certificate[] { TEST_CERT }, null);
             }
-        }, new Executable() {
+        })), arguments(named("checkServerTrusted with SSLEngine", new Executable() {
             @Override
             public void execute() throws Throwable {
                 NON_MATCHING_MANAGER.checkServerTrusted(new X509Certificate[] { TEST_CERT }, null, (SSLEngine) null);
             }
-        }, new Executable() {
+        })), arguments(named("checkServerTrusted with SSLSocket", new Executable() {
             @Override
             public void execute() throws Throwable {
                 NON_MATCHING_MANAGER.checkServerTrusted(new X509Certificate[] { TEST_CERT }, null, (SSLSocket) null);
             }
-        });
+        })));
     }
 
     @ParameterizedTest
@@ -311,7 +327,10 @@ public class EnhancedX509ExtendedTrustManagerTest {
         CertificateException exception = assertThrows(CertificateException.class, executable);
         // We should wrap the original cause with our own.
         assertInstanceOf(CertificateException.class, exception.getCause());
-        assertThat(exception.getMessage()).contains("some.netty.io");
+        String message = exception.getMessage();
+        assertThat(message).contains(SAN_ENTRY_DNS);
+        assertThat(message).contains(SAN_ENTRY_IP);
+        assertThat(message).contains("CN=" + COMMON_NAME);
     }
 
     @ParameterizedTest

--- a/handler/src/test/java/io/netty/handler/ssl/EnhancedX509ExtendedTrustManagerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/EnhancedX509ExtendedTrustManagerTest.java
@@ -40,6 +40,7 @@ import javax.security.auth.x500.X500Principal;
 
 import static io.netty.handler.ssl.EnhancingX509ExtendedTrustManager.ALTNAME_DNS;
 import static io.netty.handler.ssl.EnhancingX509ExtendedTrustManager.ALTNAME_IP;
+import static io.netty.handler.ssl.EnhancingX509ExtendedTrustManager.ALTNAME_URI;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -52,6 +53,8 @@ public class EnhancedX509ExtendedTrustManagerTest {
 
     private static final String SAN_ENTRY_DNS = "some.netty.io";
     private static final String SAN_ENTRY_IP = "127.0.0.1";
+    private static final String SAN_ENTRY_URI = "URI:https://uri.netty.io/profile";
+    private static final String SAN_ENTRY_RFC822 = "info@netty.io";
     private static final String COMMON_NAME = "leaf.netty.io";
 
     private static final X509Certificate TEST_CERT = new X509Certificate() {
@@ -59,7 +62,8 @@ public class EnhancedX509ExtendedTrustManagerTest {
         @Override
         public Collection<List<?>> getSubjectAlternativeNames() {
             return Arrays.asList(Arrays.asList(1, new Object()),
-                    Arrays.asList(ALTNAME_DNS, "some.netty.io"), Arrays.asList(ALTNAME_IP, "127.0.0.1"));
+                    Arrays.asList(ALTNAME_DNS, SAN_ENTRY_DNS), Arrays.asList(ALTNAME_IP, SAN_ENTRY_IP),
+                    Arrays.asList(ALTNAME_URI, SAN_ENTRY_URI), Arrays.asList(1 /* rfc822Name */, SAN_ENTRY_RFC822));
         }
 
         @Override
@@ -328,9 +332,11 @@ public class EnhancedX509ExtendedTrustManagerTest {
         // We should wrap the original cause with our own.
         assertInstanceOf(CertificateException.class, exception.getCause());
         String message = exception.getMessage();
-        assertThat(message).contains(SAN_ENTRY_DNS);
-        assertThat(message).contains(SAN_ENTRY_IP);
+        assertThat(message).contains("DNS:" + SAN_ENTRY_DNS);
+        assertThat(message).contains("IP:" + SAN_ENTRY_IP);
+        assertThat(message).contains("URI:" + SAN_ENTRY_URI);
         assertThat(message).contains("CN=" + COMMON_NAME);
+        assertThat(message).doesNotContain(SAN_ENTRY_RFC822);
     }
 
     @ParameterizedTest

--- a/handler/src/test/java/io/netty/handler/ssl/EnhancedX509ExtendedTrustManagerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/EnhancedX509ExtendedTrustManagerTest.java
@@ -17,10 +17,12 @@
 package io.netty.handler.ssl;
 
 import io.netty.util.internal.EmptyArrays;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
 
 import java.math.BigInteger;
 import java.net.Socket;
@@ -33,7 +35,10 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
+import javax.net.ssl.ExtendedSSLSession;
+import javax.net.ssl.SNIHostName;
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.X509ExtendedTrustManager;
 import javax.security.auth.x500.X500Principal;
@@ -51,6 +56,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 public class EnhancedX509ExtendedTrustManagerTest {
 
+    private static final String HOSTNAME = "netty.io";
     private static final String SAN_ENTRY_DNS = "some.netty.io";
     private static final String SAN_ENTRY_IP = "127.0.0.1";
     private static final String SAN_ENTRY_URI = "URI:https://uri.netty.io/profile";
@@ -212,7 +218,7 @@ public class EnhancedX509ExtendedTrustManagerTest {
         @Override
         public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket)
                 throws CertificateException {
-            throw new CertificateException("No subject alternative DNS name matching netty.io.");
+            throw newCertificateExceptionWithMatchingMessage();
         }
 
         @Override
@@ -223,7 +229,7 @@ public class EnhancedX509ExtendedTrustManagerTest {
         @Override
         public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine)
                 throws CertificateException {
-            throw new CertificateException("No subject alternative DNS name matching netty.io.");
+            throw newCertificateExceptionWithMatchingMessage();
         }
 
         @Override
@@ -234,12 +240,16 @@ public class EnhancedX509ExtendedTrustManagerTest {
         @Override
         public void checkServerTrusted(X509Certificate[] chain, String authType)
                 throws CertificateException {
-            throw new CertificateException("No subject alternative DNS name matching netty.io.");
+            throw newCertificateExceptionWithMatchingMessage();
         }
 
         @Override
         public X509Certificate[] getAcceptedIssuers() {
             return new X509Certificate[0];
+        }
+
+        private CertificateException newCertificateExceptionWithMatchingMessage() {
+            return new CertificateException("No subject alternative DNS name matching " + HOSTNAME + " found.");
         }
     });
 
@@ -252,14 +262,27 @@ public class EnhancedX509ExtendedTrustManagerTest {
         })), arguments(named("checkServerTrusted with SSLEngine", new Executable() {
             @Override
             public void execute() throws Throwable {
-                MATCHING_MANAGER.checkServerTrusted(new X509Certificate[] { TEST_CERT }, null, (SSLEngine) null);
+                SSLSession session = mockSSLSession();
+                SSLEngine engine = Mockito.mock(SSLEngine.class);
+                Mockito.when(engine.getHandshakeSession()).thenReturn(session);
+                MATCHING_MANAGER.checkServerTrusted(new X509Certificate[] { TEST_CERT }, null, engine);
             }
         })), arguments(named("checkServerTrusted with SSLSocket", new Executable() {
             @Override
             public void execute() throws Throwable {
-                MATCHING_MANAGER.checkServerTrusted(new X509Certificate[] { TEST_CERT }, null, (SSLSocket) null);
+                SSLSession session = mockSSLSession();
+                SSLSocket socket = Mockito.mock(SSLSocket.class);
+                Mockito.when(socket.getHandshakeSession()).thenReturn(session);
+                MATCHING_MANAGER.checkServerTrusted(new X509Certificate[] { TEST_CERT }, null, socket);
             }
         })));
+    }
+
+    private static SSLSession mockSSLSession() {
+        ExtendedSSLSession session = Mockito.mock(ExtendedSSLSession.class);
+        Mockito.when(session.getRequestedServerNames()).thenReturn(Arrays.asList(new SNIHostName(HOSTNAME)));
+        Mockito.when(session.getPeerHost()).thenReturn(HOSTNAME);
+        return session;
     }
 
     private static final EnhancingX509ExtendedTrustManager NON_MATCHING_MANAGER =
@@ -327,11 +350,16 @@ public class EnhancedX509ExtendedTrustManagerTest {
 
     @ParameterizedTest
     @MethodSource("throwingMatchingExecutables")
-    void testEnhanceException(Executable executable)  {
+    void testEnhanceException(Executable executable, TestInfo testInfo)  {
         CertificateException exception = assertThrows(CertificateException.class, executable);
         // We should wrap the original cause with our own.
         assertInstanceOf(CertificateException.class, exception.getCause());
         String message = exception.getMessage();
+        if (testInfo.getDisplayName().contains("with")) {
+            // The following data can be extracted only when we run the test with SSLEngine or SSLSocket:
+            assertThat(message).contains("SNIHostName=" + HOSTNAME);
+            assertThat(message).contains("peerHost=" + HOSTNAME);
+        }
         assertThat(message).contains("DNS:" + SAN_ENTRY_DNS);
         assertThat(message).contains("IP:" + SAN_ENTRY_IP);
         assertThat(message).contains("URI:" + SAN_ENTRY_URI);


### PR DESCRIPTION
Motivation:

This is an improvement for the feature introduced in #13381:
1. Include IP addresses in case matching happens via `HostnameChecker.matchIP`.
2. Include `URI` entries to detect when hostname verification should be disabled.
3. Include common name in case verification fallbacks to `CN` from subject.
4. Include both SNI hostname and peerHost to observe what was used for both paths inside `HostnameChecker`.
5. Split entries by cert in the chain.
6. Catch more use-cases (exception messages) coming from `HostnameChecker`.

Modifications:
- Enhance `EnhancingX509ExtendedTrustManager.throwEnhancedCertificateException` to include DNS, IP, URI types of SAN entries, CN as well as SNI hostname and peerHost.
- Modify tests to assert new behavior.

Result:

More details in the exception message related to full logic of `HostnameChecker`. Example:
```
No subject alternative DNS name matching netty.io found for SNIHostName=netty.io and peerHost=netty.io in the chain of 1 certificate(s): 1. subjectAlternativeNames=[DNS:some.netty.io, IP:127.0.0.1, URI:URI:https://uri.netty.io/profile], CN=leaf.netty.io.
```