### PR TITLE
Fix typo: 'Begining' -> 'Beginning' in HpackDecoderTest

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackDecoderTest.java
@@ -404,7 +404,7 @@ public class HpackDecoderTest {
     }
 
     @Test
-    public void testDynamicTableSizeUpdateAfterTheBeginingOfTheBlock() throws Http2Exception {
+    public void testDynamicTableSizeUpdateAfterTheBeginningOfTheBlock() throws Http2Exception {
         assertThrows(Http2Exception.class, new Executable() {
             @Override
             public void execute() throws Throwable {


### PR DESCRIPTION
Fix typo in test method name: 'Begining' -> 'Beginning'