### PR TITLE
Fix javadocs as Channel*Handler is now an interface

### DIFF
--- a/transport/src/main/java/io/netty/channel/ChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandlerContext.java
@@ -42,7 +42,7 @@ import io.netty.util.AttributeKey;
  * You can keep the {@link ChannelHandlerContext} for later use, such as
  * triggering an event outside the handler methods, even from a different thread.
  * <pre>
- * public class MyHandler extends {@link ChannelHandler} {
+ * public class MyHandler implements {@link ChannelHandler} {
  *
  *     <b>private {@link ChannelHandlerContext} ctx;</b>
  *

--- a/transport/src/main/java/io/netty/channel/ChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/ChannelPipeline.java
@@ -156,7 +156,7 @@ import java.util.NoSuchElementException;
  * and the following example shows how the event propagation is usually done:
  *
  * <pre>
- * public class MyInboundHandler extends {@link ChannelInboundHandler} {
+ * public class MyInboundHandler implements {@link ChannelInboundHandler} {
  *     {@code @Override}
  *     public void channelActive({@link ChannelHandlerContext} ctx) {
  *         System.out.println("Connected!");
@@ -164,7 +164,7 @@ import java.util.NoSuchElementException;
  *     }
  * }
  *
- * public class MyOutboundHandler extends {@link ChannelOutboundHandler} {
+ * public class MyOutboundHandler implements {@link ChannelOutboundHandler} {
  *     {@code @Override}
  *     public void close({@link ChannelHandlerContext} ctx, {@link ChannelPromise} promise) {
  *         System.out.println("Closing ..");


### PR DESCRIPTION
Motivation:

Our javadocs still used extends for code examples while implements is correct now

Modifications:

Replace extends by implements

Result:

Correct code examples in javadocs