### PR TITLE
Channel*Invoker: Remove self return and just return void

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicChannel.java
@@ -52,12 +52,6 @@ import java.net.SocketAddress;
  */
 public interface QuicChannel extends Channel {
 
-    @Override
-    QuicChannel read();
-
-    @Override
-    QuicChannel flush();
-
     /**
      * Returns the used {@link SSLEngine} or {@code null} if none is used (yet).
      *

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicStreamChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicStreamChannel.java
@@ -99,10 +99,4 @@ public interface QuicStreamChannel extends Channel {
 
     @Override
     QuicChannel parent();
-
-    @Override
-    QuicStreamChannel read();
-
-    @Override
-    QuicStreamChannel flush();
 }

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicChannel.java
@@ -445,18 +445,6 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     }
 
     @Override
-    public QuicChannel flush() {
-        super.flush();
-        return this;
-    }
-
-    @Override
-    public QuicChannel read() {
-        super.read();
-        return this;
-    }
-
-    @Override
     public void createStream(QuicStreamType type, @Nullable ChannelHandler handler,
                              Promise<QuicStreamChannel> promise) {
         if (executor().inEventLoop()) {

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicStreamChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicStreamChannel.java
@@ -195,18 +195,6 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
     }
 
     @Override
-    public QuicStreamChannel flush() {
-        pipeline.flush();
-        return this;
-    }
-
-    @Override
-    public QuicStreamChannel read() {
-        pipeline.read();
-        return this;
-    }
-
-    @Override
     public ChannelConfig config() {
         return config;
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
@@ -111,9 +111,9 @@ class WebSocketClientProtocolHandshakeHandler implements ChannelInboundHandler {
                 }
 
                 if (localHandshakePromise.tryFailure(new WebSocketClientHandshakeException("handshake timed out"))) {
-                    ctx.flush()
-                       .fireUserEventTriggered(ClientHandshakeStateEvent.HANDSHAKE_TIMEOUT)
-                       .close();
+                    ctx.flush();
+                    ctx.fireUserEventTriggered(ClientHandshakeStateEvent.HANDSHAKE_TIMEOUT);
+                    ctx.close();
                 }
             }
         }, handshakeTimeoutMillis, TimeUnit.MILLISECONDS);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
@@ -146,9 +146,9 @@ class WebSocketServerProtocolHandshakeHandler implements ChannelInboundHandler {
             public void run() {
                 if (!localHandshakePromise.isDone() &&
                     localHandshakePromise.tryFailure(new WebSocketServerHandshakeException("handshake timed out"))) {
-                    ctx.flush()
-                       .fireUserEventTriggered(ServerHandshakeStateEvent.HANDSHAKE_TIMEOUT)
-                       .close();
+                    ctx.flush();
+                    ctx.fireUserEventTriggered(ServerHandshakeStateEvent.HANDSHAKE_TIMEOUT);
+                    ctx.close();
                 }
             }
         }, handshakeTimeoutMillis, TimeUnit.MILLISECONDS);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
@@ -458,18 +458,6 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
     }
 
     @Override
-    public Channel read() {
-        pipeline().read();
-        return this;
-    }
-
-    @Override
-    public Channel flush() {
-        pipeline().flush();
-        return this;
-    }
-
-    @Override
     public Future<Void> bind(SocketAddress localAddress) {
         return pipeline().bind(localAddress);
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
@@ -238,13 +238,10 @@ public class DefaultHttp2ConnectionDecoderTest {
         decode(decoder).onSettingsAckRead(ctx);
 
         // Disallow any further flushes now that settings ACK has been sent
-        when(ctx.flush()).then(new Answer<ChannelHandlerContext>() {
-            @Override
-            public ChannelHandlerContext answer(InvocationOnMock invocationOnMock) {
-                fail();
-                return null;
-            }
-        });
+        doAnswer(invocationOnMock -> {
+            fail();
+            return null;
+        }).when(ctx).flush();
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
@@ -200,13 +200,10 @@ public class DefaultHttp2ConnectionEncoderTest {
                 return newSucceededFuture();
             }
         }).when(ctx).newSucceededFuture(eq(null));
-        when(ctx.flush()).thenAnswer(new Answer<ChannelHandlerContext>() {
-            @Override
-            public ChannelHandlerContext answer(InvocationOnMock invocationOnMock) {
-                fail("forbidden");
-                return null;
-            }
-        });
+        doAnswer(invocationOnMock -> {
+            fail("forbidden");
+            return null;
+        }).when(ctx).flush();
         when(channel.alloc()).thenReturn(PooledByteBufAllocator.DEFAULT);
 
         // Use a server-side connection so we can test server push.

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -44,8 +45,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 /**
  * Tests for {@link DefaultHttp2LocalFlowController}.
@@ -81,21 +80,11 @@ public class DefaultHttp2LocalFlowControllerTest {
     private void setupChannelHandlerContext(boolean allowFlush) {
         reset(ctx);
         when(ctx.newPromise()).thenReturn(promise);
-        if (allowFlush) {
-            when(ctx.flush()).then(new Answer<ChannelHandlerContext>() {
-                @Override
-                public ChannelHandlerContext answer(InvocationOnMock invocationOnMock) {
-                    return ctx;
-                }
-            });
-        } else {
-            when(ctx.flush()).then(new Answer<ChannelHandlerContext>() {
-                @Override
-                public ChannelHandlerContext answer(InvocationOnMock invocationOnMock) {
-                    fail("forbidden");
-                    return null;
-                }
-            });
+        if (!allowFlush) {
+            doAnswer(invocationOnMock -> {
+                fail("forbidden");
+                return null;
+            }).when(ctx).flush();
         }
         when(ctx.executor()).thenReturn(executor);
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
@@ -43,6 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.atLeastOnce;
@@ -94,7 +95,10 @@ public abstract class DefaultHttp2RemoteFlowControllerTest {
 
         when(config.getWriteBufferWaterMark()).thenReturn(new WriteBufferWaterMark(0, Integer.MAX_VALUE));
         when(ctx.newPromise()).thenReturn(promise);
-        when(ctx.flush()).thenThrow(new AssertionFailedError("forbidden"));
+        doAnswer(invocationOnMock -> {
+            fail("forbidden");
+            return null;
+        }).when(ctx).flush();
         setChannelWritability(true);
         when(channel.config()).thenReturn(config);
         when(executor.inEventLoop()).thenReturn(true);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameInboundWriter.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameInboundWriter.java
@@ -162,63 +162,53 @@ final class Http2FrameInboundWriter {
         }
 
         @Override
-        public ChannelHandlerContext fireChannelRegistered() {
+        public void fireChannelRegistered() {
             channel.pipeline().fireChannelRegistered();
-            return this;
         }
 
         @Override
-        public ChannelHandlerContext fireChannelUnregistered() {
+        public void fireChannelUnregistered() {
             channel.pipeline().fireChannelUnregistered();
-            return this;
         }
 
         @Override
-        public ChannelHandlerContext fireChannelActive() {
+        public void fireChannelActive() {
             channel.pipeline().fireChannelActive();
-            return this;
         }
 
         @Override
-        public ChannelHandlerContext fireChannelInactive() {
+        public void fireChannelInactive() {
             channel.pipeline().fireChannelInactive();
-            return this;
         }
 
         @Override
-        public ChannelHandlerContext fireExceptionCaught(Throwable cause) {
+        public void fireExceptionCaught(Throwable cause) {
             channel.pipeline().fireExceptionCaught(cause);
-            return this;
         }
 
         @Override
-        public ChannelHandlerContext fireUserEventTriggered(Object evt) {
+        public void fireUserEventTriggered(Object evt) {
             channel.pipeline().fireUserEventTriggered(evt);
-            return this;
         }
 
         @Override
-        public ChannelHandlerContext fireChannelRead(Object msg) {
+        public void fireChannelRead(Object msg) {
             channel.pipeline().fireChannelRead(msg);
-            return this;
         }
 
         @Override
-        public ChannelHandlerContext fireChannelReadComplete() {
+        public void fireChannelReadComplete() {
             channel.pipeline().fireChannelReadComplete();
-            return this;
         }
 
         @Override
-        public ChannelHandlerContext fireChannelWritabilityChanged() {
+        public void fireChannelWritabilityChanged() {
             channel.pipeline().fireChannelWritabilityChanged();
-            return this;
         }
 
         @Override
-        public ChannelHandlerContext fireChannelShutdown(ChannelShutdownType type) {
+        public void fireChannelShutdown(ChannelShutdownType type) {
             channel.pipeline().fireChannelShutdown(type);
-            return this;
         }
 
         @Override
@@ -227,15 +217,13 @@ final class Http2FrameInboundWriter {
         }
 
         @Override
-        public ChannelHandlerContext read() {
+        public void read() {
             channel.read();
-            return this;
         }
 
         @Override
-        public ChannelHandlerContext flush() {
+        public void flush() {
             channel.pipeline().fireChannelReadComplete();
-            return this;
         }
 
         @Override

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/EmbeddedQuicChannel.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/EmbeddedQuicChannel.java
@@ -122,18 +122,6 @@ final class EmbeddedQuicChannel extends EmbeddedChannel implements QuicChannel {
     }
 
     @Override
-    public EmbeddedQuicChannel flush() {
-        super.flush();
-        return this;
-    }
-
-    @Override
-    public EmbeddedQuicChannel read() {
-        super.read();
-        return this;
-    }
-
-    @Override
     public long peerAllowedStreams(QuicStreamType type) {
         return peerAllowedStreams.getOrDefault(type, Long.MAX_VALUE);
     }

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/EmbeddedQuicStreamChannel.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/EmbeddedQuicStreamChannel.java
@@ -91,18 +91,6 @@ final class EmbeddedQuicStreamChannel extends EmbeddedChannel implements QuicStr
     }
 
     @Override
-    public EmbeddedQuicStreamChannel flush() {
-        super.flush();
-        return this;
-    }
-
-    @Override
-    public EmbeddedQuicStreamChannel read() {
-        super.read();
-        return this;
-    }
-
-    @Override
     @Nullable
     public QuicStreamPriority priority() {
         return null;

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
@@ -65,6 +65,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -110,10 +111,10 @@ public class MqttCodecTest {
         MockitoAnnotations.initMocks(this);
         when(ctx.channel()).thenReturn(channel);
         when(ctx.alloc()).thenReturn(ALLOCATOR);
-        when(ctx.fireChannelRead(any())).then((Answer<ChannelHandlerContext>) invocation -> {
-            out.add(invocation.getArguments()[0]);
-            return ctx;
-        });
+        doAnswer(invocationOnMock -> {
+            out.add(invocationOnMock.getArgument(0));
+            return null;
+        }).when(ctx).fireChannelRead(any());
         when(channel.attr(MqttCodecUtil.MQTT_VERSION_KEY)).thenReturn(versionAttrMock);
     }
 

--- a/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
@@ -1349,18 +1349,6 @@ public class PcapWriteHandlerTest {
         }
 
         @Override
-        public EmbeddedDatagramChannel flush() {
-            super.flush();
-            return this;
-        }
-
-        @Override
-        public EmbeddedDatagramChannel read() {
-            super.read();
-            return this;
-        }
-
-        @Override
         public boolean isConnected() {
             return true;
         }

--- a/microbench/src/main/java/io/netty/microbench/channel/DefaultChannelPipelineBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/channel/DefaultChannelPipelineBenchmark.java
@@ -36,7 +36,6 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
-import org.openjdk.jmh.infra.Blackhole;
 
 import java.util.SplittableRandom;
 
@@ -344,28 +343,28 @@ public class DefaultChannelPipelineBenchmark extends AbstractMicrobenchmark {
 
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     @Benchmark
-    public void propagateEvent(Blackhole hole) {
+    public void propagateEvent() {
         ChannelPipeline pipeline = pipelines[pipelineCounter++ & pipelineArrayMask];
-        hole.consume(pipeline.fireChannelReadComplete());
+        pipeline.fireChannelReadComplete();
     }
 
     @OperationsPerInvocation(12)
     @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     @Benchmark()
-    public void propagateVariety(Blackhole hole) {
+    public void propagateVariety() {
         int index = pipelineCounter++ & pipelineArrayMask;
         ChannelPipeline pipeline = pipelines[index];
-        hole.consume(pipeline.fireChannelActive());             // 1
-        hole.consume(pipeline.fireChannelRead(MESSAGE));        // 2
-        hole.consume(pipeline.fireChannelRead(MESSAGE));        // 3
-        pipeline.write(MESSAGE, promises[index]);               // 4
-        hole.consume(pipeline.fireChannelRead(MESSAGE));        // 5
-        hole.consume(pipeline.fireChannelRead(MESSAGE));        // 6
-        pipeline.write(MESSAGE, promises[index]);               // 7
-        hole.consume(pipeline.fireChannelReadComplete());       // 8
-        hole.consume(pipeline.fireUserEventTriggered(MESSAGE)); // 9
-        hole.consume(pipeline.fireChannelWritabilityChanged()); // 10
-        hole.consume(pipeline.flush());                         // 11
-        hole.consume(pipeline.fireChannelInactive());           // 12
+        pipeline.fireChannelActive();             // 1
+        pipeline.fireChannelRead(MESSAGE);        // 2
+        pipeline.fireChannelRead(MESSAGE);        // 3
+        pipeline.write(MESSAGE, promises[index]); // 4
+        pipeline.fireChannelRead(MESSAGE);        // 5
+        pipeline.fireChannelRead(MESSAGE);        // 6
+        pipeline.write(MESSAGE, promises[index]); // 7
+        pipeline.fireChannelReadComplete();       // 8
+        pipeline.fireUserEventTriggered(MESSAGE); // 9
+        pipeline.fireChannelWritabilityChanged(); // 10
+        pipeline.flush();                         // 11
+        pipeline.fireChannelInactive();           // 12
     }
 }

--- a/microbench/src/main/java/io/netty/microbench/channel/DefaultChannelPipelineDuplexHandlerBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/channel/DefaultChannelPipelineDuplexHandlerBenchmark.java
@@ -29,7 +29,6 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
-import org.openjdk.jmh.infra.Blackhole;
 
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
@@ -83,13 +82,13 @@ public class DefaultChannelPipelineDuplexHandlerBenchmark extends AbstractMicrob
     }
 
     @Benchmark
-    public void propagateEvent(Blackhole hole) {
-        hole.consume(pipeline.fireChannelReadComplete());
+    public void propagateEvent() {
+        pipeline.fireChannelReadComplete();
     }
 
     @Benchmark
     @Threads(4)
-    public void parallelPropagateEvent(Blackhole hole) {
-        hole.consume(pipeline.fireChannelReadComplete());
+    public void parallelPropagateEvent() {
+        pipeline.fireChannelReadComplete();
     }
 }

--- a/microbench/src/main/java/io/netty/microbench/channel/EmbeddedChannelHandlerContext.java
+++ b/microbench/src/main/java/io/netty/microbench/channel/EmbeddedChannelHandlerContext.java
@@ -75,27 +75,27 @@ public abstract class EmbeddedChannelHandlerContext implements ChannelHandlerCon
     }
 
     @Override
-    public final ChannelHandlerContext fireChannelRegistered() {
-        return this;
+    public final void fireChannelRegistered() {
+        // NOOP
     }
 
     @Override
-    public final ChannelHandlerContext fireChannelUnregistered() {
-        return this;
+    public final void fireChannelUnregistered() {
+        // NOOP
     }
 
     @Override
-    public final ChannelHandlerContext fireChannelActive() {
-        return this;
+    public final void fireChannelActive() {
+        // NOOP
     }
 
     @Override
-    public final ChannelHandlerContext fireChannelInactive() {
-        return this;
+    public final void fireChannelInactive() {
+        // NOOP
     }
 
     @Override
-    public final ChannelHandlerContext fireExceptionCaught(Throwable cause) {
+    public final void fireExceptionCaught(Throwable cause) {
         if (handler() instanceof ChannelInboundHandler) {
             try {
                 ((ChannelInboundHandler) handler()).exceptionCaught(this, cause);
@@ -103,29 +103,26 @@ public abstract class EmbeddedChannelHandlerContext implements ChannelHandlerCon
                 handleException(e);
             }
         }
-        return this;
     }
 
     @Override
-    public final ChannelHandlerContext fireUserEventTriggered(Object event) {
+    public final void fireUserEventTriggered(Object event) {
         ReferenceCountUtil.release(event);
-        return this;
     }
 
     @Override
-    public final ChannelHandlerContext fireChannelRead(Object msg) {
+    public final void fireChannelRead(Object msg) {
         ReferenceCountUtil.release(msg);
-        return this;
     }
 
     @Override
-    public final ChannelHandlerContext fireChannelReadComplete() {
-        return this;
+    public final void fireChannelReadComplete() {
+        // NOOP
     }
 
     @Override
-    public final ChannelHandlerContext fireChannelWritabilityChanged() {
-        return this;
+    public final void fireChannelWritabilityChanged() {
+        // NOOP
     }
 
     @Override
@@ -201,13 +198,12 @@ public abstract class EmbeddedChannelHandlerContext implements ChannelHandlerCon
     }
 
     @Override
-    public final ChannelHandlerContext read() {
+    public final void read() {
         try {
             channel().read();
         } catch (Exception e) {
             handleException(e);
         }
-        return this;
     }
 
     @Override
@@ -221,9 +217,8 @@ public abstract class EmbeddedChannelHandlerContext implements ChannelHandlerCon
     }
 
     @Override
-    public final ChannelHandlerContext flush() {
+    public final void flush() {
         channel().flush();
-        return this;
     }
 
     @Override
@@ -262,8 +257,8 @@ public abstract class EmbeddedChannelHandlerContext implements ChannelHandlerCon
     }
 
     @Override
-    public ChannelHandlerContext fireChannelShutdown(ChannelShutdownType type) {
-        return this;
+    public void fireChannelShutdown(ChannelShutdownType type) {
+        // NOOP
     }
 
     @Override

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -457,18 +457,6 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
     }
 
     @Override
-    public DatagramChannel read() {
-        super.read();
-        return this;
-    }
-
-    @Override
-    public DatagramChannel flush() {
-        super.flush();
-        return this;
-    }
-
-    @Override
     protected void doDisconnect(Promise<Void> promise) {
         try {
             socket.disconnect();

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
@@ -218,18 +218,6 @@ public final class EpollServerSocketChannel extends AbstractEpollChannel impleme
         return config;
     }
 
-    @Override
-    public ServerSocketChannel read() {
-        super.read();
-        return this;
-    }
-
-    @Override
-    public ServerSocketChannel flush() {
-        super.flush();
-        return this;
-    }
-
     private Channel newChildChannel(EventLoop eventLoop, int fd, byte[] address, int offset, int len) {
         if (socket.protocolFamily() ==  SocketProtocolFamily.UNIX) {
             return new EpollSocketChannel(eventLoop, this, new LinuxSocket(fd, SocketProtocolFamily.UNIX));

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannel.java
@@ -133,18 +133,6 @@ public final class EpollSocketChannel extends AbstractEpollChannel implements So
     }
 
     @Override
-    public SocketChannel read() {
-        super.read();
-        return this;
-    }
-
-    @Override
-    public SocketChannel flush() {
-        super.flush();
-        return this;
-    }
-
-    @Override
     protected boolean isAllowHalfClosure() {
         return this.config.isAllowHalfClosure();
     }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
@@ -283,18 +283,6 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
     }
 
     @Override
-    public DatagramChannel read() {
-        super.read();
-        return this;
-    }
-
-    @Override
-    public DatagramChannel flush() {
-        super.flush();
-        return this;
-    }
-
-    @Override
     protected void doDisconnect(Promise<Void> promise) {
         try {
             // TODO: use io_uring for this too...

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringServerSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringServerSocketChannel.java
@@ -318,18 +318,6 @@ public final class IoUringServerSocketChannel extends AbstractIoUringChannel imp
         return config;
     }
 
-    @Override
-    public ServerSocketChannel read() {
-        super.read();
-        return this;
-    }
-
-    @Override
-    public ServerSocketChannel flush() {
-        super.flush();
-        return this;
-    }
-
     private Channel newChildChannel(EventLoop eventLoop, int fd, ByteBuffer acceptedAddressMemory) {
         IoUringIoHandler handler = registration().attachment();
         LinuxSocket socket = new LinuxSocket(fd, this.socket.protocolFamily());

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
@@ -91,18 +91,6 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
     }
 
     @Override
-    public SocketChannel read() {
-        super.read();
-        return this;
-    }
-
-    @Override
-    public SocketChannel flush() {
-        super.flush();
-        return this;
-    }
-
-    @Override
     public ServerSocketChannel parent() {
         return (ServerSocketChannel) super.parent();
     }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
@@ -275,18 +275,6 @@ public final class KQueueDatagramChannel extends AbstractKQueueChannel implement
         }
     }
 
-    @Override
-    public DatagramChannel read() {
-        super.read();
-        return this;
-    }
-
-    @Override
-    public DatagramChannel flush() {
-        super.flush();
-        return this;
-    }
-
     private boolean doWriteMessage(Object msg) throws Exception {
         final ByteBuf data;
         SocketAddress remoteAddress;

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueServerSocketChannel.java
@@ -193,18 +193,6 @@ public final class KQueueServerSocketChannel extends AbstractKQueueChannel imple
         return config;
     }
 
-    @Override
-    public ServerSocketChannel read() {
-        super.read();
-        return this;
-    }
-
-    @Override
-    public ServerSocketChannel flush() {
-        super.flush();
-        return this;
-    }
-
     private Channel newChildChannel(EventLoop eventLoop, int fd, byte[] address, int offset, int len) {
         if (socket.protocolFamily() == SocketProtocolFamily.UNIX) {
             return new KQueueSocketChannel(eventLoop, this, new BsdSocket(fd, SocketProtocolFamily.UNIX), true);

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannel.java
@@ -100,18 +100,6 @@ public final class KQueueSocketChannel extends AbstractKQueueChannel implements 
     }
 
     @Override
-    public SocketChannel read() {
-        super.read();
-        return this;
-    }
-
-    @Override
-    public SocketChannel flush() {
-        super.flush();
-        return this;
-    }
-
-    @Override
     protected boolean isAllowHalfClosure() {
         return config.isAllowHalfClosure();
     }

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/SctpChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/SctpChannel.java
@@ -131,10 +131,4 @@ public interface SctpChannel extends Channel {
      * Will notify the given {@link Promise} and return a {@link Future}
      */
     void unbindAddress(InetAddress localAddress, Promise<Void> promise);
-
-    @Override
-    SctpChannel read();
-
-    @Override
-    SctpChannel flush();
 }

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
@@ -127,18 +127,6 @@ public class NioSctpChannel extends AbstractNioMessageChannel implements io.nett
     }
 
     @Override
