### PR TITLE
Improve exception message generated by `EnhancingX509ExtendedTrustMan…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/EnhancingX509ExtendedTrustManager.java
+++ b/handler/src/main/java/io/netty/handler/ssl/EnhancingX509ExtendedTrustManager.java
@@ -21,15 +21,30 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Collection;
 import java.util.List;
+import javax.naming.ldap.LdapName;
+import javax.naming.ldap.Rdn;
+import javax.net.ssl.ExtendedSSLSession;
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocket;
 import javax.net.ssl.X509ExtendedTrustManager;
 import javax.net.ssl.X509TrustManager;
+import javax.security.auth.x500.X500Principal;
 
 /**
  * Wraps an existing {@link X509ExtendedTrustManager} and enhances the {@link CertificateException} that is thrown
  * because of hostname validation.
  */
 final class EnhancingX509ExtendedTrustManager extends X509ExtendedTrustManager {
+
+    // Constants for subject alt names of type DNS and IP. See X509Certificate#getSubjectAlternativeNames() javadocs.
+    static final int ALTNAME_DNS = 2;
+    static final int ALTNAME_URI = 6;
+    static final int ALTNAME_IP = 7;
+    private static final String SEPARATOR = ", ";
+
     private final X509ExtendedTrustManager wrapped;
 
     EnhancingX509ExtendedTrustManager(X509TrustManager wrapped) {
@@ -48,7 +63,8 @@ final class EnhancingX509ExtendedTrustManager extends X509ExtendedTrustManager {
         try {
             wrapped.checkServerTrusted(chain, authType, socket);
         } catch (CertificateException e) {
-            throwEnhancedCertificateException(chain, e);
+            throwEnhancedCertificateException(e, chain,
+                    socket instanceof SSLSocket ? ((SSLSocket) socket).getHandshakeSession() : null);
         }
     }
 
@@ -64,7 +80,7 @@ final class EnhancingX509ExtendedTrustManager extends X509ExtendedTrustManager {
         try {
             wrapped.checkServerTrusted(chain, authType, engine);
         } catch (CertificateException e) {
-            throwEnhancedCertificateException(chain, e);
+            throwEnhancedCertificateException(e, chain, engine != null ? engine.getHandshakeSession() : null);
         }
     }
 
@@ -80,7 +96,7 @@ final class EnhancingX509ExtendedTrustManager extends X509ExtendedTrustManager {
         try {
             wrapped.checkServerTrusted(chain, authType);
         } catch (CertificateException e) {
-            throwEnhancedCertificateException(chain, e);
+            throwEnhancedCertificateException(e, chain, null);
         }
     }
 
@@ -89,32 +105,91 @@ final class EnhancingX509ExtendedTrustManager extends X509ExtendedTrustManager {
         return wrapped.getAcceptedIssuers();
     }
 
-    private static void throwEnhancedCertificateException(X509Certificate[] chain, CertificateException e)
-            throws CertificateException {
+    private static void throwEnhancedCertificateException(CertificateException e, X509Certificate[] chain,
+                                                          SSLSession session) throws CertificateException {
         // Matching the message is the best we can do sadly.
         String message = e.getMessage();
-        if (message != null && e.getMessage().startsWith("No subject alternative DNS name matching")) {
-            StringBuilder names = new StringBuilder(64);
+        if (message != null &&
+                (message.startsWith("No subject alternative") || message.startsWith("No name matching"))) {
+            StringBuilder sb = new StringBuilder(128);
+            sb.append(message);
+            // Some exception messages from sun.security.util.HostnameChecker may end with a dot that we don't need
+            if (message.charAt(message.length() - 1) == '.') {
+                sb.setLength(sb.length() - 1);
+            }
+            if (session != null) {
+                sb.append(" for SNIHostName=").append(getSNIHostName(session))
+                        .append(" and peerHost=").append(session.getPeerHost());
+            }
+            sb.append(" in the chain of ").append(chain.length).append(" certificate(s):");
             for (int i = 0; i < chain.length; i++) {
                 X509Certificate cert = chain[i];
                 Collection<List<?>> collection = cert.getSubjectAlternativeNames();
+                sb.append(' ').append(i + 1).append(". subjectAlternativeNames=[");
                 if (collection != null) {
+                    boolean hasNames = false;
                     for (List<?> altNames : collection) {
-                        // 2 is dNSName. See X509Certificate javadocs.
-                        if (altNames.size() >= 2 && ((Integer) altNames.get(0)).intValue() == 2) {
-                            names.append((String) altNames.get(1)).append(",");
+                        if (altNames.size() < 2) {
+                            // We expect at least a pair of 'nameType:value' in that list.
+                            continue;
                         }
+                        final int nameType = ((Integer) altNames.get(0)).intValue();
+                        if (nameType == ALTNAME_DNS) {
+                            sb.append("DNS");
+                        } else if (nameType == ALTNAME_IP) {
+                            sb.append("IP");
+                        } else if (nameType == ALTNAME_URI) {
+                            // URI names are common in some environments with gRPC services that use SPIFFEs.
+                            // Though the hostname matcher won't be looking at them, having them there can help
+                            // debugging cases where hostname verification was enabled when it shouldn't be.
+                            sb.append("URI");
+                        } else {
+                            continue;
+                        }
+                        sb.append(':').append((String) altNames.get(1)).append(SEPARATOR);
+                        hasNames = true;
+                    }
+                    if (hasNames) {
+                        // Strip of the last separator
+                        sb.setLength(sb.length() - SEPARATOR.length());
                     }
                 }
+                sb.append("], CN=").append(getCommonName(cert)).append('.');
             }
-            if (names.length() != 0) {
-                // Strip of ,
-                names.setLength(names.length() - 1);
-                throw new CertificateException(message +
-                        " Subject alternative DNS names in the certificate chain of " + chain.length +
-                        " certificate(s): " + names, e);
-            }
+            throw new CertificateException(sb.toString(), e);
         }
         throw e;
+    }
+
+    private static String getSNIHostName(SSLSession session) {
+        if (!(session instanceof ExtendedSSLSession)) {
+            return null;
+        }
+        List<SNIServerName> names = ((ExtendedSSLSession) session).getRequestedServerNames();
+        for (SNIServerName sni : names) {
+            if (sni instanceof SNIHostName) {
+                SNIHostName hostName = (SNIHostName) sni;
+                return hostName.getAsciiName();
+            }
+        }
+        return null;
+    }
+
+    private static String getCommonName(X509Certificate cert) {
+        try {
+            // 1. Get the X500Principal (better than getSubjectDN which is implementation dependent and deprecated)
+            X500Principal principal = cert.getSubjectX500Principal();
+            // 2. Parse the DN using LdapName
+            LdapName ldapName = new LdapName(principal.getName());
+            // 3. Iterate over the Relative Distinguished Names (RDNs) to find CN
+            for (Rdn rdn : ldapName.getRdns()) {
+                if (rdn.getType().equalsIgnoreCase("CN")) {
+                    return rdn.getValue().toString();
+                }
+            }
+        } catch (Exception ignore) {
+            // ignore
+        }
+        return "null";
     }
 }


### PR DESCRIPTION
…ager` (#16056)

Motivation:

This is an improvement for the feature introduced in #13381:
1. Include IP addresses in case matching happens via `HostnameChecker.matchIP`.
2. Include `URI` entries to detect when hostname verification should be disabled.
3. Include common name in case verification fallbacks to `CN` from subject.
4. Include both SNI hostname and peerHost to observe what was used for both paths inside `HostnameChecker`.
5. Split entries by cert in the chain.
6. Catch more use-cases (exception messages) coming from `HostnameChecker`.

Modifications:
- Enhance `EnhancingX509ExtendedTrustManager.throwEnhancedCertificateException` to include DNS, IP, URI types of SAN entries, CN as well as SNI hostname and peerHost.
- Modify tests to assert new behavior.

Result:

More details in the exception message related to full logic of `HostnameChecker`. Example:
```
No subject alternative DNS name matching netty.io found for SNIHostName=netty.io and peerHost=netty.io in the chain of 1 certificate(s): 1. subjectAlternativeNames=[DNS:some.netty.io, IP:127.0.0.1, URI:URI:https://uri.netty.io/profile], CN=leaf.netty.io.
```

