### PR TITLE
Buddy allocation for large buffers in adaptive allocator (#16053)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -18,6 +18,7 @@ package io.netty.buffer;
 import io.netty.util.ByteProcessor;
 import io.netty.util.CharsetUtil;
 import io.netty.util.IllegalReferenceCountException;
+import io.netty.util.IntConsumer;
 import io.netty.util.IntSupplier;
 import io.netty.util.NettyRuntime;
 import io.netty.util.Recycler.EnhancedHandle;
@@ -27,13 +28,13 @@ import io.netty.util.concurrent.FastThreadLocalThread;
 import io.netty.util.concurrent.MpscAtomicIntegerArrayQueue;
 import io.netty.util.concurrent.MpscIntQueue;
 import io.netty.util.internal.ObjectPool;
+import io.netty.util.internal.MathUtil;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.ReferenceCountUpdater;
 import io.netty.util.internal.SuppressJava6Requirement;
 import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.ThreadExecutorMap;
-import io.netty.util.internal.ThreadLocalRandom;
 import io.netty.util.internal.UnstableApi;
 
 import java.io.IOException;
@@ -149,7 +150,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
             8704, // 8192 + 512
             16384,
             16896, // 16384 + 512
-            32768,
+            32768, // TODO: Remove the 32k and 64k size classes once we're smarter about choosing chunks
             65536,
     };
     private static final ChunkReleasePredicate CHUNK_RELEASE_ALWAYS = new ChunkReleasePredicate() {
@@ -166,7 +167,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
     };
 
     private static final int SIZE_CLASSES_COUNT = SIZE_CLASSES.length;
