### PR TITLE
Adding Experimental WebTransport settings in HTTP/3 Settings

### DIFF
--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3SettingIdentifier.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3SettingIdentifier.java
@@ -17,9 +17,10 @@ package io.netty.handler.codec.http3;
 
 import org.jetbrains.annotations.Nullable;
 
+import io.netty.util.internal.UnstableApi;
+
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -86,7 +87,26 @@ public enum Http3SettingIdentifier {
      * <br>
      * Enables use of the CONNECT protocol in HTTP/3 when set to 1; disabled when 0.
      */
-    HTTP3_SETTINGS_H3_DATAGRAM(0x33);
+    HTTP3_SETTINGS_H3_DATAGRAM(0x33),
+    
+    /**
+     * Incubating WebTransport
+     * https://ietf-wg-webtrans.github.io/draft-ietf-webtrans-http3/draft-ietf-webtrans-http3.html#name-http-3-settings-parameter-r
+     */
+    @UnstableApi
+    HTTP3_SETTINGS_ENABLE_WEBTRANSPORT(0x2b603742),
+
+    @UnstableApi
+    HTTP3_SETTINGS_WT_MAX_SESSIONS(0x14e9cd29),
+    
+    @UnstableApi
+    HTTP3_SETTINGS_WT_INITIAL_MAX_STREAMS_UNI(0x2b64),
+    
+    @UnstableApi
+    HTTP3_SETTINGS_WT_INITIAL_MAX_STREAMS_BIDI(0x2b65),
+    
+    @UnstableApi
+    HTTP3_SETTINGS_WT_INITIAL_MAX_DATA(0x2b61);
 
     private final long id;
 

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3Settings.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3Settings.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.http3;
 
 import io.netty.util.collection.LongObjectHashMap;
 import io.netty.util.collection.LongObjectMap;
+import io.netty.util.internal.UnstableApi;
 
 import javax.annotation.Nullable;
 import java.util.Iterator;
@@ -223,6 +224,122 @@ public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
      */
     public Http3Settings enableH3Datagram(boolean enabled) {
         put(Http3SettingIdentifier.HTTP3_SETTINGS_H3_DATAGRAM.id(), enabled ? TRUE : FALSE);
+        return this;
+    }
+
+    /**
+     * Returns whether the {@code ENABLE_WEBTRANSPORT} setting is enabled.
+     *
+     * @return {@code true} if enabled, {@code false} if disabled, or {@code null} if not set
+     */
+    @UnstableApi
+    @Nullable
+    public Boolean webTransportEnabled() {
+        Long value = get(Http3SettingIdentifier.HTTP3_SETTINGS_ENABLE_WEBTRANSPORT.id());
+        return value == null ? null : TRUE.equals(value);
+    }
+
+    /**
+     * Sets the {@code ENABLE_WEBTRANSPORT} settings identifier.
+     *
+     * @param enabled whether to enable the WebTransport
+     * @return this instance for method chaining
+     */
+    @UnstableApi
+    public Http3Settings enableWebTransport(boolean enabled) {
+        put(Http3SettingIdentifier.HTTP3_SETTINGS_ENABLE_WEBTRANSPORT.id(), enabled ? TRUE : FALSE);
+        return this;
+    }
+
+    /**
+     * Returns the {@code WT_MAX_SESSIONS} value.
+     *
+     * @return the maximum number of sessions, or {@code null} if not set
+     */
+    @Nullable
+    @UnstableApi
+    public Long wtMaxSessions() {
+        return get(Http3SettingIdentifier.HTTP3_SETTINGS_WT_MAX_SESSIONS.id());
+    }
+
+    /**
+     * Sets the {@code WT_MAX_SESSIONS} value.
+     *
+     * @param value the maximum number of sessions (must be ≥ 0)
+     * @return this instance for method chaining
+     */
+    @UnstableApi
+    public Http3Settings wtMaxSessions(long value) {
+        put(Http3SettingIdentifier.HTTP3_SETTINGS_WT_MAX_SESSIONS.id(), value);
+        return this;
+    }
+
+    /**
+     * Returns the {@code WT_INITIAL_MAX_STREAMS_UNI} value.
+     *
+     * @return the initial maximum number of unidirectional streams, or {@code null} if not set
+     */
+    @Nullable
+    @UnstableApi
+    public Long wtInitialMaxStreamsUni() {
+        return get(Http3SettingIdentifier.HTTP3_SETTINGS_WT_INITIAL_MAX_STREAMS_UNI.id());
+    }
+
+    /**
+     * Sets the {@code WT_INITIAL_MAX_STREAMS_UNI} value.
+     *
+     * @param value the initial maximum number of unidirectional streams (must be ≥ 0)
+     * @return this instance for method chaining
+     */
+    @UnstableApi
+    public Http3Settings wtInitialMaxStreamsUni(long value) {
+        put(Http3SettingIdentifier.HTTP3_SETTINGS_WT_INITIAL_MAX_STREAMS_UNI.id(), value);
+        return this;
+    }
+
+    /**
+     * Returns the {@code WT_INITIAL_MAX_STREAMS_BIDI} value.
+     *
+     * @return the initial maximum number of bidirectional streams, or {@code null} if not set
+     */
+    @Nullable
+    @UnstableApi
+    public Long wtInitialMaxStreamsBidi() {
+        return get(Http3SettingIdentifier.HTTP3_SETTINGS_WT_INITIAL_MAX_STREAMS_BIDI.id());
+    }
+
+    /**
+     * Sets the {@code WT_INITIAL_MAX_STREAMS_BIDI} value.
+     *
+     * @param value the initial maximum number of bidirectional streams (must be ≥ 0)
+     * @return this instance for method chaining
+     */
+    @UnstableApi
+    public Http3Settings wtInitialMaxStreamsBidi(long value) {
+        put(Http3SettingIdentifier.HTTP3_SETTINGS_WT_INITIAL_MAX_STREAMS_BIDI.id(), value);
+        return this;
+    }
+
+    /**
+     * Returns the {@code WT_INITIAL_MAX_DATA} value.
+     *
+     * @return the initial maximum data, or {@code null} if not set
+     */
+    @Nullable
+    @UnstableApi
+    public Long wtInitialMaxData() {
+        return get(Http3SettingIdentifier.HTTP3_SETTINGS_WT_INITIAL_MAX_DATA.id());
+    }
+
+    /**
+     * Sets the {@code WT_INITIAL_MAX_DATA} value.
+     *
+     * @param value the initial maximum data (must be ≥ 0)
+     * @return this instance for method chaining
+     */
+    @UnstableApi
+    public Http3Settings wtInitialMaxData(long value) {
+        put(Http3SettingIdentifier.HTTP3_SETTINGS_WT_INITIAL_MAX_DATA.id(), value);
         return this;
     }
 


### PR DESCRIPTION
Introduced new HTTP/3 setting identifiers and corresponding methods in Http3Settings for WebTransport support, including enabling WebTransport and configuring session and stream limits. Marked these APIs as `@UnstableApi` to indicate their experimental status.

**Motivation:**

Experimental support to webtransport

**Modification:**

added required settings in `Http3SettingIdentifier` enum and typed accessors , marked them with `@Unstableapi` since its rfc is in draft version

**Result:**

add experimental support to webtransport
