### PR TITLE
Add SLH-DSA algorithms to pkitesting CertificateBuilder

### DIFF
--- a/pkitesting/src/main/java/io/netty/pkitesting/Algorithms.java
+++ b/pkitesting/src/main/java/io/netty/pkitesting/Algorithms.java
@@ -54,6 +54,30 @@ final class Algorithms {
                 return "2.16.840.1.101.3.4.3.18";
             case "ml-dsa-87":
                 return "2.16.840.1.101.3.4.3.19";
+            case "slh-dsa-sha2-128s":
+                return "2.16.840.1.101.3.4.3.20";
+            case "slh-dsa-sha2-128f":
+                return "2.16.840.1.101.3.4.3.21";
+            case "slh-dsa-shake-128s":
+                return "2.16.840.1.101.3.4.3.22";
+            case "slh-dsa-shake-128f":
+                return "2.16.840.1.101.3.4.3.23";
+            case "slh-dsa-sha2-192s":
+                return "2.16.840.1.101.3.4.3.24";
+            case "slh-dsa-sha2-192f":
+                return "2.16.840.1.101.3.4.3.25";
+            case "slh-dsa-shake-192s":
+                return "2.16.840.1.101.3.4.3.26";
+            case "slh-dsa-shake-192f":
+                return "2.16.840.1.101.3.4.3.27";
+            case "slh-dsa-sha2-256s":
+                return "2.16.840.1.101.3.4.3.28";
+            case "slh-dsa-sha2-256f":
+                return "2.16.840.1.101.3.4.3.29";
+            case "slh-dsa-shake-256s":
+                return "2.16.840.1.101.3.4.3.30";
+            case "slh-dsa-shake-256f":
+                return "2.16.840.1.101.3.4.3.31";
             default:
                 throw new UnsupportedOperationException("Algorithm not supported: " + algorithmIdentifier);
         }
