### PR TITLE
Fix OCSP signature validation when responder is not the issuer (#16079)

### DIFF
--- a/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspClient.java
+++ b/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspClient.java
@@ -42,6 +42,7 @@ import org.bouncycastle.asn1.x509.AuthorityInformationAccess;
 import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.Extensions;
 import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateHolder;
 import org.bouncycastle.cert.ocsp.BasicOCSPResp;
 import org.bouncycastle.cert.ocsp.CertificateID;
@@ -55,9 +56,22 @@ import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder;
 
 import java.net.InetAddress;
 import java.net.URL;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.security.cert.CertPathBuilder;
+import java.security.cert.CertPathBuilderException;
+import java.security.cert.CertStore;
 import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.security.cert.CollectionCertStoreParameters;
+import java.security.cert.PKIXBuilderParameters;
+import java.security.cert.TrustAnchor;
+import java.security.cert.X509CertSelector;
 import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import static io.netty.handler.codec.http.HttpMethod.POST;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
@@ -264,14 +278,83 @@ final class OcspClient {
     /**
      * Validate OCSP response signature
      */
-    private static void validateSignature(BasicOCSPResp resp, X509Certificate certificate) throws OCSPException {
+    static void validateSignature(BasicOCSPResp resp, X509Certificate issuerCertificate) throws OCSPException {
         try {
-            ContentVerifierProvider verifier = new JcaContentVerifierProviderBuilder().build(certificate);
-            if (!resp.isSignatureValid(verifier)) {
-                throw new OCSPException("OCSP signature is not valid");
+            X509CertificateHolder[] certs = resp.getCerts();
+            JcaContentVerifierProviderBuilder providerBuilder = new JcaContentVerifierProviderBuilder();
+
+            // If responder certificate is included, validate the chain
+            if (certs != null && certs.length > 0) {
+
+                // Use the first included certificate to verify the OCSP response signature.
+                X509CertificateHolder responderCert = certs[0];
+
+                // Verify OCSP response signature using responder cert
+                ContentVerifierProvider responderVerifier = providerBuilder.build(responderCert);
+
+                if (!resp.isSignatureValid(responderVerifier)) {
+                    throw new OCSPException("OCSP response signature is not valid");
+                }
+
+                // Build chain from responder certificate to issuer using CertPathBuilder
+                validateCertificateChain(responderCert, certs, issuerCertificate);
+            } else {
+                // Validate signature using issuer certificate
+                ContentVerifierProvider issuerVerifier = providerBuilder.build(issuerCertificate);
+
+                if (!resp.isSignatureValid(issuerVerifier)) {
+                    throw new OCSPException("OCSP response signature is not valid");
+                }
             }
         } catch (OperatorCreationException e) {
             throw new OCSPException("Error validating OCSP-Signature", e);
+        } catch (CertificateException e) {
+            throw new OCSPException("Error while processing certificates for OCSP signature validation", e);
+        }
+    }
+
+    /**
+     * Validates that a certificate chain can be built from the responder certificate to the issuer.
+     * Uses Java's CertPathBuilder to construct and validate the chain.
+     */
+    private static void validateCertificateChain(X509CertificateHolder responderCert,
+                                                   X509CertificateHolder[] allCerts,
+                                                   X509Certificate issuerCertificate) throws OCSPException {
+        try {
+            // Convert BouncyCastle certificate holders to Java X509Certificates
+            List<X509Certificate> certList = new ArrayList<>(allCerts.length);
+            for (X509CertificateHolder certHolder : allCerts) {
+                certList.add(new JcaX509CertificateConverter().getCertificate(certHolder));
+            }
+
+            // Create a CertStore with all the certificates from the OCSP response
+            CertStore certStore = CertStore.getInstance("Collection",
+                    new CollectionCertStoreParameters(certList));
+
+            // Set up the target certificate selector for the responder certificate
+            X509CertSelector targetConstraints = new X509CertSelector();
+            targetConstraints.setCertificate(new JcaX509CertificateConverter().getCertificate(responderCert));
+
+            // Set up trust anchor with the issuer certificate
+            TrustAnchor trustAnchor = new TrustAnchor(issuerCertificate, null);
+
+            // Build PKIX parameters
+            PKIXBuilderParameters pkixParams = new PKIXBuilderParameters(
+                    Collections.singleton(trustAnchor), targetConstraints);
+            pkixParams.addCertStore(certStore);
+            pkixParams.setRevocationEnabled(false); // Don't check revocation when validating OCSP response
+
+            // Build and validate the certificate path
+            CertPathBuilder builder = CertPathBuilder.getInstance("PKIX");
+            builder.build(pkixParams);
+
+            // If we reach here, the chain is valid
+        } catch (CertPathBuilderException e) {
+            throw new OCSPException("OCSP responder certificate is not trusted by issuer: " + e.getMessage(), e);
+        } catch (InvalidAlgorithmParameterException | NoSuchAlgorithmException e) {
+            throw new OCSPException("Error setting up certificate path validation", e);
+        } catch (CertificateException e) {
+            throw new OCSPException("Error converting certificates for path validation", e);
         }
     }
 

--- a/handler-ssl-ocsp/src/test/java/io/netty/handler/ssl/ocsp/OcspClientTest.java
+++ b/handler-ssl-ocsp/src/test/java/io/netty/handler/ssl/ocsp/OcspClientTest.java
@@ -15,26 +15,44 @@
  */
 package io.netty.handler.ssl.ocsp;
 
+import io.netty.pkitesting.CertificateBuilder;
+import io.netty.pkitesting.X509Bundle;
 import io.netty.util.concurrent.Promise;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateHolder;
 import org.bouncycastle.cert.ocsp.BasicOCSPResp;
+import org.bouncycastle.cert.ocsp.BasicOCSPRespBuilder;
+import org.bouncycastle.cert.ocsp.CertificateID;
+import org.bouncycastle.cert.ocsp.CertificateStatus;
+import org.bouncycastle.cert.ocsp.OCSPException;
+import org.bouncycastle.cert.ocsp.RespID;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import javax.net.ssl.HttpsURLConnection;
 import java.io.IOException;
 import java.net.URL;
 import java.security.cert.X509Certificate;
+import java.util.Date;
 import java.util.concurrent.ExecutionException;
 
 import static io.netty.handler.ssl.ocsp.OcspServerCertificateValidator.createDefaultResolver;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class OcspClientTest extends AbstractOcspTest {
 
-    @Test
-    void simpleOcspQueryTest() throws IOException, ExecutionException, InterruptedException {
+    @ParameterizedTest
+    @ValueSource(strings = {"https://netty.io", "https://apple.com"})
+    void simpleOcspQueryTest(String urlString) throws IOException, ExecutionException, InterruptedException {
         HttpsURLConnection httpsConnection = null;
         try {
-            URL url = new URL("https://netty.io");
+            URL url = new URL(urlString);
             httpsConnection = (HttpsURLConnection) url.openConnection();
             httpsConnection.connect();
 
@@ -54,5 +72,109 @@ class OcspClientTest extends AbstractOcspTest {
                 httpsConnection.disconnect();
             }
         }
+    }
+
+    @Test
+    void validateSignatureWithIncludedChainSucceeds() throws Exception {
+        X509Bundle rootIssuer = new CertificateBuilder()
+                .algorithm(CertificateBuilder.Algorithm.rsa2048)
+                .subject("CN=SomeRootCA")
+                .setIsCertificateAuthority(true)
+                .buildSelfSigned();
+
+        X509Bundle intermediateIssuer = new CertificateBuilder()
+                .algorithm(CertificateBuilder.Algorithm.rsa2048)
+                .subject("CN=SomeIntermediateCA")
+                .setIsCertificateAuthority(true)
+                .buildIssuedBy(rootIssuer);
+
+        X509Bundle ocspResponder = new CertificateBuilder()
+                .algorithm(CertificateBuilder.Algorithm.rsa2048)
+                .subject("CN=SomeOCSPResponder")
+                .buildIssuedBy(intermediateIssuer);
+
+        // Create actual OCSP response with the responder's certificate
+        X509CertificateHolder responderHolder = new JcaX509CertificateHolder(ocspResponder.getCertificate());
+        X509CertificateHolder intermediateHolder = new JcaX509CertificateHolder(intermediateIssuer.getCertificate());
+
+        // Create a minimal BasicOCSPResp that contains the certificate chain
+        BasicOCSPResp resp = createBasicOcspResponse(
+                ocspResponder,
+                new X509CertificateHolder[]{responderHolder, intermediateHolder}
+        );
+
+        assertDoesNotThrow(() -> OcspClient.validateSignature(resp, rootIssuer.getCertificate()));
+    }
+
+    @Test
+    void validateSignatureWithInvalidChainThrows() throws Exception {
+        // Build an unrelated responder chain so nothing is signed by the provided issuer (using RSA)
+        X509Bundle issuerBundle = new CertificateBuilder()
+                .algorithm(CertificateBuilder.Algorithm.rsa2048)
+                .subject("CN=Issuer")
+                .setIsCertificateAuthority(true)
+                .buildSelfSigned();
+
+        // Different CA
+        X509Bundle otherRoot = new CertificateBuilder()
+                .algorithm(CertificateBuilder.Algorithm.rsa2048)
+                .subject("CN=SomeRootCA")
+                .setIsCertificateAuthority(true)
+                .buildSelfSigned();
+
+        X509Bundle otherIntermediate = new CertificateBuilder()
+                .algorithm(CertificateBuilder.Algorithm.rsa2048)
+                .subject("CN=SomeIntermediateCA")
+                .setIsCertificateAuthority(true)
+                .buildIssuedBy(otherRoot);
+
+        X509Bundle otherResponder = new CertificateBuilder()
+                .algorithm(CertificateBuilder.Algorithm.rsa2048)
+                .subject("CN=SomeResponder")
+                .buildIssuedBy(otherIntermediate);
+
+        X509CertificateHolder responderHolder = new JcaX509CertificateHolder(otherResponder.getCertificate());
+        X509CertificateHolder intermediateHolder = new JcaX509CertificateHolder(otherIntermediate.getCertificate());
+
+        // Create actual OCSP response with untrusted chain
+        BasicOCSPResp resp = createBasicOcspResponse(
+                otherResponder,
+                new X509CertificateHolder[]{responderHolder, intermediateHolder}
+        );
+
+        assertThrows(OCSPException.class, () ->
+                OcspClient.validateSignature(resp, issuerBundle.getCertificate())
+        );
+    }
+
+    private static BasicOCSPResp createBasicOcspResponse(X509Bundle responderBundle,
+                                                         X509CertificateHolder[] certChain) throws Exception {
+        X509Bundle dummyCert = new CertificateBuilder()
+                .algorithm(CertificateBuilder.Algorithm.rsa2048)
+                .subject("CN=DummyCert")
+                .setIsCertificateAuthority(true)
+                .buildSelfSigned();
+
+        // Create certificate ID for OCSP response
+        CertificateID certId = new CertificateID(
+                new JcaDigestCalculatorProviderBuilder().build().get(CertificateID.HASH_SHA1),
+                new JcaX509CertificateHolder(dummyCert.getCertificate()),
+                dummyCert.getCertificate().getSerialNumber()
+        );
+
+        // Create response builder with responder ID based on certificate
+        X509CertificateHolder responderHolder = new JcaX509CertificateHolder(responderBundle.getCertificate());
+        RespID respID = new RespID(responderHolder.getSubject());
+
+        BasicOCSPRespBuilder respBuilder = new BasicOCSPRespBuilder(respID);
+
+        // Add response for the certificate (status: good)
+        respBuilder.addResponse(certId, CertificateStatus.GOOD);
+
+        // Build and sign the response with the responder's private key
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA")
+                .build(responderBundle.getKeyPair().getPrivate());
+
+        return respBuilder.build(signer, certChain, new Date());
     }
 }


### PR DESCRIPTION
Motivation:
OCSP validation currently fails when responses are signed by dedicated OCSP responder certificates.
While this is not very common, it is used by apple.com and many other high-traffic websites.

Modification:
Updated the `validateSignature` method to validate OCSP responses signed by delegated OCSP responders and establish a full chain of trust back to the issuer.

Result:
Fixes #15829