### PR TITLE
Avoid UnsupportedOperationException in CompositeeByteBuf when noUnsafe is true (#16097)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -923,8 +923,7 @@ public final class ByteBufUtil {
             if (buffer.hasArray()) {
                 return safeArrayWriteUtf8(buffer.array(), buffer.arrayOffset() + writerIndex, seq, start, end);
             }
-            if (buffer.isDirect()) {
-                assert buffer.nioBufferCount() == 1;
+            if (buffer.isDirect() && buffer.nioBufferCount() == 1) {
                 final ByteBuffer internalDirectBuffer = buffer.internalNioBuffer(writerIndex, reservedBytes);
                 final int bufferPosition = internalDirectBuffer.position();
                 return safeDirectWriteUtf8(internalDirectBuffer, bufferPosition, seq, start, end);


### PR DESCRIPTION
Motivation:

On Java 25, Netty defaults to io.netty.noUnsafe=true. The following code throws UnsupportedOperationException:
``` java
CompositeByteBuf compositeByteBuf = ByteBufAllocator.DEFAULT.compositeDirectBuffer();
compositeByteBuf.addComponent(ByteBufAllocator.DEFAULT.directBuffer(2));
compositeByteBuf.addComponent(ByteBufAllocator.DEFAULT.directBuffer(2));
ByteBufUtil.writeUtf8(compositeByteBuf, "");
```
This happens because ByteBufUtil#writeUtf8(AbstractByteBuf, ...) uses ByteBuf#internalNioBuffer, which throws UnsupportedOperationException when a CompositeByteBuf is composed of multiple DirectByteBuf components. With io.netty.noUnsafe=false, Netty uses the safe UTF-8 write path, so the issue is not triggered.

The existing unit test did not catch this because it uses a direct=false compositeByteBuf; after calling `writeByte`, a heapBytebuf component is added, so the failing path is avoided.

https://github.com/netty/netty/blob/11938b53522a578b7e113e4fe85baa560e7aa841/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java#L459-L463

Modification:

1. Avoid UnsupportedOperationException in ByteBufUtil#writeUtf8 for direct CompositeByteBuf when io.netty.noUnsafe=true.
2.	Fix the unit test to cover the failing scenario.

Result:

Resolves UnsupportedOperationException when writing UTF-8 to direct CompositeByteBuf with noUnsafe.

(cherry picked from commit db33c486a48069548eb1226d36e015fded2a553f)