### PR TITLE
fix: prevent DGC init failure if IpMulticastAll cannot be set (#16104)

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelConfig;
+import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
@@ -118,7 +119,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
             // Configure IP_MULTICAST_ALL - disable by default to match the behaviour of NIO.
             try {
                 fd.setIpMulticastAll(IP_MULTICAST_ALL);
-            } catch (IOException e) {
+        } catch (IOException | ChannelException e) {
                 logger.debug("Failed to set IP_MULTICAST_ALL to {}", IP_MULTICAST_ALL, e);
             }
         }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
@@ -17,6 +17,7 @@ package io.netty.channel.uring;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelConfig;
+import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelShutdownType;
@@ -117,7 +118,7 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
         // Configure IP_MULTICAST_ALL - disable by default to match the behaviour of NIO.
         try {
             fd.setIpMulticastAll(IP_MULTICAST_ALL);
-        } catch (IOException e) {
+        } catch (IOException | ChannelException e) {
             logger.debug("Failed to set IP_MULTICAST_ALL to {}", IP_MULTICAST_ALL, e);
         }
 


### PR DESCRIPTION
Motivation:
If the channel option IP_MULTICAST_ALL or IPV6_MULTICAST_ALL cannot be set for an epoll/uring datagram channel, the initialization of said channel fails as the option is set in the constructor of said class (the exception is thrown by `netty_unix_socket_setOption` -> `netty_unix_socket_setOptionHandleError` ->
`netty_unix_socket_optionHandleError`)

Modification:
Catch the thrown `ChannelException` (`io.netty.channel.ChannelException: setsockopt() failed: Protocol not available`) and debug log it instead of returning it back to the caller.

Result:
No more init exceptions in the constructor of `IoUringDatagramChannel` / `EpollDatagramChannel`.

Fixes #16082
Also reported on Discord:
https://canary.discord.com/channels/936310574684438528/939129056945913866/1457800915863076875

(cherry picked from commit e14a3bd84c95cd3f9cf19aab11e4a65c35f76f90)
