### PR TITLE
Ensure ChannelPromise that are used by ChannelOutboundHandler will al… (#16052)

### DIFF
--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -23,7 +23,9 @@ import io.netty.util.concurrent.AbstractEventExecutor;
 import io.netty.util.concurrent.DefaultPromise;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;
+import io.netty.util.concurrent.PromiseNotifier;
 import io.netty.util.internal.ObjectPool.Handle;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PromiseNotificationUtil;
@@ -366,8 +368,27 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         }
     }
 
+    /**
+     * Check if the given {@link Promise} is using the same {@link EventExecutor} as this
+     * {@link ChannelHandlerContext} and if not return a new {@link Promise} that runs on the same
+     * {@link EventExecutor} as this {@link ChannelHandlerContext}. The result of the new {@link Promise} is
+     * cascaded to the old {@link Promise}.
+     *
+     * This is done to ensure that {@link FutureListener}s that are added to the {@link Promise} by an
+     * {@link ChannelOutboundHandler} are executed in the same thread as the handler itself. By doing so we can
+     * ensure that there are not issues even if fields etc that are stored in the handler are modified by the listener.
+     */
+    private Promise<Void> ensurePromiseUseCorrectExecutor(Promise<Void> promise) {
+        if (!promise.executor().inEventLoop()) {
+            Promise<Void> newPromise = newPromise();
+            PromiseNotifier.cascade(newPromise, promise);
+            return newPromise;
+        }
+        return promise;
+    }
+
     @Override
