### PR TITLE
Correctly return all TransportParameters (#16162)

### DIFF
--- a/codec-native-quic/src/main/c/netty_quic_quiche.c
+++ b/codec-native-quic/src/main/c/netty_quic_quiche.c
@@ -578,7 +578,8 @@ static jlongArray netty_quiche_conn_peer_transport_params(JNIEnv* env, jclass cl
         (jlong)params.peer_initial_max_streams_bidi,
         (jlong)params.peer_initial_max_streams_uni,
         (jlong)params.peer_ack_delay_exponent,
-        (jlong)params.peer_disable_active_migration ? 1: 0,
+        (jlong)params.peer_max_ack_delay,
+        (jlong)(params.peer_disable_active_migration == true ? 1: 0),
         (jlong)params.peer_active_conn_id_limit,
         (jlong)params.peer_max_datagram_frame_size
     };

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicTransportParametersTest.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicTransportParametersTest.java
@@ -88,7 +88,8 @@ public class QuicTransportParametersTest extends AbstractQuicTest {
         assertThat(parameters.ackDelayExponent()).isGreaterThanOrEqualTo(1L);
         assertThat(parameters.maxAckDelay()).isGreaterThanOrEqualTo(1L);
         assertFalse(parameters.disableActiveMigration());
-        assertThat(parameters.activeConnIdLimit()).isGreaterThanOrEqualTo(1L);
+        // -1 is the max value for an uint64_t that is converted to int64_t.
+        assertThat(parameters.activeConnIdLimit()).isEqualTo(-1L);
         assertThat(parameters.maxDatagramFrameSize()).isGreaterThanOrEqualTo(0L);
     }
 }


### PR DESCRIPTION
Motivation:

We did miss to also include the peer_max_ack_delay in the returned
params.

Modifications:

- Correctly return peer_max_ack_delay as well
- Adjust test

Result:

No more test-failures. Port of
https://github.com/netty/netty-incubator-codec-quic/pull/843