### PR TITLE
Add support for cross-signing to pkitesting

### DIFF
--- a/pkitesting/src/main/java/io/netty/pkitesting/X509Bundle.java
+++ b/pkitesting/src/main/java/io/netty/pkitesting/X509Bundle.java
@@ -36,6 +36,7 @@ import java.security.cert.TrustAnchor;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.LinkedHashSet;
 import java.util.List;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManager;
@@ -428,5 +429,27 @@ public final class X509Bundle {
         }
         kmf.init(toKeyStore(EmptyArrays.EMPTY_CHARS), EmptyArrays.EMPTY_CHARS);
         return kmf;
+    }
+
+    /**
+     * Create a new {@link X509Bundle} that has the leaf and root certificates of <em>this</em> bundle,
+     * but a certificate path that is the combination all the intermediate certificates of both this and the given
+     * bundle.
+     * <p>
+     * This is useful when building a bundle with a cross-signed certificate,
+     * or when you just want to have additional unrelated intermediate certificates in the path.
+     *
+     * @param other The other bundle.
+     * @return A new {@link X509Bundle} that has the leaf and root of this bundle,
+     * but the combined intermediates of both bundles.
+     */
+    public X509Bundle mergeIntermediates(X509Bundle other) {
+        LinkedHashSet<X509Certificate> certs = new LinkedHashSet<>(Arrays.asList(certPath));
+        X509Certificate[] otherPath = other.certPath;
+        for (int i = 1; i < otherPath.length; i++) {
+            X509Certificate intermediate = otherPath[i];
+            certs.add(intermediate);
+        }
+        return fromCertificatePath(certs.toArray(EmptyArrays.EMPTY_X509_CERTIFICATES), root, keyPair);
     }
 }

--- a/pkitesting/src/test/java/io/netty/pkitesting/CertificateBuilderTest.java
+++ b/pkitesting/src/test/java/io/netty/pkitesting/CertificateBuilderTest.java
@@ -424,6 +424,47 @@ class CertificateBuilderTest {
         assertThrows(NullPointerException.class, () -> bundle.getPrivateKeyPEM());
     }
 
+    @Test
+    void generateCertificateWithGivenKeyPair() throws Exception {
+        X509Bundle root = BASE.copy()
+                .setIsCertificateAuthority(true)
+                .setKeyUsage(true, KeyUsage.digitalSignature, KeyUsage.keyCertSign, KeyUsage.cRLSign)
+                .buildSelfSigned();
+        KeyPair keyPair = Algorithm.ecp256.generateKeyPair(new SecureRandom(), null);
+        X509Bundle bundle = BASE.copy()
+                .subject("CN=leaf.netty.io")
+                .keyPair(keyPair)
+                .buildIssuedBy(root);
+        assertThat(bundle.getKeyPair().getPublic()).isSameAs(keyPair.getPublic());
+        assertThat(bundle.getKeyPair().getPrivate()).isSameAs(keyPair.getPrivate());
+        assertNotNull(bundle.getPrivateKeyPEM());
+    }
+
+    @Test
+    void authenticatingCrossSignedCertificate() throws Exception {
+        CertificateBuilder caBuilder = BASE.copy()
+                .setIsCertificateAuthority(true)
+                .setKeyUsage(true, KeyUsage.digitalSignature, KeyUsage.keyCertSign, KeyUsage.cRLSign);
+
+        // Roots. Different subjects.
+        X509Bundle oldRoot = caBuilder.subject("CN=root-a").buildSelfSigned();
+        X509Bundle newRoot = caBuilder.subject("CN=root-b").buildSelfSigned();
+
+        // Intermediates. Same subject. Will be cross-signed.
+        CertificateBuilder intermediateBuilder = caBuilder.copy().subject("CN=issuer.netty.io");
+        X509Bundle oldIssuer = intermediateBuilder.buildIssuedBy(oldRoot);
+        X509Bundle crossIssuer = intermediateBuilder.keyPair(oldIssuer.getKeyPair()).buildIssuedBy(newRoot);
+
+        // Leaf. Cross-signed by cross-signed issuer.
+        CertificateBuilder leafBuilder = BASE.copy().subject("CN=leaf.netty.io").addExtendedKeyUsageClientAuth();
+        X509Bundle leaf = leafBuilder.buildIssuedBy(crossIssuer)
+                .mergeIntermediates(leafBuilder.buildIssuedBy(oldIssuer));
+
+        // This trust manager only knows about the old root. It will throw if it can't find a path to it.
+        X509TrustManager oldRootTrustManager = (X509TrustManager) oldRoot.toTrustManager();
+        oldRootTrustManager.checkClientTrusted(leaf.getCertificatePath(), "UNKNOWN");
+    }
+
     private static X509TrustManager getX509TrustManager(X509Bundle root) throws Exception {
         TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
         PKIXBuilderParameters params = new PKIXBuilderParameters(Collections.singleton(


### PR DESCRIPTION
Motivation:
Cross-signing certificates is surprisingly common in the internet PKI systems. Our netty-pkitesting needs to be able to model this.

Modification:
To be able to cross-signing certificates, we really just need to be able to reuse a KeyPair when building certificates. A convenient method for merging intermediate certificates into the path is also added. Tests are added that demonstrate successful use of cross-signing.

Result:
We can now test scenarios with cross-signed certificates.