@@ -62,13 +86,25 @@ final class Algorithms {
     static KeyPairGenerator keyPairGenerator(String keyType, AlgorithmParameterSpec spec,
             SecureRandom rng, Provider provider) throws GeneralSecurityException {
         try {
-            KeyPairGenerator keyGen = KeyPairGenerator.getInstance(keyType);
-            keyGen.initialize(spec, rng);
+            KeyPairGenerator keyGen;
+            if (provider == null) {
+                keyGen = KeyPairGenerator.getInstance(keyType);
+            } else {
+                keyGen = KeyPairGenerator.getInstance(keyType, provider);
+            }
+            try {
+                keyGen.initialize(spec, rng);
+            } catch (UnsupportedOperationException ignore) {
+                // The key generators for some algorithms, in some providers, don't support key gen initialization.
+            }
             return keyGen;
         } catch (GeneralSecurityException e) {
+            if (provider != null) {
+                 // Don't fall back to BouncyCastle if we were explicitly told to use a specific provider.
+                throw e;
+            }
             try {
-                KeyPairGenerator keyGen = KeyPairGenerator.getInstance(keyType,
-                    provider != null ? provider : bouncyCastle());
+                KeyPairGenerator keyGen = KeyPairGenerator.getInstance(keyType, bouncyCastle());
                 keyGen.initialize(spec, rng);
                 return keyGen;
             } catch (GeneralSecurityException ex) {

--- a/pkitesting/src/main/java/io/netty/pkitesting/CertificateBuilder.java
+++ b/pkitesting/src/main/java/io/netty/pkitesting/CertificateBuilder.java
@@ -972,7 +972,7 @@ public final class CertificateBuilder {
         /**
          * The ML-KEM-512 algorithm is the NIST FIPS 203 version of the post-quantum Kyber algorithm.
          * It has 128-bits of classical security strength, and is claimed to meet NIST Level 1
-         * quantum security strength (equivalent to finding the key for an AES-1128 block).
+         * quantum security strength (equivalent to finding the key for an AES-128 block).
          * <p>
          * This algorithm was added in Java 24, and may not be supported everywhere.
          */
@@ -992,7 +992,104 @@ public final class CertificateBuilder {
          * <p>
          * This algorithm was added in Java 24, and may not be supported everywhere.
          */
-        mlKem1024("ML-KEM", namedParameterSpec("ML-KEM-1024"), UNSUPPORTED_SIGN);
+        mlKem1024("ML-KEM", namedParameterSpec("ML-KEM-1024"), UNSUPPORTED_SIGN),
+        /**
+         * The SLH-DSA-SHA2-128s algorithm is the NIST FIPS 205 of the post-quantum SPHINCS+ algorithm.
+         * It has 128-bits of classical security strength, and is claimed to meet NIST Level 1
+         * quantum security strength (equivalent to finding the key for an AES-128 block).
+         * <p>
+         * SLH-DSA algorithms with the 's' suffix have relatively smaller signatures but are much slower.
+         */
+        slhDsaSha2_128s("SLH-DSA", namedParameterSpec("SLH-DSA-SHA2-128s"), "SLH-DSA-SHA2-128s"),
+        /**
+         * The SLH-DSA-SHA2-128f algorithm is the NIST FIPS 205 of the post-quantum SPHINCS+ algorithm.
+         * It has 128-bits of classical security strength, and is claimed to meet NIST Level 1
+         * quantum security strength (equivalent to finding the key for an AES-128 block).
+         * <p>
+         * SLH-DSA algorithms with the 'f' suffix have larger signatures but are much faster.
+         */
+        slhDsaSha2_128f("SLH-DSA", namedParameterSpec("SLH-DSA-SHA2-128f"), "SLH-DSA-SHA2-128f"),
+        /**
+         * The SLH-DSA-SHAKE-128s algorithm is the NIST FIPS 205 of the post-quantum SPHINCS+ algorithm.
+         * It has 128-bits of classical security strength, and is claimed to meet NIST Level 1
+         * quantum security strength (equivalent to finding the key for an AES-128 block).
+         * <p>
+         * SLH-DSA algorithms with the 's' suffix have relatively smaller signatures but are much slower.
+         */
+        slhDsaShake_128s("SLH-DSA", namedParameterSpec("SLH-DSA-SHAKE-128s"), "SLH-DSA-SHAKE-128s"),
+        /**
+         * The SLH-DSA-SHAKE-128f algorithm is the NIST FIPS 205 of the post-quantum SPHINCS+ algorithm.
+         * It has 128-bits of classical security strength, and is claimed to meet NIST Level 1
+         * quantum security strength (equivalent to finding the key for an AES-128 block).
+         * <p>
+         * SLH-DSA algorithms with the 'f' suffix have larger signatures but are much faster.
+         */
+        slhDsaShake_128f("SLH-DSA", namedParameterSpec("SLH-DSA-SHAKE-128f"), "SLH-DSA-SHAKE-128f"),
+        /**
+         * The SLH-DSA-SHA2-192 algorithm is the NIST FIPS 205 of the post-quantum SPHINCS+ algorithm.
+         * It has 192-bits of classical security strength, and is claimed to meet NIST Level 3
+         * quantum security strength (equivalent to finding the key for an AES-192 block).
+         * <p>
+         * SLH-DSA algorithms with the 's' suffix have relatively smaller signatures but are much slower.
+         */
+        slhDsaSha2_192s("SLH-DSA", namedParameterSpec("SLH-DSA-SHA2-192s"), "SLH-DSA-SHA2-192s"),
+        /**
+         * The SLH-DSA-SHA2-192f algorithm is the NIST FIPS 205 of the post-quantum SPHINCS+ algorithm.
+         * It has 192-bits of classical security strength, and is claimed to meet NIST Level 3
+         * quantum security strength (equivalent to finding the key for an AES-192 block).
+         * <p>
+         * SLH-DSA algorithms with the 'f' suffix have larger signatures but are much faster.
+         */
+        slhDsaSha2_192f("SLH-DSA", namedParameterSpec("SLH-DSA-SHA2-192f"), "SLH-DSA-SHA2-192f"),
+        /**
+         * The SLH-DSA-SHAKE-192s algorithm is the NIST FIPS 205 of the post-quantum SPHINCS+ algorithm.
+         * It has 192-bits of classical security strength, and is claimed to meet NIST Level 3
+         * quantum security strength (equivalent to finding the key for an AES-192 block).
+         * <p>
+         * SLH-DSA algorithms with the 's' suffix have relatively smaller signatures but are much slower.
+         */
+        slhDsaShake_192s("SLH-DSA", namedParameterSpec("SLH-DSA-SHAKE-192s"), "SLH-DSA-SHAKE-192s"),
+        /**
+         * The SLH-DSA-SHAKE-192f algorithm is the NIST FIPS 205 of the post-quantum SPHINCS+ algorithm.
+         * It has 192-bits of classical security strength, and is claimed to meet NIST Level 3
+         * quantum security strength (equivalent to finding the key for an AES-192 block).
+         * <p>
+         * SLH-DSA algorithms with the 'f' suffix have larger signatures but are much faster.
+         */
+        slhDsaShake_192f("SLH-DSA", namedParameterSpec("SLH-DSA-SHAKE-192f"), "SLH-DSA-SHAKE-192f"),
+        /**
+         * The SLH-DSA-SHA2-256s algorithm is the NIST FIPS 205 of the post-quantum SPHINCS+ algorithm.
+         * It has 256-bits of classical security strength, and is claimed to meet NIST Level 5
+         * quantum security strength (equivalent to finding the key for an AES-256 block).
+         * <p>
+         * SLH-DSA algorithms with the 's' suffix have relatively smaller signatures but are much slower.
+         */
+        slhDsaSha2_256s("SLH-DSA", namedParameterSpec("SLH-DSA-SHA2-256s"), "SLH-DSA-SHA2-256s"),
+        /**
+         * The SLH-DSA-SHA2-256f algorithm is the NIST FIPS 205 of the post-quantum SPHINCS+ algorithm.
+         * It has 256-bits of classical security strength, and is claimed to meet NIST Level 5
+         * quantum security strength (equivalent to finding the key for an AES-256 block).
+         * <p>
+         * SLH-DSA algorithms with the 'f' suffix have larger signatures but are much faster.
+         */
+        slhDsaSha2_256f("SLH-DSA", namedParameterSpec("SLH-DSA-SHA2-256f"), "SLH-DSA-SHA2-256f"),
+        /**
+         * The SLH-DSA-SHAKE-256s algorithm is the NIST FIPS 205 of the post-quantum SPHINCS+ algorithm.
+         * It has 256-bits of classical security strength, and is claimed to meet NIST Level 5
+         * quantum security strength (equivalent to finding the key for an AES-256 block).
+         * <p>
+         * SLH-DSA algorithms with the 's' suffix have relatively smaller signatures but are much slower.
+         */
+        slhDsaShake_256s("SLH-DSA", namedParameterSpec("SLH-DSA-SHAKE-256s"), "SLH-DSA-SHAKE-256s"),
+        /**
+         * The SLH-DSA-SHAKE-256f algorithm is the NIST FIPS 205 of the post-quantum SPHINCS+ algorithm.
+         * It has 256-bits of classical security strength, and is claimed to meet NIST Level 5
+         * quantum security strength (equivalent to finding the key for an AES-256 block).
+         * <p>
+         * SLH-DSA algorithms with the 'f' suffix have larger signatures but are much faster.
+         */
+        slhDsaShake_256f("SLH-DSA", namedParameterSpec("SLH-DSA-SHAKE-256f"), "SLH-DSA-SHAKE-256f"),
+        ;
 
         final String keyType;
         final AlgorithmParameterSpec parameterSpec;

--- a/pkitesting/src/test/java/io/netty/pkitesting/CertificateBuilderTest.java
+++ b/pkitesting/src/test/java/io/netty/pkitesting/CertificateBuilderTest.java
@@ -19,6 +19,7 @@ import io.netty.pkitesting.CertificateBuilder.Algorithm;
 import io.netty.pkitesting.CertificateBuilder.KeyUsage;
 import io.netty.util.internal.PlatformDependent;
 
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.jsse.provider.BouncyCastleJsseProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
@@ -108,7 +109,7 @@ class CertificateBuilderTest {
     void createKeyPairWithProvider(Algorithm algorithm) throws Exception {
         assumeTrue(algorithm.isSupported());
 
-        KeyPair keyPair = algorithm.generateKeyPair(RNG, new BouncyCastleJsseProvider());
+        KeyPair keyPair = algorithm.generateKeyPair(RNG, new BouncyCastleProvider());
         assertNotNull(keyPair);
         assertNotNull(keyPair.getPrivate());
         assertNotNull(keyPair.getPublic());


### PR DESCRIPTION
Motivation:
These NIST FIPS 205 post-quantum signing algorithms have fairly small public and private keys, but have much larger signatures, and can be much slower. They are, however, useful for code signing, and offer a fallback in case fundamental weaknesses are found in lattice-based algorithms.

Modification:
Add enum variants and OIDs for each of the 12 variants of SLH-DSA.

Our test suite is already parameterized and pick them up automatically.

BouncyCastle also already support them.

Result:
SLH-DSA is available in netty-pkitesting.