### PR TITLE
Expose QuicSslContextBuilder::sni

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicSslContextBuilder.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicSslContextBuilder.java
@@ -179,7 +179,27 @@ public final class QuicSslContextBuilder {
         this.forServer = forServer;
     }
 
-    private QuicSslContextBuilder sni(Mapping<? super String, ? extends QuicSslContext> mapping) {
+    /**
+     * Enables
+     * <a href="https://quicwg.org/ops-drafts/draft-ietf-quic-manageability.html#name-server-name-indication-sni">
+     *     SNI</a> support on the server side.
+     * <p>
+     * The provided {@link Mapping} receives the hostname from the client and returns the
+     * {@link QuicSslContext} to use for that connection. The returned context's settings
+     * (such as {@link #clientAuth(ClientAuth)}, {@link #trustManager(TrustManagerFactory)}, etc.)
+     * will be applied to the connection.
+     * <p>
+     * Use {@link io.netty.util.DomainWildcardMappingBuilder} to create the {@link Mapping} when
+     * matching against domain patterns is needed.
+     *
+     * @param mapping the {@link Mapping} that maps hostnames to {@link QuicSslContext} instances
+     * @return this builder
+     * @throws NullPointerException if {@code mapping} is {@code null}
+     */
+    public QuicSslContextBuilder sni(Mapping<? super String, ? extends QuicSslContext> mapping) {
+        if (!forServer) {
+            throw new UnsupportedOperationException("Only supported for server");
+        }
         this.mapping = checkNotNull(mapping, "mapping");
         return this;
     }

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicChannelConnectTest.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicChannelConnectTest.java
@@ -1543,6 +1543,78 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
 
     @ParameterizedTest
     @MethodSource("newSslTaskExecutors")
+    public void testSniWithClientAuth(Executor executor) throws Throwable {
+        String hostname = "quic.netty.io";
+
+        QuicSslContext sniServerSslContext = QuicSslContextBuilder.forServer(
+                QuicTestUtils.SELF_SIGNED_CERTIFICATE.privateKey(), null,
+                QuicTestUtils.SELF_SIGNED_CERTIFICATE.certificate())
+                .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                .clientAuth(ClientAuth.REQUIRE)
+                .applicationProtocols(QuicTestUtils.PROTOS).build();
+
+        QuicSslContext serverSslContext = QuicSslContextBuilder.forServer(
+                QuicTestUtils.SELF_SIGNED_CERTIFICATE.privateKey(), null,
+                QuicTestUtils.SELF_SIGNED_CERTIFICATE.certificate())
+                .sni(new DomainWildcardMappingBuilder<>(sniServerSslContext)
+                        .add(hostname, sniServerSslContext).build())
+                .applicationProtocols(QuicTestUtils.PROTOS).build();
+
+        CountDownLatch sniEventLatch = new CountDownLatch(1);
+        CountDownLatch sslEventLatch = new CountDownLatch(1);
+        Channel server = QuicTestUtils.newServer(QuicTestUtils.newQuicServerBuilder(executor, serverSslContext),
+                TestQuicTokenHandler.INSTANCE, new ChannelInboundHandlerAdapter() {
+                    @Override
+                    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                        if (evt instanceof SniCompletionEvent) {
+                            if (hostname.equals(((SniCompletionEvent) evt).hostname())) {
+                                sniEventLatch.countDown();
+                            }
+                        } else if (evt instanceof SslHandshakeCompletionEvent) {
+                            if (((SslHandshakeCompletionEvent) evt).isSuccess()) {
+                                sslEventLatch.countDown();
+                            }
+                        }
+                        super.userEventTriggered(ctx, evt);
+                    }
+                },
+                new ChannelInboundHandlerAdapter());
+
+        InetSocketAddress address = (InetSocketAddress) server.localAddress();
+
+        QuicSslContext clientSslContext = QuicSslContextBuilder.forClient()
+                .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                .keyManager(QuicTestUtils.SELF_SIGNED_CERTIFICATE.privateKey(), null,
+                        QuicTestUtils.SELF_SIGNED_CERTIFICATE.certificate())
+                .applicationProtocols(QuicTestUtils.PROTOS).build();
+
+        Channel channel = QuicTestUtils.newClient(QuicTestUtils.newQuicClientBuilder(executor)
+                .sslEngineProvider(c -> clientSslContext.newEngine(c.alloc(), hostname, 8080)));
+        try {
+            ChannelActiveVerifyHandler clientQuicChannelHandler = new ChannelActiveVerifyHandler();
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
+                    .handler(clientQuicChannelHandler)
+                    .streamHandler(new ChannelInboundHandlerAdapter())
+                    .remoteAddress(address)
+                    .connect()
+                    .get();
+
+            quicChannel.close().sync();
+            ChannelFuture closeFuture = quicChannel.closeFuture().await();
+            assertTrue(closeFuture.isSuccess());
+            clientQuicChannelHandler.assertState();
+            sniEventLatch.await();
+            sslEventLatch.await();
+        } finally {
+            server.close().sync();
+            channel.close().sync();
+
+            shutdown(executor);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("newSslTaskExecutors")
     public void testConnectKeyless(Executor executor) throws Throwable {
         testConnectKeyless0(executor, false);
     }


### PR DESCRIPTION
**Motivation:**

In order to be able to receive the `SniCompletionEvent` sni mapping needs to be used, however, the function `QuicSslContextBuilder::buildForServerWithSni` doesn't allow setting `ClientAuth` and alternativly the builder doesn't allow setting the SNI mapping.

This means there is currently no way to use both SNI mapping and support/enforce client certs with QUIC.

**Modification:**

Expose the `QuicSslContextBuilder::sni` so that its possible to create a `QuicSslContext` with SNI mapping alongside other settings.

Also adds `QuicChannelConnectTest::testSniWithClientAuth` to validate

**Result:**

The following then works to allow both receiving the `SniCompletionEvent` and require a client cert
```
// Build context with clientAuth and trustManager configured
QuicSslContext sniContext = QuicSslContextBuilder.forServer(key, null, cert)
    .applicationProtocols("alpn/1")
    .clientAuth(ClientAuth.REQUIRE)
    // ... 
    .build();

// Create SNI-enabled context using the builder's sni() method
QuicSslContext serverContext = QuicSslContextBuilder.forServer(key, null, cert)
    .clientAuth(ClientAuth.REQUIRE)
    .sni(hostname -> sniContext)
    .build();
```