### PR TITLE
DecodeBuffer API

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/DecodeBuffer.java
+++ b/buffer/src/main/java/io/netty/buffer/DecodeBuffer.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import io.netty.util.internal.RecyclableArrayList;
+
+import java.util.Objects;
+
+public final class DecodeBuffer implements AutoCloseable {
+    private final ByteBufAllocator alloc;
+    private RecyclableArrayList items;
+    private ByteBuf decoding;
+
+    private DecodeBuffer(ByteBufAllocator alloc) {
+        this.alloc = alloc;
+        this.items = RecyclableArrayList.newInstance();
+    }
+
+    public static DecodeBuffer create(ByteBufAllocator alloc) {
+        return new DecodeBuffer(alloc);
+    }
+
+    public void add(ByteBuf buf) {
+        if (decoding != null) {
+            throw new IllegalStateException("Decoding in progress");
+        }
+        if (!buf.isReadable()) {
+            buf.release();
+            return;
+        }
+        // TODO: limit number of components?
+        items.add(buf);
+    }
+
+    public ByteBuf startDecode() {
+        if (decoding != null) {
+            throw new IllegalStateException("Decoding in progress");
+        }
+
+        // create a view of the buffered data with independent readerIndex
+        ByteBuf b;
+        if (items.isEmpty()) {
+            b = Unpooled.EMPTY_BUFFER;
+        } else if (items.size() == 1) {
+            b = ((ByteBuf) items.get(0)).retainedSlice();
+        } else {
+            CompositeByteBuf cbb = alloc.compositeBuffer(items.size());
+            for (Object item : items) {
+                cbb.addComponent(true, ((ByteBuf) item).retain());
+            }
+            b = cbb;
+        }
+        assert b.readerIndex() == 0;
+        this.decoding = b;
+        return b;
+    }
+
+    public void stopDecode(ByteBuf b) {
+        if (decoding != Objects.requireNonNull(b, "b")) {
+            throw new IllegalArgumentException("Decoding not in progress, or wrong buffer passed to stopDecode");
+        }
+
+        int read = b.readerIndex();
+        int toDrop = 0;
+        while (read > 0 && toDrop < items.size()) {
+            ByteBuf head = (ByteBuf) items.get(toDrop);
+            if (head.readableBytes() > read) {
+                // apply readerIndex of temporary decode buffer onto our permanent copy
+                head.skipBytes(read);
+                break;
+            } else {
+                read -= head.readableBytes();
+                head.release();
+                toDrop++;
+            }
+        }
+        // drop any buffers that have been fully decoded
+        items.subList(0, toDrop).clear();
+
+        this.decoding = null;
+    }
+
+    @Override
+    public void close() {
+        for (Object item : items) {
+            ((ByteBuf) item).release();
+        }
+        items.recycle();
+        items = null; // safety net, makes other operations fail
+    }
+}

--- a/buffer/src/test/java/io/netty/buffer/DecodeBufferTest.java
+++ b/buffer/src/test/java/io/netty/buffer/DecodeBufferTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.CharBuffer;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DecodeBufferTest {
+    private static ByteBuf utf8(String s) {
+        return ByteBufUtil.encodeString(ByteBufAllocator.DEFAULT, CharBuffer.wrap(s), StandardCharsets.UTF_8);
+    }
+
+    @Test
+    public void simple() {
+        ByteBuf read1;
+        ByteBuf read2;
+        ByteBuf read3;
+
+        try (DecodeBuffer db = DecodeBuffer.create(ByteBufAllocator.DEFAULT)) {
+            // write ops (total 6 bytes)
+            db.add(utf8("foo"));
+            db.add(utf8("bar"));
+
+            // read op (3 bytes)
+            ByteBuf decode = db.startDecode();
+            try {
+                read1 = decode.readRetainedSlice(3);
+            } finally {
+                db.stopDecode(decode);
+                decode.release();
+            }
+
+            // write op (3 bytes)
+            db.add(utf8("baz"));
+
+            // read ops (total 6 bytes)
+            decode = db.startDecode();
+            try {
+                read2 = decode.readRetainedSlice(4);
+            } finally {
+                db.stopDecode(decode);
+                decode.release();
+            }
+
+            decode = db.startDecode();
+            try {
+                read3 = decode.readRetainedSlice(2);
+            } finally {
+                db.stopDecode(decode);
+                decode.release();
+            }
+        }
+
+        assertEquals("foo", read1.toString(StandardCharsets.UTF_8));
+        assertEquals("barb", read2.toString(StandardCharsets.UTF_8));
+        assertEquals("az", read3.toString(StandardCharsets.UTF_8));
+
+        read1.release();
+        read2.release();
+        read3.release();
+    }
+}


### PR DESCRIPTION
Motivation:

Many netty codecs accumulate input data in a buffer and decode it iteratively. ByteToMessageDecoder is the most prominent example. The implementations are scattered and come with tradeoffs:

- When using CompositeByteBuf, indexed buffer access is more expensive.
- When using a single large cumulation buffer, there are copy operations.
- Discarding read bytes is impossible if the decoder uses readRetainedSlice and keeps a reference to some read bytes.

Modification:

Introduce a new DecodeBuffer class that implements a composite-like cumulation approach, but uses temporary buffers for decode operations.

Result:

Avoid CompositeByteBuf for the single-buffer base case.

Any readRetainedSlice calls avoid locking the *entire* buffered input forever, though they still prevent the full CompositeByteBuf for that decode operation from being released.