### PR TITLE
Buddy allocation for large buffers in adaptive allocator (#16053)

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/AdaptivePoolingAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptivePoolingAllocatorTest.java
@@ -15,52 +15,11 @@
  */
 package io.netty.buffer;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class AdaptivePoolingAllocatorTest implements Supplier<String> {
-    private int i;
-
-    @BeforeEach
-    void setUp() {
-        i = 0;
-    }
-
-    @Override
-    public String get() {
-        return "i = " + i;
-    }
-
-    @Test
-    void sizeBucketComputations() throws Exception {
-        assertSizeBucket(0, 16 * 1024);
-        assertSizeBucket(1, 24 * 1024);
-        assertSizeBucket(2, 32 * 1024);
-        assertSizeBucket(3, 48 * 1024);
-        assertSizeBucket(4, 64 * 1024);
-        assertSizeBucket(5, 96 * 1024);
-        assertSizeBucket(6, 128 * 1024);
-        assertSizeBucket(7, 192 * 1024);
-        assertSizeBucket(8, 256 * 1024);
-        assertSizeBucket(9, 384 * 1024);
-        assertSizeBucket(10, 512 * 1024);
-        assertSizeBucket(11, 768 * 1024);
-        assertSizeBucket(12, 1024 * 1024);
-        assertSizeBucket(13, 1792 * 1024);
-        assertSizeBucket(14, 2048 * 1024);
-        assertSizeBucket(15, 3072 * 1024);
-        // The sizeBucket function will be used for sizes up to 8 MiB
-        assertSizeBucket(15, 4 * 1024 * 1024);
-        assertSizeBucket(15, 5 * 1024 * 1024);
-        assertSizeBucket(15, 6 * 1024 * 1024);
-        assertSizeBucket(15, 7 * 1024 * 1024);
-        assertSizeBucket(15, 8 * 1024 * 1024);
-    }
-
+class AdaptivePoolingAllocatorTest {
     @Test
     void sizeClassComputations() throws Exception {
         final int[] sizeClasses = AdaptivePoolingAllocator.getSizeClasses();
@@ -78,12 +37,6 @@ class AdaptivePoolingAllocatorTest implements Supplier<String> {
             int sizeToTest = size;
             assertEquals(expectedSizeClass, AdaptivePoolingAllocator.sizeClassIndexOf(size),
                          () -> "size = " + sizeToTest);
-        }
-    }
-
-    private void assertSizeBucket(int expectedSizeBucket, int maxSizeIncluded) {
-        for (; i <= maxSizeIncluded; i++) {
-            assertEquals(expectedSizeBucket, AdaptivePoolingAllocator.sizeToBucket(i), this);
         }
     }
 }


### PR DESCRIPTION
Motivation:

The histogram bump allocating chunks have poor chunk and memory reuse in practice, which leads to higher memory usage than the pooled allocator whenever an application performs enough allocations of buffers that don't fit in our size-classed chunks.

Buddy allocation should in theory reduce memory consumption by allowing memory reuse within a chunk, similar to the size-classed chunks, but for variable power-of-two sized allocations.

We've found that beyond 16k-20k buffer sizes, allocations predominantly comes in power-of-two sizes, hence buddy allocation should be a good fit for this size regime.

Modification:

* Implement a new chunk type that does buddy allocation, based on an array-embedded binary search tree.
* The tree is encoded as a dense byte array, with two bits marking node or child-node usage, and six bits to encode the node size.
* The histogram pointer-bump allocating chunk implementation is removed, which unlocks potential simplifications and optimizations that will benefit both buddy and size-classed chunks.
* The 32k and 64k size classes are kept for the time being, to keep chunk churn under control, but they are planned to be removed in a follow-up PR.

Result:

We generally get improvements to memory usage, because the buddy allocator is able to reuse its chunks before they are fully deallocated. If the 32k and 64k size-classes are removed, then the improvements continue to hold up, but we see an increase in allocation churn for buddy chunks.
This needs to be investigated and solved before we can remove the 32k and 64k size-classes.
Presumably, it comes down to making better decisions about the size of the buddy chunks, and in picking which chunks to allocate from next once a magazine has exhausted its current chunk.

(cherry picked from commit 2dbc1e7c5c7b8d7b62a4b487fc7e1d705765fbca)