### PR TITLE
Change cargo ndk flag from -p to --platform

### DIFF
--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -817,7 +817,7 @@
                       <equals arg1="${platform}" arg2="android" />
                       <then>
                         <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
-                          <arg line="ndk ${cargoTarget} -p ${androidNdkVersion} -- build -p quiche --features &quot;ffi qlog&quot; --release" />
+                          <arg line="ndk ${cargoTarget} --platform ${androidNdkVersion} -- build -p quiche --features &quot;ffi qlog&quot; --release" />
                           <env key="CFLAGS" value="${extraCflags}" />
                           <env key="CXXFLAGS" value="${extraCxxflags}" />
                           <env key="QUICHE_BSSL_PATH" value="${boringsslHomeDir}/" />


### PR DESCRIPTION
Motivation:

The shorthand flag was changed from -p to -P in newer versions (https://github.com/bbqsrc/cargo-ndk/commit/c6936333698ed5177105b9e60bcdfb9e2d971d74). Use the long form --platform flag so it can work with both old and new cargo-ndk versions.

Modification:
Change the maven invocation of cargo-ndk to use `--platform` instead of `-p`