### PR TITLE
EventLoopGroup should not extend ScheduledExecutorService

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
@@ -24,16 +24,16 @@ import org.jetbrains.annotations.Async.Execute;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.List;
-import java.util.concurrent.AbstractExecutorService;
+import java.util.Objects;
 import java.util.concurrent.Callable;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.TimeUnit;
 
 /**
  * Abstract base class for {@link EventExecutor} implementations.
  */
-public abstract class AbstractEventExecutor extends AbstractExecutorService implements EventExecutor {
+public abstract class AbstractEventExecutor implements EventExecutor {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(AbstractEventExecutor.class);
 
     static final long DEFAULT_SHUTDOWN_QUIET_PERIOD = 2;
@@ -72,67 +72,42 @@ public abstract class AbstractEventExecutor extends AbstractExecutorService impl
         return shutdownGracefully(DEFAULT_SHUTDOWN_QUIET_PERIOD, DEFAULT_SHUTDOWN_TIMEOUT, TimeUnit.SECONDS);
     }
 
+    @Override
+    public final Future<?> submit(Runnable task) {
+        Objects.requireNonNull(task, "task");
+        RunnableFuture<Void> ftask = newTaskFor(task, null);
+        execute(ftask);
+        return (Future<?>) ftask;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public final <T> Future<T> submit(Runnable task, T result) {
+        Objects.requireNonNull(task, "task");
+        RunnableFuture<T> ftask = newTaskFor(task, result);
+        execute(ftask);
+        return (Future<T>) ftask;
+    }
+
     /**
-     * @deprecated {@link #shutdownGracefully(long, long, TimeUnit)} or {@link #shutdownGracefully()} instead.
+     * @throws RejectedExecutionException {@inheritDoc}
+     * @throws NullPointerException       {@inheritDoc}
      */
     @Override
-    @Deprecated
-    public abstract void shutdown();
-
-    /**
-     * @deprecated {@link #shutdownGracefully(long, long, TimeUnit)} or {@link #shutdownGracefully()} instead.
-     */
-    @Override
-    @Deprecated
-    public List<Runnable> shutdownNow() {
-        shutdown();
-        return Collections.emptyList();
+    @SuppressWarnings("unchecked")
+    public final <T> Future<T> submit(Callable<T> task) {
+        Objects.requireNonNull(task, "task");
+        RunnableFuture<T> ftask = newTaskFor(task);
+        execute(ftask);
+        return (Future<T>) ftask;
     }
 
-    @Override
-    public Future<?> submit(Runnable task) {
-        return (Future<?>) super.submit(task);
-    }
-
-    @Override
-    public <T> Future<T> submit(Runnable task, T result) {
-        return (Future<T>) super.submit(task, result);
-    }
-
-    @Override
-    public <T> Future<T> submit(Callable<T> task) {
-        return (Future<T>) super.submit(task);
-    }
-
-    @Override
     protected final <T> RunnableFuture<T> newTaskFor(Runnable runnable, T value) {
         return new PromiseTask<T>(this, runnable, value);
     }
 
-    @Override
     protected final <T> RunnableFuture<T> newTaskFor(Callable<T> callable) {
         return new PromiseTask<T>(this, callable);
-    }
-
-    @Override
-    public ScheduledFuture<?> schedule(Runnable command, long delay,
-                                       TimeUnit unit) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
-        throw new UnsupportedOperationException();
     }
 
     @SuppressWarnings("unchecked")
@@ -142,6 +117,10 @@ public abstract class AbstractEventExecutor extends AbstractExecutorService impl
             return (Future<V>) succeededFuture;
         }
         return EventExecutor.super.newSucceededFuture(result);
+    }
+
+    protected final <T> ScheduledFuture<T> newFailedScheduledFuture(Throwable cause) {
+        return new FailedScheduledFuture<>(this, cause);
     }
 
     /**

--- a/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutorGroup.java
@@ -70,46 +70,6 @@ public abstract class AbstractEventExecutorGroup implements EventExecutorGroup {
         return shutdownGracefully(DEFAULT_SHUTDOWN_QUIET_PERIOD, DEFAULT_SHUTDOWN_TIMEOUT, TimeUnit.SECONDS);
     }
 
-    /**
-     * @deprecated {@link #shutdownGracefully(long, long, TimeUnit)} or {@link #shutdownGracefully()} instead.
-     */
-    @Override
-    @Deprecated
-    public abstract void shutdown();
-
-    /**
-     * @deprecated {@link #shutdownGracefully(long, long, TimeUnit)} or {@link #shutdownGracefully()} instead.
-     */
-    @Override
-    @Deprecated
-    public List<Runnable> shutdownNow() {
-        shutdown();
-        return Collections.emptyList();
-    }
-
-    @Override
-    public <T> List<java.util.concurrent.Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
-            throws InterruptedException {
-        return next().invokeAll(tasks);
-    }
-
-    @Override
-    public <T> List<java.util.concurrent.Future<T>> invokeAll(
-            Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
-        return next().invokeAll(tasks, timeout, unit);
-    }
-
-    @Override
-    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
-        return next().invokeAny(tasks);
-    }
-
-    @Override
-    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
-            throws InterruptedException, ExecutionException, TimeoutException {
-        return next().invokeAny(tasks, timeout, unit);
-    }
-
     @Override
     public void execute(Runnable command) {
         next().execute(command);

--- a/common/src/main/java/io/netty/util/concurrent/EventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/EventExecutorGroup.java
@@ -140,9 +140,9 @@ public interface EventExecutorGroup extends Executor, Iterable<EventExecutor> {
      * @throws IllegalArgumentException if delay less than or equal to zero
      */
     ScheduledFuture<?> scheduleWithFixedDelay(Runnable command,
-                                                                          long initialDelay,
-                                                                          long delay,
-                                                                          TimeUnit unit);
+                                              long initialDelay,
+                                              long delay,
+                                              TimeUnit unit);
 
     /**
      * Returns {@code true} if this executor has been shut down.
@@ -171,8 +171,7 @@ public interface EventExecutorGroup extends Executor, Iterable<EventExecutor> {
      *         {@code false} if the timeout elapsed before termination
      * @throws InterruptedException if interrupted while waiting
      */
-    boolean awaitTermination(long timeout, TimeUnit unit)
-            throws InterruptedException;
+    boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException;
 
     /**
      * Submits a value-returning task for execution and returns a

--- a/common/src/main/java/io/netty/util/concurrent/EventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/EventExecutorGroup.java
@@ -16,9 +16,11 @@
 package io.netty.util.concurrent;
 
 import java.util.Iterator;
-import java.util.List;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -27,7 +29,203 @@ import java.util.concurrent.TimeUnit;
  * life-cycle and allows shutting them down in a global fashion.
  *
  */
-public interface EventExecutorGroup extends ScheduledExecutorService, Iterable<EventExecutor> {
+public interface EventExecutorGroup extends Executor, Iterable<EventExecutor> {
+
+    /**
+     * Submits a one-shot task that becomes enabled after the given delay.
+     *
+     * @param command the task to execute
+     * @param delay the time from now to delay execution
+     * @param unit the time unit of the delay parameter
+     * @return a ScheduledFuture representing pending completion of
+     *         the task and whose {@code get()} method will return
+     *         {@code null} upon completion
+     * @throws RejectedExecutionException if the task cannot be
+     *         scheduled for execution
+     * @throws NullPointerException if command or unit is null
+     */
+    ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit);
+
+    /**
+     * Submits a value-returning one-shot task that becomes enabled
+     * after the given delay.
+     *
+     * @param callable the function to execute
+     * @param delay the time from now to delay execution
+     * @param unit the time unit of the delay parameter
+     * @param <V> the type of the callable's result
+     * @return a ScheduledFuture that can be used to extract result or cancel
+     * @throws RejectedExecutionException if the task cannot be
+     *         scheduled for execution
+     * @throws NullPointerException if callable or unit is null
+     */
+     <V> ScheduledFuture<V> schedule(Callable<V> callable,
+                                     long delay, TimeUnit unit);
+
+    /**
+     * Submits a periodic action that becomes enabled first after the
+     * given initial delay, and subsequently with the given period;
+     * that is, executions will commence after
+     * {@code initialDelay}, then {@code initialDelay + period}, then
+     * {@code initialDelay + 2 * period}, and so on.
+     *
+     * <p>The sequence of task executions continues indefinitely until
+     * one of the following exceptional completions occur:
+     * <ul>
+     * <li>The task is {@linkplain java.util.concurrent.Future#cancel explicitly cancelled}
+     * via the returned future.
+     * <li>The executor terminates, also resulting in task cancellation.
+     * <li>An execution of the task throws an exception.  In this case
+     * calling {@link java.util.concurrent.Future#get() get} on the returned future will throw
+     * {@link ExecutionException}, holding the exception as its cause.
+     * </ul>
+     * Subsequent executions are suppressed.  Subsequent calls to
+     * {@link java.util.concurrent.Future#isDone isDone()} on the returned future will
+     * return {@code true}.
+     *
+     * <p>If any execution of this task takes longer than its period, then
+     * subsequent executions may start late, but will not concurrently
+     * execute.
+     *
+     * @param command the task to execute
+     * @param initialDelay the time to delay first execution
+     * @param period the period between successive executions
+     * @param unit the time unit of the initialDelay and period parameters
+     * @return a ScheduledFuture representing pending completion of
+     *         the series of repeated tasks.  The future's {@link
+     *         java.util.concurrent.Future#get() get()} method will never return normally,
+     *         and will throw an exception upon task cancellation or
+     *         abnormal termination of a task execution.
+     * @throws RejectedExecutionException if the task cannot be
+     *         scheduled for execution
+     * @throws NullPointerException if command or unit is null
+     * @throws IllegalArgumentException if period less than or equal to zero
+     */
+    ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay,
+                                           long period, TimeUnit unit);
+
+    /**
+     * Submits a periodic action that becomes enabled first after the
+     * given initial delay, and subsequently with the given delay
+     * between the termination of one execution and the commencement of
+     * the next.
+     *
+     * <p>The sequence of task executions continues indefinitely until
+     * one of the following exceptional completions occur:
+     * <ul>
+     * <li>The task is {@linkplain java.util.concurrent.Future#cancel explicitly cancelled}
+     * via the returned future.
+     * <li>The executor terminates, also resulting in task cancellation.
+     * <li>An execution of the task throws an exception.  In this case
+     * calling {@link java.util.concurrent.Future#get() get} on the returned future will throw
+     * {@link ExecutionException}, holding the exception as its cause.
+     * </ul>
+     * Subsequent executions are suppressed.  Subsequent calls to
+     * {@link java.util.concurrent.Future#isDone isDone()} on the returned future will
+     * return {@code true}.
+     *
+     * @param command the task to execute
+     * @param initialDelay the time to delay first execution
+     * @param delay the delay between the termination of one
+     * execution and the commencement of the next
+     * @param unit the time unit of the initialDelay and delay parameters
+     * @return a ScheduledFuture representing pending completion of
+     *         the series of repeated tasks.  The future's {@link
+     *         java.util.concurrent.Future#get() get()} method will never return normally,
+     *         and will throw an exception upon task cancellation or
+     *         abnormal termination of a task execution.
+     * @throws RejectedExecutionException if the task cannot be
+     *         scheduled for execution
+     * @throws NullPointerException if command or unit is null
+     * @throws IllegalArgumentException if delay less than or equal to zero
+     */
+    ScheduledFuture<?> scheduleWithFixedDelay(Runnable command,
+                                                                          long initialDelay,
+                                                                          long delay,
+                                                                          TimeUnit unit);
+
+    /**
+     * Returns {@code true} if this executor has been shut down.
+     *
+     * @return {@code true} if this executor has been shut down
+     */
+    boolean isShutdown();
+
+    /**
+     * Returns {@code true} if all tasks have completed following shut down.
+     * Note that {@code isTerminated} is never {@code true} unless
+     * either {@code shutdown} or {@code shutdownNow} was called first.
+     *
+     * @return {@code true} if all tasks have completed following shut down
+     */
+    boolean isTerminated();
+
+    /**
+     * Blocks until all tasks have completed execution after a shutdown
+     * request, or the timeout occurs, or the current thread is
+     * interrupted, whichever happens first.
+     *
+     * @param timeout the maximum time to wait
+     * @param unit the time unit of the timeout argument
+     * @return {@code true} if this executor terminated and
+     *         {@code false} if the timeout elapsed before termination
+     * @throws InterruptedException if interrupted while waiting
+     */
+    boolean awaitTermination(long timeout, TimeUnit unit)
+            throws InterruptedException;
+
+    /**
+     * Submits a value-returning task for execution and returns a
+     * Future representing the pending results of the task. The
+     * Future's {@code get} method will return the task's result upon
+     * successful completion.
+     *
+     * <p>
+     * If you would like to immediately block waiting
+     * for a task, you can use constructions of the form
+     * {@code result = exec.submit(aCallable).get();}
+     *
+     * <p>Note: The {@link Executors} class includes a set of methods
+     * that can convert some other common closure-like objects,
+     * for example, {@link java.security.PrivilegedAction} to
+     * {@link Callable} form so they can be submitted.
+     *
+     * @param task the task to submit
+     * @param <T> the type of the task's result
+     * @return a Future representing pending completion of the task
+     * @throws RejectedExecutionException if the task cannot be
+     *         scheduled for execution
+     * @throws NullPointerException if the task is null
+     */
+    <T> Future<T> submit(Callable<T> task);
+
+    /**
+     * Submits a Runnable task for execution and returns a Future
+     * representing that task. The Future's {@code get} method will
+     * return the given result upon successful completion.
+     *
+     * @param task the task to submit
+     * @param result the result to return
+     * @param <T> the type of the result
+     * @return a Future representing pending completion of the task
+     * @throws RejectedExecutionException if the task cannot be
+     *         scheduled for execution
+     * @throws NullPointerException if the task is null
+     */
+    <T> Future<T> submit(Runnable task, T result);
+
+    /**
+     * Submits a Runnable task for execution and returns a Future
+     * representing that task. The Future's {@code get} method will
+     * return {@code null} upon <em>successful</em> completion.
+     *
+     * @param task the task to submit
+     * @return a Future representing pending completion of the task
+     * @throws RejectedExecutionException if the task cannot be
+     *         scheduled for execution
+     * @throws NullPointerException if the task is null
+     */
+    Future<?> submit(Runnable task);
 
     /**
      * Returns {@code true} if and only if all {@link EventExecutor}s managed by this {@link EventExecutorGroup}
@@ -45,12 +243,11 @@ public interface EventExecutorGroup extends ScheduledExecutorService, Iterable<E
     /**
      * Signals this executor that the caller wants the executor to be shut down.  Once this method is called,
      * {@link #isShuttingDown()} starts to return {@code true}, and the executor prepares to shut itself down.
-     * Unlike {@link #shutdown()}, graceful shutdown ensures that no tasks are submitted for <i>'the quiet period'</i>
-     * (usually a couple seconds) before it shuts itself down.  If a task is submitted during the quiet period,
+     * If a task is submitted during the quiet period,
      * it is guaranteed to be accepted and the quiet period will start over.
      *
      * @param quietPeriod the quiet period as described in the documentation
-     * @param timeout     the maximum amount of time to wait until the executor is {@linkplain #shutdown()}
+     * @param timeout     the maximum amount of time to wait until the executor is shutdown
      *                    regardless if a task was submitted during the quiet period
      * @param unit        the unit of {@code quietPeriod} and {@code timeout}
      *
@@ -63,21 +260,6 @@ public interface EventExecutorGroup extends ScheduledExecutorService, Iterable<E
      * {@link EventExecutorGroup} have been terminated.
      */
     Future<?> terminationFuture();
-
-    /**
-     * @deprecated {@link #shutdownGracefully(long, long, TimeUnit)} or {@link #shutdownGracefully()} instead.
-     */
-    @Override
-    @Deprecated
-    void shutdown();
-
-    /**
-     * @deprecated {@link #shutdownGracefully(long, long, TimeUnit)} or {@link #shutdownGracefully()} instead.
-     */
-    @Override
-    @Deprecated
-    List<Runnable> shutdownNow();
-
     /**
      * Returns one of the {@link EventExecutor}s managed by this {@link EventExecutorGroup}.
      */
@@ -85,15 +267,6 @@ public interface EventExecutorGroup extends ScheduledExecutorService, Iterable<E
 
     @Override
     Iterator<EventExecutor> iterator();
-
-    @Override
-    Future<?> submit(Runnable task);
-
-    @Override
-    <T> Future<T> submit(Runnable task, T result);
-
-    @Override
-    <T> Future<T> submit(Callable<T> task);
 
     /**
      * The ticker for this executor. Usually the {@link #schedule} methods will follow the
@@ -107,16 +280,4 @@ public interface EventExecutorGroup extends ScheduledExecutorService, Iterable<E
     default Ticker ticker() {
         return Ticker.systemTicker();
     }
-
-    @Override
-    ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit);
-
-    @Override
-    <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit);
-
-    @Override
-    ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit);
-
-    @Override
-    ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit);
 }

--- a/common/src/main/java/io/netty/util/concurrent/FailedFuture.java
+++ b/common/src/main/java/io/netty/util/concurrent/FailedFuture.java
@@ -23,7 +23,7 @@ import io.netty.util.internal.PlatformDependent;
  * recommended to use {@link EventExecutor#newFailedFuture(Throwable)}
  * instead of calling the constructor of this future.
  */
-public final class FailedFuture<V> extends CompleteFuture<V> {
+public class FailedFuture<V> extends CompleteFuture<V> {
 
     private final Throwable cause;
 

--- a/common/src/main/java/io/netty/util/concurrent/FailedScheduledFuture.java
+++ b/common/src/main/java/io/netty/util/concurrent/FailedScheduledFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The Netty Project
+ * Copyright 2026 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -33,6 +33,6 @@ final class FailedScheduledFuture<V> extends FailedFuture<V> implements Schedule
 
     @Override
     public int compareTo(@NotNull Delayed o) {
-        return 0;
+        return Long.compare(0L, o.getDelay(TimeUnit.NANOSECONDS));
     }
 }

--- a/common/src/main/java/io/netty/util/concurrent/FailedScheduledFuture.java
+++ b/common/src/main/java/io/netty/util/concurrent/FailedScheduledFuture.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.concurrent;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.Delayed;
+import java.util.concurrent.TimeUnit;
+
+final class FailedScheduledFuture<V> extends FailedFuture<V> implements ScheduledFuture<V> {
+
+    FailedScheduledFuture(EventExecutor executor, Throwable cause) {
+        super(executor, cause);
+    }
+
+    @Override
+    public long getDelay(@NotNull TimeUnit unit) {
+        return 0;
+    }
+
+    @Override
+    public int compareTo(@NotNull Delayed o) {
+        return 0;
+    }
+}

--- a/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
@@ -179,12 +179,6 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor im
     }
 
     @Override
-    @Deprecated
-    public void shutdown() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public boolean isShuttingDown() {
         return false;
     }

--- a/common/src/main/java/io/netty/util/concurrent/ImmediateEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/ImmediateEventExecutor.java
@@ -21,6 +21,7 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.util.ArrayDeque;
 import java.util.Queue;
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -78,10 +79,6 @@ public final class ImmediateEventExecutor extends AbstractEventExecutor {
     }
 
     @Override
-    @Deprecated
-    public void shutdown() { }
-
-    @Override
     public boolean isShuttingDown() {
         return false;
     }
@@ -125,6 +122,26 @@ public final class ImmediateEventExecutor extends AbstractEventExecutor {
         } else {
             DELAYED_RUNNABLES.get().add(command);
         }
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        return newFailedScheduledFuture(new UnsupportedOperationException());
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+        return newFailedScheduledFuture(new UnsupportedOperationException());
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+        return newFailedScheduledFuture(new UnsupportedOperationException());
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+        return newFailedScheduledFuture(new UnsupportedOperationException());
     }
 
     @Override

