### PR TITLE
Wrap ECONNREFUSED in PortUnreachableException for UDP (#16131)

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramConnectedWriteExceptionTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramConnectedWriteExceptionTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.testsuite.transport.socket;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.socket.DatagramPacket;
+import io.netty.testsuite.transport.TestsuitePermutation;
+import io.netty.util.CharsetUtil;
+import io.netty.util.NetUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import java.net.InetSocketAddress;
+import java.net.PortUnreachableException;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DatagramConnectedWriteExceptionTest extends AbstractClientSocketTest {
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
+        return SocketTestPermutation.INSTANCE.datagramSocket();
+    }
+
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+    @DisabledOnOs(OS.WINDOWS)
+    public void testWriteThrowsPortUnreachableException(TestInfo testInfo) throws Throwable {
+        run(testInfo, (Runner<Bootstrap>) this::testWriteExceptionAfterServerStop);
+    }
+
+    protected void testWriteExceptionAfterServerStop(Bootstrap clientBootstrap) throws Throwable {
+        CountDownLatch serverReceivedLatch = new CountDownLatch(1);
+        Bootstrap serverBootstrap = clientBootstrap.clone()
+                .option(ChannelOption.SO_BROADCAST, false)
+                .handler(new SimpleChannelInboundHandler<DatagramPacket>() {
+
+                    @Override
+                    protected void channelRead0(ChannelHandlerContext ctx, DatagramPacket msg) {
+                        serverReceivedLatch.countDown();
+                    }
+                });
+
+        Channel serverChannel = serverBootstrap.bind(new InetSocketAddress(NetUtil.LOCALHOST, 0)).sync().channel();
+        InetSocketAddress serverAddress = (InetSocketAddress) serverChannel.localAddress();
+
+        clientBootstrap.option(ChannelOption.AUTO_READ, false)
+                .handler(new SimpleChannelInboundHandler<DatagramPacket>() {
+
+                    @Override
+                    protected void channelRead0(ChannelHandlerContext ctx, DatagramPacket msg) {
+                        // no-op
+                    }
+                });
+
+        Channel clientChannel = clientBootstrap.connect(serverAddress).sync().channel();
+
+        CountDownLatch clientFirstSendLatch = new CountDownLatch(1);
+        try {
+            ByteBuf firstMessage = Unpooled.wrappedBuffer("First message".getBytes(CharsetUtil.UTF_8));
+            clientChannel.writeAndFlush(firstMessage)
+                    .addListener(future -> {
+                        if (future.isSuccess()) {
+                            clientFirstSendLatch.countDown();
+                        }
+                    });
+
+            assertTrue(serverReceivedLatch.await(5, TimeUnit.SECONDS), "Server should receive first message");
+            assertTrue(clientFirstSendLatch.await(5, TimeUnit.SECONDS), "Client should send first message");
+
+            serverChannel.close().sync();
+
+            AtomicReference<Throwable> writeException = new AtomicReference<>();
+            CountDownLatch writesCompleteLatch = new CountDownLatch(10);
+
+            for (int i = 0; i < 10; i++) {
+                ByteBuf message = Unpooled.wrappedBuffer(("Message " + i).getBytes(CharsetUtil.UTF_8));
+                clientChannel.writeAndFlush(message)
+                        .addListener(future -> {
+                            if (!future.isSuccess()) {
+                                writeException.compareAndSet(null, future.cause());
+                            }
+                            writesCompleteLatch.countDown();
+                        });
+                Thread.sleep(50);
+            }
+
+            assertTrue(writesCompleteLatch.await(5, TimeUnit.SECONDS), "All writes should complete");
+
+            assertNotNull(writeException.get(), "Should have captured a write exception");
+
+            assertInstanceOf(PortUnreachableException.class, writeException.get(), "Expected " +
+                    "PortUnreachableException but got: " + writeException.get().getClass().getName());
+        } finally {
+            if (clientChannel != null) {
+                clientChannel.close().sync();
+            }
+        }
+    }
+}

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramConnectedWriteExceptionTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramConnectedWriteExceptionTest.java
@@ -28,7 +28,6 @@ import io.netty.channel.socket.DatagramPacket;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
-import io.netty.util.concurrent.FutureListener;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
@@ -57,7 +56,12 @@ public class DatagramConnectedWriteExceptionTest extends AbstractClientSocketTes
     @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
     @DisabledOnOs(OS.WINDOWS)
     public void testWriteThrowsPortUnreachableException(TestInfo testInfo) throws Throwable {
-        run(testInfo, (Runner<Bootstrap>) this::testWriteExceptionAfterServerStop);
+        run(testInfo, new Runner<Bootstrap>() {
+            @Override
+            public void run(Bootstrap bootstrap) throws Throwable {
+                testWriteExceptionAfterServerStop(bootstrap);
+            }
+        });
     }
 
     protected void testWriteExceptionAfterServerStop(Bootstrap clientBootstrap) throws Throwable {
@@ -104,7 +108,7 @@ public class DatagramConnectedWriteExceptionTest extends AbstractClientSocketTes
 
             serverChannel.close().sync();
 
-            final AtomicReference<Throwable> writeException = new AtomicReference<>();
+            final AtomicReference<Throwable> writeException = new AtomicReference<Throwable>();
             final CountDownLatch writesCompleteLatch = new CountDownLatch(10);
 
             for (int i = 0; i < 10; i++) {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramConnectedWriteExceptionTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramConnectedWriteExceptionTest.java
@@ -19,6 +19,8 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.SimpleChannelInboundHandler;
@@ -26,6 +28,7 @@ import io.netty.channel.socket.DatagramPacket;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
+import io.netty.util.concurrent.FutureListener;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
@@ -58,7 +61,7 @@ public class DatagramConnectedWriteExceptionTest extends AbstractClientSocketTes
     }
 
     protected void testWriteExceptionAfterServerStop(Bootstrap clientBootstrap) throws Throwable {
-        CountDownLatch serverReceivedLatch = new CountDownLatch(1);
+        final CountDownLatch serverReceivedLatch = new CountDownLatch(1);
         Bootstrap serverBootstrap = clientBootstrap.clone()
                 .option(ChannelOption.SO_BROADCAST, false)
                 .handler(new SimpleChannelInboundHandler<DatagramPacket>() {
@@ -83,13 +86,16 @@ public class DatagramConnectedWriteExceptionTest extends AbstractClientSocketTes
 
         Channel clientChannel = clientBootstrap.connect(serverAddress).sync().channel();
 
-        CountDownLatch clientFirstSendLatch = new CountDownLatch(1);
+        final CountDownLatch clientFirstSendLatch = new CountDownLatch(1);
         try {
             ByteBuf firstMessage = Unpooled.wrappedBuffer("First message".getBytes(CharsetUtil.UTF_8));
             clientChannel.writeAndFlush(firstMessage)
-                    .addListener(future -> {
-                        if (future.isSuccess()) {
-                            clientFirstSendLatch.countDown();
+                    .addListener(new ChannelFutureListener() {
+                        @Override
+                        public void operationComplete(ChannelFuture future) {
+                            if (future.isSuccess()) {
+                                clientFirstSendLatch.countDown();
+                            }
                         }
                     });
 
@@ -98,17 +104,20 @@ public class DatagramConnectedWriteExceptionTest extends AbstractClientSocketTes
 
             serverChannel.close().sync();
 
-            AtomicReference<Throwable> writeException = new AtomicReference<>();
-            CountDownLatch writesCompleteLatch = new CountDownLatch(10);
+            final AtomicReference<Throwable> writeException = new AtomicReference<>();
+            final CountDownLatch writesCompleteLatch = new CountDownLatch(10);
 
             for (int i = 0; i < 10; i++) {
                 ByteBuf message = Unpooled.wrappedBuffer(("Message " + i).getBytes(CharsetUtil.UTF_8));
                 clientChannel.writeAndFlush(message)
-                        .addListener(future -> {
-                            if (!future.isSuccess()) {
-                                writeException.compareAndSet(null, future.cause());
+                        .addListener(new ChannelFutureListener() {
+                            @Override
+                            public void operationComplete(ChannelFuture future) {
+                                if (!future.isSuccess()) {
+                                    writeException.compareAndSet(null, future.cause());
+                                }
+                                writesCompleteLatch.countDown();
                             }
-                            writesCompleteLatch.countDown();
                         });
                 Thread.sleep(50);
             }

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -415,7 +415,14 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
             return true;
         }
 
-        return doWriteOrSendBytes(data, remoteAddress, false) > 0;
+        try {
+            return doWriteOrSendBytes(data, remoteAddress, false) > 0;
+        } catch (NativeIoException e) {
+            if (remoteAddress == null) {
+                throw translateForConnected(e);
+            }
+            throw e;
+        }
     }
 
     private static void checkUnresolved(AddressedEnvelope<?, ?> envelope) {

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDatagramConnectedWriteExceptionTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDatagramConnectedWriteExceptionTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.kqueue;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.testsuite.transport.TestsuitePermutation;
+import io.netty.testsuite.transport.socket.DatagramConnectedWriteExceptionTest;
+
+import java.util.List;
+
+public class KQueueDatagramConnectedWriteExceptionTest extends DatagramConnectedWriteExceptionTest {
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
+        return KQueueSocketTestPermutation.INSTANCE.datagramSocket();
+    }
+}


### PR DESCRIPTION
Motivation:

Currently, `KQueueDatagramChannel` handles `ECONNREFUSED` inconsistently
depending on how data is sent:
- `sendToAddress()` (Unconnected): Correctly wraps errors in
`PortUnreachableException`.
- `writeAddress()` (Connected): Returns raw `ECONNREFUSED`, causing an
inconsistency with `NIO` behaviour.

In `NIO`, the exception is thrown from the write path:

```
 java.net.PortUnreachableException
    at java.base/sun.nio.ch.DatagramDispatcher.write0(Native Method)
    at java.base/sun.nio.ch.DatagramDispatcher.write(DatagramDispatcher.java:51)
    at java.base/sun.nio.ch.IOUtil.writeFromNativeBuffer(IOUtil.java:137)
    at java.base/sun.nio.ch.IOUtil.write(IOUtil.java:81)
    at java.base/sun.nio.ch.IOUtil.write(IOUtil.java:58)
    at java.base/sun.nio.ch.DatagramChannelImpl.write(DatagramChannelImpl.java:1160)
    at io.netty.channel.socket.nio.NioDatagramChannel.doWriteMessage(NioDatagramChannel.java:309)
```

Modifications:

- Introduced `translateForConnected()` to handle error mapping
specifically for the connected state.
- Updated `doWriteMessage()` to apply this translation when the channel
is connected (`remoteAddress == null`) and `writeAddress()` fails with
`ECONNREFUSED`.

Result:

Improved behavioural parity between `KQueue` and `NIO` transports. Users
will now receive a consistent `PortUnreachableException` regardless of
the send path used.

---------

Co-authored-by: Norman Maurer <norman_maurer@apple.com>
