### PR TITLE
Set default maxFieldSectionSize to 16MB (#16088)

### DIFF
--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3Settings.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3Settings.java
@@ -254,7 +254,7 @@ public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
         return new Http3Settings()
                 .qpackMaxTableCapacity(0)
                 .qpackBlockedStreams(0)
-                .maxFieldSectionSize(Long.MAX_VALUE)
+                .maxFieldSectionSize(16 * 1024 * 1024)
                 .enableConnectProtocol(false)
                 .enableH3Datagram(false);
     }

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3SettingsTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3SettingsTest.java
@@ -46,7 +46,7 @@ public class Http3SettingsTest {
         assertEquals(0L, settings.qpackMaxTableCapacity());
         assertEquals(0L, settings.qpackBlockedStreams());
         assertEquals(Boolean.FALSE, settings.connectProtocolEnabled());
-        assertEquals(Long.MAX_VALUE, settings.maxFieldSectionSize());
+        assertEquals(16 * 1024 * 1024, settings.maxFieldSectionSize());
         assertEquals(Boolean.FALSE, settings.h3DatagramEnabled());
     }
 


### PR DESCRIPTION
Use 16MB as default maxFieldSectionSize instead of Long.MAX_VALUE

### **Motivation**

Long.MAX_VALUE cannot be encoded as a valid QUIC varint (only 62 value bits are usable, so Max can be 2^62-1 but JAVA Long MAX = 2^63-1), which can cause HTTP/3/WebTransport negotiation failures. A large but bounded default is safer and more compatible across implementations. as per
[RFC9000](https://datatracker.ietf.org/doc/html/rfc9000?#name-variable-length-integer-enc) <img width="400" height="300" alt="Screenshot 2025-12-26 at 12 29 19 AM" src="https://github.com/user-attachments/assets/535048fd-1893-4ffd-bc9e-46c9d802e189" />

### **Modification**

Changed default maxFieldSectionSize from Long.MAX_VALUE to 16 * 1024 * 1024 (16MB).
Result
Fixes #16087 
Uses a QUIC-compliant value and prevents failures during SETTINGS exchange with peers.

> Note : This did not affect any flow uses `new Http3Settings() `only if
implementations use `Http3Settings.defaultSettings()`