--- a/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java
@@ -199,14 +199,6 @@ public abstract class MultithreadEventExecutorGroup extends AbstractEventExecuto
     }
 
     @Override
-    @Deprecated
-    public void shutdown() {
-        for (EventExecutor l: children) {
-            l.shutdown();
-        }
-    }
-
-    @Override
     public boolean isShuttingDown() {
         for (EventExecutor l: children) {
             if (!l.isShuttingDown()) {

--- a/common/src/main/java/io/netty/util/concurrent/NonStickyEventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/NonStickyEventExecutorGroup.java
@@ -19,15 +19,11 @@ import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.UnstableApi;
 
-import java.util.Collection;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -94,18 +90,6 @@ public final class NonStickyEventExecutorGroup implements EventExecutorGroup {
     @Override
     public Future<?> terminationFuture() {
         return group.terminationFuture();
-    }
-
-    @SuppressWarnings("deprecation")
-    @Override
-    public void shutdown() {
-        group.shutdown();
-    }
-
-    @SuppressWarnings("deprecation")
-    @Override
-    public List<Runnable> shutdownNow() {
-        return group.shutdownNow();
     }
 
     @Override
@@ -182,29 +166,6 @@ public final class NonStickyEventExecutorGroup implements EventExecutorGroup {
     @Override
     public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
         return group.awaitTermination(timeout, unit);
-    }
-
-    @Override
-    public <T> List<java.util.concurrent.Future<T>> invokeAll(
-            Collection<? extends Callable<T>> tasks) throws InterruptedException {
-        return group.invokeAll(tasks);
-    }
-
-    @Override
-    public <T> List<java.util.concurrent.Future<T>> invokeAll(
-            Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
-        return group.invokeAll(tasks, timeout, unit);
-    }
-
-    @Override
-    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
-        return group.invokeAny(tasks);
-    }
-
-    @Override
-    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
-            throws InterruptedException, ExecutionException, TimeoutException {
-        return group.invokeAny(tasks, timeout, unit);
     }
 
     @Override
@@ -314,11 +275,6 @@ public final class NonStickyEventExecutorGroup implements EventExecutorGroup {
         }
 
         @Override
-        public void shutdown() {
-            executor.shutdown();
-        }
-
-        @Override
         public boolean isShutdown() {
             return executor.isShutdown();
         }
@@ -343,6 +299,27 @@ public final class NonStickyEventExecutorGroup implements EventExecutorGroup {
                 // execute ourself. At worst this will be a NOOP when run() is called.
                 executor.execute(this);
             }
+        }
+
+        @Override
+        public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+            return newFailedScheduledFuture(new UnsupportedOperationException());
+        }
+
+        @Override
+        public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+            return newFailedScheduledFuture(new UnsupportedOperationException());
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+            return newFailedScheduledFuture(new UnsupportedOperationException());
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleWithFixedDelay(
+                Runnable command, long initialDelay, long delay, TimeUnit unit) {
+            return newFailedScheduledFuture(new UnsupportedOperationException());
         }
     }
 }

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -25,24 +25,18 @@ import org.jetbrains.annotations.Async.Schedule;
 
 import java.lang.Thread.State;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.concurrent.locks.Lock;