-    public io.netty.channel.sctp.SctpChannel read() {
-        super.read();
-        return this;
-    }
-
-    @Override
-    public io.netty.channel.sctp.SctpChannel flush() {
-        super.flush();
-        return this;
-    }
-
-    @Override
     protected void doShutdown(ChannelShutdownType type, Promise<Void> promise) {
         promise.setFailure(new UnsupportedOperationException());
     }

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpServerChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpServerChannel.java
@@ -26,7 +26,6 @@ import io.netty.channel.ChannelShutdownType;
 import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.ServerChannel;
 import io.netty.channel.ServerChannelRecvByteBufAllocator;
 import io.netty.channel.nio.AbstractNioMessageChannel;
 import io.netty.channel.nio.NioIoHandle;
@@ -78,18 +77,6 @@ public class NioSctpServerChannel extends AbstractNioMessageChannel
         this.childEventLoopGroup =
                 validateEventLoopGroup(childEventLoopGroup, "childEventLoopGroup", NioIoHandle.class);
         config = new NioSctpServerChannelConfig(this, javaChannel());
-    }
-
-    @Override
-    public ServerChannel read() {
-        super.read();
-        return this;
-    }
-
-    @Override
-    public ServerChannel flush() {
-        super.flush();
-        return this;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -133,7 +133,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
     }
 
     @Override
