### PR TITLE
Limit QUIC stream and field section sizes to protocol max

### DIFF
--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ConnectionHandler.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ConnectionHandler.java
@@ -71,8 +71,9 @@ public abstract class Http3ConnectionHandler extends ChannelInboundHandlerAdapte
         }
         Long maxFieldSectionSize = localSettings.get(Http3SettingsFrame.HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE);
         if (maxFieldSectionSize == null) {
-            // Just use the maximum value we can represent via a Long.
-            maxFieldSectionSize = Long.MAX_VALUE;
+             // Default value in rfc is unlimited
+             // but Quic can have max 2^62-1 max value as TWO bits reserved for Variable-Length Integer Encoding
+            maxFieldSectionSize = (1L << 62) - 1;
         }
         this.maxTableCapacity = localSettings.getOrDefault(HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY, 0);
         int maxBlockedStreams = toIntExact(localSettings.getOrDefault(HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS, 0));

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/EmbeddedQuicChannel.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/EmbeddedQuicChannel.java
@@ -64,6 +64,16 @@ final class EmbeddedQuicChannel extends EmbeddedChannel implements QuicChannel {
     private final ConcurrentLinkedQueue<Integer> closeErrorCodes = new ConcurrentLinkedQueue<>();
     private QuicChannelConfig config;
 
+    /**
+     * TWO bits reserved for Variable-Length Integer Encoding
+     * <a href="https://datatracker.ietf.org/doc/html/rfc9000?#name-variable-length-integer-enc">rfc9000</a>
+     * TWO LSB used for distinguish Client/Server initiated stream & Bi/unidirection
+     * these are not reserved but part of it
+     * <a href="https://datatracker.ietf.org/doc/html/rfc9000?#name-stream-types-and-identifier">rfc9000</a>
+     * so we can max stream per stream type (bi/uni) = (2^62-1)/2
+     */
+    private static final long MAX_PEER_STREAMS_PER_STREAM_TYPE = ((1L << 62) - 1) / 2;
+
     EmbeddedQuicChannel(boolean server) {
         this(server, new ChannelHandler[0]);
     }
@@ -140,10 +150,13 @@ final class EmbeddedQuicChannel extends EmbeddedChannel implements QuicChannel {
 
     @Override
     public long peerAllowedStreams(QuicStreamType type) {
-        return peerAllowedStreams.getOrDefault(type, Long.MAX_VALUE);
+        return peerAllowedStreams.getOrDefault(type, MAX_PEER_STREAMS_PER_STREAM_TYPE);
     }
 
     public void peerAllowedStreams(QuicStreamType type, long peerAllowedStreams) {
+        if (peerAllowedStreams > MAX_PEER_STREAMS_PER_STREAM_TYPE) {
+            peerAllowedStreams = MAX_PEER_STREAMS_PER_STREAM_TYPE;
+        }
         this.peerAllowedStreams.put(type, peerAllowedStreams);
     }
 


### PR DESCRIPTION
Updated the default maxFieldSectionSize in Http3ConnectionHandler to (2^62) - 1, aligning with QUIC variable-length integer limits defined in RFC 9000. Introduced MAX_PEER_STREAMS_PER_STREAM_TYPE in EmbeddedQuicChannel and enforced this maximum for peer allowed streams, ensuring compliance with QUIC stream identifier constraints.

**Motivation**
QUIC uses 62-bit variable-length integers, allowing values up to (2^62) - 1. The previous default did not fully reflect this limit.
Additionally, peer stream limits are applied per stream direction and initiator, but the current stream type model arbitrarily uses or allows Long.MAX_VALUE. This required enforcing a corrected maximum per stream type.

**Modification**
Set maxFieldSectionSize default to (2^62) - 1.
Introduced MAX_PEER_STREAMS_PER_STREAM_TYPE to ((1L << 62) - 1) / 2
Enforced the maximum when storing peer allowed stream counts.

**Result**
Aligns HTTP/3 settings and peer stream limits with RFC 9000 and prevents invalid stream allocations.