@@ -842,12 +836,6 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
     }
 
     @Override
-    @Deprecated
-    public void shutdown() {
-        shutdown0(-1, -1, ST_SHUTDOWN);
-    }
-
-    @Override
     public boolean isShuttingDown() {
         return state >= ST_SHUTTING_DOWN;
     }
@@ -1046,39 +1034,6 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
 
         if (!addTaskWakesUp && immediate) {
             wakeup(inEventLoop);
-        }
-    }
-
-    @Override
-    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
-        throwIfInEventLoop("invokeAny");
-        return super.invokeAny(tasks);
-    }
-
-    @Override
-    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
-            throws InterruptedException, ExecutionException, TimeoutException {
-        throwIfInEventLoop("invokeAny");
-        return super.invokeAny(tasks, timeout, unit);
-    }
-
-    @Override
-    public <T> List<java.util.concurrent.Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
-            throws InterruptedException {
-        throwIfInEventLoop("invokeAll");
-        return super.invokeAll(tasks);
-    }
-
-    @Override
-    public <T> List<java.util.concurrent.Future<T>> invokeAll(
-            Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
-        throwIfInEventLoop("invokeAll");
-        return super.invokeAll(tasks, timeout, unit);
-    }
-
-    private void throwIfInEventLoop(String method) {
-        if (inEventLoop()) {
-            throw new RejectedExecutionException("Calling " + method + " from within the EventLoop is not allowed");
         }
     }
 

