### PR TITLE
Update BouncyCastle from 1.82 to 1.83 (#16096)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -424,7 +424,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <netty.build.version>31</netty.build.version>
-    <bouncycastle.version>1.82</bouncycastle.version>
+    <bouncycastle.version>1.83</bouncycastle.version>
     <argLine.common>
       -server
       -dsa -da -ea:io.netty...

--- a/testsuite-jpms/pom.xml
+++ b/testsuite-jpms/pom.xml
@@ -188,10 +188,12 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk18on</artifactId>
+      <version>1.82</version> <!-- TODO reverted version to avoid jlink breakage introduced in 1.83 -->
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk18on</artifactId>
+      <version>1.82</version> <!-- TODO reverted version to avoid jlink breakage introduced in 1.83 -->
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/testsuite-jpms/src/main/java/module-info.java
+++ b/testsuite-jpms/src/main/java/module-info.java
@@ -27,5 +27,4 @@ module io.netty.testsuite_jpms.main {
     requires io.netty.tcnative.classes.openssl;
     requires io.netty.codec.http3;
     requires io.netty.codec.classes.quic;
-    requires org.bouncycastle.provider;
 }


### PR DESCRIPTION
Motivation:
Use the latest version of BouncyCastle in pkitesting and SelfSignedCertificate.

Modification:
Bump our BouncyCastle version to 1.83.

Result:
We're on the latest BouncyCastle version.
See their release notes:
https://www.bouncycastle.org/resources/new-release-composite-signatures_unsigned-certificates_and_crmf-cmp-challenge-response/