### PR TITLE
Expose yield points while processing I/O on the transports

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
@@ -46,7 +46,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static java.lang.Math.min;
-import static java.lang.System.nanoTime;
 
 /**
  * {@link IoHandler} which uses epoll under the covers. Only works on Linux!
@@ -457,13 +456,13 @@ public class EpollIoHandler implements IoHandler {
                 handled = strategy;
                 if (context.shouldReportActiveIoTime()) {
                     long activeIoStartTimeNanos = System.nanoTime();
-                    if (processReady(events, strategy)) {
+                    if (processReady(context, events, strategy)) {
                         prevDeadlineNanos = NONE;
                     }
                     long activeIoEndTimeNanos = System.nanoTime();
                     context.reportActiveIoTime(activeIoEndTimeNanos - activeIoStartTimeNanos);
                 } else {
-                    if (processReady(events, strategy)) {
+                    if (processReady(context, events, strategy)) {
                         prevDeadlineNanos = NONE;
                     }
                 }
@@ -499,8 +498,9 @@ public class EpollIoHandler implements IoHandler {
     }
 
     // Returns true if a timerFd event was encountered
-    private boolean processReady(EpollEventArray events, int ready) {
+    private boolean processReady(IoHandlerContext context, EpollEventArray events, int ready) {
         boolean timerFired = false;
+        context.beforeIoTasks();
         for (int i = 0; i < ready; i ++) {
             final int fd = events.fd(i);
             if (fd == eventFd.intValue()) {
@@ -524,6 +524,7 @@ public class EpollIoHandler implements IoHandler {
                         // deleted before or the file descriptor was closed before.
                     }
                 }
+                context.afterIoTask();
             }
         }
         return timerFired;

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -179,18 +179,21 @@ public final class IoUringIoHandler implements IoHandler {
         if (context.shouldReportActiveIoTime()) {
             // Timer starts after the blocking wait, around the processing of completions.
             long activeIoStartTimeNanos = System.nanoTime();
-            processed = processCompletionsAndHandleOverflow(submissionQueue, completionQueue, this::handle);
+            processed = processCompletionsAndHandleOverflow(context, submissionQueue, completionQueue, this::handle);
             long activeIoEndTimeNanos = System.nanoTime();
             context.reportActiveIoTime(activeIoEndTimeNanos - activeIoStartTimeNanos);
         } else {
-            processed = processCompletionsAndHandleOverflow(submissionQueue, completionQueue, this::handle);
+            processed = processCompletionsAndHandleOverflow(context, submissionQueue, completionQueue, this::handle);
         }
         return processed;
     }
 
-    private int processCompletionsAndHandleOverflow(SubmissionQueue submissionQueue, CompletionQueue completionQueue,
-                                         CompletionCallback callback) {
+    private int processCompletionsAndHandleOverflow(IoHandlerContext context, SubmissionQueue submissionQueue,
+                                                    CompletionQueue completionQueue, CompletionCallback callback) {
         int processed = 0;
+        if (context != null) {
+            context.beforeIoTasks();
+        }
         // Bound the maximum number of times this will loop before we return and so execute some non IO stuff.
         // 128 here is just some sort of bound and another number might be ok as well.
         for (int i = 0; i < 128; i++) {
@@ -208,6 +211,9 @@ public final class IoUringIoHandler implements IoHandler {
                 break;
             }
             processed += p;
+            if (context != null) {
+                context.afterIoTask();
+            }
         }
         return processed;
     }
@@ -364,7 +370,7 @@ public final class IoUringIoHandler implements IoHandler {
         submissionQueue.submitAndGet();
 
         while (completionQueue.hasCompletions()) {
-            processCompletionsAndHandleOverflow(submissionQueue, completionQueue, this::handle);
+            processCompletionsAndHandleOverflow(null, submissionQueue, completionQueue, this::handle);
             if (submissionQueue.count() > 0) {
                 submissionQueue.submitAndGetNow();
             }
@@ -431,7 +437,7 @@ public final class IoUringIoHandler implements IoHandler {
             completionQueue.process(handler);
             while (!handler.eventFdDrained) {
                 submissionQueue.submitAndGet();
-                processCompletionsAndHandleOverflow(submissionQueue, completionQueue, handler);
+                processCompletionsAndHandleOverflow(null ,submissionQueue, completionQueue, handler);
             }
         }
         // We've consumed any pending eventfd read and `eventfdAsyncNotify` should never

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoHandler.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoHandler.java
@@ -189,7 +189,8 @@ public final class KQueueIoHandler implements IoHandler {
         return numEvents;
     }
 
-    private void processReady(int ready) {
+    private void processReady(IoHandlerContext context, int ready) {
+        context.beforeIoTasks();
         for (int i = 0; i < ready; ++i) {
             final short filter = eventList.filter(i);
             final short flags = eventList.flags(i);
@@ -212,6 +213,7 @@ public final class KQueueIoHandler implements IoHandler {
                 continue;
             }
             registration.handle(ident, filter, flags, eventList.fflags(i), eventList.data(i), id);
+            context.afterIoTask();
         }
     }
 
@@ -273,11 +275,11 @@ public final class KQueueIoHandler implements IoHandler {
                 if (context.shouldReportActiveIoTime()) {
                     // The Timer starts after the blocking kqueueWait() call returns with events.
                     long activeIoStartTimeNanos = System.nanoTime();
-                    processReady(strategy);
+                    processReady(context, strategy);
                     long activeIoEndTimeNanos = System.nanoTime();
                     context.reportActiveIoTime(activeIoEndTimeNanos - activeIoStartTimeNanos);
                 } else {
-                    processReady(strategy);
+                    processReady(context, strategy);
                 }
             } else if (context.shouldReportActiveIoTime()) {
                 context.reportActiveIoTime(0);

--- a/transport/src/main/java/io/netty/channel/IoHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/IoHandlerContext.java
@@ -32,6 +32,14 @@ public interface IoHandlerContext {
      */
     boolean canBlock();
 