--- a/common/src/test/java/io/netty/util/concurrent/AbstractScheduledEventExecutorTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/AbstractScheduledEventExecutorTest.java
@@ -136,11 +136,6 @@ public class AbstractScheduledEventExecutorTest {
         }
 
         @Override
-        public void shutdown() {
-            // NOOP
-        }
-
-        @Override
         public Future<?> shutdownGracefully(long quietPeriod, long timeout, TimeUnit unit) {
             throw new UnsupportedOperationException();
         }

--- a/common/src/test/java/io/netty/util/concurrent/DefaultPromiseTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/DefaultPromiseTest.java
@@ -87,10 +87,6 @@ public class DefaultPromiseTest {
         }
 
         @Override
-        public void shutdown() {
-        }
-
-        @Override
         public boolean isShutdown() {
             return false;
         }

--- a/common/src/test/java/io/netty/util/concurrent/NonStickyEventExecutorGroupTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/NonStickyEventExecutorGroupTest.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -139,20 +140,11 @@ public class NonStickyEventExecutorGroupTest {
         final AtomicInteger executeCount = new AtomicInteger();
 
         final EventExecutorGroup wrapper = new AbstractEventExecutorGroup() {
-            @Override
-            public void shutdown() {
-                shutdownGracefully();
-            }
 
             private final EventExecutor executor = new AbstractEventExecutor(this) {
                 @Override
                 public boolean inEventLoop(Thread thread) {
                     return underlying.inEventLoop(thread);
-                }
-
-                @Override
-                public void shutdown() {
-                    shutdownGracefully();
                 }
 
                 @Override
@@ -194,6 +186,28 @@ public class NonStickyEventExecutorGroupTest {
                 @Override
                 public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
                     return underlying.awaitTermination(timeout, unit);
+                }
+
+                @Override
+                public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+                    return underlying.schedule(command, delay, unit);
+                }
+
+                @Override
+                public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+                    return underlying.schedule(callable, delay, unit);
+                }
+
+                @Override
+                public ScheduledFuture<?> scheduleAtFixedRate(
+                        Runnable command, long initialDelay, long period, TimeUnit unit) {
+                    return underlying.scheduleAtFixedRate(command, initialDelay, period, unit);
+                }
+
+                @Override
+                public ScheduledFuture<?> scheduleWithFixedDelay(
+                        Runnable command, long initialDelay, long delay, TimeUnit unit) {
+                    return underlying.scheduleWithFixedDelay(command, initialDelay, delay, unit);
                 }
             };
 

--- a/common/src/test/java/io/netty/util/concurrent/SingleThreadEventExecutorTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/SingleThreadEventExecutorTest.java
@@ -20,9 +20,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.function.Executable;
 
-import java.util.Collections;
-import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -316,87 +313,6 @@ public class SingleThreadEventExecutorTest {
         assertEquals(thread.isDaemon(), threadProperties.isDaemon());
         assertTrue(threadProperties.stackTrace().length > 0);
         executor.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS).syncUninterruptibly();
