### PR TITLE
allocation free AdaptiveByteBuf::setBytes(byte[])

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -1679,8 +1679,13 @@ final class AdaptivePoolingAllocator {
         @Override
         public ByteBuf setBytes(int index, byte[] src, int srcIndex, int length) {
             checkIndex(index, length);
-            ByteBuffer tmp = (ByteBuffer) internalNioBuffer().clear().position(index);
-            tmp.put(src, srcIndex, length);
+            if (tmpNioBuf == null && PlatformDependent.javaVersion() >= 13) {
+                ByteBuffer dstBuffer = rootParent()._internalNioBuffer();
+                PlatformDependent.absolutePut(dstBuffer, idx(index), src, srcIndex, length);
+            } else {
+                ByteBuffer tmp = (ByteBuffer) internalNioBuffer().clear().position(index);
+                tmp.put(src, srcIndex, length);
+            }
             return this;
         }
 

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -1064,8 +1064,18 @@ public final class PlatformDependent {
         }
     }
 
+    public static ByteBuffer absolutePut(ByteBuffer dst, int dstOffset, byte[] src, int srcOffset, int length) {
+        if (PlatformDependent0.hasAbsolutePutArrayMethod()) {
+            return PlatformDependent0.absolutePut(dst, dstOffset, src, srcOffset, length);
+        } else {
+            ByteBuffer tmp = (ByteBuffer) dst.duplicate().clear().position(dstOffset).limit(dstOffset + length);
+            tmp.put(ByteBuffer.wrap(src, srcOffset, length));
+            return dst;
+        }
+    }
+
     public static ByteBuffer absolutePut(ByteBuffer dst, int dstOffset, ByteBuffer src, int srcOffset, int length) {
-        if (PlatformDependent0.hasAbsolutePutMethod()) {
+        if (PlatformDependent0.hasAbsolutePutBufferMethod()) {
             return PlatformDependent0.absolutePut(dst, dstOffset, src, srcOffset, length);
         } else {
             ByteBuffer a = (ByteBuffer) dst.duplicate().clear().position(dstOffset).limit(dstOffset + length);


### PR DESCRIPTION
Motivation:
The adaptive buffer's setBytes(byte[]) method requires the underlying internal NIO buffer to be materialized, but temporary buffers (which won't get flushed to the network) are not granted to have it, causing an unwanted allocation

Modification:
Java 13 expose ad-hoc method which allow using the root parent NIO buffer, saving materializing the internal NIO buffer.

Result:
Cheaper setBytes