+    default void beforeIoTasks() {
+        // no-op
+    }
+
+    default void afterIoTask() {
+        // no-op
+    }
+
     /**
      * Returns the amount of time left until the scheduled task with the closest deadline should run.
      *

--- a/transport/src/main/java/io/netty/channel/ManualIoEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/ManualIoEventLoop.java
@@ -67,6 +67,17 @@ public class ManualIoEventLoop extends AbstractScheduledEventExecutor implements
         }
 
         @Override
+        public void beforeIoTasks() {
+            ManualIoEventLoop.this.beforeIoTasks();
+        }
+
+        @Override
+        public void afterIoTask() {
+            ManualIoEventLoop.this.afterIoTask();
+        }
+
+
+        @Override
         public long delayNanos(long currentTimeNanos) {
             assert inEventLoop();
             return 0;
@@ -96,6 +107,20 @@ public class ManualIoEventLoop extends AbstractScheduledEventExecutor implements
      */
     protected boolean canBlock() {
         return true;
+    }
+
+    /**
+     * This method is intended to be executed prior to any I/O-related batch of operations.
+     */
+    protected void beforeIoTasks() {
+
+    }
+
+    /**
+     * This method is intended to be executed after any I/O-related operation.
+     */
+    protected void afterIoTask() {
+
     }
 
     /**
@@ -654,6 +679,16 @@ public class ManualIoEventLoop extends AbstractScheduledEventExecutor implements
         public boolean canBlock() {
             assert inEventLoop();
             return !hasTasks() && !hasScheduledTasks() && ManualIoEventLoop.this.canBlock();
+        }
+
+        @Override
+        public void beforeIoTasks() {
+            ManualIoEventLoop.this.beforeIoTasks();
+        }
+
+        @Override
+        public void afterIoTask() {
+            ManualIoEventLoop.this.afterIoTask();
         }
 
         @Override

--- a/transport/src/main/java/io/netty/channel/nio/NioIoHandler.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioIoHandler.java
@@ -481,11 +481,11 @@ public final class NioIoHandler implements IoHandler {
             if (context.shouldReportActiveIoTime()) {
                 // We start the timer after the blocking select() call has returned.
                 long activeIoStartTimeNanos = System.nanoTime();
-                handled = processSelectedKeys();
+                handled = processSelectedKeys(context);
                 long activeIoEndTimeNanos = System.nanoTime();
                 context.reportActiveIoTime(activeIoEndTimeNanos - activeIoStartTimeNanos);
             } else {
-                handled = processSelectedKeys();
+                handled = processSelectedKeys(context);
             }
         } catch (Error e) {
             throw e;
@@ -507,11 +507,11 @@ public final class NioIoHandler implements IoHandler {
         }
     }
 
-    private int processSelectedKeys() {
+    private int processSelectedKeys(IoHandlerContext context) {
         if (selectedKeys != null) {
-            return processSelectedKeysOptimized();
+            return processSelectedKeysOptimized(context);
         } else {
-            return processSelectedKeysPlain(selector.selectedKeys());
+            return processSelectedKeysPlain(context, selector.selectedKeys());
         }
     }
 
@@ -524,7 +524,7 @@ public final class NioIoHandler implements IoHandler {
         }
     }
 
-    private int processSelectedKeysPlain(Set<SelectionKey> selectedKeys) {
+    private int processSelectedKeysPlain(IoHandlerContext context, Set<SelectionKey> selectedKeys) {
         // check if the set is empty and if so just return to not create garbage by
         // creating a new Iterator every time even if there is nothing to process.
         // See https://github.com/netty/netty/issues/597
@@ -532,6 +532,7 @@ public final class NioIoHandler implements IoHandler {
             return 0;
         }
 
+        context.beforeIoTasks();
         Iterator<SelectionKey> i = selectedKeys.iterator();
         int handled = 0;
         for (;;) {
@@ -540,6 +541,8 @@ public final class NioIoHandler implements IoHandler {
 
             processSelectedKey(k);
             ++handled;
+
+            context.afterIoTask();
 
             if (!i.hasNext()) {
                 break;
@@ -560,8 +563,9 @@ public final class NioIoHandler implements IoHandler {
         return handled;
     }
 
-    private int processSelectedKeysOptimized() {
+    private int processSelectedKeysOptimized(IoHandlerContext context) {
         int handled = 0;
+        context.beforeIoTasks();
         for (int i = 0; i < selectedKeys.size; ++i) {
             final SelectionKey k = selectedKeys.keys[i];
             // null out entry in the array to allow to have it GC'ed once the Channel close
@@ -579,6 +583,7 @@ public final class NioIoHandler implements IoHandler {
                 selectAgain();
                 i = -1;
             }
+            context.afterIoTask();
         }
         return handled;
     }


### PR DESCRIPTION
Motivation:

Using Netty with a manual event loop as VirtualThread requires suspend/resume it, but right now
running I/O cannot impose any time budget to the I/O processing

Modification:

Inject yield callbacks which can be overriden by a manual EventLoop to yield the I/O loop

Result:

Fixes #<still missing>. 

It's related https://github.com/franz1981/Netty-VirtualThread-Scheduler/issues/78

I still have to produce a test which shows the benefit of it: opening in Draft to explain what this could looks like.