### PR TITLE
chore: Remove warning when compile with Java 25

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,2 @@
+--enable-native-access=ALL-UNNAMED
+--sun-misc-unsafe-memory-access=allow


### PR DESCRIPTION
Motivation:

It's a warning when running Maven with JDK25

Modification:

Add two options to the mvn config

Result:

The warning is gone now.