-    public ChannelHandlerContext fireChannelRegistered() {
+    public void fireChannelRegistered() {
         AbstractChannelHandlerContext next = findContextInbound(MASK_CHANNEL_REGISTERED);
         if (next.executor().inEventLoop()) {
             if (next.invokeHandler()) {
@@ -151,11 +151,10 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         } else {
             next.executor().execute(this::fireChannelRegistered);
         }
-        return this;
     }
 
     @Override
-    public ChannelHandlerContext fireChannelUnregistered() {
+    public void fireChannelUnregistered() {
         final AbstractChannelHandlerContext next = findContextInbound(MASK_CHANNEL_UNREGISTERED);
         if (next.executor().inEventLoop()) {
             if (next.invokeHandler()) {
@@ -173,11 +172,10 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         } else {
             next.executor().execute(this::fireChannelUnregistered);
         }
-        return this;
     }
 
     @Override
-    public ChannelHandlerContext fireChannelActive() {
+    public void fireChannelActive() {
         AbstractChannelHandlerContext next = findContextInbound(MASK_CHANNEL_ACTIVE);
         if (next.executor().inEventLoop()) {
             if (next.invokeHandler()) {
@@ -195,11 +193,10 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         } else {
             next.executor().execute(this::fireChannelActive);
         }
-        return this;
     }
 
     @Override
-    public ChannelHandlerContext fireChannelInactive() {
+    public void fireChannelInactive() {
         AbstractChannelHandlerContext next = findContextInbound(MASK_CHANNEL_INACTIVE);
         if (next.executor().inEventLoop()) {
             if (next.invokeHandler()) {
@@ -217,11 +214,10 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         } else {
             next.executor().execute(this::fireChannelInactive);
         }
-        return this;
     }
 
     @Override
-    public ChannelHandlerContext fireExceptionCaught(final Throwable cause) {
+    public void fireExceptionCaught(final Throwable cause) {
         AbstractChannelHandlerContext next = findContextInbound(MASK_EXCEPTION_CAUGHT);
         ObjectUtil.checkNotNull(cause, "cause");
         if (next.executor().inEventLoop()) {
@@ -236,7 +232,6 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
                 }
             }
         }
-        return this;
     }
 
     private void invokeFireExceptionCaught(final Throwable cause) {
@@ -265,7 +260,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
     }
 
     @Override
-    public ChannelHandlerContext fireUserEventTriggered(final Object event) {
+    public void fireUserEventTriggered(final Object event) {
         ObjectUtil.checkNotNull(event, "event");
         AbstractChannelHandlerContext next = findContextInbound(MASK_USER_EVENT_TRIGGERED);
         if (next.executor().inEventLoop()) {
@@ -284,11 +279,10 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         } else {
             next.executor().execute(() -> fireUserEventTriggered(event));
         }
-        return this;
     }
 
     @Override
-    public ChannelHandlerContext fireChannelRead(final Object msg) {
+    public void fireChannelRead(final Object msg) {
         AbstractChannelHandlerContext next = findContextInbound(MASK_CHANNEL_READ);
         if (next.executor().inEventLoop()) {
             final Object m = pipeline.touch(msg, next);
@@ -307,11 +301,10 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         } else {
             next.executor().execute(() -> fireChannelRead(msg));
         }
-        return this;
     }
 
     @Override
-    public ChannelHandlerContext fireChannelReadComplete() {
+    public void fireChannelReadComplete() {
         AbstractChannelHandlerContext next = findContextInbound(MASK_CHANNEL_READ_COMPLETE);
         if (next.executor().inEventLoop()) {
             if (next.invokeHandler()) {
@@ -329,11 +322,10 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         } else {
             next.executor().execute(getContextTasks().fireChannelReadCompleteTask);
         }
-        return this;
     }
 
     @Override
-    public ChannelHandlerContext fireChannelWritabilityChanged() {
+    public void fireChannelWritabilityChanged() {
         AbstractChannelHandlerContext next = findContextInbound(MASK_CHANNEL_WRITABILITY_CHANGED);
         if (next.executor().inEventLoop()) {
             if (next.invokeHandler()) {
@@ -351,11 +343,10 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         } else {
             next.executor().execute(getContextTasks().fireChannelWritabilityChangedTask);
         }
-        return this;
     }
 
     @Override
-    public ChannelHandlerContext fireChannelShutdown(ChannelShutdownType type) {
+    public void fireChannelShutdown(ChannelShutdownType type) {
         AbstractChannelHandlerContext next = findContextInbound(MASK_CHANNEL_SHUTDOWN);
         if (next.executor().inEventLoop()) {
             if (next.invokeHandler()) {
@@ -373,7 +364,6 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         } else {
             next.executor().execute(() -> fireChannelShutdown(type));
         }
-        return this;
     }
 
     @Override
@@ -583,7 +573,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
     }
 
     @Override
-    public ChannelHandlerContext read() {
+    public void read() {
         final AbstractChannelHandlerContext next = findContextOutbound(MASK_READ);
         if (next.executor().inEventLoop()) {
             if (next.invokeHandler()) {
@@ -601,7 +591,6 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         } else {
             next.executor().execute(getContextTasks().readTask);
         }
-        return this;
     }
 
     @Override
@@ -617,7 +606,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
     }
 
     @Override
-    public ChannelHandlerContext flush() {
+    public void flush() {
         final AbstractChannelHandlerContext next = findContextOutbound(MASK_FLUSH);
         EventExecutor executor = next.executor();
         if (executor.inEventLoop()) {
@@ -636,8 +625,6 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         } else {
             safeExecute(executor, getContextTasks().flushTask, channel().newPromise(), null, false);
         }
-
-        return this;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/AbstractServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractServerChannel.java
@@ -45,18 +45,6 @@ public abstract class AbstractServerChannel extends AbstractChannel implements S
     }
 
     @Override
-    public ServerChannel read() {
-        super.read();
-        return this;
-    }
-
-    @Override
-    public ServerChannel flush() {
-        super.flush();
-        return this;
-    }
-
-    @Override
     public EventLoopGroup childEventExecutorGroup() {
         return childEventLoopGroup;
     }

--- a/transport/src/main/java/io/netty/channel/Channel.java
+++ b/transport/src/main/java/io/netty/channel/Channel.java
@@ -237,15 +237,13 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, Comparabl
     }
 
     @Override
-    default Channel read() {
+    default void read() {
         pipeline().read();
-        return this;
     }
 
     @Override
-    default Channel flush() {
+    default void flush() {
         pipeline().flush();
-        return this;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/ChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandlerContext.java
@@ -107,42 +107,6 @@ public interface ChannelHandlerContext extends ChannelInboundInvoker, ChannelOut
      */
     boolean isRemoved();
 
-    @Override
-    ChannelHandlerContext fireChannelRegistered();
-
-    @Override
-    ChannelHandlerContext fireChannelUnregistered();
-
-    @Override
-    ChannelHandlerContext fireChannelActive();
-
-    @Override
-    ChannelHandlerContext fireChannelInactive();
-
-    @Override
-    ChannelHandlerContext fireExceptionCaught(Throwable cause);
-
-    @Override
-    ChannelHandlerContext fireUserEventTriggered(Object evt);
-
-    @Override
-    ChannelHandlerContext fireChannelRead(Object msg);
-
-    @Override
-    ChannelHandlerContext fireChannelReadComplete();
-
-    @Override
-    ChannelHandlerContext fireChannelShutdown(ChannelShutdownType type);
-
-    @Override
-    ChannelHandlerContext fireChannelWritabilityChanged();
-
-    @Override
-    ChannelHandlerContext read();
-
-    @Override
-    ChannelHandlerContext flush();
-
     /**
      * Return the assigned {@link ChannelPipeline}
      */

--- a/transport/src/main/java/io/netty/channel/ChannelInboundInvoker.java
+++ b/transport/src/main/java/io/netty/channel/ChannelInboundInvoker.java
@@ -24,7 +24,7 @@ public interface ChannelInboundInvoker {
      * called of the next  {@link ChannelInboundHandler} contained in the  {@link ChannelPipeline} of the
      * {@link Channel}.
      */
-    ChannelInboundInvoker fireChannelRegistered();
+    void fireChannelRegistered();
 
     /**
      * A {@link Channel} was unregistered from its {@link EventLoop}.
@@ -33,7 +33,7 @@ public interface ChannelInboundInvoker {
      * called of the next  {@link ChannelInboundHandler} contained in the  {@link ChannelPipeline} of the
      * {@link Channel}.
      */
-    ChannelInboundInvoker fireChannelUnregistered();
+    void fireChannelUnregistered();
 
     /**
      * A {@link Channel} is active now, which means it is connected.
@@ -42,7 +42,7 @@ public interface ChannelInboundInvoker {
      * called of the next  {@link ChannelInboundHandler} contained in the  {@link ChannelPipeline} of the
      * {@link Channel}.
      */
-    ChannelInboundInvoker fireChannelActive();
+    void fireChannelActive();
 
     /**
      * A {@link Channel} is inactive now, which means it is closed.
@@ -51,7 +51,7 @@ public interface ChannelInboundInvoker {
      * called of the next  {@link ChannelInboundHandler} contained in the  {@link ChannelPipeline} of the
      * {@link Channel}.
      */
-    ChannelInboundInvoker fireChannelInactive();
+    void fireChannelInactive();
 
     /**
      * A {@link Channel} received an {@link Throwable} in one of its inbound operations.
@@ -60,7 +60,7 @@ public interface ChannelInboundInvoker {
      * method  called of the next  {@link ChannelInboundHandler} contained in the  {@link ChannelPipeline} of the
      * {@link Channel}.
      */
-    ChannelInboundInvoker fireExceptionCaught(Throwable cause);
+    void fireExceptionCaught(Throwable cause);
 
     /**
      * A {@link Channel} received an user defined event.
@@ -69,7 +69,7 @@ public interface ChannelInboundInvoker {
      * method  called of the next  {@link ChannelInboundHandler} contained in the  {@link ChannelPipeline} of the
      * {@link Channel}.
      */
-    ChannelInboundInvoker fireUserEventTriggered(Object event);
+    void fireUserEventTriggered(Object event);
 
     /**
      * A {@link Channel} received a message.
@@ -78,19 +78,19 @@ public interface ChannelInboundInvoker {
      * method  called of the next {@link ChannelInboundHandler} contained in the  {@link ChannelPipeline} of the
      * {@link Channel}.
      */
-    ChannelInboundInvoker fireChannelRead(Object msg);
+    void fireChannelRead(Object msg);
 
     /**
      * Triggers an {@link ChannelInboundHandler#channelReadComplete(ChannelHandlerContext)}
      * event to the next {@link ChannelInboundHandler} in the {@link ChannelPipeline}.
      */
-    ChannelInboundInvoker fireChannelReadComplete();
+    void fireChannelReadComplete();
 
     /**
      * Triggers an {@link ChannelInboundHandler#channelWritabilityChanged(ChannelHandlerContext)}
      * event to the next {@link ChannelInboundHandler} in the {@link ChannelPipeline}.
      */
-    ChannelInboundInvoker fireChannelWritabilityChanged();
+    void fireChannelWritabilityChanged();
 
     /**
      * A {@link Channel} was shutdown in a specific direction.
@@ -100,5 +100,5 @@ public interface ChannelInboundInvoker {
      * called of the next  {@link ChannelHandler} contained in the  {@link ChannelPipeline} of the
      * {@link Channel}.
      */
-    ChannelInboundInvoker fireChannelShutdown(ChannelShutdownType type);
+    void fireChannelShutdown(ChannelShutdownType type);
 }

--- a/transport/src/main/java/io/netty/channel/ChannelOutboundInvoker.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundInvoker.java
@@ -256,7 +256,7 @@ public interface ChannelOutboundInvoker {
      * method called of the next {@link ChannelOutboundHandler} contained in the {@link ChannelPipeline} of the
      * {@link Channel}.
      */
-    ChannelOutboundInvoker read();
+    void read();
 
     /**
      * Request to write a message via this {@link ChannelHandlerContext} through the {@link ChannelPipeline}.
@@ -279,7 +279,7 @@ public interface ChannelOutboundInvoker {
     /**
      * Request to flush all pending messages via this ChannelOutboundInvoker.
      */
-    ChannelOutboundInvoker flush();
+    void flush();
 
     /**
      * Shortcut for call {@link #write(Object, Promise)} and {@link #flush()}.

--- a/transport/src/main/java/io/netty/channel/ChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/ChannelPipeline.java
@@ -16,9 +16,6 @@
 package io.netty.channel;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.util.concurrent.DefaultPromise;
-import io.netty.util.concurrent.FailedFuture;
-import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 
 import java.net.SocketAddress;
@@ -500,52 +497,4 @@ public interface ChannelPipeline
      * handler names and whose values are handlers.
      */
     Map<String, ChannelHandler> toMap();
-
-    @Override
-    ChannelPipeline fireChannelRegistered();
-
-    @Override
-    ChannelPipeline fireChannelUnregistered();
-
-    @Override
-    ChannelPipeline fireChannelActive();
-
-    @Override
-    ChannelPipeline fireChannelInactive();
-
-    @Override
-    ChannelPipeline fireExceptionCaught(Throwable cause);
-
-    @Override
-    ChannelPipeline fireUserEventTriggered(Object event);
-
-    @Override
-    ChannelPipeline fireChannelRead(Object msg);
-
-    @Override
-    ChannelPipeline fireChannelReadComplete();
-
-    @Override
-    ChannelPipeline fireChannelWritabilityChanged();
-
-    @Override
-    ChannelPipeline fireChannelShutdown(ChannelShutdownType type);
-
-    @Override
-    ChannelPipeline flush();
-
-    @Override
-    default <T> Promise<T> newPromise() {
-        return executor().newPromise();
-    }
-
-    @Override
-    default <T> Future<T> newFailedFuture(Throwable cause) {
-        return executor().newFailedFuture(cause);
-    }
-
-    @Override
-    default <T> Future<T> newSucceededFuture(T result) {
-        return executor().newSucceededFuture(result);
-    }
 }

--- a/transport/src/main/java/io/netty/channel/CombinedChannelDuplexHandler.java
+++ b/transport/src/main/java/io/netty/channel/CombinedChannelDuplexHandler.java
@@ -407,63 +407,53 @@ public class CombinedChannelDuplexHandler<I extends ChannelInboundHandler, O ext
         }
 
         @Override
-        public ChannelHandlerContext fireChannelRegistered() {
+        public void fireChannelRegistered() {
             ctx.fireChannelRegistered();
-            return this;
         }
 
         @Override
-        public ChannelHandlerContext fireChannelUnregistered() {
+        public void fireChannelUnregistered() {
             ctx.fireChannelUnregistered();
-            return this;
         }
 
         @Override
-        public ChannelHandlerContext fireChannelActive() {
+        public void fireChannelActive() {
             ctx.fireChannelActive();
-            return this;
         }
 
         @Override
-        public ChannelHandlerContext fireChannelInactive() {
+        public void fireChannelInactive() {
             ctx.fireChannelInactive();
-            return this;
         }
 
         @Override
-        public ChannelHandlerContext fireExceptionCaught(Throwable cause) {
+        public void fireExceptionCaught(Throwable cause) {
             ctx.fireExceptionCaught(cause);
-            return this;
         }
 
         @Override
-        public ChannelHandlerContext fireUserEventTriggered(Object event) {
+        public void fireUserEventTriggered(Object event) {
             ctx.fireUserEventTriggered(event);
-            return this;
         }
 
         @Override
-        public ChannelHandlerContext fireChannelRead(Object msg) {
+        public void fireChannelRead(Object msg) {
             ctx.fireChannelRead(msg);
-            return this;
         }
 
         @Override
-        public ChannelHandlerContext fireChannelReadComplete() {
+        public void fireChannelReadComplete() {
             ctx.fireChannelReadComplete();
-            return this;
         }
 
         @Override
-        public ChannelHandlerContext fireChannelWritabilityChanged() {
+        public void fireChannelWritabilityChanged() {
             ctx.fireChannelWritabilityChanged();
-            return this;
         }
 
         @Override
-        public ChannelHandlerContext fireChannelShutdown(ChannelShutdownType type) {
+        public void fireChannelShutdown(ChannelShutdownType type) {
             ctx.fireChannelShutdown(type);
-            return this;
         }
 
         @Override
@@ -538,9 +528,8 @@ public class CombinedChannelDuplexHandler<I extends ChannelInboundHandler, O ext
         }
 
         @Override
-        public ChannelHandlerContext read() {
+        public void read() {
             ctx.read();
-            return this;
         }
 
         @Override
@@ -554,9 +543,8 @@ public class CombinedChannelDuplexHandler<I extends ChannelInboundHandler, O ext
         }
 
         @Override
-        public ChannelHandlerContext flush() {
+        public void flush() {
             ctx.flush();
-            return this;
         }
 
         @Override

--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -718,7 +718,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
     }
 
     @Override
-    public final ChannelPipeline fireChannelRegistered() {
+    public final void fireChannelRegistered() {
         if (head.executor().inEventLoop()) {
             if (head.invokeHandler()) {
                 head.channelRegistered(head);
@@ -728,11 +728,10 @@ public class DefaultChannelPipeline implements ChannelPipeline {
         } else {
             head.executor().execute(this::fireChannelRegistered);
         }
-        return this;
     }
 
     @Override
-    public final ChannelPipeline fireChannelUnregistered() {
+    public final void fireChannelUnregistered() {
         if (head.executor().inEventLoop()) {
             if (head.invokeHandler()) {
                 head.channelUnregistered(head);
@@ -742,11 +741,10 @@ public class DefaultChannelPipeline implements ChannelPipeline {
         } else {
             head.executor().execute(this::fireChannelUnregistered);
         }
-        return this;
     }
 
     @Override
-    public final ChannelPipeline fireChannelShutdown(ChannelShutdownType type) {
+    public final void fireChannelShutdown(ChannelShutdownType type) {
         if (head.executor().inEventLoop()) {
             if (head.invokeHandler()) {
                 head.channelShutdown(head, type);
@@ -756,7 +754,6 @@ public class DefaultChannelPipeline implements ChannelPipeline {
         } else {
             head.executor().execute(() -> head.fireChannelShutdown(type));
         }
-        return this;
     }
 
     /**
@@ -828,7 +825,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
     }
 
     @Override
-    public final ChannelPipeline fireChannelActive() {
+    public final void fireChannelActive() {
         if (head.executor().inEventLoop()) {
             if (head.invokeHandler()) {
                 head.channelActive(head);
@@ -838,11 +835,10 @@ public class DefaultChannelPipeline implements ChannelPipeline {
         } else {
             head.executor().execute(this::fireChannelActive);
         }
-        return this;
     }
 
     @Override
-    public final ChannelPipeline fireChannelInactive() {
+    public final void fireChannelInactive() {
         if (head.executor().inEventLoop()) {
             if (head.invokeHandler()) {
                 head.channelInactive(head);
@@ -852,11 +848,10 @@ public class DefaultChannelPipeline implements ChannelPipeline {
         } else {
             head.executor().execute(this::fireChannelInactive);
         }
-        return this;
     }
 
     @Override
-    public final ChannelPipeline fireExceptionCaught(Throwable cause) {
+    public final void fireExceptionCaught(Throwable cause) {
         if (head.executor().inEventLoop()) {
             if (head.invokeHandler()) {
                 head.exceptionCaught(head, cause);
@@ -866,11 +861,10 @@ public class DefaultChannelPipeline implements ChannelPipeline {
         } else {
             head.executor().execute(() -> fireExceptionCaught(cause));
         }
-        return this;
     }
 
     @Override
-    public final ChannelPipeline fireUserEventTriggered(Object event) {
+    public final void fireUserEventTriggered(Object event) {
         if (head.executor().inEventLoop()) {
             if (head.invokeHandler()) {
                 head.userEventTriggered(head, event);
@@ -880,11 +874,10 @@ public class DefaultChannelPipeline implements ChannelPipeline {
         } else {
             head.executor().execute(() -> fireUserEventTriggered(event));
         }
-        return this;
     }
 
     @Override
-    public final ChannelPipeline fireChannelRead(Object msg) {
+    public final void fireChannelRead(Object msg) {
         if (head.executor().inEventLoop()) {
             if (head.invokeHandler()) {
                 head.channelRead(head, msg);
@@ -894,11 +887,10 @@ public class DefaultChannelPipeline implements ChannelPipeline {
         } else {
             head.executor().execute(() -> fireChannelRead(msg));
         }
-        return this;
     }
 
     @Override
-    public final ChannelPipeline fireChannelReadComplete() {
+    public final void fireChannelReadComplete() {
         if (head.executor().inEventLoop()) {
             if (head.invokeHandler()) {
                 head.channelReadComplete(head);
@@ -908,11 +900,10 @@ public class DefaultChannelPipeline implements ChannelPipeline {
         } else {
             head.executor().execute(this::fireChannelReadComplete);
         }
-        return this;
     }
 
     @Override
-    public final ChannelPipeline fireChannelWritabilityChanged() {
+    public final void fireChannelWritabilityChanged() {
         if (head.executor().inEventLoop()) {
             if (head.invokeHandler()) {
                 head.channelWritabilityChanged(head);
@@ -922,7 +913,6 @@ public class DefaultChannelPipeline implements ChannelPipeline {
         } else {
             head.executor().execute(this::fireChannelWritabilityChanged);
         }
-        return this;
     }
 
     @Override
@@ -961,9 +951,8 @@ public class DefaultChannelPipeline implements ChannelPipeline {
     }
 
     @Override
-    public final ChannelPipeline flush() {
+    public final void flush() {
         tail.flush();
-        return this;
     }
 
     @Override
@@ -1003,9 +992,8 @@ public class DefaultChannelPipeline implements ChannelPipeline {
     }
 
     @Override
-    public final ChannelPipeline read() {
+    public final void read() {
         tail.read();
-        return this;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/ServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/ServerChannel.java
@@ -26,10 +26,4 @@ public interface ServerChannel extends Channel {
      * @return  the used child group.
      */
     EventLoopGroup childEventExecutorGroup();
-
-    @Override
-    ServerChannel read();
-
-    @Override
-    ServerChannel flush();
 }

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
@@ -699,7 +699,7 @@ public class EmbeddedChannel extends AbstractChannel {
     }
 
     @Override
-    public EmbeddedChannel flush() {
+    public void flush() {
         executingStackCnt++;
         try {
             super.flush();
@@ -707,7 +707,6 @@ public class EmbeddedChannel extends AbstractChannel {
             executingStackCnt--;
             maybeRunPendingTasks();
         }
-        return this;
     }
 
     @Override
@@ -755,7 +754,7 @@ public class EmbeddedChannel extends AbstractChannel {
     }
 
     @Override
-    public Channel read() {
+    public void read() {
         executingStackCnt++;
         try {
             super.read();
@@ -763,7 +762,6 @@ public class EmbeddedChannel extends AbstractChannel {
             executingStackCnt--;
             maybeRunPendingTasks();
         }
-        return this;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/socket/DatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/DatagramChannel.java
@@ -219,10 +219,4 @@ public interface DatagramChannel extends Channel {
      * The given {@link Future} will be notified and also returned.
      */
     void block(InetAddress multicastAddress, InetAddress sourceToBlock, Promise<Void> future);
-
-    @Override
-    DatagramChannel read();
-
-    @Override
-    DatagramChannel flush();
 }

--- a/transport/src/main/java/io/netty/channel/socket/ServerSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/ServerSocketChannel.java
@@ -40,9 +40,4 @@ import io.netty.channel.ServerChannel;
  */
 public interface ServerSocketChannel extends ServerChannel {
 
-    @Override
-    ServerSocketChannel read();
-
-    @Override
-    ServerSocketChannel flush();
 }

--- a/transport/src/main/java/io/netty/channel/socket/SocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/SocketChannel.java
@@ -50,13 +50,4 @@ import io.netty.channel.ChannelShutdownDirection;
 public interface SocketChannel extends Channel {
     @Override
     ServerSocketChannel parent();
-
-    @Override
-    boolean isShutdown(ChannelShutdownDirection direction);
-
-    @Override
-    SocketChannel read();
-
-    @Override
-    SocketChannel flush();
 }

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
@@ -527,18 +527,6 @@ public final class NioDatagramChannel
     }
 
     @Override
-    public io.netty.channel.socket.DatagramChannel read() {
-        super.read();
-        return this;
-    }
-
-    @Override
-    public io.netty.channel.socket.DatagramChannel flush() {
-        super.flush();
-        return this;
-    }
-
-    @Override
     @Deprecated
     protected void setReadPending(boolean readPending) {
         super.setReadPending(readPending);

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioServerSocketChannel.java
@@ -249,18 +249,6 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel
         throw new UnsupportedOperationException();
     }
 
-    @Override
-    public io.netty.channel.socket.ServerSocketChannel read() {
-        super.read();
-        return this;
-    }
-
-    @Override
-    public io.netty.channel.socket.ServerSocketChannel flush() {
-        super.flush();
-        return this;
-    }
-
     private static final class NioServerSocketChannelConfig extends DefaultChannelConfig {
 
         final NetworkChannel jdkChannel;

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
@@ -127,18 +127,6 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
         config = new NioSocketChannelConfig(this, channel);
     }
 
-    @Override
-    public io.netty.channel.socket.SocketChannel read() {
-        super.read();
-        return this;
-    }
-
-    @Override
-    public io.netty.channel.socket.SocketChannel flush() {
-        super.flush();
-        return this;
-    }
-
     protected boolean isAllowHalfClosure() {
         return config.isAllowHalfClosure();
     }

--- a/transport/src/test/java/io/netty/bootstrap/ServerBootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/ServerBootstrapTest.java
@@ -276,18 +276,6 @@ public class ServerBootstrapTest {
         }
 
         @Override
-        public ServerChannel read() {
-            super.read();
-            return this;
-        }
-
-        @Override
-        public ServerChannel flush() {
-            super.flush();
-            return this;
-        }
-
-        @Override
         protected void doBind(SocketAddress localAddress, Promise<Void> promise) {
             active = true;
             promise.setSuccess(null);


### PR DESCRIPTION
Motivation:

We sometimes had methods return itself which just made things more complicated (as it was often easy to miss overriding things in sub-interfaces etc) as method chaining is not really useful with these methods.

Modifications:

Change return type to void

Result:

API cleanup