### PR TITLE
Improve exception message generated by `EnhancingX509ExtendedTrustManager` (#16056)

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/EnhancingX509ExtendedTrustManager.java
+++ b/handler/src/main/java/io/netty/handler/ssl/EnhancingX509ExtendedTrustManager.java
@@ -18,15 +18,22 @@ package io.netty.handler.ssl;
 
 import io.netty.util.internal.SuppressJava6Requirement;
 
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.X509ExtendedTrustManager;
-import javax.net.ssl.X509TrustManager;
 import java.net.Socket;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Collection;
 import java.util.List;
-
+import javax.naming.ldap.LdapName;
+import javax.naming.ldap.Rdn;
+import javax.net.ssl.ExtendedSSLSession;
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SNIServerName;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.X509ExtendedTrustManager;
+import javax.net.ssl.X509TrustManager;
+import javax.security.auth.x500.X500Principal;
 
 /**
  * Wraps an existing {@link X509ExtendedTrustManager} and enhances the {@link CertificateException} that is thrown
@@ -34,6 +41,13 @@ import java.util.List;
  */
 @SuppressJava6Requirement(reason = "Usage guarded by java version check")
 final class EnhancingX509ExtendedTrustManager extends X509ExtendedTrustManager {
+
+    // Constants for subject alt names of type DNS and IP. See X509Certificate#getSubjectAlternativeNames() javadocs.
+    static final int ALTNAME_DNS = 2;
+    static final int ALTNAME_URI = 6;
+    static final int ALTNAME_IP = 7;
+    private static final String SEPARATOR = ", ";
+
     private final X509ExtendedTrustManager wrapped;
 
     EnhancingX509ExtendedTrustManager(X509TrustManager wrapped) {
@@ -52,7 +66,8 @@ final class EnhancingX509ExtendedTrustManager extends X509ExtendedTrustManager {
         try {
             wrapped.checkServerTrusted(chain, authType, socket);
         } catch (CertificateException e) {
-            throwEnhancedCertificateException(chain, e);
+            throwEnhancedCertificateException(e, chain,
+                    socket instanceof SSLSocket ? ((SSLSocket) socket).getHandshakeSession() : null);
         }
     }
 
@@ -68,7 +83,7 @@ final class EnhancingX509ExtendedTrustManager extends X509ExtendedTrustManager {
         try {
             wrapped.checkServerTrusted(chain, authType, engine);
         } catch (CertificateException e) {
-            throwEnhancedCertificateException(chain, e);
+            throwEnhancedCertificateException(e, chain, engine != null ? engine.getHandshakeSession() : null);
         }
     }
 
@@ -84,7 +99,7 @@ final class EnhancingX509ExtendedTrustManager extends X509ExtendedTrustManager {
         try {
             wrapped.checkServerTrusted(chain, authType);
         } catch (CertificateException e) {
-            throwEnhancedCertificateException(chain, e);
+            throwEnhancedCertificateException(e, chain, null);
         }
     }
 
@@ -93,32 +108,91 @@ final class EnhancingX509ExtendedTrustManager extends X509ExtendedTrustManager {
         return wrapped.getAcceptedIssuers();
     }
 
-    private static void throwEnhancedCertificateException(X509Certificate[] chain, CertificateException e)
-            throws CertificateException {
+    private static void throwEnhancedCertificateException(CertificateException e, X509Certificate[] chain,
+                                                          SSLSession session) throws CertificateException {
         // Matching the message is the best we can do sadly.
         String message = e.getMessage();
-        if (message != null && e.getMessage().startsWith("No subject alternative DNS name matching")) {
-            StringBuilder names = new StringBuilder(64);
+        if (message != null &&
+                (message.startsWith("No subject alternative") || message.startsWith("No name matching"))) {
+            StringBuilder sb = new StringBuilder(128);
+            sb.append(message);
+            // Some exception messages from sun.security.util.HostnameChecker may end with a dot that we don't need
+            if (message.charAt(message.length() - 1) == '.') {
+                sb.setLength(sb.length() - 1);
+            }
+            if (session != null) {
+                sb.append(" for SNIHostName=").append(getSNIHostName(session))
+                        .append(" and peerHost=").append(session.getPeerHost());
+            }
+            sb.append(" in the chain of ").append(chain.length).append(" certificate(s):");
             for (int i = 0; i < chain.length; i++) {
                 X509Certificate cert = chain[i];
                 Collection<List<?>> collection = cert.getSubjectAlternativeNames();
+                sb.append(' ').append(i + 1).append(". subjectAlternativeNames=[");
                 if (collection != null) {
+                    boolean hasNames = false;
                     for (List<?> altNames : collection) {
-                        // 2 is dNSName. See X509Certificate javadocs.
-                        if (altNames.size() >= 2 && ((Integer) altNames.get(0)).intValue() == 2) {
-                            names.append((String) altNames.get(1)).append(",");
+                        if (altNames.size() < 2) {
+                            // We expect at least a pair of 'nameType:value' in that list.
+                            continue;
                         }
+                        final int nameType = ((Integer) altNames.get(0)).intValue();
+                        if (nameType == ALTNAME_DNS) {
+                            sb.append("DNS");
+                        } else if (nameType == ALTNAME_IP) {
+                            sb.append("IP");
+                        } else if (nameType == ALTNAME_URI) {
+                            // URI names are common in some environments with gRPC services that use SPIFFEs.
+                            // Though the hostname matcher won't be looking at them, having them there can help
+                            // debugging cases where hostname verification was enabled when it shouldn't be.
+                            sb.append("URI");
+                        } else {
+                            continue;
+                        }
+                        sb.append(':').append((String) altNames.get(1)).append(SEPARATOR);
+                        hasNames = true;
+                    }
+                    if (hasNames) {
+                        // Strip of the last separator
+                        sb.setLength(sb.length() - SEPARATOR.length());
                     }
                 }
+                sb.append("], CN=").append(getCommonName(cert)).append('.');
             }
-            if (names.length() != 0) {
-                // Strip of ,
-                names.setLength(names.length() - 1);
-                throw new CertificateException(message +
-                        " Subject alternative DNS names in the certificate chain of " + chain.length +
-                        " certificate(s): " + names, e);
-            }
+            throw new CertificateException(sb.toString(), e);
         }
         throw e;
+    }
+
+    private static String getSNIHostName(SSLSession session) {
+        if (!(session instanceof ExtendedSSLSession)) {
+            return null;
+        }
+        List<SNIServerName> names = ((ExtendedSSLSession) session).getRequestedServerNames();
+        for (SNIServerName sni : names) {
+            if (sni instanceof SNIHostName) {
+                SNIHostName hostName = (SNIHostName) sni;
+                return hostName.getAsciiName();
+            }
+        }
+        return null;
+    }
+
+    private static String getCommonName(X509Certificate cert) {
+        try {
+            // 1. Get the X500Principal (better than getSubjectDN which is implementation dependent and deprecated)
+            X500Principal principal = cert.getSubjectX500Principal();
+            // 2. Parse the DN using LdapName
+            LdapName ldapName = new LdapName(principal.getName());
+            // 3. Iterate over the Relative Distinguished Names (RDNs) to find CN
+            for (Rdn rdn : ldapName.getRdns()) {
+                if (rdn.getType().equalsIgnoreCase("CN")) {
+                    return rdn.getValue().toString();
+                }
+            }
+        } catch (Exception ignore) {
+            // ignore
+        }
+        return "null";
     }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/EnhancedX509ExtendedTrustManagerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/EnhancedX509ExtendedTrustManagerTest.java
@@ -21,7 +21,6 @@ import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
@@ -53,8 +52,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
-import static org.junit.jupiter.api.Named.named;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 public class EnhancedX509ExtendedTrustManagerTest {
 
@@ -255,16 +252,16 @@ public class EnhancedX509ExtendedTrustManagerTest {
         }
     });
 
-    static List<Arguments> throwingMatchingExecutables() {
+    static List<Executable> throwingMatchingExecutables() {
         if (PlatformDependent.javaVersion() < 8) {
             return Collections.emptyList();
         }
-        return Arrays.asList(arguments(named("checkServerTrusted", new Executable() {
+        return Arrays.asList(new Executable() {
             @Override
             public void execute() throws Throwable {
                 MATCHING_MANAGER.checkServerTrusted(new X509Certificate[] { TEST_CERT }, null);
             }
-        })), arguments(named("checkServerTrusted with SSLEngine", new Executable() {
+        }, new Executable() {
             @Override
             public void execute() throws Throwable {
                 SSLSession session = mockSSLSessionWithSNIHostNameAndPeerHost(HOSTNAME);
@@ -272,7 +269,7 @@ public class EnhancedX509ExtendedTrustManagerTest {
                 Mockito.when(engine.getHandshakeSession()).thenReturn(session);
                 MATCHING_MANAGER.checkServerTrusted(new X509Certificate[] { TEST_CERT }, null, engine);
             }
-        })), arguments(named("checkServerTrusted with SSLSocket", new Executable() {
+        }, new Executable() {
             @Override
             public void execute() throws Throwable {
                 SSLSession session = mockSSLSessionWithSNIHostNameAndPeerHost(HOSTNAME);
@@ -280,7 +277,7 @@ public class EnhancedX509ExtendedTrustManagerTest {
                 Mockito.when(socket.getHandshakeSession()).thenReturn(session);
                 MATCHING_MANAGER.checkServerTrusted(new X509Certificate[] { TEST_CERT }, null, socket);
             }
-        })));
+        });
     }
 
     private static final EnhancingX509ExtendedTrustManager NON_MATCHING_MANAGER =
@@ -327,23 +324,23 @@ public class EnhancedX509ExtendedTrustManagerTest {
                 }
             });
 
-    static List<Arguments> throwingNonMatchingExecutables() {
-        return Arrays.asList(arguments(named("checkServerTrusted", new Executable() {
+    static List<Executable> throwingNonMatchingExecutables() {
+        return Arrays.asList(new Executable() {
             @Override
             public void execute() throws Throwable {
                 NON_MATCHING_MANAGER.checkServerTrusted(new X509Certificate[] { TEST_CERT }, null);
             }
-        })), arguments(named("checkServerTrusted with SSLEngine", new Executable() {
+        }, new Executable() {
             @Override
             public void execute() throws Throwable {
                 NON_MATCHING_MANAGER.checkServerTrusted(new X509Certificate[] { TEST_CERT }, null, (SSLEngine) null);
             }
-        })), arguments(named("checkServerTrusted with SSLSocket", new Executable() {
+        }, new Executable() {
             @Override
             public void execute() throws Throwable {
                 NON_MATCHING_MANAGER.checkServerTrusted(new X509Certificate[] { TEST_CERT }, null, (SSLSocket) null);
             }
-        })));
+        });
     }
 
     @ParameterizedTest

--- a/handler/src/test/java/io/netty/handler/ssl/EnhancedX509ExtendedTrustManagerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/EnhancedX509ExtendedTrustManagerTest.java
@@ -33,6 +33,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -255,6 +256,9 @@ public class EnhancedX509ExtendedTrustManagerTest {
     });
 
     static List<Arguments> throwingMatchingExecutables() {
+        if (PlatformDependent.javaVersion() < 8) {
+            return Collections.emptyList();
+        }
         return Arrays.asList(arguments(named("checkServerTrusted", new Executable() {
             @Override
             public void execute() throws Throwable {

--- a/handler/src/test/java/io/netty/handler/ssl/EnhancedX509ExtendedTrustManagerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/EnhancedX509ExtendedTrustManagerTest.java
@@ -17,6 +17,7 @@
 package io.netty.handler.ssl;
 
 import io.netty.util.internal.EmptyArrays;
+import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -35,8 +36,6 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
-import javax.net.ssl.ExtendedSSLSession;
-import javax.net.ssl.SNIHostName;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocket;
@@ -46,11 +45,13 @@ import javax.security.auth.x500.X500Principal;
 import static io.netty.handler.ssl.EnhancingX509ExtendedTrustManager.ALTNAME_DNS;
 import static io.netty.handler.ssl.EnhancingX509ExtendedTrustManager.ALTNAME_IP;
 import static io.netty.handler.ssl.EnhancingX509ExtendedTrustManager.ALTNAME_URI;
+import static io.netty.handler.ssl.SniClientJava8TestUtil.mockSSLSessionWithSNIHostNameAndPeerHost;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.api.Named.named;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
@@ -262,7 +263,7 @@ public class EnhancedX509ExtendedTrustManagerTest {
         })), arguments(named("checkServerTrusted with SSLEngine", new Executable() {
             @Override
             public void execute() throws Throwable {
-                SSLSession session = mockSSLSession();
+                SSLSession session = mockSSLSessionWithSNIHostNameAndPeerHost(HOSTNAME);
                 SSLEngine engine = Mockito.mock(SSLEngine.class);
                 Mockito.when(engine.getHandshakeSession()).thenReturn(session);
                 MATCHING_MANAGER.checkServerTrusted(new X509Certificate[] { TEST_CERT }, null, engine);
@@ -270,19 +271,12 @@ public class EnhancedX509ExtendedTrustManagerTest {
         })), arguments(named("checkServerTrusted with SSLSocket", new Executable() {
             @Override
             public void execute() throws Throwable {
-                SSLSession session = mockSSLSession();
+                SSLSession session = mockSSLSessionWithSNIHostNameAndPeerHost(HOSTNAME);
                 SSLSocket socket = Mockito.mock(SSLSocket.class);
                 Mockito.when(socket.getHandshakeSession()).thenReturn(session);
                 MATCHING_MANAGER.checkServerTrusted(new X509Certificate[] { TEST_CERT }, null, socket);
             }
         })));
-    }
-
-    private static SSLSession mockSSLSession() {
-        ExtendedSSLSession session = Mockito.mock(ExtendedSSLSession.class);
-        Mockito.when(session.getRequestedServerNames()).thenReturn(Arrays.asList(new SNIHostName(HOSTNAME)));
-        Mockito.when(session.getPeerHost()).thenReturn(HOSTNAME);
-        return session;
     }
 
     private static final EnhancingX509ExtendedTrustManager NON_MATCHING_MANAGER =
@@ -351,6 +345,7 @@ public class EnhancedX509ExtendedTrustManagerTest {
     @ParameterizedTest
     @MethodSource("throwingMatchingExecutables")
     void testEnhanceException(Executable executable, TestInfo testInfo)  {
+        assumeTrue(PlatformDependent.javaVersion() >= 8);
         CertificateException exception = assertThrows(CertificateException.class, executable);
         // We should wrap the original cause with our own.
         assertInstanceOf(CertificateException.class, exception.getCause());
@@ -370,6 +365,7 @@ public class EnhancedX509ExtendedTrustManagerTest {
     @ParameterizedTest
     @MethodSource("throwingNonMatchingExecutables")
     void testNotEnhanceException(Executable executable) {
+        assumeTrue(PlatformDependent.javaVersion() >= 8);
         CertificateException exception = assertThrows(CertificateException.class, executable);
         // We should not wrap the original cause with our own.
         assertNull(exception.getCause());

--- a/handler/src/test/java/io/netty/handler/ssl/SniClientJava8TestUtil.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniClientJava8TestUtil.java
@@ -350,7 +350,8 @@ final class SniClientJava8TestUtil {
 
     static SSLSession mockSSLSessionWithSNIHostNameAndPeerHost(String hostname) {
         ExtendedSSLSession session = Mockito.mock(ExtendedSSLSession.class);
-        Mockito.when(session.getRequestedServerNames()).thenReturn(Arrays.asList(new SNIHostName(hostname)));
+        SNIServerName sniName = new SNIHostName(hostname);
+        Mockito.when(session.getRequestedServerNames()).thenReturn(Arrays.asList(sniName));
         Mockito.when(session.getPeerHost()).thenReturn(hostname);
         return session;
     }

--- a/handler/src/test/java/io/netty/handler/ssl/SniClientJava8TestUtil.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniClientJava8TestUtil.java
@@ -35,6 +35,7 @@ import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.ThrowableUtil;
+import org.mockito.Mockito;
 
 import javax.net.ssl.ExtendedSSLSession;
 import javax.net.ssl.KeyManager;
@@ -64,6 +65,7 @@ import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -344,5 +346,12 @@ final class SniClientJava8TestUtil {
                 }
             }, factory.getProvider(), factory.getAlgorithm());
         }
+    }
+
+    static SSLSession mockSSLSessionWithSNIHostNameAndPeerHost(String hostname) {
+        ExtendedSSLSession session = Mockito.mock(ExtendedSSLSession.class);
+        Mockito.when(session.getRequestedServerNames()).thenReturn(Arrays.asList(new SNIHostName(hostname)));
+        Mockito.when(session.getPeerHost()).thenReturn(hostname);
+        return session;
     }
 }


### PR DESCRIPTION
Motivation:

This is an improvement for the feature introduced in #13381:
1. Include IP addresses in case matching happens via `HostnameChecker.matchIP`.
2. Include `URI` entries to detect when hostname verification should be disabled.
3. Include common name in case verification fallbacks to `CN` from subject.
4. Include both SNI hostname and peerHost to observe what was used for both paths inside `HostnameChecker`.
5. Split entries by cert in the chain.
6. Catch more use-cases (exception messages) coming from `HostnameChecker`.

Modifications:
- Enhance `EnhancingX509ExtendedTrustManager.throwEnhancedCertificateException` to include DNS, IP, URI types of SAN entries, CN as well as SNI hostname and peerHost.
- Modify tests to assert new behavior.

Result:

More details in the exception message related to full logic of `HostnameChecker`. Example:
```
No subject alternative DNS name matching netty.io found for SNIHostName=netty.io and peerHost=netty.io in the chain of 1 certificate(s): 1. subjectAlternativeNames=[DNS:some.netty.io, IP:127.0.0.1, URI:URI:https://uri.netty.io/profile], CN=leaf.netty.io.
```