### PR TITLE
Update BouncyCastle from 1.82 to 1.83

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -715,7 +715,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <netty.build.version>31</netty.build.version>
     <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
-    <bouncycastle.version>1.82</bouncycastle.version>
+    <bouncycastle.version>1.83</bouncycastle.version>
     <argLine.common>
       -server
       -dsa -da -ea:io.netty...

--- a/testsuite-jpms/pom.xml
+++ b/testsuite-jpms/pom.xml
@@ -204,10 +204,12 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk18on</artifactId>
+      <version>1.82</version> <!-- TODO reverted version to avoid jlink breakage introduced in 1.83 -->
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk18on</artifactId>
+      <version>1.82</version> <!-- TODO reverted version to avoid jlink breakage introduced in 1.83 -->
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/testsuite-jpms/src/main/java/module-info.java
+++ b/testsuite-jpms/src/main/java/module-info.java
@@ -27,5 +27,4 @@ module io.netty.testsuite_jpms.main {
     requires io.netty.tcnative.classes.openssl;
     requires io.netty.codec.http3;
     requires io.netty.codec.classes.quic;
-    requires org.bouncycastle.provider;
 }

--- a/testsuite-jpms/src/test/java/module-info.java
+++ b/testsuite-jpms/src/test/java/module-info.java
@@ -44,7 +44,6 @@ open module io.netty.testsuite_jpms.test {
     requires io.netty.codec.http3;
     requires io.netty.codec.classes.quic;
     requires org.jboss.marshalling;
-    requires org.bouncycastle.pkix;
 
     requires static org.slf4j;
     requires static ch.qos.logback.core;


### PR DESCRIPTION
Motivation:
Use the latest version of BouncyCastle in pkitesting and SelfSignedCertificate.

Modification:
Bump our BouncyCastle version to 1.83.

Result:
We're on the latest BouncyCastle version.
See their release notes: https://www.bouncycastle.org/resources/new-release-composite-signatures_unsigned-certificates_and_crmf-cmp-challenge-response/