### PR TITLE
Avoid UnsupportedOperationException in CompositeeByteBuf when noUnsafe is true

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -923,8 +923,7 @@ public final class ByteBufUtil {
             if (buffer.hasArray()) {
                 return safeArrayWriteUtf8(buffer.array(), buffer.arrayOffset() + writerIndex, seq, start, end);
             }
-            if (buffer.isDirect()) {
-                assert buffer.nioBufferCount() == 1;
+            if (buffer.isDirect() && buffer.nioBufferCount() == 1) {
                 final ByteBuffer internalDirectBuffer = buffer.internalNioBuffer(writerIndex, reservedBytes);
                 final int bufferPosition = internalDirectBuffer.position();
                 return safeDirectWriteUtf8(internalDirectBuffer, bufferPosition, seq, start, end);

--- a/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
@@ -45,9 +45,10 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class ByteBufUtilTest {
     private static final String PARAMETERIZED_NAME = "bufferType = {0}";
+    private final AdaptiveByteBufAllocator adaptiveByteBufAllocator = new AdaptiveByteBufAllocator();
 
     private enum BufferType {
-        DIRECT_UNPOOLED, DIRECT_POOLED, HEAP_POOLED, HEAP_UNPOOLED
+        DIRECT_UNPOOLED, DIRECT_POOLED, DIRECT_ADAPTIVE, HEAP_POOLED, HEAP_UNPOOLED, HEAP_ADAPTIVE
     }
 
     private ByteBuf buffer(BufferType bufferType, int capacity) {
@@ -61,6 +62,10 @@ public class ByteBufUtilTest {
             return PooledByteBufAllocator.DEFAULT.directBuffer(capacity);
         case HEAP_POOLED:
             return PooledByteBufAllocator.DEFAULT.buffer(capacity);
+        case DIRECT_ADAPTIVE:
+            return adaptiveByteBufAllocator.directBuffer(capacity);
+        case HEAP_ADAPTIVE:
+            return adaptiveByteBufAllocator.heapBuffer(capacity);
         default:
             throw new AssertionError("unexpected buffer type: " + bufferType);
         }
@@ -77,6 +82,10 @@ public class ByteBufUtilTest {
                 return PooledByteBufAllocator.DEFAULT.compositeDirectBuffer();
             case HEAP_POOLED:
                 return PooledByteBufAllocator.DEFAULT.compositeHeapBuffer();
+            case DIRECT_ADAPTIVE:
+                return adaptiveByteBufAllocator.compositeDirectBuffer();
+            case HEAP_ADAPTIVE:
+                return adaptiveByteBufAllocator.compositeHeapBuffer();
             default:
                 throw new AssertionError("unexpected buffer type: " + bufferType);
         }
@@ -87,7 +96,9 @@ public class ByteBufUtilTest {
                 { BufferType.DIRECT_POOLED },
                 { BufferType.DIRECT_UNPOOLED },
                 { BufferType.HEAP_POOLED },
-                { BufferType.HEAP_UNPOOLED }
+                { BufferType.HEAP_UNPOOLED },
+                { BufferType.DIRECT_ADAPTIVE },
+                { BufferType.HEAP_ADAPTIVE }
         });
     }
 

--- a/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
@@ -66,6 +66,22 @@ public class ByteBufUtilTest {
         }
     }
 
+    private CompositeByteBuf compositeByteBuf(BufferType bufferType) {
+        switch (bufferType) {
+
+            case DIRECT_UNPOOLED:
+                return  UnpooledByteBufAllocator.DEFAULT.compositeDirectBuffer();
+            case HEAP_UNPOOLED:
+                return  UnpooledByteBufAllocator.DEFAULT.compositeHeapBuffer();
+            case DIRECT_POOLED:
+                return PooledByteBufAllocator.DEFAULT.compositeDirectBuffer();
+            case HEAP_POOLED:
+                return PooledByteBufAllocator.DEFAULT.compositeHeapBuffer();
+            default:
+                throw new AssertionError("unexpected buffer type: " + bufferType);
+        }
+    }
+
     public static Collection<Object[]> noUnsafe() {
         return Arrays.asList(new Object[][] {
                 { BufferType.DIRECT_POOLED },
@@ -403,7 +419,7 @@ public class ByteBufUtilTest {
         String usAscii = "NettyRocks";
         ByteBuf buf = buffer(bufferType, 16);
         buf.writeBytes(usAscii.getBytes(CharsetUtil.US_ASCII));
-        ByteBuf buf2 = Unpooled.compositeBuffer().addComponent(
+        ByteBuf buf2 = compositeByteBuf(bufferType).addComponent(
                 buffer(bufferType, 8)).addComponent(buffer(bufferType, 24));
         // write some byte so we start writing with an offset.
         buf2.writeByte(1);
@@ -422,7 +438,7 @@ public class ByteBufUtilTest {
         String usAscii = "NettyRocks";
         ByteBuf buf = buffer(bufferType, 16);
         buf.writeBytes(usAscii.getBytes(CharsetUtil.US_ASCII));
-        ByteBuf buf2 = new WrappedCompositeByteBuf(Unpooled.compositeBuffer().addComponent(
+        ByteBuf buf2 = new WrappedCompositeByteBuf(compositeByteBuf(bufferType).addComponent(
                 buffer(bufferType, 8)).addComponent(buffer(bufferType, 24)));
         // write some byte so we start writing with an offset.
         buf2.writeByte(1);
@@ -456,7 +472,7 @@ public class ByteBufUtilTest {
         String utf8 = "Some UTF-8 like äÄ∏ŒŒ";
         ByteBuf buf = buffer(bufferType, 16);
         buf.writeBytes(utf8.getBytes(CharsetUtil.UTF_8));
-        ByteBuf buf2 = Unpooled.compositeBuffer().addComponent(
+        ByteBuf buf2 = compositeByteBuf(bufferType).addComponent(
                 buffer(bufferType, 8)).addComponent(buffer(bufferType, 24));
         // write some byte so we start writing with an offset.
         buf2.writeByte(1);
@@ -475,7 +491,7 @@ public class ByteBufUtilTest {
         String utf8 = "Some UTF-8 like äÄ∏ŒŒ";
         ByteBuf buf = buffer(bufferType, 16);
         buf.writeBytes(utf8.getBytes(CharsetUtil.UTF_8));
-        ByteBuf buf2 = new WrappedCompositeByteBuf(Unpooled.compositeBuffer().addComponent(
+        ByteBuf buf2 = new WrappedCompositeByteBuf(compositeByteBuf(bufferType).addComponent(
                 buffer(bufferType, 8)).addComponent(buffer(bufferType, 24)));
         // write some byte so we start writing with an offset.
         buf2.writeByte(1);
@@ -816,7 +832,7 @@ public class ByteBufUtilTest {
     @ParameterizedTest(name = PARAMETERIZED_NAME)
     @MethodSource("noUnsafe")
     public void testToStringDoesNotThrowIndexOutOfBounds(BufferType bufferType) {
-        CompositeByteBuf buffer = Unpooled.compositeBuffer();
+        CompositeByteBuf buffer = compositeByteBuf(bufferType);
         try {
             byte[] bytes = "1234".getBytes(CharsetUtil.UTF_8);
             buffer.addComponent(buffer(bufferType, bytes.length).writeBytes(bytes));


### PR DESCRIPTION
Motivation:

On Java 25, Netty defaults to io.netty.noUnsafe=true. The following code throws UnsupportedOperationException:
``` java
CompositeByteBuf compositeByteBuf = ByteBufAllocator.DEFAULT.compositeDirectBuffer();
compositeByteBuf.addComponent(ByteBufAllocator.DEFAULT.directBuffer(2));
compositeByteBuf.addComponent(ByteBufAllocator.DEFAULT.directBuffer(2));
ByteBufUtil.writeUtf8(compositeByteBuf, "");
```
This happens because ByteBufUtil#writeUtf8(AbstractByteBuf, ...) uses ByteBuf#internalNioBuffer, which throws UnsupportedOperationException when a CompositeByteBuf is composed of multiple DirectByteBuf components. With io.netty.noUnsafe=false, Netty uses the safe UTF-8 write path, so the issue is not triggered.

The existing unit test did not catch this because it uses a direct=false compositeByteBuf; after calling `writeByte`, a heapBytebuf component is added, so the failing path is avoided.

https://github.com/netty/netty/blob/11938b53522a578b7e113e4fe85baa560e7aa841/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java#L459-L463

Modification:

1.	Avoid UnsupportedOperationException in ByteBufUtil#writeUtf8 for direct CompositeByteBuf when io.netty.noUnsafe=true.
2.	Fix the unit test to cover the failing scenario.

Result:

Resolves UnsupportedOperationException when writing UTF-8 to direct CompositeByteBuf with noUnsafe.
