### PR TITLE
Propagate the "android" property into individual iterations (#16113)

### DIFF
--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -330,18 +330,21 @@
                     <itemWithProperty>
                       <name>arm64-v8a</name>
                       <properties>
+                        <android>${android}</android>
                         <skipIteration>true</skipIteration>
                       </properties>
                     </itemWithProperty>
                     <itemWithProperty>
                       <name>x86</name>
                       <properties>
+                        <android>${android}</android>
                         <skipIteration>true</skipIteration>
                       </properties>
                     </itemWithProperty>
                     <itemWithProperty>
                       <name>x86_64</name>
                       <properties>
+                        <android>${android}</android>
                         <skipIteration>true</skipIteration>
                       </properties>
                     </itemWithProperty>


### PR DESCRIPTION
Motivation:

Within the iterations for each architecture, propagate `-Dandroid=true`
if it is defined. Without this, the individual iterations fails because
it cannot find the netty-transport-native-epoll target, which is
supposed to be used only in non-Android Linux tests.

Modification:

In codec-native-quic, the iterator-maven-plugin invocation, propagate
the Android property (e.g. when defined by `-Dandroid=true` from command
line) into the child invocations for each architecture.

Co-authored-by: Maurice Lam <yukl@google.com>
Co-authored-by: Norman Maurer <norman_maurer@apple.com>