### PR TITLE
Add missing return which could lead to double notification of a promise and so unexpected exception

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicStreamChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicStreamChannel.java
@@ -711,6 +711,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
             } catch (UnsupportedOperationException e) {
                 ReferenceCountUtil.release(msg);
                 promise.setFailure(e);
+                return;
             }
 
             boolean wasFinSent = QuicheQuicStreamChannel.this.finSent;


### PR DESCRIPTION
Motivation:

When we fail the promise because of an unsupported message we need to
return early.

Modifications:

Add missing return

Result:

Correctly handle unsupported messages. Port of https://github.com/netty/netty-incubator-codec-quic/pull/845
