### PR TITLE
Await termination of SslHandler executor (#16138)

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/CipherSuiteCanaryTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/CipherSuiteCanaryTest.java
@@ -223,16 +223,17 @@ public class CipherSuiteCanaryTest {
                     }
                 } finally {
                     server.close().sync();
+
+                    if (executorService != null) {
+                        executorService.shutdown();
+                        assertTrue(executorService.awaitTermination(5, TimeUnit.SECONDS));
+                    }
                 }
             } finally {
                 ReferenceCountUtil.release(sslClientContext);
             }
         } finally {
             ReferenceCountUtil.release(sslServerContext);
-
-            if (executorService != null) {
-                executorService.shutdown();
-            }
         }
     }
 

--- a/handler/src/test/java/io/netty/handler/ssl/DelayingExecutor.java
+++ b/handler/src/test/java/io/netty/handler/ssl/DelayingExecutor.java
@@ -42,7 +42,8 @@ final class DelayingExecutor implements Executor {
                 PlatformDependent.threadLocalRandom().nextInt(100), TimeUnit.MILLISECONDS);
     }
 
-    void shutdown() {
+    boolean shutdownAndAwaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
         service.shutdown();
+        return service.awaitTermination(timeout, unit);
     }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslPrivateKeyMethodTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslPrivateKeyMethodTest.java
@@ -58,8 +58,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -110,11 +108,11 @@ public class OpenSslPrivateKeyMethodTest {
     }
 
     @AfterAll
-    public static void destroy() {
+    public static void destroy() throws InterruptedException {
         if (OpenSsl.isBoringSSL() || OpenSsl.isAWSLC()) {
             GROUP.shutdownGracefully();
             CERT.delete();
-            EXECUTOR.shutdown();
+            assertTrue(EXECUTOR.shutdownAndAwaitTermination(5, TimeUnit.SECONDS));
         }
     }
 

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -547,7 +547,7 @@ public abstract class SSLEngineTest {
         if (clientGroupShutdownFuture != null) {
             clientGroupShutdownFuture.sync();
         }
-        delegatingExecutor.shutdown();
+        assertTrue(delegatingExecutor.shutdownAndAwaitTermination(5, TimeUnit.SECONDS));
         serverException = null;
         clientException = null;
     }

--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -1000,7 +1000,7 @@ public class SslHandlerTest {
         try {
             testHandshakeWithExecutor(executorService, SslProvider.JDK, false);
         } finally {
-            executorService.shutdown();
+            assertTrue(executorService.shutdownAndAwaitTermination(5, TimeUnit.SECONDS));
         }
     }
 
@@ -1029,7 +1029,7 @@ public class SslHandlerTest {
         try {
             testHandshakeWithExecutor(executorService, SslProvider.OPENSSL, false);
         } finally {
-            executorService.shutdown();
+            assertTrue(executorService.shutdownAndAwaitTermination(5, TimeUnit.SECONDS));
         }
     }
 
@@ -1054,7 +1054,7 @@ public class SslHandlerTest {
         try {
             testHandshakeWithExecutor(executorService, SslProvider.JDK, true);
         } finally {
-            executorService.shutdown();
+            assertTrue(executorService.shutdownAndAwaitTermination(5, TimeUnit.SECONDS));
         }
     }
 
@@ -1083,7 +1083,7 @@ public class SslHandlerTest {
         try {
             testHandshakeWithExecutor(executorService, SslProvider.OPENSSL, true);
         } finally {
-            executorService.shutdown();
+            assertTrue(executorService.shutdownAndAwaitTermination(5, TimeUnit.SECONDS));
         }
     }
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
@@ -206,6 +206,7 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
         } finally {
             if (executorService != null) {
                 executorService.shutdown();
+                assertTrue(executorService.awaitTermination(5, TimeUnit.SECONDS));
             }
         }
     }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
@@ -381,6 +381,7 @@ public class SocketSslEchoTest extends AbstractSocketTest {
         clientChannel.close().awaitUninterruptibly();
         sc.close().awaitUninterruptibly();
         delegatedTaskExecutor.shutdown();
+        assertTrue(delegatedTaskExecutor.awaitTermination(5, TimeUnit.SECONDS));
 
         if (serverException.get() != null && !(serverException.get() instanceof IOException)) {
             throw serverException.get();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslGreetingTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslGreetingTest.java
@@ -58,6 +58,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class SocketSslGreetingTest extends AbstractSocketTest {
@@ -179,6 +180,7 @@ public class SocketSslGreetingTest extends AbstractSocketTest {
         } finally {
             if (executorService != null) {
                 executorService.shutdown();
+                assertTrue(executorService.awaitTermination(5, TimeUnit.SECONDS));
             }
         }
     }

--- a/transport-blockhound-tests/src/test/java/io/netty/util/internal/NettyBlockHoundIntegrationTest.java
+++ b/transport-blockhound-tests/src/test/java/io/netty/util/internal/NettyBlockHoundIntegrationTest.java
@@ -250,6 +250,7 @@ public class NettyBlockHoundIntegrationTest {
             testHandshakeWithExecutor(executorService, "TLSv1.2");
         } finally {
             executorService.shutdown();
+            assertTrue(executorService.awaitTermination(5, TimeUnit.SECONDS));
         }
     }
 
@@ -261,6 +262,7 @@ public class NettyBlockHoundIntegrationTest {
             testHandshakeWithExecutor(executorService, "TLSv1.3");
         } finally {
             executorService.shutdown();
+            assertTrue(executorService.awaitTermination(5, TimeUnit.SECONDS));
         }
     }
 


### PR DESCRIPTION
Motivation:

We should await the termination of the executor that is used by the
SslHandler to ensure clean shutdown in tests.

Modifications:

- Await termination in test-code

Result:

Correctly handle shutdown of executor
