### PR TITLE
HTTP3: Allow to support non-standard HTTP3 settings

### DIFF
--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/DefaultHttp3SettingsFrame.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/DefaultHttp3SettingsFrame.java
@@ -108,7 +108,8 @@ public final class DefaultHttp3SettingsFrame implements Http3SettingsFrame {
      * @return              the newly created copy.
      */
     public static DefaultHttp3SettingsFrame copyOf(Http3SettingsFrame settingsFrame) {
-        DefaultHttp3SettingsFrame copy = new DefaultHttp3SettingsFrame();
+        Http3Settings settingsCopy = new Http3Settings(settingsFrame.settings().nonStandardSettingsValidator);
+        DefaultHttp3SettingsFrame copy = new DefaultHttp3SettingsFrame(settingsCopy);
         if (settingsFrame instanceof DefaultHttp3SettingsFrame) {
             copy.settings.putAll(((DefaultHttp3SettingsFrame) settingsFrame).settings);
         } else {

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ClientConnectionHandler.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ClientConnectionHandler.java
@@ -99,7 +99,7 @@ public final class Http3ClientConnectionHandler extends Http3ConnectionHandler {
     void initUnidirectionalStream(ChannelHandlerContext ctx, QuicStreamChannel streamChannel) {
         final long maxTableCapacity = maxTableCapacity();
         streamChannel.pipeline().addLast(
-                new Http3UnidirectionalStreamInboundClientHandler(codecFactory, (id, v) -> false,
+                new Http3UnidirectionalStreamInboundClientHandler(codecFactory, nonStandardSettingsValidator,
                         localControlStreamHandler, remoteControlStreamHandler,
                         unknownInboundStreamHandlerFactory, pushStreamHandlerFactory,
                         () -> new QpackEncoderHandler(maxTableCapacity, qpackDecoder),

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ClientConnectionHandler.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ClientConnectionHandler.java
@@ -54,8 +54,37 @@ public final class Http3ClientConnectionHandler extends Http3ConnectionHandler {
                                         @Nullable LongFunction<ChannelHandler> pushStreamHandlerFactory,
                                         @Nullable LongFunction<ChannelHandler> unknownInboundStreamHandlerFactory,
                                         @Nullable Http3SettingsFrame localSettings, boolean disableQpackDynamicTable) {
+        this(inboundControlStreamHandler, pushStreamHandlerFactory, unknownInboundStreamHandlerFactory, localSettings,
+                disableQpackDynamicTable, null);
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param inboundControlStreamHandler           the {@link ChannelHandler} which will be notified about
+     *                                              {@link Http3RequestStreamFrame}s or {@code null} if the user is not
+     *                                              interested in these.
+     * @param pushStreamHandlerFactory              the {@link LongFunction} that will provide a custom
+     *                                              {@link ChannelHandler} for push streams {@code null} if no special
+     *                                              handling should be done. When present, push ID will be passed as an
+     *                                              argument to the {@link LongFunction}.
+     * @param unknownInboundStreamHandlerFactory    the {@link LongFunction} that will provide a custom
+     *                                              {@link ChannelHandler} for unknown inbound stream types or
+     *                                              {@code null} if no special handling should be done.
+     * @param localSettings                         the local {@link Http3SettingsFrame} that should be sent to the
+     *                                              remote peer or {@code null} if the default settings should be used.
+     * @param disableQpackDynamicTable              If QPACK dynamic table should be disabled.
+     * @param nonStandardSettingsValidator          the {@link Http3Settings.NonStandardHttp3SettingsValidator} to use
+     *                                              when validating settings that are non-standard.
+     */
+    public Http3ClientConnectionHandler(@Nullable ChannelHandler inboundControlStreamHandler,
+                                        @Nullable LongFunction<ChannelHandler> pushStreamHandlerFactory,
+                                        @Nullable LongFunction<ChannelHandler> unknownInboundStreamHandlerFactory,
+                                        @Nullable Http3SettingsFrame localSettings, boolean disableQpackDynamicTable,
+                                        @Nullable Http3Settings.NonStandardHttp3SettingsValidator
+                                                nonStandardSettingsValidator) {
         super(false, inboundControlStreamHandler, unknownInboundStreamHandlerFactory, localSettings,
-                disableQpackDynamicTable);
+                disableQpackDynamicTable, nonStandardSettingsValidator);
         this.pushStreamHandlerFactory = pushStreamHandlerFactory;
     }
 
@@ -70,7 +99,7 @@ public final class Http3ClientConnectionHandler extends Http3ConnectionHandler {
     void initUnidirectionalStream(ChannelHandlerContext ctx, QuicStreamChannel streamChannel) {
         final long maxTableCapacity = maxTableCapacity();
         streamChannel.pipeline().addLast(
-                new Http3UnidirectionalStreamInboundClientHandler(codecFactory,
+                new Http3UnidirectionalStreamInboundClientHandler(codecFactory, (id, v) -> false,
                         localControlStreamHandler, remoteControlStreamHandler,
                         unknownInboundStreamHandlerFactory, pushStreamHandlerFactory,
                         () -> new QpackEncoderHandler(maxTableCapacity, qpackDecoder),

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ConnectionHandler.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ConnectionHandler.java
@@ -42,6 +42,7 @@ public abstract class Http3ConnectionHandler extends ChannelInboundHandlerAdapte
     final Http3ControlStreamOutboundHandler remoteControlStreamHandler;
     final QpackDecoder qpackDecoder;
     final QpackEncoder qpackEncoder;
+    final Http3Settings.NonStandardHttp3SettingsValidator nonStandardSettingsValidator;
     private boolean controlStreamCreationInProgress;
 
     final long maxTableCapacity;
@@ -61,9 +62,15 @@ public abstract class Http3ConnectionHandler extends ChannelInboundHandlerAdapte
      */
     Http3ConnectionHandler(boolean server, @Nullable ChannelHandler inboundControlStreamHandler,
                            @Nullable LongFunction<ChannelHandler> unknownInboundStreamHandlerFactory,
-                           @Nullable Http3SettingsFrame localSettings, boolean disableQpackDynamicTable) {
+                           @Nullable Http3SettingsFrame localSettings, boolean disableQpackDynamicTable,
+                           @Nullable Http3Settings.NonStandardHttp3SettingsValidator nonStandardSettingsValidator) {
         this.unknownInboundStreamHandlerFactory = unknownInboundStreamHandlerFactory;
         this.disableQpackDynamicTable = disableQpackDynamicTable;
+        if (nonStandardSettingsValidator != null) {
+            this.nonStandardSettingsValidator = nonStandardSettingsValidator;
+        } else {
+            this.nonStandardSettingsValidator = (id, value) -> false;
+        }
         if (localSettings == null) {
             localSettings = new DefaultHttp3SettingsFrame();
         } else {
@@ -81,7 +88,8 @@ public abstract class Http3ConnectionHandler extends ChannelInboundHandlerAdapte
         qpackEncoder = new QpackEncoder();
         codecFactory = Http3FrameCodec.newFactory(qpackDecoder, maxFieldSectionSize, qpackEncoder);
         remoteControlStreamHandler =  new Http3ControlStreamOutboundHandler(server, localSettings,
-                codecFactory.newCodec(Http3FrameTypeValidator.NO_VALIDATION, NO_STATE, NO_STATE));
+                codecFactory.newCodec(Http3FrameTypeValidator.NO_VALIDATION, NO_STATE, NO_STATE,
+                        this.nonStandardSettingsValidator));
         localControlStreamHandler = new Http3ControlStreamInboundHandler(server, inboundControlStreamHandler,
                 qpackEncoder, remoteControlStreamHandler);
     }
@@ -121,7 +129,8 @@ public abstract class Http3ConnectionHandler extends ChannelInboundHandlerAdapte
      */
     final ChannelHandler newCodec(Http3RequestStreamCodecState encodeState,
                                   Http3RequestStreamCodecState decodeState) {
-        return codecFactory.newCodec(Http3RequestStreamFrameTypeValidator.INSTANCE, encodeState, decodeState);
+        return codecFactory.newCodec(
+                Http3RequestStreamFrameTypeValidator.INSTANCE, encodeState, decodeState, nonStandardSettingsValidator);
     }
 
     final ChannelHandler newRequestStreamValidationHandler(

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3FrameCodec.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3FrameCodec.java
@@ -62,7 +62,7 @@ final class Http3FrameCodec extends ByteToMessageDecoder implements ChannelOutbo
     private final QpackEncoder qpackEncoder;
     private final Http3RequestStreamCodecState encodeState;
     private final Http3RequestStreamCodecState decodeState;
-
+    private final Http3Settings.NonStandardHttp3SettingsValidator nonStandardSettingsValidator;
     private boolean firstFrame = true;
     private boolean error;
     private long type = -1;
@@ -77,19 +77,22 @@ final class Http3FrameCodec extends ByteToMessageDecoder implements ChannelOutbo
         checkNotNull(qpackDecoder, "qpackDecoder");
 
         // QPACK decoder and encoder are shared between streams in a connection.
-        return (validator, encodeState, decodeState) -> new Http3FrameCodec(validator, qpackDecoder,
-                maxHeaderListSize, qpackEncoder, encodeState, decodeState);
+        return (validator, encodeState, decodeState,
+                nonStandardSettingsValidator) -> new Http3FrameCodec(validator, qpackDecoder,
+                maxHeaderListSize, qpackEncoder, encodeState, decodeState, nonStandardSettingsValidator);
     }
 
     Http3FrameCodec(Http3FrameTypeValidator validator, QpackDecoder qpackDecoder,
                     long maxHeaderListSize, QpackEncoder qpackEncoder, Http3RequestStreamCodecState encodeState,
-                    Http3RequestStreamCodecState decodeState) {
+                    Http3RequestStreamCodecState decodeState,
+                    Http3Settings.NonStandardHttp3SettingsValidator nonStandardSettingsValidator) {
         this.validator = checkNotNull(validator, "validator");
         this.qpackDecoder = checkNotNull(qpackDecoder, "qpackDecoder");
         this.maxHeaderListSize = checkPositive(maxHeaderListSize, "maxHeaderListSize");
         this.qpackEncoder = checkNotNull(qpackEncoder, "qpackEncoder");
         this.encodeState = checkNotNull(encodeState, "encodeState");
         this.decodeState = checkNotNull(decodeState, "decodeState");
+        this.nonStandardSettingsValidator = nonStandardSettingsValidator;
     }
 
     @Override
@@ -352,7 +355,8 @@ final class Http3FrameCodec extends ByteToMessageDecoder implements ChannelOutbo
 
     @Nullable
     private Http3SettingsFrame decodeSettings(ChannelHandlerContext ctx, ByteBuf in, int payLoadLength) {
-        Http3SettingsFrame settingsFrame = new DefaultHttp3SettingsFrame();
+        Http3SettingsFrame settingsFrame = new DefaultHttp3SettingsFrame(
+                new Http3Settings(nonStandardSettingsValidator));
         while (payLoadLength > 0) {
             int keyLen = numBytesForVariableLengthInteger(in.getByte(in.readerIndex()));
             long key = readVariableLengthInteger(in, keyLen);
@@ -812,6 +816,7 @@ final class Http3FrameCodec extends ByteToMessageDecoder implements ChannelOutbo
          * @return new codec instance for the passed {@code streamType}.
          */
         ChannelHandler newCodec(Http3FrameTypeValidator validator, Http3RequestStreamCodecState encodeState,
-                                Http3RequestStreamCodecState decodeState);
+                                Http3RequestStreamCodecState decodeState,
+                                Http3Settings.NonStandardHttp3SettingsValidator nonStandardSettingsValidator);
     }
 }

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ServerConnectionHandler.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ServerConnectionHandler.java
@@ -60,8 +60,35 @@ public final class Http3ServerConnectionHandler extends Http3ConnectionHandler {
                                         @Nullable ChannelHandler inboundControlStreamHandler,
                                         @Nullable LongFunction<ChannelHandler> unknownInboundStreamHandlerFactory,
                                         @Nullable Http3SettingsFrame localSettings, boolean disableQpackDynamicTable) {
+        this(requestStreamHandler, inboundControlStreamHandler, unknownInboundStreamHandlerFactory,
+                localSettings, disableQpackDynamicTable, null);
+    }
+
+    /**
+     * Create a new instance.
+     * @param requestStreamHandler                  the {@link ChannelHandler} that is used for each new request stream.
+     *                                              This handler will receive {@link Http3HeadersFrame} and
+     *                                              {@link Http3DataFrame}s.
+     * @param inboundControlStreamHandler           the {@link ChannelHandler} which will be notified about
+     *                                              {@link Http3RequestStreamFrame}s or {@code null} if the user is not
+     *                                              interested in these.
+     * @param unknownInboundStreamHandlerFactory    the {@link LongFunction} that will provide a custom
+     *                                              {@link ChannelHandler} for unknown inbound stream types or
+     *                                              {@code null} if no special handling should be done.
+     * @param localSettings                         the local {@link Http3SettingsFrame} that should be sent to the
+     *                                              remote peer or {@code null} if the default settings should be used.
+     * @param disableQpackDynamicTable              If QPACK dynamic table should be disabled.
+     * @param nonStandardSettingsValidator          the {@link Http3Settings.NonStandardHttp3SettingsValidator} to
+     *                                              use when validating settings that are non-standard.
+     */
+    public Http3ServerConnectionHandler(ChannelHandler requestStreamHandler,
+                                        @Nullable ChannelHandler inboundControlStreamHandler,
+                                        @Nullable LongFunction<ChannelHandler> unknownInboundStreamHandlerFactory,
+                                        @Nullable Http3SettingsFrame localSettings, boolean disableQpackDynamicTable,
+                                        @Nullable Http3Settings.NonStandardHttp3SettingsValidator
+                                                nonStandardSettingsValidator) {
         super(true, inboundControlStreamHandler, unknownInboundStreamHandlerFactory, localSettings,
-                disableQpackDynamicTable);
+                disableQpackDynamicTable, nonStandardSettingsValidator);
         this.requestStreamHandler = ObjectUtil.checkNotNull(requestStreamHandler, "requestStreamHandler");
     }
 
@@ -82,7 +109,7 @@ public final class Http3ServerConnectionHandler extends Http3ConnectionHandler {
     void initUnidirectionalStream(ChannelHandlerContext ctx, QuicStreamChannel streamChannel) {
         final long maxTableCapacity = maxTableCapacity();
         streamChannel.pipeline().addLast(
-                new Http3UnidirectionalStreamInboundServerHandler(codecFactory,
+                new Http3UnidirectionalStreamInboundServerHandler(codecFactory, nonStandardSettingsValidator,
                         localControlStreamHandler, remoteControlStreamHandler,
                         unknownInboundStreamHandlerFactory,
                         () -> new QpackEncoderHandler(maxTableCapacity, qpackDecoder),

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3Settings.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3Settings.java
@@ -46,7 +46,7 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
 public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
 
     private final LongObjectMap<Long> settings;
-
+    final NonStandardHttp3SettingsValidator nonStandardSettingsValidator;
     private static final Long TRUE = 1L;
     private static final Long FALSE = 0L;
 
@@ -54,26 +54,19 @@ public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
      * Creates a new instance
      */
     public Http3Settings() {
+        // Ignore non-standard settings by default.
+        this((id, v) -> false);
+    }
+
+    /**
+     * Creates a new instance
+     *
+     * @param nonStandardSettingsValidator the {@link NonStandardHttp3SettingsValidator} to use to check if a specific
+     *                                     setting that is non-standard should be supported or not.
+     */
+    public Http3Settings(NonStandardHttp3SettingsValidator nonStandardSettingsValidator) {
         this.settings = new LongObjectHashMap<>(Http3SettingIdentifier.values().length);
-    }
-
-    /**
-     * Creates a new instance with the specified initial capacity.
-     *
-     * @param initialCapacity initial capacity of the underlying map
-     */
-    Http3Settings(int initialCapacity) {
-        this.settings = new LongObjectHashMap<>(initialCapacity);
-    }
-
-    /**
-     * Creates a new instance with the specified initial capacity and load factor.
-     *
-     * @param initialCapacity initial capacity of the underlying map
-     * @param loadFactor load factor for the underlying map
-     */
-    Http3Settings(int initialCapacity, float loadFactor) {
-        this.settings = new LongObjectHashMap<>(initialCapacity, loadFactor);
+        this.nonStandardSettingsValidator = checkNotNull(nonStandardSettingsValidator, "nonStandardSettingsValidator");
     }
 
     /**
@@ -97,13 +90,15 @@ public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
 
         Http3SettingIdentifier identifier = Http3SettingIdentifier.fromId(key);
 
-        // When Non-Standard/Unknown settings identifier identifier present - Ignore
         if (identifier == null) {
-            return null;
+            // When Non-Standard/Unknown settings identifier present check if we should ignore it or not.
+            if (!nonStandardSettingsValidator.validate(key, value)) {
+                return null;
+            }
+        } else {
+            //Validation
+            verifyStandardSetting(identifier, value);
         }
-
-        //Validation
-        verifyStandardSetting(identifier, value);
 
         return settings.put(key, value);
     }
@@ -369,5 +364,21 @@ public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
                             + toHexString(identifier.id()) + " invalid: " + value);
                 }
         }
+    }
+
+    /**
+     * Allows to handle non-standard settings. By default non-standard settings will be ignore as defined by the
+     * RFC.
+     */
+    public interface NonStandardHttp3SettingsValidator {
+        /**
+         * Validate the setting with the given id and value.
+         *
+         * @param id        the id of the setting
+         * @param value     the value of the setting
+         * @return          {@code true} if the settings is supported, {@code false} otherwise.
+         * @throws IllegalArgumentException if the given {@code value} is not supported for the id.
+         */
+        boolean validate(long id, Long value) throws IllegalArgumentException;
     }
 }

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3UnidirectionalStreamInboundClientHandler.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3UnidirectionalStreamInboundClientHandler.java
@@ -29,12 +29,14 @@ final class Http3UnidirectionalStreamInboundClientHandler extends Http3Unidirect
 
     Http3UnidirectionalStreamInboundClientHandler(
             Http3FrameCodecFactory codecFactory,
+            Http3Settings.NonStandardHttp3SettingsValidator nonStandardSettingsValidator,
             Http3ControlStreamInboundHandler localControlStreamHandler,
             Http3ControlStreamOutboundHandler remoteControlStreamHandler,
             @Nullable LongFunction<ChannelHandler> unknownStreamHandlerFactory,
             @Nullable LongFunction<ChannelHandler> pushStreamHandlerFactory,
             Supplier<ChannelHandler> qpackEncoderHandlerFactory, Supplier<ChannelHandler> qpackDecoderHandlerFactory) {
-        super(codecFactory, localControlStreamHandler, remoteControlStreamHandler, unknownStreamHandlerFactory,
+        super(codecFactory, nonStandardSettingsValidator,
+                localControlStreamHandler, remoteControlStreamHandler, unknownStreamHandlerFactory,
                 qpackEncoderHandlerFactory, qpackDecoderHandlerFactory);
         this.pushStreamHandlerFactory = pushStreamHandlerFactory == null ? __ -> ReleaseHandler.INSTANCE :
                 pushStreamHandlerFactory;

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3UnidirectionalStreamInboundHandler.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3UnidirectionalStreamInboundHandler.java
@@ -22,6 +22,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.http3.Http3FrameCodec.Http3FrameCodecFactory;
+import io.netty.handler.codec.http3.Http3Settings.NonStandardHttp3SettingsValidator;
 import io.netty.util.AttributeKey;
 import io.netty.util.ReferenceCountUtil;
 import org.jetbrains.annotations.Nullable;
@@ -47,6 +48,7 @@ abstract class Http3UnidirectionalStreamInboundHandler extends ByteToMessageDeco
             AttributeKey.valueOf("H3_REMOTE_QPACK_ENCODER_STREAM");
 
     final Http3FrameCodecFactory codecFactory;
+    final NonStandardHttp3SettingsValidator nonStandardSettingsValidator;
     final Http3ControlStreamInboundHandler localControlStreamHandler;
     final Http3ControlStreamOutboundHandler remoteControlStreamHandler;
     final Supplier<ChannelHandler> qpackEncoderHandlerFactory;
@@ -54,12 +56,14 @@ abstract class Http3UnidirectionalStreamInboundHandler extends ByteToMessageDeco
     final LongFunction<ChannelHandler> unknownStreamHandlerFactory;
 
     Http3UnidirectionalStreamInboundHandler(Http3FrameCodecFactory codecFactory,
+                                            NonStandardHttp3SettingsValidator nonStandardSettingsValidator,
                                             Http3ControlStreamInboundHandler localControlStreamHandler,
                                             Http3ControlStreamOutboundHandler remoteControlStreamHandler,
                                             @Nullable LongFunction<ChannelHandler> unknownStreamHandlerFactory,
                                             Supplier<ChannelHandler> qpackEncoderHandlerFactory,
                                             Supplier<ChannelHandler> qpackDecoderHandlerFactory) {
         this.codecFactory = codecFactory;
+        this.nonStandardSettingsValidator = nonStandardSettingsValidator;
         this.localControlStreamHandler = localControlStreamHandler;
         this.remoteControlStreamHandler = remoteControlStreamHandler;
         this.qpackEncoderHandlerFactory = qpackEncoderHandlerFactory;
@@ -117,7 +121,7 @@ abstract class Http3UnidirectionalStreamInboundHandler extends ByteToMessageDeco
             // Replace this handler with the codec now.
             ctx.pipeline().replace(this, null,
                     codecFactory.newCodec(Http3ControlStreamFrameTypeValidator.INSTANCE, NO_STATE,
-                            NO_STATE));
+                            NO_STATE, nonStandardSettingsValidator));
         } else {
             // Only one control stream is allowed.
             // See https://quicwg.org/base-drafts/draft-ietf-quic-http.html#section-6.2.1

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3UnidirectionalStreamInboundServerHandler.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3UnidirectionalStreamInboundServerHandler.java
@@ -19,6 +19,7 @@ package io.netty.handler.codec.http3;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http3.Http3FrameCodec.Http3FrameCodecFactory;
+import io.netty.handler.codec.http3.Http3Settings.NonStandardHttp3SettingsValidator;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.function.LongFunction;
@@ -27,13 +28,14 @@ import java.util.function.Supplier;
 final class Http3UnidirectionalStreamInboundServerHandler extends Http3UnidirectionalStreamInboundHandler {
 
     Http3UnidirectionalStreamInboundServerHandler(Http3FrameCodecFactory codecFactory,
+                                                  NonStandardHttp3SettingsValidator nonStandardSettingsValidator,
                                                   Http3ControlStreamInboundHandler localControlStreamHandler,
                                                   Http3ControlStreamOutboundHandler remoteControlStreamHandler,
                                                   @Nullable LongFunction<ChannelHandler> unknownStreamHandlerFactory,
                                                   Supplier<ChannelHandler> qpackEncoderHandlerFactory,
                                                   Supplier<ChannelHandler> qpackDecoderHandlerFactory) {
-        super(codecFactory, localControlStreamHandler, remoteControlStreamHandler, unknownStreamHandlerFactory,
-                qpackEncoderHandlerFactory, qpackDecoderHandlerFactory);
+        super(codecFactory, nonStandardSettingsValidator, localControlStreamHandler, remoteControlStreamHandler,
+                unknownStreamHandlerFactory, qpackEncoderHandlerFactory, qpackDecoderHandlerFactory);
     }
 
     @Override

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3FrameCodecTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3FrameCodecTest.java
@@ -127,7 +127,7 @@ public class Http3FrameCodecTest {
                         Http3RequestStreamDecodeStateValidator decStateValidator =
                                 new Http3RequestStreamDecodeStateValidator();
                         ch.pipeline().addLast(new Http3FrameCodec(Http3FrameTypeValidator.NO_VALIDATION, decoder,
-                                MAX_HEADER_SIZE, encoder, encStateValidator, decStateValidator));
+                                MAX_HEADER_SIZE, encoder, encStateValidator, decStateValidator, (id, v) -> false));
                         ch.pipeline().addLast(encStateValidator);
                         ch.pipeline().addLast(decStateValidator);
                     }

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3PushStreamTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3PushStreamTest.java
@@ -192,7 +192,9 @@ public class Http3PushStreamTest {
     private EmbeddedQuicStreamChannel newClientStreamUninitialized() throws InterruptedException, ExecutionException {
         return (EmbeddedQuicStreamChannel) clientChannel.createStream(UNIDIRECTIONAL,
                 new Http3UnidirectionalStreamInboundClientHandler(
-                        (__, encodeState, decodeState) -> clientConnectionHandler.newCodec(encodeState, decodeState),
+                        (__, encodeState, decodeState, ___) ->
+                                clientConnectionHandler.newCodec(encodeState, decodeState),
+                        (id, v) -> false,
                         clientConnectionHandler.localControlStreamHandler,
                         clientConnectionHandler.remoteControlStreamHandler, null,
                         __ -> new Http3PushStreamClientInitializer() {

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3SettingsTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3SettingsTest.java
@@ -17,9 +17,12 @@ package io.netty.handler.codec.http3;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Map;
+import java.util.Set;
 import java.util.Spliterator;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -190,6 +193,30 @@ public class Http3SettingsTest {
         Http3Settings settings = new Http3Settings((id, v) -> customKey == id);
         settings.put(customKey, 123L);
         assertNotNull(settings.get(customKey));
+    }
+
+    @Test
+    void testCustomSettingsValidatorAllowsAndRejectsMultipleKeys() {
+        Set<Long> allowedKeys = new HashSet<>(Arrays.asList(
+                0xdeadbeefL,
+                0xcafebabeL
+        ));
+
+        long rejectedKey = 0xfeedfaceL;
+
+        Http3Settings settings = new Http3Settings(
+                (id, v) -> allowedKeys.contains(id)
+        );
+
+        // Allowed keys
+        allowedKeys.forEach(key -> {
+            settings.put(key, 1L);
+            assertNotNull(settings.get(key));
+        });
+
+        // Rejected key
+        settings.put(rejectedKey, 1L);
+        assertNull(settings.get(rejectedKey));
     }
 
     @Test

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3SettingsTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3SettingsTest.java
@@ -32,7 +32,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**
  * unit tests for {@link Http3Settings}.
@@ -183,6 +182,14 @@ public class Http3SettingsTest {
         long customKey = 0xdeadbeefL;
         settings.put(customKey, 123L);
         assertNull(settings.get(customKey));
+    }
+
+    @Test
+    void testCustomSettingsNotIgnoredWithValidator() {
+        long customKey = 0xdeadbeefL;
+        Http3Settings settings = new Http3Settings((id, v) -> customKey == id);
+        settings.put(customKey, 123L);
+        assertNotNull(settings.get(customKey));
     }
 
     @Test

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3UnidirectionalStreamInboundHandlerTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3UnidirectionalStreamInboundHandlerTest.java
@@ -264,11 +264,13 @@ public class Http3UnidirectionalStreamInboundHandlerTest {
     private Http3UnidirectionalStreamInboundHandler newUniStreamInboundHandler(boolean server,
             @Nullable LongFunction<ChannelHandler> unknownStreamHandlerFactory) {
         return server ?
-                new Http3UnidirectionalStreamInboundServerHandler((v, __, ___) -> new CodecHandler(),
+                new Http3UnidirectionalStreamInboundServerHandler((v, __, ___, ____) -> new CodecHandler(),
+                        (id, v) -> false,
                         localControlStreamHandler, remoteControlStreamHandler, unknownStreamHandlerFactory,
                         () -> new QpackEncoderHandler((long) Integer.MAX_VALUE, qpackDecoder),
                         () -> new QpackDecoderHandler(qpackEncoder)) :
-                new Http3UnidirectionalStreamInboundClientHandler((v, __, ___) -> new CodecHandler(),
+                new Http3UnidirectionalStreamInboundClientHandler((v, __, ___, ____) -> new CodecHandler(),
+                        (id, v) -> false,
                         localControlStreamHandler, remoteControlStreamHandler,
                         unknownStreamHandlerFactory,
                         pushId -> new Http3PushStreamClientInitializer() {


### PR DESCRIPTION
Motivation:

To be able to add extensions that are still in draft we need a way to also allow non-standard HTTP3 settings. This was not possible before.

Modifications:

- Allow to plugin a NonStandardHttp3SettingsValidator to support non-standard settings
- Add unit test

Result:

Be able to support non-standard HTTP3 settings and so allow to add support for drafts