-    }
-
-    @Test
-    @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
-    public void testInvokeAnyInEventLoop() {
-        testInvokeInEventLoop(true, false);
-    }
-
-    @Test
-    @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
-    public void testInvokeAnyInEventLoopWithTimeout() {
-        testInvokeInEventLoop(true, true);
-    }
-
-    @Test
-    @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
-    public void testInvokeAllInEventLoop() {
-        testInvokeInEventLoop(false, false);
-    }
-
-    @Test
-    @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
-    public void testInvokeAllInEventLoopWithTimeout() {
-        testInvokeInEventLoop(false, true);
-    }
-
-    private static void testInvokeInEventLoop(final boolean any, final boolean timeout) {
-        final SingleThreadEventExecutor executor = new SingleThreadEventExecutor(null,
-                Executors.defaultThreadFactory(), true) {
-            @Override
-            protected void run() {
-                while (!confirmShutdown()) {
-                    Runnable task = takeTask();
-                    if (task != null) {
-                        task.run();
-                    }
-                }
-            }
-        };
-        try {
-            assertThrows(RejectedExecutionException.class, new Executable() {
-                @Override
-                public void execute() throws Throwable {
-                    final Promise<Void> promise = executor.newPromise();
-                    executor.execute(new Runnable() {
-                        @Override
-                        public void run() {
-                            try {
-                                Set<Callable<Boolean>> set = Collections.<Callable<Boolean>>singleton(
-                                        new Callable<Boolean>() {
-                                    @Override
-                                    public Boolean call() throws Exception {
-                                        promise.setFailure(new AssertionError("Should never execute the Callable"));
-                                        return Boolean.TRUE;
-                                    }
-                                });
-                                if (any) {
-                                    if (timeout) {
-                                        executor.invokeAny(set, 10, TimeUnit.SECONDS);
-                                    } else {
-                                        executor.invokeAny(set);
-                                    }
-                                } else {
-                                    if (timeout) {
-                                        executor.invokeAll(set, 10, TimeUnit.SECONDS);
-                                    } else {
-                                        executor.invokeAll(set);
-                                    }
-                                }
-                                promise.setFailure(new AssertionError("Should never reach here"));
-                            } catch (Throwable cause) {
-                                promise.setFailure(cause);
-                            }
-                        }
-                    });
-                    promise.syncUninterruptibly();
-                }
-            });
-        } finally {
-            executor.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS).syncUninterruptibly();
-        }
     }
 
     static class LatchTask extends CountDownLatch implements Runnable {

--- a/common/src/test/java/io/netty/util/internal/ThreadExecutorMapTest.java
+++ b/common/src/test/java/io/netty/util/internal/ThreadExecutorMapTest.java
@@ -20,9 +20,11 @@ import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.ImmediateExecutor;
+import io.netty.util.concurrent.ScheduledFuture;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -32,10 +34,6 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class ThreadExecutorMapTest {
     private static final EventExecutor EVENT_EXECUTOR = new AbstractEventExecutor() {
-        @Override
-        public void shutdown() {
-            throw new UnsupportedOperationException();
-        }
 
         @Override
         public boolean inEventLoop(Thread thread) {
@@ -74,6 +72,27 @@ public class ThreadExecutorMapTest {
 
         @Override
         public void execute(@NotNull Runnable command) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleWithFixedDelay(
+                Runnable command, long initialDelay, long delay, TimeUnit unit) {
             throw new UnsupportedOperationException();
         }
     };

--- a/handler/src/main/java/io/netty/handler/traffic/GlobalChannelTrafficCounter.java
+++ b/handler/src/main/java/io/netty/handler/traffic/GlobalChannelTrafficCounter.java
@@ -18,6 +18,7 @@ package io.netty.handler.traffic;
 import static io.netty.util.internal.ObjectUtil.checkNotNullWithIAE;
 
 import io.netty.handler.traffic.GlobalChannelTrafficShapingHandler.PerChannel;
+import io.netty.util.concurrent.EventExecutor;
 
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -36,7 +37,7 @@ public class GlobalChannelTrafficCounter extends TrafficCounter {
      * @param checkInterval the checkInterval in millisecond between two computations.
      */
     public GlobalChannelTrafficCounter(GlobalChannelTrafficShapingHandler trafficShapingHandler,
-            ScheduledExecutorService executor, String name, long checkInterval) {
+                                       EventExecutor executor, String name, long checkInterval) {
         super(trafficShapingHandler, executor, name, checkInterval);
         checkNotNullWithIAE(executor, "executor");
     }

--- a/handler/src/main/java/io/netty/handler/traffic/GlobalChannelTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/GlobalChannelTrafficShapingHandler.java
@@ -35,7 +35,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -146,7 +145,7 @@ public class GlobalChannelTrafficShapingHandler extends AbstractTrafficShapingHa
     /**
      * Create the global TrafficCounter
      */
-    void createGlobalTrafficCounter(ScheduledExecutorService executor) {
+    void createGlobalTrafficCounter(EventExecutor executor) {
         // Default
         setMaxDeviation(DEFAULT_DEVIATION, DEFAULT_SLOWDOWN, DEFAULT_ACCELERATION);
         checkNotNullWithIAE(executor, "executor");
@@ -164,7 +163,7 @@ public class GlobalChannelTrafficShapingHandler extends AbstractTrafficShapingHa
      * Create a new instance.
      *
      * @param executor
-     *            the {@link ScheduledExecutorService} to use for the {@link TrafficCounter}.
+     *            the {@link EventExecutor} to use for the {@link TrafficCounter}.
      * @param writeGlobalLimit
      *            0 or a limit in bytes/s
      * @param readGlobalLimit
@@ -179,7 +178,7 @@ public class GlobalChannelTrafficShapingHandler extends AbstractTrafficShapingHa
      * @param maxTime
      *            The maximum delay to wait in case of traffic excess.
      */
-    public GlobalChannelTrafficShapingHandler(ScheduledExecutorService executor,
+    public GlobalChannelTrafficShapingHandler(EventExecutor executor,
             long writeGlobalLimit, long readGlobalLimit,
             long writeChannelLimit, long readChannelLimit,
             long checkInterval, long maxTime) {
@@ -193,7 +192,7 @@ public class GlobalChannelTrafficShapingHandler extends AbstractTrafficShapingHa
      * Create a new instance.
      *
      * @param executor
-     *          the {@link ScheduledExecutorService} to use for the {@link TrafficCounter}.
+     *          the {@link EventExecutor} to use for the {@link TrafficCounter}.
      * @param writeGlobalLimit
      *            0 or a limit in bytes/s
      * @param readGlobalLimit
@@ -206,7 +205,7 @@ public class GlobalChannelTrafficShapingHandler extends AbstractTrafficShapingHa
      *          The delay between two computations of performances for
      *            channels or 0 if no stats are to be computed.
      */
-    public GlobalChannelTrafficShapingHandler(ScheduledExecutorService executor,
+    public GlobalChannelTrafficShapingHandler(EventExecutor executor,
             long writeGlobalLimit, long readGlobalLimit,
             long writeChannelLimit, long readChannelLimit,
             long checkInterval) {
@@ -220,7 +219,7 @@ public class GlobalChannelTrafficShapingHandler extends AbstractTrafficShapingHa
      * Create a new instance.
      *
      * @param executor
-     *          the {@link ScheduledExecutorService} to use for the {@link TrafficCounter}.
+     *          the {@link EventExecutor} to use for the {@link TrafficCounter}.
      * @param writeGlobalLimit
      *            0 or a limit in bytes/s
      * @param readGlobalLimit
@@ -230,7 +229,7 @@ public class GlobalChannelTrafficShapingHandler extends AbstractTrafficShapingHa
      * @param readChannelLimit
      *            0 or a limit in bytes/s
      */
-    public GlobalChannelTrafficShapingHandler(ScheduledExecutorService executor,
+    public GlobalChannelTrafficShapingHandler(EventExecutor executor,
             long writeGlobalLimit, long readGlobalLimit,
             long writeChannelLimit, long readChannelLimit) {
         super(writeGlobalLimit, readGlobalLimit);
@@ -243,12 +242,12 @@ public class GlobalChannelTrafficShapingHandler extends AbstractTrafficShapingHa
      * Create a new instance.
      *
      * @param executor
-     *          the {@link ScheduledExecutorService} to use for the {@link TrafficCounter}.
+     *          the {@link EventExecutor} to use for the {@link TrafficCounter}.
      * @param checkInterval
      *          The delay between two computations of performances for
      *            channels or 0 if no stats are to be computed.
      */
-    public GlobalChannelTrafficShapingHandler(ScheduledExecutorService executor, long checkInterval) {
+    public GlobalChannelTrafficShapingHandler(EventExecutor executor, long checkInterval) {
         super(checkInterval);
         createGlobalTrafficCounter(executor);
     }
@@ -257,9 +256,9 @@ public class GlobalChannelTrafficShapingHandler extends AbstractTrafficShapingHa
      * Create a new instance.
      *
      * @param executor
-     *          the {@link ScheduledExecutorService} to use for the {@link TrafficCounter}.
+     *          the {@link EventExecutor} to use for the {@link TrafficCounter}.
      */
-    public GlobalChannelTrafficShapingHandler(ScheduledExecutorService executor) {
+    public GlobalChannelTrafficShapingHandler(EventExecutor executor) {
         createGlobalTrafficCounter(executor);
     }
 

--- a/handler/src/main/java/io/netty/handler/traffic/GlobalTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/GlobalTrafficShapingHandler.java
@@ -101,7 +101,7 @@ public class GlobalTrafficShapingHandler extends AbstractTrafficShapingHandler {
     /**
      * Create the global TrafficCounter.
      */
-    void createGlobalTrafficCounter(ScheduledExecutorService executor) {
+    void createGlobalTrafficCounter(EventExecutor executor) {
         TrafficCounter tc = new TrafficCounter(this,
                 ObjectUtil.checkNotNull(executor, "executor"),
                 "GlobalTC",
@@ -120,7 +120,7 @@ public class GlobalTrafficShapingHandler extends AbstractTrafficShapingHandler {
      * Create a new instance.
      *
      * @param executor
-     *            the {@link ScheduledExecutorService} to use for the {@link TrafficCounter}.
+     *            the {@link EventExecutor} to use for the {@link TrafficCounter}.
      * @param writeLimit
      *            0 or a limit in bytes/s
      * @param readLimit
@@ -131,7 +131,7 @@ public class GlobalTrafficShapingHandler extends AbstractTrafficShapingHandler {
      * @param maxTime
      *            The maximum delay to wait in case of traffic excess.
      */
-    public GlobalTrafficShapingHandler(ScheduledExecutorService executor, long writeLimit, long readLimit,
+    public GlobalTrafficShapingHandler(EventExecutor executor, long writeLimit, long readLimit,
             long checkInterval, long maxTime) {
         super(writeLimit, readLimit, checkInterval, maxTime);
         createGlobalTrafficCounter(executor);
@@ -142,7 +142,7 @@ public class GlobalTrafficShapingHandler extends AbstractTrafficShapingHandler {
      * default max time as delay allowed value of 15000 ms.
      *
      * @param executor
-     *          the {@link ScheduledExecutorService} to use for the {@link TrafficCounter}.
+     *          the {@link EventExecutor} to use for the {@link TrafficCounter}.
      * @param writeLimit
      *          0 or a limit in bytes/s
      * @param readLimit
@@ -151,7 +151,7 @@ public class GlobalTrafficShapingHandler extends AbstractTrafficShapingHandler {
      *          The delay between two computations of performances for
      *            channels or 0 if no stats are to be computed.
      */
-    public GlobalTrafficShapingHandler(ScheduledExecutorService executor, long writeLimit,
+    public GlobalTrafficShapingHandler(EventExecutor executor, long writeLimit,
             long readLimit, long checkInterval) {
         super(writeLimit, readLimit, checkInterval);
         createGlobalTrafficCounter(executor);
@@ -168,7 +168,7 @@ public class GlobalTrafficShapingHandler extends AbstractTrafficShapingHandler {
      * @param readLimit
      *          0 or a limit in bytes/s
      */
-    public GlobalTrafficShapingHandler(ScheduledExecutorService executor, long writeLimit,
+    public GlobalTrafficShapingHandler(EventExecutor executor, long writeLimit,
             long readLimit) {
         super(writeLimit, readLimit);
         createGlobalTrafficCounter(executor);
@@ -184,7 +184,7 @@ public class GlobalTrafficShapingHandler extends AbstractTrafficShapingHandler {
      *          The delay between two computations of performances for
      *            channels or 0 if no stats are to be computed.
      */
-    public GlobalTrafficShapingHandler(ScheduledExecutorService executor, long checkInterval) {
+    public GlobalTrafficShapingHandler(EventExecutor executor, long checkInterval) {
         super(checkInterval);
         createGlobalTrafficCounter(executor);
     }

--- a/handler/src/main/java/io/netty/handler/traffic/TrafficCounter.java
+++ b/handler/src/main/java/io/netty/handler/traffic/TrafficCounter.java
@@ -17,6 +17,8 @@ package io.netty.handler.traffic;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static io.netty.util.internal.ObjectUtil.checkNotNullWithIAE;
+
+import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -147,7 +149,7 @@ public class TrafficCounter {
     /**
      * Executor that will run the monitor
      */
-    final ScheduledExecutorService executor;
+    final EventExecutor executor;
     /**
      * Monitor created once in start()
      */
@@ -251,7 +253,7 @@ public class TrafficCounter {
      * @param checkInterval
      *            the checkInterval in millisecond between two computations.
      */
-    public TrafficCounter(ScheduledExecutorService executor, String name, long checkInterval) {
+    public TrafficCounter(EventExecutor executor, String name, long checkInterval) {
 
         this.name = checkNotNull(name, "name");
         trafficShapingHandler = null;
@@ -275,7 +277,7 @@ public class TrafficCounter {
      *            the checkInterval in millisecond between two computations.
      */
     public TrafficCounter(
-            AbstractTrafficShapingHandler trafficShapingHandler, ScheduledExecutorService executor,
+            AbstractTrafficShapingHandler trafficShapingHandler, EventExecutor executor,
             String name, long checkInterval) {
         this.name = checkNotNull(name, "name");
         this.trafficShapingHandler = checkNotNullWithIAE(trafficShapingHandler, "trafficShapingHandler");

--- a/handler/src/test/java/io/netty/handler/traffic/FileRegionThrottleTest.java
+++ b/handler/src/test/java/io/netty/handler/traffic/FileRegionThrottleTest.java
@@ -88,7 +88,7 @@ public class FileRegionThrottleTest {
     @Test
     public void testGlobalWriteThrottle() throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
-        final GlobalTrafficShapingHandler gtsh = new GlobalTrafficShapingHandler(group, WRITE_LIMIT, 0);
+        final GlobalTrafficShapingHandler gtsh = new GlobalTrafficShapingHandler(group.next(), WRITE_LIMIT, 0);
         ServerBootstrap bs = new ServerBootstrap();
         bs.group(group).channel(NioServerSocketChannel.class).childHandler(new ChannelInitializer<SocketChannel>() {
             @Override

--- a/handler/src/test/java/io/netty/handler/traffic/TrafficShapingHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/traffic/TrafficShapingHandlerTest.java
@@ -16,9 +16,6 @@
 
 package io.netty.handler.traffic;
 
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.Unpooled;
@@ -34,6 +31,8 @@ import io.netty.channel.local.LocalIoHandler;
 import io.netty.channel.local.LocalServerChannel;
 import io.netty.util.Attribute;
 import io.netty.util.CharsetUtil;
+import io.netty.util.concurrent.DefaultEventExecutorGroup;
+import io.netty.util.concurrent.EventExecutorGroup;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -45,27 +44,27 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 public class TrafficShapingHandlerTest {
 
     private static final long READ_LIMIT_BYTES_PER_SECOND = 1;
-    private static final ScheduledExecutorService SES = Executors.newSingleThreadScheduledExecutor();
+    private static final EventExecutorGroup SES = new DefaultEventExecutorGroup(1);
     private static final EventLoopGroup GROUP = new MultiThreadIoEventLoopGroup(1, LocalIoHandler.newFactory());
 
     @AfterAll
     public static void destroy() {
         GROUP.shutdownGracefully();
-        SES.shutdown();
+        SES.shutdownGracefully();
     }
 
     @Test
     public void testHandlerRemove() throws Exception {
         testHandlerRemove0(new ChannelTrafficShapingHandler(0, READ_LIMIT_BYTES_PER_SECOND));
         GlobalTrafficShapingHandler trafficHandler1 =
-                new GlobalTrafficShapingHandler(SES, 0, READ_LIMIT_BYTES_PER_SECOND);
+                new GlobalTrafficShapingHandler(SES.next(), 0, READ_LIMIT_BYTES_PER_SECOND);
         try {
             testHandlerRemove0(trafficHandler1);
         } finally {
             trafficHandler1.release();
         }
         GlobalChannelTrafficShapingHandler trafficHandler2 =
-                new GlobalChannelTrafficShapingHandler(SES, 0,
+                new GlobalChannelTrafficShapingHandler(SES.next(), 0,
                         READ_LIMIT_BYTES_PER_SECOND, 0, READ_LIMIT_BYTES_PER_SECOND);
         try {
             testHandlerRemove0(trafficHandler2);

--- a/microbench/src/main/java/io/netty/microbench/concurrent/BurstCostExecutorsBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/concurrent/BurstCostExecutorsBenchmark.java
@@ -34,10 +34,12 @@ import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -176,8 +178,8 @@ public class BurstCostExecutorsBenchmark extends AbstractMicrobenchmark {
     @Param({ "0", "10" })
     private int work;
 
-    private ExecutorService executor;
-    private ExecutorService executorToShutdown;
+    private Executor executor;
+    private AutoCloseable executorToShutdown;
 
     @Setup
     public void setup() {
@@ -188,23 +190,27 @@ public class BurstCostExecutorsBenchmark extends AbstractMicrobenchmark {
             //4 is to leave some room between the offers and 1024 is to leave some room
             //between producer/consumer when work is > 0 and 1 producer.
             //If work = 0 then the task queue is supposed to be near empty most of the time.
-            executor = new SpinExecutorService(Math.min(1024, burstLength * 4));
-            executorToShutdown = executor;
+            io.netty.microbench.concurrent.BurstCostExecutorsBenchmark.SpinExecutorService spinExecutor
+                    = new SpinExecutorService(Math.min(1024, burstLength * 4));
+            executor = spinExecutor;
+            executorToShutdown = spinExecutor;
             break;
         case defaultEventExecutor:
-            executor = new DefaultEventExecutor();
-            executorToShutdown = executor;
+            io.netty.util.concurrent.EventExecutor eventExecutor = new DefaultEventExecutor();
+            executor = eventExecutor;
+            executorToShutdown = eventExecutor::shutdownGracefully;
             break;
         case juc:
-            executor = Executors.newSingleThreadScheduledExecutor();
-            executorToShutdown = executor;
+            java.util.concurrent.ScheduledExecutorService scheduled = Executors.newSingleThreadScheduledExecutor();
+            executor = scheduled;
+            executorToShutdown = scheduled;
             break;
         }
     }
 
     @TearDown
-    public void tearDown() {
-        executorToShutdown.shutdown();
+    public void tearDown() throws Exception {
+        executorToShutdown.close();
     }
 
     @State(Scope.Thread)
@@ -293,7 +299,7 @@ public class BurstCostExecutorsBenchmark extends AbstractMicrobenchmark {
     }
 
     private int executeBurst(final PerThreadState state) {
-        final ExecutorService executor = this.executor;
+        final Executor executor = this.executor;
         final int burstLength = this.burstLength;
         final Runnable completeTask = state.completeTask;
         for (int i = 0; i < burstLength; i++) {

--- a/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmark.java
@@ -20,6 +20,7 @@ import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.FastThreadLocalThread;
 import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.ScheduledFuture;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SystemPropertyUtil;
@@ -30,6 +31,7 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -53,10 +55,6 @@ public class AbstractMicrobenchmark extends AbstractMicrobenchmarkBase {
                     new LinkedBlockingQueue<Runnable>(),
                     new DefaultThreadFactory(prefix));
             EventExecutor eventExecutor = new AbstractEventExecutor() {
-                @Override
-                public void shutdown() {
-                    throw new UnsupportedOperationException();
-                }
 
                 @Override
                 public boolean inEventLoop(Thread thread) {
@@ -95,6 +93,28 @@ public class AbstractMicrobenchmark extends AbstractMicrobenchmarkBase {
 
                 @Override
                 public void execute(Runnable command) {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public ScheduledFuture<?> scheduleAtFixedRate(
+                        Runnable command, long initialDelay, long period, TimeUnit unit) {
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public ScheduledFuture<?> scheduleWithFixedDelay(
+                        Runnable command, long initialDelay, long delay, TimeUnit unit) {
                     throw new UnsupportedOperationException();
                 }
             };

--- a/microbench/src/main/java/io/netty/microbench/util/AbstractSharedExecutorMicrobenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/util/AbstractSharedExecutorMicrobenchmark.java
@@ -19,9 +19,11 @@ import io.netty.channel.EventLoop;
 import io.netty.util.concurrent.AbstractEventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
+import io.netty.util.concurrent.ScheduledFuture;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 import org.openjdk.jmh.annotations.Fork;
@@ -99,13 +101,6 @@ public class AbstractSharedExecutorMicrobenchmark extends AbstractMicrobenchmark
             return executor.terminationFuture();
         }
 
-        @Override
-        @Deprecated
-        public void shutdown() {
-            executor.shutdown();
-        }
-
-        @Override
         public boolean isShuttingDown() {
             return executor.isShuttingDown();
         }
@@ -138,6 +133,27 @@ public class AbstractSharedExecutorMicrobenchmark extends AbstractMicrobenchmark
         @Override
         public <V> Promise<V> newPromise() {
             return executor.newPromise();
+        }
+
+        @Override
+        public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+            return executor.schedule(command, delay, unit);
+        }
+
+        @Override
+        public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+            return executor.schedule(callable, delay, unit);
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+            return executor.scheduleAtFixedRate(command, initialDelay, period, unit);
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleWithFixedDelay(
+                Runnable command, long initialDelay, long delay, TimeUnit unit) {
+            return executor.scheduleWithFixedDelay(command, initialDelay, delay, unit);
         }
     }
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
@@ -124,7 +124,7 @@ public abstract class AbstractSingleThreadEventLoopTest {
     public void shutdownBeforeStart() throws Exception {
         EventLoopGroup group = newEventLoopGroup();
         assertFalse(group.awaitTermination(2, TimeUnit.MILLISECONDS));
-        group.shutdown();
+        group.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS);
         assertTrue(group.awaitTermination(200, TimeUnit.MILLISECONDS));
     }
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/TrafficShapingHandlerTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/TrafficShapingHandlerTest.java
@@ -348,13 +348,15 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
         final AbstractTrafficShapingHandler handler;
         if (limitRead) {
             if (globalLimit) {
-                handler = new GlobalTrafficShapingHandler(groupForGlobal, 0, bandwidthFactor * messageSize, check);
+                handler = new GlobalTrafficShapingHandler(
+                        groupForGlobal.next(), 0, bandwidthFactor * messageSize, check);
             } else {
                 handler = new ChannelTrafficShapingHandler(0, bandwidthFactor * messageSize, check);
             }
         } else if (limitWrite) {
             if (globalLimit) {
-                handler = new GlobalTrafficShapingHandler(groupForGlobal, bandwidthFactor * messageSize, 0, check);
+                handler = new GlobalTrafficShapingHandler(
+                        groupForGlobal.next(), bandwidthFactor * messageSize, 0, check);
             } else {
                 handler = new ChannelTrafficShapingHandler(bandwidthFactor * messageSize, 0, check);
             }

--- a/transport/src/main/java/io/netty/channel/ManualIoEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/ManualIoEventLoop.java
@@ -26,15 +26,10 @@ import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.ThreadExecutorMap;
 
-import java.util.Collection;
-import java.util.List;
 import java.util.Objects;
 import java.util.Queue;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -470,12 +465,6 @@ public class ManualIoEventLoop extends AbstractScheduledEventExecutor implements
     }
 
     @Override
-    @Deprecated
-    public final void shutdown() {
-        shutdown0(-1, -1, ST_SHUTDOWN);
-    }
-
-    @Override
     public final Future<?> terminationFuture() {
         return terminationFuture;
     }
@@ -583,45 +572,6 @@ public class ManualIoEventLoop extends AbstractScheduledEventExecutor implements
         // No tasks were added for last quiet period - hopefully safe to shut down.
         // (Hopefully because we really cannot make a guarantee that there will be no execute() calls by a user.)
         return true;
-    }
-
-    @Override
-    public final <T> T invokeAny(Collection<? extends Callable<T>> tasks)
-            throws InterruptedException, ExecutionException {
-        // We need to check if the method was called from within the EventLoop as this would cause a deadlock.
-        throwIfInEventLoop("invokeAny");
-        return super.invokeAny(tasks);
-    }
-
-    @Override
-    public final <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
-            throws InterruptedException, ExecutionException, TimeoutException {
-        // We need to check if the method was called from within the EventLoop as this would cause a deadlock.
-        throwIfInEventLoop("invokeAny");
-        return super.invokeAny(tasks, timeout, unit);
-    }
-
-    @Override
-    public final <T> List<java.util.concurrent.Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
-            throws InterruptedException {
-        // We need to check if the method was called from within the EventLoop as this would cause a deadlock.
-        throwIfInEventLoop("invokeAll");
-        return super.invokeAll(tasks);
-    }
-
-    @Override
-    public final <T> List<java.util.concurrent.Future<T>> invokeAll(
-            Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
-        // We need to check if the method was called from within the EventLoop as this would cause a deadlock.
-        throwIfInEventLoop("invokeAll");
-        return super.invokeAll(tasks, timeout, unit);
-    }
-
-    private void throwIfInEventLoop(String method) {
-        if (inEventLoop()) {
-            throw new RejectedExecutionException(
-                    "Calling " + method + " from within the EventLoop is not allowed as it would deadlock");
-        }
     }
 
     private class BlockingIoHandlerContext implements IoHandlerContext {

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedEventLoop.java
@@ -111,12 +111,6 @@ final class EmbeddedEventLoop extends AbstractScheduledEventExecutor implements 
     }
 
     @Override
-    @Deprecated
-    public void shutdown() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public boolean isShuttingDown() {
         return false;
     }

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
@@ -38,6 +38,7 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
+import io.netty.util.concurrent.ScheduledFuture;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -56,6 +57,7 @@ import java.util.NoSuchElementException;
 import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -2125,16 +2127,6 @@ public class DefaultChannelPipelineTest {
         }
 
         @Override
-        public void shutdown() {
-            wrapped.shutdown();
-        }
-
-        @Override
-        public List<Runnable> shutdownNow() {
-            return wrapped.shutdownNow();
-        }
-
-        @Override
         public boolean isShutdown() {
             return wrapped.isShutdown();
         }
@@ -2162,6 +2154,27 @@ public class DefaultChannelPipelineTest {
         @Override
         public void execute(Runnable command) {
             wrapped.execute(command);
+        }
+
+        @Override
+        public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleWithFixedDelay(
+                Runnable command, long initialDelay, long delay, TimeUnit unit) {
+            throw new UnsupportedOperationException();
         }
     }
 }

--- a/transport/src/test/java/io/netty/channel/ManualIoEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/ManualIoEventLoopTest.java
@@ -19,23 +19,16 @@ import io.netty.channel.local.LocalIoHandler;
 import io.netty.channel.nio.NioIoHandler;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.MockTicker;
-import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.Ticker;
 import io.netty.util.internal.ThreadExecutorMap;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-import java.util.Collections;
-import java.util.Set;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -60,7 +53,7 @@ public class ManualIoEventLoopTest {
 
         assertEquals(1, eventLoop.runNow());
         assertTrue(runnable.isDone());
-        eventLoop.shutdown();
+        eventLoop.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS);
         while (!eventLoop.isTerminated()) {
             eventLoop.runNow();
         }
@@ -91,7 +84,7 @@ public class ManualIoEventLoopTest {
         assertThat(waitTime).isGreaterThan(System.nanoTime() - current);
 
         assertTrue(runnable.isDone());
-        eventLoop.shutdown();
+        eventLoop.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS);
 
         while (!eventLoop.isTerminated()) {
             eventLoop.runNow();
@@ -105,7 +98,7 @@ public class ManualIoEventLoopTest {
         Thread ownerThread = new Thread();
         ManualIoEventLoop eventLoop = new ManualIoEventLoop(ownerThread, executor ->
                 new TestIoHandler(semaphore));
-        eventLoop.shutdown();
+        eventLoop.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS);
         assertTrue(eventLoop.isShuttingDown());
         // we expect wakeup to be called!
         assertEquals(1, semaphore.availablePermits());
@@ -132,92 +125,12 @@ public class ManualIoEventLoopTest {
         eventLoop.execute(() -> queue.offer(ThreadExecutorMap.currentExecutor()));
         assertEquals(1, eventLoop.runNow());
         assertSame(eventLoop, queue.take());
-        eventLoop.shutdown();
+        eventLoop.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS);
 
         while (!eventLoop.isTerminated()) {
             eventLoop.runNow();
         }
         eventLoop.terminationFuture().sync();
-    }
-
-    @Test
-    @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
-    public void testInvokeAnyInEventLoop() {
-        testInvokeInEventLoop(true, false);
-    }
-
-    @Test
-    @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
-    public void testInvokeAnyInEventLoopWithTimeout() {
-        testInvokeInEventLoop(true, true);
-    }
-
-    @Test
-    @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
-    public void testInvokeAllInEventLoop() {
-        testInvokeInEventLoop(false, false);
-    }
-
-    @Test
-    @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
-    public void testInvokeAllInEventLoopWithTimeout() {
-        testInvokeInEventLoop(false, true);
-    }
-
-    private static void testInvokeInEventLoop(final boolean any, final boolean timeout) {
-        Semaphore semaphore = new Semaphore(0);
-        ManualIoEventLoop eventLoop = new ManualIoEventLoop(Thread.currentThread(), executor ->
-                new TestIoHandler(semaphore));
-        try {
-            assertThrows(RejectedExecutionException.class, new Executable() {
-                @Override
-                public void execute() throws Throwable {
-                    final Promise<Void> promise = eventLoop.newPromise();
-                    eventLoop.execute(new Runnable() {
-                        @Override
-                        public void run() {
-                            try {
-                                Set<Callable<Boolean>> set = Collections.<Callable<Boolean>>singleton(
-                                        new Callable<Boolean>() {
-                                            @Override
-                                            public Boolean call() {
-                                                promise.setFailure(
-                                                        new AssertionError("Should never execute the Callable"));
-                                                return Boolean.TRUE;
-                                            }
-                                        });
-                                if (any) {
-                                    if (timeout) {
-                                        eventLoop.invokeAny(set, 10, TimeUnit.SECONDS);
-                                    } else {
-                                        eventLoop.invokeAny(set);
-                                    }
-                                } else {
-                                    if (timeout) {
-                                        eventLoop.invokeAll(set, 10, TimeUnit.SECONDS);
-                                    } else {
-                                        eventLoop.invokeAll(set);
-                                    }
-                                }
-                                promise.setFailure(new AssertionError("Should never reach here"));
-                            } catch (Throwable cause) {
-                                promise.setFailure(cause);
-                            }
-                        }
-                    });
-                    while (!promise.isDone()) {
-                        eventLoop.runNow();
-                    }
-                    promise.syncUninterruptibly();
-                }
-            });
-        } finally {
-            eventLoop.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS);
-            while (!eventLoop.isTerminated()) {
-                eventLoop.runNow();
-            }
-            assertTrue(eventLoop.terminationFuture().isSuccess());
-        }
     }
 
     @Test

--- a/transport/src/test/java/io/netty/channel/SingleThreadEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/SingleThreadEventLoopTest.java
@@ -109,7 +109,7 @@ public class SingleThreadEventLoopTest {
     @Test
     @SuppressWarnings("deprecation")
     public void shutdownBeforeStart() throws Exception {
-        loopA.shutdown();
+        loopA.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS).sync();
         assertRejection(loopA);
     }
 
@@ -128,7 +128,7 @@ public class SingleThreadEventLoopTest {
         latch.await();
 
         // Request the event loop thread to stop.
-        loopA.shutdown();
+        loopA.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS).sync();
         assertRejection(loopA);
 
         assertTrue(loopA.isShutdown());
@@ -359,7 +359,7 @@ public class SingleThreadEventLoopTest {
         assertEquals(1, ranTasks.get());
 
         // Shut down the event loop to test if the other tasks are run before termination.
-        loopA.shutdown();
+        loopA.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS);
 
         // Let the other tasks run.
         latch.countDown();
@@ -378,7 +378,7 @@ public class SingleThreadEventLoopTest {
     @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
     @SuppressWarnings("deprecation")
     public void testRegistrationAfterShutdown() throws Exception {
-        loopA.shutdown();
+        loopA.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS);
 
         // Disable logging temporarily.
         Logger root = (Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
@@ -408,7 +408,7 @@ public class SingleThreadEventLoopTest {
     @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
     @SuppressWarnings("deprecation")
     public void testRegistrationAfterShutdown2() throws Exception {
-        loopA.shutdown();
+        loopA.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS);
         final CountDownLatch latch = new CountDownLatch(1);
         Channel ch = new LocalChannel(loopA);
         Promise<Void> promise = ch.newPromise();

--- a/transport/src/test/java/io/netty/channel/nio/NioEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/nio/NioEventLoopTest.java
@@ -172,7 +172,7 @@ public class NioEventLoopTest extends AbstractEventLoopTest {
                 }
             });
             t.start();
-            group.shutdownNow();
+            group.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS);
             t.join();
             group.terminationFuture().syncUninterruptibly();
             assertInstanceOf(RejectedExecutionException.class, error.get());


### PR DESCRIPTION
Motivation:

Our EventLoopGroup should better not extend ScheduledExecutorService to not limit our selves

Modifications:

- EventLoopGroup does not extend ScheduledExecutorServie anymore
- Fix up tests

Result:

Hierarchy cleanup