-    private static final byte[] SIZE_INDEXES = new byte[(SIZE_CLASSES[SIZE_CLASSES_COUNT - 1] / 32) + 1];
+    private static final byte[] SIZE_INDEXES = new byte[SIZE_CLASSES[SIZE_CLASSES_COUNT - 1] / 32 + 1];
 
     static {
         if (MAGAZINE_BUFFER_QUEUE_CAPACITY < 2) {
@@ -195,7 +196,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
         chunkRegistry = new ChunkRegistry();
         sizeClassedMagazineGroups = createMagazineGroupSizeClasses(this, false);
         largeBufferMagazineGroup = new MagazineGroup(
-                this, chunkAllocator, new HistogramChunkControllerFactory(true), false);
+                this, chunkAllocator, new BuddyChunkControllerFactory(), false);
         threadLocalGroup = new FastThreadLocal<MagazineGroup[]>() {
             @Override
             protected MagazineGroup[] initialValue() {
@@ -355,10 +356,6 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
 
     private void free() {
         largeBufferMagazineGroup.free();
-    }
-
-    static int sizeToBucket(int size) {
-        return HistogramChunkController.sizeToBucket(size);
     }
 
     @SuppressJava6Requirement(reason = "Guarded by version check")
@@ -560,12 +557,6 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
 
     private static final class SizeClassChunkController implements ChunkController {
 
-        private static final ChunkReleasePredicate FALSE_PREDICATE = new ChunkReleasePredicate() {
-            @Override
-            public boolean shouldReleaseChunk(int chunkSize) {
-                return false;
-            }
-        };
         private final ChunkAllocator chunkAllocator;
         private final int segmentSize;
         private final int chunkSize;
@@ -596,224 +587,46 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
             AbstractByteBuf chunkBuffer = chunkAllocator.allocate(chunkSize, chunkSize);
             assert chunkBuffer.capacity() == chunkSize;
             SizeClassedChunk chunk = new SizeClassedChunk(chunkBuffer, magazine, true,
-                    segmentSize, segmentOffsets, FALSE_PREDICATE);
+                    segmentSize, segmentOffsets, CHUNK_RELEASE_NEVER);
             chunkRegistry.add(chunk);
             return chunk;
         }
     }
 
-    private static final class HistogramChunkControllerFactory implements ChunkControllerFactory {
-        private final boolean shareable;
-
-        private HistogramChunkControllerFactory(boolean shareable) {
-            this.shareable = shareable;
-        }
-
+    private static final class BuddyChunkControllerFactory implements ChunkControllerFactory {
         @Override
         public ChunkController create(MagazineGroup group) {
-            return new HistogramChunkController(group, shareable);
+            return new BuddyChunkController(group);
         }
     }
 
-    private static final class HistogramChunkController implements ChunkController, ChunkReleasePredicate {
-        private static final int MIN_DATUM_TARGET = 1024;
-        private static final int MAX_DATUM_TARGET = 65534;
-        private static final int INIT_DATUM_TARGET = 9;
-        private static final int HISTO_BUCKET_COUNT = 16;
-        private static final int[] HISTO_BUCKETS = {
-                16 * 1024,
-                24 * 1024,
-                32 * 1024,
-                48 * 1024,
-                64 * 1024,
-                96 * 1024,
-                128 * 1024,
-                192 * 1024,
-                256 * 1024,
-                384 * 1024,
-                512 * 1024,
-                768 * 1024,
-                1024 * 1024,
-                1792 * 1024,
-                2048 * 1024,
-                3072 * 1024
-        };
-
-        private final MagazineGroup group;
-        private final boolean shareable;
-        private final short[][] histos = {
-                new short[HISTO_BUCKET_COUNT], new short[HISTO_BUCKET_COUNT],
-                new short[HISTO_BUCKET_COUNT], new short[HISTO_BUCKET_COUNT],
-        };
+    private static final class BuddyChunkController implements ChunkController {
+        private final ChunkAllocator chunkAllocator;
         private final ChunkRegistry chunkRegistry;
-        private short[] histo = histos[0];
-        private final int[] sums = new int[HISTO_BUCKET_COUNT];
 
-        private int histoIndex;
-        private int datumCount;
-        private int datumTarget = INIT_DATUM_TARGET;
-        private boolean hasHadRotation;
-        private volatile int sharedPrefChunkSize = MIN_CHUNK_SIZE;
-        private volatile int localPrefChunkSize = MIN_CHUNK_SIZE;
-        private volatile int localUpperBufSize;
-
-        private HistogramChunkController(MagazineGroup group, boolean shareable) {
-            this.group = group;
-            this.shareable = shareable;
+        BuddyChunkController(MagazineGroup group) {
+            chunkAllocator = group.chunkAllocator;
             chunkRegistry = group.allocator.chunkRegistry;
         }
 
         @Override
-        public int computeBufferCapacity(
-                int requestedSize, int maxCapacity, boolean isReallocation) {
-            if (!isReallocation) {
-                // Only record allocation size if it's not caused by a reallocation that was triggered by capacity
-                // change of the buffer.
-                recordAllocationSize(requestedSize);
-            }
-
-            // Predict starting capacity from localUpperBufSize, but place limits on the max starting capacity
-            // based on the requested size, because localUpperBufSize can potentially be quite large.
-            int startCapLimits;
-            if (requestedSize <= 32768) { // Less than or equal to 32 KiB.
-                startCapLimits = 65536; // Use at most 64 KiB, which is also the AdaptiveRecvByteBufAllocator max.
-            } else {
-                startCapLimits = requestedSize * 2; // Otherwise use at most twice the requested memory.
-            }
-            int startingCapacity = Math.min(startCapLimits, localUpperBufSize);
-            startingCapacity = Math.max(requestedSize, Math.min(maxCapacity, startingCapacity));
-            return startingCapacity;
-        }
-
-        private void recordAllocationSize(int bufferSizeToRecord) {
-            // Use the preserved size from the reused AdaptiveByteBuf, if available.
-            // Otherwise, use the requested buffer size.
-            // This way, we better take into account
-            if (bufferSizeToRecord == 0) {
-                return;
-            }
-            int bucket = sizeToBucket(bufferSizeToRecord);
-            histo[bucket]++;
-            if (datumCount++ == datumTarget) {
-                rotateHistograms();
-            }
-        }
-
-        static int sizeToBucket(int size) {
-            int index = binarySearchInsertionPoint(Arrays.binarySearch(HISTO_BUCKETS, size));
-            return index >= HISTO_BUCKETS.length ? HISTO_BUCKETS.length - 1 : index;
-        }
-
-        private static int binarySearchInsertionPoint(int index) {
-            if (index < 0) {
-                index = -(index + 1);
-            }
-            return index;
-        }
-
-        static int bucketToSize(int sizeBucket) {
-            return HISTO_BUCKETS[sizeBucket];
-        }
-
-        private void rotateHistograms() {
-            short[][] hs = histos;
-            for (int i = 0; i < HISTO_BUCKET_COUNT; i++) {
-                sums[i] = (hs[0][i] & 0xFFFF) + (hs[1][i] & 0xFFFF) + (hs[2][i] & 0xFFFF) + (hs[3][i] & 0xFFFF);
-            }
-            int sum = 0;
-            for (int count : sums) {
-                sum  += count;
-            }
-            int targetPercentile = (int) (sum * 0.99);
-            int sizeBucket = 0;
-            for (; sizeBucket < sums.length; sizeBucket++) {
-                if (sums[sizeBucket] > targetPercentile) {
-                    break;
-                }
-                targetPercentile -= sums[sizeBucket];
-            }
-            hasHadRotation = true;
-            int percentileSize = bucketToSize(sizeBucket);
-            int prefChunkSize = Math.max(percentileSize * BUFS_PER_CHUNK, MIN_CHUNK_SIZE);
-            localUpperBufSize = percentileSize;
-            localPrefChunkSize = prefChunkSize;
-            if (shareable) {
-                for (Magazine mag : group.magazines) {
-                    HistogramChunkController statistics = (HistogramChunkController) mag.chunkController;
-                    prefChunkSize = Math.max(prefChunkSize, statistics.localPrefChunkSize);
-                }
-            }
-            if (sharedPrefChunkSize != prefChunkSize) {
-                // Preferred chunk size changed. Increase check frequency.
-                datumTarget = Math.max(datumTarget >> 1, MIN_DATUM_TARGET);
-                sharedPrefChunkSize = prefChunkSize;
-            } else {
-                // Preferred chunk size did not change. Check less often.
-                datumTarget = Math.min(datumTarget << 1, MAX_DATUM_TARGET);
-            }
-
-            histoIndex = histoIndex + 1 & 3;
-            histo = histos[histoIndex];
-            datumCount = 0;
-            Arrays.fill(histo, (short) 0);
-        }
-
-        /**
-         * Get the preferred chunk size, based on statistics from the {@linkplain #recordAllocationSize(int) recorded}
-         * allocation sizes.
-         * <p>
-         * This method must be thread-safe.
-         *
-         * @return The currently preferred chunk allocation size.
-         */
-        int preferredChunkSize() {
-            return sharedPrefChunkSize;
+        public int computeBufferCapacity(int requestedSize, int maxCapacity, boolean isReallocation) {
+            return MathUtil.safeFindNextPositivePowerOfTwo(requestedSize);
         }
 
         @Override
         public void initializeSharedStateIn(ChunkController chunkController) {
-            HistogramChunkController statistics = (HistogramChunkController) chunkController;
-            int sharedPrefChunkSize = this.sharedPrefChunkSize;
-            statistics.localPrefChunkSize = sharedPrefChunkSize;
-            statistics.sharedPrefChunkSize = sharedPrefChunkSize;
+            // NOOP
         }
 
         @Override
         public Chunk newChunkAllocation(int promptingSize, Magazine magazine) {
-            int size = Math.max(promptingSize * BUFS_PER_CHUNK, preferredChunkSize());
-            int minChunks = size / MIN_CHUNK_SIZE;
-            if (MIN_CHUNK_SIZE * minChunks < size) {
-                // Round up to nearest whole MIN_CHUNK_SIZE unit. The MIN_CHUNK_SIZE is an even multiple of many
-                // popular small page sizes, like 4k, 16k, and 64k, which makes it easier for the system allocator
-                // to manage the memory in terms of whole pages. This reduces memory fragmentation,
-                // but without the potentially high overhead that power-of-2 chunk sizes would bring.
-                size = MIN_CHUNK_SIZE * (1 + minChunks);
-            }
-
-            // Limit chunks to the max size, even if the histogram suggests to go above it.
-            size = Math.min(size, MAX_CHUNK_SIZE);
-
-            // If we haven't rotated the histogram yet, optimisticly record this chunk size as our preferred.
-            if (!hasHadRotation && sharedPrefChunkSize == MIN_CHUNK_SIZE) {
-                sharedPrefChunkSize = size;
-            }
-
-            ChunkAllocator chunkAllocator = group.chunkAllocator;
-            Chunk chunk = new Chunk(chunkAllocator.allocate(size, size), magazine, true, this);
+            int chunkSize = Math.min(MAX_CHUNK_SIZE,
+                    MathUtil.safeFindNextPositivePowerOfTwo(BUFS_PER_CHUNK * promptingSize));
+            BuddyChunk chunk = new BuddyChunk(chunkAllocator.allocate(chunkSize, chunkSize), magazine,
+                    CHUNK_RELEASE_NEVER);
             chunkRegistry.add(chunk);
             return chunk;
-        }
-
-        @Override
-        public boolean shouldReleaseChunk(int chunkSize) {
-            int preferredSize = preferredChunkSize();
-            int givenChunks = chunkSize / MIN_CHUNK_SIZE;
-            int preferredChunks = preferredSize / MIN_CHUNK_SIZE;
-            int deviation = Math.abs(givenChunks - preferredChunks);
-
-            // Retire chunks with a 5% probability per unit of MIN_CHUNK_SIZE deviation from preference.
-            return deviation != 0 &&
-                    ThreadLocalRandom.current().nextDouble() * 20.0 < deviation;
         }
     }
 
@@ -925,8 +738,8 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
             if (curr != null) {
                 // We have a Chunk that has some space left.
                 int remainingCapacity = curr.remainingCapacity();
-                if (remainingCapacity > startingCapacity) {
-                    curr.readInitInto(buf, size, startingCapacity, maxCapacity);
+                if (remainingCapacity > startingCapacity &&
+                        curr.readInitInto(buf, size, startingCapacity, maxCapacity)) {
                     // We still have some bytes left that we can use for the next allocation, just early return.
                     return true;
                 }
@@ -935,11 +748,9 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                 // null and release it once we are done.
                 current = null;
                 if (remainingCapacity >= size) {
-                    try {
-                        curr.readInitInto(buf, size, remainingCapacity, maxCapacity);
-                        return true;
-                    } finally {
+                    if (curr.readInitInto(buf, size, remainingCapacity, maxCapacity)) {
                         curr.releaseFromMagazine();
+                        return true;
                     }
                 }
 
@@ -971,9 +782,9 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                 }
 
                 int remainingCapacity = curr.remainingCapacity();
-                if (remainingCapacity > startingCapacity) {
+                if (remainingCapacity > startingCapacity &&
+                        curr.readInitInto(buf, size, startingCapacity, maxCapacity)) {
                     // We have a Chunk that has some space left.
-                    curr.readInitInto(buf, size, startingCapacity, maxCapacity);
                     current = curr;
                     return true;
                 }
@@ -982,8 +793,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                     // At this point we know that this will be the last time curr will be used, so directly set it to
                     // null and release it once we are done.
                     try {
-                        curr.readInitInto(buf, size, remainingCapacity, maxCapacity);
-                        return true;
+                        return curr.readInitInto(buf, size, remainingCapacity, maxCapacity);
                     } finally {
                         // Release in a finally block so even if readInitInto(...) would throw we would still correctly
                         // release the current chunk before null it out.
@@ -1017,14 +827,15 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
             }
 
             current = curr;
+            boolean success;
             try {
                 int remainingCapacity = curr.remainingCapacity();
                 assert remainingCapacity >= size;
                 if (remainingCapacity > startingCapacity) {
-                    curr.readInitInto(buf, size, startingCapacity, maxCapacity);
+                    success = curr.readInitInto(buf, size, startingCapacity, maxCapacity);
                     curr = null;
                 } else {
-                    curr.readInitInto(buf, size, remainingCapacity, maxCapacity);
+                    success = curr.readInitInto(buf, size, remainingCapacity, maxCapacity);
                 }
             } finally {
                 if (curr != null) {
@@ -1034,7 +845,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                     current = null;
                 }
             }
-            return true;
+            return success;
         }
 
         private void restoreMagazineFreed() {
@@ -1250,7 +1061,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
         /**
          * Called when a ByteBuf is done using its allocation in this chunk.
          */
-        boolean releaseSegment(int ignoredSegmentId) {
+        boolean releaseSegment(int ignoredSegmentId, int size) {
             return release();
         }
 
@@ -1266,7 +1077,6 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
             } else {
                 updater.resetRefCnt(this);
                 delegate.setIndex(0, 0);
-                allocatedBytes = 0;
                 if (!mag.trySetNextInLine(this)) {
                     // As this Chunk does not belong to the mag anymore we need to decrease the used memory .
                     detachFromMagazine();
@@ -1282,7 +1092,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
             }
         }
 
-        public void readInitInto(AdaptiveByteBuf buf, int size, int startingCapacity, int maxCapacity) {
+        public boolean readInitInto(AdaptiveByteBuf buf, int size, int startingCapacity, int maxCapacity) {
             int startIndex = allocatedBytes;
             allocatedBytes = startIndex + startingCapacity;
             Chunk chunk = this;
@@ -1299,6 +1109,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                     chunk.release();
                 }
             }
+            return true;
         }
 
         public int remainingCapacity() {
@@ -1333,10 +1144,10 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
         }
 
         @Override
-        public void readInitInto(AdaptiveByteBuf buf, int size, int startingCapacity, int maxCapacity) {
+        public boolean readInitInto(AdaptiveByteBuf buf, int size, int startingCapacity, int maxCapacity) {
             int startIndex = freeList.poll();
             if (startIndex == FREE_LIST_EMPTY) {
-                throw new IllegalStateException("Free list is empty");
+                return false;
             }
             allocatedBytes += segmentSize;
             Chunk chunk = this;
@@ -1350,9 +1161,10 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
                     // the chunk again as we retained it before calling buf.init(...). Beside this we also need to
                     // restore the old allocatedBytes value.
                     allocatedBytes -= segmentSize;
-                    chunk.releaseSegment(startIndex);
+                    chunk.releaseSegment(startIndex, startingCapacity);
                 }
             }
+            return true;
         }
 
         @Override
@@ -1383,11 +1195,184 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
         }
 
         @Override
-        boolean releaseSegment(int startIndex) {
+        boolean releaseSegment(int startIndex, int size) {
             boolean released = release();
             boolean segmentReturned = freeList.offer(startIndex);
             assert segmentReturned: "Unable to return segment " + startIndex + " to free list";
             return released;
+        }
+    }
+
+    private static final class BuddyChunk extends Chunk implements IntConsumer {
+        private static final int MIN_BUDDY_SIZE = 32768;
+        private static final byte IS_CLAIMED = (byte) (1 << 7);
+        private static final byte HAS_CLAIMED_CHILDREN = 1 << 6;
+        private static final byte SHIFT_MASK = ~(IS_CLAIMED | HAS_CLAIMED_CHILDREN);
+        private static final int PACK_OFFSET_MASK = 0xFFFF;
+        private static final int PACK_SIZE_SHIFT = Integer.SIZE - Integer.numberOfLeadingZeros(PACK_OFFSET_MASK);
+
+        private final MpscIntQueue freeList;
+        // The bits of each buddy: [1: is claimed][1: has claimed children][30: MIN_BUDDY_SIZE shift to get size]
+        private final byte[] buddies;
+        private final int freeListCapacity;
+
+        BuddyChunk(AbstractByteBuf delegate, Magazine magazine, ChunkReleasePredicate chunkReleasePredicate) {
+            super(delegate, magazine, true, chunkReleasePredicate);
+            int capacity = delegate.capacity();
+            int capFactor = capacity / MIN_BUDDY_SIZE;
+            int tree = (capFactor << 1) - 1;
+            int maxShift = Integer.numberOfTrailingZeros(capFactor);
+            assert maxShift <= 30; // The top 2 bits are used for marking.
+            freeListCapacity = tree >> 1; // At most half of tree (all leaf nodes) can be freed.
+            freeList = new MpscAtomicIntegerArrayQueue(freeListCapacity, -1);
+            buddies = new byte[1 + tree];
+
+            // Generate the buddies entries.
+            int index = 1;
+            int runLength = 1;
+            int currentRun = 0;
+            while (maxShift > 0) {
+                buddies[index++] = (byte) maxShift;
+                if (++currentRun == runLength) {
+                    currentRun = 0;
+                    runLength <<= 1;
+                    maxShift--;
+                }
+            }
+        }
+
+        @Override
+        public boolean readInitInto(AdaptiveByteBuf buf, int size, int startingCapacity, int maxCapacity) {
+            if (!freeList.isEmpty()) {
+                freeList.drain(freeListCapacity, this);
+            }
+            int startIndex = chooseFirstFreeBuddy(1, startingCapacity, 0);
+            if (startIndex == -1) {
+                return false;
+            }
+            Chunk chunk = this;
+            chunk.retain();
+            try {
+                buf.init(delegate, this, 0, 0, startIndex, size, startingCapacity, maxCapacity);
+                allocatedBytes += startingCapacity;
+                chunk = null;
+            } finally {
+                if (chunk != null) {
+                    // If chunk is not null we know that buf.init(...) failed and so we need to manually release
+                    // the chunk again as we retained it before calling buf.init(...).
+                    chunk.release();
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public void accept(int packed) {
+            // Called by allocating thread when draining freeList.
+            int size = MIN_BUDDY_SIZE << (packed >> PACK_SIZE_SHIFT);
+            int offset = (packed & PACK_OFFSET_MASK) * MIN_BUDDY_SIZE;
+            unreserveMatchingBuddy(1, size, offset, 0);
+            allocatedBytes -= size;
+        }
+
+        @Override
+        boolean releaseSegment(int startingIndex, int size) {
+            int packedOffset = startingIndex / MIN_BUDDY_SIZE;
+            int packedSize = Integer.numberOfTrailingZeros(size / MIN_BUDDY_SIZE) << PACK_SIZE_SHIFT;
+            int packed = packedOffset | packedSize;
+            freeList.offer(packed);
+            return release();
+        }
+
+        @Override
+        public int remainingCapacity() {
+            if (!freeList.isEmpty()) {
+                freeList.drain(freeListCapacity, this);
+            }
+            return super.remainingCapacity();
+        }
+
+        @Override
+        boolean releaseFromMagazine() {
+            // Buddy chunks can be reused before they become empty.
+            // We can therefor put them in the shared queue as soon as the magazine is done with this chunk.
+            Magazine mag = magazine;
+            detachFromMagazine();
+            if (!mag.offerToQueue(this)) {
+                return super.releaseFromMagazine();
+            }
+            return false;
+        }
+
+        /**
+         * Claim a suitable buddy and return its start offset into the delegate chunk, or return -1 if nothing claimed.
+         */
+        private int chooseFirstFreeBuddy(int index, int size, int currOffset) {
+            byte[] buddies = this.buddies;
+            while (index < buddies.length) {
+                byte buddy = buddies[index];
+                int currValue = MIN_BUDDY_SIZE << (buddy & SHIFT_MASK);
+                if (currValue < size || (buddy & IS_CLAIMED) == IS_CLAIMED) {
+                    return -1;
+                }
+                if (currValue == size && (buddy & HAS_CLAIMED_CHILDREN) == 0) {
+                    buddies[index] |= IS_CLAIMED;
+                    return currOffset;
+                }
+                int found = chooseFirstFreeBuddy(index << 1, size, currOffset);
+                if (found != -1) {
+                    buddies[index] |= HAS_CLAIMED_CHILDREN;
+                    return found;
+                }
+                index = (index << 1) + 1;
+                currOffset += currValue >> 1; // Bump offset to skip first half of this layer.
+            }
+            return -1;
+        }
+
+        /**
+         * Un-reserve the matching buddy and return whether there are any other child or sibling reservations.
+         */
+        private boolean unreserveMatchingBuddy(int index, int size, int offset, int currOffset) {
+            byte[] buddies = this.buddies;
+            if (buddies.length <= index) {
+                return false;
+            }
+            byte buddy = buddies[index];
+            int currSize = MIN_BUDDY_SIZE << (buddy & SHIFT_MASK);
+
+            if (currSize == size) {
+                // We're at the right size level.
+                if (currOffset == offset) {
+                    buddies[index] &= SHIFT_MASK;
+                    return false;
+                }
+                throw new IllegalStateException("The intended segment was not found at index " +
+                        index + ", for size " + size + " and offset " + offset);
+            }
+
+            // We're at a parent size level. Use the target offset to guide our drill-down path.
+            boolean claims;
+            int siblingIndex;
+            if (offset < currOffset + (currSize >> 1)) {
+                // Must be down the left path.
+                claims = unreserveMatchingBuddy(index << 1, size, offset, currOffset);
+                siblingIndex = (index << 1) + 1;
+            } else {
+                // Must be down the rigth path.
+                claims = unreserveMatchingBuddy((index << 1) + 1, size, offset, currOffset + (currSize >> 1));
+                siblingIndex = index << 1;
+            }
+            if (!claims) {
+                // No other claims down the path we took. Check if the sibling has claims.
+                byte sibling = buddies[siblingIndex];
+                if ((sibling & SHIFT_MASK) == sibling) {
+                    // No claims in the sibling. We can clear this level as well.
+                    buddies[index] &= SHIFT_MASK;
+                    return false;
+                }
+            }
+            return true;
         }
     }
 
@@ -1462,11 +1447,12 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
             int readerIndex = this.readerIndex;
             int writerIndex = this.writerIndex;
             int baseOldRootIndex = startIndex;
-            int oldCapacity = length;
+            int oldLength = length;
+            int oldCapacity = maxFastCapacity;
             AbstractByteBuf oldRoot = rootParent();
             allocator.reallocate(newCapacity, maxCapacity(), this);
-            oldRoot.getBytes(baseOldRootIndex, this, 0, oldCapacity);
-            chunk.releaseSegment(baseOldRootIndex);
+            oldRoot.getBytes(baseOldRootIndex, this, 0, oldLength);
+            chunk.releaseSegment(baseOldRootIndex, oldCapacity);
             this.readerIndex = readerIndex;
             this.writerIndex = writerIndex;
             return this;
@@ -1843,7 +1829,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
         @Override
         protected void deallocate() {
             if (chunk != null) {
-                chunk.releaseSegment(startIndex);
+                chunk.releaseSegment(startIndex, maxFastCapacity);
             }
             tmpNioBuf = null;
             chunk = null;

--- a/buffer/src/test/java/io/netty/buffer/AdaptivePoolingAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptivePoolingAllocatorTest.java
@@ -15,52 +15,11 @@
  */
 package io.netty.buffer;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class AdaptivePoolingAllocatorTest implements Supplier<String> {
-    private int i;
-
-    @BeforeEach
-    void setUp() {
-        i = 0;
-    }
-
-    @Override
-    public String get() {
-        return "i = " + i;
-    }
-
-    @Test
-    void sizeBucketComputations() throws Exception {
-        assertSizeBucket(0, 16 * 1024);
-        assertSizeBucket(1, 24 * 1024);
-        assertSizeBucket(2, 32 * 1024);
-        assertSizeBucket(3, 48 * 1024);
-        assertSizeBucket(4, 64 * 1024);
-        assertSizeBucket(5, 96 * 1024);
-        assertSizeBucket(6, 128 * 1024);
-        assertSizeBucket(7, 192 * 1024);
-        assertSizeBucket(8, 256 * 1024);
-        assertSizeBucket(9, 384 * 1024);
-        assertSizeBucket(10, 512 * 1024);
-        assertSizeBucket(11, 768 * 1024);
-        assertSizeBucket(12, 1024 * 1024);
-        assertSizeBucket(13, 1792 * 1024);
-        assertSizeBucket(14, 2048 * 1024);
-        assertSizeBucket(15, 3072 * 1024);
-        // The sizeBucket function will be used for sizes up to 8 MiB
-        assertSizeBucket(15, 4 * 1024 * 1024);
-        assertSizeBucket(15, 5 * 1024 * 1024);
-        assertSizeBucket(15, 6 * 1024 * 1024);
-        assertSizeBucket(15, 7 * 1024 * 1024);
-        assertSizeBucket(15, 8 * 1024 * 1024);
-    }
-
+class AdaptivePoolingAllocatorTest {
     @Test
     void sizeClassComputations() throws Exception {
         final int[] sizeClasses = AdaptivePoolingAllocator.getSizeClasses();
@@ -75,20 +34,7 @@ class AdaptivePoolingAllocatorTest implements Supplier<String> {
 
     private static void assertSizeClassOf(int expectedSizeClass, int previousSizeIncluded, int maxSizeIncluded) {
         for (int size = previousSizeIncluded; size <= maxSizeIncluded; size++) {
-            final int sizeToTest = size;
-            Supplier<String> messageSupplier = new Supplier<String>() {
-                @Override
-                public String get() {
-                    return "size = " + sizeToTest;
-                }
-            };
-            assertEquals(expectedSizeClass, AdaptivePoolingAllocator.sizeClassIndexOf(size), messageSupplier);
-        }
-    }
-
-    private void assertSizeBucket(int expectedSizeBucket, int maxSizeIncluded) {
-        for (; i <= maxSizeIncluded; i++) {
-            assertEquals(expectedSizeBucket, AdaptivePoolingAllocator.sizeToBucket(i), this);
+            assertEquals(expectedSizeClass, AdaptivePoolingAllocator.sizeClassIndexOf(size), "size = " + size);
         }
     }
 }


### PR DESCRIPTION
Motivation:

The histogram bump allocating chunks have poor chunk and memory reuse in practice, which leads to higher memory usage than the pooled allocator whenever an application performs enough allocations of buffers that don't fit in our size-classed chunks.

Buddy allocation should in theory reduce memory consumption by allowing memory reuse within a chunk, similar to the size-classed chunks, but for variable power-of-two sized allocations.

We've found that beyond 16k-20k buffer sizes, allocations predominantly comes in power-of-two sizes, hence buddy allocation should be a good fit for this size regime.

Modification:

* Implement a new chunk type that does buddy allocation, based on an array-embedded binary search tree.
* The tree is encoded as a dense byte array, with two bits marking node or child-node usage, and six bits to encode the node size.
* The histogram pointer-bump allocating chunk implementation is removed, which unlocks potential simplifications and optimizations that will benefit both buddy and size-classed chunks.
* The 32k and 64k size classes are kept for the time being, to keep chunk churn under control, but they are planned to be removed in a follow-up PR.

Result:

We generally get improvements to memory usage, because the buddy allocator is able to reuse its chunks before they are fully deallocated. If the 32k and 64k size-classes are removed, then the improvements continue to hold up, but we see an increase in allocation churn for buddy chunks.
This needs to be investigated and solved before we can remove the 32k and 64k size-classes.
Presumably, it comes down to making better decisions about the size of the buddy chunks, and in picking which chunks to allocate from next once a magazine has exhausted its current chunk.

(cherry picked from commit 2dbc1e7c5c7b8d7b62a4b487fc7e1d705765fbca)