-    public void register(final Promise<Void> promise) {
+    public void register(Promise<Void> promise) {
         if (isNotValidPromise(promise)) {
             // cancelled
             return;
@@ -377,6 +398,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         EventExecutor executor = next.executor();
         if (executor.inEventLoop()) {
             if (next.invokeHandler()) {
+                promise = ensurePromiseUseCorrectExecutor(promise);
                 try {
                     next.saveCurrentPendingBytesIfNeeded();
                     ((ChannelOutboundHandler) next.handler()).register(next, promise);
@@ -389,12 +411,13 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
                 next.register(promise);
             }
         } else {
-            safeExecute(executor, () -> register(promise), promise, null, false);
+            final Promise<Void> p = promise;
+            safeExecute(executor, () -> register(p), p, null, false);
         }
     }
 
     @Override
-    public void bind(final SocketAddress localAddress, final Promise<Void> promise) {
+    public void bind(final SocketAddress localAddress, Promise<Void> promise) {
         ObjectUtil.checkNotNull(localAddress, "localAddress");
         if (isNotValidPromise(promise)) {
             // cancelled
@@ -405,6 +428,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         EventExecutor executor = next.executor();
         if (executor.inEventLoop()) {
             if (next.invokeHandler()) {
+                promise = ensurePromiseUseCorrectExecutor(promise);
                 try {
                     next.saveCurrentPendingBytesIfNeeded();
                     ((ChannelOutboundHandler) next.handler()).bind(next, localAddress, promise);
@@ -417,7 +441,8 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
                 next.bind(localAddress, promise);
             }
         } else {
-            safeExecute(executor, () -> bind(localAddress, promise), promise, null, false);
+            final Promise<Void> p = promise;
+            safeExecute(executor, () -> bind(localAddress, p), p, null, false);
         }
     }
 
@@ -428,7 +453,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
 
     @Override
     public void connect(
-            final SocketAddress remoteAddress, final SocketAddress localAddress, final Promise<Void> promise) {
+            final SocketAddress remoteAddress, final SocketAddress localAddress, Promise<Void> promise) {
         ObjectUtil.checkNotNull(remoteAddress, "remoteAddress");
 
         if (isNotValidPromise(promise)) {
@@ -440,6 +465,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         EventExecutor executor = next.executor();
         if (executor.inEventLoop()) {
             if (next.invokeHandler()) {
+                promise = ensurePromiseUseCorrectExecutor(promise);
                 try {
                     next.saveCurrentPendingBytesIfNeeded();
                     ((ChannelOutboundHandler) next.handler()).connect(next, remoteAddress, localAddress, promise);
@@ -452,12 +478,13 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
                 next.connect(remoteAddress, localAddress, promise);
             }
         } else {
-            safeExecute(executor, () -> connect(remoteAddress, localAddress, promise), promise, null, false);
+            final Promise<Void> p = promise;
+            safeExecute(executor, () -> connect(remoteAddress, localAddress, p), p, null, false);
         }
     }
 
     @Override
-    public void disconnect(final Promise<Void> promise) {
+    public void disconnect(Promise<Void> promise) {
         if (!pipeline.hasDisconnect) {
             // Translate disconnect to close if the channel has no notion of disconnect-reconnect.
             // So far, UDP/IP is the only transport that has such behavior.
@@ -473,6 +500,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         EventExecutor executor = next.executor();
         if (executor.inEventLoop()) {
             if (next.invokeHandler()) {
+                promise = ensurePromiseUseCorrectExecutor(promise);
                 try {
                     next.saveCurrentPendingBytesIfNeeded();
                     ((ChannelOutboundHandler) next.handler()).disconnect(next, promise);
@@ -485,12 +513,13 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
                 next.disconnect(promise);
             }
         } else {
-            safeExecute(executor, () -> disconnect(promise), promise, null, false);
+            final Promise<Void> p = promise;
+            safeExecute(executor, () -> disconnect(p), p, null, false);
         }
     }
 
     @Override
-    public void close(final Promise<Void> promise) {
+    public void close(Promise<Void> promise) {
         if (isNotValidPromise(promise)) {
             // cancelled
             return;
@@ -500,6 +529,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         EventExecutor executor = next.executor();
         if (executor.inEventLoop()) {
             if (next.invokeHandler()) {
+                promise = ensurePromiseUseCorrectExecutor(promise);
                 try {
                     next.saveCurrentPendingBytesIfNeeded();
                     ((ChannelOutboundHandler) next.handler()).close(next, promise);
@@ -512,12 +542,13 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
                 next.close(promise);
             }
         } else {
-            safeExecute(executor, () -> close(promise), promise, null, false);
+            final Promise<Void> p = promise;
+            safeExecute(executor, () -> close(p), p, null, false);
         }
     }
 
     @Override
-    public void deregister(final Promise<Void> promise) {
+    public void deregister(Promise<Void> promise) {
         if (isNotValidPromise(promise)) {
             // cancelled
             return;
@@ -527,6 +558,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         EventExecutor executor = next.executor();
         if (executor.inEventLoop()) {
             if (next.invokeHandler()) {
+                promise = ensurePromiseUseCorrectExecutor(promise);
                 try {
                     next.saveCurrentPendingBytesIfNeeded();
                     ((ChannelOutboundHandler) next.handler()).deregister(next, promise);
@@ -539,7 +571,8 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
                 next.deregister(promise);
             }
         } else {
-            safeExecute(executor, () -> deregister(promise), promise, null, false);
+            final Promise<Void> p = promise;
+            safeExecute(executor, () -> deregister(p), p, null, false);
         }
     }
 
@@ -556,6 +589,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         EventExecutor executor = next.executor();
         if (executor.inEventLoop()) {
             if (next.invokeHandler()) {
+                promise = ensurePromiseUseCorrectExecutor(promise);
                 try {
                     next.saveCurrentPendingBytesIfNeeded();
                     ((ChannelOutboundHandler) next.handler()).shutdown(next, type, promise);
@@ -568,7 +602,8 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
                 next.shutdown(type, promise);
             }
         } else {
-            safeExecute(executor, () -> shutdown(type, promise), promise, null, false);
+            final Promise<Void> p = promise;
+            safeExecute(executor, () -> shutdown(type, p), p, null, false);
         }
     }
 
@@ -640,6 +675,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
             EventExecutor executor = next.executor();
             if (executor.inEventLoop()) {
                 if (next.invokeHandler()) {
+                    promise = ensurePromiseUseCorrectExecutor(promise);
                     try {
                         next.saveCurrentPendingBytesIfNeeded();
                         ((ChannelOutboundHandler) next.handler()).write(next, msg, promise);

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
@@ -18,8 +18,6 @@ package io.netty.channel;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerMask.Skip;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.local.LocalAddress;
@@ -32,9 +30,12 @@ import io.netty.util.AbstractReferenceCounted;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ReferenceCounted;
 import io.netty.util.concurrent.AbstractEventExecutor;
+import io.netty.util.concurrent.DefaultEventExecutor;
+import io.netty.util.concurrent.DefaultPromise;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.EventExecutorGroup;
 import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
 import org.junit.jupiter.api.AfterAll;
@@ -53,6 +54,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -899,6 +901,124 @@ public class DefaultChannelPipelineTest {
                 assertEquals(8, handler1.outboundBuffer.peek());
             }
         }).sync();
+    }
+
+    @Test
+    public void testPromiseCorrectExecutor() throws Exception {
+        final ChannelPipeline pipeline = new LocalChannel(group.next()).pipeline();
+        final BlockingQueue<Boolean> queue = new ArrayBlockingQueue<Boolean>(6);
+        EventExecutor executor = new DefaultEventExecutor();
+        try {
+            pipeline.addLast(new ChannelOutboundHandler() {
+                @Override
+                public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, Promise<Void> promise) {
+                    promise.setSuccess(null);
+                }
+
+                @Override
+                public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress,
+                                    SocketAddress localAddress, Promise<Void> promise) {
+                    promise.setSuccess(null);
+                }
+
+                @Override
+                public void disconnect(ChannelHandlerContext ctx, Promise<Void> promise) {
+                    promise.setSuccess(null);
+                }
+
+                @Override
+                public void close(ChannelHandlerContext ctx, Promise<Void> promise) {
+                    promise.setSuccess(null);
+                }
+
+                @Override
+                public void deregister(ChannelHandlerContext ctx, Promise<Void> promise) {
+                    promise.setSuccess(null);
+                }
+
+                @Override
+                public void write(ChannelHandlerContext ctx, Object msg, Promise<Void> promise) {
+                    promise.setSuccess(null);
+                }
+            }, new ChannelOutboundHandler() {
+
+                FutureListener<Void> listener;
+
+                @Override
+                public void handlerAdded(ChannelHandlerContext ctx) {
+                    listener = f -> {
+                        queue.add(ctx.executor().inEventLoop());
+                    };
+                }
+
+                @Override
+                public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, Promise<Void> promise) {
+                    ctx.bind(localAddress, promise.addListener(listener));
+                }
+
+                @Override
+                public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress,
+                                    SocketAddress localAddress, Promise<Void> promise) {
+                    ctx.connect(remoteAddress, localAddress, promise.addListener(listener));
+                }
+
+                @Override
+                public void disconnect(ChannelHandlerContext ctx, Promise<Void> promise) {
+                    ctx.disconnect(promise.addListener(listener));
+                }
+
+                @Override
+                public void close(ChannelHandlerContext ctx, Promise<Void> promise) {
+                    ctx.close(promise.addListener(listener));
+                }
+
+                @Override
+                public void deregister(ChannelHandlerContext ctx, Promise<Void> promise) {
+                    ctx.deregister(promise.addListener(listener));
+                }
+
+                @Override
+                public void write(ChannelHandlerContext ctx, Object msg, Promise<Void> promise) {
+                    ctx.write(msg, promise.addListener(listener));
+                }
+            });
+            pipeline.channel().register();
+
+            Promise<Void> promise = new DefaultPromise<>(executor);
+            pipeline.bind(new SocketAddress() { }, promise);
+            promise.sync();
+
+            promise = new DefaultPromise<>(executor);
+            pipeline.connect(new SocketAddress() { }, promise);
+            promise.sync();
+
+            promise = new DefaultPromise<>(executor);
+            pipeline.disconnect(promise);
+            promise.sync();
+
+            promise = new DefaultPromise<>(executor);
+            pipeline.close(promise);
+            promise.sync();
+
+            promise = new DefaultPromise<>(executor);
+            pipeline.deregister(promise);
+            promise.sync();
+
+            promise = new DefaultPromise<>(executor);
+            pipeline.write("", promise);
+            promise.sync();
+        } finally {
+            // Remove the handlers before closing so we don't intercept it.
+            while (pipeline.lastContext() != null) {
+                pipeline.removeLast();
+            }
+            pipeline.close();
+            executor.shutdownGracefully();
+        }
+
+        for (int i = 0; i < 6; i++) {
+            assertTrue(queue.take());
+        }
     }
 
     @Test


### PR DESCRIPTION
…ways complete in the assumed thread.

Motivation:

At the moment we often make the assumption that the
ChannelFutureListener attached by an ChannelOutboundHandler will execute
in the same thread as the ChannelOutboundHandler by itself. This is not
really safe to assume as the user can pass in a ChannelPromise that is
tight to another EventExecutor or the previous ChannelOutboundHandler
might use a different EventExecutor as the current one and might have
created the ChannelPromise.

Modifications:

- If the ChannelPromise is not using the "correct" EventExecutor just
create a new one, cascade its result to the original ChannelPromise and
pass the new ChannelPromise to the ChannelOutboundHandler. This ensures
we execute stuff in the assumed thread.
- Add unit test

Result:

More safe behaviour when executing ChannelOutboundHandler
