### PR TITLE
SSL: Ensure used cipher in test can be used by any Java version (#16180)

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -628,11 +628,7 @@ public abstract class SSLEngineTest {
             serverEngine = wrapEngine(serverSslCtx.newEngine(UnpooledByteBufAllocator.DEFAULT));
 
             // Set the server to only support a single TLSv1.2 cipher
-            final String serverCipher =
-                    // JDK24+ does not support TLS_RSA_* ciphers by default anymore:
-                    // See https://www.java.com/en/configure_crypto.html
-                    PlatformDependent.javaVersion() >= 24 ? "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256" :
-                            "TLS_RSA_WITH_AES_128_CBC_SHA";
+            final String serverCipher = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256";
             serverEngine.setEnabledCipherSuites(new String[] { serverCipher });
 
             // Set the client to only support a single TLSv1.3 cipher
@@ -2267,11 +2263,7 @@ public abstract class SSLEngineTest {
         SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         // Select a mandatory cipher from the TLSv1.2 RFC https://www.ietf.org/rfc/rfc5246.txt so handshakes won't fail
         // due to no shared/supported cipher.
-        final String sharedCipher =
-                // JDK24+ does not support TLS_RSA_* ciphers by default anymore:
-                // See https://www.java.com/en/configure_crypto.html
-                PlatformDependent.javaVersion() >= 24 ? "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256" :
-                "TLS_RSA_WITH_AES_128_CBC_SHA";
+        final String sharedCipher = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256";
         clientSslCtx = wrapContext(param, SslContextBuilder.forClient()
                 .trustManager(InsecureTrustManagerFactory.INSTANCE)
                 .ciphers(Collections.singletonList(sharedCipher))
@@ -2304,11 +2296,7 @@ public abstract class SSLEngineTest {
         SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         // Select a mandatory cipher from the TLSv1.2 RFC https://www.ietf.org/rfc/rfc5246.txt so handshakes won't fail
         // due to no shared/supported cipher.
-        final String sharedCipher =
-                // JDK24+ does not support TLS_RSA_* ciphers by default anymore:
-                // See https://www.java.com/en/configure_crypto.html
-                PlatformDependent.javaVersion() >= 24 ? "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256" :
-                        "TLS_RSA_WITH_AES_128_CBC_SHA";
+        final String sharedCipher = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256";
         clientSslCtx = wrapContext(param, SslContextBuilder.forClient()
                 .trustManager(InsecureTrustManagerFactory.INSTANCE)
                 .ciphers(Collections.singletonList(sharedCipher), SupportedCipherSuiteFilter.INSTANCE)


### PR DESCRIPTION
Motivation:

SHA1 ciphers are not allowed anymore by default in recent JDK updates,
just use TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 as a replacement

Modifications:

Use TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256

Result:

Build should pass again even on latest JDK patch releases