### PR TITLE
Fix incorrect assert when handling id to channel mappings (#16163)

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicCodec.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicCodec.java
@@ -82,7 +82,7 @@ abstract class QuicheQuicCodec implements ChannelInboundHandler, ChannelOutbound
 
     private void addMapping(QuicheQuicChannel channel, ByteBuffer id) {
         QuicheQuicChannel ch = connectionIdToChannel.put(id, channel);
-        assert ch == null;
+        assert ch == null || ch == channel;
     }
 
     private void removeMapping(QuicheQuicChannel channel, ByteBuffer id) {

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicChannelConnectTest.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicChannelConnectTest.java
@@ -1800,6 +1800,92 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
         }
     }
 
+    @ParameterizedTest
+    @MethodSource("newSslTaskExecutors")
+    public void testConnectWithActiveConnectionIdLimit(Executor executor) throws Throwable {
+        int numBytes = 8;
+
+        class ExceptionHandler extends ChannelInboundHandlerAdapter {
+
+            private final AtomicReference<Throwable> causeRef = new AtomicReference<>();
+            @Override
+            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                causeRef.compareAndSet(null, cause);
+            }
+
+            void assertNoException() throws Throwable {
+                Throwable t = causeRef.get();
+                if (t != null) {
+                    fail(t);
+                }
+            }
+        }
+
+        ExceptionHandler serverExceptionHandler = new ExceptionHandler();
+        ExceptionHandler clientExceptionHandler = new ExceptionHandler();
+
+        ChannelActiveVerifyHandler serverQuicChannelHandler = new ChannelActiveVerifyHandler();
+
+        CountDownLatch serverLatch = new CountDownLatch(1);
+        CountDownLatch clientLatch = new CountDownLatch(1);
+
+        // Disable token validation
+        Channel server = QuicTestUtils.newServer(
+                QuicTestUtils.newQuicServerBuilder(executor).activeConnectionIdLimit(4), NoQuicTokenHandler.INSTANCE,
+                serverQuicChannelHandler, new BytesCountingHandler(serverLatch, numBytes));
+        server.pipeline().addLast(serverExceptionHandler);
+        InetSocketAddress address = (InetSocketAddress) server.localAddress();
+        Channel channel = QuicTestUtils.newClient(
+                QuicTestUtils.newQuicClientBuilder(executor).activeConnectionIdLimit(4));
+        channel.pipeline().addLast(clientExceptionHandler);
+        try {
+            ChannelActiveVerifyHandler clientQuicChannelHandler = new ChannelActiveVerifyHandler();
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
+                    .handler(clientQuicChannelHandler)
+                    .streamHandler(new ChannelInboundHandlerAdapter())
+                    .remoteAddress(address)
+                    .connect()
+                    .get();
+            QuicConnectionAddress localAddress = (QuicConnectionAddress) quicChannel.localAddress();
+            QuicConnectionAddress remoteAddress = (QuicConnectionAddress) quicChannel.remoteAddress();
+            assertNotNull(localAddress);
+            assertNotNull(remoteAddress);
+
+            QuicStreamChannel stream = quicChannel.createStream(QuicStreamType.BIDIRECTIONAL,
+                    new BytesCountingHandler(clientLatch, numBytes)).get();
+            stream.writeAndFlush(Unpooled.directBuffer().writeZero(numBytes)).sync();
+            clientLatch.await();
+
+            QuicheQuicSslEngine quicheQuicSslEngine = (QuicheQuicSslEngine) quicChannel.sslEngine();
+            assertNotNull(quicheQuicSslEngine);
+            assertEquals(QuicTestUtils.PROTOS[0],
+                    // Just do the cast as getApplicationProtocol() only exists in SSLEngine itself since Java9+ and
+                    // we may run on an earlier version
+                    quicheQuicSslEngine.getApplicationProtocol());
+            stream.close().sync();
+            quicChannel.close().sync();
+            ChannelFuture closeFuture = quicChannel.closeFuture().await();
+            assertTrue(closeFuture.isSuccess());
+
+            clientQuicChannelHandler.assertState();
+            serverQuicChannelHandler.assertState();
+
+            assertEquals(serverQuicChannelHandler.localAddress(), remoteAddress);
+            assertEquals(serverQuicChannelHandler.remoteAddress(), localAddress);
+
+            serverExceptionHandler.assertNoException();
+            clientExceptionHandler.assertNoException();
+        } finally {
+            serverLatch.await();
+
+            server.close().sync();
+            // Close the parent Datagram channel as well.
+            channel.close().sync();
+
+            shutdown(executor);
+        }
+    }
+
     private static final class ChannelActiveVerifyHandler extends QuicChannelValidationHandler {
         private final BlockingQueue<Integer> states = new LinkedBlockingQueue<>();
 

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicChannelConnectTest.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicChannelConnectTest.java
@@ -1805,7 +1805,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
     public void testConnectWithActiveConnectionIdLimit(Executor executor) throws Throwable {
         int numBytes = 8;
 
-        class ExceptionHandler extends ChannelInboundHandlerAdapter {
+        class ExceptionHandler implements ChannelInboundHandler {
 
             private final AtomicReference<Throwable> causeRef = new AtomicReference<>();
             @Override
@@ -1842,7 +1842,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
             ChannelActiveVerifyHandler clientQuicChannelHandler = new ChannelActiveVerifyHandler();
             QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
                     .handler(clientQuicChannelHandler)
-                    .streamHandler(new ChannelInboundHandlerAdapter())
+                    .streamHandler(new ChannelInboundHandler() { })
                     .remoteAddress(address)
                     .connect()
                     .get();
@@ -1864,7 +1864,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
                     quicheQuicSslEngine.getApplicationProtocol());
             stream.close().sync();
             quicChannel.close().sync();
-            ChannelFuture closeFuture = quicChannel.closeFuture().await();
+            Future<Void> closeFuture = quicChannel.closeFuture().await();
             assertTrue(closeFuture.isSuccess());
 
             clientQuicChannelHandler.assertState();


### PR DESCRIPTION
Motivation:

We had an incorrect / incomplete assert that could cause exceptions when
handling id to channel mappings.

Modifications:

- Fix assert
- Add unit test

Result:

Correctly handle id to channel mappings in all cases. Port of
https://github.com/netty/netty-incubator-codec-quic/pull/844