### PR TITLE
Fix leak in OpenSslPrivateKeyMethodTest (#16145)

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslPrivateKeyMethodTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslPrivateKeyMethodTest.java
@@ -111,8 +111,8 @@ public class OpenSslPrivateKeyMethodTest {
     public static void destroy() throws InterruptedException {
         if (OpenSsl.isBoringSSL() || OpenSsl.isAWSLC()) {
             GROUP.shutdownGracefully();
-            CERT.delete();
             assertTrue(EXECUTOR.shutdownAndAwaitTermination(5, TimeUnit.SECONDS));
+            CERT.delete();
         }
     }
 


### PR DESCRIPTION
Motivation:

We sometimes did get a leak report. This was due we not waited for the
EventLoopGroup to shutdown before we also shutdown the delegating
Executor.

Modifications:

Sync during shutdown

Result:

No more leak report
