### PR TITLE
Improve exception message when first HTTP2SettingsFrame has the ack f… (#16153)

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -46,10 +46,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.netty.buffer.Unpooled.copiedBuffer;
+import static io.netty.handler.codec.http2.Http2CodecUtil.FRAME_HEADER_LENGTH;
 import static io.netty.handler.codec.http2.Http2CodecUtil.connectionPrefaceBuf;
+import static io.netty.handler.codec.http2.Http2CodecUtil.writeFrameHeaderInternal;
 import static io.netty.handler.codec.http2.Http2Error.CANCEL;
 import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2Error.STREAM_CLOSED;
+import static io.netty.handler.codec.http2.Http2FrameTypes.SETTINGS;
 import static io.netty.handler.codec.http2.Http2Stream.State.CLOSED;
 import static io.netty.handler.codec.http2.Http2Stream.State.IDLE;
 import static io.netty.util.CharsetUtil.US_ASCII;
@@ -295,6 +298,20 @@ public class Http2ConnectionHandlerTest {
         ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
         verify(frameWriter).writeGoAway(eq(ctx), eq(Integer.MAX_VALUE), eq(PROTOCOL_ERROR.code()),
                 captor.capture(), any(Promise.class));
+        assertEquals(0, captor.getValue().refCnt());
+    }
+
+    @Test
+    public void serverReceivingInvalidClientSettingsAfterPrefaceShouldHandleException() throws Exception {
+        ByteBuf buf = ctx.alloc().buffer(FRAME_HEADER_LENGTH);
+        writeFrameHeaderInternal(buf, 0, SETTINGS, new Http2Flags().ack(true), 0);
+
+        when(connection.isServer()).thenReturn(true);
+        handler = newHandler();
+        handler.channelRead(ctx, Unpooled.wrappedBuffer(connectionPrefaceBuf(), buf));
+        ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
+        verify(frameWriter).writeGoAway(eq(ctx), eq(Integer.MAX_VALUE), eq(PROTOCOL_ERROR.code()),
+                captor.capture(), eq(promise));
         assertEquals(0, captor.getValue().refCnt());
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -311,7 +311,7 @@ public class Http2ConnectionHandlerTest {
         handler.channelRead(ctx, Unpooled.wrappedBuffer(connectionPrefaceBuf(), buf));
         ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
         verify(frameWriter).writeGoAway(eq(ctx), eq(Integer.MAX_VALUE), eq(PROTOCOL_ERROR.code()),
-                captor.capture(), eq(promise));
+                captor.capture(), any(Promise.class));
         assertEquals(0, captor.getValue().refCnt());
     }
 


### PR DESCRIPTION
…lag set

Motivation:

The first HTTP2SettingsFrame must not have the ACK flag set. We already
did correctly enforce this but the exception that we used was
missleading

Modifications:

- Clarify exception
- Add unit test

Result:

Related to https://github.com/netty/netty/issues/16142