### PR TITLE
SslHandler: Only resume on EventLoop if EventLoop is not shutting down already

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1919,6 +1919,10 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
 
         void runComplete() {
             EventExecutor executor = ctx.executor();
+            if (executor.isShuttingDown()) {
+                // The executor is already shutting down, just return.
+                return;
+            }
             // Jump back on the EventExecutor. We do this even if we are already on the EventLoop to guard against
             // reentrancy issues. Failing to do so could lead to the situation of tryDecode(...) be called and so
             // channelRead(...) while still in the decode loop. In this case channelRead(...) might release the input


### PR DESCRIPTION
Motivation:

In our logs we sometimes did see `RejectionExecutionException` as the EventLoop was already shutdown when we tried to move back from the delegating Executor to the EventLoop.

Modifications:

Check if the EventLoop is already shutting down and only if not try to resume work on it.

Result:

Don't cause exceptions when we already have shutdown the EventLoopGroup and using a delegating Executor
