### PR TITLE
Fix leak in OpenSslPrivateKeyMethodTest (#16145)

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslPrivateKeyMethodTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslPrivateKeyMethodTest.java
@@ -116,7 +116,7 @@ public class OpenSslPrivateKeyMethodTest {
     @AfterAll
     public static void destroy() throws InterruptedException {
         if (OpenSsl.isBoringSSL() || OpenSsl.isAWSLC()) {
-            GROUP.shutdownGracefully();
+            GROUP.shutdownGracefully().sync();
             assertTrue(EXECUTOR.shutdownAndAwaitTermination(5, TimeUnit.SECONDS));
         }
     }


### PR DESCRIPTION
Motivation:

We sometimes did get a leak report. This was due we not waited for the
EventLoopGroup to shutdown before we also shutdown the delegating
Executor.

Modifications:

Sync during shutdown

Result:

No more leak report