### PR TITLE
[io_uring] submit send over write for sockets (#16095)

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
@@ -295,7 +295,7 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
             int length = buf.readableBytes();
             short opsid = nextOpsId();
 
-            ops = IoUringIoOps.newWrite(fd, (byte) 0, 0, address, length, opsid);
+            ops = IoUringIoOps.newSend(fd, (byte) 0, 0, address, length, opsid);
         }
         byte opCode = ops.opcode();
         writeId = registration.submit(ops);


### PR DESCRIPTION
Motivation:

Update io_uring channels to use `send` over `write`.

This is a simple change piggy backing on previous discussions ([ref](https://github.com/netty/netty/issues/12673)). Ultimately, `send` is more performant than `write` when its known the target is a socket.

Other reference
[here](https://talawah.io/blog/extreme-http-performance-tuning-one-point-two-million/#send-recv).

Modification:

io_uring submit `send` over `write` for single messages. No flags are provided or introduced by this.

Result:

I released the [patched
jar](https://github.com/awmcc90/netty/releases/tag/4.2-patched) and tested it via a [vertx
benchmark](https://github.com/awmcc90/FrameworkBenchmarks/commit/506c108bc36afda75ec31780808f7ff995fc348f) I maintain in TFB. Its a smaller optimization but there are fewer instructions executed in the single `send` path than in the `write` path. The relevant flamegraphs are attached to this PR.