### PR TITLE
Reimplement IORING_OP_SENDMSG_ZC  (#16130)

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
@@ -167,8 +167,9 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
     protected int scheduleWriteMultiple(ChannelOutboundBuffer in) {
         assert writeId == 0;
 
-        if (IoUring.isSendmsgZcSupported() && (
-                (IoUringSocketChannelConfig) config()).shouldWriteZeroCopy((int) in.totalPendingWriteBytes())) {
+        IoUringSocketChannelConfig config = (IoUringSocketChannelConfig) config();
+        ByteBuf current = (ByteBuf) in.current();
+        if (IoUring.isSendmsgZcSupported() && current != null && config.shouldWriteZeroCopy(current.readableBytes())) {
             IoUringIoHandler handler = registration().attachment();
 
             IovArray iovArray = handler.iovArray();
@@ -177,7 +178,16 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
             // buffers.
             iovArray.maxCount(Native.MAX_SKB_FRAGS);
             try {
-                in.forEachFlushedMessage(iovArray);
+                in.forEachFlushedMessage((ChannelOutboundBuffer.MessageProcessor) msg -> {
+                    if (msg instanceof ByteBuf) {
+                        ByteBuf buf = (ByteBuf) msg;
+                        int length = buf.readableBytes();
+                        if (config.shouldWriteZeroCopy(length)) {
+                            return iovArray.processMessage(msg);
+                        }
+                    }
+                    return false;
+                });
             } catch (Exception e) {
                 // This should never happen, anyway fallback to single write.
                 return scheduleWriteSingle(in.current());


### PR DESCRIPTION
Motivation:

https://github.com/axboe/liburing/issues/1191

On HTTP workloads that send a large amount of data, we observe significant CPU time spent copying userspace buffers into kernel socket buffers. This makes zero-copy sends an attractive optimization.

However, this approach also slightly increases CPU usage for workloads that mainly send small buffers such as HTTP headers. In practice, every large data buffer is usually accompanied by one or more small header buffers, which also incur zero-copy related overhead.

Previously, the decision to use sendmsg_zc was based on the total pending write size, i.e.:

``` java
shouldWriteZeroCopy(in.totalPendingWriteBytes())
```

This means that as long as the aggregate size exceeded the zero-copy threshold, all buffers in the batch (including small headers) were included in the sendmsg_zc operation.

This limits the overall benefit of zero-copy, as in mixed-size buffer scenarios (e.g. headers combined with large payloads) we cannot fully realize the advantages of send_zc or sendmsg_zc.

Modification:

This change refines the behavior so that:
• sendmsg_zc is only used for multiple buffers that individually satisfy the zero-copy size threshold
• Buffers that do not meet the send_zc eligibility criteria are excluded from the zero-copy batch
• Small buffers (e.g. headers) are no longer forced through the zero-copy path simply because they are adjacent to large buffers

In other words, this change applies sendmsg_zc selectively, rather than batching buffers of mixed sizes indiscriminately.

Result:

Reimplement IORING_OP_SENDMSG_ZC
Fix #16086