### PR TITLE
Future.sync*() should rethrow by wrapping errors in a CompletionExcep…

### DIFF
--- a/codec-base/src/test/java/io/netty/handler/codec/ByteToMessageCodecTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/ByteToMessageCodecTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class ByteToMessageCodecTest {
 
     @Test
-    public void testForwardPendingData() {
+    public void testForwardPendingData() throws Exception {
         ByteToMessageCodec<Integer> codec = new ByteToMessageCodec<Integer>() {
             @Override
             protected void encode(ChannelHandlerContext ctx, Integer msg, ByteBuf out) {

--- a/codec-base/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
@@ -49,7 +49,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class ByteToMessageDecoderTest {
 
     @Test
-    public void testRemoveItself() {
+    public void testRemoveItself() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new ByteToMessageDecoder() {
             private boolean removed;
 
@@ -71,7 +71,7 @@ public class ByteToMessageDecoderTest {
     }
 
     @Test
-    public void testRemoveItselfWriteBuffer() {
+    public void testRemoveItselfWriteBuffer() throws Exception {
         final ByteBuf buf = Unpooled.buffer().writeBytes(new byte[] {'a', 'b', 'c'});
         EmbeddedChannel channel = new EmbeddedChannel(new ByteToMessageDecoder() {
             private boolean removed;
@@ -102,7 +102,7 @@ public class ByteToMessageDecoderTest {
      * this case input is read fully.
      */
     @Test
-    public void testInternalBufferClearReadAll() {
+    public void testInternalBufferClearReadAll() throws Exception {
         final ByteBuf buf = Unpooled.buffer().writeBytes(new byte[] {'a'});
         EmbeddedChannel channel = newInternalBufferTestChannel();
         assertFalse(channel.writeInbound(buf));
@@ -114,7 +114,7 @@ public class ByteToMessageDecoderTest {
      * this case input was not fully read.
      */
     @Test
-    public void testInternalBufferClearReadPartly() {
+    public void testInternalBufferClearReadPartly() throws Exception {
         final ByteBuf buf = Unpooled.buffer().writeBytes(new byte[] {'a', 'b'});
         EmbeddedChannel channel = newInternalBufferTestChannel();
         assertTrue(channel.writeInbound(buf));
@@ -146,7 +146,7 @@ public class ByteToMessageDecoderTest {
     }
 
     @Test
-    public void handlerRemovedWillNotReleaseBufferIfDecodeInProgress() {
+    public void handlerRemovedWillNotReleaseBufferIfDecodeInProgress() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new ByteToMessageDecoder() {
             @Override
             protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
@@ -172,7 +172,7 @@ public class ByteToMessageDecoderTest {
     }
 
     @Test
-    public void testFireChannelReadCompleteOnInactive() throws InterruptedException {
+    public void testFireChannelReadCompleteOnInactive() throws Exception {
         final BlockingQueue<Integer> queue = new LinkedBlockingDeque<Integer>();
         final ByteBuf buf = Unpooled.buffer().writeBytes(new byte[] {'a', 'b'});
         EmbeddedChannel channel = new EmbeddedChannel(new ByteToMessageDecoder() {
@@ -216,7 +216,7 @@ public class ByteToMessageDecoderTest {
 
     // See https://github.com/netty/netty/issues/4635
     @Test
-    public void testRemoveWhileInCallDecode() {
+    public void testRemoveWhileInCallDecode() throws Exception {
         final Object upgradeMessage = new Object();
         final ByteToMessageDecoder decoder = new ByteToMessageDecoder() {
             @Override
@@ -247,7 +247,7 @@ public class ByteToMessageDecoderTest {
     }
 
     @Test
-    public void testDecodeLastEmptyBuffer() {
+    public void testDecodeLastEmptyBuffer() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new ByteToMessageDecoder() {
             @Override
             protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
@@ -267,7 +267,7 @@ public class ByteToMessageDecoderTest {
     }
 
     @Test
-    public void testDecodeLastNonEmptyBuffer() {
+    public void testDecodeLastNonEmptyBuffer() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new ByteToMessageDecoder() {
             private boolean decodeLast;
 
@@ -309,7 +309,7 @@ public class ByteToMessageDecoderTest {
     }
 
     @Test
-    public void testReadOnlyBuffer() {
+    public void testReadOnlyBuffer() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new ByteToMessageDecoder() {
             @Override
             protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
@@ -448,7 +448,7 @@ public class ByteToMessageDecoderTest {
     }
 
     @Test
-    public void testDoesNotOverRead() {
+    public void testDoesNotOverRead() throws Exception {
         ReadInterceptingHandler interceptor = new ReadInterceptingHandler();
 
         EmbeddedChannel channel = new EmbeddedChannel();
@@ -491,7 +491,7 @@ public class ByteToMessageDecoderTest {
     }
 
     @Test
-    public void testDoesNotOverReadOnChannelReadComplete() {
+    public void testDoesNotOverReadOnChannelReadComplete() throws Exception {
         ReadInterceptingHandler interceptor = new ReadInterceptingHandler();
         EmbeddedChannel channel = new EmbeddedChannel(interceptor, new ByteToMessageDecoder() {
             @Override
@@ -522,7 +522,7 @@ public class ByteToMessageDecoderTest {
     }
 
     @Test
-    public void testDisorder() {
+    public void testDisorder() throws Exception {
         ByteToMessageDecoder decoder = new ByteToMessageDecoder() {
             int count;
 
@@ -549,7 +549,7 @@ public class ByteToMessageDecoderTest {
     }
 
     @Test
-    public void testDecodeLast() {
+    public void testDecodeLast() throws Exception {
         final AtomicBoolean removeHandler = new AtomicBoolean();
         EmbeddedChannel channel = new EmbeddedChannel(new ByteToMessageDecoder() {
 
@@ -575,7 +575,7 @@ public class ByteToMessageDecoderTest {
     }
 
     @Test
-    void testUnexpectRead() {
+    void testUnexpectRead() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel();
         channel.config().setAutoRead(false);
         ReadInterceptingHandler interceptor = new ReadInterceptingHandler();
@@ -596,46 +596,51 @@ public class ByteToMessageDecoderTest {
     }
 
     @Test
-    public void testReuseInputBufferJustLargeEnoughToContainMessage_MergeCumulator() {
+    public void testReuseInputBufferJustLargeEnoughToContainMessage_MergeCumulator() throws Exception {
         testReusedBuffer(Unpooled.buffer(16), false, ByteToMessageDecoder.MERGE_CUMULATOR);
     }
 
     @Test
-    public void testReuseInputBufferJustLargeEnoughToContainMessagePartiallyReceived2x_MergeCumulator() {
+    public void testReuseInputBufferJustLargeEnoughToContainMessagePartiallyReceived2x_MergeCumulator()
+            throws Exception {
         testReusedBuffer(Unpooled.buffer(16), true, ByteToMessageDecoder.MERGE_CUMULATOR);
     }
 
     @Test
-    public void testReuseInputBufferSufficientlyLargeToContainDuplicateMessage_MergeCumulator() {
+    public void testReuseInputBufferSufficientlyLargeToContainDuplicateMessage_MergeCumulator() throws Exception {
         testReusedBuffer(Unpooled.buffer(1024), false, ByteToMessageDecoder.MERGE_CUMULATOR);
     }
 
     @Test
-    public void testReuseInputBufferSufficientlyLargeToContainDuplicateMessagePartiallyReceived2x_MergeCumulator() {
+    public void testReuseInputBufferSufficientlyLargeToContainDuplicateMessagePartiallyReceived2x_MergeCumulator()
+            throws Exception {
         testReusedBuffer(Unpooled.buffer(1024), true, ByteToMessageDecoder.MERGE_CUMULATOR);
     }
 
     @Test
-    public void testReuseInputBufferJustLargeEnoughToContainMessage_CompositeCumulator() {
+    public void testReuseInputBufferJustLargeEnoughToContainMessage_CompositeCumulator() throws Exception {
         testReusedBuffer(Unpooled.buffer(16), false, ByteToMessageDecoder.COMPOSITE_CUMULATOR);
     }
 
     @Test
-    public void testReuseInputBufferJustLargeEnoughToContainMessagePartiallyReceived2x_CompositeCumulator() {
+    public void testReuseInputBufferJustLargeEnoughToContainMessagePartiallyReceived2x_CompositeCumulator()
+            throws Exception{
         testReusedBuffer(Unpooled.buffer(16), true, ByteToMessageDecoder.COMPOSITE_CUMULATOR);
     }
 
     @Test
-    public void testReuseInputBufferSufficientlyLargeToContainDuplicateMessage_CompositeCumulator() {
+    public void testReuseInputBufferSufficientlyLargeToContainDuplicateMessage_CompositeCumulator() throws Exception {
         testReusedBuffer(Unpooled.buffer(1024), false, ByteToMessageDecoder.COMPOSITE_CUMULATOR);
     }
 
     @Test
-    public void testReuseInputBufferSufficientlyLargeToContainDuplicateMessagePartiallyReceived2x_CompositeCumulator() {
+    public void testReuseInputBufferSufficientlyLargeToContainDuplicateMessagePartiallyReceived2x_CompositeCumulator()
+            throws Exception {
         testReusedBuffer(Unpooled.buffer(1024), true, ByteToMessageDecoder.COMPOSITE_CUMULATOR);
     }
 
-    static void testReusedBuffer(ByteBuf buffer, boolean secondPartial, ByteToMessageDecoder.Cumulator cumulator) {
+    static void testReusedBuffer(ByteBuf buffer, boolean secondPartial, ByteToMessageDecoder.Cumulator cumulator)
+            throws Exception {
         ByteToMessageDecoder decoder = new ByteToMessageDecoder() {
             @Override
             protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {

--- a/codec-base/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
@@ -624,7 +624,7 @@ public class ByteToMessageDecoderTest {
 
     @Test
     public void testReuseInputBufferJustLargeEnoughToContainMessagePartiallyReceived2x_CompositeCumulator()
-            throws Exception{
+            throws Exception {
         testReusedBuffer(Unpooled.buffer(16), true, ByteToMessageDecoder.COMPOSITE_CUMULATOR);
     }
 

--- a/codec-base/src/test/java/io/netty/handler/codec/DatagramPacketDecoderTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/DatagramPacketDecoderTest.java
@@ -46,12 +46,12 @@ public class DatagramPacketDecoderTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    public void tearDown() throws Exception {
         assertFalse(channel.finish());
     }
 
     @Test
-    public void testDecode() {
+    public void testDecode() throws Exception {
         InetSocketAddress recipient = SocketUtils.socketAddress("127.0.0.1", 10000);
         InetSocketAddress sender = SocketUtils.socketAddress("127.0.0.1", 20000);
         ByteBuf content = Unpooled.wrappedBuffer("netty".getBytes(CharsetUtil.UTF_8));

--- a/codec-base/src/test/java/io/netty/handler/codec/DatagramPacketEncoderTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/DatagramPacketEncoderTest.java
@@ -45,21 +45,21 @@ public class DatagramPacketEncoderTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    public void tearDown() throws Exception {
         assertFalse(channel.finish());
     }
 
     @Test
-    public void testEncode() {
+    public void testEncode() throws Exception {
         testEncode(false);
     }
 
     @Test
-    public void testEncodeWithSenderIsNull() {
+    public void testEncodeWithSenderIsNull() throws Exception {
         testEncode(true);
     }
 
-    private void testEncode(boolean senderIsNull) {
+    private void testEncode(boolean senderIsNull) throws Exception {
         InetSocketAddress recipient = SocketUtils.socketAddress("127.0.0.1", 10000);
         InetSocketAddress sender = senderIsNull ? null : SocketUtils.socketAddress("127.0.0.1", 20000);
         assertTrue(channel.writeOutbound(
@@ -75,7 +75,7 @@ public class DatagramPacketEncoderTest {
     }
 
     @Test
-    public void testUnmatchedMessageType() {
+    public void testUnmatchedMessageType() throws Exception {
         InetSocketAddress recipient = SocketUtils.socketAddress("127.0.0.1", 10000);
         InetSocketAddress sender = SocketUtils.socketAddress("127.0.0.1", 20000);
         DefaultAddressedEnvelope<Long, InetSocketAddress> envelope =
@@ -90,7 +90,7 @@ public class DatagramPacketEncoderTest {
     }
 
     @Test
-    public void testUnmatchedType() {
+    public void testUnmatchedType() throws Exception {
         String netty = "netty";
         assertTrue(channel.writeOutbound(netty));
         assertSame(netty, channel.readOutbound());

--- a/codec-base/src/test/java/io/netty/handler/codec/DelimiterBasedFrameDecoderTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/DelimiterBasedFrameDecoderTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 public class DelimiterBasedFrameDecoderTest {
 
     @Test
-    public void testMultipleLinesStrippedDelimiters() {
+    public void testMultipleLinesStrippedDelimiters() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new DelimiterBasedFrameDecoder(8192, true,
                 Delimiters.lineDelimiter()));
         ch.writeInbound(Unpooled.copiedBuffer("TestLine\r\ng\r\n", Charset.defaultCharset()));
@@ -48,7 +48,7 @@ public class DelimiterBasedFrameDecoderTest {
     }
 
     @Test
-    public void testIncompleteLinesStrippedDelimiters() {
+    public void testIncompleteLinesStrippedDelimiters() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new DelimiterBasedFrameDecoder(8192, true,
                 Delimiters.lineDelimiter()));
         ch.writeInbound(Unpooled.copiedBuffer("Test", Charset.defaultCharset()));
@@ -68,7 +68,7 @@ public class DelimiterBasedFrameDecoderTest {
     }
 
     @Test
-    public void testMultipleLines() {
+    public void testMultipleLines() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new DelimiterBasedFrameDecoder(8192, false,
                 Delimiters.lineDelimiter()));
         ch.writeInbound(Unpooled.copiedBuffer("TestLine\r\ng\r\n", Charset.defaultCharset()));
@@ -86,7 +86,7 @@ public class DelimiterBasedFrameDecoderTest {
     }
 
     @Test
-    public void testIncompleteLines() {
+    public void testIncompleteLines() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new DelimiterBasedFrameDecoder(8192, false,
                 Delimiters.lineDelimiter()));
         ch.writeInbound(Unpooled.copiedBuffer("Test", Charset.defaultCharset()));

--- a/codec-base/src/test/java/io/netty/handler/codec/LengthFieldBasedFrameDecoderTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/LengthFieldBasedFrameDecoderTest.java
@@ -20,10 +20,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.CompletionException;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -31,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class LengthFieldBasedFrameDecoderTest {
 
     @Test
-    public void testDiscardTooLongFrame1() {
+    public void testDiscardTooLongFrame1() throws Exception {
         ByteBuf buf = Unpooled.buffer();
         buf.writeInt(32);
         for (int i = 0; i < 32; i++) {
@@ -40,8 +37,7 @@ public class LengthFieldBasedFrameDecoderTest {
         buf.writeInt(1);
         buf.writeByte('a');
         EmbeddedChannel channel = new EmbeddedChannel(new LengthFieldBasedFrameDecoder(16, 0, 4));
-        Throwable cause = assertThrows(CompletionException.class, () -> channel.writeInbound(buf));
-        assertInstanceOf(TooLongFrameException.class, cause.getCause());
+        assertThrows(TooLongFrameException.class, () -> channel.writeInbound(buf));
         assertTrue(channel.finish());
 
         ByteBuf b = channel.readInbound();
@@ -55,7 +51,7 @@ public class LengthFieldBasedFrameDecoderTest {
     }
 
     @Test
-    public void testDiscardTooLongFrame2() {
+    public void testDiscardTooLongFrame2() throws Exception {
         ByteBuf buf = Unpooled.buffer();
         buf.writeInt(32);
         for (int i = 0; i < 32; i++) {
@@ -64,9 +60,8 @@ public class LengthFieldBasedFrameDecoderTest {
         buf.writeInt(1);
         buf.writeByte('a');
         EmbeddedChannel channel = new EmbeddedChannel(new LengthFieldBasedFrameDecoder(16, 0, 4));
-        Throwable cause = assertThrows(CompletionException.class,
+        assertThrows(TooLongFrameException.class,
                 () -> channel.writeInbound(buf.readRetainedSlice(14)));
-        assertInstanceOf(TooLongFrameException.class, cause.getCause());
         assertTrue(channel.writeInbound(buf.readRetainedSlice(buf.readableBytes())));
 
         assertTrue(channel.finish());

--- a/codec-base/src/test/java/io/netty/handler/codec/LengthFieldBasedFrameDecoderTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/LengthFieldBasedFrameDecoderTest.java
@@ -20,10 +20,13 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.CompletionException;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class LengthFieldBasedFrameDecoderTest {
 
@@ -37,12 +40,8 @@ public class LengthFieldBasedFrameDecoderTest {
         buf.writeInt(1);
         buf.writeByte('a');
         EmbeddedChannel channel = new EmbeddedChannel(new LengthFieldBasedFrameDecoder(16, 0, 4));
-        try {
-            channel.writeInbound(buf);
-            fail();
-        } catch (TooLongFrameException e) {
-            // expected
-        }
+        Throwable cause = assertThrows(CompletionException.class, () -> channel.writeInbound(buf));
+        assertInstanceOf(TooLongFrameException.class, cause.getCause());
         assertTrue(channel.finish());
 
         ByteBuf b = channel.readInbound();
@@ -65,12 +64,9 @@ public class LengthFieldBasedFrameDecoderTest {
         buf.writeInt(1);
         buf.writeByte('a');
         EmbeddedChannel channel = new EmbeddedChannel(new LengthFieldBasedFrameDecoder(16, 0, 4));
-        try {
-            channel.writeInbound(buf.readRetainedSlice(14));
-            fail();
-        } catch (TooLongFrameException e) {
-            // expected
-        }
+        Throwable cause = assertThrows(CompletionException.class,
+                () -> channel.writeInbound(buf.readRetainedSlice(14)));
+        assertInstanceOf(TooLongFrameException.class, cause.getCause());
         assertTrue(channel.writeInbound(buf.readRetainedSlice(buf.readableBytes())));
 
         assertTrue(channel.finish());

--- a/codec-base/src/test/java/io/netty/handler/codec/LineBasedFrameDecoderTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/LineBasedFrameDecoderTest.java
@@ -21,12 +21,9 @@ import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.CompletionException;
-
 import static io.netty.buffer.Unpooled.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -75,9 +72,8 @@ public class LineBasedFrameDecoderTest {
     public void testTooLongLine1() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new LineBasedFrameDecoder(16, false, false));
 
-        Throwable cause = assertThrows(CompletionException.class,
+        assertThrows(TooLongFrameException.class,
                 () -> ch.writeInbound(copiedBuffer("12345678901234567890\r\nfirst\nsecond", CharsetUtil.US_ASCII)));
-        assertInstanceOf(TooLongFrameException.class, cause.getCause());
 
         ByteBuf buf = ch.readInbound();
         ByteBuf buf2 = copiedBuffer("first\n", CharsetUtil.US_ASCII);
@@ -93,9 +89,8 @@ public class LineBasedFrameDecoderTest {
         EmbeddedChannel ch = new EmbeddedChannel(new LineBasedFrameDecoder(16, false, false));
 
         assertFalse(ch.writeInbound(copiedBuffer("12345678901234567", CharsetUtil.US_ASCII)));
-        Throwable cause = assertThrows(CompletionException.class,
+        assertThrows(TooLongFrameException.class,
                 () -> ch.writeInbound(copiedBuffer("890\r\nfirst\r\n", CharsetUtil.US_ASCII)));
-        assertInstanceOf(TooLongFrameException.class, cause.getCause());
 
         ByteBuf buf = ch.readInbound();
         ByteBuf buf2 = copiedBuffer("first\r\n", CharsetUtil.US_ASCII);
@@ -110,9 +105,8 @@ public class LineBasedFrameDecoderTest {
     public void testTooLongLineWithFailFast() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new LineBasedFrameDecoder(16, false, true));
 
-        Throwable cause = assertThrows(CompletionException.class,
+        assertThrows(TooLongFrameException.class,
                 () -> ch.writeInbound(copiedBuffer("12345678901234567", CharsetUtil.US_ASCII)));
-        assertInstanceOf(TooLongFrameException.class, cause.getCause());
 
         assertFalse(ch.writeInbound(copiedBuffer("890", CharsetUtil.US_ASCII)));
         assertTrue(ch.writeInbound(copiedBuffer("123\r\nfirst\r\n", CharsetUtil.US_ASCII)));
@@ -188,9 +182,8 @@ public class LineBasedFrameDecoderTest {
         EmbeddedChannel ch = new EmbeddedChannel(new LineBasedFrameDecoder(2, false, false));
         assertFalse(ch.writeInbound(wrappedBuffer(new byte[] { 0, 1, 2 })));
         assertFalse(ch.writeInbound(wrappedBuffer(new byte[]{ 3, 4 })));
-        Throwable cause = assertThrows(CompletionException.class,
+        assertThrows(TooLongFrameException.class,
                 () -> ch.writeInbound(wrappedBuffer(new byte[] { '\n' })));
-        assertInstanceOf(TooLongFrameException.class, cause.getCause());
 
         assertFalse(ch.writeInbound(wrappedBuffer(new byte[] { '5' })));
         assertTrue(ch.writeInbound(wrappedBuffer(new byte[] { '\n' })));

--- a/codec-base/src/test/java/io/netty/handler/codec/LineBasedFrameDecoderTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/LineBasedFrameDecoderTest.java
@@ -21,13 +21,15 @@ import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.CompletionException;
+
 import static io.netty.buffer.Unpooled.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class LineBasedFrameDecoderTest {
     @Test
@@ -73,12 +75,9 @@ public class LineBasedFrameDecoderTest {
     public void testTooLongLine1() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new LineBasedFrameDecoder(16, false, false));
 
-        try {
-            ch.writeInbound(copiedBuffer("12345678901234567890\r\nfirst\nsecond", CharsetUtil.US_ASCII));
-            fail();
-        } catch (Exception e) {
-            assertInstanceOf(TooLongFrameException.class, e);
-        }
+        Throwable cause = assertThrows(CompletionException.class,
+                () -> ch.writeInbound(copiedBuffer("12345678901234567890\r\nfirst\nsecond", CharsetUtil.US_ASCII)));
+        assertInstanceOf(TooLongFrameException.class, cause.getCause());
 
         ByteBuf buf = ch.readInbound();
         ByteBuf buf2 = copiedBuffer("first\n", CharsetUtil.US_ASCII);
@@ -94,12 +93,9 @@ public class LineBasedFrameDecoderTest {
         EmbeddedChannel ch = new EmbeddedChannel(new LineBasedFrameDecoder(16, false, false));
 
         assertFalse(ch.writeInbound(copiedBuffer("12345678901234567", CharsetUtil.US_ASCII)));
-        try {
-            ch.writeInbound(copiedBuffer("890\r\nfirst\r\n", CharsetUtil.US_ASCII));
-            fail();
-        } catch (Exception e) {
-            assertInstanceOf(TooLongFrameException.class, e);
-        }
+        Throwable cause = assertThrows(CompletionException.class,
+                () -> ch.writeInbound(copiedBuffer("890\r\nfirst\r\n", CharsetUtil.US_ASCII)));
+        assertInstanceOf(TooLongFrameException.class, cause.getCause());
 
         ByteBuf buf = ch.readInbound();
         ByteBuf buf2 = copiedBuffer("first\r\n", CharsetUtil.US_ASCII);
@@ -114,12 +110,9 @@ public class LineBasedFrameDecoderTest {
     public void testTooLongLineWithFailFast() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new LineBasedFrameDecoder(16, false, true));
 
-        try {
-            ch.writeInbound(copiedBuffer("12345678901234567", CharsetUtil.US_ASCII));
-            fail();
-        } catch (Exception e) {
-            assertInstanceOf(TooLongFrameException.class, e);
-        }
+        Throwable cause = assertThrows(CompletionException.class,
+                () -> ch.writeInbound(copiedBuffer("12345678901234567", CharsetUtil.US_ASCII)));
+        assertInstanceOf(TooLongFrameException.class, cause.getCause());
 
         assertFalse(ch.writeInbound(copiedBuffer("890", CharsetUtil.US_ASCII)));
         assertTrue(ch.writeInbound(copiedBuffer("123\r\nfirst\r\n", CharsetUtil.US_ASCII)));
@@ -195,12 +188,10 @@ public class LineBasedFrameDecoderTest {
         EmbeddedChannel ch = new EmbeddedChannel(new LineBasedFrameDecoder(2, false, false));
         assertFalse(ch.writeInbound(wrappedBuffer(new byte[] { 0, 1, 2 })));
         assertFalse(ch.writeInbound(wrappedBuffer(new byte[]{ 3, 4 })));
-        try {
-            ch.writeInbound(wrappedBuffer(new byte[] { '\n' }));
-            fail();
-        } catch (TooLongFrameException expected) {
-            // Expected once we received a full frame.
-        }
+        Throwable cause = assertThrows(CompletionException.class,
+                () -> ch.writeInbound(wrappedBuffer(new byte[] { '\n' })));
+        assertInstanceOf(TooLongFrameException.class, cause.getCause());
+
         assertFalse(ch.writeInbound(wrappedBuffer(new byte[] { '5' })));
         assertTrue(ch.writeInbound(wrappedBuffer(new byte[] { '\n' })));
 

--- a/codec-base/src/test/java/io/netty/handler/codec/MessageAggregatorTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/MessageAggregatorTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
@@ -34,8 +33,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.function.Executable;
-
-import java.util.concurrent.CompletionException;
 
 public class MessageAggregatorTest {
     private static final class ReadCounter implements ChannelOutboundHandler {
@@ -113,13 +110,12 @@ public class MessageAggregatorTest {
         assertFalse(embedded.writeInbound(first));
 
         assertEquals(2, counter.value);
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
+        assertThrows(PrematureChannelClosureException.class, new Executable() {
             @Override
-            public void execute() {
+            public void execute() throws Exception {
                 embedded.finish();
             }
         });
-        assertInstanceOf(PrematureChannelClosureException.class, cause.getCause());
         assertEquals(0, first.refCnt());
     }
 

--- a/codec-base/src/test/java/io/netty/handler/codec/MessageAggregatorTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/MessageAggregatorTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
@@ -33,6 +34,8 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.function.Executable;
+
+import java.util.concurrent.CompletionException;
 
 public class MessageAggregatorTest {
     private static final class ReadCounter implements ChannelOutboundHandler {
@@ -110,12 +113,13 @@ public class MessageAggregatorTest {
         assertFalse(embedded.writeInbound(first));
 
         assertEquals(2, counter.value);
-        assertThrows(PrematureChannelClosureException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 embedded.finish();
             }
         });
+        assertInstanceOf(PrematureChannelClosureException.class, cause.getCause());
         assertEquals(0, first.refCnt());
     }
 

--- a/codec-base/src/test/java/io/netty/handler/codec/MessageToMessageDecoderTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/MessageToMessageDecoderTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class MessageToMessageDecoderTest {
 
     @Test
-    void testReadIfNotAutoReadWhenNotSharable() {
+    void testReadIfNotAutoReadWhenNotSharable() throws Exception {
         ReadCountHandler readCountHandler = new ReadCountHandler();
         EmbeddedChannel channel = new EmbeddedChannel(new MessageToMessageDecoder<String>() {
             private int count;

--- a/codec-base/src/test/java/io/netty/handler/codec/MessageToMessageEncoderTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/MessageToMessageEncoderTest.java
@@ -25,12 +25,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
-import java.util.concurrent.CompletionException;
 
 public class MessageToMessageEncoderTest {
 
@@ -45,17 +43,16 @@ public class MessageToMessageEncoderTest {
                 throw new Exception();
             }
         });
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
+         assertThrows(EncoderException.class, new Executable() {
             @Override
-            public void execute() {
+            public void execute() throws Exception {
                 channel.writeOutbound(new Object());
             }
         });
-        assertInstanceOf(EncoderException.class, cause.getCause());
     }
 
     @Test
-    public void testIntermediateWriteFailures() {
+    public void testIntermediateWriteFailures() throws Exception {
         ChannelHandler encoder = new MessageToMessageEncoder<Object>() {
             @Override
             protected void encode(ChannelHandlerContext ctx, Object msg, List<Object> out) {

--- a/codec-base/src/test/java/io/netty/handler/codec/MessageToMessageEncoderTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/MessageToMessageEncoderTest.java
@@ -25,10 +25,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
+import java.util.concurrent.CompletionException;
 
 public class MessageToMessageEncoderTest {
 
@@ -43,12 +45,13 @@ public class MessageToMessageEncoderTest {
                 throw new Exception();
             }
         });
-        assertThrows(EncoderException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 channel.writeOutbound(new Object());
             }
         });
+        assertInstanceOf(EncoderException.class, cause.getCause());
     }
 
     @Test

--- a/codec-base/src/test/java/io/netty/handler/codec/bytes/ByteArrayDecoderTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/bytes/ByteArrayDecoderTest.java
@@ -36,7 +36,7 @@ public class ByteArrayDecoderTest {
     }
 
     @Test
-    public void testDecode() {
+    public void testDecode() throws Exception {
         byte[] b = new byte[2048];
         new Random().nextBytes(b);
         ch.writeInbound(wrappedBuffer(b));
@@ -44,13 +44,13 @@ public class ByteArrayDecoderTest {
     }
 
     @Test
-    public void testDecodeEmpty() {
+    public void testDecodeEmpty() throws Exception {
         ch.writeInbound(EMPTY_BUFFER);
         assertArrayEquals(EmptyArrays.EMPTY_BYTES, ch.readInbound());
     }
 
     @Test
-    public void testDecodeOtherType() {
+    public void testDecodeOtherType() throws Exception {
         String str = "Meep!";
         ch.writeInbound(str);
         assertSame(str, ch.readInbound());

--- a/codec-base/src/test/java/io/netty/handler/codec/bytes/ByteArrayEncoderTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/bytes/ByteArrayEncoderTest.java
@@ -39,12 +39,12 @@ public class ByteArrayEncoderTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    public void tearDown() throws Exception {
         assertFalse(ch.finish());
     }
 
     @Test
-    public void testEncode() {
+    public void testEncode() throws Exception {
         byte[] b = new byte[2048];
         new Random().nextBytes(b);
         ch.writeOutbound(b);
@@ -54,13 +54,13 @@ public class ByteArrayEncoderTest {
     }
 
     @Test
-    public void testEncodeEmpty() {
+    public void testEncodeEmpty() throws Exception {
         ch.writeOutbound(EmptyArrays.EMPTY_BYTES);
         assertSame(EMPTY_BUFFER, ch.readOutbound());
     }
 
     @Test
-    public void testEncodeOtherType() {
+    public void testEncodeOtherType() throws Exception {
         String str = "Meep!";
         ch.writeOutbound(str);
         assertSame(str, ch.readOutbound());

--- a/codec-base/src/test/java/io/netty/handler/codec/frame/DelimiterBasedFrameDecoderTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/frame/DelimiterBasedFrameDecoderTest.java
@@ -18,20 +18,15 @@ package io.netty.handler.codec.frame;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.DelimiterBasedFrameDecoder;
 import io.netty.handler.codec.Delimiters;
 import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.CompletionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class DelimiterBasedFrameDecoderTest {
 
@@ -42,9 +37,8 @@ public class DelimiterBasedFrameDecoderTest {
 
         for (int i = 0; i < 2; i ++) {
             ch.writeInbound(Unpooled.wrappedBuffer(new byte[] { 1, 2 }));
-            Throwable cause = assertThrows(CompletionException.class,
+            assertThrows(TooLongFrameException.class,
                     () -> ch.writeInbound(Unpooled.wrappedBuffer(new byte[] { 0 })));
-            assertInstanceOf(TooLongFrameException.class, cause.getCause());
 
             ch.writeInbound(Unpooled.wrappedBuffer(new byte[] { 'A', 0 }));
             ByteBuf buf = ch.readInbound();
@@ -60,9 +54,8 @@ public class DelimiterBasedFrameDecoderTest {
                 new DelimiterBasedFrameDecoder(1, Delimiters.nulDelimiter()));
 
         for (int i = 0; i < 2; i ++) {
-            Throwable cause = assertThrows(CompletionException.class,
+            assertThrows(TooLongFrameException.class,
                     () -> ch.writeInbound(Unpooled.wrappedBuffer(new byte[] { 1, 2 })));
-            assertInstanceOf(TooLongFrameException.class, cause.getCause());
             ch.writeInbound(Unpooled.wrappedBuffer(new byte[] { 0, 'A', 0 }));
             ByteBuf buf = ch.readInbound();
             assertEquals("A", buf.toString(CharsetUtil.ISO_8859_1));

--- a/codec-base/src/test/java/io/netty/handler/codec/frame/DelimiterBasedFrameDecoderTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/frame/DelimiterBasedFrameDecoderTest.java
@@ -25,7 +25,11 @@ import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.CompletionException;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -38,12 +42,9 @@ public class DelimiterBasedFrameDecoderTest {
 
         for (int i = 0; i < 2; i ++) {
             ch.writeInbound(Unpooled.wrappedBuffer(new byte[] { 1, 2 }));
-            try {
-                assertTrue(ch.writeInbound(Unpooled.wrappedBuffer(new byte[] { 0 })));
-                fail(DecoderException.class.getSimpleName() + " must be raised.");
-            } catch (TooLongFrameException e) {
-                // Expected
-            }
+            Throwable cause = assertThrows(CompletionException.class,
+                    () -> ch.writeInbound(Unpooled.wrappedBuffer(new byte[] { 0 })));
+            assertInstanceOf(TooLongFrameException.class, cause.getCause());
 
             ch.writeInbound(Unpooled.wrappedBuffer(new byte[] { 'A', 0 }));
             ByteBuf buf = ch.readInbound();
@@ -59,13 +60,9 @@ public class DelimiterBasedFrameDecoderTest {
                 new DelimiterBasedFrameDecoder(1, Delimiters.nulDelimiter()));
 
         for (int i = 0; i < 2; i ++) {
-            try {
-                assertTrue(ch.writeInbound(Unpooled.wrappedBuffer(new byte[] { 1, 2 })));
-                fail(DecoderException.class.getSimpleName() + " must be raised.");
-            } catch (TooLongFrameException e) {
-                // Expected
-            }
-
+            Throwable cause = assertThrows(CompletionException.class,
+                    () -> ch.writeInbound(Unpooled.wrappedBuffer(new byte[] { 1, 2 })));
+            assertInstanceOf(TooLongFrameException.class, cause.getCause());
             ch.writeInbound(Unpooled.wrappedBuffer(new byte[] { 0, 'A', 0 }));
             ByteBuf buf = ch.readInbound();
             assertEquals("A", buf.toString(CharsetUtil.ISO_8859_1));

--- a/codec-base/src/test/java/io/netty/handler/codec/frame/LengthFieldBasedFrameDecoderTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/frame/LengthFieldBasedFrameDecoderTest.java
@@ -24,10 +24,12 @@ import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.CompletionException;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class LengthFieldBasedFrameDecoderTest {
     @Test
@@ -37,12 +39,9 @@ public class LengthFieldBasedFrameDecoderTest {
 
         for (int i = 0; i < 2; i ++) {
             assertFalse(ch.writeInbound(Unpooled.wrappedBuffer(new byte[] { 0, 0, 0, 2 })));
-            try {
-                assertTrue(ch.writeInbound(Unpooled.wrappedBuffer(new byte[] { 0, 0 })));
-                fail(DecoderException.class.getSimpleName() + " must be raised.");
-            } catch (TooLongFrameException e) {
-                // Expected
-            }
+            Throwable cause = assertThrows(CompletionException.class,
+                    () -> ch.writeInbound(Unpooled.wrappedBuffer(new byte[] { 0, 0 })));
+            assertInstanceOf(TooLongFrameException.class, cause.getCause());
 
             ch.writeInbound(Unpooled.wrappedBuffer(new byte[] { 0, 0, 0, 1, 'A' }));
             ByteBuf buf = ch.readInbound();
@@ -57,12 +56,9 @@ public class LengthFieldBasedFrameDecoderTest {
                 new LengthFieldBasedFrameDecoder(5, 0, 4, 0, 4));
 
         for (int i = 0; i < 2; i ++) {
-            try {
-                assertTrue(ch.writeInbound(Unpooled.wrappedBuffer(new byte[] { 0, 0, 0, 2 })));
-                fail(DecoderException.class.getSimpleName() + " must be raised.");
-            } catch (TooLongFrameException e) {
-                // Expected
-            }
+            Throwable cause = assertThrows(CompletionException.class,
+                    () -> ch.writeInbound(Unpooled.wrappedBuffer(new byte[] { 0, 0, 0, 2 })));
+            assertInstanceOf(TooLongFrameException.class, cause.getCause());
 
             ch.writeInbound(Unpooled.wrappedBuffer(new byte[] { 0, 0, 0, 0, 0, 1, 'A' }));
             ByteBuf buf = ch.readInbound();

--- a/codec-base/src/test/java/io/netty/handler/codec/frame/LengthFieldBasedFrameDecoderTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/frame/LengthFieldBasedFrameDecoderTest.java
@@ -18,17 +18,13 @@ package io.netty.handler.codec.frame;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.CompletionException;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class LengthFieldBasedFrameDecoderTest {
@@ -39,9 +35,8 @@ public class LengthFieldBasedFrameDecoderTest {
 
         for (int i = 0; i < 2; i ++) {
             assertFalse(ch.writeInbound(Unpooled.wrappedBuffer(new byte[] { 0, 0, 0, 2 })));
-            Throwable cause = assertThrows(CompletionException.class,
+            assertThrows(TooLongFrameException.class,
                     () -> ch.writeInbound(Unpooled.wrappedBuffer(new byte[] { 0, 0 })));
-            assertInstanceOf(TooLongFrameException.class, cause.getCause());
 
             ch.writeInbound(Unpooled.wrappedBuffer(new byte[] { 0, 0, 0, 1, 'A' }));
             ByteBuf buf = ch.readInbound();
@@ -56,9 +51,8 @@ public class LengthFieldBasedFrameDecoderTest {
                 new LengthFieldBasedFrameDecoder(5, 0, 4, 0, 4));
 
         for (int i = 0; i < 2; i ++) {
-            Throwable cause = assertThrows(CompletionException.class,
+            assertThrows(TooLongFrameException.class,
                     () -> ch.writeInbound(Unpooled.wrappedBuffer(new byte[] { 0, 0, 0, 2 })));
-            assertInstanceOf(TooLongFrameException.class, cause.getCause());
 
             ch.writeInbound(Unpooled.wrappedBuffer(new byte[] { 0, 0, 0, 0, 0, 1, 'A' }));
             ByteBuf buf = ch.readInbound();

--- a/codec-base/src/test/java/io/netty/handler/codec/frame/LengthFieldPrependerTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/frame/LengthFieldPrependerTest.java
@@ -25,14 +25,11 @@ import org.junit.jupiter.api.Test;
 
 import static io.netty.buffer.Unpooled.*;
 import java.nio.ByteOrder;
-import java.util.concurrent.CompletionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class LengthFieldPrependerTest {
 
@@ -88,8 +85,7 @@ public class LengthFieldPrependerTest {
     @Test
     public void testAdjustedLengthLessThanZero() throws Exception {
         final EmbeddedChannel ch = new EmbeddedChannel(new LengthFieldPrepender(4, -2));
-        Throwable cause = assertThrows(CompletionException.class, () -> ch.writeOutbound(msg));
-        assertInstanceOf(EncoderException.class, cause.getCause());
+        assertThrows(EncoderException.class, () -> ch.writeOutbound(msg));
     }
 
     @Test

--- a/codec-base/src/test/java/io/netty/handler/codec/frame/LengthFieldPrependerTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/frame/LengthFieldPrependerTest.java
@@ -25,10 +25,13 @@ import org.junit.jupiter.api.Test;
 
 import static io.netty.buffer.Unpooled.*;
 import java.nio.ByteOrder;
+import java.util.concurrent.CompletionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class LengthFieldPrependerTest {
@@ -85,12 +88,8 @@ public class LengthFieldPrependerTest {
     @Test
     public void testAdjustedLengthLessThanZero() throws Exception {
         final EmbeddedChannel ch = new EmbeddedChannel(new LengthFieldPrepender(4, -2));
-        try {
-            ch.writeOutbound(msg);
-            fail(EncoderException.class.getSimpleName() + " must be raised.");
-        } catch (EncoderException e) {
-            // Expected
-        }
+        Throwable cause = assertThrows(CompletionException.class, () -> ch.writeOutbound(msg));
+        assertInstanceOf(EncoderException.class, cause.getCause());
     }
 
     @Test

--- a/codec-base/src/test/java/io/netty/handler/codec/json/JsonObjectDecoderTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/json/JsonObjectDecoderTest.java
@@ -27,11 +27,9 @@ import org.junit.jupiter.api.function.Executable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.CompletionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -40,7 +38,7 @@ public class JsonObjectDecoderTest {
     private static final Logger log = LoggerFactory.getLogger(JsonObjectDecoderTest.class);
 
     @Test
-    public void testJsonObjectOverMultipleWrites() {
+    public void testJsonObjectOverMultipleWrites() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new JsonObjectDecoder());
 
         String objectPart1 = "{ \"firstname\": \"John";
@@ -60,7 +58,7 @@ public class JsonObjectDecoderTest {
     }
 
     @Test
-    public void testMultipleJsonObjectsOverMultipleWrites() {
+    public void testMultipleJsonObjectsOverMultipleWrites() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new JsonObjectDecoder());
 
         String objectPart1 = "{\"name\":\"Jo";
@@ -81,7 +79,7 @@ public class JsonObjectDecoderTest {
     }
 
     @Test
-    public void testJsonArrayOverMultipleWrites() {
+    public void testJsonArrayOverMultipleWrites() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new JsonObjectDecoder());
 
         String arrayPart1 = "[{\"test";
@@ -105,7 +103,7 @@ public class JsonObjectDecoderTest {
     }
 
     @Test
-    public void testStreamJsonArrayOverMultipleWrites1() {
+    public void testStreamJsonArrayOverMultipleWrites1() throws Exception {
         String[] array = new String[] {
                 "   [{\"test",
                 "case\"  : \"\\\"}]Escaped dou\\\"ble quotes \\\" in JSON str\\\"ing\"",
@@ -121,7 +119,7 @@ public class JsonObjectDecoderTest {
     }
 
     @Test
-    public void testStreamJsonArrayOverMultipleWrites2() {
+    public void testStreamJsonArrayOverMultipleWrites2() throws Exception {
         String[] array = new String[] {
                 "   [{\"test",
                 "case\"  : \"\\\"}]Escaped dou\\\"ble quotes \\\" in JSON str\\\"ing\"",
@@ -137,7 +135,7 @@ public class JsonObjectDecoderTest {
     }
 
     @Test
-    public void testStreamJsonArrayOverMultipleWrites3() {
+    public void testStreamJsonArrayOverMultipleWrites3() throws Exception {
         String[] array = new String[] {
                 "   [{\"test",
                 "case\"  : \"\\\"}]Escaped dou\\\"ble quotes \\\" in JSON str\\\"ing\"",
@@ -153,7 +151,7 @@ public class JsonObjectDecoderTest {
     }
 
     private static void doTestStreamJsonArrayOverMultipleWrites(int indexDataAvailable,
-            String[] array, String[] result) {
+            String[] array, String[] result) throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new JsonObjectDecoder(true));
 
         boolean dataAvailable = false;
@@ -177,7 +175,7 @@ public class JsonObjectDecoderTest {
     }
 
     @Test
-    public void testSingleByteStream() {
+    public void testSingleByteStream() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new JsonObjectDecoder());
 
         String json = "{\"foo\" : {\"bar\" : [{},{}]}}";
@@ -193,7 +191,7 @@ public class JsonObjectDecoderTest {
     }
 
     @Test
-    public void testBackslashInString1() {
+    public void testBackslashInString1() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new JsonObjectDecoder());
         // {"foo" : "bar\""}
         String json = "{\"foo\" : \"bar\\\"\"}";
@@ -208,7 +206,7 @@ public class JsonObjectDecoderTest {
     }
 
     @Test
-    public void testBackslashInString2() {
+    public void testBackslashInString2() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new JsonObjectDecoder());
         // {"foo" : "bar\\"}
         String json = "{\"foo\" : \"bar\\\\\"}";
@@ -223,7 +221,7 @@ public class JsonObjectDecoderTest {
     }
 
     @Test
-    public void testBackslashInString3() {
+    public void testBackslashInString3() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new JsonObjectDecoder());
         // {"foo" : "bar\\\""}
         String json = "{\"foo\" : \"bar\\\\\\\"\"}";
@@ -238,7 +236,7 @@ public class JsonObjectDecoderTest {
     }
 
     @Test
-    public void testMultipleJsonObjectsInOneWrite() {
+    public void testMultipleJsonObjectsInOneWrite() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new JsonObjectDecoder());
 
         String object1 = "{\"key\" : \"value1\"}",
@@ -261,23 +259,22 @@ public class JsonObjectDecoderTest {
     }
 
     @Test
-    public void testNonJsonContent1() {
+    public void testNonJsonContent1() throws Exception {
         final EmbeddedChannel ch = new EmbeddedChannel(new JsonObjectDecoder());
         try {
-            Throwable cause = assertThrows(CompletionException.class, new Executable() {
+            assertThrows(CorruptedFrameException.class, new Executable() {
                 @Override
-                public void execute() {
+                public void execute() throws Exception {
                     ch.writeInbound(Unpooled.copiedBuffer("  b [1,2,3]", CharsetUtil.UTF_8));
                 }
             });
-            assertInstanceOf(CorruptedFrameException.class, cause.getCause());
         } finally {
             assertFalse(ch.finish());
         }
     }
 
     @Test
-    public void testNonJsonContent2() {
+    public void testNonJsonContent2() throws Exception {
         final EmbeddedChannel ch = new EmbeddedChannel(new JsonObjectDecoder());
         ch.writeInbound(Unpooled.copiedBuffer("  [1,2,3]  ", CharsetUtil.UTF_8));
 
@@ -286,36 +283,34 @@ public class JsonObjectDecoderTest {
         res.release();
 
         try {
-            Throwable cause = assertThrows(CompletionException.class, new Executable() {
+            assertThrows(CorruptedFrameException.class, new Executable() {
                 @Override
-                public void execute() {
+                public void execute() throws Exception {
                     ch.writeInbound(Unpooled.copiedBuffer(" a {\"key\" : 10}", CharsetUtil.UTF_8));
                 }
             });
-            assertInstanceOf(CorruptedFrameException.class, cause.getCause());
         } finally {
             assertFalse(ch.finish());
         }
     }
 
     @Test
-    public void testMaxObjectLength() {
+    public void testMaxObjectLength() throws Exception {
         final EmbeddedChannel ch = new EmbeddedChannel(new JsonObjectDecoder(6));
         try {
-            Throwable cause = assertThrows(CompletionException.class, new Executable() {
+            assertThrows(TooLongFrameException.class, new Executable() {
                 @Override
                 public void execute() throws Throwable {
                     ch.writeInbound(Unpooled.copiedBuffer("[2,4,5]", CharsetUtil.UTF_8));
                 }
             });
-            assertInstanceOf(TooLongFrameException.class, cause.getCause());
         } finally {
             assertFalse(ch.finish());
         }
     }
 
     @Test
-    public void testOneJsonObjectPerWrite() {
+    public void testOneJsonObjectPerWrite() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new JsonObjectDecoder());
 
         String object1 = "{\"key\" : \"value1\"}",
@@ -340,7 +335,7 @@ public class JsonObjectDecoderTest {
     }
 
     @Test
-    public void testSpecialJsonCharsInString() {
+    public void testSpecialJsonCharsInString() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new JsonObjectDecoder());
 
         String object = "{ \"key\" : \"[]{}}\\\"}}'}\"}";
@@ -354,7 +349,7 @@ public class JsonObjectDecoderTest {
     }
 
     @Test
-    public void testStreamArrayElementsSimple() {
+    public void testStreamArrayElementsSimple() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new JsonObjectDecoder(Integer.MAX_VALUE, true));
 
         String array = "[  12, \"bla\"  , 13.4   \t  ,{\"key0\" : [1,2], \"key1\" : 12, \"key2\" : {}} , " +
@@ -395,7 +390,7 @@ public class JsonObjectDecoderTest {
     }
 
     @Test
-    public void testCorruptedFrameException() {
+    public void testCorruptedFrameException() throws Exception {
         final String part1 = "{\"a\":{\"b\":{\"c\":{ \"d\":\"27301\", \"med\":\"d\", \"path\":\"27310\"} }," +
                 " \"status\":\"OK\" } }{\"";
         final String part2 = "a\":{\"b\":{\"c\":{\"ory\":[{\"competi\":[{\"event\":[{" + "\"externalI\":{\"external\"" +

--- a/codec-base/src/test/java/io/netty/handler/codec/json/JsonObjectDecoderTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/json/JsonObjectDecoderTest.java
@@ -24,14 +24,21 @@ import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.CompletionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JsonObjectDecoderTest {
+    private static final Logger log = LoggerFactory.getLogger(JsonObjectDecoderTest.class);
+
     @Test
     public void testJsonObjectOverMultipleWrites() {
         EmbeddedChannel ch = new EmbeddedChannel(new JsonObjectDecoder());
@@ -257,12 +264,13 @@ public class JsonObjectDecoderTest {
     public void testNonJsonContent1() {
         final EmbeddedChannel ch = new EmbeddedChannel(new JsonObjectDecoder());
         try {
-            assertThrows(CorruptedFrameException.class, new Executable() {
+            Throwable cause = assertThrows(CompletionException.class, new Executable() {
                 @Override
                 public void execute() {
                     ch.writeInbound(Unpooled.copiedBuffer("  b [1,2,3]", CharsetUtil.UTF_8));
                 }
             });
+            assertInstanceOf(CorruptedFrameException.class, cause.getCause());
         } finally {
             assertFalse(ch.finish());
         }
@@ -278,12 +286,13 @@ public class JsonObjectDecoderTest {
         res.release();
 
         try {
-            assertThrows(CorruptedFrameException.class, new Executable() {
+            Throwable cause = assertThrows(CompletionException.class, new Executable() {
                 @Override
                 public void execute() {
                     ch.writeInbound(Unpooled.copiedBuffer(" a {\"key\" : 10}", CharsetUtil.UTF_8));
                 }
             });
+            assertInstanceOf(CorruptedFrameException.class, cause.getCause());
         } finally {
             assertFalse(ch.finish());
         }
@@ -293,12 +302,13 @@ public class JsonObjectDecoderTest {
     public void testMaxObjectLength() {
         final EmbeddedChannel ch = new EmbeddedChannel(new JsonObjectDecoder(6));
         try {
-            assertThrows(TooLongFrameException.class, new Executable() {
+            Throwable cause = assertThrows(CompletionException.class, new Executable() {
                 @Override
                 public void execute() throws Throwable {
                     ch.writeInbound(Unpooled.copiedBuffer("[2,4,5]", CharsetUtil.UTF_8));
                 }
             });
+            assertInstanceOf(TooLongFrameException.class, cause.getCause());
         } finally {
             assertFalse(ch.finish());
         }

--- a/codec-base/src/test/java/io/netty/handler/codec/json/JsonObjectDecoderTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/json/JsonObjectDecoderTest.java
@@ -24,9 +24,6 @@ import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -35,7 +32,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JsonObjectDecoderTest {
-    private static final Logger log = LoggerFactory.getLogger(JsonObjectDecoderTest.class);
 
     @Test
     public void testJsonObjectOverMultipleWrites() throws Exception {

--- a/codec-base/src/test/java/io/netty/handler/codec/string/LineEncoderTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/string/LineEncoderTest.java
@@ -28,13 +28,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class LineEncoderTest {
 
     @Test
-    public void testEncode() {
+    public void testEncode() throws Exception {
         testLineEncode(LineSeparator.DEFAULT, "abc");
         testLineEncode(LineSeparator.WINDOWS, "abc");
         testLineEncode(LineSeparator.UNIX, "abc");
     }
 
-    private static void testLineEncode(LineSeparator lineSeparator, String msg) {
+    private static void testLineEncode(LineSeparator lineSeparator, String msg) throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new LineEncoder(lineSeparator, CharsetUtil.UTF_8));
         assertTrue(channel.writeOutbound(msg));
         ByteBuf buf = channel.readOutbound();

--- a/codec-base/src/test/java/io/netty/handler/codec/string/StringDecoderTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/string/StringDecoderTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 public class StringDecoderTest {
 
     @Test
-    public void testDecode() {
+    public void testDecode() throws Exception {
         String msg = "abc123";
         ByteBuf byteBuf = Unpooled.copiedBuffer(msg, CharsetUtil.UTF_8);
         EmbeddedChannel channel = new EmbeddedChannel(new StringDecoder());

--- a/codec-base/src/test/java/io/netty/handler/codec/string/StringEncoderTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/string/StringEncoderTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 public class StringEncoderTest {
 
     @Test
-    public void testEncode() {
+    public void testEncode() throws Exception {
         String msg = "Test";
         EmbeddedChannel channel = new EmbeddedChannel(new StringEncoder());
         Assertions.assertTrue(channel.writeOutbound(msg));

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/AbstractDecoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/AbstractDecoderTest.java
@@ -59,7 +59,7 @@ public abstract class AbstractDecoderTest extends AbstractCompressionTest {
     protected abstract EmbeddedChannel createChannel();
 
     @AfterEach
-    public void destroyChannel() {
+    public void destroyChannel() throws Exception {
         if (channel != null) {
             channel.finishAndReleaseAll();
             channel = null;
@@ -135,7 +135,7 @@ public abstract class AbstractDecoderTest extends AbstractCompressionTest {
         return decompressed;
     }
 
-    protected static void tryDecodeAndCatchBufLeaks(final EmbeddedChannel channel, final ByteBuf data) {
+    protected static void tryDecodeAndCatchBufLeaks(final EmbeddedChannel channel, final ByteBuf data) throws Exception {
         try {
             channel.writeInbound(data);
         } finally {

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/AbstractDecoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/AbstractDecoderTest.java
@@ -135,7 +135,8 @@ public abstract class AbstractDecoderTest extends AbstractCompressionTest {
         return decompressed;
     }
 
-    protected static void tryDecodeAndCatchBufLeaks(final EmbeddedChannel channel, final ByteBuf data) throws Exception {
+    protected static void tryDecodeAndCatchBufLeaks(final EmbeddedChannel channel, final ByteBuf data)
+            throws Exception {
         try {
             channel.writeInbound(data);
         } finally {

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/AbstractEncoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/AbstractEncoderTest.java
@@ -44,7 +44,7 @@ public abstract class AbstractEncoderTest extends AbstractCompressionTest {
     protected abstract EmbeddedChannel createChannel();
 
     @AfterEach
-    public void destroyChannel() {
+    public void destroyChannel() throws Exception {
         if (channel != null) {
             channel.finishAndReleaseAll();
             channel = null;

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/AbstractIntegrationTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/AbstractIntegrationTest.java
@@ -157,7 +157,7 @@ public abstract class AbstractIntegrationTest {
         testIdentity(data, false);
     }
 
-    protected void testIdentity(final byte[] data, boolean heapBuffer) {
+    protected void testIdentity(final byte[] data, boolean heapBuffer) throws Exception {
         initChannels();
         final ByteBuf in = heapBuffer? Unpooled.wrappedBuffer(data) :
                 Unpooled.directBuffer(data.length).writeBytes(data);

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/BrotliDecoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/BrotliDecoderTest.java
@@ -84,7 +84,7 @@ public class BrotliDecoderTest {
     }
 
     @AfterEach
-    public void destroyChannel() {
+    public void destroyChannel() throws Exception {
         if (channel != null) {
             channel.finishAndReleaseAll();
             channel = null;
@@ -107,23 +107,23 @@ public class BrotliDecoderTest {
 
     @ParameterizedTest
     @MethodSource("smallData")
-    public void testDecompressionOfSmallChunkOfData(ByteBuf data) {
+    public void testDecompressionOfSmallChunkOfData(ByteBuf data) throws Exception {
         testDecompression(WRAPPED_BYTES_SMALL.duplicate(), data);
     }
 
     @ParameterizedTest
     @MethodSource("largeData")
-    public void testDecompressionOfLargeChunkOfData(ByteBuf data) {
+    public void testDecompressionOfLargeChunkOfData(ByteBuf data) throws Exception {
         testDecompression(WRAPPED_BYTES_LARGE.duplicate(), data);
     }
 
     @ParameterizedTest
     @MethodSource("largeData")
-    public void testDecompressionOfBatchedFlowOfData(ByteBuf data) {
+    public void testDecompressionOfBatchedFlowOfData(ByteBuf data) throws Exception {
         testDecompressionOfBatchedFlow(WRAPPED_BYTES_LARGE, data);
     }
 
-    private void testDecompression(final ByteBuf expected, final ByteBuf data) {
+    private void testDecompression(final ByteBuf expected, final ByteBuf data) throws Exception {
         assertTrue(channel.writeInbound(data));
 
         ByteBuf decompressed = readDecompressed(channel);
@@ -132,7 +132,7 @@ public class BrotliDecoderTest {
         decompressed.release();
     }
 
-    private void testDecompressionOfBatchedFlow(final ByteBuf expected, final ByteBuf data) {
+    private void testDecompressionOfBatchedFlow(final ByteBuf expected, final ByteBuf data) throws Exception {
         final int compressedLength = data.readableBytes();
         int written = 0, length = RANDOM.nextInt(100);
         while (written + length < compressedLength) {

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/BrotliEncoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/BrotliEncoderTest.java
@@ -46,13 +46,13 @@ public class BrotliEncoderTest extends AbstractEncoderTest {
     }
 
     @Override
-    public void destroyChannel() {
+    public void destroyChannel() throws Exception {
         ENCODER_CHANNEL.finishAndReleaseAll();
         DECODER_CHANNEL.finishAndReleaseAll();
     }
 
     @Override
-    protected ByteBuf decompress(ByteBuf compressed, int originalLength) {
+    protected ByteBuf decompress(ByteBuf compressed, int originalLength) throws Exception {
         DECODER_CHANNEL.writeInbound(compressed);
 
         ByteBuf aggregatedBuffer = Unpooled.buffer();

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/Bzip2DecoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/Bzip2DecoderTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.concurrent.CompletionException;
 
 import static io.netty.handler.codec.compression.Bzip2Constants.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -54,11 +55,7 @@ public class Bzip2DecoderTest extends AbstractDecoderTest {
                 destroyChannel();
                 fail();
             } catch (CompletionException exception) {
-                if (exception.getCause() instanceof DecompressionException) {
-                    // expected
-                } else {
-                    throw exception;
-                }
+                assertThat(exception).hasCauseInstanceOf(DecompressionException.class);
             }
         }
     }

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/Bzip2DecoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/Bzip2DecoderTest.java
@@ -24,8 +24,10 @@ import org.junit.jupiter.api.function.Executable;
 
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
+import java.util.concurrent.CompletionException;
 
 import static io.netty.handler.codec.compression.Bzip2Constants.*;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -53,8 +55,12 @@ public class Bzip2DecoderTest extends AbstractDecoderTest {
             try {
                 destroyChannel();
                 fail();
-            } catch (DecompressionException ignored) {
-                // expected
+            } catch (CompletionException exception) {
+                if (exception.getCause() instanceof DecompressionException) {
+                    // expected
+                } else {
+                    throw exception;
+                }
             }
         }
     }
@@ -63,12 +69,13 @@ public class Bzip2DecoderTest extends AbstractDecoderTest {
     public void testUnexpectedStreamIdentifier() {
         final ByteBuf in = Unpooled.buffer();
         in.writeLong(1823080128301928729L); //random value
-        assertThrows(DecompressionException.class, new Executable() {
+        CompletionException cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 writeInboundDestroyAndExpectDecompressionException(in);
             }
         }, "Unexpected stream identifier contents");
+        assertInstanceOf(DecompressionException.class, cause.getCause());
     }
 
     @Test
@@ -77,12 +84,13 @@ public class Bzip2DecoderTest extends AbstractDecoderTest {
         in.writeMedium(MAGIC_NUMBER);
         in.writeByte('0');  //incorrect block size
 
-        assertThrows(DecompressionException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 channel.writeInbound(in);
             }
         }, "block size is invalid");
+        assertInstanceOf(DecompressionException.class, cause.getCause());
     }
 
     @Test
@@ -94,12 +102,13 @@ public class Bzip2DecoderTest extends AbstractDecoderTest {
         in.writeMedium(11); //incorrect block header
         in.writeInt(11111); //block CRC
 
-        assertThrows(DecompressionException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 channel.writeInbound(in);
             }
         }, "bad block header");
+        assertInstanceOf(DecompressionException.class, cause.getCause());
     }
 
     @Test
@@ -111,12 +120,13 @@ public class Bzip2DecoderTest extends AbstractDecoderTest {
         in.writeMedium(END_OF_STREAM_MAGIC_2);
         in.writeInt(1);  //wrong storedCombinedCRC
 
-        assertThrows(DecompressionException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 channel.writeInbound(in);
             }
         }, "stream CRC error");
+        assertInstanceOf(DecompressionException.class, cause.getCause());
     }
 
     @Test
@@ -124,12 +134,13 @@ public class Bzip2DecoderTest extends AbstractDecoderTest {
         final byte[] data = Arrays.copyOf(DATA, DATA.length);
         data[41] = (byte) 0xDD;
 
-        assertThrows(DecompressionException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 tryDecodeAndCatchBufLeaks(channel, Unpooled.wrappedBuffer(data));
             }
         }, "stream CRC error");
+        assertInstanceOf(DecompressionException.class, cause.getCause());
     }
 
     @Test
@@ -138,12 +149,13 @@ public class Bzip2DecoderTest extends AbstractDecoderTest {
         data[25] = 0x70;
 
         final ByteBuf in = Unpooled.wrappedBuffer(data);
-        assertThrows(DecompressionException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 channel.writeInbound(in);
             }
         }, "incorrect huffman groups number");
+        assertInstanceOf(DecompressionException.class, cause.getCause());
     }
 
     @Test
@@ -152,12 +164,13 @@ public class Bzip2DecoderTest extends AbstractDecoderTest {
         data[25] = 0x2F;
 
         final ByteBuf in = Unpooled.wrappedBuffer(data);
-        assertThrows(DecompressionException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 channel.writeInbound(in);
             }
         }, "incorrect selectors number");
+        assertInstanceOf(DecompressionException.class, cause.getCause());
     }
 
     @Test
@@ -166,12 +179,13 @@ public class Bzip2DecoderTest extends AbstractDecoderTest {
         data[11] = 0x77;
 
         final ByteBuf in = Unpooled.wrappedBuffer(data);
-        assertThrows(DecompressionException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 writeInboundDestroyAndExpectDecompressionException(in);
             }
         }, "block CRC error");
+        assertInstanceOf(DecompressionException.class, cause.getCause());
     }
 
     @Test
@@ -180,12 +194,13 @@ public class Bzip2DecoderTest extends AbstractDecoderTest {
         data[14] = (byte) 0xFF;
 
         final ByteBuf in = Unpooled.wrappedBuffer(data);
-        assertThrows(DecompressionException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 writeInboundDestroyAndExpectDecompressionException(in);
             }
         }, "start pointer invalid");
+        assertInstanceOf(DecompressionException.class, cause.getCause());
     }
 
     @Override

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/Bzip2DecoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/Bzip2DecoderTest.java
@@ -20,14 +20,12 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
 import java.util.concurrent.CompletionException;
 
 import static io.netty.handler.codec.compression.Bzip2Constants.*;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -48,7 +46,7 @@ public class Bzip2DecoderTest extends AbstractDecoderTest {
         return new EmbeddedChannel(new Bzip2Decoder());
     }
 
-    private void writeInboundDestroyAndExpectDecompressionException(ByteBuf in) {
+    private void writeInboundDestroyAndExpectDecompressionException(ByteBuf in) throws Exception {
         try {
             channel.writeInbound(in);
         } finally {
@@ -69,13 +67,8 @@ public class Bzip2DecoderTest extends AbstractDecoderTest {
     public void testUnexpectedStreamIdentifier() {
         final ByteBuf in = Unpooled.buffer();
         in.writeLong(1823080128301928729L); //random value
-        CompletionException cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                writeInboundDestroyAndExpectDecompressionException(in);
-            }
-        }, "Unexpected stream identifier contents");
-        assertInstanceOf(DecompressionException.class, cause.getCause());
+        assertThrows(DecompressionException.class,
+                () -> writeInboundDestroyAndExpectDecompressionException(in), "Unexpected stream identifier contents");
     }
 
     @Test
@@ -84,13 +77,8 @@ public class Bzip2DecoderTest extends AbstractDecoderTest {
         in.writeMedium(MAGIC_NUMBER);
         in.writeByte('0');  //incorrect block size
 
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                channel.writeInbound(in);
-            }
-        }, "block size is invalid");
-        assertInstanceOf(DecompressionException.class, cause.getCause());
+        assertThrows(DecompressionException.class,
+                () -> channel.writeInbound(in), "block size is invalid");
     }
 
     @Test
@@ -101,14 +89,8 @@ public class Bzip2DecoderTest extends AbstractDecoderTest {
         in.writeMedium(11); //incorrect block header
         in.writeMedium(11); //incorrect block header
         in.writeInt(11111); //block CRC
-
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                channel.writeInbound(in);
-            }
-        }, "bad block header");
-        assertInstanceOf(DecompressionException.class, cause.getCause());
+        assertThrows(DecompressionException.class,
+                () -> channel.writeInbound(in), "bad block header");
     }
 
     @Test
@@ -120,13 +102,8 @@ public class Bzip2DecoderTest extends AbstractDecoderTest {
         in.writeMedium(END_OF_STREAM_MAGIC_2);
         in.writeInt(1);  //wrong storedCombinedCRC
 
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                channel.writeInbound(in);
-            }
-        }, "stream CRC error");
-        assertInstanceOf(DecompressionException.class, cause.getCause());
+        assertThrows(DecompressionException.class,
+                () -> channel.writeInbound(in), "stream CRC error");
     }
 
     @Test
@@ -134,13 +111,8 @@ public class Bzip2DecoderTest extends AbstractDecoderTest {
         final byte[] data = Arrays.copyOf(DATA, DATA.length);
         data[41] = (byte) 0xDD;
 
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                tryDecodeAndCatchBufLeaks(channel, Unpooled.wrappedBuffer(data));
-            }
-        }, "stream CRC error");
-        assertInstanceOf(DecompressionException.class, cause.getCause());
+        assertThrows(DecompressionException.class,
+                () -> tryDecodeAndCatchBufLeaks(channel, Unpooled.wrappedBuffer(data)), "stream CRC error");
     }
 
     @Test
@@ -149,13 +121,8 @@ public class Bzip2DecoderTest extends AbstractDecoderTest {
         data[25] = 0x70;
 
         final ByteBuf in = Unpooled.wrappedBuffer(data);
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                channel.writeInbound(in);
-            }
-        }, "incorrect huffman groups number");
-        assertInstanceOf(DecompressionException.class, cause.getCause());
+        assertThrows(DecompressionException.class,
+                () -> channel.writeInbound(in), "incorrect huffman groups number");
     }
 
     @Test
@@ -164,13 +131,8 @@ public class Bzip2DecoderTest extends AbstractDecoderTest {
         data[25] = 0x2F;
 
         final ByteBuf in = Unpooled.wrappedBuffer(data);
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                channel.writeInbound(in);
-            }
-        }, "incorrect selectors number");
-        assertInstanceOf(DecompressionException.class, cause.getCause());
+        assertThrows(DecompressionException.class,
+                () -> channel.writeInbound(in), "incorrect selectors number");
     }
 
     @Test
@@ -179,13 +141,8 @@ public class Bzip2DecoderTest extends AbstractDecoderTest {
         data[11] = 0x77;
 
         final ByteBuf in = Unpooled.wrappedBuffer(data);
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                writeInboundDestroyAndExpectDecompressionException(in);
-            }
-        }, "block CRC error");
-        assertInstanceOf(DecompressionException.class, cause.getCause());
+        assertThrows(DecompressionException.class,
+                () -> writeInboundDestroyAndExpectDecompressionException(in), "block CRC error");
     }
 
     @Test
@@ -194,13 +151,8 @@ public class Bzip2DecoderTest extends AbstractDecoderTest {
         data[14] = (byte) 0xFF;
 
         final ByteBuf in = Unpooled.wrappedBuffer(data);
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                writeInboundDestroyAndExpectDecompressionException(in);
-            }
-        }, "start pointer invalid");
-        assertInstanceOf(DecompressionException.class, cause.getCause());
+        assertThrows(DecompressionException.class,
+                () -> writeInboundDestroyAndExpectDecompressionException(in), "start pointer invalid");
     }
 
     @Override

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/FastLzIntegrationTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/FastLzIntegrationTest.java
@@ -62,7 +62,7 @@ public class FastLzIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Override   // test batched flow of data
-    protected void testIdentity(final byte[] data, boolean heapBuffer) {
+    protected void testIdentity(final byte[] data, boolean heapBuffer) throws Exception {
         initChannels();
         final ByteBuf original = heapBuffer? Unpooled.wrappedBuffer(data) :
                 Unpooled.directBuffer(data.length).writeBytes(data);

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/JdkZlibTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/JdkZlibTest.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Queue;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.zip.CRC32;
 import java.util.zip.Deflater;
@@ -39,6 +40,7 @@ import java.util.zip.GZIPOutputStream;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -59,12 +61,13 @@ public class JdkZlibTest extends ZlibTest {
     @Test
     @Override
     public void testZLIB_OR_NONE3() throws Exception {
-        assertThrows(DecompressionException.class, new Executable() {
+        CompletionException cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
                 JdkZlibTest.super.testZLIB_OR_NONE3();
             }
         });
+        assertInstanceOf(DecompressionException.class, cause.getCause());
     }
 
     @Test
@@ -222,9 +225,10 @@ public class JdkZlibTest extends ZlibTest {
         compressed[compressed.length - 8] ^= 0xFF;
 
         EmbeddedChannel ch = new EmbeddedChannel(new JdkZlibDecoder(ZlibWrapper.GZIP, Integer.MAX_VALUE));
-        assertThrows(DecompressionException.class, () -> {
+        Throwable cause = assertThrows(CompletionException.class, () -> {
             ch.writeInbound(Unpooled.wrappedBuffer(compressed));
         });
+        assertInstanceOf(DecompressionException.class, cause.getCause());
         ch.finishAndReleaseAll();
     }
 
@@ -241,9 +245,10 @@ public class JdkZlibTest extends ZlibTest {
         compressed[compressed.length - 4] ^= 0xFF;
 
         EmbeddedChannel ch = new EmbeddedChannel(new JdkZlibDecoder(ZlibWrapper.GZIP, Integer.MAX_VALUE));
-        assertThrows(DecompressionException.class, () -> {
+        Throwable cause = assertThrows(CompletionException.class, () -> {
             ch.writeInbound(Unpooled.wrappedBuffer(compressed));
         });
+        assertInstanceOf(DecompressionException.class, cause.getCause());
         ch.finishAndReleaseAll();
     }
 

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/JdkZlibTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/JdkZlibTest.java
@@ -24,23 +24,19 @@ import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
 import org.apache.commons.compress.utils.IOUtils;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Queue;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.zip.CRC32;
 import java.util.zip.Deflater;
 import java.util.zip.GZIPOutputStream;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -61,18 +57,12 @@ public class JdkZlibTest extends ZlibTest {
     @Test
     @Override
     public void testZLIB_OR_NONE3() throws Exception {
-        CompletionException cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                JdkZlibTest.super.testZLIB_OR_NONE3();
-            }
-        });
-        assertInstanceOf(DecompressionException.class, cause.getCause());
+        assertThrows(DecompressionException.class, JdkZlibTest.super::testZLIB_OR_NONE3);
     }
 
     @Test
     // verifies backward compatibility
-    public void testConcatenatedStreamsReadFirstOnly() throws IOException {
+    public void testConcatenatedStreamsReadFirstOnly() throws Exception {
         EmbeddedChannel chDecoderGZip = new EmbeddedChannel(createDecoder(ZlibWrapper.GZIP));
 
         try (InputStream resourceAsStream = getClass().getResourceAsStream("/multiple.gz")) {
@@ -92,7 +82,7 @@ public class JdkZlibTest extends ZlibTest {
     }
 
     @Test
-    public void testConcatenatedStreamsReadFully() throws IOException {
+    public void testConcatenatedStreamsReadFully() throws Exception {
         EmbeddedChannel chDecoderGZip = new EmbeddedChannel(new JdkZlibDecoder(true, 0));
 
         try (InputStream resourceAsStream = getClass().getResourceAsStream("/multiple.gz")) {
@@ -114,7 +104,7 @@ public class JdkZlibTest extends ZlibTest {
     }
 
     @Test
-    public void testConcatenatedStreamsReadFullyWhenFragmented() throws IOException {
+    public void testConcatenatedStreamsReadFullyWhenFragmented() throws Exception {
         EmbeddedChannel chDecoderGZip = new EmbeddedChannel(new JdkZlibDecoder(true, 0));
 
         try (InputStream resourceAsStream = getClass().getResourceAsStream("/multiple.gz")) {
@@ -225,10 +215,9 @@ public class JdkZlibTest extends ZlibTest {
         compressed[compressed.length - 8] ^= 0xFF;
 
         EmbeddedChannel ch = new EmbeddedChannel(new JdkZlibDecoder(ZlibWrapper.GZIP, Integer.MAX_VALUE));
-        Throwable cause = assertThrows(CompletionException.class, () -> {
+        assertThrows(DecompressionException.class, () -> {
             ch.writeInbound(Unpooled.wrappedBuffer(compressed));
         });
-        assertInstanceOf(DecompressionException.class, cause.getCause());
         ch.finishAndReleaseAll();
     }
 
@@ -245,10 +234,9 @@ public class JdkZlibTest extends ZlibTest {
         compressed[compressed.length - 4] ^= 0xFF;
 
         EmbeddedChannel ch = new EmbeddedChannel(new JdkZlibDecoder(ZlibWrapper.GZIP, Integer.MAX_VALUE));
-        Throwable cause = assertThrows(CompletionException.class, () -> {
+        assertThrows(DecompressionException.class, () -> {
             ch.writeInbound(Unpooled.wrappedBuffer(compressed));
         });
-        assertInstanceOf(DecompressionException.class, cause.getCause());
         ch.finishAndReleaseAll();
     }
 

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/Lz4FrameDecoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/Lz4FrameDecoderTest.java
@@ -20,14 +20,11 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import net.jpountz.lz4.LZ4BlockOutputStream;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
-import java.util.concurrent.CompletionException;
 
 import static io.netty.handler.codec.compression.Lz4Constants.*;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class Lz4FrameDecoderTest extends AbstractDecoderTest {
@@ -56,13 +53,7 @@ public class Lz4FrameDecoderTest extends AbstractDecoderTest {
         data[1] = 0x00;
 
         final ByteBuf in = Unpooled.wrappedBuffer(data);
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                channel.writeInbound(in);
-            }
-        }, "unexpected block identifier");
-        assertInstanceOf(DecompressionException.class, cause.getCause());
+        assertThrows(DecompressionException.class, () -> channel.writeInbound(in), "unexpected block identifier");
     }
 
     @Test
@@ -71,13 +62,7 @@ public class Lz4FrameDecoderTest extends AbstractDecoderTest {
         data[12] = (byte) 0xFF;
 
         final ByteBuf in = Unpooled.wrappedBuffer(data);
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                channel.writeInbound(in);
-            }
-        }, "invalid compressedLength");
-        assertInstanceOf(DecompressionException.class, cause.getCause());
+        assertThrows(DecompressionException.class, () -> channel.writeInbound(in), "invalid compressedLength");
     }
 
     @Test
@@ -86,13 +71,8 @@ public class Lz4FrameDecoderTest extends AbstractDecoderTest {
         data[16] = (byte) 0xFF;
 
         final ByteBuf in = Unpooled.wrappedBuffer(data);
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                channel.writeInbound(in);
-            }
-        }, "invalid decompressedLength");
-        assertInstanceOf(DecompressionException.class, cause.getCause());
+        assertThrows(DecompressionException.class,
+                () -> channel.writeInbound(in), "invalid decompressedLength");
     }
 
     @Test
@@ -101,13 +81,7 @@ public class Lz4FrameDecoderTest extends AbstractDecoderTest {
         data[13] = 0x01;
 
         final ByteBuf in = Unpooled.wrappedBuffer(data);
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                channel.writeInbound(in);
-            }
-        }, "mismatch");
-        assertInstanceOf(DecompressionException.class, cause.getCause());
+        assertThrows(DecompressionException.class, () -> channel.writeInbound(in), "mismatch");
     }
 
     @Test
@@ -116,13 +90,7 @@ public class Lz4FrameDecoderTest extends AbstractDecoderTest {
         data[8] = 0x36;
 
         final ByteBuf in = Unpooled.wrappedBuffer(data);
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                channel.writeInbound(in);
-            }
-        }, "unexpected blockType");
-        assertInstanceOf(DecompressionException.class, cause.getCause());
+        assertThrows(DecompressionException.class, () -> channel.writeInbound(in), "unexpected blockType");
     }
 
     @Test
@@ -131,13 +99,8 @@ public class Lz4FrameDecoderTest extends AbstractDecoderTest {
         data[17] = 0x01;
 
         final ByteBuf in = Unpooled.wrappedBuffer(data);
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                channel.writeInbound(in);
-            }
-        }, "mismatching checksum");
-        assertInstanceOf(DecompressionException.class, cause.getCause());
+        assertThrows(DecompressionException.class,
+                () -> channel.writeInbound(in), "mismatching checksum");
     }
 
     @Test
@@ -145,14 +108,8 @@ public class Lz4FrameDecoderTest extends AbstractDecoderTest {
         final byte[] data = Arrays.copyOf(DATA, DATA.length);
         data[44] = 0x01;
 
-        Throwable cause = assertThrows(CompletionException.class,
-                new Executable() {
-                    @Override
-                    public void execute() {
-                        tryDecodeAndCatchBufLeaks(channel, Unpooled.wrappedBuffer(data));
-                    }
-                }, "checksum error");
-        assertInstanceOf(DecompressionException.class, cause.getCause());
+        assertThrows(DecompressionException.class,
+                () -> tryDecodeAndCatchBufLeaks(channel, Unpooled.wrappedBuffer(data)), "checksum error");
     }
 
     @Override

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/Lz4FrameDecoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/Lz4FrameDecoderTest.java
@@ -24,8 +24,10 @@ import org.junit.jupiter.api.function.Executable;
 
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
+import java.util.concurrent.CompletionException;
 
 import static io.netty.handler.codec.compression.Lz4Constants.*;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class Lz4FrameDecoderTest extends AbstractDecoderTest {
@@ -54,12 +56,13 @@ public class Lz4FrameDecoderTest extends AbstractDecoderTest {
         data[1] = 0x00;
 
         final ByteBuf in = Unpooled.wrappedBuffer(data);
-        assertThrows(DecompressionException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 channel.writeInbound(in);
             }
         }, "unexpected block identifier");
+        assertInstanceOf(DecompressionException.class, cause.getCause());
     }
 
     @Test
@@ -68,12 +71,13 @@ public class Lz4FrameDecoderTest extends AbstractDecoderTest {
         data[12] = (byte) 0xFF;
 
         final ByteBuf in = Unpooled.wrappedBuffer(data);
-        assertThrows(DecompressionException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 channel.writeInbound(in);
             }
         }, "invalid compressedLength");
+        assertInstanceOf(DecompressionException.class, cause.getCause());
     }
 
     @Test
@@ -82,12 +86,13 @@ public class Lz4FrameDecoderTest extends AbstractDecoderTest {
         data[16] = (byte) 0xFF;
 
         final ByteBuf in = Unpooled.wrappedBuffer(data);
-        assertThrows(DecompressionException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 channel.writeInbound(in);
             }
         }, "invalid decompressedLength");
+        assertInstanceOf(DecompressionException.class, cause.getCause());
     }
 
     @Test
@@ -96,12 +101,13 @@ public class Lz4FrameDecoderTest extends AbstractDecoderTest {
         data[13] = 0x01;
 
         final ByteBuf in = Unpooled.wrappedBuffer(data);
-        assertThrows(DecompressionException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 channel.writeInbound(in);
             }
         }, "mismatch");
+        assertInstanceOf(DecompressionException.class, cause.getCause());
     }
 
     @Test
@@ -110,12 +116,13 @@ public class Lz4FrameDecoderTest extends AbstractDecoderTest {
         data[8] = 0x36;
 
         final ByteBuf in = Unpooled.wrappedBuffer(data);
-        assertThrows(DecompressionException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 channel.writeInbound(in);
             }
         }, "unexpected blockType");
+        assertInstanceOf(DecompressionException.class, cause.getCause());
     }
 
     @Test
@@ -124,12 +131,13 @@ public class Lz4FrameDecoderTest extends AbstractDecoderTest {
         data[17] = 0x01;
 
         final ByteBuf in = Unpooled.wrappedBuffer(data);
-        assertThrows(DecompressionException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 channel.writeInbound(in);
             }
         }, "mismatching checksum");
+        assertInstanceOf(DecompressionException.class, cause.getCause());
     }
 
     @Test
@@ -137,13 +145,14 @@ public class Lz4FrameDecoderTest extends AbstractDecoderTest {
         final byte[] data = Arrays.copyOf(DATA, DATA.length);
         data[44] = 0x01;
 
-        assertThrows(DecompressionException.class,
+        Throwable cause = assertThrows(CompletionException.class,
                 new Executable() {
                     @Override
                     public void execute() {
                         tryDecodeAndCatchBufLeaks(channel, Unpooled.wrappedBuffer(data));
                     }
                 }, "checksum error");
+        assertInstanceOf(DecompressionException.class, cause.getCause());
     }
 
     @Override

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/Lz4FrameEncoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/Lz4FrameEncoderTest.java
@@ -197,7 +197,7 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
     }
 
     @Test
-    public void testFlush() {
+    public void testFlush() throws Exception {
         Lz4FrameEncoder encoder = new Lz4FrameEncoder();
         EmbeddedChannel channel = new EmbeddedChannel(encoder);
         int size = 27;
@@ -214,7 +214,7 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
     }
 
     @Test
-    public void testAllocatingAroundBlockSize() {
+    public void testAllocatingAroundBlockSize() throws Exception {
         int blockSize = 100;
         Lz4FrameEncoder encoder = newEncoder(blockSize, Lz4FrameEncoder.DEFAULT_MAX_ENCODE_SIZE);
         EmbeddedChannel channel = new EmbeddedChannel(encoder);

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/LzfDecoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/LzfDecoderTest.java
@@ -23,7 +23,10 @@ import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
+import java.util.concurrent.CompletionException;
+
 import static com.ning.compress.lzf.LZFChunk.*;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class LzfDecoderTest extends AbstractDecoderTest {
@@ -43,12 +46,13 @@ public class LzfDecoderTest extends AbstractDecoderTest {
         in.writeByte(BLOCK_TYPE_NON_COMPRESSED);
         in.writeShort(0);
 
-        assertThrows(DecompressionException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 channel.writeInbound(in);
             }
         }, "unexpected block identifier");
+        assertInstanceOf(DecompressionException.class, cause.getCause());
     }
 
     @Test
@@ -59,12 +63,13 @@ public class LzfDecoderTest extends AbstractDecoderTest {
         in.writeByte(0xFF);   //random value
         in.writeInt(0);
 
-        assertThrows(DecompressionException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 channel.writeInbound(in);
             }
         }, "unknown type of chunk");
+        assertInstanceOf(DecompressionException.class, cause.getCause());
     }
 
     @Override

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/LzfDecoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/LzfDecoderTest.java
@@ -21,12 +21,8 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
-
-import java.util.concurrent.CompletionException;
 
 import static com.ning.compress.lzf.LZFChunk.*;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class LzfDecoderTest extends AbstractDecoderTest {
@@ -46,13 +42,8 @@ public class LzfDecoderTest extends AbstractDecoderTest {
         in.writeByte(BLOCK_TYPE_NON_COMPRESSED);
         in.writeShort(0);
 
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                channel.writeInbound(in);
-            }
-        }, "unexpected block identifier");
-        assertInstanceOf(DecompressionException.class, cause.getCause());
+        Throwable cause = assertThrows(DecompressionException.class,
+                () -> channel.writeInbound(in), "unexpected block identifier");
     }
 
     @Test
@@ -63,13 +54,7 @@ public class LzfDecoderTest extends AbstractDecoderTest {
         in.writeByte(0xFF);   //random value
         in.writeInt(0);
 
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                channel.writeInbound(in);
-            }
-        }, "unknown type of chunk");
-        assertInstanceOf(DecompressionException.class, cause.getCause());
+        assertThrows(DecompressionException.class, () -> channel.writeInbound(in), "unknown type of chunk");
     }
 
     @Override

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/SnappyFrameDecoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/SnappyFrameDecoderTest.java
@@ -23,8 +23,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
+import java.util.concurrent.CompletionException;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -48,12 +51,13 @@ public class SnappyFrameDecoderTest {
             0x03, 0x01, 0x00, 0x00, 0x00
         });
 
-        assertThrows(DecompressionException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 channel.writeInbound(in);
             }
         });
+        assertInstanceOf(DecompressionException.class, cause.getCause());
     }
 
     @Test
@@ -62,12 +66,13 @@ public class SnappyFrameDecoderTest {
             -0x80, 0x05, 0x00, 0x00, 'n', 'e', 't', 't', 'y'
         });
 
-        assertThrows(DecompressionException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 channel.writeInbound(in);
             }
         });
+        assertInstanceOf(DecompressionException.class, cause.getCause());
     }
 
     @Test
@@ -76,12 +81,13 @@ public class SnappyFrameDecoderTest {
             (byte) 0xff, 0x06, 0x00, 0x00, 's', 'n', 'e', 't', 't', 'y'
         });
 
-        assertThrows(DecompressionException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 channel.writeInbound(in);
             }
         });
+        assertInstanceOf(DecompressionException.class, cause.getCause());
     }
 
     @Test
@@ -90,12 +96,13 @@ public class SnappyFrameDecoderTest {
             -0x7f, 0x06, 0x00, 0x00, 's', 'n', 'e', 't', 't', 'y'
         });
 
-        assertThrows(DecompressionException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 channel.writeInbound(in);
             }
         });
+        assertInstanceOf(DecompressionException.class, cause.getCause());
     }
 
     @Test
@@ -104,12 +111,13 @@ public class SnappyFrameDecoderTest {
             0x01, 0x05, 0x00, 0x00, 'n', 'e', 't', 't', 'y'
         });
 
-        assertThrows(DecompressionException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
                 channel.writeInbound(in);
             }
         });
+        assertInstanceOf(DecompressionException.class, cause.getCause());
     }
 
     @Test
@@ -118,12 +126,13 @@ public class SnappyFrameDecoderTest {
             0x00, 0x05, 0x00, 0x00, 'n', 'e', 't', 't', 'y'
         });
 
-        assertThrows(DecompressionException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 channel.writeInbound(in);
             }
         });
+        assertInstanceOf(DecompressionException.class, cause.getCause());
     }
 
     @Test
@@ -190,12 +199,13 @@ public class SnappyFrameDecoderTest {
                     0x01, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 'n', 'e', 't', 't', 'y'
             });
 
-            assertThrows(DecompressionException.class, new Executable() {
+            Throwable cause = assertThrows(CompletionException.class, new Executable() {
                 @Override
                 public void execute() {
                     channel.writeInbound(in);
                 }
             });
+            assertInstanceOf(DecompressionException.class, cause.getCause());
         } finally {
             channel.finishAndReleaseAll();
         }

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/SnappyFrameDecoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/SnappyFrameDecoderTest.java
@@ -23,11 +23,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
-import java.util.concurrent.CompletionException;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -41,7 +38,7 @@ public class SnappyFrameDecoderTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    public void tearDown() throws Exception {
         assertFalse(channel.finishAndReleaseAll());
     }
 
@@ -51,13 +48,7 @@ public class SnappyFrameDecoderTest {
             0x03, 0x01, 0x00, 0x00, 0x00
         });
 
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                channel.writeInbound(in);
-            }
-        });
-        assertInstanceOf(DecompressionException.class, cause.getCause());
+        assertThrows(DecompressionException.class, () -> channel.writeInbound(in));
     }
 
     @Test
@@ -66,13 +57,7 @@ public class SnappyFrameDecoderTest {
             -0x80, 0x05, 0x00, 0x00, 'n', 'e', 't', 't', 'y'
         });
 
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                channel.writeInbound(in);
-            }
-        });
-        assertInstanceOf(DecompressionException.class, cause.getCause());
+        assertThrows(DecompressionException.class, () -> channel.writeInbound(in));
     }
 
     @Test
@@ -81,13 +66,12 @@ public class SnappyFrameDecoderTest {
             (byte) 0xff, 0x06, 0x00, 0x00, 's', 'n', 'e', 't', 't', 'y'
         });
 
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
+        assertThrows(DecompressionException.class, new Executable() {
             @Override
-            public void execute() {
+            public void execute() throws Exception {
                 channel.writeInbound(in);
             }
         });
-        assertInstanceOf(DecompressionException.class, cause.getCause());
     }
 
     @Test
@@ -96,13 +80,7 @@ public class SnappyFrameDecoderTest {
             -0x7f, 0x06, 0x00, 0x00, 's', 'n', 'e', 't', 't', 'y'
         });
 
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                channel.writeInbound(in);
-            }
-        });
-        assertInstanceOf(DecompressionException.class, cause.getCause());
+        assertThrows(DecompressionException.class, () -> channel.writeInbound(in));
     }
 
     @Test
@@ -111,13 +89,7 @@ public class SnappyFrameDecoderTest {
             0x01, 0x05, 0x00, 0x00, 'n', 'e', 't', 't', 'y'
         });
 
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                channel.writeInbound(in);
-            }
-        });
-        assertInstanceOf(DecompressionException.class, cause.getCause());
+        assertThrows(DecompressionException.class, () -> channel.writeInbound(in));
     }
 
     @Test
@@ -126,17 +98,11 @@ public class SnappyFrameDecoderTest {
             0x00, 0x05, 0x00, 0x00, 'n', 'e', 't', 't', 'y'
         });
 
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                channel.writeInbound(in);
-            }
-        });
-        assertInstanceOf(DecompressionException.class, cause.getCause());
+        assertThrows(DecompressionException.class, () -> channel.writeInbound(in));
     }
 
     @Test
-    public void testReservedSkippableSkipsInput() {
+    public void testReservedSkippableSkipsInput() throws Exception {
         ByteBuf in = Unpooled.wrappedBuffer(new byte[] {
            (byte) 0xff, 0x06, 0x00, 0x00, 0x73, 0x4e, 0x61, 0x50, 0x70, 0x59,
            -0x7f, 0x05, 0x00, 0x00, 'n', 'e', 't', 't', 'y'
@@ -149,7 +115,7 @@ public class SnappyFrameDecoderTest {
     }
 
     @Test
-    public void testUncompressedDataAppendsToOut() {
+    public void testUncompressedDataAppendsToOut() throws Exception {
         ByteBuf in = Unpooled.wrappedBuffer(new byte[] {
            (byte) 0xff, 0x06, 0x00, 0x00, 0x73, 0x4e, 0x61, 0x50, 0x70, 0x59,
             0x01, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 'n', 'e', 't', 't', 'y'
@@ -166,7 +132,7 @@ public class SnappyFrameDecoderTest {
     }
 
     @Test
-    public void testCompressedDataDecodesAndAppendsToOut() {
+    public void testCompressedDataDecodesAndAppendsToOut() throws Exception {
         ByteBuf in = Unpooled.wrappedBuffer(new byte[] {
            (byte) 0xff, 0x06, 0x00, 0x00, 0x73, 0x4e, 0x61, 0x50, 0x70, 0x59,
             0x00, 0x0B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -190,7 +156,7 @@ public class SnappyFrameDecoderTest {
     // uncompressed string "netty"
 
     @Test
-    public void testInvalidChecksumThrowsException() {
+    public void testInvalidChecksumThrowsException() throws Exception {
         final EmbeddedChannel channel = new EmbeddedChannel(new SnappyFrameDecoder(true));
         try {
             // checksum here is presented as 0
@@ -199,20 +165,14 @@ public class SnappyFrameDecoderTest {
                     0x01, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 'n', 'e', 't', 't', 'y'
             });
 
-            Throwable cause = assertThrows(CompletionException.class, new Executable() {
-                @Override
-                public void execute() {
-                    channel.writeInbound(in);
-                }
-            });
-            assertInstanceOf(DecompressionException.class, cause.getCause());
+            assertThrows(DecompressionException.class, () -> channel.writeInbound(in));
         } finally {
             channel.finishAndReleaseAll();
         }
     }
 
     @Test
-    public void testInvalidChecksumDoesNotThrowException() {
+    public void testInvalidChecksumDoesNotThrowException() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new SnappyFrameDecoder(true));
         try {
             // checksum here is presented as a282986f (little endian)

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/SnappyIntegrationTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/SnappyIntegrationTest.java
@@ -71,14 +71,14 @@ public class SnappyIntegrationTest extends AbstractIntegrationTest {
 
     // Tests that copies do not attempt to overrun into a previous frame chunk
     @Test
-    public void test5323211032315942961() {
+    public void test5323211032315942961() throws Exception {
         testWithSeed(5323211032315942961L);
     }
 
     // Tests that when generating the hash lookup table for finding copies, we
     // do not exceed the length of the input when there are no copies
     @Test
-    public void test7088170877360183401() {
+    public void test7088170877360183401() throws Exception {
         testWithSeed(7088170877360183401L);
     }
 
@@ -101,7 +101,7 @@ public class SnappyIntegrationTest extends AbstractIntegrationTest {
         }
     }
 
-    private void testWithSeed(long seed) {
+    private void testWithSeed(long seed) throws Exception {
         byte[] data = new byte[16 * 1048576];
         new Random(seed).nextBytes(data);
         testIdentity(data, true);

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/ZlibCrossTest2.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/ZlibCrossTest2.java
@@ -18,6 +18,9 @@ package io.netty.handler.codec.compression;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
+import java.util.concurrent.CompletionException;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ZlibCrossTest2 extends ZlibTest {
@@ -35,11 +38,12 @@ public class ZlibCrossTest2 extends ZlibTest {
     @Test
     @Override
     public void testZLIB_OR_NONE3() throws Exception {
-        assertThrows(DecompressionException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
                 ZlibCrossTest2.super.testZLIB_OR_NONE3();
             }
         });
+        assertInstanceOf(DecompressionException.class, cause.getCause());
     }
 }

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/ZlibCrossTest2.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/ZlibCrossTest2.java
@@ -16,11 +16,7 @@
 package io.netty.handler.codec.compression;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
-import java.util.concurrent.CompletionException;
-
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ZlibCrossTest2 extends ZlibTest {
@@ -38,12 +34,6 @@ public class ZlibCrossTest2 extends ZlibTest {
     @Test
     @Override
     public void testZLIB_OR_NONE3() throws Exception {
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                ZlibCrossTest2.super.testZLIB_OR_NONE3();
-            }
-        });
-        assertInstanceOf(DecompressionException.class, cause.getCause());
+        assertThrows(DecompressionException.class, ZlibCrossTest2.super::testZLIB_OR_NONE3);
     }
 }

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/ZlibTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/ZlibTest.java
@@ -25,13 +25,11 @@ import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.EmptyArrays;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Random;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.GZIPInputStream;
@@ -268,23 +266,8 @@ public abstract class ZlibTest {
         }
     }
 
-    private static void dispose(EmbeddedChannel ch) {
-        if (ch.finish()) {
-            for (;;) {
-                Object msg = ch.readInbound();
-                if (msg == null) {
-                    break;
-                }
-                ReferenceCountUtil.release(msg);
-            }
-            for (;;) {
-                Object msg = ch.readOutbound();
-                if (msg == null) {
-                    break;
-                }
-                ReferenceCountUtil.release(msg);
-            }
-        }
+    private static void dispose(EmbeddedChannel ch) throws Exception {
+        ch.finishAndReleaseAll();
     }
 
     // Test for https://github.com/netty/netty/issues/2572
@@ -350,7 +333,7 @@ public abstract class ZlibTest {
         testGZIPCompressOnly0(BYTES_LARGE);
     }
 
-    private void testGZIPCompressOnly0(byte[] data) throws IOException {
+    private void testGZIPCompressOnly0(byte[] data) throws Exception {
         EmbeddedChannel chEncoder = new EmbeddedChannel(createEncoder(ZlibWrapper.GZIP));
         if (data != null) {
             chEncoder.writeOutbound(Unpooled.wrappedBuffer(data));
@@ -417,13 +400,8 @@ public abstract class ZlibTest {
         TestByteBufAllocator alloc = new TestByteBufAllocator(chDecoder.alloc());
         chDecoder.config().setAllocator(alloc);
 
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                chDecoder.writeInbound(Unpooled.wrappedBuffer(deflate(BYTES_LARGE)));
-            }
-        });
-        DecompressionException e = (DecompressionException) cause.getCause();
+        DecompressionException e = assertThrows(DecompressionException.class,
+                () -> chDecoder.writeInbound(Unpooled.wrappedBuffer(deflate(BYTES_LARGE))));
         assertTrue(e.getMessage().startsWith("Decompression buffer has reached maximum size"));
         assertEquals(maxAllocation, alloc.getMaxAllocation());
         assertTrue(decoder.isClosed());

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/ZlibTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/ZlibTest.java
@@ -31,6 +31,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Random;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.GZIPInputStream;
@@ -416,12 +417,13 @@ public abstract class ZlibTest {
         TestByteBufAllocator alloc = new TestByteBufAllocator(chDecoder.alloc());
         chDecoder.config().setAllocator(alloc);
 
-        DecompressionException e = assertThrows(DecompressionException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
                 chDecoder.writeInbound(Unpooled.wrappedBuffer(deflate(BYTES_LARGE)));
             }
         });
+        DecompressionException e = (DecompressionException) cause.getCause();
         assertTrue(e.getMessage().startsWith("Decompression buffer has reached maximum size"));
         assertEquals(maxAllocation, alloc.getMaxAllocation());
         assertTrue(decoder.isClosed());

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsQueryTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsQueryTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class DnsQueryTest {
 
     @Test
-    public void testEncodeAndDecodeQuery() {
+    public void testEncodeAndDecodeQuery() throws Exception {
         InetSocketAddress addr = SocketUtils.socketAddress("8.8.8.8", 53);
         EmbeddedChannel writeChannel = new EmbeddedChannel(new DatagramDnsQueryEncoder());
         EmbeddedChannel readChannel = new EmbeddedChannel(new DatagramDnsQueryDecoder());

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsResponseTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsResponseTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
 import java.net.InetSocketAddress;
+import java.util.concurrent.CompletionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -100,12 +101,13 @@ public class DnsResponseTest {
         final EmbeddedChannel embedder = new EmbeddedChannel(new DatagramDnsResponseDecoder());
         final ByteBuf packet = embedder.alloc().buffer(512).writeBytes(malformedLoopPacket);
         try {
-            assertThrows(CorruptedFrameException.class, new Executable() {
+            Throwable cause = assertThrows(CompletionException.class, new Executable() {
                 @Override
                 public void execute() {
                     embedder.writeInbound(new DatagramPacket(packet, null, new InetSocketAddress(0)));
                 }
             });
+            assertInstanceOf(CorruptedFrameException.class, cause.getCause());
         } finally {
             assertFalse(embedder.finish());
         }
@@ -116,12 +118,13 @@ public class DnsResponseTest {
         final EmbeddedChannel embedder = new EmbeddedChannel(new DatagramDnsResponseDecoder());
         final ByteBuf packet = embedder.alloc().buffer(512);
         try {
-            assertThrows(CorruptedFrameException.class, new Executable() {
+            Throwable cause = assertThrows(CompletionException.class, new Executable() {
                 @Override
                 public void execute() {
                     embedder.writeInbound(new DatagramPacket(packet, null, new InetSocketAddress(0)));
                 }
             });
+            assertInstanceOf(CorruptedFrameException.class, cause.getCause());
         } finally {
             assertFalse(embedder.finish());
         }

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsResponseTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsResponseTest.java
@@ -22,10 +22,8 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.handler.codec.CorruptedFrameException;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 import java.net.InetSocketAddress;
-import java.util.concurrent.CompletionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -74,7 +72,7 @@ public class DnsResponseTest {
     };
 
     @Test
-    public void readResponseTest() {
+    public void readResponseTest() throws Exception {
         EmbeddedChannel embedder = new EmbeddedChannel(new DatagramDnsResponseDecoder());
         for (byte[] p: packets) {
             ByteBuf packet = embedder.alloc().buffer(512).writeBytes(p);
@@ -97,34 +95,24 @@ public class DnsResponseTest {
     }
 
     @Test
-    public void readMalformedResponseTest() {
+    public void readMalformedResponseTest() throws Exception {
         final EmbeddedChannel embedder = new EmbeddedChannel(new DatagramDnsResponseDecoder());
         final ByteBuf packet = embedder.alloc().buffer(512).writeBytes(malformedLoopPacket);
         try {
-            Throwable cause = assertThrows(CompletionException.class, new Executable() {
-                @Override
-                public void execute() {
-                    embedder.writeInbound(new DatagramPacket(packet, null, new InetSocketAddress(0)));
-                }
-            });
-            assertInstanceOf(CorruptedFrameException.class, cause.getCause());
+            assertThrows(CorruptedFrameException.class,
+                    () -> embedder.writeInbound(new DatagramPacket(packet, null, new InetSocketAddress(0))));
         } finally {
             assertFalse(embedder.finish());
         }
     }
 
     @Test
-    public void readIncompleteResponseTest() {
+    public void readIncompleteResponseTest() throws Exception {
         final EmbeddedChannel embedder = new EmbeddedChannel(new DatagramDnsResponseDecoder());
         final ByteBuf packet = embedder.alloc().buffer(512);
         try {
-            Throwable cause = assertThrows(CompletionException.class, new Executable() {
-                @Override
-                public void execute() {
-                    embedder.writeInbound(new DatagramPacket(packet, null, new InetSocketAddress(0)));
-                }
-            });
-            assertInstanceOf(CorruptedFrameException.class, cause.getCause());
+            assertThrows(CorruptedFrameException.class,
+                    () -> embedder.writeInbound(new DatagramPacket(packet, null, new InetSocketAddress(0))));
         } finally {
             assertFalse(embedder.finish());
         }

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/TcpDnsTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/TcpDnsTest.java
@@ -33,7 +33,7 @@ public class TcpDnsTest {
     private static final byte[] QUERY_RESULT = new byte[]{(byte) 192, (byte) 168, 1, 1};
 
     @Test
-    public void testQueryDecode() {
+    public void testQueryDecode() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new TcpDnsQueryDecoder());
 
         int randomID = new Random().nextInt(60000 - 1000) + 1000;
@@ -49,7 +49,7 @@ public class TcpDnsTest {
     }
 
     @Test
-    public void testDecoderLeak() {
+    public void testDecoderLeak() throws Exception {
         EmbeddedChannel decoder = new EmbeddedChannel(new TcpDnsQueryDecoder());
         EmbeddedChannel encoder = new EmbeddedChannel(new TcpDnsQueryEncoder());
         int randomID = new Random().nextInt(60000 - 1000) + 1000;
@@ -71,7 +71,7 @@ public class TcpDnsTest {
     }
 
     @Test
-    public void testResponseEncode() {
+    public void testResponseEncode() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new TcpDnsResponseEncoder());
 
         int randomID = new Random().nextInt(60000 - 1000) + 1000;

--- a/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HAProxyMessageDecoderTest.java
+++ b/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HAProxyMessageDecoderTest.java
@@ -26,20 +26,17 @@ import io.netty.util.CharsetUtil;
 import io.netty.util.concurrent.Future;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.List;
-import java.util.concurrent.CompletionException;
 
 import static io.netty.buffer.Unpooled.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -54,7 +51,7 @@ public class HAProxyMessageDecoderTest {
     }
 
     @Test
-    public void testIPV4Decode() {
+    public void testIPV4Decode() throws Exception {
         int startChannels = ch.pipeline().names().size();
         String header = "PROXY TCP4 192.168.0.1 192.168.0.11 56324 443\r\n";
         ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII));
@@ -75,7 +72,7 @@ public class HAProxyMessageDecoderTest {
     }
 
     @Test
-    public void testIPV6Decode() {
+    public void testIPV6Decode() throws Exception {
         int startChannels = ch.pipeline().names().size();
         String header = "PROXY TCP6 2001:0db8:85a3:0000:0000:8a2e:0370:7334 1050:0:0:0:5:600:300c:326b 56324 443\r\n";
         ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII));
@@ -96,7 +93,7 @@ public class HAProxyMessageDecoderTest {
     }
 
     @Test
-    public void testUnknownProtocolDecode() {
+    public void testUnknownProtocolDecode() throws Exception {
         int startChannels = ch.pipeline().names().size();
         String header = "PROXY UNKNOWN 192.168.0.1 192.168.0.11 56324 443\r\n";
         ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII));
@@ -119,127 +116,75 @@ public class HAProxyMessageDecoderTest {
     @Test
     public void testV1NoUDP() {
         final String header = "PROXY UDP4 192.168.0.1 192.168.0.11 56324 443\r\n";
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII));
-            }
-        });
-        assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
+        assertThrows(HAProxyProtocolException.class,
+                () -> ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII)));
     }
 
     @Test
     public void testInvalidPort() {
         final String header = "PROXY TCP4 192.168.0.1 192.168.0.11 80000 443\r\n";
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII));
-            }
-        });
-        assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
+        assertThrows(HAProxyProtocolException.class,
+                () -> ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII)));
     }
 
     @Test
     public void testInvalidIPV4Address() {
         final String header = "PROXY TCP4 299.168.0.1 192.168.0.11 56324 443\r\n";
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII));
-            }
-        });
-        assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
+        assertThrows(HAProxyProtocolException.class,
+                () -> ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII)));
     }
 
     @Test
     public void testInvalidIPV6Address() {
         final String header =
                 "PROXY TCP6 r001:0db8:85a3:0000:0000:8a2e:0370:7334 1050:0:0:0:5:600:300c:326b 56324 443\r\n";
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII));
-            }
-        });
-        assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
+        assertThrows(HAProxyProtocolException.class,
+                () -> ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII)));
     }
 
     @Test
     public void testInvalidProtocol() {
         final String header = "PROXY TCP7 192.168.0.1 192.168.0.11 56324 443\r\n";
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII));
-            }
-        });
-        assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
+        assertThrows(HAProxyProtocolException.class, () -> ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII)));
     }
 
     @Test
     public void testMissingParams() {
         final String header = "PROXY TCP4 192.168.0.1 192.168.0.11 56324\r\n";
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII));
-            }
-        });
-        assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
+        assertThrows(HAProxyProtocolException.class, () -> ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII)));
     }
 
     @Test
     public void testTooManyParams() {
         final String header = "PROXY TCP4 192.168.0.1 192.168.0.11 56324 443 123\r\n";
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII));
-            }
-        });
-        assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
+        assertThrows(HAProxyProtocolException.class,
+                () -> ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII)));
     }
 
     @Test
     public void testInvalidCommand() {
         final String header = "PING TCP4 192.168.0.1 192.168.0.11 56324 443\r\n";
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII));
-            }
-        });
-        assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
+        assertThrows(HAProxyProtocolException.class,
+                () -> ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII)));
     }
 
     @Test
     public void testInvalidEOL() {
         final String header = "PROXY TCP4 192.168.0.1 192.168.0.11 56324 443\nGET / HTTP/1.1\r\n";
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII));
-            }
-        });
-        assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
+        assertThrows(HAProxyProtocolException.class,
+                () -> ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII)));
     }
 
     @Test
     public void testHeaderTooLong() {
         final String header = "PROXY TCP4 192.168.0.1 192.168.0.11 56324 " +
                         "00000000000000000000000000000000000000000000000000000000000000000443\r\n";
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII));
-            }
-        });
-        assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
+        assertThrows(HAProxyProtocolException.class,
+                () -> ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII)));
     }
 
     @Test
-    public void testFailSlowHeaderTooLong() {
+    public void testFailSlowHeaderTooLong() throws Exception {
         final EmbeddedChannel slowFailCh = new EmbeddedChannel(new HAProxyMessageDecoder(false));
         try {
             String headerPart1 = "PROXY TCP4 192.168.0.1 192.168.0.11 56324 " +
@@ -252,38 +197,28 @@ public class HAProxyMessageDecoderTest {
             final String headerPart3 = "end of header\r\n";
 
             int discarded = headerPart1.length() + headerPart2.length() + headerPart3.length() - 2;
-            CompletionException cause = assertThrows(CompletionException.class, new Executable() {
-                @Override
-                public void execute() {
-                    slowFailCh.writeInbound(copiedBuffer(headerPart3, CharsetUtil.US_ASCII));
-                }
-            }, "over " + discarded);
-            assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
+            assertThrows(HAProxyProtocolException.class,
+                    () -> slowFailCh.writeInbound(copiedBuffer(headerPart3, CharsetUtil.US_ASCII)), "over " + discarded);
         } finally {
             assertFalse(slowFailCh.finishAndReleaseAll());
         }
     }
 
     @Test
-    public void testFailFastHeaderTooLong() {
+    public void testFailFastHeaderTooLong() throws Exception {
         final EmbeddedChannel fastFailCh = new EmbeddedChannel(new HAProxyMessageDecoder(true));
         try {
             final String headerPart1 = "PROXY TCP4 192.168.0.1 192.168.0.11 56324 " +
                                  "000000000000000000000000000000000000000000000000000000000000000000000443";
-            Throwable cause = assertThrows(CompletionException.class, new Executable() {
-                        @Override
-                        public void execute() {
-                            fastFailCh.writeInbound(copiedBuffer(headerPart1, CharsetUtil.US_ASCII));
-                        }
-                    }, "over " + headerPart1.length());
-            assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
+            assertThrows(HAProxyProtocolException.class,
+                    () -> fastFailCh.writeInbound(copiedBuffer(headerPart1, CharsetUtil.US_ASCII)), "over " + headerPart1.length());
         } finally {
             assertFalse(fastFailCh.finishAndReleaseAll());
         }
     }
 
     @Test
-    public void testIncompleteHeader() {
+    public void testIncompleteHeader() throws Exception {
         String header = "PROXY TCP4 192.168.0.1 192.168.0.11 56324";
         ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII));
         assertNull(ch.readInbound());
@@ -296,7 +231,7 @@ public class HAProxyMessageDecoderTest {
         String header = "GET / HTTP/1.1\r\n";
         try {
             ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII));
-        } catch (CompletionException ppex) {
+        } catch (Exception ppex) {
             // swallow this exception since we're just testing to be sure the channel was closed
         }
         boolean isComplete = closeFuture.awaitUninterruptibly(5000);
@@ -333,7 +268,7 @@ public class HAProxyMessageDecoderTest {
     }
 
     @Test
-    public void testV2IPV4Decode() {
+    public void testV2IPV4Decode() throws Exception {
         byte[] header = new byte[28];
         header[0] = 0x0D; // Binary Prefix
         header[1] = 0x0A; // -----
@@ -389,7 +324,7 @@ public class HAProxyMessageDecoderTest {
     }
 
     @Test
-    public void testV2UDPDecode() {
+    public void testV2UDPDecode() throws Exception {
         byte[] header = new byte[28];
         header[0] = 0x0D; // Binary Prefix
         header[1] = 0x0A; // -----
@@ -445,7 +380,7 @@ public class HAProxyMessageDecoderTest {
     }
 
     @Test
-    public void testv2IPV6Decode() {
+    public void testv2IPV6Decode() throws Exception {
         byte[] header = new byte[52];
         header[0] = 0x0D; // Binary Prefix
         header[1] = 0x0A; // -----
@@ -525,7 +460,7 @@ public class HAProxyMessageDecoderTest {
     }
 
     @Test
-    public void testv2UnixDecode() {
+    public void testv2UnixDecode() throws Exception {
         byte[] header = new byte[232];
         header[0] = 0x0D; // Binary Prefix
         header[1] = 0x0A; // -----
@@ -604,7 +539,7 @@ public class HAProxyMessageDecoderTest {
     }
 
     @Test
-    public void testV2LocalProtocolDecode() {
+    public void testV2LocalProtocolDecode() throws Exception {
         byte[] header = new byte[28];
         header[0] = 0x0D; // Binary Prefix
         header[1] = 0x0A; // -----
@@ -660,7 +595,7 @@ public class HAProxyMessageDecoderTest {
     }
 
     @Test
-    public void testV2UnknownProtocolDecode() {
+    public void testV2UnknownProtocolDecode() throws Exception {
         byte[] header = new byte[28];
         header[0] = 0x0D; // Binary Prefix
         header[1] = 0x0A; // -----
@@ -716,7 +651,7 @@ public class HAProxyMessageDecoderTest {
     }
 
     @Test
-    public void testV2WithSslTLVs() {
+    public void testV2WithSslTLVs() throws Exception {
         ch = new EmbeddedChannel(new HAProxyMessageDecoder());
 
         final byte[] bytes = {
@@ -779,7 +714,7 @@ public class HAProxyMessageDecoderTest {
     }
 
     @Test
-    public void testReleaseHAProxyMessage() {
+    public void testReleaseHAProxyMessage() throws Exception {
         ch = new EmbeddedChannel(new HAProxyMessageDecoder());
 
         final byte[] bytes = {
@@ -824,7 +759,7 @@ public class HAProxyMessageDecoderTest {
     }
 
     @Test
-    public void testV2WithTLV() {
+    public void testV2WithTLV() throws Exception {
         ch = new EmbeddedChannel(new HAProxyMessageDecoder(4));
 
         byte[] header = new byte[236];
@@ -949,13 +884,7 @@ public class HAProxyMessageDecoderTest {
         header[26] = 0x01; // Destination Port
         header[27] = (byte) 0xbb; // -----
 
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                ch.writeInbound(copiedBuffer(header));
-            }
-        });
-        assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
+        assertThrows(HAProxyProtocolException.class, () -> ch.writeInbound(copiedBuffer(header)));
     }
 
     @Test
@@ -993,13 +922,7 @@ public class HAProxyMessageDecoderTest {
         header[24] = (byte) 0xdc; // Source Port
         header[25] = 0x04; // -----
 
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                ch.writeInbound(copiedBuffer(header));
-            }
-        });
-        assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
+        assertThrows(HAProxyProtocolException.class, () -> ch.writeInbound(copiedBuffer(header)));
     }
 
     @Test
@@ -1040,13 +963,7 @@ public class HAProxyMessageDecoderTest {
         header[26] = 0x01; // Destination Port
         header[27] = (byte) 0xbb; // -----
 
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                ch.writeInbound(copiedBuffer(header));
-            }
-        });
-        assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
+        assertThrows(HAProxyProtocolException.class, () -> ch.writeInbound(copiedBuffer(header)));
     }
 
     @Test
@@ -1087,13 +1004,7 @@ public class HAProxyMessageDecoderTest {
         header[26] = 0x01; // Destination Port
         header[27] = (byte) 0xbb; // -----
 
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                ch.writeInbound(copiedBuffer(header));
-            }
-        });
-        assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
+        assertThrows(HAProxyProtocolException.class, () -> ch.writeInbound(copiedBuffer(header)));
     }
 
     @Test
@@ -1136,17 +1047,11 @@ public class HAProxyMessageDecoderTest {
         header[26] = 0x01; // Destination Port
         header[27] = (byte) 0xbb; // -----
 
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                ch.writeInbound(copiedBuffer(header));
-            }
-        });
-        assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
+        assertThrows(HAProxyProtocolException.class, () -> ch.writeInbound(copiedBuffer(header)));
     }
 
     @Test
-    public void testV2IncompleteHeader() {
+    public void testV2IncompleteHeader() throws Exception {
         byte[] header = new byte[13];
         header[0] = 0x0D; // Binary Prefix
         header[1] = 0x0A; // -----
@@ -1268,12 +1173,6 @@ public class HAProxyMessageDecoderTest {
         data.writeBytes(numsWrite.array());
         data.writeBytes(header);
 
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                ch.writeInbound(data);
-            }
-        });
-        assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
+        assertThrows(HAProxyProtocolException.class, () -> ch.writeInbound(data));
     }
 }

--- a/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HAProxyMessageDecoderTest.java
+++ b/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HAProxyMessageDecoderTest.java
@@ -32,12 +32,14 @@ import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.List;
+import java.util.concurrent.CompletionException;
 
 import static io.netty.buffer.Unpooled.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -117,113 +119,123 @@ public class HAProxyMessageDecoderTest {
     @Test
     public void testV1NoUDP() {
         final String header = "PROXY UDP4 192.168.0.1 192.168.0.11 56324 443\r\n";
-        assertThrows(HAProxyProtocolException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII));
             }
         });
+        assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
     }
 
     @Test
     public void testInvalidPort() {
         final String header = "PROXY TCP4 192.168.0.1 192.168.0.11 80000 443\r\n";
-        assertThrows(HAProxyProtocolException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII));
             }
         });
+        assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
     }
 
     @Test
     public void testInvalidIPV4Address() {
         final String header = "PROXY TCP4 299.168.0.1 192.168.0.11 56324 443\r\n";
-        assertThrows(HAProxyProtocolException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII));
             }
         });
+        assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
     }
 
     @Test
     public void testInvalidIPV6Address() {
         final String header =
                 "PROXY TCP6 r001:0db8:85a3:0000:0000:8a2e:0370:7334 1050:0:0:0:5:600:300c:326b 56324 443\r\n";
-        assertThrows(HAProxyProtocolException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII));
             }
         });
+        assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
     }
 
     @Test
     public void testInvalidProtocol() {
         final String header = "PROXY TCP7 192.168.0.1 192.168.0.11 56324 443\r\n";
-        assertThrows(HAProxyProtocolException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII));
             }
         });
+        assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
     }
 
     @Test
     public void testMissingParams() {
         final String header = "PROXY TCP4 192.168.0.1 192.168.0.11 56324\r\n";
-        assertThrows(HAProxyProtocolException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII));
             }
         });
+        assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
     }
 
     @Test
     public void testTooManyParams() {
         final String header = "PROXY TCP4 192.168.0.1 192.168.0.11 56324 443 123\r\n";
-        assertThrows(HAProxyProtocolException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII));
             }
         });
+        assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
     }
 
     @Test
     public void testInvalidCommand() {
         final String header = "PING TCP4 192.168.0.1 192.168.0.11 56324 443\r\n";
-        assertThrows(HAProxyProtocolException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII));
             }
         });
+        assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
     }
 
     @Test
     public void testInvalidEOL() {
         final String header = "PROXY TCP4 192.168.0.1 192.168.0.11 56324 443\nGET / HTTP/1.1\r\n";
-        assertThrows(HAProxyProtocolException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII));
             }
         });
+        assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
     }
 
     @Test
     public void testHeaderTooLong() {
         final String header = "PROXY TCP4 192.168.0.1 192.168.0.11 56324 " +
                         "00000000000000000000000000000000000000000000000000000000000000000443\r\n";
-        assertThrows(HAProxyProtocolException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII));
             }
         });
+        assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
     }
 
     @Test
@@ -240,12 +252,13 @@ public class HAProxyMessageDecoderTest {
             final String headerPart3 = "end of header\r\n";
 
             int discarded = headerPart1.length() + headerPart2.length() + headerPart3.length() - 2;
-            assertThrows(HAProxyProtocolException.class, new Executable() {
+            CompletionException cause = assertThrows(CompletionException.class, new Executable() {
                 @Override
                 public void execute() {
                     slowFailCh.writeInbound(copiedBuffer(headerPart3, CharsetUtil.US_ASCII));
                 }
             }, "over " + discarded);
+            assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
         } finally {
             assertFalse(slowFailCh.finishAndReleaseAll());
         }
@@ -257,12 +270,13 @@ public class HAProxyMessageDecoderTest {
         try {
             final String headerPart1 = "PROXY TCP4 192.168.0.1 192.168.0.11 56324 " +
                                  "000000000000000000000000000000000000000000000000000000000000000000000443";
-            assertThrows(HAProxyProtocolException.class, new Executable() {
+            Throwable cause = assertThrows(CompletionException.class, new Executable() {
                         @Override
                         public void execute() {
                             fastFailCh.writeInbound(copiedBuffer(headerPart1, CharsetUtil.US_ASCII));
                         }
                     }, "over " + headerPart1.length());
+            assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
         } finally {
             assertFalse(fastFailCh.finishAndReleaseAll());
         }
@@ -282,7 +296,7 @@ public class HAProxyMessageDecoderTest {
         String header = "GET / HTTP/1.1\r\n";
         try {
             ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII));
-        } catch (HAProxyProtocolException ppex) {
+        } catch (CompletionException ppex) {
             // swallow this exception since we're just testing to be sure the channel was closed
         }
         boolean isComplete = closeFuture.awaitUninterruptibly(5000);
@@ -935,12 +949,13 @@ public class HAProxyMessageDecoderTest {
         header[26] = 0x01; // Destination Port
         header[27] = (byte) 0xbb; // -----
 
-        assertThrows(HAProxyProtocolException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 ch.writeInbound(copiedBuffer(header));
             }
         });
+        assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
     }
 
     @Test
@@ -978,12 +993,13 @@ public class HAProxyMessageDecoderTest {
         header[24] = (byte) 0xdc; // Source Port
         header[25] = 0x04; // -----
 
-        assertThrows(HAProxyProtocolException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 ch.writeInbound(copiedBuffer(header));
             }
         });
+        assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
     }
 
     @Test
@@ -1024,12 +1040,13 @@ public class HAProxyMessageDecoderTest {
         header[26] = 0x01; // Destination Port
         header[27] = (byte) 0xbb; // -----
 
-        assertThrows(HAProxyProtocolException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 ch.writeInbound(copiedBuffer(header));
             }
         });
+        assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
     }
 
     @Test
@@ -1070,12 +1087,13 @@ public class HAProxyMessageDecoderTest {
         header[26] = 0x01; // Destination Port
         header[27] = (byte) 0xbb; // -----
 
-        assertThrows(HAProxyProtocolException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 ch.writeInbound(copiedBuffer(header));
             }
         });
+        assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
     }
 
     @Test
@@ -1118,12 +1136,13 @@ public class HAProxyMessageDecoderTest {
         header[26] = 0x01; // Destination Port
         header[27] = (byte) 0xbb; // -----
 
-        assertThrows(HAProxyProtocolException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 ch.writeInbound(copiedBuffer(header));
             }
         });
+        assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
     }
 
     @Test
@@ -1249,11 +1268,12 @@ public class HAProxyMessageDecoderTest {
         data.writeBytes(numsWrite.array());
         data.writeBytes(header);
 
-        assertThrows(HAProxyProtocolException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 ch.writeInbound(data);
             }
         });
+        assertInstanceOf(HAProxyProtocolException.class, cause.getCause());
     }
 }

--- a/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HAProxyMessageDecoderTest.java
+++ b/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HAProxyMessageDecoderTest.java
@@ -197,8 +197,8 @@ public class HAProxyMessageDecoderTest {
             final String headerPart3 = "end of header\r\n";
 
             int discarded = headerPart1.length() + headerPart2.length() + headerPart3.length() - 2;
-            assertThrows(HAProxyProtocolException.class,
-                    () -> slowFailCh.writeInbound(copiedBuffer(headerPart3, CharsetUtil.US_ASCII)), "over " + discarded);
+            assertThrows(HAProxyProtocolException.class, () -> slowFailCh.writeInbound(
+                    copiedBuffer(headerPart3, CharsetUtil.US_ASCII)), "over " + discarded);
         } finally {
             assertFalse(slowFailCh.finishAndReleaseAll());
         }
@@ -210,8 +210,8 @@ public class HAProxyMessageDecoderTest {
         try {
             final String headerPart1 = "PROXY TCP4 192.168.0.1 192.168.0.11 56324 " +
                                  "000000000000000000000000000000000000000000000000000000000000000000000443";
-            assertThrows(HAProxyProtocolException.class,
-                    () -> fastFailCh.writeInbound(copiedBuffer(headerPart1, CharsetUtil.US_ASCII)), "over " + headerPart1.length());
+            assertThrows(HAProxyProtocolException.class, () -> fastFailCh.writeInbound(
+                    copiedBuffer(headerPart1, CharsetUtil.US_ASCII)), "over " + headerPart1.length());
         } finally {
             assertFalse(fastFailCh.finishAndReleaseAll());
         }

--- a/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HaProxyMessageEncoderTest.java
+++ b/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HaProxyMessageEncoderTest.java
@@ -45,7 +45,7 @@ public class HaProxyMessageEncoderTest {
     private static final int IPv6_ADDRESS_BYTES_LENGTH = 36;
 
     @Test
-    public void testIPV4EncodeProxyV1() {
+    public void testIPV4EncodeProxyV1() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(INSTANCE);
 
         HAProxyMessage message = new HAProxyMessage(
@@ -63,7 +63,7 @@ public class HaProxyMessageEncoderTest {
     }
 
     @Test
-    public void testIPV6EncodeProxyV1() {
+    public void testIPV6EncodeProxyV1() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(INSTANCE);
 
         HAProxyMessage message = new HAProxyMessage(
@@ -81,7 +81,7 @@ public class HaProxyMessageEncoderTest {
     }
 
     @Test
-    public void testIPv4EncodeProxyV2() {
+    public void testIPv4EncodeProxyV2() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(INSTANCE);
 
         HAProxyMessage message = new HAProxyMessage(
@@ -130,7 +130,7 @@ public class HaProxyMessageEncoderTest {
     }
 
     @Test
-    public void testIPv6EncodeProxyV2() {
+    public void testIPv6EncodeProxyV2() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(INSTANCE);
 
         HAProxyMessage message = new HAProxyMessage(
@@ -186,7 +186,7 @@ public class HaProxyMessageEncoderTest {
     }
 
     @Test
-    public void testUnixEncodeProxyV2() {
+    public void testUnixEncodeProxyV2() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(INSTANCE);
 
         HAProxyMessage message = new HAProxyMessage(
@@ -229,7 +229,7 @@ public class HaProxyMessageEncoderTest {
     }
 
     @Test
-    public void testTLVEncodeProxy() {
+    public void testTLVEncodeProxy() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(INSTANCE);
 
         List<HAProxyTLV> tlvs = new ArrayList<HAProxyTLV>();
@@ -272,7 +272,7 @@ public class HaProxyMessageEncoderTest {
     }
 
     @Test
-    public void testSslTLVEncodeProxy() {
+    public void testSslTLVEncodeProxy() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(INSTANCE);
 
         List<HAProxyTLV> tlvs = new ArrayList<HAProxyTLV>();
@@ -327,7 +327,7 @@ public class HaProxyMessageEncoderTest {
     }
 
     @Test
-    public void testEncodeLocalProxyV2() {
+    public void testEncodeLocalProxyV2() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(INSTANCE);
 
         HAProxyMessage message = new HAProxyMessage(

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentDecoder.java
@@ -248,7 +248,7 @@ public abstract class HttpContentDecoder extends MessageToMessageDecoder<HttpObj
         super.handlerAdded(ctx);
     }
 
-    private void cleanup() {
+    private void cleanup() throws Exception {
         if (decoder != null) {
             // Clean-up the previous decoder if not cleaned up correctly.
             boolean nonEmpty = decoder.finishAndReleaseAll();

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentEncoder.java
@@ -227,7 +227,7 @@ public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpReque
         }
     }
 
-    private void encodeFullResponse(HttpResponse newRes, HttpContent content, List<Object> out) {
+    private void encodeFullResponse(HttpResponse newRes, HttpContent content, List<Object> out) throws Exception {
         int existingMessages = out.size();
         encodeContent(content, out);
 
@@ -268,7 +268,7 @@ public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpReque
         }
     }
 
-    private boolean encodeContent(HttpContent c, List<Object> out) {
+    private boolean encodeContent(HttpContent c, List<Object> out) throws Exception {
         ByteBuf content = c.content();
 
         encode(content, out);
@@ -318,7 +318,7 @@ public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpReque
         super.channelInactive(ctx);
     }
 
-    private void cleanup() {
+    private void cleanup() throws Exception {
         if (encoder != null) {
             // Clean-up the previous encoder if not cleaned up correctly.
             encoder.finishAndReleaseAll();
@@ -336,13 +336,13 @@ public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpReque
         }
     }
 
-    private void encode(ByteBuf in, List<Object> out) {
+    private void encode(ByteBuf in, List<Object> out) throws Exception {
         // call retain here as it will call release after its written to the channel
         encoder.writeOutbound(in.retain());
         fetchEncoderOutput(out);
     }
 
-    private void finishEncode(List<Object> out) {
+    private void finishEncode(List<Object> out) throws Exception {
         if (encoder.finish()) {
             fetchEncoderOutput(out);
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateDecoder.java
@@ -108,7 +108,7 @@ abstract class DeflateDecoder extends WebSocketExtensionDecoder {
         super.channelInactive(ctx);
     }
 
-    private ByteBuf decompressContent(ChannelHandlerContext ctx, WebSocketFrame msg) {
+    private ByteBuf decompressContent(ChannelHandlerContext ctx, WebSocketFrame msg) throws Exception {
         if (decoder == null) {
             if (!(msg instanceof TextWebSocketFrame) && !(msg instanceof BinaryWebSocketFrame)) {
                 throw new CodecException("unexpected initial frame type: " + msg.getClass().getName());
@@ -156,7 +156,7 @@ abstract class DeflateDecoder extends WebSocketExtensionDecoder {
         return compositeDecompressedContent;
     }
 
-    private void cleanup() {
+    private void cleanup() throws Exception {
         if (decoder != null) {
             // Clean-up the previous encoder if not cleaned up correctly.
             decoder.finishAndReleaseAll();

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateEncoder.java
@@ -115,7 +115,7 @@ abstract class DeflateEncoder extends WebSocketExtensionEncoder {
         super.handlerRemoved(ctx);
     }
 
-    private ByteBuf compressContent(ChannelHandlerContext ctx, WebSocketFrame msg) {
+    private ByteBuf compressContent(ChannelHandlerContext ctx, WebSocketFrame msg) throws Exception {
         if (encoder == null) {
             encoder = EmbeddedChannel.builder()
                     .handlers(ZlibCodecFactory.newZlibEncoder(
@@ -158,7 +158,7 @@ abstract class DeflateEncoder extends WebSocketExtensionEncoder {
         return compressedContent;
     }
 
-    private void cleanup() {
+    private void cleanup() throws Exception {
         if (encoder != null) {
             // Clean-up the previous encoder if not cleaned up correctly.
             encoder.finishAndReleaseAll();

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpChunkedInputTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpChunkedInputTest.java
@@ -61,22 +61,22 @@ public class HttpChunkedInputTest {
     }
 
     @Test
-    public void testChunkedStream() {
+    public void testChunkedStream() throws Exception {
         check(new HttpChunkedInput(new ChunkedStream(new ByteArrayInputStream(BYTES))));
     }
 
     @Test
-    public void testChunkedNioStream() {
+    public void testChunkedNioStream() throws Exception {
         check(new HttpChunkedInput(new ChunkedNioStream(Channels.newChannel(new ByteArrayInputStream(BYTES)))));
     }
 
     @Test
-    public void testChunkedFile() throws IOException {
+    public void testChunkedFile() throws Exception {
         check(new HttpChunkedInput(new ChunkedFile(TMP)));
     }
 
     @Test
-    public void testChunkedNioFile() throws IOException {
+    public void testChunkedNioFile() throws Exception {
         check(new HttpChunkedInput(new ChunkedNioFile(TMP)));
     }
 
@@ -116,7 +116,7 @@ public class HttpChunkedInputTest {
         assertNull(input.readChunk(ByteBufAllocator.DEFAULT));
     }
 
-    private static void check(ChunkedInput<?>... inputs) {
+    private static void check(ChunkedInput<?>... inputs) throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new ChunkedWriteHandler());
 
         for (ChunkedInput<?> input : inputs) {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpClientCodecTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpClientCodecTest.java
@@ -31,7 +31,6 @@ import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
-import io.netty.handler.codec.CodecException;
 import io.netty.handler.codec.PrematureChannelClosureException;
 import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
@@ -39,7 +38,6 @@ import io.netty.util.concurrent.Future;
 import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
 
 import static io.netty.util.ReferenceCountUtil.release;
@@ -53,7 +51,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class HttpClientCodecTest {
 
@@ -67,7 +64,7 @@ public class HttpClientCodecTest {
     private static final String CHUNKED_RESPONSE = INCOMPLETE_CHUNKED_RESPONSE + "\r\n";
 
     @Test
-    public void testConnectWithResponseContent() {
+    public void testConnectWithResponseContent() throws Exception {
         HttpClientCodec codec = new HttpClientCodec(4096, 8192, 8192, true);
         EmbeddedChannel ch = new EmbeddedChannel(codec);
 
@@ -76,7 +73,7 @@ public class HttpClientCodecTest {
     }
 
     @Test
-    public void testFailsNotOnRequestResponseChunked() {
+    public void testFailsNotOnRequestResponseChunked() throws Exception {
         HttpClientCodec codec = new HttpClientCodec(4096, 8192, 8192, true);
         EmbeddedChannel ch = new EmbeddedChannel(codec);
 
@@ -85,7 +82,7 @@ public class HttpClientCodecTest {
     }
 
     @Test
-    public void testFailsOnMissingResponse() {
+    public void testFailsOnMissingResponse() throws Exception {
         HttpClientCodec codec = new HttpClientCodec(4096, 8192, 8192, true);
         EmbeddedChannel ch = new EmbeddedChannel(codec);
 
@@ -94,12 +91,11 @@ public class HttpClientCodecTest {
         ByteBuf buffer = ch.readOutbound();
         assertNotNull(buffer);
         buffer.release();
-        Throwable cause = assertThrows(CompletionException.class, ch::finish);
-        assertInstanceOf(PrematureChannelClosureException.class, cause.getCause());
+        assertThrows(PrematureChannelClosureException.class, ch::finish);
     }
 
     @Test
-    public void testFailsOnIncompleteChunkedResponse() {
+    public void testFailsOnIncompleteChunkedResponse() throws Exception {
         HttpClientCodec codec = new HttpClientCodec(4096, 8192, 8192, true);
         EmbeddedChannel ch = new EmbeddedChannel(codec);
 
@@ -114,8 +110,7 @@ public class HttpClientCodecTest {
         ((HttpContent) ch.readInbound()).release(); // Chunk 'second'
         assertNull(ch.readInbound());
 
-        Throwable cause = assertThrows(CompletionException.class, ch::finish);
-        assertInstanceOf(PrematureChannelClosureException.class, cause.getCause());
+        assertThrows(PrematureChannelClosureException.class, ch::finish);
     }
 
     @Test
@@ -227,12 +222,13 @@ public class HttpClientCodecTest {
         assertFalse(ch.finish(), "Channel finish failed.");
     }
 
-    private static void sendRequestAndReadResponse(EmbeddedChannel ch, HttpMethod httpMethod, String response) {
+    private static void sendRequestAndReadResponse(EmbeddedChannel ch, HttpMethod httpMethod, String response)
+            throws Exception {
         sendRequestAndReadResponse(ch, httpMethod, response, new Consumer());
     }
 
     private static void sendRequestAndReadResponse(EmbeddedChannel ch, HttpMethod httpMethod, String response,
-                                                   Consumer responseConsumer) {
+                                                   Consumer responseConsumer) throws Exception {
         assertTrue(ch.writeOutbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, httpMethod, "http://localhost/")),
                 "Channel outbound write failed.");
         assertTrue(ch.writeInbound(Unpooled.copiedBuffer(response, CharsetUtil.ISO_8859_1)),
@@ -274,7 +270,7 @@ public class HttpClientCodecTest {
     }
 
     @Test
-    public void testDecodesFinalResponseAfterSwitchingProtocols() {
+    public void testDecodesFinalResponseAfterSwitchingProtocols() throws Exception {
         String SWITCHING_PROTOCOLS_RESPONSE = "HTTP/1.1 101 Switching Protocols\r\n" +
                 "Connection: Upgrade\r\n" +
                 "Upgrade: TLS/1.2, HTTP/1.1\r\n\r\n";
@@ -304,7 +300,7 @@ public class HttpClientCodecTest {
     }
 
     @Test
-    public void testWebSocket00Response() {
+    public void testWebSocket00Response() throws Exception {
         byte[] data = ("HTTP/1.1 101 WebSocket Protocol Handshake\r\n" +
                 "Upgrade: WebSocket\r\n" +
                 "Connection: Upgrade\r\n" +
@@ -328,7 +324,7 @@ public class HttpClientCodecTest {
     }
 
     @Test
-    public void testWebDavResponse() {
+    public void testWebDavResponse() throws Exception {
         byte[] data = ("HTTP/1.1 102 Processing\r\n" +
                        "Status-URI: Status-URI:http://status.com; 404\r\n" +
                        "\r\n" +
@@ -348,7 +344,7 @@ public class HttpClientCodecTest {
     }
 
     @Test
-    public void testInformationalResponseKeepsPairsInSync() {
+    public void testInformationalResponseKeepsPairsInSync() throws Exception {
         byte[] data = ("HTTP/1.1 102 Processing\r\n" +
                 "Status-URI: Status-URI:http://status.com; 404\r\n" +
                 "\r\n").getBytes();
@@ -390,7 +386,7 @@ public class HttpClientCodecTest {
     }
 
     @Test
-    public void testMultipleResponses() {
+    public void testMultipleResponses() throws Exception {
         String response = "HTTP/1.1 200 OK\r\n" +
                 "Content-Length: 0\r\n\r\n";
 
@@ -413,7 +409,7 @@ public class HttpClientCodecTest {
     }
 
     @Test
-    public void testWriteThroughAfterUpgrade() {
+    public void testWriteThroughAfterUpgrade() throws Exception {
         HttpClientCodec codec = new HttpClientCodec();
         EmbeddedChannel ch = new EmbeddedChannel(codec);
         codec.prepareUpgradeFrom(null);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpClientCodecTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpClientCodecTest.java
@@ -39,6 +39,7 @@ import io.netty.util.concurrent.Future;
 import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
 
 import static io.netty.util.ReferenceCountUtil.release;
@@ -50,6 +51,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -92,12 +94,8 @@ public class HttpClientCodecTest {
         ByteBuf buffer = ch.readOutbound();
         assertNotNull(buffer);
         buffer.release();
-        try {
-            ch.finish();
-            fail();
-        } catch (CodecException e) {
-            assertTrue(e instanceof PrematureChannelClosureException);
-        }
+        Throwable cause = assertThrows(CompletionException.class, ch::finish);
+        assertInstanceOf(PrematureChannelClosureException.class, cause.getCause());
     }
 
     @Test
@@ -116,12 +114,8 @@ public class HttpClientCodecTest {
         ((HttpContent) ch.readInbound()).release(); // Chunk 'second'
         assertNull(ch.readInbound());
 
-        try {
-            ch.finish();
-            fail();
-        } catch (CodecException e) {
-            assertTrue(e instanceof PrematureChannelClosureException);
-        }
+        Throwable cause = assertThrows(CompletionException.class, ch::finish);
+        assertInstanceOf(PrematureChannelClosureException.class, cause.getCause());
     }
 
     @Test

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpClientUpgradeHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpClientUpgradeHandlerTest.java
@@ -22,15 +22,12 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CompletionException;
 
 import io.netty.util.concurrent.Promise;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -77,7 +74,7 @@ public class HttpClientUpgradeHandlerTest {
     }
 
     @Test
-    public void testSuccessfulUpgrade() {
+    public void testSuccessfulUpgrade() throws Exception {
         HttpClientUpgradeHandler.SourceCodec sourceCodec = new FakeSourceCodec();
         HttpClientUpgradeHandler.UpgradeCodec upgradeCodec = new FakeUpgradeCodec();
         HttpClientUpgradeHandler handler = new HttpClientUpgradeHandler(sourceCodec, upgradeCodec, 1024);
@@ -130,7 +127,7 @@ public class HttpClientUpgradeHandlerTest {
     }
 
     @Test
-    public void testUpgradeRejected() {
+    public void testUpgradeRejected() throws Exception {
         HttpClientUpgradeHandler.SourceCodec sourceCodec = new FakeSourceCodec();
         HttpClientUpgradeHandler.UpgradeCodec upgradeCodec = new FakeUpgradeCodec();
         HttpClientUpgradeHandler handler = new HttpClientUpgradeHandler(sourceCodec, upgradeCodec, 1024);
@@ -167,7 +164,7 @@ public class HttpClientUpgradeHandlerTest {
     }
 
     @Test
-    public void testEarlyBailout() {
+    public void testEarlyBailout() throws Exception {
         HttpClientUpgradeHandler.SourceCodec sourceCodec = new FakeSourceCodec();
         HttpClientUpgradeHandler.UpgradeCodec upgradeCodec = new FakeUpgradeCodec();
         HttpClientUpgradeHandler handler = new HttpClientUpgradeHandler(sourceCodec, upgradeCodec, 1024);
@@ -199,7 +196,7 @@ public class HttpClientUpgradeHandlerTest {
     }
 
     @Test
-    public void dontStripConnectionHeaders() {
+    public void dontStripConnectionHeaders() throws Exception {
         HttpClientUpgradeHandler.SourceCodec sourceCodec = new FakeSourceCodec();
         HttpClientUpgradeHandler.UpgradeCodec upgradeCodec = new FakeUpgradeCodec();
         HttpClientUpgradeHandler handler = new HttpClientUpgradeHandler(sourceCodec, upgradeCodec, 1024);
@@ -220,7 +217,7 @@ public class HttpClientUpgradeHandlerTest {
     }
 
     @Test
-    public void testMultipleUpgradeRequestsFail() {
+    public void testMultipleUpgradeRequestsFail() throws Exception {
         HttpClientUpgradeHandler.SourceCodec sourceCodec = new FakeSourceCodec();
         HttpClientUpgradeHandler.UpgradeCodec upgradeCodec = new FakeUpgradeCodec();
         HttpClientUpgradeHandler handler = new HttpClientUpgradeHandler(sourceCodec, upgradeCodec, 1024);
@@ -233,20 +230,14 @@ public class HttpClientUpgradeHandlerTest {
         assertTrue(request.release());
 
         final FullHttpRequest secondReq = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "netty.io");
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-                    @Override
-                    public void execute() throws Throwable {
-                        channel.writeOutbound(secondReq);
-                    }
-                });
-        assertInstanceOf(IllegalStateException.class, cause.getCause());
+        assertThrows(IllegalStateException.class, () -> channel.writeOutbound(secondReq));
 
         assertEquals(0, secondReq.refCnt());
         assertFalse(channel.finish());
     }
 
     @Test
-    public void forwardOnFailure() {
+    public void forwardOnFailure() throws Exception {
         HttpClientUpgradeHandler.SourceCodec sourceCodec = new FakeSourceCodec();
         HttpClientUpgradeHandler.UpgradeCodec upgradeCodec = new FakeUpgradeCodec();
         HttpClientUpgradeHandler handler = new HttpClientUpgradeHandler(sourceCodec, upgradeCodec, 1024);
@@ -261,9 +252,8 @@ public class HttpClientUpgradeHandlerTest {
                 HttpVersion.HTTP_1_1, HttpResponseStatus.SWITCHING_PROTOCOLS);
         response.headers().add(HttpHeaderNames.UPGRADE, "");
         assertFalse(channel.writeInbound(response));
-        Throwable cause = assertThrows(CompletionException.class,
+        assertThrows(IllegalStateException.class,
                 () -> channel.writeInbound(LastHttpContent.EMPTY_LAST_CONTENT));
-        assertInstanceOf(IllegalStateException.class, cause.getCause());
 
         FullHttpResponse full = channel.readInbound();
         assertTrue(full.release());

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpClientUpgradeHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpClientUpgradeHandlerTest.java
@@ -22,6 +22,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletionException;
 
 import io.netty.util.concurrent.Promise;
 import org.junit.jupiter.api.Test;
@@ -29,6 +30,7 @@ import org.junit.jupiter.api.function.Executable;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -231,12 +233,13 @@ public class HttpClientUpgradeHandlerTest {
         assertTrue(request.release());
 
         final FullHttpRequest secondReq = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "netty.io");
-        assertThrows(IllegalStateException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
                     @Override
                     public void execute() throws Throwable {
                         channel.writeOutbound(secondReq);
                     }
                 });
+        assertInstanceOf(IllegalStateException.class, cause.getCause());
 
         assertEquals(0, secondReq.refCnt());
         assertFalse(channel.finish());
@@ -258,7 +261,9 @@ public class HttpClientUpgradeHandlerTest {
                 HttpVersion.HTTP_1_1, HttpResponseStatus.SWITCHING_PROTOCOLS);
         response.headers().add(HttpHeaderNames.UPGRADE, "");
         assertFalse(channel.writeInbound(response));
-        assertThrows(IllegalStateException.class, () -> channel.writeInbound(LastHttpContent.EMPTY_LAST_CONTENT));
+        Throwable cause = assertThrows(CompletionException.class,
+                () -> channel.writeInbound(LastHttpContent.EMPTY_LAST_CONTENT));
+        assertInstanceOf(IllegalStateException.class, cause.getCause());
 
         FullHttpResponse full = channel.readInbound();
         assertTrue(full.release());

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorOptionsTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorOptionsTest.java
@@ -118,7 +118,7 @@ class HttpContentCompressorOptionsTest {
     }
 
     @Test
-    void testAcceptEncodingHttpRequest() {
+    void testAcceptEncodingHttpRequest() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new HttpContentCompressor(null));
         ch.writeInbound(newRequest());
         FullHttpRequest fullHttpRequest = ch.readInbound();

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletionException;
 
 import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,6 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -621,13 +623,12 @@ public class HttpContentCompressorTest {
         ch.writeOutbound(new DefaultFullHttpResponse(
                 HttpVersion.HTTP_1_1, HttpResponseStatus.OK, Unpooled.EMPTY_BUFFER));
 
-        try {
-            ch.writeOutbound(new DefaultFullHttpResponse(
-                    HttpVersion.HTTP_1_1, HttpResponseStatus.OK, Unpooled.EMPTY_BUFFER));
-            fail();
-        } catch (EncoderException e) {
-            assertTrue(e.getCause() instanceof IllegalStateException);
-        }
+        Throwable cause = assertThrows(CompletionException.class,
+                () -> ch.writeOutbound(new DefaultFullHttpResponse(
+                        HttpVersion.HTTP_1_1, HttpResponseStatus.OK, Unpooled.EMPTY_BUFFER)));
+        EncoderException e = assertInstanceOf(EncoderException.class, cause.getCause());
+        assertInstanceOf(IllegalStateException.class, e.getCause());
+
         assertTrue(ch.finish());
         for (;;) {
             Object message = ch.readOutbound();

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorTest.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.CompletionException;
 
 import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -623,11 +622,10 @@ public class HttpContentCompressorTest {
         ch.writeOutbound(new DefaultFullHttpResponse(
                 HttpVersion.HTTP_1_1, HttpResponseStatus.OK, Unpooled.EMPTY_BUFFER));
 
-        Throwable cause = assertThrows(CompletionException.class,
+        Throwable cause = assertThrows(EncoderException.class,
                 () -> ch.writeOutbound(new DefaultFullHttpResponse(
                         HttpVersion.HTTP_1_1, HttpResponseStatus.OK, Unpooled.EMPTY_BUFFER)));
-        EncoderException e = assertInstanceOf(EncoderException.class, cause.getCause());
-        assertInstanceOf(IllegalStateException.class, e.getCause());
+        assertInstanceOf(IllegalStateException.class, cause.getCause());
 
         assertTrue(ch.finish());
         for (;;) {
@@ -822,7 +820,7 @@ public class HttpContentCompressorTest {
     }
 
     @Test
-    public void testMultipleAcceptEncodingHeaders() {
+    public void testMultipleAcceptEncodingHeaders() throws Exception {
         FullHttpRequest request = newRequest();
         request.headers().set(HttpHeaderNames.ACCEPT_ENCODING, "unknown; q=1.0")
                .add(HttpHeaderNames.ACCEPT_ENCODING, "gzip; q=0.5")
@@ -855,7 +853,7 @@ public class HttpContentCompressorTest {
     }
 
     @Test
-    public void testEmpty() {
+    public void testEmpty() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new HttpContentCompressor());
         assertTrue(ch.writeInbound(newRequest()));
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentDecoderTest.java
@@ -37,7 +37,6 @@ import org.junit.jupiter.api.condition.DisabledIf;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -86,7 +85,7 @@ public class HttpContentDecoderTest {
     }
 
     @Test
-    public void testRequestDecompression() {
+    public void testRequestDecompression() throws Exception {
         // baseline test: request decoder, content decompressor && request aggregator work as expected
         HttpRequestDecoder decoder = new HttpRequestDecoder();
         HttpContentDecoder decompressor = new HttpContentDecompressor(0);
@@ -113,7 +112,7 @@ public class HttpContentDecoderTest {
     }
 
     @Test
-    public void testChunkedRequestDecompression() {
+    public void testChunkedRequestDecompression() throws Exception {
         HttpResponseDecoder decoder = new HttpResponseDecoder();
         HttpContentDecoder decompressor = new HttpContentDecompressor(0);
 
@@ -155,7 +154,7 @@ public class HttpContentDecoderTest {
     }
 
     @Test
-    public void testSnappyResponseDecompression() {
+    public void testSnappyResponseDecompression() throws Exception {
         // baseline test: response decoder, content decompressor && request aggregator work as expected
         HttpResponseDecoder decoder = new HttpResponseDecoder();
         HttpContentDecoder decompressor = new HttpContentDecompressor(0);
@@ -182,7 +181,7 @@ public class HttpContentDecoderTest {
     }
 
     @Test
-    public void testResponseDecompression() {
+    public void testResponseDecompression() throws Exception {
         // baseline test: response decoder, content decompressor && request aggregator work as expected
         HttpResponseDecoder decoder = new HttpResponseDecoder();
         HttpContentDecoder decompressor = new HttpContentDecompressor(0);
@@ -346,7 +345,7 @@ public class HttpContentDecoderTest {
     }
 
     @Test
-    public void testExpectContinueResponse1() {
+    public void testExpectContinueResponse1() throws Exception {
         // request with header "Expect: 100-continue" must be replied with one "100 Continue" response
         // case 1: no ContentDecoder in chain at all (baseline test)
         HttpRequestDecoder decoder = new HttpRequestDecoder();
@@ -374,7 +373,7 @@ public class HttpContentDecoderTest {
     }
 
     @Test
-    public void testExpectContinueResponse2() {
+    public void testExpectContinueResponse2() throws Exception {
         // request with header "Expect: 100-continue" must be replied with one "100 Continue" response
         // case 2: contentDecoder is in chain, but the content is not encoded, should be no-op
         HttpRequestDecoder decoder = new HttpRequestDecoder();
@@ -400,7 +399,7 @@ public class HttpContentDecoderTest {
     }
 
     @Test
-    public void testExpectContinueResponse3() {
+    public void testExpectContinueResponse3() throws Exception {
         // request with header "Expect: 100-continue" must be replied with one "100 Continue" response
         // case 3: ContentDecoder is in chain and content is encoded
         HttpRequestDecoder decoder = new HttpRequestDecoder();
@@ -427,7 +426,7 @@ public class HttpContentDecoderTest {
     }
 
     @Test
-    public void testExpectContinueResponse4() {
+    public void testExpectContinueResponse4() throws Exception {
         // request with header "Expect: 100-continue" must be replied with one "100 Continue" response
         // case 4: ObjectAggregator is up in chain
         HttpRequestDecoder decoder = new HttpRequestDecoder();
@@ -454,7 +453,7 @@ public class HttpContentDecoderTest {
     }
 
     @Test
-    public void testExpectContinueResetHttpObjectDecoder() {
+    public void testExpectContinueResetHttpObjectDecoder() throws Exception {
         // request with header "Expect: 100-continue" must be replied with one "100 Continue" response
         // case 5: Test that HttpObjectDecoder correctly resets its internal state after a failed expectation.
         HttpRequestDecoder decoder = new HttpRequestDecoder();
@@ -508,7 +507,7 @@ public class HttpContentDecoderTest {
     }
 
     @Test
-    public void testRequestContentLength1() {
+    public void testRequestContentLength1() throws Exception {
         // case 1: test that ContentDecompressor either sets the correct Content-Length header
         // or removes it completely (handlers down the chain must rely on LastHttpContent object)
 
@@ -538,7 +537,7 @@ public class HttpContentDecoderTest {
     }
 
     @Test
-    public void testRequestContentLength2() {
+    public void testRequestContentLength2() throws Exception {
         // case 2: if HttpObjectAggregator is down the chain, then correct Content-Length header must be set
 
         // force content to be in more than one chunk (5 bytes/chunk)
@@ -569,7 +568,7 @@ public class HttpContentDecoderTest {
     }
 
     @Test
-    public void testResponseContentLength1() {
+    public void testResponseContentLength1() throws Exception {
         // case 1: test that ContentDecompressor either sets the correct Content-Length header
         // or removes it completely (handlers down the chain must rely on LastHttpContent object)
 
@@ -602,7 +601,7 @@ public class HttpContentDecoderTest {
     }
 
     @Test
-    public void testResponseContentLength2() {
+    public void testResponseContentLength2() throws Exception {
         // case 2: if HttpObjectAggregator is down the chain, then correct Content-Length header must be set
 
         // force content to be in more than one chunk (5 bytes/chunk)
@@ -632,7 +631,7 @@ public class HttpContentDecoderTest {
     }
 
     @Test
-    public void testFullHttpRequest() {
+    public void testFullHttpRequest() throws Exception {
         // test that ContentDecoder can be used after the ObjectAggregator
         HttpRequestDecoder decoder = new HttpRequestDecoder(4096, 4096, 5);
         HttpObjectAggregator aggregator = new HttpObjectAggregator(1024);
@@ -659,7 +658,7 @@ public class HttpContentDecoderTest {
     }
 
     @Test
-    public void testFullHttpResponse() {
+    public void testFullHttpResponse() throws Exception {
         // test that ContentDecoder can be used after the ObjectAggregator
         HttpResponseDecoder decoder = new HttpResponseDecoder(4096, 4096, 5);
         HttpObjectAggregator aggregator = new HttpObjectAggregator(1024);
@@ -687,7 +686,7 @@ public class HttpContentDecoderTest {
 
     // See https://github.com/netty/netty/issues/5892
     @Test
-    public void testFullHttpResponseEOF() {
+    public void testFullHttpResponseEOF() throws Exception {
         // test that ContentDecoder can be used after the ObjectAggregator
         HttpResponseDecoder decoder = new HttpResponseDecoder(4096, 4096, 5);
         HttpContentDecoder decompressor = new HttpContentDecompressor(0);
@@ -714,7 +713,7 @@ public class HttpContentDecoderTest {
     }
 
     @Test
-    public void testCleanupThrows() {
+    public void testCleanupThrows() throws Exception {
         HttpContentDecoder decoder = new HttpContentDecoder() {
             @Override
             protected EmbeddedChannel newContentDecoder(String contentEncoding) throws Exception {
@@ -741,15 +740,14 @@ public class HttpContentDecoderTest {
         assertTrue(channel.writeInbound(content));
         assertEquals(1, content.refCnt());
 
-        Throwable cause = assertThrows(CompletionException.class, channel::finishAndReleaseAll);
-        assertInstanceOf(CodecException.class, cause.getCause().getCause());
+        assertThrows(CodecException.class, channel::finishAndReleaseAll);
 
         assertTrue(channelInactiveCalled.get());
         assertEquals(0, content.refCnt());
     }
 
     @Test
-    public void testTransferCodingGZIP() {
+    public void testTransferCodingGZIP() throws Exception {
         String requestStr = "POST / HTTP/1.1\r\n" +
                 "Content-Length: " + GZ_HELLO_WORLD.length + "\r\n" +
                 "Transfer-Encoding: gzip\r\n" +
@@ -781,7 +779,7 @@ public class HttpContentDecoderTest {
     }
 
     @Test
-    public void testTransferCodingGZIPAndChunked() {
+    public void testTransferCodingGZIPAndChunked() throws Exception {
         String requestStr = "POST / HTTP/1.1\r\n" +
                 "Host: example.com\r\n" +
                 "Content-Type: application/x-www-form-urlencoded\r\n" +
@@ -820,7 +818,7 @@ public class HttpContentDecoderTest {
         channel.releaseInbound();
     }
 
-    private static byte[] gzDecompress(byte[] input) {
+    private static byte[] gzDecompress(byte[] input) throws Exception {
         ZlibDecoder decoder = ZlibCodecFactory.newZlibDecoder(ZlibWrapper.GZIP, 0);
         EmbeddedChannel channel = new EmbeddedChannel(decoder);
         assertTrue(channel.writeInbound(Unpooled.copiedBuffer(input)));
@@ -875,7 +873,7 @@ public class HttpContentDecoderTest {
         return contentLength;
     }
 
-    private static byte[] gzCompress(byte[] input) {
+    private static byte[] gzCompress(byte[] input) throws Exception {
         ZlibEncoder encoder = ZlibCodecFactory.newZlibEncoder(ZlibWrapper.GZIP);
         EmbeddedChannel channel = new EmbeddedChannel(encoder);
         assertTrue(channel.writeOutbound(Unpooled.wrappedBuffer(input)));

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentDecoderTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.condition.DisabledIf;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -45,8 +46,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class HttpContentDecoderTest {
     private static final String HELLO_WORLD = "hello, world";
@@ -739,12 +740,10 @@ public class HttpContentDecoderTest {
         HttpContent content = new DefaultHttpContent(Unpooled.buffer().writeZero(10));
         assertTrue(channel.writeInbound(content));
         assertEquals(1, content.refCnt());
-        try {
-            channel.finishAndReleaseAll();
-            fail();
-        } catch (CodecException expected) {
-            // expected
-        }
+
+        Throwable cause = assertThrows(CompletionException.class, channel::finishAndReleaseAll);
+        assertInstanceOf(CodecException.class, cause.getCause());
+
         assertTrue(channelInactiveCalled.get());
         assertEquals(0, content.refCnt());
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentDecoderTest.java
@@ -742,7 +742,7 @@ public class HttpContentDecoderTest {
         assertEquals(1, content.refCnt());
 
         Throwable cause = assertThrows(CompletionException.class, channel::finishAndReleaseAll);
-        assertInstanceOf(CodecException.class, cause.getCause());
+        assertInstanceOf(CodecException.class, cause.getCause().getCause());
 
         assertTrue(channelInactiveCalled.get());
         assertEquals(0, content.refCnt());

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentDecompressorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentDecompressorTest.java
@@ -41,7 +41,7 @@ public class HttpContentDecompressorTest {
 
     // See https://github.com/netty/netty/issues/8915.
     @Test
-    public void testInvokeReadWhenNotProduceMessage() {
+    public void testInvokeReadWhenNotProduceMessage() throws Exception {
         final AtomicInteger readCalled = new AtomicInteger();
         EmbeddedChannel channel = new EmbeddedChannel(new ChannelOutboundHandler() {
             @Override
@@ -97,7 +97,7 @@ public class HttpContentDecompressorTest {
     @ParameterizedTest
     @MethodSource("encodings")
     @DisabledForSlowLeakDetection
-    public void testZipBomb(String encoding) {
+    public void testZipBomb(String encoding) throws Exception {
         int chunkSize = 1024 * 1024;
         int numberOfChunks = 256;
         int memoryLimit = chunkSize * 128;

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentEncoderTest.java
@@ -27,9 +27,7 @@ import io.netty.handler.codec.EncoderException;
 import io.netty.handler.codec.MessageToByteEncoder;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
@@ -397,7 +395,7 @@ public class HttpContentEncoderTest {
     }
 
     @Test
-    public void testCleanupThrows() {
+    public void testCleanupThrows() throws Exception {
         HttpContentEncoder encoder = new HttpContentEncoder() {
             @Override
             protected Result beginEncode(HttpResponse httpResponse, String acceptEncoding) throws Exception {
@@ -425,13 +423,7 @@ public class HttpContentEncoderTest {
         HttpContent content = new DefaultHttpContent(Unpooled.buffer().writeZero(10));
         assertTrue(channel.writeOutbound(content));
         assertEquals(1, content.refCnt());
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                channel.finishAndReleaseAll();
-            }
-        });
-        assertInstanceOf(CodecException.class, cause.getCause().getCause());
+        assertThrows(CodecException.class, channel::finishAndReleaseAll);
 
         assertTrue(channelInactiveCalled.get());
         assertEquals(0, content.refCnt());

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentEncoderTest.java
@@ -29,6 +29,7 @@ import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
@@ -424,12 +425,13 @@ public class HttpContentEncoderTest {
         HttpContent content = new DefaultHttpContent(Unpooled.buffer().writeZero(10));
         assertTrue(channel.writeOutbound(content));
         assertEquals(1, content.refCnt());
-        assertThrows(CodecException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 channel.finishAndReleaseAll();
             }
         });
+        assertInstanceOf(CodecException.class, cause.getCause());
 
         assertTrue(channelInactiveCalled.get());
         assertEquals(0, content.refCnt());

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentEncoderTest.java
@@ -431,7 +431,7 @@ public class HttpContentEncoderTest {
                 channel.finishAndReleaseAll();
             }
         });
-        assertInstanceOf(CodecException.class, cause.getCause());
+        assertInstanceOf(CodecException.class, cause.getCause().getCause());
 
         assertTrue(channelInactiveCalled.get());
         assertEquals(0, content.refCnt());

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpInvalidMessageTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpInvalidMessageTest.java
@@ -105,7 +105,7 @@ public class HttpInvalidMessageTest {
         ensureInboundTrafficDiscarded(ch);
     }
 
-    private void ensureInboundTrafficDiscarded(EmbeddedChannel ch) {
+    private void ensureInboundTrafficDiscarded(EmbeddedChannel ch) throws Exception {
         // Generate a lot of random traffic to ensure that it's discarded silently.
         byte[] data = new byte[1048576];
         rnd.nextBytes(data);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpObjectAggregatorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpObjectAggregatorTest.java
@@ -32,7 +32,6 @@ import org.mockito.Mockito;
 
 import java.nio.channels.ClosedChannelException;
 import java.util.List;
-import java.util.concurrent.CompletionException;
 
 import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -48,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class HttpObjectAggregatorTest {
 
     @Test
-    public void testAggregate() {
+    public void testAggregate() throws Exception {
         HttpObjectAggregator aggr = new HttpObjectAggregator(1024 * 1024);
         EmbeddedChannel embedder = new EmbeddedChannel(aggr);
 
@@ -87,7 +86,7 @@ public class HttpObjectAggregatorTest {
     }
 
     @Test
-    public void testAggregateWithTrailer() {
+    public void testAggregateWithTrailer() throws Exception {
         HttpObjectAggregator aggr = new HttpObjectAggregator(1024 * 1024);
         EmbeddedChannel embedder = new EmbeddedChannel(aggr);
         HttpRequest message = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "http://localhost");
@@ -117,7 +116,7 @@ public class HttpObjectAggregatorTest {
     }
 
     @Test
-    public void testOversizedRequest() {
+    public void testOversizedRequest() throws Exception {
         final EmbeddedChannel embedder = new EmbeddedChannel(new HttpObjectAggregator(4));
         HttpRequest message = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.PUT, "http://localhost");
         HttpContent chunk1 = new DefaultHttpContent(Unpooled.copiedBuffer("test", CharsetUtil.US_ASCII));
@@ -133,19 +132,13 @@ public class HttpObjectAggregatorTest {
         assertEquals("0", response.headers().get(HttpHeaderNames.CONTENT_LENGTH));
         assertFalse(embedder.isOpen());
 
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                embedder.writeInbound(chunk3);
-            }
-        });
-        assertInstanceOf(ClosedChannelException.class, cause.getCause());
+        assertThrows(ClosedChannelException.class, () -> embedder.writeInbound(chunk3));
 
         assertFalse(embedder.finish());
     }
 
     @Test
-    public void testOversizedRequestWithContentLengthAndDecoder() {
+    public void testOversizedRequestWithContentLengthAndDecoder() throws Exception {
         EmbeddedChannel embedder = new EmbeddedChannel(new HttpRequestDecoder(), new HttpObjectAggregator(4, false));
         assertFalse(embedder.writeInbound(Unpooled.copiedBuffer(
                 "PUT /upload HTTP/1.1\r\n" +
@@ -196,7 +189,7 @@ public class HttpObjectAggregatorTest {
     }
 
     @Test
-    public void testOversizedRequestWithoutKeepAlive() {
+    public void testOversizedRequestWithoutKeepAlive() throws Exception {
         // send an HTTP/1.0 request with no keep-alive header
         HttpRequest message = new DefaultHttpRequest(HttpVersion.HTTP_1_0, HttpMethod.PUT, "http://localhost");
         HttpUtil.setContentLength(message, 5);
@@ -204,13 +197,13 @@ public class HttpObjectAggregatorTest {
     }
 
     @Test
-    public void testOversizedRequestWithContentLength() {
+    public void testOversizedRequestWithContentLength() throws Exception {
         HttpRequest message = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.PUT, "http://localhost");
         HttpUtil.setContentLength(message, 5);
         checkOversizedRequest(message);
     }
 
-    private static void checkOversizedRequest(HttpRequest message) {
+    private static void checkOversizedRequest(HttpRequest message) throws Exception {
         final EmbeddedChannel embedder = new EmbeddedChannel(new HttpObjectAggregator(4));
 
         assertFalse(embedder.writeInbound(message));
@@ -224,13 +217,8 @@ public class HttpObjectAggregatorTest {
         if (serverShouldCloseConnection(message, response)) {
             assertFalse(embedder.isOpen());
 
-            Throwable cause = assertThrows(CompletionException.class, new Executable() {
-                @Override
-                public void execute() {
-                    embedder.writeInbound(new DefaultHttpContent(Unpooled.EMPTY_BUFFER));
-                }
-            });
-            assertInstanceOf(ClosedChannelException.class, cause.getCause());
+            assertThrows(ClosedChannelException.class,
+                    () -> embedder.writeInbound(new DefaultHttpContent(Unpooled.EMPTY_BUFFER)));
             assertFalse(embedder.finish());
         } else {
             assertTrue(embedder.isOpen());
@@ -280,7 +268,7 @@ public class HttpObjectAggregatorTest {
     }
 
     @Test
-    public void testOversizedResponse() {
+    public void testOversizedResponse() throws Exception {
         final EmbeddedChannel embedder = new EmbeddedChannel(new HttpObjectAggregator(4));
         HttpResponse message = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
         HttpContent chunk1 = new DefaultHttpContent(Unpooled.copiedBuffer("test", CharsetUtil.US_ASCII));
@@ -289,13 +277,7 @@ public class HttpObjectAggregatorTest {
         assertFalse(embedder.writeInbound(message));
         assertFalse(embedder.writeInbound(chunk1));
 
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                embedder.writeInbound(chunk2);
-            }
-        });
-        assertInstanceOf(TooLongHttpContentException.class, cause.getCause());
+        assertThrows(TooLongHttpContentException.class, () -> embedder.writeInbound(chunk2));
 
         assertFalse(embedder.isOpen());
         assertFalse(embedder.finish());
@@ -328,16 +310,11 @@ public class HttpObjectAggregatorTest {
         ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
         aggr.handlerAdded(ctx);
         Mockito.verifyNoMoreInteractions(ctx);
-        assertThrows(IllegalStateException.class, new Executable() {
-            @Override
-            public void execute() {
-                aggr.setMaxCumulationBufferComponents(10);
-            }
-        });
+        assertThrows(IllegalStateException.class, () -> aggr.setMaxCumulationBufferComponents(10));
     }
 
     @Test
-    public void testAggregateTransferEncodingChunked() {
+    public void testAggregateTransferEncodingChunked() throws Exception {
         HttpObjectAggregator aggr = new HttpObjectAggregator(1024 * 1024);
         EmbeddedChannel embedder = new EmbeddedChannel(aggr);
 
@@ -365,7 +342,7 @@ public class HttpObjectAggregatorTest {
     }
 
     @Test
-    public void testBadRequest() {
+    public void testBadRequest() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new HttpRequestDecoder(), new HttpObjectAggregator(1024 * 1024));
         ch.writeInbound(Unpooled.copiedBuffer("GET / HTTP/1.0 with extra\r\n", CharsetUtil.UTF_8));
         Object inbound = ch.readInbound();
@@ -387,7 +364,7 @@ public class HttpObjectAggregatorTest {
     }
 
     @Test
-    public void testOversizedRequestWith100Continue() {
+    public void testOversizedRequestWith100Continue() throws Exception {
         EmbeddedChannel embedder = new EmbeddedChannel(new HttpObjectAggregator(8));
 
         // Send an oversized request with 100 continue.
@@ -434,12 +411,12 @@ public class HttpObjectAggregatorTest {
     }
 
     @Test
-    public void testUnsupportedExpectHeaderExpectation() {
+    public void testUnsupportedExpectHeaderExpectation() throws Exception {
         runUnsupportedExceptHeaderExceptionTest(true);
         runUnsupportedExceptHeaderExceptionTest(false);
     }
 
-    private static void runUnsupportedExceptHeaderExceptionTest(final boolean close) {
+    private static void runUnsupportedExceptHeaderExceptionTest(final boolean close) throws Exception {
         final HttpObjectAggregator aggregator;
         final int maxContentLength = 4;
         if (close) {
@@ -480,7 +457,7 @@ public class HttpObjectAggregatorTest {
     }
 
     @Test
-    public void testValidRequestWith100ContinueAndDecoder() {
+    public void testValidRequestWith100ContinueAndDecoder() throws Exception {
         EmbeddedChannel embedder = new EmbeddedChannel(new HttpRequestDecoder(), new HttpObjectAggregator(100));
         embedder.writeInbound(Unpooled.copiedBuffer(
             "GET /upload HTTP/1.1\r\n" +
@@ -497,7 +474,7 @@ public class HttpObjectAggregatorTest {
     }
 
     @Test
-    public void testOversizedRequestWith100ContinueAndDecoder() {
+    public void testOversizedRequestWith100ContinueAndDecoder() throws Exception {
         EmbeddedChannel embedder = new EmbeddedChannel(new HttpRequestDecoder(), new HttpObjectAggregator(4));
         embedder.writeInbound(Unpooled.copiedBuffer(
                 "PUT /upload HTTP/1.1\r\n" +
@@ -526,7 +503,7 @@ public class HttpObjectAggregatorTest {
     }
 
     @Test
-    public void testOversizedRequestWith100ContinueAndDecoderCloseConnection() {
+    public void testOversizedRequestWith100ContinueAndDecoderCloseConnection() throws Exception {
         EmbeddedChannel embedder = new EmbeddedChannel(new HttpRequestDecoder(), new HttpObjectAggregator(4, true));
         embedder.writeInbound(Unpooled.copiedBuffer(
                 "PUT /upload HTTP/1.1\r\n" +
@@ -545,7 +522,7 @@ public class HttpObjectAggregatorTest {
     }
 
     @Test
-    public void testRequestAfterOversized100ContinueAndDecoder() {
+    public void testRequestAfterOversized100ContinueAndDecoder() throws Exception {
         EmbeddedChannel embedder = new EmbeddedChannel(new HttpRequestDecoder(), new HttpObjectAggregator(15));
 
         // Write first request with Expect: 100-continue.
@@ -592,7 +569,7 @@ public class HttpObjectAggregatorTest {
     }
 
     @Test
-    public void testReplaceAggregatedRequest() {
+    public void testReplaceAggregatedRequest() throws Exception {
         EmbeddedChannel embedder = new EmbeddedChannel(new HttpObjectAggregator(1024 * 1024));
 
         Exception boom = new Exception("boom");
@@ -610,7 +587,7 @@ public class HttpObjectAggregatorTest {
     }
 
     @Test
-    public void testReplaceAggregatedResponse() {
+    public void testReplaceAggregatedResponse() throws Exception {
         EmbeddedChannel embedder = new EmbeddedChannel(new HttpObjectAggregator(1024 * 1024));
 
         Exception boom = new Exception("boom");
@@ -628,7 +605,7 @@ public class HttpObjectAggregatorTest {
     }
 
     @Test
-    public void testSelectiveRequestAggregation() {
+    public void testSelectiveRequestAggregation() throws Exception {
         HttpObjectAggregator myPostAggregator = new HttpObjectAggregator(1024 * 1024) {
             @Override
             protected boolean isStartMessage(HttpObject msg) throws Exception {
@@ -687,7 +664,7 @@ public class HttpObjectAggregatorTest {
     }
 
     @Test
-    public void testSelectiveResponseAggregation() {
+    public void testSelectiveResponseAggregation() throws Exception {
         HttpObjectAggregator myTextAggregator = new HttpObjectAggregator(1024 * 1024) {
             @Override
             protected boolean isStartMessage(HttpObject msg) throws Exception {
@@ -747,23 +724,17 @@ public class HttpObjectAggregatorTest {
     }
 
     @Test
-    public void testPrematureClosureWithChunkedEncodingAndAggregator() {
+    public void testPrematureClosureWithChunkedEncodingAndAggregator() throws Exception {
         final EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder(), new HttpObjectAggregator(1024));
 
         // Write the partial response.
         assertFalse(ch.writeInbound(Unpooled.copiedBuffer(
                 "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n8\r\n12345678", CharsetUtil.US_ASCII)));
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                ch.finish();
-            }
-        });
-        assertInstanceOf(PrematureChannelClosureException.class, cause.getCause());
+        assertThrows(PrematureChannelClosureException.class, ch::finish);
     }
 
     @Test
-    public void invalidContinueLength() {
+    public void invalidContinueLength() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new HttpServerCodec(), new HttpObjectAggregator(1024));
 
         channel.writeInbound(Unpooled.copiedBuffer("POST / HTTP/1.1\r\n" +

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpObjectAggregatorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpObjectAggregatorTest.java
@@ -133,12 +133,13 @@ public class HttpObjectAggregatorTest {
         assertEquals("0", response.headers().get(HttpHeaderNames.CONTENT_LENGTH));
         assertFalse(embedder.isOpen());
 
-        assertThrows(ClosedChannelException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 embedder.writeInbound(chunk3);
             }
         });
+        assertInstanceOf(ClosedChannelException.class, cause.getCause());
 
         assertFalse(embedder.finish());
     }
@@ -223,13 +224,13 @@ public class HttpObjectAggregatorTest {
         if (serverShouldCloseConnection(message, response)) {
             assertFalse(embedder.isOpen());
 
-            assertThrows(ClosedChannelException.class, new Executable() {
+            Throwable cause = assertThrows(CompletionException.class, new Executable() {
                 @Override
                 public void execute() {
                     embedder.writeInbound(new DefaultHttpContent(Unpooled.EMPTY_BUFFER));
                 }
             });
-
+            assertInstanceOf(ClosedChannelException.class, cause.getCause());
             assertFalse(embedder.finish());
         } else {
             assertTrue(embedder.isOpen());

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpObjectAggregatorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpObjectAggregatorTest.java
@@ -32,6 +32,7 @@ import org.mockito.Mockito;
 
 import java.nio.channels.ClosedChannelException;
 import java.util.List;
+import java.util.concurrent.CompletionException;
 
 import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -287,12 +288,13 @@ public class HttpObjectAggregatorTest {
         assertFalse(embedder.writeInbound(message));
         assertFalse(embedder.writeInbound(chunk1));
 
-        assertThrows(TooLongHttpContentException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 embedder.writeInbound(chunk2);
             }
         });
+        assertInstanceOf(TooLongHttpContentException.class, cause.getCause());
 
         assertFalse(embedder.isOpen());
         assertFalse(embedder.finish());
@@ -750,12 +752,13 @@ public class HttpObjectAggregatorTest {
         // Write the partial response.
         assertFalse(ch.writeInbound(Unpooled.copiedBuffer(
                 "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n8\r\n12345678", CharsetUtil.US_ASCII)));
-        assertThrows(PrematureChannelClosureException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 ch.finish();
             }
         });
+        assertInstanceOf(PrematureChannelClosureException.class, cause.getCause());
     }
 
     @Test

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -73,42 +73,42 @@ public class HttpRequestDecoderTest {
     }
 
     @Test
-    public void testDecodeWholeRequestAtOnceCRLFDelimiters() {
+    public void testDecodeWholeRequestAtOnceCRLFDelimiters() throws Exception {
         testDecodeWholeRequestAtOnce(CONTENT_CRLF_DELIMITERS);
     }
 
     @Test
-    public void testDecodeWholeRequestAtOnceLFDelimiters() {
+    public void testDecodeWholeRequestAtOnceLFDelimiters() throws Exception {
         testDecodeWholeRequestAtOnce(CONTENT_LF_DELIMITERS);
     }
 
     @Test
-    public void testDecodeWholeRequestAtOnceMixedDelimiters() {
+    public void testDecodeWholeRequestAtOnceMixedDelimiters() throws Exception {
         testDecodeWholeRequestAtOnce(CONTENT_MIXED_DELIMITERS);
     }
 
     @Test
-    public void testDecodeWholeRequestAtOnceFailesWithLFDelimiters() {
+    public void testDecodeWholeRequestAtOnceFailesWithLFDelimiters() throws Exception {
         testDecodeWholeRequestAtOnce(CONTENT_LF_DELIMITERS, HttpObjectDecoder.DEFAULT_MAX_HEADER_SIZE, true, true);
     }
 
     @Test
-    public void testDecodeWholeRequestAtOnceFailsWithMixedDelimiters() {
+    public void testDecodeWholeRequestAtOnceFailsWithMixedDelimiters() throws Exception {
         testDecodeWholeRequestAtOnce(CONTENT_MIXED_DELIMITERS, HttpObjectDecoder.DEFAULT_MAX_HEADER_SIZE, true, true);
     }
 
     @Test
-    public void testDecodeWholeRequestAtOnceMixedDelimitersWithIntegerOverflowOnMaxBodySize() {
+    public void testDecodeWholeRequestAtOnceMixedDelimitersWithIntegerOverflowOnMaxBodySize() throws Exception {
         testDecodeWholeRequestAtOnce(CONTENT_MIXED_DELIMITERS, Integer.MAX_VALUE, false, false);
         testDecodeWholeRequestAtOnce(CONTENT_MIXED_DELIMITERS, Integer.MAX_VALUE - 1, false, false);
     }
 
-    private static void testDecodeWholeRequestAtOnce(byte[] content) {
+    private static void testDecodeWholeRequestAtOnce(byte[] content) throws Exception {
         testDecodeWholeRequestAtOnce(content, HttpObjectDecoder.DEFAULT_MAX_HEADER_SIZE, false, false);
     }
 
     private static void testDecodeWholeRequestAtOnce(byte[] content, int maxHeaderSize, boolean strictLineParsing,
-                                                     boolean expectFailure) {
+                                                     boolean expectFailure) throws Exception {
         HttpDecoderConfig config = new HttpDecoderConfig()
                 .setMaxHeaderSize(maxHeaderSize)
                 .setStrictLineParsing(strictLineParsing);
@@ -153,39 +153,39 @@ public class HttpRequestDecoderTest {
     }
 
     @Test
-    public void testDecodeWholeRequestInMultipleStepsCRLFDelimiters() {
+    public void testDecodeWholeRequestInMultipleStepsCRLFDelimiters() throws Exception {
         testDecodeWholeRequestInMultipleSteps(CONTENT_CRLF_DELIMITERS, true, false);
     }
 
     @Test
-    public void testDecodeWholeRequestInMultipleStepsLFDelimiters() {
+    public void testDecodeWholeRequestInMultipleStepsLFDelimiters() throws Exception {
         testDecodeWholeRequestInMultipleSteps(CONTENT_LF_DELIMITERS, false, false);
     }
 
     @Test
-    public void testDecodeWholeRequestInMultipleStepsMixedDelimiters() {
+    public void testDecodeWholeRequestInMultipleStepsMixedDelimiters() throws Exception {
         testDecodeWholeRequestInMultipleSteps(CONTENT_MIXED_DELIMITERS, false, false);
     }
 
     @Test
-    public void testDecodeWholeRequestInMultipleStepsFailsWithLFDelimiters() {
+    public void testDecodeWholeRequestInMultipleStepsFailsWithLFDelimiters() throws Exception {
         testDecodeWholeRequestInMultipleSteps(CONTENT_LF_DELIMITERS, true, true);
     }
 
     @Test
-    public void testDecodeWholeRequestInMultipleStepsFailsWithMixedDelimiters() {
+    public void testDecodeWholeRequestInMultipleStepsFailsWithMixedDelimiters() throws Exception {
         testDecodeWholeRequestInMultipleSteps(CONTENT_MIXED_DELIMITERS, true, true);
     }
 
     private static void testDecodeWholeRequestInMultipleSteps(
-            byte[] content, boolean strictLineParsing, boolean expectFailure) {
+            byte[] content, boolean strictLineParsing, boolean expectFailure) throws Exception {
         for (int i = 1; i < content.length; i++) {
             testDecodeWholeRequestInMultipleSteps(content, i, strictLineParsing, expectFailure);
         }
     }
 
     private static void testDecodeWholeRequestInMultipleSteps(
-            byte[] content, int fragmentSize, boolean strictLineParsing, boolean expectFailure) {
+            byte[] content, int fragmentSize, boolean strictLineParsing, boolean expectFailure) throws Exception {
         HttpDecoderConfig config = new HttpDecoderConfig()
                 .setStrictLineParsing(strictLineParsing);
         EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder(config));
@@ -235,7 +235,7 @@ public class HttpRequestDecoderTest {
     }
 
     @Test
-    public void testMultiLineHeader() {
+    public void testMultiLineHeader() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
         String crlf = "\r\n";
         String request =  "GET /some/path HTTP/1.1" + crlf +
@@ -258,7 +258,7 @@ public class HttpRequestDecoderTest {
     }
 
     @Test
-    public void testEmptyHeaderValue() {
+    public void testEmptyHeaderValue() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
         String crlf = "\r\n";
         String request =  "GET /some/path HTTP/1.1" + crlf +
@@ -270,7 +270,7 @@ public class HttpRequestDecoderTest {
     }
 
     @Test
-    public void test100Continue() {
+    public void test100Continue() throws Exception {
         HttpRequestDecoder decoder = new HttpRequestDecoder();
         EmbeddedChannel channel = new EmbeddedChannel(decoder);
         String oversized =
@@ -294,7 +294,7 @@ public class HttpRequestDecoderTest {
     }
 
     @Test
-    public void test100ContinueWithBadClient() {
+    public void test100ContinueWithBadClient() throws Exception {
         HttpRequestDecoder decoder = new HttpRequestDecoder();
         EmbeddedChannel channel = new EmbeddedChannel(decoder);
         String oversized =
@@ -324,7 +324,7 @@ public class HttpRequestDecoderTest {
     }
 
     @Test
-    public void testMessagesSplitBetweenMultipleBuffers() {
+    public void testMessagesSplitBetweenMultipleBuffers() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
         String crlf = "\r\n";
         String str1 = "GET /some/path HTTP/1.1" + crlf +
@@ -355,7 +355,7 @@ public class HttpRequestDecoderTest {
     }
 
     @Test
-    public void testTooLargeInitialLine() {
+    public void testTooLargeInitialLine() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder(10, 1024, 1024));
         String requestStr = "GET /some/path HTTP/1.1\r\n" +
                 "Host: localhost1\r\n\r\n";
@@ -368,16 +368,16 @@ public class HttpRequestDecoderTest {
     }
 
     @Test
-    public void testTooLargeInitialLineWithWSOnly() {
+    public void testTooLargeInitialLineWithWSOnly() throws Exception {
         testTooLargeInitialLineWithControlCharsOnly("                    ");
     }
 
     @Test
-    public void testTooLargeInitialLineWithCRLFOnly() {
+    public void testTooLargeInitialLineWithCRLFOnly() throws Exception {
         testTooLargeInitialLineWithControlCharsOnly("\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n");
     }
 
-    private static void testTooLargeInitialLineWithControlCharsOnly(String controlChars) {
+    private static void testTooLargeInitialLineWithControlCharsOnly(String controlChars) throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder(15, 1024, 1024));
         String requestStr = controlChars + "GET / HTTP/1.1\r\n" +
                 "Host: localhost1\r\n\r\n";
@@ -390,7 +390,7 @@ public class HttpRequestDecoderTest {
     }
 
     @Test
-    public void testInitialLineWithLeadingControlChars() {
+    public void testInitialLineWithLeadingControlChars() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
         String crlf = "\r\n";
         String request =  crlf + "GET /some/path HTTP/1.1" + crlf +
@@ -404,7 +404,7 @@ public class HttpRequestDecoderTest {
     }
 
     @Test
-    public void testTooLargeHeaders() {
+    public void testTooLargeHeaders() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder(1024, 10, 1024));
         String requestStr = "GET /some/path HTTP/1.1\r\n" +
                 "Host: localhost1\r\n\r\n";
@@ -444,31 +444,31 @@ public class HttpRequestDecoderTest {
     }
 
     @Test
-    public void testHeaderNameStartsWithControlChar1c() {
+    public void testHeaderNameStartsWithControlChar1c() throws Exception {
         testHeaderNameStartsWithControlChar(0x1c);
     }
 
     @Test
-    public void testHeaderNameStartsWithControlChar1d() {
+    public void testHeaderNameStartsWithControlChar1d() throws Exception {
         testHeaderNameStartsWithControlChar(0x1d);
     }
 
     @Test
-    public void testHeaderNameStartsWithControlChar1e() {
+    public void testHeaderNameStartsWithControlChar1e() throws Exception {
         testHeaderNameStartsWithControlChar(0x1e);
     }
 
     @Test
-    public void testHeaderNameStartsWithControlChar1f() {
+    public void testHeaderNameStartsWithControlChar1f() throws Exception {
         testHeaderNameStartsWithControlChar(0x1f);
     }
 
     @Test
-    public void testHeaderNameStartsWithControlChar0c() {
+    public void testHeaderNameStartsWithControlChar0c() throws Exception {
         testHeaderNameStartsWithControlChar(0x0c);
     }
 
-    private void testHeaderNameStartsWithControlChar(int controlChar) {
+    private void testHeaderNameStartsWithControlChar(int controlChar) throws Exception {
         ByteBuf requestBuffer = Unpooled.buffer();
         requestBuffer.writeCharSequence("GET /some/path HTTP/1.1\r\n" +
                 "Host: netty.io\r\n", CharsetUtil.US_ASCII);
@@ -478,31 +478,31 @@ public class HttpRequestDecoderTest {
     }
 
     @Test
-    public void testHeaderNameEndsWithControlChar1c() {
+    public void testHeaderNameEndsWithControlChar1c() throws Exception {
         testHeaderNameEndsWithControlChar(0x1c);
     }
 
     @Test
-    public void testHeaderNameEndsWithControlChar1d() {
+    public void testHeaderNameEndsWithControlChar1d() throws Exception {
         testHeaderNameEndsWithControlChar(0x1d);
     }
 
     @Test
-    public void testHeaderNameEndsWithControlChar1e() {
+    public void testHeaderNameEndsWithControlChar1e() throws Exception {
         testHeaderNameEndsWithControlChar(0x1e);
     }
 
     @Test
-    public void testHeaderNameEndsWithControlChar1f() {
+    public void testHeaderNameEndsWithControlChar1f() throws Exception {
         testHeaderNameEndsWithControlChar(0x1f);
     }
 
     @Test
-    public void testHeaderNameEndsWithControlChar0c() {
+    public void testHeaderNameEndsWithControlChar0c() throws Exception {
         testHeaderNameEndsWithControlChar(0x0c);
     }
 
-    private void testHeaderNameEndsWithControlChar(int controlChar) {
+    private void testHeaderNameEndsWithControlChar(int controlChar) throws Exception {
         ByteBuf requestBuffer = Unpooled.buffer();
         requestBuffer.writeCharSequence("GET /some/path HTTP/1.1\r\n" +
                 "Host: netty.io\r\n", CharsetUtil.US_ASCII);
@@ -513,7 +513,7 @@ public class HttpRequestDecoderTest {
     }
 
     @Test
-    public void testWhitespace() {
+    public void testWhitespace() throws Exception {
         String requestStr = "GET /some/path HTTP/1.1\r\n" +
                 "Transfer-Encoding : chunked\r\n" +
                 "Host: netty.io\r\n\r\n";
@@ -521,7 +521,7 @@ public class HttpRequestDecoderTest {
     }
 
     @Test
-    public void testWhitespaceInTransferEncoding01() {
+    public void testWhitespaceInTransferEncoding01() throws Exception {
         String requestStr = "GET /some/path HTTP/1.1\r\n" +
                 "Transfer-Encoding : chunked\r\n" +
                 "Content-Length: 1\r\n" +
@@ -531,7 +531,7 @@ public class HttpRequestDecoderTest {
     }
 
     @Test
-    public void testWhitespaceInTransferEncoding02() {
+    public void testWhitespaceInTransferEncoding02() throws Exception {
         String requestStr = "POST / HTTP/1.1" +
                 "Transfer-Encoding : chunked\r\n" +
                 "Host: target.com" +
@@ -544,7 +544,7 @@ public class HttpRequestDecoderTest {
     }
 
     @Test
-    public void testHeaderWithNoValueAndMissingColon() {
+    public void testHeaderWithNoValueAndMissingColon() throws Exception {
         String requestStr = "GET /some/path HTTP/1.1\r\n" +
                 "Content-Length: 0\r\n" +
                 "Host:\r\n" +
@@ -553,7 +553,7 @@ public class HttpRequestDecoderTest {
     }
 
     @Test
-    public void testMultipleContentLengthHeaders() {
+    public void testMultipleContentLengthHeaders() throws Exception {
         String requestStr = "GET /some/path HTTP/1.1\r\n" +
                 "Content-Length: 1\r\n" +
                 "Content-Length: 0\r\n\r\n" +
@@ -562,7 +562,7 @@ public class HttpRequestDecoderTest {
     }
 
     @Test
-    public void testMultipleContentLengthHeaders2() {
+    public void testMultipleContentLengthHeaders2() throws Exception {
         String requestStr = "GET /some/path HTTP/1.1\r\n" +
                 "Content-Length: 1\r\n" +
                 "Connection: close\r\n" +
@@ -572,7 +572,7 @@ public class HttpRequestDecoderTest {
     }
 
     @Test
-    public void testContentLengthHeaderWithCommaValue() {
+    public void testContentLengthHeaderWithCommaValue() throws Exception {
         String requestStr = "GET /some/path HTTP/1.1\r\n" +
                 "Content-Length: 1,1\r\n\r\n" +
                 "b";
@@ -580,7 +580,7 @@ public class HttpRequestDecoderTest {
     }
 
     @Test
-    public void testMultipleContentLengthHeadersWithFolding() {
+    public void testMultipleContentLengthHeadersWithFolding() throws Exception {
         String requestStr = "POST / HTTP/1.1\r\n" +
                 "Host: example.com\r\n" +
                 "Connection: close\r\n" +
@@ -592,19 +592,19 @@ public class HttpRequestDecoderTest {
     }
 
     @Test
-    public void testContentLengthAndTransferEncodingHeadersWithVerticalTab() {
+    public void testContentLengthAndTransferEncodingHeadersWithVerticalTab() throws Exception {
         testContentLengthAndTransferEncodingHeadersWithInvalidSeparator((char) 0x0b, false);
         testContentLengthAndTransferEncodingHeadersWithInvalidSeparator((char) 0x0b, true);
     }
 
     @Test
-    public void testContentLengthAndTransferEncodingHeadersWithCR() {
+    public void testContentLengthAndTransferEncodingHeadersWithCR() throws Exception {
         testContentLengthAndTransferEncodingHeadersWithInvalidSeparator((char) 0x0d, false);
         testContentLengthAndTransferEncodingHeadersWithInvalidSeparator((char) 0x0d, true);
     }
 
     private static void testContentLengthAndTransferEncodingHeadersWithInvalidSeparator(
-            char separator, boolean extraLine) {
+            char separator, boolean extraLine) throws Exception {
         String requestStr = "POST / HTTP/1.1\r\n" +
                 "Host: example.com\r\n" +
                 "Connection: close\r\n" +
@@ -616,7 +616,7 @@ public class HttpRequestDecoderTest {
     }
 
     @Test
-    public void testContentLengthHeaderAndChunked() {
+    public void testContentLengthHeaderAndChunked() throws Exception {
         String requestStr = "POST / HTTP/1.1\r\n" +
                 "Host: example.com\r\n" +
                 "Connection: close\r\n" +
@@ -696,7 +696,7 @@ public class HttpRequestDecoderTest {
     }
 
     @Test
-    public void testOrderOfHeadersWithContentLength() {
+    public void testOrderOfHeadersWithContentLength() throws Exception {
         String requestStr = "GET /some/path HTTP/1.1\r\n" +
                 "Host: example.com\r\n" +
                 "Content-Length: 5\r\n" +
@@ -713,7 +713,7 @@ public class HttpRequestDecoderTest {
     }
 
     @Test
-    public void testHttpMessageDecoderResult() {
+    public void testHttpMessageDecoderResult() throws Exception {
         String requestStr = "PUT /some/path HTTP/1.1\r\n" +
                 "Content-Length: 11\r\n" +
                 "Connection: close\r\n\r\n" +
@@ -770,7 +770,7 @@ public class HttpRequestDecoderTest {
     }
 
     @Test
-    public void testChunkSizeOverflow() {
+    public void testChunkSizeOverflow() throws Exception {
         String requestStr = "PUT /some/path HTTP/1.1\r\n" +
                 "Transfer-Encoding: chunked\r\n\r\n" +
                 "8ccccccc\r\n";
@@ -786,7 +786,7 @@ public class HttpRequestDecoderTest {
     }
 
     @Test
-    public void testChunkSizeOverflow2() {
+    public void testChunkSizeOverflow2() throws Exception {
         String requestStr = "PUT /some/path HTTP/1.1\r\n" +
                 "Transfer-Encoding: chunked\r\n\r\n" +
                 "bbbbbbbe;\r\n\r\n";
@@ -804,29 +804,29 @@ public class HttpRequestDecoderTest {
     @ParameterizedTest
     @ValueSource(strings = { "HTP/1.1", "HTTP", "HTTP/1x", "Something/1.1", "HTTP/1",
             "HTTP/1.11", "HTTP/11.1", "HTTP/A.1", "HTTP/1.B"})
-    public void testInvalidVersion(String version) {
+    public void testInvalidVersion(String version) throws Exception {
         testInvalidHeaders0("GET / " + version + "\r\nHost: whatever\r\n\r\n");
     }
 
     @ParameterizedTest
     // See https://www.unicode.org/charts/nameslist/n_0000.html
     @ValueSource(strings = { "\r", "\u000b", "\u000c" })
-    public void testHeaderValueWithInvalidSuffix(String suffix) {
+    public void testHeaderValueWithInvalidSuffix(String suffix) throws Exception {
         testInvalidHeaders0("GET / HTTP/1.1\r\nHost: whatever\r\nTest-Key: test-value" + suffix + "\r\n\r\n");
     }
 
     @Test
-    public void testLeadingWhitespaceInFirstHeaderName() {
+    public void testLeadingWhitespaceInFirstHeaderName() throws Exception {
         testInvalidHeaders0("POST / HTTP/1.1\r\n\tContent-Length: 1\r\n\r\nX");
     }
 
    @Test
-    public void testNulInInitialLine() {
+    public void testNulInInitialLine() throws Exception {
         testInvalidHeaders0("GET / HTTP/1.1\u0000\r\nHost: whatever\r\n\r\n");
     }
 
     @Test
-    void reentrantClose() {
+    void reentrantClose() throws Exception {
         String requestStr = "GET / HTTP/1.1\r\n" +
                 "Host: example.com\r\n" +
                 "Content-Length: 0\r\n" +
@@ -862,11 +862,11 @@ public class HttpRequestDecoderTest {
         assertFalse(channel.finish());
     }
 
-    private static void testInvalidHeaders0(String requestStr) {
+    private static void testInvalidHeaders0(String requestStr) throws Exception {
         testInvalidHeaders0(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII));
     }
 
-    private static void testInvalidHeaders0(ByteBuf requestBuffer) {
+    private static void testInvalidHeaders0(ByteBuf requestBuffer) throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
         assertTrue(channel.writeInbound(requestBuffer));
         HttpRequest request = channel.readInbound();

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestEncoderTest.java
@@ -295,7 +295,7 @@ public class HttpRequestEncoderTest {
     }
 
     @Test
-    public void testCustomMessageEmptyLastContent() {
+    public void testCustomMessageEmptyLastContent() throws Exception {
         HttpRequestEncoder encoder = new HttpRequestEncoder();
         EmbeddedChannel channel = new EmbeddedChannel(encoder);
         HttpRequest customMsg = new CustomFullHttpRequest(HttpVersion.HTTP_1_1,

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
@@ -48,7 +48,7 @@ public class HttpResponseDecoderTest {
      * @see <a href="https://github.com/netty/netty/issues/3445">#3445</a>
      */
     @Test
-    public void testMaxHeaderSize1() {
+    public void testMaxHeaderSize1() throws Exception {
         final int maxHeaderSize = 8192;
 
         final EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder(4096, maxHeaderSize, 8192));
@@ -80,7 +80,7 @@ public class HttpResponseDecoderTest {
      * Complementary test case of {@link #testMaxHeaderSize1()} When it actually exceeds the maximum, it should fail.
      */
     @Test
-    public void testMaxHeaderSize2() {
+    public void testMaxHeaderSize2() throws Exception {
         final int maxHeaderSize = 8192;
 
         final EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder(4096, maxHeaderSize, 8192));
@@ -135,7 +135,7 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
-    public void testResponseChunked() {
+    public void testResponseChunked() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder());
         ch.writeInbound(Unpooled.copiedBuffer("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n",
                 CharsetUtil.US_ASCII));
@@ -177,7 +177,7 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
-    public void testResponseChunkedWithValidUncommonPatterns() {
+    public void testResponseChunkedWithValidUncommonPatterns() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder());
         ch.writeInbound(Unpooled.copiedBuffer("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n",
                                               CharsetUtil.US_ASCII));
@@ -249,7 +249,7 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
-    public void testResponseChunkedWithControlChars() {
+    public void testResponseChunkedWithControlChars() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder());
         ch.writeInbound(Unpooled.copiedBuffer("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n",
                                               CharsetUtil.US_ASCII));
@@ -289,7 +289,7 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
-    public void testResponseDisallowPartialChunks() {
+    public void testResponseDisallowPartialChunks() throws Exception {
         HttpResponseDecoder decoder = new HttpResponseDecoder(
             HttpObjectDecoder.DEFAULT_MAX_INITIAL_LINE_LENGTH,
             HttpObjectDecoder.DEFAULT_MAX_HEADER_SIZE,
@@ -341,7 +341,7 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
-    public void testResponseChunkedExceedMaxChunkSize() {
+    public void testResponseChunkedExceedMaxChunkSize() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder(4096, 8192, 32));
         ch.writeInbound(
                 Unpooled.copiedBuffer("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n", CharsetUtil.US_ASCII));
@@ -493,7 +493,7 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
-    public void testLastResponseWithEmptyHeaderAndEmptyContent() {
+    public void testLastResponseWithEmptyHeaderAndEmptyContent() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder());
         ch.writeInbound(Unpooled.copiedBuffer("HTTP/1.1 200 OK\r\n\r\n", CharsetUtil.US_ASCII));
 
@@ -512,7 +512,7 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
-    public void testLastResponseWithoutContentLengthHeader() {
+    public void testLastResponseWithoutContentLengthHeader() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder());
         ch.writeInbound(Unpooled.copiedBuffer("HTTP/1.1 200 OK\r\n\r\n", CharsetUtil.US_ASCII));
 
@@ -536,7 +536,7 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
-    public void testLastResponseWithHeaderRemoveTrailingSpaces() {
+    public void testLastResponseWithHeaderRemoveTrailingSpaces() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder());
         ch.writeInbound(Unpooled.copiedBuffer(
                 "HTTP/1.1 200 OK\r\nX-Header: h2=h2v2; Expires=Wed, 09-Jun-2021 10:18:14 GMT       \r\n\r\n",
@@ -563,7 +563,7 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
-    public void testResetContentResponseWithTransferEncoding() {
+    public void testResetContentResponseWithTransferEncoding() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder());
         assertTrue(ch.writeInbound(Unpooled.copiedBuffer(
                 "HTTP/1.1 205 Reset Content\r\n" +
@@ -585,7 +585,7 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
-    public void testLastResponseWithTrailingHeader() {
+    public void testLastResponseWithTrailingHeader() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder());
         ch.writeInbound(Unpooled.copiedBuffer(
                 "HTTP/1.1 200 OK\r\n" +
@@ -616,7 +616,7 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
-    public void testLastResponseWithTrailingHeaderFragmented() {
+    public void testLastResponseWithTrailingHeaderFragmented() throws Exception {
         byte[] data = ("HTTP/1.1 200 OK\r\n" +
                 "Transfer-Encoding: chunked\r\n" +
                 "\r\n" +
@@ -630,7 +630,8 @@ public class HttpResponseDecoderTest {
         }
     }
 
-    private static void testLastResponseWithTrailingHeaderFragmented(byte[] content, int fragmentSize) {
+    private static void testLastResponseWithTrailingHeaderFragmented(byte[] content, int fragmentSize)
+            throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder());
         int headerLength = 47;
         // split up the header
@@ -666,7 +667,7 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
-    public void testResponseWithContentLength() {
+    public void testResponseWithContentLength() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder());
         ch.writeInbound(Unpooled.copiedBuffer(
                 "HTTP/1.1 200 OK\r\n" +
@@ -699,7 +700,7 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
-    public void testResponseWithContentLengthFragmented() {
+    public void testResponseWithContentLengthFragmented() throws Exception {
         byte[] data = ("HTTP/1.1 200 OK\r\n" +
                 "Content-Length: 10\r\n" +
                 "\r\n").getBytes(CharsetUtil.US_ASCII);
@@ -709,7 +710,7 @@ public class HttpResponseDecoderTest {
         }
     }
 
-    private static void testResponseWithContentLengthFragmented(byte[] header, int fragmentSize) {
+    private static void testResponseWithContentLengthFragmented(byte[] header, int fragmentSize) throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder());
         // split up the header
         for (int a = 0; a < header.length;) {
@@ -747,7 +748,7 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
-    public void testOrderOfHeadersWithContentLength() {
+    public void testOrderOfHeadersWithContentLength() throws Exception {
         String requestStr = "HTTP/1.1 200 OK\r\n" +
                 "Content-Type: text/plain; charset=UTF-8\r\n" +
                 "Content-Length: 5\r\n" +
@@ -764,7 +765,7 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
-    public void testWebSocketResponse() {
+    public void testWebSocketResponse() throws Exception {
         byte[] data = ("HTTP/1.1 101 WebSocket Protocol Handshake\r\n" +
                 "Upgrade: WebSocket\r\n" +
                 "Connection: Upgrade\r\n" +
@@ -789,7 +790,7 @@ public class HttpResponseDecoderTest {
 
     // See https://github.com/netty/netty/issues/2173
     @Test
-    public void testWebSocketResponseWithDataFollowing() {
+    public void testWebSocketResponseWithDataFollowing() throws Exception {
         byte[] data = ("HTTP/1.1 101 WebSocket Protocol Handshake\r\n" +
                 "Upgrade: WebSocket\r\n" +
                 "Connection: Upgrade\r\n" +
@@ -824,7 +825,7 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
-    public void testGarbageHeaders() {
+    public void testGarbageHeaders() throws Exception {
         // A response without headers - from https://github.com/netty/netty/issues/2103
         byte[] data = ("<html>\r\n" +
                 "<head><title>400 Bad Request</title></head>\r\n" +
@@ -860,7 +861,7 @@ public class HttpResponseDecoderTest {
      * the connection is closed.
      */
     @Test
-    public void testGarbageChunk() {
+    public void testGarbageChunk() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseDecoder());
         String responseWithIllegalChunk =
                 "HTTP/1.1 200 OK\r\n" +
@@ -883,7 +884,7 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
-    public void testWhiteSpaceGarbageChunk() {
+    public void testWhiteSpaceGarbageChunk() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseDecoder());
         String responseWithIllegalChunk =
                 "HTTP/1.1 200 OK\r\n" +
@@ -906,7 +907,7 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
-    public void testLeadingWhiteSpacesSemiColonGarbageChunk() {
+    public void testLeadingWhiteSpacesSemiColonGarbageChunk() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseDecoder());
         String responseWithIllegalChunk =
                 "HTTP/1.1 200 OK\r\n" +
@@ -929,7 +930,7 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
-    public void testControlCharGarbageChunk() {
+    public void testControlCharGarbageChunk() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseDecoder());
         String responseWithIllegalChunk =
                 "HTTP/1.1 200 OK\r\n" +
@@ -952,7 +953,7 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
-    public void testLeadingWhiteSpacesControlCharGarbageChunk() {
+    public void testLeadingWhiteSpacesControlCharGarbageChunk() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseDecoder());
         String responseWithIllegalChunk =
                 "HTTP/1.1 200 OK\r\n" +
@@ -975,7 +976,7 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
-    public void testGarbageChunkAfterWhiteSpaces() {
+    public void testGarbageChunkAfterWhiteSpaces() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseDecoder());
         String responseWithIllegalChunk =
                 "HTTP/1.1 200 OK\r\n" +
@@ -1055,7 +1056,7 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
-    public void testConnectionClosedBeforeHeadersReceived() {
+    public void testConnectionClosedBeforeHeadersReceived() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseDecoder());
         String responseInitialLine =
                 "HTTP/1.1 200 OK\r\n";
@@ -1068,7 +1069,7 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
-    public void testTrailerWithEmptyLineInSeparateBuffer() {
+    public void testTrailerWithEmptyLineInSeparateBuffer() throws Exception {
         HttpResponseDecoder decoder = new HttpResponseDecoder();
         EmbeddedChannel channel = new EmbeddedChannel(decoder);
 
@@ -1097,7 +1098,7 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
-    public void testWhitespace() {
+    public void testWhitespace() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseDecoder());
         String requestStr = "HTTP/1.1 200 OK\r\n" +
                 "Transfer-Encoding : chunked\r\n" +
@@ -1112,7 +1113,7 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
-    public void testHttpMessageDecoderResult() {
+    public void testHttpMessageDecoderResult() throws Exception {
         String responseStr = "HTTP/1.1 200 OK\r\n" +
                 "Content-Length: 11\r\n" +
                 "Connection: close\r\n\r\n" +
@@ -1132,7 +1133,7 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
-    public void testStatusWithoutReasonPhrase() {
+    public void testStatusWithoutReasonPhrase() throws Exception {
         String responseStr = "HTTP/1.1 200 \r\n" +
                 "Content-Length: 0\r\n\r\n";
         EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseDecoder());
@@ -1146,31 +1147,31 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
-    public void testHeaderNameStartsWithControlChar1c() {
+    public void testHeaderNameStartsWithControlChar1c() throws Exception {
         testHeaderNameStartsWithControlChar(0x1c);
     }
 
     @Test
-    public void testHeaderNameStartsWithControlChar1d() {
+    public void testHeaderNameStartsWithControlChar1d() throws Exception {
         testHeaderNameStartsWithControlChar(0x1d);
     }
 
     @Test
-    public void testHeaderNameStartsWithControlChar1e() {
+    public void testHeaderNameStartsWithControlChar1e() throws Exception {
         testHeaderNameStartsWithControlChar(0x1e);
     }
 
     @Test
-    public void testHeaderNameStartsWithControlChar1f() {
+    public void testHeaderNameStartsWithControlChar1f() throws Exception {
         testHeaderNameStartsWithControlChar(0x1f);
     }
 
     @Test
-    public void testHeaderNameStartsWithControlChar0c() {
+    public void testHeaderNameStartsWithControlChar0c() throws Exception {
         testHeaderNameStartsWithControlChar(0x0c);
     }
 
-    private void testHeaderNameStartsWithControlChar(int controlChar) {
+    private void testHeaderNameStartsWithControlChar(int controlChar) throws Exception {
         ByteBuf responseBuffer = Unpooled.buffer();
         responseBuffer.writeCharSequence("HTTP/1.1 200 OK\r\n" +
                 "Host: netty.io\r\n", CharsetUtil.US_ASCII);
@@ -1180,31 +1181,31 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
-    public void testHeaderNameEndsWithControlChar1c() {
+    public void testHeaderNameEndsWithControlChar1c() throws Exception {
         testHeaderNameEndsWithControlChar(0x1c);
     }
 
     @Test
-    public void testHeaderNameEndsWithControlChar1d() {
+    public void testHeaderNameEndsWithControlChar1d() throws Exception {
         testHeaderNameEndsWithControlChar(0x1d);
     }
 
     @Test
-    public void testHeaderNameEndsWithControlChar1e() {
+    public void testHeaderNameEndsWithControlChar1e() throws Exception {
         testHeaderNameEndsWithControlChar(0x1e);
     }
 
     @Test
-    public void testHeaderNameEndsWithControlChar1f() {
+    public void testHeaderNameEndsWithControlChar1f() throws Exception {
         testHeaderNameEndsWithControlChar(0x1f);
     }
 
     @Test
-    public void testHeaderNameEndsWithControlChar0c() {
+    public void testHeaderNameEndsWithControlChar0c() throws Exception {
         testHeaderNameEndsWithControlChar(0x0c);
     }
 
-    private static void testHeaderNameEndsWithControlChar(int controlChar) {
+    private static void testHeaderNameEndsWithControlChar(int controlChar) throws Exception {
         ByteBuf responseBuffer = Unpooled.buffer();
         responseBuffer.writeCharSequence("HTTP/1.1 200 OK\r\n" +
                 "Host: netty.io\r\n", CharsetUtil.US_ASCII);
@@ -1217,12 +1218,12 @@ public class HttpResponseDecoderTest {
     @ParameterizedTest
     @ValueSource(strings = { "HTP/1.1", "HTTP", "HTTP/1x", "Something/1.1", "HTTP/1",
             "HTTP/1.11", "HTTP/11.1", "HTTP/A.1", "HTTP/1.B"})
-    public void testInvalidVersion(String version) {
+    public void testInvalidVersion(String version) throws Exception {
         testInvalidHeaders0(Unpooled.copiedBuffer(
                 version + " 200 OK\r\nHost: whatever\r\n\r\n", CharsetUtil.US_ASCII));
     }
 
-    private static void testInvalidHeaders0(ByteBuf responseBuffer) {
+    private static void testInvalidHeaders0(ByteBuf responseBuffer) throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseDecoder());
         assertTrue(channel.writeInbound(responseBuffer));
         HttpResponse response = channel.readInbound();

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseEncoderTest.java
@@ -271,7 +271,7 @@ public class HttpResponseEncoderTest {
     }
 
     private static void assertEmptyResponse(EmbeddedChannel channel, HttpResponseStatus status,
-                                            CharSequence headerName, boolean headerStripped) {
+                                            CharSequence headerName, boolean headerStripped) throws Exception {
         HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, status);
         if (HttpHeaderNames.CONTENT_LENGTH.contentEquals(headerName)) {
             response.headers().set(headerName, "0");
@@ -357,16 +357,17 @@ public class HttpResponseEncoderTest {
     }
 
     @Test
-    public void testStatusResetContentTransferContentLength() {
+    public void testStatusResetContentTransferContentLength() throws Exception {
         testStatusResetContentTransferContentLength0(HttpHeaderNames.CONTENT_LENGTH, Unpooled.buffer().writeLong(8));
     }
 
     @Test
-    public void testStatusResetContentTransferEncoding() {
+    public void testStatusResetContentTransferEncoding() throws Exception {
         testStatusResetContentTransferContentLength0(HttpHeaderNames.TRANSFER_ENCODING, Unpooled.buffer().writeLong(8));
     }
 
-    private static void testStatusResetContentTransferContentLength0(CharSequence headerName, ByteBuf content) {
+    private static void testStatusResetContentTransferContentLength0(CharSequence headerName, ByteBuf content)
+            throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseEncoder());
 
         HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.RESET_CONTENT);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerCodecTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerCodecTest.java
@@ -118,7 +118,7 @@ public class HttpServerCodecTest {
     }
 
     @Test
-    public void testChunkedHeadResponse() {
+    public void testChunkedHeadResponse() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new HttpServerCodec());
 
         // Send the request headers.
@@ -149,7 +149,7 @@ public class HttpServerCodecTest {
     }
 
     @Test
-    public void testChunkedHeadFullHttpResponse() {
+    public void testChunkedHeadFullHttpResponse() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new HttpServerCodec());
 
         // Send the request headers.

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerExpectContinueHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerExpectContinueHandlerTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class HttpServerExpectContinueHandlerTest {
 
     @Test
-    public void shouldRespondToExpectedHeader() {
+    public void shouldRespondToExpectedHeader() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new HttpServerExpectContinueHandler() {
             @Override
             protected HttpResponse acceptMessage(HttpRequest request) {
@@ -52,7 +52,7 @@ public class HttpServerExpectContinueHandlerTest {
     }
 
     @Test
-    public void shouldAllowCustomResponses() {
+    public void shouldAllowCustomResponses() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(
             new HttpServerExpectContinueHandler() {
                 @Override

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerKeepAliveHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerKeepAliveHandlerTest.java
@@ -117,7 +117,8 @@ public class HttpServerKeepAliveHandlerTest {
     @ParameterizedTest
     @MethodSource("connectionCloseProvider")
     public void testConnectionCloseHeaderHandledCorrectly(
-            HttpVersion httpVersion, HttpResponseStatus responseStatus, int setSelfDefinedMessageLength) throws Exception {
+            HttpVersion httpVersion, HttpResponseStatus responseStatus, int setSelfDefinedMessageLength)
+            throws Exception {
         HttpResponse response = new DefaultFullHttpResponse(httpVersion, responseStatus);
         response.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
         setupMessageLength(response, setSelfDefinedMessageLength);
@@ -133,7 +134,8 @@ public class HttpServerKeepAliveHandlerTest {
     @ParameterizedTest
     @MethodSource("connectionCloseProvider")
     public void testConnectionCloseHeaderHandledCorrectlyForVoidPromise(
-            HttpVersion httpVersion, HttpResponseStatus responseStatus, int setSelfDefinedMessageLength) throws Exception {
+            HttpVersion httpVersion, HttpResponseStatus responseStatus, int setSelfDefinedMessageLength)
+            throws Exception {
         HttpResponse response = new DefaultFullHttpResponse(httpVersion, responseStatus);
         response.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
         setupMessageLength(response, setSelfDefinedMessageLength);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerKeepAliveHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerKeepAliveHandlerTest.java
@@ -117,7 +117,7 @@ public class HttpServerKeepAliveHandlerTest {
     @ParameterizedTest
     @MethodSource("connectionCloseProvider")
     public void testConnectionCloseHeaderHandledCorrectly(
-            HttpVersion httpVersion, HttpResponseStatus responseStatus, int setSelfDefinedMessageLength) {
+            HttpVersion httpVersion, HttpResponseStatus responseStatus, int setSelfDefinedMessageLength) throws Exception {
         HttpResponse response = new DefaultFullHttpResponse(httpVersion, responseStatus);
         response.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
         setupMessageLength(response, setSelfDefinedMessageLength);
@@ -133,7 +133,7 @@ public class HttpServerKeepAliveHandlerTest {
     @ParameterizedTest
     @MethodSource("connectionCloseProvider")
     public void testConnectionCloseHeaderHandledCorrectlyForVoidPromise(
-            HttpVersion httpVersion, HttpResponseStatus responseStatus, int setSelfDefinedMessageLength) {
+            HttpVersion httpVersion, HttpResponseStatus responseStatus, int setSelfDefinedMessageLength) throws Exception {
         HttpResponse response = new DefaultFullHttpResponse(httpVersion, responseStatus);
         response.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
         setupMessageLength(response, setSelfDefinedMessageLength);
@@ -151,7 +151,7 @@ public class HttpServerKeepAliveHandlerTest {
     public void testPipelineKeepAlive(boolean isKeepAliveResponseExpected, HttpVersion httpVersion,
                                        HttpResponseStatus responseStatus,
                                        String sendKeepAlive, int setSelfDefinedMessageLength,
-                                       AsciiString setResponseConnection) {
+                                       AsciiString setResponseConnection) throws Exception {
         FullHttpRequest firstRequest = new DefaultFullHttpRequest(httpVersion, HttpMethod.GET, "/v1/foo/bar");
         setKeepAlive(firstRequest, true);
         FullHttpRequest secondRequest = new DefaultFullHttpRequest(httpVersion, HttpMethod.GET, "/v1/foo/bar");

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerUpgradeHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerUpgradeHandlerTest.java
@@ -67,7 +67,7 @@ public class HttpServerUpgradeHandlerTest {
     }
 
     @Test
-    public void upgradesPipelineInSameMethodInvocation() {
+    public void upgradesPipelineInSameMethodInvocation() throws Exception {
         final HttpServerCodec httpServerCodec = new HttpServerCodec();
         final UpgradeCodecFactory factory = new UpgradeCodecFactory() {
             @Override
@@ -153,7 +153,7 @@ public class HttpServerUpgradeHandlerTest {
     }
 
     @Test
-    public void skippedUpgrade() {
+    public void skippedUpgrade() throws Exception {
         final HttpServerCodec httpServerCodec = new HttpServerCodec();
         final UpgradeCodecFactory factory = new UpgradeCodecFactory() {
             @Override
@@ -198,7 +198,7 @@ public class HttpServerUpgradeHandlerTest {
 
     @ParameterizedTest
     @ValueSource(booleans = { true, false })
-    public void upgradeFail(boolean removeAfterFirst) {
+    public void upgradeFail(boolean removeAfterFirst) throws Exception {
         final HttpServerCodec httpServerCodec = new HttpServerCodec();
         final UpgradeCodecFactory factory = new UpgradeCodecFactory() {
             @Override
@@ -242,7 +242,7 @@ public class HttpServerUpgradeHandlerTest {
     }
 
     @Test
-    public void upgradeExpect() {
+    public void upgradeExpect() throws Exception {
         final HttpServerCodec httpServerCodec = new HttpServerCodec();
         final UpgradeCodecFactory factory = new UpgradeCodecFactory() {
             @Override

--- a/codec-http/src/test/java/io/netty/handler/codec/http/MultipleContentLengthHeadersTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/MultipleContentLengthHeadersTest.java
@@ -57,7 +57,7 @@ public class MultipleContentLengthHeadersTest {
     @ParameterizedTest
     @MethodSource("parameters")
     public void testMultipleContentLengthHeadersBehavior(boolean allowDuplicateContentLengths,
-                                                         boolean sameValue, boolean singleField) {
+                                                         boolean sameValue, boolean singleField) throws Exception {
         EmbeddedChannel channel = newChannel(allowDuplicateContentLengths);
         String requestStr = setupRequestString(sameValue, singleField);
         assertTrue(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
@@ -96,7 +96,7 @@ public class MultipleContentLengthHeadersTest {
     }
 
     @Test
-    public void testDanglingComma() {
+    public void testDanglingComma() throws Exception {
         EmbeddedChannel channel = newChannel(false);
         String requestStr = "GET /some/path HTTP/1.1\r\n" +
                             "Content-Length: 1,\r\n" +

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cors/CorsHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cors/CorsHandlerTest.java
@@ -59,14 +59,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class CorsHandlerTest {
 
     @Test
-    public void nonCorsRequest() {
+    public void nonCorsRequest() throws Exception {
         final HttpResponse response = simpleRequest(forAnyOrigin().build(), null);
         assertFalse(response.headers().contains(ACCESS_CONTROL_ALLOW_ORIGIN));
         assertTrue(ReferenceCountUtil.release(response));
     }
 
     @Test
-    public void simpleRequestWithAnyOrigin() {
+    public void simpleRequestWithAnyOrigin() throws Exception {
         final HttpResponse response = simpleRequest(forAnyOrigin().build(), "http://localhost:7777");
         assertEquals("*", response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN));
         assertNull(response.headers().get(ACCESS_CONTROL_ALLOW_HEADERS));
@@ -74,7 +74,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void simpleRequestWithNullOrigin() {
+    public void simpleRequestWithNullOrigin() throws Exception {
         final HttpResponse response = simpleRequest(forOrigin("http://test.com").allowNullOrigin()
                 .allowCredentials()
                 .build(), "null");
@@ -85,7 +85,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void simpleRequestWithOrigin() {
+    public void simpleRequestWithOrigin() throws Exception {
         final String origin = "http://localhost:8888";
         final HttpResponse response = simpleRequest(forOrigin(origin).build(), origin);
         assertEquals(origin, response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN));
@@ -94,7 +94,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void simpleRequestWithOrigins() {
+    public void simpleRequestWithOrigins() throws Exception {
         final String origin1 = "http://localhost:8888";
         final String origin2 = "https://localhost:8888";
         final String[] origins = {origin1, origin2};
@@ -110,7 +110,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void simpleRequestWithNoMatchingOrigin() {
+    public void simpleRequestWithNoMatchingOrigin() throws Exception {
         final String origin = "http://localhost:8888";
         final HttpResponse response = simpleRequest(
                 forOrigins("https://localhost:8888").build(), origin);
@@ -120,7 +120,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void preflightDeleteRequestWithCustomHeaders() {
+    public void preflightDeleteRequestWithCustomHeaders() throws Exception {
         final CorsConfig config = forOrigin("http://localhost:8888")
                 .allowedRequestMethods(GET, DELETE)
                 .build();
@@ -133,7 +133,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void preflightGetRequestWithCustomHeaders() {
+    public void preflightGetRequestWithCustomHeaders() throws Exception {
         final CorsConfig config = forOrigin("http://localhost:8888")
                 .allowedRequestMethods(OPTIONS, GET, DELETE)
                 .allowedRequestHeaders("content-type", "xheader1")
@@ -149,7 +149,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void preflightRequestWithDefaultHeaders() {
+    public void preflightRequestWithDefaultHeaders() throws Exception {
         final CorsConfig config = forOrigin("http://localhost:8888").build();
         final HttpResponse response = preflightRequest(config, "http://localhost:8888", "content-type, xheader1");
         assertEquals("0", response.headers().get(CONTENT_LENGTH));
@@ -159,7 +159,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void preflightRequestWithCustomHeader() {
+    public void preflightRequestWithCustomHeader() throws Exception {
         final CorsConfig config = forOrigin("http://localhost:8888")
                 .preflightResponseHeader("CustomHeader", "somevalue")
                 .build();
@@ -171,7 +171,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void preflightRequestWithUnauthorizedOrigin() {
+    public void preflightRequestWithUnauthorizedOrigin() throws Exception {
         final String origin = "http://host";
         final CorsConfig config = forOrigin("http://localhost").build();
         final HttpResponse response = preflightRequest(config, origin, "xheader1");
@@ -180,7 +180,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void preflightRequestWithCustomHeaders() {
+    public void preflightRequestWithCustomHeaders() throws Exception {
         final String headerName = "CustomHeader";
         final String value1 = "value1";
         final String value2 = "value2";
@@ -194,7 +194,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void preflightRequestWithCustomHeadersIterable() {
+    public void preflightRequestWithCustomHeadersIterable() throws Exception {
         final String headerName = "CustomHeader";
         final String value1 = "value1";
         final String value2 = "value2";
@@ -208,7 +208,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void preflightRequestWithValueGenerator() {
+    public void preflightRequestWithValueGenerator() throws Exception {
         final CorsConfig config = forOrigin("http://localhost:8888")
                 .preflightResponseHeader("GenHeader", new Callable<String>() {
                     @Override
@@ -223,7 +223,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void preflightRequestWithNullOrigin() {
+    public void preflightRequestWithNullOrigin() throws Exception {
         final String origin = "null";
         final CorsConfig config = forOrigin(origin)
                 .allowNullOrigin()
@@ -236,7 +236,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void preflightRequestAllowCredentials() {
+    public void preflightRequestAllowCredentials() throws Exception {
         final String origin = "null";
         final CorsConfig config = forOrigin(origin).allowCredentials().build();
         final HttpResponse response = preflightRequest(config, origin, "content-type, xheader1");
@@ -245,7 +245,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void preflightRequestDoNotAllowCredentials() {
+    public void preflightRequestDoNotAllowCredentials() throws Exception {
         final CorsConfig config = forOrigin("http://localhost:8888").build();
         final HttpResponse response = preflightRequest(config, "http://localhost:8888", "");
         // the only valid value for Access-Control-Allow-Credentials is true.
@@ -254,7 +254,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void simpleRequestCustomHeaders() {
+    public void simpleRequestCustomHeaders() throws Exception {
         final CorsConfig config = forAnyOrigin().exposeHeaders("custom1", "custom2").build();
         final HttpResponse response = simpleRequest(config, "http://localhost:7777");
         assertEquals("*", response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN));
@@ -264,7 +264,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void simpleRequestAllowCredentials() {
+    public void simpleRequestAllowCredentials() throws Exception {
         final CorsConfig config = forAnyOrigin().allowCredentials().build();
         final HttpResponse response = simpleRequest(config, "http://localhost:7777");
         assertEquals("true", response.headers().get(ACCESS_CONTROL_ALLOW_CREDENTIALS));
@@ -272,7 +272,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void simpleRequestDoNotAllowCredentials() {
+    public void simpleRequestDoNotAllowCredentials() throws Exception {
         final CorsConfig config = forAnyOrigin().build();
         final HttpResponse response = simpleRequest(config, "http://localhost:7777");
         assertFalse(response.headers().contains(ACCESS_CONTROL_ALLOW_CREDENTIALS));
@@ -280,7 +280,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void anyOriginAndAllowCredentialsShouldEchoRequestOrigin() {
+    public void anyOriginAndAllowCredentialsShouldEchoRequestOrigin() throws Exception {
         final CorsConfig config = forAnyOrigin().allowCredentials().build();
         final HttpResponse response = simpleRequest(config, "http://localhost:7777");
         assertEquals("true", response.headers().get(ACCESS_CONTROL_ALLOW_CREDENTIALS));
@@ -290,7 +290,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void simpleRequestExposeHeaders() {
+    public void simpleRequestExposeHeaders() throws Exception {
         final CorsConfig config = forAnyOrigin().exposeHeaders("one", "two").build();
         final HttpResponse response = simpleRequest(config, "http://localhost:7777");
         assertThat(response.headers().get(ACCESS_CONTROL_EXPOSE_HEADERS)).contains("one");
@@ -299,7 +299,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void simpleRequestShortCircuit() {
+    public void simpleRequestShortCircuit() throws Exception {
         final CorsConfig config = forOrigin("http://localhost:8080").shortCircuit().build();
         final HttpResponse response = simpleRequest(config, "http://localhost:7777");
         assertEquals(FORBIDDEN, response.status());
@@ -308,7 +308,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void simpleRequestNoShortCircuit() {
+    public void simpleRequestNoShortCircuit() throws Exception {
         final CorsConfig config = forOrigin("http://localhost:8080").build();
         final HttpResponse response = simpleRequest(config, "http://localhost:7777");
         assertEquals(OK, response.status());
@@ -317,7 +317,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void shortCircuitNonCorsRequest() {
+    public void shortCircuitNonCorsRequest() throws Exception {
         final CorsConfig config = forOrigin("https://localhost").shortCircuit().build();
         final HttpResponse response = simpleRequest(config, null);
         assertEquals(OK, response.status());
@@ -326,7 +326,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void shortCircuitWithConnectionKeepAliveShouldStayOpen() {
+    public void shortCircuitWithConnectionKeepAliveShouldStayOpen() throws Exception {
         final CorsConfig config = forOrigin("http://localhost:8080").shortCircuit().build();
         final EmbeddedChannel channel = new EmbeddedChannel(new CorsHandler(config));
         final FullHttpRequest request = createHttpRequest(GET);
@@ -344,7 +344,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void shortCircuitWithoutConnectionShouldStayOpen() {
+    public void shortCircuitWithoutConnectionShouldStayOpen() throws Exception {
         final CorsConfig config = forOrigin("http://localhost:8080").shortCircuit().build();
         final EmbeddedChannel channel = new EmbeddedChannel(new CorsHandler(config));
         final FullHttpRequest request = createHttpRequest(GET);
@@ -361,7 +361,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void shortCircuitWithConnectionCloseShouldClose() {
+    public void shortCircuitWithConnectionCloseShouldClose() throws Exception {
         final CorsConfig config = forOrigin("http://localhost:8080").shortCircuit().build();
         final EmbeddedChannel channel = new EmbeddedChannel(new CorsHandler(config));
         final FullHttpRequest request = createHttpRequest(GET);
@@ -379,7 +379,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void preflightRequestShouldReleaseRequest() {
+    public void preflightRequestShouldReleaseRequest() throws Exception {
         final CorsConfig config = forOrigin("http://localhost:8888")
                 .preflightResponseHeader("CustomHeader", Arrays.asList("value1", "value2"))
                 .build();
@@ -440,7 +440,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void forbiddenShouldReleaseRequest() {
+    public void forbiddenShouldReleaseRequest() throws Exception {
         final CorsConfig config = forOrigin("https://localhost").shortCircuit().build();
         final EmbeddedChannel channel = new EmbeddedChannel(new CorsHandler(config), new EchoHandler());
         final FullHttpRequest request = createHttpRequest(GET);
@@ -452,7 +452,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void differentConfigsPerOrigin() {
+    public void differentConfigsPerOrigin() throws Exception {
         String host1 = "http://host1:80";
         String host2 = "http://host2";
         CorsConfig rule1 = forOrigin(host1).allowedRequestMethods(HttpMethod.GET).build();
@@ -471,7 +471,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void specificConfigPrecedenceOverGeneric() {
+    public void specificConfigPrecedenceOverGeneric() throws Exception {
         String host1 = "http://host1";
         String host2 = "http://host2";
 
@@ -492,7 +492,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void simpleRequestAllowPrivateNetwork() {
+    public void simpleRequestAllowPrivateNetwork() throws Exception {
         final CorsConfig config = forOrigin("http://localhost:8888").allowPrivateNetwork().build();
         final EmbeddedChannel channel = new EmbeddedChannel(new CorsHandler(config));
         final FullHttpRequest request = optionsRequest("http://localhost:8888", "", null);
@@ -505,7 +505,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void simpleRequestDoNotAllowPrivateNetwork() {
+    public void simpleRequestDoNotAllowPrivateNetwork() throws Exception {
         final CorsConfig config = forOrigin("http://localhost:8888").build();
         final EmbeddedChannel channel = new EmbeddedChannel(new CorsHandler(config));
         final FullHttpRequest request = optionsRequest("http://localhost:8888", "", null);
@@ -518,7 +518,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void preflightEmptyLastDiscarded() {
+    public void preflightEmptyLastDiscarded() throws Exception {
         CorsConfig config = forOrigin("http://allowed").build();
         EmbeddedChannel ch = new EmbeddedChannel(new CorsHandler(config));
 
@@ -541,7 +541,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void preflightSecondEmptyLastForwardedAfterFirstDiscard() {
+    public void preflightSecondEmptyLastForwardedAfterFirstDiscard() throws Exception {
         CorsConfig config = forOrigin("http://allowed").build();
         EmbeddedChannel ch = new EmbeddedChannel(new CorsHandler(config));
 
@@ -564,7 +564,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void preflightSecondNonEmptyLastDiscarded() {
+    public void preflightSecondNonEmptyLastDiscarded() throws Exception {
         CorsConfig config = forOrigin("http://allowed").build();
         EmbeddedChannel ch = new EmbeddedChannel(new CorsHandler(config));
 
@@ -586,7 +586,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void preflightNonEmptyLastForwarded() {
+    public void preflightNonEmptyLastForwarded() throws Exception {
         CorsConfig config = forOrigin("http://allowed").build();
         EmbeddedChannel ch = new EmbeddedChannel(new CorsHandler(config));
 
@@ -608,7 +608,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void testNormalRequestForwarded() {
+    public void testNormalRequestForwarded() throws Exception {
         CorsConfig config = forOrigin("http://allowed").build();
         EmbeddedChannel ch = new EmbeddedChannel(new CorsHandler(config));
 
@@ -631,7 +631,7 @@ public class CorsHandlerTest {
     }
 
     @Test
-    public void preflightEmptyLastDiscardedThenNewRequestForwarded() {
+    public void preflightEmptyLastDiscardedThenNewRequestForwarded() throws Exception {
         CorsConfig config = forOrigin("http://allowed").build();
         EmbeddedChannel ch = new EmbeddedChannel(new CorsHandler(config));
 
@@ -665,20 +665,20 @@ public class CorsHandlerTest {
         assertFalse(ch.finish());
     }
 
-    private static HttpResponse simpleRequest(final CorsConfig config, final String origin) {
+    private static HttpResponse simpleRequest(final CorsConfig config, final String origin) throws Exception {
         return simpleRequest(config, origin, null);
     }
 
     private static HttpResponse simpleRequest(final CorsConfig config,
                                               final String origin,
-                                              final String requestHeaders) {
+                                              final String requestHeaders) throws Exception {
         return simpleRequest(config, origin, requestHeaders, GET);
     }
 
     private static HttpResponse simpleRequest(final CorsConfig config,
                                               final String origin,
                                               final String requestHeaders,
-                                              final HttpMethod method) {
+                                              final HttpMethod method) throws Exception {
         final EmbeddedChannel channel = new EmbeddedChannel(new CorsHandler(config), new EchoHandler());
         final FullHttpRequest httpRequest = createHttpRequest(method);
         if (origin != null) {
@@ -695,14 +695,14 @@ public class CorsHandlerTest {
 
     private static HttpResponse preflightRequest(final CorsConfig config,
                                                  final String origin,
-                                                 final String requestHeaders) {
+                                                 final String requestHeaders) throws Exception {
         return preflightRequest(Collections.singletonList(config), origin, requestHeaders, config.isShortCircuit());
     }
 
     private static HttpResponse preflightRequest(final List<CorsConfig> configs,
                                                  final String origin,
                                                  final String requestHeaders,
-                                                 final boolean isSHortCircuit) {
+                                                 final boolean isSHortCircuit) throws Exception {
         final EmbeddedChannel channel = new EmbeddedChannel(new CorsHandler(configs, isSHortCircuit));
         assertFalse(channel.writeInbound(optionsRequest(origin, requestHeaders, null)));
         HttpResponse response = channel.readOutbound();

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocket00FrameEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocket00FrameEncoderTest.java
@@ -27,7 +27,7 @@ public class WebSocket00FrameEncoderTest {
 
     // Test for https://github.com/netty/netty/issues/2768
     @Test
-    public void testMultipleWebSocketCloseFrames() {
+    public void testMultipleWebSocketCloseFrames() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new WebSocket00FrameEncoder());
         assertTrue(channel.writeOutbound(new CloseWebSocketFrame()));
         assertTrue(channel.writeOutbound(new CloseWebSocketFrame()));

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocket08EncoderDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocket08EncoderDecoderTest.java
@@ -20,8 +20,6 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.CompletionException;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -61,7 +59,7 @@ public class WebSocket08EncoderDecoderTest {
     }
 
     @Test
-    public void testWebSocketProtocolViolation() {
+    public void testWebSocketProtocolViolation() throws Exception {
         // Given
         initTestData();
 
@@ -114,8 +112,8 @@ public class WebSocket08EncoderDecoderTest {
 
         try {
             testBinaryWithLen(outChannel, inChannel, testDataLength);
-        } catch (CompletionException e) {
-            corrupted = (CorruptedWebSocketFrameException) e.getCause();
+        } catch (Exception e) {
+            corrupted = (CorruptedWebSocketFrameException) e;
         }
 
         BinaryWebSocketFrame exceedingFrame = inChannel.readInbound();
@@ -127,7 +125,7 @@ public class WebSocket08EncoderDecoderTest {
     }
 
     @Test
-    public void testWebSocketEncodingAndDecoding() {
+    public void testWebSocketEncodingAndDecoding() throws Exception {
         initTestData();
 
         // Test without masking
@@ -149,7 +147,7 @@ public class WebSocket08EncoderDecoderTest {
         binTestData.release();
     }
 
-    private void executeTests(EmbeddedChannel outChannel, EmbeddedChannel inChannel) {
+    private void executeTests(EmbeddedChannel outChannel, EmbeddedChannel inChannel) throws Exception {
         // Test at the boundaries of each message type, because this shifts the position of the mask field
         // Test min. 4 lengths to check for problems related to an uneven frame length
         executeTests(outChannel, inChannel, 0);
@@ -172,12 +170,14 @@ public class WebSocket08EncoderDecoderTest {
         executeTests(outChannel, inChannel, 65539);
     }
 
-    private void executeTests(EmbeddedChannel outChannel, EmbeddedChannel inChannel, int testDataLength) {
+    private void executeTests(EmbeddedChannel outChannel, EmbeddedChannel inChannel, int testDataLength)
+            throws Exception {
         testTextWithLen(outChannel, inChannel, testDataLength);
         testBinaryWithLen(outChannel, inChannel, testDataLength);
     }
 
-    private void testTextWithLen(EmbeddedChannel outChannel, EmbeddedChannel inChannel, int testDataLength) {
+    private void testTextWithLen(EmbeddedChannel outChannel, EmbeddedChannel inChannel, int testDataLength)
+            throws Exception {
         String testStr = strTestData.substring(0, testDataLength);
         outChannel.writeOutbound(new TextWebSocketFrame(testStr));
 
@@ -191,7 +191,8 @@ public class WebSocket08EncoderDecoderTest {
         txt.release();
     }
 
-    private void testBinaryWithLen(EmbeddedChannel outChannel, EmbeddedChannel inChannel, int testDataLength) {
+    private void testBinaryWithLen(EmbeddedChannel outChannel, EmbeddedChannel inChannel, int testDataLength)
+            throws Exception {
         binTestData.retain(); // need to retain for sending and still keeping it
         binTestData.setIndex(0, testDataLength); // Send only len bytes
         outChannel.writeOutbound(new BinaryWebSocketFrame(binTestData));
@@ -210,7 +211,7 @@ public class WebSocket08EncoderDecoderTest {
         binFrame.release();
     }
 
-    private void transfer(EmbeddedChannel outChannel, EmbeddedChannel inChannel) {
+    private void transfer(EmbeddedChannel outChannel, EmbeddedChannel inChannel) throws Exception {
         // Transfer encoded data into decoder
         // Loop because there might be multiple frames (gathering write)
         for (;;) {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocket08EncoderDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocket08EncoderDecoderTest.java
@@ -20,6 +20,8 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.CompletionException;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -112,8 +114,8 @@ public class WebSocket08EncoderDecoderTest {
 
         try {
             testBinaryWithLen(outChannel, inChannel, testDataLength);
-        } catch (CorruptedWebSocketFrameException e) {
-            corrupted = e;
+        } catch (CompletionException e) {
+            corrupted = (CorruptedWebSocketFrameException) e.getCause();
         }
 
         BinaryWebSocketFrame exceedingFrame = inChannel.readInbound();

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameDecoderTest.java
@@ -21,9 +21,11 @@ import org.junit.jupiter.api.function.Executable;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.CompletionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -81,12 +83,14 @@ public class WebSocket08FrameDecoderTest {
         final ByteBuf invalidFrame = Unpooled.buffer(10).writeByte(0x81)
                                              .writeByte(0xFF).writeLong(-1L);
 
-        Throwable exception = assertThrows(CorruptedWebSocketFrameException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 channel.writeInbound(invalidFrame);
             }
         });
+
+        Throwable exception = assertInstanceOf(CorruptedWebSocketFrameException.class, cause.getCause());
         assertEquals("invalid data frame length (negative length)", exception.getMessage());
 
         CloseWebSocketFrame closeFrame = channel.readOutbound();

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameDecoderTest.java
@@ -17,15 +17,12 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.CompletionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -83,14 +80,8 @@ public class WebSocket08FrameDecoderTest {
         final ByteBuf invalidFrame = Unpooled.buffer(10).writeByte(0x81)
                                              .writeByte(0xFF).writeLong(-1L);
 
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                channel.writeInbound(invalidFrame);
-            }
-        });
-
-        Throwable exception = assertInstanceOf(CorruptedWebSocketFrameException.class, cause.getCause());
+        CorruptedWebSocketFrameException exception = assertThrows(CorruptedWebSocketFrameException.class,
+                () -> channel.writeInbound(invalidFrame));
         assertEquals("invalid data frame length (negative length)", exception.getMessage());
 
         CloseWebSocketFrame closeFrame = channel.readOutbound();

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshakerTest.java
@@ -208,7 +208,7 @@ public abstract class WebSocketClientHandshakerTest {
     }
 
     @Test
-    public void testInvalidHostWhenIncorrectWebSocketURI() {
+    public void testInvalidHostWhenIncorrectWebSocketURI() throws Exception {
         URI uri = URI.create("/ws");
         EmbeddedChannel channel = new EmbeddedChannel(new HttpClientCodec());
         final WebSocketClientHandshaker handshaker = newHandshaker(uri, null, null, false, true);
@@ -222,7 +222,7 @@ public abstract class WebSocketClientHandshakerTest {
     }
 
     @Test
-    public void testInvalidOriginWhenIncorrectWebSocketURI() {
+    public void testInvalidOriginWhenIncorrectWebSocketURI() throws Exception {
         URI uri = URI.create("/ws");
         EmbeddedChannel channel = new EmbeddedChannel(new HttpClientCodec());
         HttpHeaders headers = new DefaultHttpHeaders();
@@ -319,17 +319,17 @@ public abstract class WebSocketClientHandshakerTest {
 
     @Test
     @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
-    public void testHttpResponseAndFrameInSameBuffer() {
+    public void testHttpResponseAndFrameInSameBuffer() throws Exception {
         testHttpResponseAndFrameInSameBuffer(false);
     }
 
     @Test
     @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
-    public void testHttpResponseAndFrameInSameBufferCodec() {
+    public void testHttpResponseAndFrameInSameBufferCodec() throws Exception {
         testHttpResponseAndFrameInSameBuffer(true);
     }
 
-    private void testHttpResponseAndFrameInSameBuffer(boolean codec) {
+    private void testHttpResponseAndFrameInSameBuffer(boolean codec) throws Exception {
         String url = "ws://localhost:9999/ws";
         final WebSocketClientHandshaker shaker = newHandshaker(URI.create(url));
         final WebSocketClientHandshaker handshaker = new WebSocketClientHandshaker(
@@ -476,7 +476,7 @@ public abstract class WebSocketClientHandshakerTest {
     }
 
     @Test
-    public void testHandshakeForHttpResponseWithoutAggregator() {
+    public void testHandshakeForHttpResponseWithoutAggregator() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestEncoder(), new HttpResponseDecoder());
         URI uri = URI.create("ws://localhost:9999/chat");
         WebSocketClientHandshaker clientHandshaker = newHandshaker(uri);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketFrameAggregatorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketFrameAggregatorTest.java
@@ -23,11 +23,8 @@ import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.CompletionException;
-
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -45,7 +42,7 @@ public class WebSocketFrameAggregatorTest {
     }
 
     @Test
-    public void testAggregationBinary() {
+    public void testAggregationBinary() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new WebSocketFrameAggregator(Integer.MAX_VALUE));
         channel.writeInbound(new BinaryWebSocketFrame(true, 1, Unpooled.wrappedBuffer(content1)));
         channel.writeInbound(new BinaryWebSocketFrame(false, 0, Unpooled.wrappedBuffer(content1)));
@@ -80,7 +77,7 @@ public class WebSocketFrameAggregatorTest {
     }
 
     @Test
-    public void testAggregationText() {
+    public void testAggregationText() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new WebSocketFrameAggregator(Integer.MAX_VALUE));
         channel.writeInbound(new TextWebSocketFrame(true, 1, Unpooled.wrappedBuffer(content1)));
         channel.writeInbound(new TextWebSocketFrame(false, 0, Unpooled.wrappedBuffer(content1)));
@@ -120,9 +117,8 @@ public class WebSocketFrameAggregatorTest {
         channel.writeInbound(new BinaryWebSocketFrame(true, 1, Unpooled.wrappedBuffer(content1)));
         channel.writeInbound(new BinaryWebSocketFrame(false, 0, Unpooled.wrappedBuffer(content1)));
 
-        Throwable cause = assertThrows(CompletionException.class, () -> channel.writeInbound(
+        assertThrows(TooLongFrameException.class, () -> channel.writeInbound(
                 new ContinuationWebSocketFrame(false, 0, Unpooled.wrappedBuffer(content2))));
-        assertInstanceOf(TooLongFrameException.class, cause.getCause());
 
         channel.writeInbound(new ContinuationWebSocketFrame(false, 0, Unpooled.wrappedBuffer(content2)));
         channel.writeInbound(new ContinuationWebSocketFrame(true, 0, Unpooled.wrappedBuffer(content2)));
@@ -130,9 +126,8 @@ public class WebSocketFrameAggregatorTest {
         channel.writeInbound(new BinaryWebSocketFrame(true, 1, Unpooled.wrappedBuffer(content1)));
         channel.writeInbound(new BinaryWebSocketFrame(false, 0, Unpooled.wrappedBuffer(content1)));
 
-        cause = assertThrows(CompletionException.class, () -> channel.writeInbound(
+        assertThrows(TooLongFrameException.class, () -> channel.writeInbound(
                 new ContinuationWebSocketFrame(false, 0, Unpooled.wrappedBuffer(content2))));
-        assertInstanceOf(TooLongFrameException.class, cause.getCause());
 
         channel.writeInbound(new ContinuationWebSocketFrame(false, 0, Unpooled.wrappedBuffer(content2)));
         channel.writeInbound(new ContinuationWebSocketFrame(true, 0, Unpooled.wrappedBuffer(content2)));

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketFrameAggregatorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketFrameAggregatorTest.java
@@ -23,11 +23,14 @@ import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.CompletionException;
+
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 
 public class WebSocketFrameAggregatorTest {
@@ -116,23 +119,21 @@ public class WebSocketFrameAggregatorTest {
         EmbeddedChannel channel = new EmbeddedChannel(new WebSocketFrameAggregator(8));
         channel.writeInbound(new BinaryWebSocketFrame(true, 1, Unpooled.wrappedBuffer(content1)));
         channel.writeInbound(new BinaryWebSocketFrame(false, 0, Unpooled.wrappedBuffer(content1)));
-        try {
-            channel.writeInbound(new ContinuationWebSocketFrame(false, 0, Unpooled.wrappedBuffer(content2)));
-            fail();
-        } catch (TooLongFrameException e) {
-            // expected
-        }
+
+        Throwable cause = assertThrows(CompletionException.class, () -> channel.writeInbound(
+                new ContinuationWebSocketFrame(false, 0, Unpooled.wrappedBuffer(content2))));
+        assertInstanceOf(TooLongFrameException.class, cause.getCause());
+
         channel.writeInbound(new ContinuationWebSocketFrame(false, 0, Unpooled.wrappedBuffer(content2)));
         channel.writeInbound(new ContinuationWebSocketFrame(true, 0, Unpooled.wrappedBuffer(content2)));
 
         channel.writeInbound(new BinaryWebSocketFrame(true, 1, Unpooled.wrappedBuffer(content1)));
         channel.writeInbound(new BinaryWebSocketFrame(false, 0, Unpooled.wrappedBuffer(content1)));
-        try {
-            channel.writeInbound(new ContinuationWebSocketFrame(false, 0, Unpooled.wrappedBuffer(content2)));
-            fail();
-        } catch (TooLongFrameException e) {
-            // expected
-        }
+
+        cause = assertThrows(CompletionException.class, () -> channel.writeInbound(
+                new ContinuationWebSocketFrame(false, 0, Unpooled.wrappedBuffer(content2))));
+        assertInstanceOf(TooLongFrameException.class, cause.getCause());
+
         channel.writeInbound(new ContinuationWebSocketFrame(false, 0, Unpooled.wrappedBuffer(content2)));
         channel.writeInbound(new ContinuationWebSocketFrame(true, 0, Unpooled.wrappedBuffer(content2)));
         for (;;) {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
@@ -292,7 +292,8 @@ public class WebSocketHandshakeHandOverTest {
      * @param srcChannel The source channel
      * @param dstChannel The destination channel
      */
-    private static void transferAllDataWithMerge(EmbeddedChannel srcChannel, EmbeddedChannel dstChannel) throws Exception {
+    private static void transferAllDataWithMerge(EmbeddedChannel srcChannel, EmbeddedChannel dstChannel)
+            throws Exception {
         ByteBuf mergedBuffer = null;
         for (;;) {
             Object srcData = srcChannel.readOutbound();

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
@@ -27,6 +27,8 @@ import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.websocketx.WebSocketClientProtocolHandler.ClientHandshakeStateEvent;
 import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler.ServerHandshakeStateEvent;
+
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,6 +40,7 @@ import org.junit.jupiter.api.function.Executable;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -183,12 +186,13 @@ public class WebSocketHandshakeHandOverTest {
         assertFalse(clientReceivedMessage);
         // Should throw WebSocketHandshakeException
         try {
-            assertThrows(WebSocketHandshakeException.class, new Executable() {
+            Throwable cause = assertThrows(CompletionException.class, new Executable() {
                 @Override
                 public void execute() {
                     handshakeHandler.getHandshakeFuture().syncUninterruptibly();
                 }
             });
+            assertInstanceOf(WebSocketHandshakeException.class, cause.getCause());
         } finally {
             serverChannel.finishAndReleaseAll();
         }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketHandshakeHandOverTest.java
@@ -292,7 +292,7 @@ public class WebSocketHandshakeHandOverTest {
      * @param srcChannel The source channel
      * @param dstChannel The destination channel
      */
-    private static void transferAllDataWithMerge(EmbeddedChannel srcChannel, EmbeddedChannel dstChannel)  {
+    private static void transferAllDataWithMerge(EmbeddedChannel srcChannel, EmbeddedChannel dstChannel) throws Exception {
         ByteBuf mergedBuffer = null;
         for (;;) {
             Object srcData = srcChannel.readOutbound();

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketProtocolHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketProtocolHandlerTest.java
@@ -18,23 +18,13 @@ package io.netty.handler.codec.http.websocketx;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelOutboundHandler;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.flow.FlowControlHandler;
-import io.netty.util.ReferenceCountUtil;
-import io.netty.util.concurrent.CompletionHandler;
-import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.Promise;
 import org.junit.jupiter.api.Test;
-
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static io.netty.util.CharsetUtil.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -44,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class WebSocketProtocolHandlerTest {
 
     @Test
-    public void testPingFrame() {
+    public void testPingFrame() throws Exception {
         ByteBuf pingData = Unpooled.copiedBuffer("Hello, world", UTF_8);
         EmbeddedChannel channel = new EmbeddedChannel(new WebSocketProtocolHandler() { });
 
@@ -60,7 +50,7 @@ public class WebSocketProtocolHandlerTest {
     }
 
     @Test
-    public void testPingPongFlowControlWhenAutoReadIsDisabled() {
+    public void testPingPongFlowControlWhenAutoReadIsDisabled() throws Exception {
         String text1 = "Hello, world #1";
         String text2 = "Hello, world #2";
         String text3 = "Hello, world #3";
@@ -119,7 +109,7 @@ public class WebSocketProtocolHandlerTest {
     }
 
     @Test
-    public void testPongFrameDropFrameFalse() {
+    public void testPongFrameDropFrameFalse() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new WebSocketProtocolHandler(false) { });
 
         PongWebSocketFrame pingResponse = new PongWebSocketFrame();
@@ -132,7 +122,7 @@ public class WebSocketProtocolHandlerTest {
     }
 
     @Test
-    public void testPongFrameDropFrameTrue() {
+    public void testPongFrameDropFrameTrue() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new WebSocketProtocolHandler(true) { });
 
         PongWebSocketFrame pingResponse = new PongWebSocketFrame();
@@ -140,7 +130,7 @@ public class WebSocketProtocolHandlerTest {
     }
 
     @Test
-    public void testTextFrame() {
+    public void testTextFrame() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new WebSocketProtocolHandler() { });
 
         TextWebSocketFrame textFrame = new TextWebSocketFrame();

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker00Test.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker00Test.java
@@ -51,12 +51,12 @@ public class WebSocketServerHandshaker00Test extends WebSocketServerHandshakerTe
     }
 
     @Test
-    public void testPerformOpeningHandshake() {
+    public void testPerformOpeningHandshake() throws Exception {
         testPerformOpeningHandshake0(true);
     }
 
     @Test
-    public void testPerformOpeningHandshakeSubProtocolNotSupported() {
+    public void testPerformOpeningHandshakeSubProtocolNotSupported() throws Exception {
         testPerformOpeningHandshake0(false);
     }
 
@@ -88,7 +88,7 @@ public class WebSocketServerHandshaker00Test extends WebSocketServerHandshakerTe
         }
     }
 
-    private static void testPerformOpeningHandshake0(boolean subProtocol) {
+    private static void testPerformOpeningHandshake0(boolean subProtocol) throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(
                 new HttpObjectAggregator(42), new HttpRequestDecoder(), new HttpResponseEncoder());
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker08Test.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker08Test.java
@@ -48,16 +48,16 @@ public class WebSocketServerHandshaker08Test extends WebSocketServerHandshakerTe
     }
 
     @Test
-    public void testPerformOpeningHandshake() {
+    public void testPerformOpeningHandshake() throws Exception {
         testPerformOpeningHandshake0(true);
     }
 
     @Test
-    public void testPerformOpeningHandshakeSubProtocolNotSupported() {
+    public void testPerformOpeningHandshakeSubProtocolNotSupported() throws Exception {
         testPerformOpeningHandshake0(false);
     }
 
-    private static void testPerformOpeningHandshake0(boolean subProtocol) {
+    private static void testPerformOpeningHandshake0(boolean subProtocol) throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(
                 new HttpObjectAggregator(42), new HttpRequestDecoder(), new HttpResponseEncoder());
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13Test.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13Test.java
@@ -37,7 +37,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
 import java.util.Iterator;
-import java.util.concurrent.CompletionException;
 
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -46,7 +45,6 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class WebSocketServerHandshaker13Test extends WebSocketServerHandshakerTest {
 
@@ -62,16 +60,16 @@ public class WebSocketServerHandshaker13Test extends WebSocketServerHandshakerTe
     }
 
     @Test
-    public void testPerformOpeningHandshake() {
+    public void testPerformOpeningHandshake() throws Exception {
         testPerformOpeningHandshake0(true);
     }
 
     @Test
-    public void testPerformOpeningHandshakeSubProtocolNotSupported() {
+    public void testPerformOpeningHandshakeSubProtocolNotSupported() throws Exception {
         testPerformOpeningHandshake0(false);
     }
 
-    private static void testPerformOpeningHandshake0(boolean subProtocol) {
+    private static void testPerformOpeningHandshake0(boolean subProtocol) throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(
                 new HttpObjectAggregator(42), new HttpResponseEncoder(), new HttpRequestDecoder());
 
@@ -86,12 +84,12 @@ public class WebSocketServerHandshaker13Test extends WebSocketServerHandshakerTe
     }
 
     @Test
-    public void testCloseReasonWithEncoderAndDecoder() {
+    public void testCloseReasonWithEncoderAndDecoder() throws Exception {
         testCloseReason0(new HttpResponseEncoder(), new HttpRequestDecoder());
     }
 
     @Test
-    public void testCloseReasonWithCodec() {
+    public void testCloseReasonWithCodec() throws Exception {
         testCloseReason0(new HttpServerCodec());
     }
 
@@ -172,7 +170,7 @@ public class WebSocketServerHandshaker13Test extends WebSocketServerHandshakerTe
         assertTrue(request.release());
     }
 
-    private static void testCloseReason0(ChannelHandler... handlers) {
+    private static void testCloseReason0(ChannelHandler... handlers) throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(
                 new HttpObjectAggregator(42));
         ch.pipeline().addLast(handlers);
@@ -181,8 +179,7 @@ public class WebSocketServerHandshaker13Test extends WebSocketServerHandshakerTe
 
         ch.writeOutbound(new BinaryWebSocketFrame(Unpooled.wrappedBuffer(new byte[8])));
         ByteBuf buffer = ch.readOutbound();
-        Throwable cause = assertThrows(CompletionException.class, () -> ch.writeInbound(buffer));
-        assertInstanceOf(CorruptedWebSocketFrameException.class, cause.getCause());
+        assertThrows(CorruptedWebSocketFrameException.class, () -> ch.writeInbound(buffer));
 
         ReferenceCounted closeMessage = ch.readOutbound();
         assertInstanceOf(ByteBuf.class, closeMessage);
@@ -190,7 +187,7 @@ public class WebSocketServerHandshaker13Test extends WebSocketServerHandshakerTe
         assertFalse(ch.finish());
     }
 
-    private static void testUpgrade0(EmbeddedChannel ch, WebSocketServerHandshaker13 handshaker) {
+    private static void testUpgrade0(EmbeddedChannel ch, WebSocketServerHandshaker13 handshaker) throws Exception {
         FullHttpRequest req = new DefaultFullHttpRequest(HTTP_1_1, HttpMethod.GET, "/chat");
         req.headers().set(HttpHeaderNames.HOST, "server.example.com");
         req.headers().set(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13Test.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13Test.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
 import java.util.Iterator;
+import java.util.concurrent.CompletionException;
 
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -180,12 +181,9 @@ public class WebSocketServerHandshaker13Test extends WebSocketServerHandshakerTe
 
         ch.writeOutbound(new BinaryWebSocketFrame(Unpooled.wrappedBuffer(new byte[8])));
         ByteBuf buffer = ch.readOutbound();
-        try {
-            ch.writeInbound(buffer);
-            fail();
-        } catch (CorruptedWebSocketFrameException expected) {
-            // expected
-        }
+        Throwable cause = assertThrows(CompletionException.class, () -> ch.writeInbound(buffer));
+        assertInstanceOf(CorruptedWebSocketFrameException.class, cause.getCause());
+
         ReferenceCounted closeMessage = ch.readOutbound();
         assertInstanceOf(ByteBuf.class, closeMessage);
         closeMessage.release();

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshakerTest.java
@@ -122,7 +122,7 @@ public abstract class WebSocketServerHandshakerTest {
     }
 
     @Test
-    public void testHandshakeForHttpRequestWithoutAggregator() {
+    public void testHandshakeForHttpRequestWithoutAggregator() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder(), new HttpResponseEncoder());
         WebSocketServerHandshaker serverHandshaker = newHandshaker("ws://example.com/chat",
                                                                    "chat", WebSocketDecoderConfig.DEFAULT);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandlerTest.java
@@ -63,16 +63,16 @@ public class WebSocketServerProtocolHandlerTest {
     }
 
     @Test
-    public void testHttpUpgradeRequestFull() {
+    public void testHttpUpgradeRequestFull() throws Exception {
         testHttpUpgradeRequest0(true);
     }
 
     @Test
-    public void testHttpUpgradeRequestNonFull() {
+    public void testHttpUpgradeRequestNonFull() throws Exception {
         testHttpUpgradeRequest0(false);
     }
 
-    private void testHttpUpgradeRequest0(boolean full) {
+    private void testHttpUpgradeRequest0(boolean full) throws Exception {
         EmbeddedChannel ch = createChannel(new MockOutboundHandler());
         ChannelHandlerContext handshakerCtx = ch.pipeline().context(WebSocketServerProtocolHandshakeHandler.class);
         writeUpgradeRequest(ch, full);
@@ -85,7 +85,7 @@ public class WebSocketServerProtocolHandlerTest {
     }
 
     @Test
-    public void testWebSocketServerProtocolHandshakeHandlerReplacedBeforeHandshake() {
+    public void testWebSocketServerProtocolHandshakeHandlerReplacedBeforeHandshake() throws Exception {
         EmbeddedChannel ch = createChannel(new MockOutboundHandler());
         ChannelHandlerContext handshakerCtx = ch.pipeline().context(WebSocketServerProtocolHandshakeHandler.class);
         ch.pipeline().addLast(new ChannelInboundHandler() {
@@ -107,7 +107,7 @@ public class WebSocketServerProtocolHandlerTest {
     }
 
     @Test
-    public void testHttpUpgradeRequestInvalidUpgradeHeader() {
+    public void testHttpUpgradeRequestInvalidUpgradeHeader() throws Exception {
         EmbeddedChannel ch = createChannel();
         FullHttpRequest httpRequestWithEntity = new WebSocketRequestBuilder().httpVersion(HTTP_1_1)
                 .method(HttpMethod.GET)
@@ -127,7 +127,7 @@ public class WebSocketServerProtocolHandlerTest {
     }
 
     @Test
-    public void testHttpUpgradeRequestMissingWSKeyHeader() {
+    public void testHttpUpgradeRequestMissingWSKeyHeader() throws Exception {
         EmbeddedChannel ch = createChannel();
         HttpRequest httpRequest = new WebSocketRequestBuilder().httpVersion(HTTP_1_1)
                 .method(HttpMethod.GET)
@@ -148,7 +148,7 @@ public class WebSocketServerProtocolHandlerTest {
     }
 
     @Test
-    public void testCreateUTF8Validator() {
+    public void testCreateUTF8Validator() throws Exception {
         WebSocketServerProtocolConfig config = WebSocketServerProtocolConfig.newBuilder()
                 .websocketPath("/test")
                 .withUTF8Validator(true)
@@ -169,7 +169,7 @@ public class WebSocketServerProtocolHandlerTest {
     }
 
     @Test
-    public void testDoNotCreateUTF8Validator() {
+    public void testDoNotCreateUTF8Validator() throws Exception {
         WebSocketServerProtocolConfig config = WebSocketServerProtocolConfig.newBuilder()
                 .websocketPath("/test")
                 .withUTF8Validator(false)
@@ -190,7 +190,7 @@ public class WebSocketServerProtocolHandlerTest {
     }
 
     @Test
-    public void testHandleTextFrame() {
+    public void testHandleTextFrame() throws Exception {
         CustomTextFrameHandler customTextFrameHandler = new CustomTextFrameHandler();
         EmbeddedChannel ch = createChannel(customTextFrameHandler);
         writeUpgradeRequest(ch);
@@ -212,7 +212,7 @@ public class WebSocketServerProtocolHandlerTest {
     }
 
     @Test
-    public void testCheckWebSocketPathStartWithSlash() {
+    public void testCheckWebSocketPathStartWithSlash() throws Exception {
         WebSocketRequestBuilder builder = new WebSocketRequestBuilder().httpVersion(HTTP_1_1)
                 .method(HttpMethod.GET)
                 .key(HttpHeaderNames.SEC_WEBSOCKET_KEY)
@@ -244,7 +244,7 @@ public class WebSocketServerProtocolHandlerTest {
     }
 
     @Test
-    public void testCheckValidWebSocketPath() {
+    public void testCheckValidWebSocketPath() throws Exception {
         HttpRequest httpRequest = new WebSocketRequestBuilder().httpVersion(HTTP_1_1)
                 .method(HttpMethod.GET)
                 .uri("/test")
@@ -272,7 +272,7 @@ public class WebSocketServerProtocolHandlerTest {
     }
 
     @Test
-    public void testCheckInvalidWebSocketPath() {
+    public void testCheckInvalidWebSocketPath() throws Exception {
         HttpRequest httpRequest = new WebSocketRequestBuilder().httpVersion(HTTP_1_1)
                 .method(HttpMethod.GET)
                 .uri("/testabc")
@@ -432,7 +432,7 @@ public class WebSocketServerProtocolHandlerTest {
     }
 
     @SuppressWarnings("SameParameterValue")
-    private <T> T decode(ByteBuf input, Class<T> clazz) {
+    private <T> T decode(ByteBuf input, Class<T> clazz) throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new WebSocket13FrameDecoder(true, false, 65536, true));
         assertTrue(ch.writeInbound(input));
         Object decoded = ch.readInbound();
@@ -462,11 +462,11 @@ public class WebSocketServerProtocolHandlerTest {
                 handler);
     }
 
-    private static void writeUpgradeRequest(EmbeddedChannel ch) {
+    private static void writeUpgradeRequest(EmbeddedChannel ch) throws Exception {
         writeUpgradeRequest(ch, true);
     }
 
-    private static void writeUpgradeRequest(EmbeddedChannel ch, boolean full) {
+    private static void writeUpgradeRequest(EmbeddedChannel ch, boolean full) throws Exception {
         HttpRequest request = WebSocketRequestBuilder.successful();
         if (full) {
             ch.writeInbound(request);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketUtf8FrameValidatorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketUtf8FrameValidatorTest.java
@@ -18,13 +18,9 @@ package io.netty.handler.codec.http.websocketx;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
-
-import java.util.concurrent.CompletionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -32,42 +28,32 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class WebSocketUtf8FrameValidatorTest {
 
     @Test
-    public void testCorruptedFrameExceptionInFinish() {
+    public void testCorruptedFrameExceptionInFinish() throws Exception {
         assertCorruptedFrameExceptionHandling(new byte[]{-50});
     }
 
     @Test
-    public void testCorruptedFrameExceptionInCheck() {
+    public void testCorruptedFrameExceptionInCheck() throws Exception {
         assertCorruptedFrameExceptionHandling(new byte[]{-8, -120, -128, -128, -128});
     }
 
     @Test
-    void testNotCloseOnProtocolViolation() {
+    void testNotCloseOnProtocolViolation() throws Exception {
         final EmbeddedChannel channel = new EmbeddedChannel(new Utf8FrameValidator(false));
         final TextWebSocketFrame frame = new TextWebSocketFrame(Unpooled.copiedBuffer(new byte[] { -50 }));
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                channel.writeInbound(frame);
-            }
-        }, "bytes are not UTF-8");
-        assertInstanceOf(CorruptedWebSocketFrameException.class, cause.getCause());
+        assertThrows(CorruptedWebSocketFrameException.class,
+                () -> channel.writeInbound(frame), "bytes are not UTF-8");
 
         assertTrue(channel.isActive());
         assertFalse(channel.finish());
         assertEquals(0, frame.refCnt());
     }
 
-    private void assertCorruptedFrameExceptionHandling(byte[] data) {
+    private void assertCorruptedFrameExceptionHandling(byte[] data) throws Exception {
         final EmbeddedChannel channel = new EmbeddedChannel(new Utf8FrameValidator());
         final TextWebSocketFrame frame = new TextWebSocketFrame(Unpooled.copiedBuffer(data));
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                channel.writeInbound(frame);
-            }
-        }, "bytes are not UTF-8");
-        assertInstanceOf(CorruptedWebSocketFrameException.class, cause.getCause());
+        assertThrows(CorruptedWebSocketFrameException.class,
+                () -> channel.writeInbound(frame), "bytes are not UTF-8");
         assertFalse(channel.isActive());
 
         CloseWebSocketFrame closeFrame = channel.readOutbound();
@@ -81,21 +67,21 @@ public class WebSocketUtf8FrameValidatorTest {
     }
 
     @Test
-    void testCloseWithStatusInTheMiddleOfFragmentAllowed() {
+    void testCloseWithStatusInTheMiddleOfFragmentAllowed() throws Exception {
         testControlFrameInTheMiddleOfFragmentAllowed(new CloseWebSocketFrame(WebSocketCloseStatus.NORMAL_CLOSURE));
     }
 
     @Test
-    void testPingInTheMiddleOfFragmentAllowed() {
+    void testPingInTheMiddleOfFragmentAllowed() throws Exception {
         testControlFrameInTheMiddleOfFragmentAllowed(new PingWebSocketFrame(Unpooled.EMPTY_BUFFER));
     }
 
     @Test
-    void testPongInTheMiddleOfFragmentAllowed() {
+    void testPongInTheMiddleOfFragmentAllowed() throws Exception {
         testControlFrameInTheMiddleOfFragmentAllowed(new PongWebSocketFrame(Unpooled.EMPTY_BUFFER));
     }
 
-    private static void testControlFrameInTheMiddleOfFragmentAllowed(WebSocketFrame controlFrame) {
+    private static void testControlFrameInTheMiddleOfFragmentAllowed(WebSocketFrame controlFrame) throws Exception {
         final EmbeddedChannel channel = new EmbeddedChannel(new Utf8FrameValidator(false));
         final TextWebSocketFrame frame = new TextWebSocketFrame(false, 0, "text");
         assertTrue(channel.writeInbound(frame));

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketUtf8FrameValidatorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketUtf8FrameValidatorTest.java
@@ -20,8 +20,11 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
+import java.util.concurrent.CompletionException;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -42,12 +45,13 @@ public class WebSocketUtf8FrameValidatorTest {
     void testNotCloseOnProtocolViolation() {
         final EmbeddedChannel channel = new EmbeddedChannel(new Utf8FrameValidator(false));
         final TextWebSocketFrame frame = new TextWebSocketFrame(Unpooled.copiedBuffer(new byte[] { -50 }));
-        assertThrows(CorruptedWebSocketFrameException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
                 channel.writeInbound(frame);
             }
         }, "bytes are not UTF-8");
+        assertInstanceOf(CorruptedWebSocketFrameException.class, cause.getCause());
 
         assertTrue(channel.isActive());
         assertFalse(channel.finish());
@@ -57,13 +61,13 @@ public class WebSocketUtf8FrameValidatorTest {
     private void assertCorruptedFrameExceptionHandling(byte[] data) {
         final EmbeddedChannel channel = new EmbeddedChannel(new Utf8FrameValidator());
         final TextWebSocketFrame frame = new TextWebSocketFrame(Unpooled.copiedBuffer(data));
-        assertThrows(CorruptedWebSocketFrameException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
                 channel.writeInbound(frame);
             }
         }, "bytes are not UTF-8");
-
+        assertInstanceOf(CorruptedWebSocketFrameException.class, cause.getCause());
         assertFalse(channel.isActive());
 
         CloseWebSocketFrame closeFrame = channel.readOutbound();

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketClientExtensionHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketClientExtensionHandlerTest.java
@@ -23,6 +23,7 @@ import io.netty.handler.codec.http.HttpResponse;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletionException;
 
 import org.junit.jupiter.api.Test;
 
@@ -253,8 +254,10 @@ public class WebSocketClientExtensionHandlerTest {
         HttpResponse res = newUpgradeResponse("main, fallback");
         try {
             ch.writeInbound(res);
-        } catch (CodecException e) {
-            return;
+        } catch (CompletionException e) {
+            if (e.getCause() instanceof CodecException) {
+                return;
+            }
         }
         fail("Expected to encounter a CodecException");
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketClientExtensionHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketClientExtensionHandlerTest.java
@@ -50,7 +50,7 @@ public class WebSocketClientExtensionHandlerTest {
             mock(WebSocketClientExtension.class, "fallbackExtension");
 
     @Test
-    public void testMainSuccess() {
+    public void testMainSuccess() throws Exception {
         // initialize
         when(mainHandshakerMock.newRequestData()).
                 thenReturn(new WebSocketExtensionData("main", Collections.<String, String>emptyMap()));
@@ -99,7 +99,7 @@ public class WebSocketClientExtensionHandlerTest {
     }
 
     @Test
-    public void testFallbackSuccess() {
+    public void testFallbackSuccess() throws Exception {
         // initialize
         when(mainHandshakerMock.newRequestData()).
                 thenReturn(new WebSocketExtensionData("main", Collections.<String, String>emptyMap()));
@@ -151,7 +151,7 @@ public class WebSocketClientExtensionHandlerTest {
     }
 
     @Test
-    public void testAllSuccess() {
+    public void testAllSuccess() throws Exception {
         // initialize
         when(mainHandshakerMock.newRequestData()).
                 thenReturn(new WebSocketExtensionData("main", Collections.<String, String>emptyMap()));
@@ -223,7 +223,7 @@ public class WebSocketClientExtensionHandlerTest {
     }
 
     @Test
-    public void testIfMainAndFallbackUseRSV1WillFail() {
+    public void testIfMainAndFallbackUseRSV1WillFail() throws Exception {
         // initialize
         when(mainHandshakerMock.newRequestData()).
                 thenReturn(new WebSocketExtensionData("main", Collections.<String, String>emptyMap()));
@@ -254,10 +254,8 @@ public class WebSocketClientExtensionHandlerTest {
         HttpResponse res = newUpgradeResponse("main, fallback");
         try {
             ch.writeInbound(res);
-        } catch (CompletionException e) {
-            if (e.getCause() instanceof CodecException) {
-                return;
-            }
+        } catch (CodecException e) {
+            return;
         }
         fail("Expected to encounter a CodecException");
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandlerTest.java
@@ -55,7 +55,7 @@ public class WebSocketServerExtensionHandlerTest {
             mock(WebSocketServerExtension.class, "main2Extension");
 
     @Test
-    public void testMainSuccess() {
+    public void testMainSuccess() throws Exception {
         // initialize
         when(mainHandshakerMock.handshakeExtension(webSocketExtensionDataMatcher("main"))).
                 thenReturn(mainExtensionMock);
@@ -110,7 +110,7 @@ public class WebSocketServerExtensionHandlerTest {
     }
 
     @Test
-    public void testCompatibleExtensionTogetherSuccess() {
+    public void testCompatibleExtensionTogetherSuccess() throws Exception {
         // initialize
         when(mainHandshakerMock.handshakeExtension(webSocketExtensionDataMatcher("main"))).
                 thenReturn(mainExtensionMock);
@@ -175,7 +175,7 @@ public class WebSocketServerExtensionHandlerTest {
     }
 
     @Test
-    public void testNoneExtensionMatchingSuccess() {
+    public void testNoneExtensionMatchingSuccess() throws Exception {
         // initialize
         when(mainHandshakerMock.handshakeExtension(webSocketExtensionDataMatcher("unknown"))).
                 thenReturn(null);
@@ -212,7 +212,7 @@ public class WebSocketServerExtensionHandlerTest {
     }
 
     @Test
-    public void testExtensionHandlerNotRemovedByFailureWritePromise() {
+    public void testExtensionHandlerNotRemovedByFailureWritePromise() throws Exception {
         // initialize
         when(mainHandshakerMock.handshakeExtension(webSocketExtensionDataMatcher("main")))
                 .thenReturn(mainExtensionMock);
@@ -239,7 +239,7 @@ public class WebSocketServerExtensionHandlerTest {
     }
 
     @Test
-    public void testExtensionMultipleRequests() {
+    public void testExtensionMultipleRequests() throws Exception {
         // initialize
         when(mainHandshakerMock.handshakeExtension(webSocketExtensionDataMatcher("main")))
                 .thenReturn(mainExtensionMock);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerFrameDeflateDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerFrameDeflateDecoderTest.java
@@ -39,7 +39,7 @@ public class PerFrameDeflateDecoderTest {
     private static final Random random = new Random();
 
     @Test
-    public void testCompressedFrame() {
+    public void testCompressedFrame() throws Exception {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(
                 ZlibCodecFactory.newZlibEncoder(ZlibWrapper.NONE, 9, 15, 8));
         EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerFrameDeflateDecoder(false, 0));
@@ -72,7 +72,7 @@ public class PerFrameDeflateDecoderTest {
     }
 
     @Test
-    public void testNormalFrame() {
+    public void testNormalFrame() throws Exception {
         EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerFrameDeflateDecoder(false, 0));
 
         // initialize
@@ -100,7 +100,7 @@ public class PerFrameDeflateDecoderTest {
 
     // See https://github.com/netty/netty/issues/4348
     @Test
-    public void testCompressedEmptyFrame() {
+    public void testCompressedEmptyFrame() throws Exception {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(
                 ZlibCodecFactory.newZlibEncoder(ZlibWrapper.NONE, 9, 15, 8));
         EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerFrameDeflateDecoder(false, 0));
@@ -123,7 +123,7 @@ public class PerFrameDeflateDecoderTest {
     }
 
     @Test
-    public void testDecompressionSkip() {
+    public void testDecompressionSkip() throws Exception {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(
                 ZlibCodecFactory.newZlibEncoder(ZlibWrapper.NONE, 9, 15, 8));
         EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerFrameDeflateDecoder(false, ALWAYS_SKIP, 0));

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerFrameDeflateEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerFrameDeflateEncoderTest.java
@@ -40,7 +40,7 @@ public class PerFrameDeflateEncoderTest {
     private static final Random random = new Random();
 
     @Test
-    public void testCompressedFrame() {
+    public void testCompressedFrame() throws Exception {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(new PerFrameDeflateEncoder(9, 15, false));
         EmbeddedChannel decoderChannel = new EmbeddedChannel(
                 ZlibCodecFactory.newZlibDecoder(ZlibWrapper.NONE, 0));
@@ -72,7 +72,7 @@ public class PerFrameDeflateEncoderTest {
     }
 
     @Test
-    public void testAlreadyCompressedFrame() {
+    public void testAlreadyCompressedFrame() throws Exception {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(new PerFrameDeflateEncoder(9, 15, false));
 
         // initialize
@@ -99,7 +99,7 @@ public class PerFrameDeflateEncoderTest {
     }
 
     @Test
-    public void testFramementedFrame() {
+    public void testFramementedFrame() throws Exception {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(new PerFrameDeflateEncoder(9, 15, false));
         EmbeddedChannel decoderChannel = new EmbeddedChannel(
                 ZlibCodecFactory.newZlibDecoder(ZlibWrapper.NONE, 0));
@@ -164,7 +164,7 @@ public class PerFrameDeflateEncoderTest {
     }
 
     @Test
-    public void testCompressionSkip() {
+    public void testCompressionSkip() throws Exception {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(
                 new PerFrameDeflateEncoder(9, 15, false, ALWAYS_SKIP));
         byte[] payload = new byte[300];

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshakerTest.java
@@ -188,7 +188,7 @@ public class PerMessageDeflateClientExtensionHandshakerTest {
     }
 
     @Test
-    public void testDecoderNoClientContext() {
+    public void testDecoderNoClientContext() throws Exception {
         PerMessageDeflateClientExtensionHandshaker handshaker =
                 new PerMessageDeflateClientExtensionHandshaker(6, true, MAX_WINDOW_SIZE, true, false, 0);
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateDecoderTest.java
@@ -50,7 +50,7 @@ public class PerMessageDeflateDecoderTest {
     private static final Random random = new Random();
 
     @Test
-    public void testCompressedFrame() {
+    public void testCompressedFrame() throws Exception {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(
                 ZlibCodecFactory.newZlibEncoder(ZlibWrapper.NONE, 9, 15, 8));
         EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerMessageDeflateDecoder(false, 0));
@@ -83,7 +83,7 @@ public class PerMessageDeflateDecoderTest {
     }
 
     @Test
-    public void testNormalFrame() {
+    public void testNormalFrame() throws Exception {
         EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerMessageDeflateDecoder(false, 0));
 
         // initialize
@@ -110,7 +110,7 @@ public class PerMessageDeflateDecoderTest {
     }
 
     @Test
-    public void testFragmentedFrame() {
+    public void testFragmentedFrame() throws Exception {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(
                 ZlibCodecFactory.newZlibEncoder(ZlibWrapper.NONE, 9, 15, 8));
         EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerMessageDeflateDecoder(false, 0));
@@ -160,7 +160,7 @@ public class PerMessageDeflateDecoderTest {
     }
 
     @Test
-    public void testMultiCompressedPayloadWithinFrame() {
+    public void testMultiCompressedPayloadWithinFrame() throws Exception {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(
                 ZlibCodecFactory.newZlibEncoder(ZlibWrapper.NONE, 9, 15, 8));
         EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerMessageDeflateDecoder(false, 0));
@@ -202,7 +202,7 @@ public class PerMessageDeflateDecoderTest {
     }
 
     @Test
-    public void testDecompressionSkipForBinaryFrame() {
+    public void testDecompressionSkipForBinaryFrame() throws Exception {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(
                 ZlibCodecFactory.newZlibEncoder(ZlibWrapper.NONE, 9, 15, 8));
         EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerMessageDeflateDecoder(false, ALWAYS_SKIP, 0));
@@ -228,7 +228,7 @@ public class PerMessageDeflateDecoderTest {
     }
 
     @Test
-    public void testSelectivityDecompressionSkip() {
+    public void testSelectivityDecompressionSkip() throws Exception {
         WebSocketExtensionFilter selectivityDecompressionFilter = new WebSocketExtensionFilter() {
             @Override
             public boolean mustSkip(WebSocketFrame frame) {
@@ -273,7 +273,7 @@ public class PerMessageDeflateDecoderTest {
     }
 
     @Test
-    public void testIllegalStateWhenDecompressionInProgress() {
+    public void testIllegalStateWhenDecompressionInProgress() throws Exception {
         WebSocketExtensionFilter selectivityDecompressionFilter = new WebSocketExtensionFilter() {
             @Override
             public boolean mustSkip(WebSocketFrame frame) {
@@ -312,13 +312,7 @@ public class PerMessageDeflateDecoderTest {
 
         //final part throwing exception
         try {
-            Throwable cause = assertThrows(CompletionException.class, new Executable() {
-                @Override
-                public void execute() {
-                    decoderChannel.writeInbound(finalPart);
-                }
-            });
-            assertInstanceOf(DecoderException.class, cause.getCause());
+            assertThrows(DecoderException.class, () -> decoderChannel.writeInbound(finalPart));
         } finally {
             assertTrue(finalPart.release());
             assertFalse(encoderChannel.finishAndReleaseAll());
@@ -326,7 +320,7 @@ public class PerMessageDeflateDecoderTest {
     }
 
     @Test
-    public void testEmptyFrameDecompression() {
+    public void testEmptyFrameDecompression() throws Exception {
         EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerMessageDeflateDecoder(false, 0));
 
         TextWebSocketFrame emptyDeflateBlockFrame = new TextWebSocketFrame(true, WebSocketExtension.RSV1,
@@ -343,7 +337,7 @@ public class PerMessageDeflateDecoderTest {
     }
 
     @Test
-    public void testFragmentedFrameWithLeftOverInLastFragment() {
+    public void testFragmentedFrameWithLeftOverInLastFragment() throws Exception {
         String hexDump = "677170647a777a737574656b707a787a6f6a7561756578756f6b7868616371716c657a6d64697479766d726f6" +
                          "269746c6376777464776f6f72767a726f64667278676764687775786f6762766d776d706b76697773777a7072" +
                          "6a6a737279707a7078697a6c69616d7461656d646278626d786f66666e686e776a7a7461746d7a776668776b6" +

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateDecoderTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
 import java.util.Random;
+import java.util.concurrent.CompletionException;
 
 import static io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionFilter.*;
 import static io.netty.handler.codec.http.websocketx.extensions.compression.DeflateDecoder.*;
@@ -39,6 +40,7 @@ import static io.netty.util.CharsetUtil.*;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -310,12 +312,13 @@ public class PerMessageDeflateDecoderTest {
 
         //final part throwing exception
         try {
-            assertThrows(DecoderException.class, new Executable() {
+            Throwable cause = assertThrows(CompletionException.class, new Executable() {
                 @Override
                 public void execute() {
                     decoderChannel.writeInbound(finalPart);
                 }
             });
+            assertInstanceOf(DecoderException.class, cause.getCause());
         } finally {
             assertTrue(finalPart.release());
             assertFalse(encoderChannel.finishAndReleaseAll());

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateEncoderTest.java
@@ -51,7 +51,7 @@ public class PerMessageDeflateEncoderTest {
     private static final Random random = new Random();
 
     @Test
-    public void testCompressedFrame() {
+    public void testCompressedFrame() throws Exception {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(new PerMessageDeflateEncoder(9, 15, false));
         EmbeddedChannel decoderChannel = new EmbeddedChannel(
                 ZlibCodecFactory.newZlibDecoder(ZlibWrapper.NONE, 0));
@@ -83,7 +83,7 @@ public class PerMessageDeflateEncoderTest {
     }
 
     @Test
-    public void testAlreadyCompressedFrame() {
+    public void testAlreadyCompressedFrame() throws Exception {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(new PerMessageDeflateEncoder(9, 15, false));
 
         // initialize
@@ -111,7 +111,7 @@ public class PerMessageDeflateEncoderTest {
     }
 
     @Test
-    public void testFragmentedFrame() {
+    public void testFragmentedFrame() throws Exception {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(new PerMessageDeflateEncoder(9, 15, false,
                                                                                           NEVER_SKIP));
         EmbeddedChannel decoderChannel = new EmbeddedChannel(
@@ -178,7 +178,7 @@ public class PerMessageDeflateEncoderTest {
     }
 
     @Test
-    public void testCompressionSkipForBinaryFrame() {
+    public void testCompressionSkipForBinaryFrame() throws Exception {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(new PerMessageDeflateEncoder(9, 15, false,
                                                                                           ALWAYS_SKIP));
         byte[] payload = new byte[300];
@@ -197,7 +197,7 @@ public class PerMessageDeflateEncoderTest {
     }
 
     @Test
-    public void testSelectivityCompressionSkip() {
+    public void testSelectivityCompressionSkip() throws Exception {
         WebSocketExtensionFilter selectivityCompressionFilter = new WebSocketExtensionFilter() {
             @Override
             public boolean mustSkip(WebSocketFrame frame) {
@@ -245,7 +245,7 @@ public class PerMessageDeflateEncoderTest {
     }
 
     @Test
-    public void testIllegalStateWhenCompressionInProgress() {
+    public void testIllegalStateWhenCompressionInProgress() throws Exception {
         WebSocketExtensionFilter selectivityCompressionFilter = new WebSocketExtensionFilter() {
             @Override
             public boolean mustSkip(WebSocketFrame frame) {
@@ -274,13 +274,7 @@ public class PerMessageDeflateEncoderTest {
 
         //final part throwing exception
         try {
-            Throwable cause = assertThrows(CompletionException.class, new Executable() {
-                @Override
-                public void execute() throws Throwable {
-                    encoderChannel.writeOutbound(finalPart);
-                }
-            });
-            assertInstanceOf(EncoderException.class, cause.getCause());
+            assertThrows(EncoderException.class, () -> encoderChannel.writeOutbound(finalPart));
         } finally {
             assertTrue(finalPart.release());
             assertFalse(encoderChannel.finishAndReleaseAll());
@@ -288,7 +282,7 @@ public class PerMessageDeflateEncoderTest {
     }
 
     @Test
-    public void testEmptyFrameCompression() {
+    public void testEmptyFrameCompression() throws Exception {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(new PerMessageDeflateEncoder(9, 15, false));
 
         TextWebSocketFrame emptyFrame = new TextWebSocketFrame("");
@@ -305,19 +299,13 @@ public class PerMessageDeflateEncoderTest {
     }
 
     @Test
-    public void testCodecExceptionForNotFinEmptyFrame() {
+    public void testCodecExceptionForNotFinEmptyFrame() throws Exception {
         final EmbeddedChannel encoderChannel = new EmbeddedChannel(new PerMessageDeflateEncoder(9, 15, false));
 
         final TextWebSocketFrame emptyNotFinFrame = new TextWebSocketFrame(false, 0, "");
 
         try {
-            Throwable cause = assertThrows(CompletionException.class, new Executable() {
-                @Override
-                public void execute() {
-                    encoderChannel.writeOutbound(emptyNotFinFrame);
-                }
-            });
-            assertInstanceOf(EncoderException.class, cause.getCause());
+            assertThrows(EncoderException.class, () -> encoderChannel.writeOutbound(emptyNotFinFrame));
         } finally {
             // EmptyByteBuf buffer
             assertFalse(emptyNotFinFrame.release());

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateEncoderTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.function.Executable;
 
 import java.util.Arrays;
 import java.util.Random;
+import java.util.concurrent.CompletionException;
 
 import static io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionFilter.*;
 import static io.netty.handler.codec.http.websocketx.extensions.compression.DeflateDecoder.*;
@@ -40,6 +41,7 @@ import static io.netty.util.CharsetUtil.*;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -272,12 +274,13 @@ public class PerMessageDeflateEncoderTest {
 
         //final part throwing exception
         try {
-            assertThrows(EncoderException.class, new Executable() {
+            Throwable cause = assertThrows(CompletionException.class, new Executable() {
                 @Override
                 public void execute() throws Throwable {
                     encoderChannel.writeOutbound(finalPart);
                 }
             });
+            assertInstanceOf(EncoderException.class, cause.getCause());
         } finally {
             assertTrue(finalPart.release());
             assertFalse(encoderChannel.finishAndReleaseAll());
@@ -308,12 +311,13 @@ public class PerMessageDeflateEncoderTest {
         final TextWebSocketFrame emptyNotFinFrame = new TextWebSocketFrame(false, 0, "");
 
         try {
-            assertThrows(EncoderException.class, new Executable() {
+            Throwable cause = assertThrows(CompletionException.class, new Executable() {
                 @Override
                 public void execute() {
                     encoderChannel.writeOutbound(emptyNotFinFrame);
                 }
             });
+            assertInstanceOf(EncoderException.class, cause.getCause());
         } finally {
             // EmptyByteBuf buffer
             assertFalse(emptyNotFinFrame.release());

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/WebSocketServerCompressionHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/WebSocketServerCompressionHandlerTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class WebSocketServerCompressionHandlerTest {
 
     @Test
-    public void testNormalSuccess() {
+    public void testNormalSuccess() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new WebSocketServerCompressionHandler(0));
 
         HttpRequest req = newUpgradeRequest(PERMESSAGE_DEFLATE_EXTENSION);
@@ -59,7 +59,7 @@ public class WebSocketServerCompressionHandlerTest {
     }
 
     @Test
-    public void testClientWindowSizeSuccess() {
+    public void testClientWindowSizeSuccess() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new WebSocketServerExtensionHandler(
                 new PerMessageDeflateServerExtensionHandshaker(6, false, 10, false, false, 0)));
 
@@ -80,7 +80,7 @@ public class WebSocketServerCompressionHandlerTest {
     }
 
     @Test
-    public void testClientWindowSizeUnavailable() {
+    public void testClientWindowSizeUnavailable() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new WebSocketServerExtensionHandler(
                 new PerMessageDeflateServerExtensionHandshaker(6, false, 10, false, false, 0)));
 
@@ -101,7 +101,7 @@ public class WebSocketServerCompressionHandlerTest {
     }
 
     @Test
-    public void testServerWindowSizeSuccess() {
+    public void testServerWindowSizeSuccess() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new WebSocketServerExtensionHandler(
                 new PerMessageDeflateServerExtensionHandshaker(6, true, 15, false, false, 0)));
 
@@ -122,7 +122,7 @@ public class WebSocketServerCompressionHandlerTest {
     }
 
     @Test
-    public void testServerWindowSizeDisable() {
+    public void testServerWindowSizeDisable() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new WebSocketServerExtensionHandler(
                 new PerMessageDeflateServerExtensionHandshaker(6, false, 15, false, false, 0)));
 
@@ -140,7 +140,7 @@ public class WebSocketServerCompressionHandlerTest {
     }
 
     @Test
-    public void testServerNoContext() {
+    public void testServerNoContext() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new WebSocketServerCompressionHandler(0));
 
         HttpRequest req = newUpgradeRequest(PERMESSAGE_DEFLATE_EXTENSION + "; " + SERVER_NO_CONTEXT);
@@ -157,7 +157,7 @@ public class WebSocketServerCompressionHandlerTest {
     }
 
     @Test
-    public void testClientNoContext() {
+    public void testClientNoContext() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new WebSocketServerCompressionHandler(0));
 
         HttpRequest req = newUpgradeRequest(PERMESSAGE_DEFLATE_EXTENSION + "; " + CLIENT_NO_CONTEXT);
@@ -177,7 +177,7 @@ public class WebSocketServerCompressionHandlerTest {
     }
 
     @Test
-    public void testServerWindowSizeDisableThenFallback() {
+    public void testServerWindowSizeDisableThenFallback() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new WebSocketServerExtensionHandler(
                 new PerMessageDeflateServerExtensionHandshaker(6, false, 15, false, false, 0)));
 

--- a/codec-http/src/test/java/io/netty/handler/codec/rtsp/RtspDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/rtsp/RtspDecoderTest.java
@@ -39,7 +39,7 @@ public class RtspDecoderTest {
      * responses. This test verifies that the issue is solved.
      */
     @Test
-    public void testReceiveAnnounce() {
+    public void testReceiveAnnounce() throws Exception {
         byte[] data1 = ("ANNOUNCE rtsp://172.20.184.218:554/d3abaaa7-65f2-"
                       + "42b4-8d6b-379f492fcf0f RTSP/1.0\r\n"
                       + "CSeq: 2\r\n"

--- a/codec-http/src/test/java/io/netty/handler/codec/rtsp/RtspEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/rtsp/RtspEncoderTest.java
@@ -39,7 +39,7 @@ public class RtspEncoderTest {
      * Test of a SETUP request, with no body.
      */
     @Test
-    public void testSendSetupRequest() {
+    public void testSendSetupRequest() throws Exception {
         String expected = "SETUP rtsp://172.10.20.30:554/d3abaaa7-65f2-42b4-"
                         + "8d6b-379f492fcf0f RTSP/1.0\r\n"
                         + "transport: MP2T/DVBC/UDP;unicast;client=01234567;"
@@ -69,7 +69,7 @@ public class RtspEncoderTest {
      * Test of a GET_PARAMETER request, with body.
      */
     @Test
-    public void testSendGetParameterRequest() {
+    public void testSendGetParameterRequest() throws Exception {
         String expected = "GET_PARAMETER rtsp://172.10.20.30:554 RTSP/1.0\r\n"
                         + "session: 2547019973447939919\r\n"
                         + "cseq: 3\r\n"
@@ -108,7 +108,7 @@ public class RtspEncoderTest {
      * Test of a 200 OK response, without body.
      */
     @Test
-    public void testSend200OkResponseWithoutBody() {
+    public void testSend200OkResponseWithoutBody() throws Exception {
         String expected = "RTSP/1.0 200 OK\r\n"
                         + "server: Testserver\r\n"
                         + "cseq: 1\r\n"
@@ -134,7 +134,7 @@ public class RtspEncoderTest {
      * Test of a 200 OK response, with body.
      */
     @Test
-    public void testSend200OkResponseWithBody() {
+    public void testSend200OkResponseWithBody() throws Exception {
         String expected = "RTSP/1.0 200 OK\r\n"
                         + "server: Testserver\r\n"
                         + "session: 2547019973447939919\r\n"

--- a/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyFrameCodecTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyFrameCodecTest.java
@@ -39,7 +39,7 @@ public class SpdyFrameCodecTest {
     );
 
     @Test
-    public void testDecodeUnknownFrame() {
+    public void testDecodeUnknownFrame() throws Exception {
         final SpdyFrameEncoder encoder = new SpdyFrameEncoder(SpdyVersion.SPDY_3_1);
         final ByteBuf buf = encoder.encodeUnknownFrame(
             UnpooledByteBufAllocator.DEFAULT,
@@ -57,7 +57,7 @@ public class SpdyFrameCodecTest {
     }
 
     @Test
-    public void testEncodeUnknownFrame() {
+    public void testEncodeUnknownFrame() throws Exception {
         final SpdyUnknownFrame spdyUnknownFrame = new DefaultSpdyUnknownFrame(
             200,
             (byte) 13,

--- a/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdySessionHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdySessionHandlerTest.java
@@ -95,7 +95,7 @@ public class SpdySessionHandlerTest {
         assertTrue(spdyHeadersFrame.headers().isEmpty());
     }
 
-    private static void testSpdySessionHandler(SpdyVersion version, boolean server) {
+    private static void testSpdySessionHandler(SpdyVersion version, boolean server) throws Exception {
         EmbeddedChannel sessionHandler = new EmbeddedChannel(
                 new SpdySessionHandler(version, server), new EchoHandler(closeSignal, server));
 
@@ -210,7 +210,7 @@ public class SpdySessionHandlerTest {
         sessionHandler.finish();
     }
 
-    private static void testSpdySessionHandlerPing(SpdyVersion version, boolean server) {
+    private static void testSpdySessionHandlerPing(SpdyVersion version, boolean server) throws Exception {
         EmbeddedChannel sessionHandler = new EmbeddedChannel(
                 new SpdySessionHandler(version, server), new EchoHandler(closeSignal, server));
 
@@ -236,7 +236,7 @@ public class SpdySessionHandlerTest {
         sessionHandler.finish();
     }
 
-    private static void testSpdySessionHandlerGoAway(SpdyVersion version, boolean server) {
+    private static void testSpdySessionHandlerGoAway(SpdyVersion version, boolean server) throws Exception {
         EmbeddedChannel sessionHandler = new EmbeddedChannel(
                 new SpdySessionHandler(version, server), new EchoHandler(closeSignal, server));
 
@@ -284,37 +284,37 @@ public class SpdySessionHandlerTest {
     }
 
     @Test
-    public void testSpdyClientSessionHandler() {
+    public void testSpdyClientSessionHandler() throws Exception {
         logger.info("Running: testSpdyClientSessionHandler v3.1");
         testSpdySessionHandler(SpdyVersion.SPDY_3_1, false);
     }
 
     @Test
-    public void testSpdyClientSessionHandlerPing() {
+    public void testSpdyClientSessionHandlerPing() throws Exception {
         logger.info("Running: testSpdyClientSessionHandlerPing v3.1");
         testSpdySessionHandlerPing(SpdyVersion.SPDY_3_1, false);
     }
 
     @Test
-    public void testSpdyClientSessionHandlerGoAway() {
+    public void testSpdyClientSessionHandlerGoAway() throws Exception {
         logger.info("Running: testSpdyClientSessionHandlerGoAway v3.1");
         testSpdySessionHandlerGoAway(SpdyVersion.SPDY_3_1, false);
     }
 
     @Test
-    public void testSpdyServerSessionHandler() {
+    public void testSpdyServerSessionHandler() throws Exception {
         logger.info("Running: testSpdyServerSessionHandler v3.1");
         testSpdySessionHandler(SpdyVersion.SPDY_3_1, true);
     }
 
     @Test
-    public void testSpdyServerSessionHandlerPing() {
+    public void testSpdyServerSessionHandlerPing() throws Exception {
         logger.info("Running: testSpdyServerSessionHandlerPing v3.1");
         testSpdySessionHandlerPing(SpdyVersion.SPDY_3_1, true);
     }
 
     @Test
-    public void testSpdyServerSessionHandlerGoAway() {
+    public void testSpdyServerSessionHandlerGoAway() throws Exception {
         logger.info("Running: testSpdyServerSessionHandlerGoAway v3.1");
         testSpdySessionHandlerGoAway(SpdyVersion.SPDY_3_1, true);
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
@@ -114,7 +114,11 @@ public class CompressorHttp2ConnectionEncoder extends DecoratingHttp2ConnectionE
             public void onStreamRemoved(Http2Stream stream) {
                 final EmbeddedChannel compressor = stream.getProperty(propertyKey);
                 if (compressor != null) {
-                    cleanup(stream, compressor);
+                    try {
+                        cleanup(stream, compressor);
+                    } catch (Exception ignore) {
+                        // ignore
+                    }
                 }
             }
         });
@@ -163,7 +167,11 @@ public class CompressorHttp2ConnectionEncoder extends DecoratingHttp2ConnectionE
             public void onStreamRemoved(Http2Stream stream) {
                 final EmbeddedChannel compressor = stream.getProperty(propertyKey);
                 if (compressor != null) {
-                    cleanup(stream, compressor);
+                    try {
+                        cleanup(stream, compressor);
+                    } catch (Exception ignore) {
+                        // ignore
+                    }
                 }
             }
         });
@@ -222,7 +230,11 @@ public class CompressorHttp2ConnectionEncoder extends DecoratingHttp2ConnectionE
             promise.tryFailure(cause);
         } finally {
             if (endOfStream) {
-                cleanup(stream, channel);
+                try {
+                    cleanup(stream, channel);
+                } catch (Exception e) {
+                    promise.tryFailure(e);
+                }
             }
         }
     }
@@ -418,7 +430,7 @@ public class CompressorHttp2ConnectionEncoder extends DecoratingHttp2ConnectionE
      * @param stream The stream for which {@code compressor} is the compressor for
      * @param compressor The compressor for {@code stream}
      */
-    void cleanup(Http2Stream stream, EmbeddedChannel compressor) {
+    void cleanup(Http2Stream stream, EmbeddedChannel compressor) throws Exception {
         compressor.finishAndReleaseAll();
         stream.removeProperty(propertyKey);
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
@@ -37,6 +37,8 @@ import io.netty.handler.codec.compression.SnappyOptions;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.PromiseCombiner;
 import io.netty.util.internal.ObjectUtil;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -57,6 +59,8 @@ import static io.netty.handler.codec.http.HttpHeaderValues.SNAPPY;
  * stream. The compression provided by this class will be applied to the data for the entire stream.
  */
 public class CompressorHttp2ConnectionEncoder extends DecoratingHttp2ConnectionEncoder {
+    private static final InternalLogger LOGGER =
+            InternalLoggerFactory.getInstance(CompressorHttp2ConnectionEncoder.class);
     // We cannot remove this because it'll be breaking change
     public static final int DEFAULT_COMPRESSION_LEVEL = 6;
     public static final int DEFAULT_WINDOW_BITS = 15;
@@ -116,8 +120,8 @@ public class CompressorHttp2ConnectionEncoder extends DecoratingHttp2ConnectionE
                 if (compressor != null) {
                     try {
                         cleanup(stream, compressor);
-                    } catch (Exception ignore) {
-                        // ignore
+                    } catch (Exception exception) {
+                        LOGGER.debug("Exception during cleanup", exception);
                     }
                 }
             }
@@ -169,8 +173,8 @@ public class CompressorHttp2ConnectionEncoder extends DecoratingHttp2ConnectionE
                 if (compressor != null) {
                     try {
                         cleanup(stream, compressor);
-                    } catch (Exception ignore) {
-                        // ignore
+                    } catch (Exception exception) {
+                        LOGGER.debug("Exception during cleanup", exception);
                     }
                 }
             }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingDecompressorFrameListener.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingDecompressorFrameListener.java
@@ -123,7 +123,11 @@ public class DelegatingDecompressorFrameListener extends Http2FrameListenerDecor
             public void onStreamRemoved(Http2Stream stream) {
                 final Http2Decompressor decompressor = decompressor(stream);
                 if (decompressor != null) {
-                    decompressor.cleanup();
+                    try {
+                        decompressor.cleanup();
+                    } catch (Exception ignore) {
+                        // ignore
+                    }
                 }
             }
         });
@@ -399,7 +403,7 @@ public class DelegatingDecompressorFrameListener extends Http2FrameListenerDecor
         /**
          * Release remaining content from the {@link EmbeddedChannel}.
          */
-        void cleanup() {
+        void cleanup() throws Exception {
             decompressor.finishAndReleaseAll();
         }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerTest.java
@@ -128,7 +128,7 @@ public class CleartextHttp2ServerUpgradeHandlerTest {
     }
 
     @Test
-    public void upgradeWithMultipleConnectionHeaders() {
+    public void upgradeWithMultipleConnectionHeaders() throws Exception {
         String upgradeString = "GET / HTTP/1.1\r\n" +
                 "Host: example.com\r\n" +
                 "Connection: keep-alive\r\n" +
@@ -139,7 +139,7 @@ public class CleartextHttp2ServerUpgradeHandlerTest {
     }
 
     @Test
-    public void requiredHeadersInSeparateConnectionHeaders() {
+    public void requiredHeadersInSeparateConnectionHeaders() throws Exception {
         String upgradeString = "GET / HTTP/1.1\r\n" +
                 "Host: example.com\r\n" +
                 "Connection: keep-alive\r\n" +
@@ -250,7 +250,7 @@ public class CleartextHttp2ServerUpgradeHandlerTest {
         return new Http2Settings().maxConcurrentStreams(100).initialWindowSize(65535);
     }
 
-    private void validateClearTextUpgrade(String upgradeString) {
+    private void validateClearTextUpgrade(String upgradeString) throws Exception {
         setUpServerChannel();
 
         ByteBuf upgrade = Unpooled.copiedBuffer(upgradeString, CharsetUtil.US_ASCII);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2DataChunkedInputTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2DataChunkedInputTest.java
@@ -73,23 +73,23 @@ public class Http2DataChunkedInputTest {
     }
 
     @Test
-    public void testChunkedStream() {
+    public void testChunkedStream() throws Exception {
         check(new Http2DataChunkedInput(new ChunkedStream(new ByteArrayInputStream(BYTES)), STREAM));
     }
 
     @Test
-    public void testChunkedNioStream() {
+    public void testChunkedNioStream() throws Exception {
         check(new Http2DataChunkedInput(new ChunkedNioStream(Channels.newChannel(new ByteArrayInputStream(BYTES))),
                 STREAM));
     }
 
     @Test
-    public void testChunkedFile() throws IOException {
+    public void testChunkedFile() throws Exception {
         check(new Http2DataChunkedInput(new ChunkedFile(TMP), STREAM));
     }
 
     @Test
-    public void testChunkedNioFile() throws IOException {
+    public void testChunkedNioFile() throws Exception {
         check(new Http2DataChunkedInput(new ChunkedNioFile(TMP), STREAM));
     }
 
@@ -130,7 +130,7 @@ public class Http2DataChunkedInputTest {
         assertNull(input.readChunk(ByteBufAllocator.DEFAULT));
     }
 
-    private static void check(ChunkedInput<?>... inputs) {
+    private static void check(ChunkedInput<?>... inputs) throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new ChunkedWriteHandler());
 
         for (ChunkedInput<?> input : inputs) {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
@@ -42,7 +42,6 @@ import io.netty.util.concurrent.GlobalEventExecutor;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.ReflectionUtil;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -223,7 +222,7 @@ public class Http2FrameCodecTest {
     }
 
     @Test
-    public void flowControlShouldBeResilientToMissingStreams() throws Http2Exception {
+    public void flowControlShouldBeResilientToMissingStreams() throws Exception {
         Http2Connection conn = new DefaultHttp2Connection(true);
         Http2ConnectionEncoder enc = new DefaultHttp2ConnectionEncoder(conn, new DefaultHttp2FrameWriter());
         Http2ConnectionDecoder dec = new DefaultHttp2ConnectionDecoder(conn, enc, new DefaultHttp2FrameReader());

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexClientUpgradeTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexClientUpgradeTest.java
@@ -19,7 +19,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
+
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -86,14 +86,11 @@ public abstract class Http2MultiplexClientUpgradeTest<C extends Http2FrameCodec>
         final C codec = newCodec(null);
         final EmbeddedChannel ch = new EmbeddedChannel(codec, newMultiplexer(null));
 
-        assertThrows(Http2Exception.class, new Executable() {
-            @Override
-            public void execute() throws Http2Exception {
-                try {
-                    codec.onHttpClientUpgrade();
-                } finally {
-                    ch.finishAndReleaseAll();
-                }
+        assertThrows(Http2Exception.class, () -> {
+            try {
+                codec.onHttpClientUpgrade();
+            } finally {
+                ch.finishAndReleaseAll();
             }
         });
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexHandlerTest.java
@@ -22,8 +22,6 @@ import org.junit.jupiter.api.function.Executable;
 
 import javax.net.ssl.SSLException;
 
-import java.util.concurrent.CompletionException;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -75,13 +73,8 @@ public class Http2MultiplexHandlerTest extends Http2MultiplexTest<Http2FrameCode
         channel.parent().pipeline().fireExceptionCaught(testExc);
 
         assertTrue(channel.isActive());
-        Throwable exc = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                inboundHandler.checkException();
-            }
-        });
-        assertEquals(testExc, exc.getCause());
+        Throwable exc = assertThrows(RuntimeException.class, inboundHandler::checkException);
+        assertEquals(testExc, exc);
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexHandlerTest.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.function.Executable;
 
 import javax.net.ssl.SSLException;
 
+import java.util.concurrent.CompletionException;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -73,13 +75,13 @@ public class Http2MultiplexHandlerTest extends Http2MultiplexTest<Http2FrameCode
         channel.parent().pipeline().fireExceptionCaught(testExc);
 
         assertTrue(channel.isActive());
-        RuntimeException exc = assertThrows(RuntimeException.class, new Executable() {
+        Throwable exc = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
                 inboundHandler.checkException();
             }
         });
-        assertEquals(testExc, exc);
+        assertEquals(testExc, exc.getCause());
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
@@ -56,6 +56,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Queue;
 import java.util.UUID;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -68,6 +69,7 @@ import static io.netty.handler.codec.http2.Http2TestUtil.bb;
 import static io.netty.util.ReferenceCountUtil.release;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -963,12 +965,13 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
 
         handler.checkException();
 
-        assertThrows(Http2NoMoreStreamIdsException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 future.syncUninterruptibly();
             }
         });
+        assertInstanceOf(Http2NoMoreStreamIdsException.class, cause.getCause());
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
@@ -103,7 +103,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     protected abstract ChannelHandler newMultiplexer(TestChannelInitializer childChannelInitializer);
 
     @BeforeEach
-    public void setUp() {
+    public void setUp() throws Exception {
         childChannelInitializer = new TestChannelInitializer();
         parentChannel = new ParentChannel();
         frameInboundWriter = new Http2FrameInboundWriter(parentChannel);
@@ -900,12 +900,13 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
 
         inboundHandler.checkException();
 
-        assertThrows(ClosedChannelException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 future.syncUninterruptibly();
             }
         });
+        assertInstanceOf(ClosedChannelException.class, cause.getCause());
     }
 
     @Test
@@ -1237,7 +1238,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     }
 
     @Test
-    public void endOfStreamDoesNotDiscardData() {
+    public void endOfStreamDoesNotDiscardData() throws Exception {
         AtomicInteger numReads = new AtomicInteger(1);
         final AtomicBoolean shouldDisableAutoRead = new AtomicBoolean();
         Consumer<ChannelHandlerContext> ctxConsumer = new Consumer<ChannelHandlerContext>() {
@@ -1337,7 +1338,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     }
 
     @Test
-    public void childQueueIsDrainedAndNewDataIsDispatchedInParentReadLoopAutoRead() {
+    public void childQueueIsDrainedAndNewDataIsDispatchedInParentReadLoopAutoRead() throws Exception {
         AtomicInteger numReads = new AtomicInteger(1);
         final AtomicInteger channelReadCompleteCount = new AtomicInteger(0);
         final AtomicBoolean shouldDisableAutoRead = new AtomicBoolean();
@@ -1400,7 +1401,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
     }
 
     @Test
-    public void childQueueIsDrainedAndNewDataIsDispatchedInParentReadLoopNoAutoRead() {
+    public void childQueueIsDrainedAndNewDataIsDispatchedInParentReadLoopNoAutoRead() throws Exception {
         final AtomicInteger numReads = new AtomicInteger(1);
         final AtomicInteger channelReadCompleteCount = new AtomicInteger(0);
         final AtomicBoolean shouldDisableAutoRead = new AtomicBoolean();

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ServerUpgradeCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ServerUpgradeCodecTest.java
@@ -39,27 +39,27 @@ import org.mockito.Mockito;
 public class Http2ServerUpgradeCodecTest {
 
     @Test
-    public void testUpgradeToHttp2ConnectionHandler() {
+    public void testUpgradeToHttp2ConnectionHandler() throws Exception {
         testUpgrade(new Http2ConnectionHandlerBuilder().frameListener(new Http2FrameAdapter()).build(), null);
     }
 
     @Test
-    public void testUpgradeToHttp2FrameCodec() {
+    public void testUpgradeToHttp2FrameCodec() throws Exception {
         testUpgrade(new Http2FrameCodecBuilder(true).build(), null);
     }
 
     @Test
-    public void testUpgradeToHttp2MultiplexCodec() {
+    public void testUpgradeToHttp2MultiplexCodec() throws Exception {
         testUpgrade(new Http2MultiplexCodecBuilder(true, new HttpInboundHandler()).build(), null);
     }
 
     @Test
-    public void testUpgradeToHttp2FrameCodecWithMultiplexer() {
+    public void testUpgradeToHttp2FrameCodecWithMultiplexer() throws Exception {
         testUpgrade(new Http2FrameCodecBuilder(true).build(),
                 new Http2MultiplexHandler(new HttpInboundHandler()));
     }
 
-    private static void testUpgrade(Http2ConnectionHandler handler, ChannelHandler multiplexer) {
+    private static void testUpgrade(Http2ConnectionHandler handler, ChannelHandler multiplexer) throws Exception {
         FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.OPTIONS, "*");
         request.headers().set(HttpHeaderNames.HOST, "netty.io");
         request.headers().set(HttpHeaderNames.CONNECTION, "Upgrade, HTTP2-Settings");

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodecTest.java
@@ -53,10 +53,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Queue;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -94,13 +96,14 @@ public class Http2StreamFrameToHttpObjectCodecTest {
     @Test
     public void encodeNonFullHttpResponse100ContinueIsRejected() throws Exception {
         final EmbeddedChannel ch = new EmbeddedChannel(new Http2StreamFrameToHttpObjectCodec(true));
-        assertThrows(EncoderException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 ch.writeOutbound(new DefaultHttpResponse(
                         HttpVersion.HTTP_1_1, HttpResponseStatus.CONTINUE));
             }
         });
+        assertInstanceOf(EncoderException.class, cause.getCause());
         ch.finishAndReleaseAll();
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodecTest.java
@@ -48,17 +48,14 @@ import io.netty.handler.ssl.SslProvider;
 import io.netty.util.CharsetUtil;
 import io.netty.util.concurrent.CompletionHandler;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Queue;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -96,14 +93,8 @@ public class Http2StreamFrameToHttpObjectCodecTest {
     @Test
     public void encodeNonFullHttpResponse100ContinueIsRejected() throws Exception {
         final EmbeddedChannel ch = new EmbeddedChannel(new Http2StreamFrameToHttpObjectCodec(true));
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                ch.writeOutbound(new DefaultHttpResponse(
-                        HttpVersion.HTTP_1_1, HttpResponseStatus.CONTINUE));
-            }
-        });
-        assertInstanceOf(EncoderException.class, cause.getCause());
+        assertThrows(EncoderException.class, () -> ch.writeOutbound(new DefaultHttpResponse(
+                HttpVersion.HTTP_1_1, HttpResponseStatus.CONTINUE)));
         ch.finishAndReleaseAll();
     }
 
@@ -784,7 +775,7 @@ public class Http2StreamFrameToHttpObjectCodecTest {
 
     @ParameterizedTest()
     @ValueSource(strings = {"204", "304"})
-    public void testDecodeResponseHeadersContentAlwaysEmpty(String statusCode) {
+    public void testDecodeResponseHeadersContentAlwaysEmpty(String statusCode) throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new Http2StreamFrameToHttpObjectCodec(false));
         Http2Headers headers = new DefaultHttp2Headers();
         headers.scheme(HttpScheme.HTTP.name());

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/AbstractHttp3FrameTypeValidationHandlerTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/AbstractHttp3FrameTypeValidationHandlerTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.CompletionException;
 
 import static io.netty.handler.codec.http3.Http3.getQpackAttributes;
 import static io.netty.handler.codec.http3.Http3.setQpackAttributes;
@@ -132,7 +133,7 @@ public abstract class AbstractHttp3FrameTypeValidationHandlerTest<T extends Http
         Http3ErrorCode errorCode = inboundErrorCodeInvalid();
         List<Http3Frame> invalidFrames = newInvalidFrames();
         for (Http3Frame invalid : invalidFrames) {
-            Exception e = assertThrows(Exception.class, () -> channel.writeInbound(invalid));
+            Throwable e = assertThrows(CompletionException.class, () -> channel.writeInbound(invalid)).getCause();
             assertException(errorCode, e);
 
             assertFrameReleased(invalid);
@@ -154,7 +155,7 @@ public abstract class AbstractHttp3FrameTypeValidationHandlerTest<T extends Http
 
         List<Http3Frame> invalidFrames = newInvalidFrames();
         for (Http3Frame invalid : invalidFrames) {
-            Exception e = assertThrows(Exception.class, () -> channel.writeOutbound(invalid));
+            Throwable e = assertThrows(CompletionException.class, () -> channel.writeOutbound(invalid)).getCause();
             Http3TestUtils.assertException(Http3ErrorCode.H3_FRAME_UNEXPECTED, e);
 
             assertFrameReleased(invalid);

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/AbstractHttp3FrameTypeValidationHandlerTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/AbstractHttp3FrameTypeValidationHandlerTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.CompletionException;
 
 import static io.netty.handler.codec.http3.Http3.getQpackAttributes;
 import static io.netty.handler.codec.http3.Http3.setQpackAttributes;
@@ -73,7 +72,7 @@ public abstract class AbstractHttp3FrameTypeValidationHandlerTest<T extends Http
     }
 
     @AfterEach
-    public void tearDown() {
+    public void tearDown() throws Exception {
         if (parent != null) {
             final QpackAttributes qpackAttributes = getQpackAttributes(parent);
             assertNotNull(qpackAttributes);
@@ -133,7 +132,7 @@ public abstract class AbstractHttp3FrameTypeValidationHandlerTest<T extends Http
         Http3ErrorCode errorCode = inboundErrorCodeInvalid();
         List<Http3Frame> invalidFrames = newInvalidFrames();
         for (Http3Frame invalid : invalidFrames) {
-            Throwable e = assertThrows(CompletionException.class, () -> channel.writeInbound(invalid)).getCause();
+            Throwable e = assertThrows(Exception.class, () -> channel.writeInbound(invalid));
             assertException(errorCode, e);
 
             assertFrameReleased(invalid);
@@ -155,7 +154,7 @@ public abstract class AbstractHttp3FrameTypeValidationHandlerTest<T extends Http
 
         List<Http3Frame> invalidFrames = newInvalidFrames();
         for (Http3Frame invalid : invalidFrames) {
-            Throwable e = assertThrows(CompletionException.class, () -> channel.writeOutbound(invalid)).getCause();
+            Throwable e = assertThrows(Exception.class, () -> channel.writeOutbound(invalid));
             Http3TestUtils.assertException(Http3ErrorCode.H3_FRAME_UNEXPECTED, e);
 
             assertFrameReleased(invalid);

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/EmbeddedQuicStreamChannel.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/EmbeddedQuicStreamChannel.java
@@ -85,7 +85,7 @@ final class EmbeddedQuicStreamChannel extends EmbeddedChannel implements QuicStr
         });
     }
 
-    boolean writeInboundWithFin(Object... msgs) {
+    boolean writeInboundWithFin(Object... msgs) throws Exception {
         shutdown(ChannelShutdownType.newInbound(0));
         boolean written = writeInbound(msgs);
         fireInputShutdownEvents();

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3ControlStreamInboundHandlerTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3ControlStreamInboundHandlerTest.java
@@ -236,7 +236,7 @@ public class Http3ControlStreamInboundHandlerTest extends
     private void writeInvalidFrame(boolean forwardControlFrames, Http3ErrorCode expectedCode, EmbeddedChannel channel,
                                    Http3Frame frame) {
         if (forwardControlFrames) {
-            Exception e = assertThrows(Exception.class, () -> channel.writeInbound(frame));
+            Throwable e = assertThrows(Exception.class, () -> channel.writeInbound(frame)).getCause();
             assertException(expectedCode, e);
         } else {
             assertFalse(channel.writeInbound(frame));

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3ControlStreamInboundHandlerTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3ControlStreamInboundHandlerTest.java
@@ -224,7 +224,7 @@ public class Http3ControlStreamInboundHandlerTest extends
     }
 
     private void writeValidFrame(boolean forwardControlFrames, EmbeddedChannel channel,
-                                 Http3ControlStreamFrame controlStreamFrame) {
+                                 Http3ControlStreamFrame controlStreamFrame) throws Exception {
         assertEquals(forwardControlFrames, channel.writeInbound(controlStreamFrame));
         if (forwardControlFrames) {
             assertFrameSame(controlStreamFrame, channel.readInbound());
@@ -234,9 +234,9 @@ public class Http3ControlStreamInboundHandlerTest extends
     }
 
     private void writeInvalidFrame(boolean forwardControlFrames, Http3ErrorCode expectedCode, EmbeddedChannel channel,
-                                   Http3Frame frame) {
+                                   Http3Frame frame) throws Exception {
         if (forwardControlFrames) {
-            Throwable e = assertThrows(Exception.class, () -> channel.writeInbound(frame)).getCause();
+            Throwable e = assertThrows(Exception.class, () -> channel.writeInbound(frame));
             assertException(expectedCode, e);
         } else {
             assertFalse(channel.writeInbound(frame));

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3ControlStreamOutboundHandlerTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3ControlStreamOutboundHandlerTest.java
@@ -190,7 +190,7 @@ public class Http3ControlStreamOutboundHandlerTest extends
     private void writeInvalidFrame(Http3ErrorCode expectedCode,
                                    EmbeddedChannel channel,
                                    Http3Frame frame) {
-        Exception e = assertThrows(Exception.class, () -> channel.writeOutbound(frame));
+        Throwable e = assertThrows(Exception.class, () -> channel.writeOutbound(frame)).getCause();
         assertException(expectedCode, e);
     }
 

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3ControlStreamOutboundHandlerTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3ControlStreamOutboundHandlerTest.java
@@ -190,11 +190,11 @@ public class Http3ControlStreamOutboundHandlerTest extends
     private void writeInvalidFrame(Http3ErrorCode expectedCode,
                                    EmbeddedChannel channel,
                                    Http3Frame frame) {
-        Throwable e = assertThrows(Exception.class, () -> channel.writeOutbound(frame)).getCause();
+        Throwable e = assertThrows(Exception.class, () -> channel.writeOutbound(frame));
         assertException(expectedCode, e);
     }
 
-    private void writeValidFrame(EmbeddedChannel channel, Http3Frame frame) {
+    private void writeValidFrame(EmbeddedChannel channel, Http3Frame frame) throws Exception {
         try {
             assertTrue(channel.writeOutbound(frame));
         } finally {

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3FrameCodecTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3FrameCodecTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static io.netty.handler.codec.http3.Http3CodecUtils.HTTP3_CANCEL_PUSH_FRAME_MAX_LEN;
@@ -47,6 +48,7 @@ import static io.netty.handler.codec.http3.Http3TestUtils.verifyClose;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -323,8 +325,9 @@ public class Http3FrameCodecTest {
 
         final DefaultHttp3HeadersFrame trailer = new DefaultHttp3HeadersFrame();
         trailer.headers().add(":method", "GET");
-        assertThrows(Http3HeadersValidationException.class,
+        Throwable cause = assertThrows(CompletionException.class,
                 () -> testFrameEncodedAndDecoded(fragmented, maxBlockedStreams, delayQpackStreams, trailer));
+        assertInstanceOf(Http3HeadersValidationException.class, cause.getCause());
     }
 
     @ParameterizedTest(name = "{index}: fragmented = {0}, maxBlockedStreams = {1}, delayQpackStreams = {2}")

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3FrameCodecTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3FrameCodecTest.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static io.netty.handler.codec.http3.Http3CodecUtils.HTTP3_CANCEL_PUSH_FRAME_MAX_LEN;
@@ -48,7 +47,6 @@ import static io.netty.handler.codec.http3.Http3TestUtils.verifyClose;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -157,7 +155,7 @@ public class Http3FrameCodecTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    public void tearDown() throws Exception {
         assertFalse(codecChannel.finish());
         assertFalse(decoderStream.finish());
         assertFalse(encoderStream.finish());
@@ -325,9 +323,8 @@ public class Http3FrameCodecTest {
 
         final DefaultHttp3HeadersFrame trailer = new DefaultHttp3HeadersFrame();
         trailer.headers().add(":method", "GET");
-        Throwable cause = assertThrows(CompletionException.class,
+        assertThrows(Http3HeadersValidationException.class,
                 () -> testFrameEncodedAndDecoded(fragmented, maxBlockedStreams, delayQpackStreams, trailer));
-        assertInstanceOf(Http3HeadersValidationException.class, cause.getCause());
     }
 
     @ParameterizedTest(name = "{index}: fragmented = {0}, maxBlockedStreams = {1}, delayQpackStreams = {2}")
@@ -678,7 +675,7 @@ public class Http3FrameCodecTest {
         return delayQpackStreams && !qpackAttributes.encoderStreamAvailable() && isHeaderFrame;
     }
 
-    private void encodeFrame(boolean delayQpackStreams, Http3Frame frame, boolean isHeaderFrame) {
+    private void encodeFrame(boolean delayQpackStreams, Http3Frame frame, boolean isHeaderFrame) throws Exception {
         boolean wroteData = codecChannel.writeOutbound(retainAndDuplicate(frame));
         assertEquals(!isWriteBuffered(delayQpackStreams, isHeaderFrame), wroteData);
     }

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3FrameToHttpObjectCodecTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3FrameToHttpObjectCodecTest.java
@@ -75,6 +75,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -87,6 +88,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -122,8 +124,9 @@ public class Http3FrameToHttpObjectCodecTest {
     @Test
     public void encodeNonFullHttpResponse100ContinueIsRejected() {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
-        assertThrows(EncoderException.class, () -> ch.writeOutbound(new DefaultHttpResponse(
+        Throwable cause = assertThrows(CompletionException.class, () -> ch.writeOutbound(new DefaultHttpResponse(
                 HttpVersion.HTTP_1_1, HttpResponseStatus.CONTINUE)));
+        assertInstanceOf(EncoderException.class, cause.getCause());
         ch.finishAndReleaseAll();
     }
 
@@ -1052,8 +1055,8 @@ public class Http3FrameToHttpObjectCodecTest {
     @Test
     public void testUnsupportedIncludeSomeDetails() {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
-        UnsupportedMessageTypeException ex = assertThrows(
-                UnsupportedMessageTypeException.class, () -> ch.writeOutbound("unsupported"));
+        UnsupportedMessageTypeException ex = (UnsupportedMessageTypeException) assertThrows(
+                CompletionException.class, () -> ch.writeOutbound("unsupported")).getCause();
         assertNotNull(ex.getMessage());
         assertFalse(ch.finish());
     }

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3FrameToHttpObjectCodecTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3FrameToHttpObjectCodecTest.java
@@ -75,7 +75,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -88,7 +87,6 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -96,7 +94,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class Http3FrameToHttpObjectCodecTest {
 
     @Test
-    public void testUpgradeEmptyFullResponse() {
+    public void testUpgradeEmptyFullResponse() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
         assertTrue(ch.writeOutbound(new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK)));
 
@@ -108,7 +106,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void encode100ContinueAsHttp2HeadersFrameThatIsNotEndStream() {
+    public void encode100ContinueAsHttp2HeadersFrameThatIsNotEndStream() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
         assertTrue(ch.writeOutbound(new DefaultFullHttpResponse(
                 HttpVersion.HTTP_1_1, HttpResponseStatus.CONTINUE)));
@@ -122,16 +120,15 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void encodeNonFullHttpResponse100ContinueIsRejected() {
+    public void encodeNonFullHttpResponse100ContinueIsRejected() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
-        Throwable cause = assertThrows(CompletionException.class, () -> ch.writeOutbound(new DefaultHttpResponse(
+        assertThrows(EncoderException.class, () -> ch.writeOutbound(new DefaultHttpResponse(
                 HttpVersion.HTTP_1_1, HttpResponseStatus.CONTINUE)));
-        assertInstanceOf(EncoderException.class, cause.getCause());
         ch.finishAndReleaseAll();
     }
 
     @Test
-    public void testUpgradeNonEmptyFullResponse() {
+    public void testUpgradeNonEmptyFullResponse() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
         ByteBuf hello = Unpooled.copiedBuffer("hello world", CharsetUtil.UTF_8);
         assertTrue(ch.writeOutbound(new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, hello)));
@@ -151,7 +148,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void testUpgradeEmptyFullResponseWithTrailers() {
+    public void testUpgradeEmptyFullResponseWithTrailers() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
         FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
         HttpHeaders trailers = response.trailingHeaders();
@@ -169,7 +166,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void testUpgradeNonEmptyFullResponseWithTrailers() {
+    public void testUpgradeNonEmptyFullResponseWithTrailers() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
         ByteBuf hello = Unpooled.copiedBuffer("hello world", CharsetUtil.UTF_8);
         FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, hello);
@@ -195,7 +192,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void testUpgradeHeaders() {
+    public void testUpgradeHeaders() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
         HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
         assertTrue(ch.writeOutbound(response));
@@ -209,7 +206,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void testUpgradeChunk() {
+    public void testUpgradeChunk() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
         ByteBuf hello = Unpooled.copiedBuffer("hello world", CharsetUtil.UTF_8);
         HttpContent content = new DefaultHttpContent(hello);
@@ -228,7 +225,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void testUpgradeEmptyEnd() {
+    public void testUpgradeEmptyEnd() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
         ch.writeOutbound(LastHttpContent.EMPTY_LAST_CONTENT);
 
@@ -244,7 +241,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void testUpgradeDataEnd() {
+    public void testUpgradeDataEnd() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
         ByteBuf hello = Unpooled.copiedBuffer("hello world", CharsetUtil.UTF_8);
         LastHttpContent end = new DefaultLastHttpContent(hello, true);
@@ -262,7 +259,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void testUpgradeDataEndWithTrailers() {
+    public void testUpgradeDataEndWithTrailers() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
         ByteBuf hello = Unpooled.copiedBuffer("hello world", CharsetUtil.UTF_8);
         LastHttpContent trailers = new DefaultLastHttpContent(hello, true);
@@ -285,7 +282,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void testDowngradeHeaders() {
+    public void testDowngradeHeaders() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
         Http3Headers headers = new DefaultHttp3Headers();
         headers.path("/");
@@ -305,7 +302,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void testDowngradeHeadersWithContentLength() {
+    public void testDowngradeHeadersWithContentLength() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
         Http3Headers headers = new DefaultHttp3Headers();
         headers.path("/");
@@ -326,7 +323,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void testDowngradeTrailers() {
+    public void testDowngradeTrailers() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
         Http3Headers headers = new DefaultHttp3Headers();
         headers.set("key", "value");
@@ -347,7 +344,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void testDowngradeData() {
+    public void testDowngradeData() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
         ByteBuf hello = Unpooled.copiedBuffer("hello world", CharsetUtil.UTF_8);
         assertTrue(ch.writeInbound(new DefaultHttp3DataFrame(hello)));
@@ -365,7 +362,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void testDowngradeEndData() {
+    public void testDowngradeEndData() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(true));
         ByteBuf hello = Unpooled.copiedBuffer("hello world", CharsetUtil.UTF_8);
         assertTrue(ch.writeInboundWithFin(new DefaultHttp3DataFrame(hello)));
@@ -391,7 +388,7 @@ public class Http3FrameToHttpObjectCodecTest {
 
     // client-specific tests
     @Test
-    public void testEncodeEmptyFullRequest() {
+    public void testEncodeEmptyFullRequest() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
         assertTrue(ch.writeOutbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/hello/world")));
 
@@ -407,7 +404,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void testEncodeNonEmptyFullRequest() {
+    public void testEncodeNonEmptyFullRequest() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
         ByteBuf hello = Unpooled.copiedBuffer("hello world", CharsetUtil.UTF_8);
         assertTrue(ch.writeOutbound(new DefaultFullHttpRequest(
@@ -432,7 +429,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void testEncodeEmptyFullRequestWithTrailers() {
+    public void testEncodeEmptyFullRequestWithTrailers() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
         FullHttpRequest request = new DefaultFullHttpRequest(
                 HttpVersion.HTTP_1_1, HttpMethod.PUT, "/hello/world");
@@ -456,7 +453,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void testEncodeNonEmptyFullRequestWithTrailers() {
+    public void testEncodeNonEmptyFullRequestWithTrailers() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
         ByteBuf hello = Unpooled.copiedBuffer("hello world", CharsetUtil.UTF_8);
         FullHttpRequest request = new DefaultFullHttpRequest(
@@ -488,7 +485,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void testEncodeRequestHeaders() {
+    public void testEncodeRequestHeaders() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
         HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/hello/world");
         assertTrue(ch.writeOutbound(request));
@@ -506,7 +503,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void testEncodeChunkAsClient() {
+    public void testEncodeChunkAsClient() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
         ByteBuf hello = Unpooled.copiedBuffer("hello world", CharsetUtil.UTF_8);
         HttpContent content = new DefaultHttpContent(hello);
@@ -524,7 +521,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void testEncodeEmptyEndAsClient() {
+    public void testEncodeEmptyEndAsClient() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
         ch.writeOutbound(LastHttpContent.EMPTY_LAST_CONTENT);
 
@@ -540,7 +537,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void testEncodeDataEndAsClient() {
+    public void testEncodeDataEndAsClient() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
         ByteBuf hello = Unpooled.copiedBuffer("hello world", CharsetUtil.UTF_8);
         LastHttpContent end = new DefaultLastHttpContent(hello, true);
@@ -558,7 +555,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void testEncodeTrailersAsClient() {
+    public void testEncodeTrailersAsClient() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
         LastHttpContent trailers = new DefaultLastHttpContent(Unpooled.EMPTY_BUFFER, true);
         HttpHeaders headers = trailers.trailingHeaders();
@@ -573,7 +570,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void testEncodeDataEndWithTrailersAsClient() {
+    public void testEncodeDataEndWithTrailersAsClient() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
         ByteBuf hello = Unpooled.copiedBuffer("hello world", CharsetUtil.UTF_8);
         LastHttpContent trailers = new DefaultLastHttpContent(hello, true);
@@ -596,7 +593,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void testEncodeFullPromiseCompletes() {
+    public void testEncodeFullPromiseCompletes() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
         Future<Void> writeFuture = ch.writeOneOutbound(new DefaultFullHttpRequest(
                 HttpVersion.HTTP_1_1, HttpMethod.GET, "/hello/world"));
@@ -615,7 +612,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void testEncodeEmptyLastPromiseCompletes() {
+    public void testEncodeEmptyLastPromiseCompletes() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
         Future<Void> f1 = ch.writeOneOutbound(new DefaultHttpRequest(
                 HttpVersion.HTTP_1_1, HttpMethod.GET, "/hello/world"));
@@ -643,7 +640,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void testEncodeMultiplePromiseCompletes() {
+    public void testEncodeMultiplePromiseCompletes() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
         Future<Void> f1 = ch.writeOneOutbound(new DefaultHttpRequest(
                 HttpVersion.HTTP_1_1, HttpMethod.GET, "/hello/world"));
@@ -668,7 +665,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void testEncodeTrailersCompletes() {
+    public void testEncodeTrailersCompletes() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
         Future<Void> f1 = ch.writeOneOutbound(new DefaultHttpRequest(
                 HttpVersion.HTTP_1_1, HttpMethod.GET, "/hello/world"));
@@ -723,7 +720,7 @@ public class Http3FrameToHttpObjectCodecTest {
             boolean last,
             boolean nonEmptyContent,
             boolean hasTrailers
-    ) {
+    ) throws Exception {
         ByteBuf content = nonEmptyContent ? Unpooled.wrappedBuffer(new byte[1]) : Unpooled.EMPTY_BUFFER;
         HttpHeaders trailers = new DefaultHttpHeaders();
         if (hasTrailers) {
@@ -807,7 +804,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void decode100ContinueHttp2HeadersAsFullHttpResponse() {
+    public void decode100ContinueHttp2HeadersAsFullHttpResponse() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
         Http3Headers headers = new DefaultHttp3Headers();
         headers.scheme(HttpScheme.HTTP.name());
@@ -828,7 +825,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void testDecodeResponseHeaders() {
+    public void testDecodeResponseHeaders() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
         Http3Headers headers = new DefaultHttp3Headers();
         headers.scheme(HttpScheme.HTTP.name());
@@ -847,7 +844,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void testDecodeResponseHeadersWithContentLength() {
+    public void testDecodeResponseHeadersWithContentLength() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
         Http3Headers headers = new DefaultHttp3Headers();
         headers.scheme(HttpScheme.HTTP.name());
@@ -867,7 +864,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void testDecodeResponseTrailersAsClient() {
+    public void testDecodeResponseTrailersAsClient() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
         Http3Headers headers = new DefaultHttp3Headers();
         headers.set("key", "value");
@@ -887,7 +884,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void testDecodeDataAsClient() {
+    public void testDecodeDataAsClient() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
         ByteBuf hello = Unpooled.copiedBuffer("hello world", CharsetUtil.UTF_8);
         assertTrue(ch.writeInbound(new DefaultHttp3DataFrame(hello)));
@@ -905,7 +902,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void testDecodeEndDataAsClient() {
+    public void testDecodeEndDataAsClient() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
         ByteBuf hello = Unpooled.copiedBuffer("hello world", CharsetUtil.UTF_8);
         assertTrue(ch.writeInboundWithFin(new DefaultHttp3DataFrame(hello)));
@@ -930,7 +927,7 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void testHostTranslated() {
+    public void testHostTranslated() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
         FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/hello/world");
         request.headers().add(HttpHeaderNames.HOST, "example.com");
@@ -1053,10 +1050,10 @@ public class Http3FrameToHttpObjectCodecTest {
     }
 
     @Test
-    public void testUnsupportedIncludeSomeDetails() {
+    public void testUnsupportedIncludeSomeDetails() throws Exception {
         EmbeddedQuicStreamChannel ch = new EmbeddedQuicStreamChannel(new Http3FrameToHttpObjectCodec(false));
-        UnsupportedMessageTypeException ex = (UnsupportedMessageTypeException) assertThrows(
-                CompletionException.class, () -> ch.writeOutbound("unsupported")).getCause();
+        UnsupportedMessageTypeException ex = assertThrows(
+                UnsupportedMessageTypeException.class, () -> ch.writeOutbound("unsupported"));
         assertNotNull(ex.getMessage());
         assertFalse(ch.finish());
     }

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3PushStreamTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3PushStreamTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 
 import static io.netty.handler.codec.http3.Http3ErrorCode.H3_ID_ERROR;
@@ -32,6 +33,7 @@ import static io.netty.handler.codec.http3.Http3TestUtils.assertFrameEquals;
 import static io.netty.handler.codec.http3.Http3TestUtils.verifyClose;
 import static io.netty.handler.codec.quic.QuicStreamType.UNIDIRECTIONAL;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -112,7 +114,9 @@ public class Http3PushStreamTest {
         final EmbeddedQuicStreamChannel serverStream = newServerStream();
         readStreamHeader(serverStream).release();
         try {
-            assertThrows(Http3Exception.class, () -> serverStream.writeOutbound(new DefaultHttp3PushPromiseFrame(1)));
+            Throwable cause = assertThrows(CompletionException.class,
+                    () -> serverStream.writeOutbound(new DefaultHttp3PushPromiseFrame(1)));
+            assertInstanceOf(Http3Exception.class, cause.getCause());
         } finally {
             assertFalse(serverStream.finish());
         }

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3PushStreamTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3PushStreamTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 
 import static io.netty.handler.codec.http3.Http3ErrorCode.H3_ID_ERROR;
@@ -33,7 +32,6 @@ import static io.netty.handler.codec.http3.Http3TestUtils.assertFrameEquals;
 import static io.netty.handler.codec.http3.Http3TestUtils.verifyClose;
 import static io.netty.handler.codec.quic.QuicStreamType.UNIDIRECTIONAL;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -91,7 +89,7 @@ public class Http3PushStreamTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    public void tearDown() throws Exception {
         assertFalse(serverLocalControlStream.finish());
         assertFalse(serverChannel.finish());
         assertFalse(clientLocalControlStream.finish());
@@ -114,9 +112,8 @@ public class Http3PushStreamTest {
         final EmbeddedQuicStreamChannel serverStream = newServerStream();
         readStreamHeader(serverStream).release();
         try {
-            Throwable cause = assertThrows(CompletionException.class,
+            assertThrows(Http3Exception.class,
                     () -> serverStream.writeOutbound(new DefaultHttp3PushPromiseFrame(1)));
-            assertInstanceOf(Http3Exception.class, cause.getCause());
         } finally {
             assertFalse(serverStream.finish());
         }
@@ -166,7 +163,8 @@ public class Http3PushStreamTest {
     }
 
     private static void writeAndReadFrame(EmbeddedQuicStreamChannel serverStream,
-                                          EmbeddedQuicStreamChannel clientStream, Http3RequestStreamFrame frame) {
+                                          EmbeddedQuicStreamChannel clientStream, Http3RequestStreamFrame frame)
+            throws Exception {
         ReferenceCountUtil.retain(frame); // retain so that we can compare later
         assertTrue(serverStream.writeOutbound(frame));
         final ByteBuf encodedFrame = serverStream.readOutbound();
@@ -211,7 +209,7 @@ public class Http3PushStreamTest {
                         }, () -> new ChannelHandler() { }, () -> new ChannelHandler() { })).get();
     }
 
-    private ByteBuf readStreamHeader(EmbeddedQuicStreamChannel serverStream) {
+    private ByteBuf readStreamHeader(EmbeddedQuicStreamChannel serverStream) throws Exception {
         serverStream.flushOutbound(); // flush the stream header
         ByteBuf streamHeader = serverStream.readOutbound();
         assertNotNull(streamHeader);

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3RequestStreamInboundHandlerTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3RequestStreamInboundHandlerTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class Http3RequestStreamInboundHandlerTest {
 
     @Test
-    public void testDetectLastViaUserEvent() {
+    public void testDetectLastViaUserEvent() throws Exception {
         EmbeddedQuicStreamChannel channel = new EmbeddedQuicStreamChannel(new TestHttp3RequestStreamInboundHandler());
         assertTrue(channel.writeInbound(new DefaultHttp3HeadersFrame()));
         assertTrue(channel.writeInbound(new DefaultHttp3DataFrame(Unpooled.buffer())));

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3RequestStreamValidationHandlerTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3RequestStreamValidationHandlerTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
 
@@ -87,7 +88,7 @@ public class Http3RequestStreamValidationHandlerTest extends Http3FrameTypeValid
         final EmbeddedQuicStreamChannel channel = newStream(QuicStreamType.BIDIRECTIONAL, newHandler(server));
         Http3DataFrame dataFrame = new DefaultHttp3DataFrame(Unpooled.buffer());
 
-        Exception e = assertThrows(Exception.class, () -> channel.writeInbound(dataFrame));
+        Throwable e = assertThrows(CompletionException.class, () -> channel.writeInbound(dataFrame)).getCause();
         assertException(H3_FRAME_UNEXPECTED, e);
 
         verifyClose(H3_FRAME_UNEXPECTED, parent);
@@ -112,7 +113,7 @@ public class Http3RequestStreamValidationHandlerTest extends Http3FrameTypeValid
         assertTrue(channel.writeInbound(dataFrame2.retainedDuplicate()));
         assertTrue(channel.writeInbound(trailersFrame));
 
-        Exception e = assertThrows(Exception.class, () -> channel.writeInbound(dataFrame3));
+        Throwable e = assertThrows(CompletionException.class, () -> channel.writeInbound(dataFrame3)).getCause();
         assertException(H3_FRAME_UNEXPECTED, e);
 
         verifyClose(H3_FRAME_UNEXPECTED, parent);
@@ -134,8 +135,8 @@ public class Http3RequestStreamValidationHandlerTest extends Http3FrameTypeValid
 
         Http3DataFrame dataFrame = new DefaultHttp3DataFrame(Unpooled.buffer());
 
-        Exception e = assertThrows(Exception.class, () -> channel.writeOutbound(dataFrame));
-       assertException(H3_FRAME_UNEXPECTED, e);
+        Throwable e = assertThrows(CompletionException.class, () -> channel.writeOutbound(dataFrame)).getCause();
+        assertException(H3_FRAME_UNEXPECTED, e);
 
         assertFalse(channel.finish());
         assertEquals(0, dataFrame.refCnt());
@@ -157,7 +158,7 @@ public class Http3RequestStreamValidationHandlerTest extends Http3FrameTypeValid
         assertTrue(channel.writeOutbound(dataFrame2.retainedDuplicate()));
         assertTrue(channel.writeOutbound(trailersFrame));
 
-        Exception e = assertThrows(Exception.class, () -> channel.writeOutbound(dat3Frame3));
+        Throwable e = assertThrows(CompletionException.class, () -> channel.writeOutbound(dat3Frame3)).getCause();
         assertException(H3_FRAME_UNEXPECTED, e);
 
         assertTrue(channel.finish());
@@ -177,7 +178,7 @@ public class Http3RequestStreamValidationHandlerTest extends Http3FrameTypeValid
         EmbeddedQuicStreamChannel channel = newClientStream(() -> true);
 
         Http3HeadersFrame headersFrame = new DefaultHttp3HeadersFrame();
-        Exception e = assertThrows(Exception.class, () -> channel.writeOutbound(headersFrame));
+        Throwable e = assertThrows(CompletionException.class, () -> channel.writeOutbound(headersFrame)).getCause();
         assertException(H3_FRAME_UNEXPECTED, e);
 
         // We should have closed the channel.

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3RequestStreamValidationHandlerTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3RequestStreamValidationHandlerTest.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
 
@@ -88,7 +87,7 @@ public class Http3RequestStreamValidationHandlerTest extends Http3FrameTypeValid
         final EmbeddedQuicStreamChannel channel = newStream(QuicStreamType.BIDIRECTIONAL, newHandler(server));
         Http3DataFrame dataFrame = new DefaultHttp3DataFrame(Unpooled.buffer());
 
-        Throwable e = assertThrows(CompletionException.class, () -> channel.writeInbound(dataFrame)).getCause();
+        Throwable e = assertThrows(Exception.class, () -> channel.writeInbound(dataFrame));
         assertException(H3_FRAME_UNEXPECTED, e);
 
         verifyClose(H3_FRAME_UNEXPECTED, parent);
@@ -113,7 +112,7 @@ public class Http3RequestStreamValidationHandlerTest extends Http3FrameTypeValid
         assertTrue(channel.writeInbound(dataFrame2.retainedDuplicate()));
         assertTrue(channel.writeInbound(trailersFrame));
 
-        Throwable e = assertThrows(CompletionException.class, () -> channel.writeInbound(dataFrame3)).getCause();
+        Throwable e = assertThrows(Exception.class, () -> channel.writeInbound(dataFrame3));
         assertException(H3_FRAME_UNEXPECTED, e);
 
         verifyClose(H3_FRAME_UNEXPECTED, parent);
@@ -135,7 +134,7 @@ public class Http3RequestStreamValidationHandlerTest extends Http3FrameTypeValid
 
         Http3DataFrame dataFrame = new DefaultHttp3DataFrame(Unpooled.buffer());
 
-        Throwable e = assertThrows(CompletionException.class, () -> channel.writeOutbound(dataFrame)).getCause();
+        Throwable e = assertThrows(Exception.class, () -> channel.writeOutbound(dataFrame));
         assertException(H3_FRAME_UNEXPECTED, e);
 
         assertFalse(channel.finish());
@@ -158,7 +157,7 @@ public class Http3RequestStreamValidationHandlerTest extends Http3FrameTypeValid
         assertTrue(channel.writeOutbound(dataFrame2.retainedDuplicate()));
         assertTrue(channel.writeOutbound(trailersFrame));
 
-        Throwable e = assertThrows(CompletionException.class, () -> channel.writeOutbound(dat3Frame3)).getCause();
+        Throwable e = assertThrows(Exception.class, () -> channel.writeOutbound(dat3Frame3));
         assertException(H3_FRAME_UNEXPECTED, e);
 
         assertTrue(channel.finish());
@@ -178,7 +177,7 @@ public class Http3RequestStreamValidationHandlerTest extends Http3FrameTypeValid
         EmbeddedQuicStreamChannel channel = newClientStream(() -> true);
 
         Http3HeadersFrame headersFrame = new DefaultHttp3HeadersFrame();
-        Throwable e = assertThrows(CompletionException.class, () -> channel.writeOutbound(headersFrame)).getCause();
+        Throwable e = assertThrows(Exception.class, () -> channel.writeOutbound(headersFrame));
         assertException(H3_FRAME_UNEXPECTED, e);
 
         // We should have closed the channel.

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3ServerPushStreamManagerTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3ServerPushStreamManagerTest.java
@@ -83,7 +83,7 @@ public class Http3ServerPushStreamManagerTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    public void tearDown() throws Exception {
         assertFalse(localControlStream.finish());
         assertFalse(channel.finish());
     }

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3UnidirectionalStreamInboundHandlerTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3UnidirectionalStreamInboundHandlerTest.java
@@ -60,7 +60,7 @@ public class Http3UnidirectionalStreamInboundHandlerTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    public void tearDown() throws Exception {
         assertFalse(parent.finish());
     }
 

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/QpackDecoderHandlerTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/QpackDecoderHandlerTest.java
@@ -20,6 +20,7 @@ import io.netty.handler.codec.quic.QuicStreamType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.CompletionException;
 import java.util.function.Consumer;
 
 import static io.netty.handler.codec.http3.Http3.setQpackAttributes;
@@ -53,7 +54,8 @@ public class QpackDecoderHandlerTest {
         setup(128L);
         encodeHeaders(headers -> headers.add(fooBar.name, fooBar.value));
 
-        Http3Exception e = assertThrows(Http3Exception.class, () -> sendAckForStreamId(decoderStream.streamId()));
+        Http3Exception e = (Http3Exception) assertThrows(CompletionException.class,
+                () -> sendAckForStreamId(decoderStream.streamId())).getCause();
         assertThat(e.getCause(), instanceOf(QpackException.class));
 
         Http3TestUtils.verifyClose(QPACK_DECODER_STREAM_ERROR, parent);
@@ -82,7 +84,8 @@ public class QpackDecoderHandlerTest {
     public void sectionAckUnknownStream() throws Exception {
         setup(128);
 
-        Http3Exception e = assertThrows(Http3Exception.class, () -> sendAckForStreamId(1));
+        Http3Exception e = (Http3Exception) assertThrows(CompletionException.class,
+                () -> sendAckForStreamId(1)).getCause();
         assertThat(e.getCause(), instanceOf(QpackException.class));
 
         Http3TestUtils.verifyClose(QPACK_DECODER_STREAM_ERROR, parent);
@@ -98,7 +101,8 @@ public class QpackDecoderHandlerTest {
         encodeHeaders(headers -> headers.add(fooBar.name, fooBar.value));
         sendAckForStreamId(decoderStream.streamId());
 
-        Http3Exception e = assertThrows(Http3Exception.class, () -> sendAckForStreamId(decoderStream.streamId()));
+        Http3Exception e = (Http3Exception) assertThrows(CompletionException.class,
+                () -> sendAckForStreamId(decoderStream.streamId())).getCause();
         assertThat(e.getCause(), instanceOf(QpackException.class));
 
         Http3TestUtils.verifyClose(QPACK_DECODER_STREAM_ERROR, parent);
@@ -154,7 +158,8 @@ public class QpackDecoderHandlerTest {
 
         sendStreamCancellation(decoderStream.streamId());
 
-        Http3Exception e = assertThrows(Http3Exception.class, () -> sendAckForStreamId(decoderStream.streamId()));
+        Http3Exception e = (Http3Exception) assertThrows(CompletionException.class,
+                () -> sendAckForStreamId(decoderStream.streamId())).getCause();
         assertThat(e.getCause(), instanceOf(QpackException.class));
 
         Http3TestUtils.verifyClose(QPACK_DECODER_STREAM_ERROR, parent);

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/QpackDecoderHandlerTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/QpackDecoderHandlerTest.java
@@ -20,7 +20,6 @@ import io.netty.handler.codec.quic.QuicStreamType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.CompletionException;
 import java.util.function.Consumer;
 
 import static io.netty.handler.codec.http3.Http3.setQpackAttributes;
@@ -44,7 +43,7 @@ public class QpackDecoderHandlerTest {
     private QpackAttributes attributes;
 
     @AfterEach
-    public void tearDown() {
+    public void tearDown() throws Exception {
         assertFalse(encoderStream.finish());
         assertFalse(decoderStream.finish());
     }
@@ -54,8 +53,8 @@ public class QpackDecoderHandlerTest {
         setup(128L);
         encodeHeaders(headers -> headers.add(fooBar.name, fooBar.value));
 
-        Http3Exception e = (Http3Exception) assertThrows(CompletionException.class,
-                () -> sendAckForStreamId(decoderStream.streamId())).getCause();
+        Http3Exception e = assertThrows(Http3Exception.class,
+                () -> sendAckForStreamId(decoderStream.streamId()));
         assertThat(e.getCause(), instanceOf(QpackException.class));
 
         Http3TestUtils.verifyClose(QPACK_DECODER_STREAM_ERROR, parent);
@@ -84,8 +83,8 @@ public class QpackDecoderHandlerTest {
     public void sectionAckUnknownStream() throws Exception {
         setup(128);
 
-        Http3Exception e = (Http3Exception) assertThrows(CompletionException.class,
-                () -> sendAckForStreamId(1)).getCause();
+        Http3Exception e = assertThrows(Http3Exception.class,
+                () -> sendAckForStreamId(1));
         assertThat(e.getCause(), instanceOf(QpackException.class));
 
         Http3TestUtils.verifyClose(QPACK_DECODER_STREAM_ERROR, parent);
@@ -101,8 +100,8 @@ public class QpackDecoderHandlerTest {
         encodeHeaders(headers -> headers.add(fooBar.name, fooBar.value));
         sendAckForStreamId(decoderStream.streamId());
 
-        Http3Exception e = (Http3Exception) assertThrows(CompletionException.class,
-                () -> sendAckForStreamId(decoderStream.streamId())).getCause();
+        Http3Exception e = assertThrows(Http3Exception.class,
+                () -> sendAckForStreamId(decoderStream.streamId()));
         assertThat(e.getCause(), instanceOf(QpackException.class));
 
         Http3TestUtils.verifyClose(QPACK_DECODER_STREAM_ERROR, parent);
@@ -158,8 +157,8 @@ public class QpackDecoderHandlerTest {
 
         sendStreamCancellation(decoderStream.streamId());
 
-        Http3Exception e = (Http3Exception) assertThrows(CompletionException.class,
-                () -> sendAckForStreamId(decoderStream.streamId())).getCause();
+        Http3Exception e = assertThrows(Http3Exception.class,
+                () -> sendAckForStreamId(decoderStream.streamId()));
         assertThat(e.getCause(), instanceOf(QpackException.class));
 
         Http3TestUtils.verifyClose(QPACK_DECODER_STREAM_ERROR, parent);
@@ -267,7 +266,7 @@ public class QpackDecoderHandlerTest {
         finishStreams();
     }
 
-    private void sendAckForStreamId(long streamId) throws Http3Exception {
+    private void sendAckForStreamId(long streamId) throws Exception {
         assertFalse(decoderStream.writeInbound(encodeSectionAck(streamId)));
     }
 
@@ -282,7 +281,7 @@ public class QpackDecoderHandlerTest {
         return ack;
     }
 
-    private void sendInsertCountIncrement(long increment) throws Http3Exception {
+    private void sendInsertCountIncrement(long increment) throws Exception {
         assertFalse(decoderStream.writeInbound(encodeInsertCountIncrement(increment)));
     }
 
@@ -297,7 +296,7 @@ public class QpackDecoderHandlerTest {
         return incr;
     }
 
-    private void sendStreamCancellation(long streamId) {
+    private void sendStreamCancellation(long streamId) throws Exception {
         assertFalse(decoderStream.writeInbound(encodeStreamCancellation(streamId)));
     }
 
@@ -341,11 +340,11 @@ public class QpackDecoderHandlerTest {
         attributes.decoderStream(decoderStream);
     }
 
-    private void finishStreams() {
+    private void finishStreams() throws Exception {
         finishStreams(true);
     }
 
-    private void finishStreams(boolean encoderPendingMessage) {
+    private void finishStreams(boolean encoderPendingMessage) throws Exception {
         assertThat("Unexpected decoder stream message", decoderStream.finishAndReleaseAll(), is(false));
         assertThat("Unexpected encoder stream message", encoderStream.finishAndReleaseAll(), is(encoderPendingMessage));
         assertThat("Unexpected parent stream message", parent.finishAndReleaseAll(), is(false));

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/QpackDecoderTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/QpackDecoderTest.java
@@ -154,7 +154,7 @@ public class QpackDecoderTest {
         }
     }
 
-    private void insertLiterals(int count) throws QpackException {
+    private void insertLiterals(int count) throws Exception {
         for (int i = 1; i <= count; i++) {
             inserted++;
             decoder.insertLiteral(decoderStream, FOO + i, BAR + i);

--- a/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheDecoderTest.java
+++ b/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheDecoderTest.java
@@ -83,7 +83,7 @@ public class BinaryMemcacheDecoderTest {
      * This tests a simple GET request with a key as the value.
      */
     @Test
-    public void shouldDecodeRequestWithSimpleValue() {
+    public void shouldDecodeRequestWithSimpleValue() throws Exception {
         ByteBuf incoming = Unpooled.buffer();
         incoming.writeBytes(GET_REQUEST);
         channel.writeInbound(incoming);
@@ -106,7 +106,7 @@ public class BinaryMemcacheDecoderTest {
      * This test makes sure that large content is emitted in chunks.
      */
     @Test
-    public void shouldDecodeRequestWithChunkedContent() {
+    public void shouldDecodeRequestWithChunkedContent() throws Exception {
         int smallBatchSize = 2;
         channel = new EmbeddedChannel(new BinaryMemcacheRequestDecoder(smallBatchSize));
 
@@ -145,7 +145,7 @@ public class BinaryMemcacheDecoderTest {
      * sizes in the middle of decoding, it can recover and decode all the time eventually.
      */
     @Test
-    public void shouldHandleNonUniformNetworkBatches() {
+    public void shouldHandleNonUniformNetworkBatches() throws Exception {
         ByteBuf incoming = Unpooled.copiedBuffer(SET_REQUEST_WITH_CONTENT);
         while (incoming.isReadable()) {
             channel.writeInbound(incoming.readBytes(5));
@@ -178,7 +178,7 @@ public class BinaryMemcacheDecoderTest {
      * get emitted as separate messages.
      */
     @Test
-    public void shouldHandleTwoMessagesInOneBatch() {
+    public void shouldHandleTwoMessagesInOneBatch() throws Exception {
         channel.writeInbound(Unpooled.buffer().writeBytes(GET_REQUEST).writeBytes(GET_REQUEST));
 
         BinaryMemcacheRequest request = channel.readInbound();
@@ -201,7 +201,7 @@ public class BinaryMemcacheDecoderTest {
     }
 
     @Test
-    public void shouldDecodeSeparatedValues() {
+    public void shouldDecodeSeparatedValues() throws Exception {
         String msgBody = "Not found";
         channel = new EmbeddedChannel(new BinaryMemcacheResponseDecoder());
 
@@ -252,7 +252,7 @@ public class BinaryMemcacheDecoderTest {
     }
 
     @Test
-    public void shouldRetainCurrentMessageWhenSendingItOut() {
+    public void shouldRetainCurrentMessageWhenSendingItOut() throws Exception {
         channel = new EmbeddedChannel(
                 new BinaryMemcacheRequestEncoder(),
                 new BinaryMemcacheRequestDecoder());

--- a/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheEncoderTest.java
+++ b/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheEncoderTest.java
@@ -27,7 +27,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
+import java.util.concurrent.CompletionException;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -155,11 +158,12 @@ public class BinaryMemcacheEncoderTest {
     @Test
     public void shouldFailWithoutLastContent() {
         channel.writeOutbound(new DefaultMemcacheContent(Unpooled.EMPTY_BUFFER));
-        assertThrows(EncoderException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 channel.writeOutbound(new DefaultBinaryMemcacheRequest());
             }
         });
+        assertInstanceOf(EncoderException.class, cause.getCause());
     }
 }

--- a/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheEncoderTest.java
+++ b/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheEncoderTest.java
@@ -25,12 +25,9 @@ import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
-import java.util.concurrent.CompletionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -49,12 +46,12 @@ public class BinaryMemcacheEncoderTest {
     }
 
     @AfterEach
-    public void teardown() {
+    public void teardown() throws Exception {
         channel.finishAndReleaseAll();
     }
 
     @Test
-    public void shouldEncodeDefaultHeader() {
+    public void shouldEncodeDefaultHeader() throws Exception {
         BinaryMemcacheRequest request = new DefaultBinaryMemcacheRequest();
 
         boolean result = channel.writeOutbound(request);
@@ -68,7 +65,7 @@ public class BinaryMemcacheEncoderTest {
     }
 
     @Test
-    public void shouldEncodeCustomHeader() {
+    public void shouldEncodeCustomHeader() throws Exception {
         BinaryMemcacheRequest request = new DefaultBinaryMemcacheRequest();
         request.setMagic((byte) 0xAA);
         request.setOpcode(BinaryMemcacheOpcodes.GET);
@@ -84,7 +81,7 @@ public class BinaryMemcacheEncoderTest {
     }
 
     @Test
-    public void shouldEncodeExtras() {
+    public void shouldEncodeExtras() throws Exception {
         String extrasContent = "netty<3memcache";
         ByteBuf extras = Unpooled.copiedBuffer(extrasContent, CharsetUtil.UTF_8);
         int extrasLength = extras.readableBytes();
@@ -102,7 +99,7 @@ public class BinaryMemcacheEncoderTest {
     }
 
     @Test
-    public void shouldEncodeKey() {
+    public void shouldEncodeKey() throws Exception {
         ByteBuf key = Unpooled.copiedBuffer("netty", CharsetUtil.UTF_8);
         int keyLength = key.readableBytes();
 
@@ -119,7 +116,7 @@ public class BinaryMemcacheEncoderTest {
     }
 
     @Test
-    public void shouldEncodeContent() {
+    public void shouldEncodeContent() throws Exception {
         DefaultMemcacheContent content1 =
             new DefaultMemcacheContent(Unpooled.copiedBuffer("Netty", CharsetUtil.UTF_8));
         DefaultLastMemcacheContent content2 =
@@ -156,14 +153,8 @@ public class BinaryMemcacheEncoderTest {
     }
 
     @Test
-    public void shouldFailWithoutLastContent() {
+    public void shouldFailWithoutLastContent() throws Exception {
         channel.writeOutbound(new DefaultMemcacheContent(Unpooled.EMPTY_BUFFER));
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                channel.writeOutbound(new DefaultBinaryMemcacheRequest());
-            }
-        });
-        assertInstanceOf(EncoderException.class, cause.getCause());
+        assertThrows(EncoderException.class, () -> channel.writeOutbound(new DefaultBinaryMemcacheRequest()));
     }
 }

--- a/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheObjectAggregatorTest.java
+++ b/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheObjectAggregatorTest.java
@@ -52,7 +52,7 @@ public class BinaryMemcacheObjectAggregatorTest {
     private EmbeddedChannel channel;
 
     @Test
-    public void shouldAggregateChunksOnDecode() {
+    public void shouldAggregateChunksOnDecode() throws Exception {
         int smallBatchSize = 2;
         channel = new EmbeddedChannel(
             new BinaryMemcacheRequestDecoder(smallBatchSize),
@@ -80,7 +80,7 @@ public class BinaryMemcacheObjectAggregatorTest {
     }
 
     @Test
-    public void shouldRetainByteBufWhenAggregating() {
+    public void shouldRetainByteBufWhenAggregating() throws Exception {
         channel = new EmbeddedChannel(
                 new BinaryMemcacheRequestEncoder(),
                 new BinaryMemcacheRequestDecoder(),

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicCodecDispatcherTest.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicCodecDispatcherTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 public class QuicCodecDispatcherTest {
 
     @Test
-    public void testPacketsAreDispatchedToCorrectChannel() throws QuicException {
+    public void testPacketsAreDispatchedToCorrectChannel() throws Exception {
         short localConnectionIdLength = 16;
 
         AtomicInteger initChannelCalled = new AtomicInteger();
@@ -88,7 +88,8 @@ public class QuicCodecDispatcherTest {
         assertEquals(channels.length, initChannelCalled.get());
     }
 
-    private static void writePacket(EmbeddedChannel[] channels, boolean shortHeader, short localConnectionIdLength) {
+    private static void writePacket(EmbeddedChannel[] channels, boolean shortHeader, short localConnectionIdLength)
+            throws Exception {
         DatagramPacket packet = createQuicPacket(
                 ThreadLocalRandom.current().nextInt(channels.length),
                 shortHeader, localConnectionIdLength);

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicheQuicCodecTest.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicheQuicCodecTest.java
@@ -42,16 +42,16 @@ public abstract class QuicheQuicCodecTest<B extends QuicCodecBuilder<B>> extends
     }
 
     @Test
-    public void testFlushStrategyUsedWithBytes() {
+    public void testFlushStrategyUsedWithBytes() throws Exception {
         testFlushStrategy(true);
     }
 
     @Test
-    public void testFlushStrategyUsedWithPackets() {
+    public void testFlushStrategyUsedWithPackets() throws Exception {
         testFlushStrategy(false);
     }
 
-    private void testFlushStrategy(boolean useBytes) {
+    private void testFlushStrategy(boolean useBytes) throws Exception {
         final int bytes = 8;
         final AtomicInteger numBytesTracker = new AtomicInteger();
         final AtomicInteger numPacketsTracker = new AtomicInteger();

--- a/codec-protobuf/src/test/java/io/netty/handler/codec/protobuf/ProtobufVarint32FrameDecoderTest.java
+++ b/codec-protobuf/src/test/java/io/netty/handler/codec/protobuf/ProtobufVarint32FrameDecoderTest.java
@@ -37,7 +37,7 @@ public class ProtobufVarint32FrameDecoderTest {
     }
 
     @Test
-    public void testTinyDecode() {
+    public void testTinyDecode() throws Exception {
         byte[] b = { 4, 1, 1, 1, 1 };
         assertFalse(ch.writeInbound(wrappedBuffer(b, 0, 1)));
         assertNull(ch.readInbound());
@@ -56,7 +56,7 @@ public class ProtobufVarint32FrameDecoderTest {
     }
 
     @Test
-    public void testRegularDecode() {
+    public void testRegularDecode() throws Exception {
         byte[] b = new byte[2048];
         for (int i = 2; i < 2048; i ++) {
             b[i] = 1;

--- a/codec-protobuf/src/test/java/io/netty/handler/codec/protobuf/ProtobufVarint32LengthFieldPrependerTest.java
+++ b/codec-protobuf/src/test/java/io/netty/handler/codec/protobuf/ProtobufVarint32LengthFieldPrependerTest.java
@@ -35,7 +35,7 @@ public class ProtobufVarint32LengthFieldPrependerTest {
     }
 
     @Test
-    public void testSize1Varint() {
+    public void testSize1Varint() throws Exception {
         final int size = 1;
         final int num = 10;
         assertEquals(size, ProtobufVarint32LengthFieldPrepender.computeRawVarint32Size(num));
@@ -58,7 +58,7 @@ public class ProtobufVarint32LengthFieldPrependerTest {
     }
 
     @Test
-    public void testSize2Varint() {
+    public void testSize2Varint() throws Exception {
         final int size = 2;
         final int num = 266;
         assertEquals(size, ProtobufVarint32LengthFieldPrepender.computeRawVarint32Size(num));
@@ -93,7 +93,7 @@ public class ProtobufVarint32LengthFieldPrependerTest {
     }
 
     @Test
-    public void testSize3Varint() {
+    public void testSize3Varint() throws Exception {
         final int size = 3;
         final int num = 0x4000;
         assertEquals(size, ProtobufVarint32LengthFieldPrepender.computeRawVarint32Size(num));
@@ -129,7 +129,7 @@ public class ProtobufVarint32LengthFieldPrependerTest {
     }
 
     @Test
-    public void testSize4Varint() {
+    public void testSize4Varint() throws Exception {
         final int size = 4;
         final int num = 0x200000;
         assertEquals(size, ProtobufVarint32LengthFieldPrepender.computeRawVarint32Size(num));
@@ -166,7 +166,7 @@ public class ProtobufVarint32LengthFieldPrependerTest {
     }
 
     @Test
-    public void testTinyEncode() {
+    public void testTinyEncode() throws Exception {
         byte[] b = { 4, 1, 1, 1, 1 };
         assertTrue(ch.writeOutbound(wrappedBuffer(b, 1, b.length - 1)));
 
@@ -181,7 +181,7 @@ public class ProtobufVarint32LengthFieldPrependerTest {
     }
 
     @Test
-    public void testRegularDecode() {
+    public void testRegularDecode() throws Exception {
         byte[] b = new byte[2048];
         for (int i = 2; i < 2048; i ++) {
             b[i] = 1;

--- a/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisDecoderTest.java
+++ b/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisDecoderTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
 import java.util.List;
+import java.util.concurrent.CompletionException;
 
 import static io.netty.handler.codec.redis.RedisCodecTestUtil.*;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -75,7 +76,7 @@ public class RedisDecoderTest {
 
     @Test
     public void shouldNotDecodeInlineCommandByDefault() {
-        assertThrows(DecoderException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 assertFalse(channel.writeInbound(byteBufOf("P")));
@@ -87,6 +88,7 @@ public class RedisDecoderTest {
                 channel.readInbound();
             }
         });
+        assertInstanceOf(DecoderException.class, cause.getCause());
     }
 
     @Test

--- a/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisDecoderTest.java
+++ b/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisDecoderTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
 import java.util.List;
-import java.util.concurrent.CompletionException;
 
 import static io.netty.handler.codec.redis.RedisCodecTestUtil.*;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -76,23 +75,19 @@ public class RedisDecoderTest {
 
     @Test
     public void shouldNotDecodeInlineCommandByDefault() {
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                assertFalse(channel.writeInbound(byteBufOf("P")));
-                assertFalse(channel.writeInbound(byteBufOf("I")));
-                assertFalse(channel.writeInbound(byteBufOf("N")));
-                assertFalse(channel.writeInbound(byteBufOf("G")));
-                assertTrue(channel.writeInbound(byteBufOf("\r\n")));
+        assertThrows(DecoderException.class, () -> {
+            assertFalse(channel.writeInbound(byteBufOf("P")));
+            assertFalse(channel.writeInbound(byteBufOf("I")));
+            assertFalse(channel.writeInbound(byteBufOf("N")));
+            assertFalse(channel.writeInbound(byteBufOf("G")));
+            assertTrue(channel.writeInbound(byteBufOf("\r\n")));
 
-                channel.readInbound();
-            }
+            channel.readInbound();
         });
-        assertInstanceOf(DecoderException.class, cause.getCause());
     }
 
     @Test
-    public void shouldDecodeInlineCommand() {
+    public void shouldDecodeInlineCommand() throws Exception {
         channel = newChannel(true);
 
         assertFalse(channel.writeInbound(byteBufOf("P")));
@@ -109,7 +104,7 @@ public class RedisDecoderTest {
     }
 
     @Test
-    public void shouldDecodeSimpleString() {
+    public void shouldDecodeSimpleString() throws Exception {
         assertFalse(channel.writeInbound(byteBufOf("+")));
         assertFalse(channel.writeInbound(byteBufOf("O")));
         assertFalse(channel.writeInbound(byteBufOf("K")));
@@ -123,7 +118,7 @@ public class RedisDecoderTest {
     }
 
     @Test
-    public void shouldDecodeTwoSimpleStrings() {
+    public void shouldDecodeTwoSimpleStrings() throws Exception {
         assertFalse(channel.writeInbound(byteBufOf("+")));
         assertFalse(channel.writeInbound(byteBufOf("O")));
         assertFalse(channel.writeInbound(byteBufOf("K")));
@@ -140,7 +135,7 @@ public class RedisDecoderTest {
     }
 
     @Test
-    public void shouldDecodeError() {
+    public void shouldDecodeError() throws Exception {
         String content = "ERROR sample message";
         assertFalse(channel.writeInbound(byteBufOf("-")));
         assertFalse(channel.writeInbound(byteBufOf(content)));
@@ -155,7 +150,7 @@ public class RedisDecoderTest {
     }
 
     @Test
-    public void shouldDecodeInteger() {
+    public void shouldDecodeInteger() throws Exception {
         long value = 1234L;
         byte[] content = bytesOf(value);
         assertFalse(channel.writeInbound(byteBufOf(":")));
@@ -170,7 +165,7 @@ public class RedisDecoderTest {
     }
 
     @Test
-    public void shouldDecodeBulkString() {
+    public void shouldDecodeBulkString() throws Exception {
         String buf1 = "bulk\nst";
         String buf2 = "ring\ntest\n1234";
         byte[] content = bytesOf(buf1 + buf2);
@@ -189,7 +184,7 @@ public class RedisDecoderTest {
     }
 
     @Test
-    public void shouldDecodeEmptyBulkString() {
+    public void shouldDecodeEmptyBulkString() throws Exception {
         byte[] content = bytesOf("");
         assertFalse(channel.writeInbound(byteBufOf("$")));
         assertFalse(channel.writeInbound(byteBufOf(Integer.toString(content.length))));
@@ -205,7 +200,7 @@ public class RedisDecoderTest {
     }
 
     @Test
-    public void shouldDecodeNullBulkString() {
+    public void shouldDecodeNullBulkString() throws Exception {
         assertFalse(channel.writeInbound(byteBufOf("$")));
         assertFalse(channel.writeInbound(byteBufOf(Integer.toString(-1))));
         assertTrue(channel.writeInbound(byteBufOf("\r\n")));
@@ -278,7 +273,7 @@ public class RedisDecoderTest {
     }
 
     @Test
-    public void shouldErrorOnDoubleReleaseArrayReferenceCounted() {
+    public void shouldErrorOnDoubleReleaseArrayReferenceCounted() throws Exception {
         ByteBuf buf = Unpooled.buffer();
         buf.writeBytes(byteBufOf("*2\r\n"));
         buf.writeBytes(byteBufOf("*3\r\n:1\r\n:2\r\n:3\r\n"));
@@ -288,16 +283,11 @@ public class RedisDecoderTest {
         final ArrayRedisMessage msg = channel.readInbound();
 
         ReferenceCountUtil.release(msg);
-        assertThrows(IllegalReferenceCountException.class, new Executable() {
-            @Override
-            public void execute() {
-                ReferenceCountUtil.release(msg);
-            }
-        });
+        assertThrows(IllegalReferenceCountException.class, () -> ReferenceCountUtil.release(msg));
     }
 
     @Test
-    public void shouldErrorOnReleaseArrayChildReferenceCounted() {
+    public void shouldErrorOnReleaseArrayChildReferenceCounted() throws Exception {
         ByteBuf buf = Unpooled.buffer();
         buf.writeBytes(byteBufOf("*2\r\n"));
         buf.writeBytes(byteBufOf("*3\r\n:1\r\n:2\r\n:3\r\n"));

--- a/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisEncoderTest.java
+++ b/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisEncoderTest.java
@@ -49,7 +49,7 @@ public class RedisEncoderTest {
     }
 
     @Test
-    public void shouldEncodeInlineCommand() {
+    public void shouldEncodeInlineCommand() throws Exception {
         RedisMessage msg = new InlineCommandRedisMessage("ping");
 
         boolean result = channel.writeOutbound(msg);
@@ -61,7 +61,7 @@ public class RedisEncoderTest {
     }
 
     @Test
-    public void shouldEncodeSimpleString() {
+    public void shouldEncodeSimpleString() throws Exception {
         RedisMessage msg = new SimpleStringRedisMessage("simple");
 
         boolean result = channel.writeOutbound(msg);
@@ -73,7 +73,7 @@ public class RedisEncoderTest {
     }
 
     @Test
-    public void shouldEncodeError() {
+    public void shouldEncodeError() throws Exception {
         RedisMessage msg = new ErrorRedisMessage("error1");
 
         boolean result = channel.writeOutbound(msg);
@@ -85,7 +85,7 @@ public class RedisEncoderTest {
     }
 
     @Test
-    public void shouldEncodeInteger() {
+    public void shouldEncodeInteger() throws Exception {
         RedisMessage msg = new IntegerRedisMessage(1234L);
 
         boolean result = channel.writeOutbound(msg);
@@ -97,7 +97,7 @@ public class RedisEncoderTest {
     }
 
     @Test
-    public void shouldEncodeBulkStringContent() {
+    public void shouldEncodeBulkStringContent() throws Exception {
         RedisMessage header = new BulkStringHeaderRedisMessage(16);
         RedisMessage body1 = new DefaultBulkStringRedisContent(byteBufOf("bulk\nstr").retain());
         RedisMessage body2 = new DefaultLastBulkStringRedisContent(byteBufOf("ing\ntest").retain());
@@ -112,7 +112,7 @@ public class RedisEncoderTest {
     }
 
     @Test
-    public void shouldEncodeFullBulkString() {
+    public void shouldEncodeFullBulkString() throws Exception {
         ByteBuf bulkString = byteBufOf("bulk\nstring\ntest").retain();
         int length = bulkString.readableBytes();
         RedisMessage msg = new FullBulkStringRedisMessage(bulkString);
@@ -126,7 +126,7 @@ public class RedisEncoderTest {
     }
 
     @Test
-    public void shouldEncodeSimpleArray() {
+    public void shouldEncodeSimpleArray() throws Exception {
         List<RedisMessage> children = new ArrayList<RedisMessage>();
         children.add(new FullBulkStringRedisMessage(byteBufOf("foo").retain()));
         children.add(new FullBulkStringRedisMessage(byteBufOf("bar").retain()));
@@ -141,7 +141,7 @@ public class RedisEncoderTest {
     }
 
     @Test
-    public void shouldEncodeNullArray() {
+    public void shouldEncodeNullArray() throws Exception {
         RedisMessage msg = ArrayRedisMessage.NULL_INSTANCE;
 
         boolean result = channel.writeOutbound(msg);
@@ -153,7 +153,7 @@ public class RedisEncoderTest {
     }
 
     @Test
-    public void shouldEncodeEmptyArray() {
+    public void shouldEncodeEmptyArray() throws Exception {
         RedisMessage msg = ArrayRedisMessage.EMPTY_INSTANCE;
 
         boolean result = channel.writeOutbound(msg);
@@ -165,7 +165,7 @@ public class RedisEncoderTest {
     }
 
     @Test
-    public void shouldEncodeNestedArray() {
+    public void shouldEncodeNestedArray() throws Exception {
         List<RedisMessage> grandChildren = new ArrayList<RedisMessage>();
         grandChildren.add(new FullBulkStringRedisMessage(byteBufOf("bar")));
         grandChildren.add(new IntegerRedisMessage(-1234L));

--- a/codec-smtp/src/test/java/io/netty/handler/codec/smtp/SmtpRequestEncoderTest.java
+++ b/codec-smtp/src/test/java/io/netty/handler/codec/smtp/SmtpRequestEncoderTest.java
@@ -21,12 +21,8 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.EncoderException;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
-
-import java.util.concurrent.CompletionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -34,72 +30,72 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class SmtpRequestEncoderTest {
 
     @Test
-    public void testEncodeEhlo() {
+    public void testEncodeEhlo() throws Exception {
         testEncode(SmtpRequests.ehlo("localhost"), "EHLO localhost\r\n");
     }
 
     @Test
-    public void testEncodeHelo() {
+    public void testEncodeHelo() throws Exception {
         testEncode(SmtpRequests.helo("localhost"), "HELO localhost\r\n");
     }
 
     @Test
-    public void testEncodeAuth() {
+    public void testEncodeAuth() throws Exception {
         testEncode(SmtpRequests.auth("LOGIN"), "AUTH LOGIN\r\n");
     }
 
     @Test
-    public void testEncodeAuthWithParameter() {
+    public void testEncodeAuthWithParameter() throws Exception {
         testEncode(SmtpRequests.auth("PLAIN", "dGVzdAB0ZXN0ADEyMzQ="), "AUTH PLAIN dGVzdAB0ZXN0ADEyMzQ=\r\n");
     }
 
     @Test
-    public void testEncodeEmpty() {
+    public void testEncodeEmpty() throws Exception {
         testEncode(SmtpRequests.empty("dGVzdAB0ZXN0ADEyMzQ="),  "dGVzdAB0ZXN0ADEyMzQ=\r\n");
     }
 
     @Test
-    public void testEncodeMail() {
+    public void testEncodeMail() throws Exception {
         testEncode(SmtpRequests.mail("me@netty.io"), "MAIL FROM:<me@netty.io>\r\n");
     }
 
     @Test
-    public void testEncodeMailNullSender() {
+    public void testEncodeMailNullSender() throws Exception {
         testEncode(SmtpRequests.mail(null), "MAIL FROM:<>\r\n");
     }
 
     @Test
-    public void testEncodeRcpt() {
+    public void testEncodeRcpt() throws Exception {
         testEncode(SmtpRequests.rcpt("me@netty.io"), "RCPT TO:<me@netty.io>\r\n");
     }
 
     @Test
-    public void testEncodeNoop() {
+    public void testEncodeNoop() throws Exception {
         testEncode(SmtpRequests.noop(), "NOOP\r\n");
     }
 
     @Test
-    public void testEncodeRset() {
+    public void testEncodeRset() throws Exception {
         testEncode(SmtpRequests.rset(), "RSET\r\n");
     }
 
     @Test
-    public void testEncodeHelp() {
+    public void testEncodeHelp() throws Exception {
         testEncode(SmtpRequests.help(null), "HELP\r\n");
     }
 
     @Test
-    public void testEncodeHelpWithArg() {
+    public void testEncodeHelpWithArg() throws Exception {
         testEncode(SmtpRequests.help("MAIL"), "HELP MAIL\r\n");
     }
 
     @Test
-    public void testEncodeData() {
+    public void testEncodeData() throws Exception {
         testEncode(SmtpRequests.data(), "DATA\r\n");
     }
 
     @Test
-    public void testEncodeDataAndContent() {
+    public void testEncodeDataAndContent() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new SmtpRequestEncoder());
         assertTrue(channel.writeOutbound(SmtpRequests.data()));
         assertTrue(channel.writeOutbound(
@@ -112,24 +108,18 @@ public class SmtpRequestEncoderTest {
     }
 
     @Test
-    public void testThrowsIfContentExpected() {
+    public void testThrowsIfContentExpected() throws Exception {
         final EmbeddedChannel channel = new EmbeddedChannel(new SmtpRequestEncoder());
         try {
             assertTrue(channel.writeOutbound(SmtpRequests.data()));
-            Throwable cause = assertThrows(CompletionException.class, new Executable() {
-                @Override
-                public void execute() {
-                    channel.writeOutbound(SmtpRequests.noop());
-                }
-            });
-            assertInstanceOf(EncoderException.class, cause.getCause());
+            assertThrows(EncoderException.class, () -> channel.writeOutbound(SmtpRequests.noop()));
         } finally {
             channel.finishAndReleaseAll();
         }
     }
 
     @Test
-    public void testRsetClearsContentExpectedFlag() {
+    public void testRsetClearsContentExpectedFlag() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new SmtpRequestEncoder());
 
         assertTrue(channel.writeOutbound(SmtpRequests.data()));
@@ -158,7 +148,7 @@ public class SmtpRequestEncoderTest {
         return writtenString;
     }
 
-    private static void testEncode(SmtpRequest request, String expected) {
+    private static void testEncode(SmtpRequest request, String expected) throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new SmtpRequestEncoder());
         assertTrue(channel.writeOutbound(request));
         assertTrue(channel.finish());

--- a/codec-smtp/src/test/java/io/netty/handler/codec/smtp/SmtpRequestEncoderTest.java
+++ b/codec-smtp/src/test/java/io/netty/handler/codec/smtp/SmtpRequestEncoderTest.java
@@ -23,7 +23,10 @@ import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
+import java.util.concurrent.CompletionException;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -113,12 +116,13 @@ public class SmtpRequestEncoderTest {
         final EmbeddedChannel channel = new EmbeddedChannel(new SmtpRequestEncoder());
         try {
             assertTrue(channel.writeOutbound(SmtpRequests.data()));
-            assertThrows(EncoderException.class, new Executable() {
+            Throwable cause = assertThrows(CompletionException.class, new Executable() {
                 @Override
                 public void execute() {
                     channel.writeOutbound(SmtpRequests.noop());
                 }
             });
+            assertInstanceOf(EncoderException.class, cause.getCause());
         } finally {
             channel.finishAndReleaseAll();
         }

--- a/codec-smtp/src/test/java/io/netty/handler/codec/smtp/SmtpResponseDecoderTest.java
+++ b/codec-smtp/src/test/java/io/netty/handler/codec/smtp/SmtpResponseDecoderTest.java
@@ -24,9 +24,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
 import java.util.List;
+import java.util.concurrent.CompletionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -114,34 +116,37 @@ public class SmtpResponseDecoderTest {
     @Test
     public void testDecodeInvalidSeparator() {
         final EmbeddedChannel channel = newChannel();
-        assertThrows(DecoderException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 channel.writeInbound(newBuffer("200:Ok\r\n"));
             }
         });
+        assertInstanceOf(DecoderException.class, cause.getCause());
     }
 
     @Test
     public void testDecodeInvalidCode() {
         final EmbeddedChannel channel = newChannel();
-        assertThrows(DecoderException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 channel.writeInbound(newBuffer("xyz Ok\r\n"));
             }
         });
+        assertInstanceOf(DecoderException.class, cause.getCause());
     }
 
     @Test
     public void testDecodeInvalidLine() {
         final EmbeddedChannel channel = newChannel();
-        assertThrows(DecoderException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 channel.writeInbound(newBuffer("Ok\r\n"));
             }
         });
+        assertInstanceOf(DecoderException.class, cause.getCause());
     }
 
     private static EmbeddedChannel newChannel() {

--- a/codec-smtp/src/test/java/io/netty/handler/codec/smtp/SmtpResponseDecoderTest.java
+++ b/codec-smtp/src/test/java/io/netty/handler/codec/smtp/SmtpResponseDecoderTest.java
@@ -21,14 +21,11 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.DecoderException;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 import java.util.List;
-import java.util.concurrent.CompletionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -36,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class SmtpResponseDecoderTest {
 
     @Test
-    public void testDecodeOneLineResponse() {
+    public void testDecodeOneLineResponse() throws Exception {
         EmbeddedChannel channel = newChannel();
         assertTrue(channel.writeInbound(newBuffer("200 Ok\r\n")));
         assertTrue(channel.finish());
@@ -51,7 +48,7 @@ public class SmtpResponseDecoderTest {
     }
 
     @Test
-    public void testDecodeOneLineResponseNoDetails() {
+    public void testDecodeOneLineResponseNoDetails() throws Exception {
         EmbeddedChannel channel = newChannel();
         assertTrue(channel.writeInbound(newBuffer("250 \r\n")));
         assertTrue(channel.finish());
@@ -63,7 +60,7 @@ public class SmtpResponseDecoderTest {
     }
 
     @Test
-    public void testDecodeOneLineResponseChunked() {
+    public void testDecodeOneLineResponseChunked() throws Exception {
         EmbeddedChannel channel = newChannel();
         assertFalse(channel.writeInbound(newBuffer("200 Ok")));
         assertTrue(channel.writeInbound(newBuffer("\r\n")));
@@ -79,7 +76,7 @@ public class SmtpResponseDecoderTest {
     }
 
     @Test
-    public void testDecodeTwoLineResponse() {
+    public void testDecodeTwoLineResponse() throws Exception {
         EmbeddedChannel channel = newChannel();
         assertTrue(channel.writeInbound(newBuffer("200-Hello\r\n200 Ok\r\n")));
         assertTrue(channel.finish());
@@ -95,7 +92,7 @@ public class SmtpResponseDecoderTest {
     }
 
     @Test
-    public void testDecodeTwoLineResponseChunked() {
+    public void testDecodeTwoLineResponseChunked() throws Exception {
         EmbeddedChannel channel = newChannel();
         assertFalse(channel.writeInbound(newBuffer("200-")));
         assertFalse(channel.writeInbound(newBuffer("Hello\r\n2")));
@@ -116,37 +113,19 @@ public class SmtpResponseDecoderTest {
     @Test
     public void testDecodeInvalidSeparator() {
         final EmbeddedChannel channel = newChannel();
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                channel.writeInbound(newBuffer("200:Ok\r\n"));
-            }
-        });
-        assertInstanceOf(DecoderException.class, cause.getCause());
+        assertThrows(DecoderException.class, () -> channel.writeInbound(newBuffer("200:Ok\r\n")));
     }
 
     @Test
     public void testDecodeInvalidCode() {
         final EmbeddedChannel channel = newChannel();
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                channel.writeInbound(newBuffer("xyz Ok\r\n"));
-            }
-        });
-        assertInstanceOf(DecoderException.class, cause.getCause());
+        assertThrows(DecoderException.class, () -> channel.writeInbound(newBuffer("xyz Ok\r\n")));
     }
 
     @Test
     public void testDecodeInvalidLine() {
         final EmbeddedChannel channel = newChannel();
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                channel.writeInbound(newBuffer("Ok\r\n"));
-            }
-        });
-        assertInstanceOf(DecoderException.class, cause.getCause());
+        assertThrows(DecoderException.class, () -> channel.writeInbound(newBuffer("Ok\r\n")));
     }
 
     private static EmbeddedChannel newChannel() {

--- a/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksAuthRequestDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksAuthRequestDecoderTest.java
@@ -30,7 +30,7 @@ public class SocksAuthRequestDecoderTest {
     private static final String password = "testPassword";
 
     @Test
-    public void testAuthRequestDecoder() {
+    public void testAuthRequestDecoder() throws Exception {
         SocksAuthRequest msg = new SocksAuthRequest(username, password);
         SocksAuthRequestDecoder decoder = new SocksAuthRequestDecoder();
         EmbeddedChannel embedder = new EmbeddedChannel(decoder);
@@ -42,7 +42,7 @@ public class SocksAuthRequestDecoderTest {
     }
 
     @Test
-    public void testAuthRequestDecoderPartialSend() {
+    public void testAuthRequestDecoderPartialSend() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new SocksAuthRequestDecoder());
         ByteBuf byteBuf = Unpooled.buffer(16);
 

--- a/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksAuthResponseDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksAuthResponseDecoderTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 public class SocksAuthResponseDecoderTest {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(SocksAuthResponseDecoderTest.class);
 
-    private static void testSocksAuthResponseDecoderWithDifferentParams(SocksAuthStatus authStatus) {
+    private static void testSocksAuthResponseDecoderWithDifferentParams(SocksAuthStatus authStatus) throws Exception {
         logger.debug("Testing SocksAuthResponseDecoder with authStatus: " + authStatus);
         SocksAuthResponse msg = new SocksAuthResponse(authStatus);
         SocksAuthResponseDecoder decoder = new SocksAuthResponseDecoder();
@@ -38,7 +38,7 @@ public class SocksAuthResponseDecoderTest {
     }
 
     @Test
-    public void testSocksCmdResponseDecoder() {
+    public void testSocksCmdResponseDecoder() throws Exception {
         for (SocksAuthStatus authStatus: SocksAuthStatus.values()) {
             testSocksAuthResponseDecoderWithDifferentParams(authStatus);
         }

--- a/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksCmdRequestDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksCmdRequestDecoderTest.java
@@ -21,8 +21,6 @@ import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.junit.jupiter.api.Test;
 
-import java.net.UnknownHostException;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -34,7 +32,7 @@ public class SocksCmdRequestDecoderTest {
     private static void testSocksCmdRequestDecoderWithDifferentParams(SocksCmdType cmdType,
                                                                       SocksAddressType addressType,
                                                                       String host,
-                                                                      int port) {
+                                                                      int port) throws Exception {
         logger.debug("Testing cmdType: " + cmdType + " addressType: " + addressType + " host: " + host +
                 " port: " + port);
         SocksCmdRequest msg = new SocksCmdRequest(cmdType, addressType, host, port);
@@ -54,7 +52,7 @@ public class SocksCmdRequestDecoderTest {
     }
 
     @Test
-    public void testCmdRequestDecoderIPv4() {
+    public void testCmdRequestDecoderIPv4() throws Exception {
         String[] hosts = {"127.0.0.1", };
         int[] ports = {1, 32769, 65535 };
         for (SocksCmdType cmdType : SocksCmdType.values()) {
@@ -67,7 +65,7 @@ public class SocksCmdRequestDecoderTest {
     }
 
     @Test
-    public void testCmdRequestDecoderIPv6() throws UnknownHostException {
+    public void testCmdRequestDecoderIPv6() throws Exception {
         String[] hosts = {SocksCommonUtils.ipv6toStr(SocketUtils.addressByName("::1").getAddress())};
         int[] ports = {1, 32769, 65535};
         for (SocksCmdType cmdType : SocksCmdType.values()) {
@@ -80,7 +78,7 @@ public class SocksCmdRequestDecoderTest {
     }
 
     @Test
-    public void testCmdRequestDecoderDomain() {
+    public void testCmdRequestDecoderDomain() throws Exception {
         String[] hosts = {"google.com" ,
                           "مثال.إختبار",
                           "παράδειγμα.δοκιμή",
@@ -104,7 +102,7 @@ public class SocksCmdRequestDecoderTest {
     }
 
     @Test
-    public void testCmdRequestDecoderUnknown() {
+    public void testCmdRequestDecoderUnknown() throws Exception {
         String host = "google.com";
         int port = 80;
         for (SocksCmdType cmdType : SocksCmdType.values()) {

--- a/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksCmdResponseDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksCmdResponseDecoderTest.java
@@ -30,7 +30,7 @@ public class SocksCmdResponseDecoderTest {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(SocksCmdResponseDecoderTest.class);
 
     private static void testSocksCmdResponseDecoderWithDifferentParams(
-            SocksCmdStatus cmdStatus, SocksAddressType addressType, String host, int port) {
+            SocksCmdStatus cmdStatus, SocksAddressType addressType, String host, int port) throws Exception {
         logger.debug("Testing cmdStatus: " + cmdStatus + " addressType: " + addressType);
         SocksResponse msg = new SocksCmdResponse(cmdStatus, addressType, host, port);
         SocksCmdResponseDecoder decoder = new SocksCmdResponseDecoder();
@@ -53,7 +53,7 @@ public class SocksCmdResponseDecoderTest {
      * Verifies that sent socks messages are decoded correctly.
      */
     @Test
-    public void testSocksCmdResponseDecoder() {
+    public void testSocksCmdResponseDecoder() throws Exception {
         for (SocksCmdStatus cmdStatus : SocksCmdStatus.values()) {
             for (SocksAddressType addressType : SocksAddressType.values()) {
                 testSocksCmdResponseDecoderWithDifferentParams(cmdStatus, addressType, null, 0);
@@ -68,7 +68,7 @@ public class SocksCmdResponseDecoderTest {
     public void testInvalidAddress() {
         assertThrows(IllegalArgumentException.class, new Executable() {
             @Override
-            public void execute() {
+            public void execute() throws Exception {
                 testSocksCmdResponseDecoderWithDifferentParams(
                         SocksCmdStatus.SUCCESS, SocksAddressType.IPv4, "1", 80);
             }
@@ -79,7 +79,7 @@ public class SocksCmdResponseDecoderTest {
      * Verifies that send socks messages are decoded correctly when bound host and port are set.
      */
     @Test
-    public void testSocksCmdResponseDecoderIncludingHost() {
+    public void testSocksCmdResponseDecoderIncludingHost() throws Exception {
         for (SocksCmdStatus cmdStatus : SocksCmdStatus.values()) {
             testSocksCmdResponseDecoderWithDifferentParams(cmdStatus, SocksAddressType.IPv4,
                     "127.0.0.1", 80);

--- a/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksCommonTestUtils.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socks/SocksCommonTestUtils.java
@@ -28,7 +28,7 @@ final class SocksCommonTestUtils {
     }
 
     @SuppressWarnings("deprecation")
-    public static void writeMessageIntoEmbedder(EmbeddedChannel embedder, SocksMessage msg) {
+    public static void writeMessageIntoEmbedder(EmbeddedChannel embedder, SocksMessage msg) throws Exception {
         ByteBuf buf = Unpooled.buffer();
         msg.encodeAsByteBuf(buf);
         embedder.writeInbound(buf);

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v4/Socks4ClientDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v4/Socks4ClientDecoderTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 public class Socks4ClientDecoderTest {
     private static final Logger logger = LoggerFactory.getLogger(Socks4ClientDecoderTest.class);
 
-    private static void test(Socks4CommandStatus cmdStatus, String dstAddr, int dstPort) {
+    private static void test(Socks4CommandStatus cmdStatus, String dstAddr, int dstPort) throws Exception {
         logger.debug("Testing cmdStatus: " + cmdStatus);
         Socks4CommandResponse msg = new DefaultSocks4CommandResponse(cmdStatus, dstAddr, dstPort);
         EmbeddedChannel embedder = new EmbeddedChannel(new Socks4ClientDecoder());
@@ -45,7 +45,7 @@ public class Socks4ClientDecoderTest {
      * Verifies that sent socks messages are decoded correctly.
      */
     @Test
-    public void testSocksCmdResponseDecoder() {
+    public void testSocksCmdResponseDecoder() throws Exception {
         test(Socks4CommandStatus.IDENTD_AUTH_FAILURE, null, 0);
         test(Socks4CommandStatus.IDENTD_UNREACHABLE, null, 0);
         test(Socks4CommandStatus.REJECTED_OR_FAILED, null, 0);

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v4/Socks4CommonTestUtils.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v4/Socks4CommonTestUtils.java
@@ -26,7 +26,7 @@ final class Socks4CommonTestUtils {
         //NOOP
     }
 
-    public static void writeMessageIntoEmbedder(EmbeddedChannel embedder, Socks4Message msg) {
+    public static void writeMessageIntoEmbedder(EmbeddedChannel embedder, Socks4Message msg) throws Exception {
         EmbeddedChannel out;
         if (msg instanceof Socks4CommandRequest) {
             out = new EmbeddedChannel(Socks4ClientEncoder.INSTANCE);

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v4/Socks4ServerDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v4/Socks4ServerDecoderTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 public class Socks4ServerDecoderTest {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(Socks4ServerDecoderTest.class);
 
-    private static void test(String userId, Socks4CommandType type, String dstAddr, int dstPort) {
+    private static void test(String userId, Socks4CommandType type, String dstAddr, int dstPort) throws Exception {
         logger.debug(
                 "Testing type: " + type + " dstAddr: " + dstAddr + " dstPort: " + dstPort +
                 " userId: " + userId);
@@ -46,7 +46,7 @@ public class Socks4ServerDecoderTest {
     }
 
     @Test
-    public void testCmdRequestDecoder() {
+    public void testCmdRequestDecoder() throws Exception {
         String[] hosts = { "127.0.0.1", };
         String[] userIds = { "test", };
         int[] ports = {1, 32769, 65535};

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/DefaultSocks5CommandResponseTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/DefaultSocks5CommandResponseTest.java
@@ -44,7 +44,7 @@ public class DefaultSocks5CommandResponseTest {
      * Verifies content of the response when domain is not specified.
      */
     @Test
-    public void testEmptyDomain() {
+    public void testEmptyDomain() throws Exception {
         Socks5CommandResponse socks5CmdResponse = new DefaultSocks5CommandResponse(
                 Socks5CommandStatus.SUCCESS, Socks5AddressType.DOMAIN);
         assertNull(socks5CmdResponse.bndAddr());
@@ -68,7 +68,7 @@ public class DefaultSocks5CommandResponseTest {
      * Verifies content of the response when IPv4 address is specified.
      */
     @Test
-    public void testIPv4Host() {
+    public void testIPv4Host() throws Exception {
         Socks5CommandResponse socks5CmdResponse = new DefaultSocks5CommandResponse(
                 Socks5CommandStatus.SUCCESS, Socks5AddressType.IPv4, "127.0.0.1", 80);
         assertEquals("127.0.0.1", socks5CmdResponse.bndAddr());
@@ -95,7 +95,7 @@ public class DefaultSocks5CommandResponseTest {
      * Verifies that empty domain is allowed Response.
      */
     @Test
-    public void testEmptyBoundAddress() {
+    public void testEmptyBoundAddress() throws Exception {
         Socks5CommandResponse socks5CmdResponse = new DefaultSocks5CommandResponse(
                 Socks5CommandStatus.SUCCESS, Socks5AddressType.DOMAIN, "", 80);
         assertEquals("", socks5CmdResponse.bndAddr());

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5CommandRequestDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5CommandRequestDecoderTest.java
@@ -23,7 +23,6 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.junit.jupiter.api.Test;
 
 import java.net.IDN;
-import java.net.UnknownHostException;
 import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -35,7 +34,7 @@ public class Socks5CommandRequestDecoderTest {
             InternalLoggerFactory.getInstance(Socks5CommandRequestDecoderTest.class);
 
     private static void test(
-            Socks5CommandType type, Socks5AddressType dstAddrType, String dstAddr, int dstPort) {
+            Socks5CommandType type, Socks5AddressType dstAddrType, String dstAddr, int dstPort) throws Exception {
         logger.debug(
                 "Testing type: " + type + " dstAddrType: " + dstAddrType +
                 " dstAddr: " + dstAddr + " dstPort: " + dstPort);
@@ -53,7 +52,7 @@ public class Socks5CommandRequestDecoderTest {
     }
 
     @Test
-    public void testCmdRequestDecoderIPv4() {
+    public void testCmdRequestDecoderIPv4() throws Exception {
         String[] hosts = {"127.0.0.1", };
         int[] ports = {1, 32769, 65535 };
         for (Socks5CommandType cmdType: Arrays.asList(Socks5CommandType.BIND,
@@ -68,7 +67,7 @@ public class Socks5CommandRequestDecoderTest {
     }
 
     @Test
-    public void testCmdRequestDecoderIPv6() throws UnknownHostException {
+    public void testCmdRequestDecoderIPv6() throws Exception {
         String[] hosts = {
                 NetUtil.bytesToIpAddress(SocketUtils.addressByName("::1").getAddress()) };
         int[] ports = {1, 32769, 65535};
@@ -84,7 +83,7 @@ public class Socks5CommandRequestDecoderTest {
     }
 
     @Test
-    public void testCmdRequestDecoderDomain() {
+    public void testCmdRequestDecoderDomain() throws Exception {
         String[] hosts = {"google.com" ,
                           "مثال.إختبار",
                           "παράδειγμα.δοκιμή",

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5CommandResponseDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5CommandResponseDecoderTest.java
@@ -78,7 +78,8 @@ public class Socks5CommandResponseDecoderTest {
      */
     @Test
     public void testInvalidAddress() {
-        assertThrows(IllegalArgumentException.class, () -> test(Socks5CommandStatus.SUCCESS, Socks5AddressType.IPv4, "1", 80));
+        assertThrows(IllegalArgumentException.class,
+                () -> test(Socks5CommandStatus.SUCCESS, Socks5AddressType.IPv4, "1", 80));
     }
 
     /**

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5CommandResponseDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5CommandResponseDecoderTest.java
@@ -19,7 +19,6 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 import java.util.Arrays;
 
@@ -45,7 +44,7 @@ public class Socks5CommandResponseDecoderTest {
     };
 
     private static void test(
-            Socks5CommandStatus status, Socks5AddressType bndAddrType, String bndAddr, int bndPort) {
+            Socks5CommandStatus status, Socks5AddressType bndAddrType, String bndAddr, int bndPort) throws Exception {
         logger.debug("Testing status: " + status + " bndAddrType: " + bndAddrType);
         Socks5CommandResponse msg =
                 new DefaultSocks5CommandResponse(status, bndAddrType, bndAddr, bndPort);
@@ -64,7 +63,7 @@ public class Socks5CommandResponseDecoderTest {
      * Verifies that sent socks messages are decoded correctly.
      */
     @Test
-    public void testSocksCmdResponseDecoder() {
+    public void testSocksCmdResponseDecoder() throws Exception {
         for (Socks5CommandStatus cmdStatus: STATUSES) {
             for (Socks5AddressType addressType : Arrays.asList(Socks5AddressType.DOMAIN,
                                                                Socks5AddressType.IPv4,
@@ -79,19 +78,14 @@ public class Socks5CommandResponseDecoderTest {
      */
     @Test
     public void testInvalidAddress() {
-        assertThrows(IllegalArgumentException.class, new Executable() {
-            @Override
-            public void execute() {
-                test(Socks5CommandStatus.SUCCESS, Socks5AddressType.IPv4, "1", 80);
-            }
-        });
+        assertThrows(IllegalArgumentException.class, () -> test(Socks5CommandStatus.SUCCESS, Socks5AddressType.IPv4, "1", 80));
     }
 
     /**
      * Verifies that send socks messages are decoded correctly when bound host and port are set.
      */
     @Test
-    public void testSocksCmdResponseDecoderIncludingHost() {
+    public void testSocksCmdResponseDecoderIncludingHost() throws Exception {
         for (Socks5CommandStatus cmdStatus : STATUSES) {
             test(cmdStatus, Socks5AddressType.IPv4,
                  "127.0.0.1", 80);

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5CommonTestUtils.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5CommonTestUtils.java
@@ -26,15 +26,15 @@ final class Socks5CommonTestUtils {
         //NOOP
     }
 
-    public static void writeFromClientToServer(EmbeddedChannel embedder, Socks5Message msg) {
+    public static void writeFromClientToServer(EmbeddedChannel embedder, Socks5Message msg) throws Exception {
         embedder.writeInbound(encodeClient(msg));
     }
 
-    public static void writeFromServerToClient(EmbeddedChannel embedder, Socks5Message msg) {
+    public static void writeFromServerToClient(EmbeddedChannel embedder, Socks5Message msg) throws Exception {
         embedder.writeInbound(encodeServer(msg));
     }
 
-    public static ByteBuf encodeClient(Socks5Message msg) {
+    public static ByteBuf encodeClient(Socks5Message msg) throws Exception {
         EmbeddedChannel out = new EmbeddedChannel(Socks5ClientEncoder.DEFAULT);
         out.writeOutbound(msg);
 
@@ -44,7 +44,7 @@ final class Socks5CommonTestUtils {
         return encoded;
     }
 
-    public static ByteBuf encodeServer(Socks5Message msg) {
+    public static ByteBuf encodeServer(Socks5Message msg) throws Exception {
         EmbeddedChannel out = new EmbeddedChannel(Socks5ServerEncoder.DEFAULT);
         out.writeOutbound(msg);
 

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5InitialRequestDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5InitialRequestDecoderTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Socks5InitialRequestDecoderTest {
     @Test
-    public void testUnpackingCausesDecodeFail() {
+    public void testUnpackingCausesDecodeFail() throws Exception {
         EmbeddedChannel e = new EmbeddedChannel(new Socks5InitialRequestDecoder());
         assertFalse(e.writeInbound(Unpooled.wrappedBuffer(new byte[]{5, 2, 0})));
         assertTrue(e.writeInbound(Unpooled.wrappedBuffer(new byte[]{1})));

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthRequestDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthRequestDecoderTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 public class Socks5PasswordAuthRequestDecoderTest {
 
     @Test
-    public void testAuthRequestDecoder() {
+    public void testAuthRequestDecoder() throws Exception {
         String username = "testUsername";
         String password = "testPassword";
         Socks5PasswordAuthRequest msg = new DefaultSocks5PasswordAuthRequest(username, password);

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthResponseDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthResponseDecoderTest.java
@@ -27,7 +27,7 @@ public class Socks5PasswordAuthResponseDecoderTest {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(
             Socks5PasswordAuthResponseDecoderTest.class);
 
-    private static void test(Socks5PasswordAuthStatus status) {
+    private static void test(Socks5PasswordAuthStatus status) throws Exception {
         logger.debug("Testing Socks5PasswordAuthResponseDecoder with status: " + status);
         Socks5PasswordAuthResponse msg = new DefaultSocks5PasswordAuthResponse(status);
         EmbeddedChannel embedder = new EmbeddedChannel(new Socks5PasswordAuthResponseDecoder());
@@ -38,7 +38,7 @@ public class Socks5PasswordAuthResponseDecoderTest {
     }
 
     @Test
-    public void testSocksCmdResponseDecoder() {
+    public void testSocksCmdResponseDecoder() throws Exception {
         test(Socks5PasswordAuthStatus.SUCCESS);
         test(Socks5PasswordAuthStatus.FAILURE);
     }

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompCommandDecodeTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompCommandDecodeTest.java
@@ -43,13 +43,13 @@ public class StompCommandDecodeTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    public void tearDown() throws Exception {
         assertFalse(channel.finish());
     }
 
     @ParameterizedTest(name = "{index}: testDecodeCommand({0}) = {1}")
     @MethodSource("stompCommands")
-    public void testDecodeCommand(String rawCommand, StompCommand expectedCommand, Boolean valid) {
+    public void testDecodeCommand(String rawCommand, StompCommand expectedCommand, Boolean valid) throws Exception {
         byte[] frameContent = String.format("%s\n\n\0", rawCommand).getBytes(UTF_8);
         ByteBuf incoming = Unpooled.wrappedBuffer(frameContent);
         assertTrue(channel.writeInbound(incoming));

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeAggregatorTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeAggregatorTest.java
@@ -23,13 +23,9 @@ import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
-
-import java.util.concurrent.CompletionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -44,12 +40,12 @@ public class StompSubframeAggregatorTest {
     }
 
     @AfterEach
-    public void teardown() {
+    public void teardown() throws Exception {
         assertFalse(channel.finish());
     }
 
     @Test
-    public void testSingleFrameDecoding() {
+    public void testSingleFrameDecoding() throws Exception {
         ByteBuf incoming = Unpooled.buffer();
         incoming.writeBytes(StompTestConstants.CONNECT_FRAME.getBytes());
         channel.writeInbound(incoming);
@@ -61,7 +57,7 @@ public class StompSubframeAggregatorTest {
     }
 
     @Test
-    public void testSingleFrameWithBodyAndContentLength() {
+    public void testSingleFrameWithBodyAndContentLength() throws Exception {
         ByteBuf incoming = Unpooled.buffer();
         incoming.writeBytes(StompTestConstants.SEND_FRAME_2.getBytes());
         channel.writeInbound(incoming);
@@ -76,7 +72,7 @@ public class StompSubframeAggregatorTest {
     }
 
     @Test
-    public void testSingleFrameWithBodyAndNoContentLength() {
+    public void testSingleFrameWithBodyAndNoContentLength() throws Exception {
         ByteBuf incoming = Unpooled.buffer();
         incoming.writeBytes(StompTestConstants.SEND_FRAME_4.getBytes());
         channel.writeInbound(incoming);
@@ -91,7 +87,7 @@ public class StompSubframeAggregatorTest {
     }
 
     @Test
-    public void testSingleFrameWithSplitBodyAndNoContentLength() {
+    public void testSingleFrameWithSplitBodyAndNoContentLength() throws Exception {
         for (int n = 0; n < StompTestConstants.SEND_FRAMES_3.length; ++n) {
             ByteBuf incoming = Unpooled.buffer();
             incoming.writeBytes(StompTestConstants.SEND_FRAMES_3[n].getBytes());
@@ -109,7 +105,7 @@ public class StompSubframeAggregatorTest {
     }
 
     @Test
-    public void testSingleFrameChunked() {
+    public void testSingleFrameChunked() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(
                 new StompSubframeDecoder(10000, 5), new StompSubframeAggregator(100000));
         ByteBuf incoming = Unpooled.buffer();
@@ -125,7 +121,7 @@ public class StompSubframeAggregatorTest {
     }
 
     @Test
-    public void testMultipleFramesDecoding() {
+    public void testMultipleFramesDecoding() throws Exception {
         ByteBuf incoming = Unpooled.buffer();
         incoming.writeBytes(StompTestConstants.CONNECT_FRAME.getBytes());
         incoming.writeBytes(StompTestConstants.CONNECTED_FRAME.getBytes());
@@ -151,12 +147,7 @@ public class StompSubframeAggregatorTest {
     public void testTooLongFrameException() {
         final EmbeddedChannel channel = new EmbeddedChannel(new StompSubframeDecoder(),
                 new StompSubframeAggregator(10));
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                channel.writeInbound(Unpooled.wrappedBuffer(StompTestConstants.SEND_FRAME_1.getBytes()));
-            }
-        });
-        assertInstanceOf(TooLongFrameException.class, cause.getCause());
+        assertThrows(TooLongFrameException.class,
+                () -> channel.writeInbound(Unpooled.wrappedBuffer(StompTestConstants.SEND_FRAME_1.getBytes())));
     }
 }

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeAggregatorTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeAggregatorTest.java
@@ -25,8 +25,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
+import java.util.concurrent.CompletionException;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -148,11 +151,12 @@ public class StompSubframeAggregatorTest {
     public void testTooLongFrameException() {
         final EmbeddedChannel channel = new EmbeddedChannel(new StompSubframeDecoder(),
                 new StompSubframeAggregator(10));
-        assertThrows(TooLongFrameException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 channel.writeInbound(Unpooled.wrappedBuffer(StompTestConstants.SEND_FRAME_1.getBytes()));
             }
         });
+        assertInstanceOf(TooLongFrameException.class, cause.getCause());
     }
 }

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeDecoderTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeDecoderTest.java
@@ -46,7 +46,7 @@ public class StompSubframeDecoderTest {
     }
 
     @Test
-    public void testSingleFrameDecoding() {
+    public void testSingleFrameDecoding() throws Exception {
         ByteBuf incoming = Unpooled.buffer();
         incoming.writeBytes(StompTestConstants.CONNECT_FRAME.getBytes());
         channel.writeInbound(incoming);
@@ -64,7 +64,7 @@ public class StompSubframeDecoderTest {
     }
 
     @Test
-    public void testSingleFrameWithBodyAndContentLength() {
+    public void testSingleFrameWithBodyAndContentLength() throws Exception {
         ByteBuf incoming = Unpooled.buffer();
         incoming.writeBytes(StompTestConstants.SEND_FRAME_2.getBytes());
         channel.writeInbound(incoming);
@@ -83,7 +83,7 @@ public class StompSubframeDecoderTest {
     }
 
     @Test
-    public void testSingleFrameWithBodyWithoutContentLength() {
+    public void testSingleFrameWithBodyWithoutContentLength() throws Exception {
         ByteBuf incoming = Unpooled.buffer();
         incoming.writeBytes(StompTestConstants.SEND_FRAME_1.getBytes());
         channel.writeInbound(incoming);
@@ -102,7 +102,7 @@ public class StompSubframeDecoderTest {
     }
 
     @Test
-    public void testSingleFrameChunked() {
+    public void testSingleFrameChunked() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new StompSubframeDecoder(10000, 5));
 
         ByteBuf incoming = Unpooled.buffer();
@@ -137,7 +137,7 @@ public class StompSubframeDecoderTest {
     }
 
     @Test
-    public void testMultipleFramesDecoding() {
+    public void testMultipleFramesDecoding() throws Exception {
         ByteBuf incoming = Unpooled.buffer();
         incoming.writeBytes(StompTestConstants.CONNECT_FRAME.getBytes());
         incoming.writeBytes(StompTestConstants.CONNECTED_FRAME.getBytes());
@@ -163,7 +163,7 @@ public class StompSubframeDecoderTest {
     }
 
     @Test
-    public void testValidateHeadersDecodingDisabled() {
+    public void testValidateHeadersDecodingDisabled() throws Exception {
         ByteBuf invalidIncoming = Unpooled.copiedBuffer(FRAME_WITH_INVALID_HEADER.getBytes(UTF_8));
         assertTrue(channel.writeInbound(invalidIncoming));
 
@@ -181,7 +181,7 @@ public class StompSubframeDecoderTest {
     }
 
     @Test
-    public void testValidateHeadersDecodingEnabled() {
+    public void testValidateHeadersDecodingEnabled() throws Exception {
         channel = new EmbeddedChannel(new StompSubframeDecoder(true));
 
         ByteBuf invalidIncoming = Unpooled.wrappedBuffer(FRAME_WITH_INVALID_HEADER.getBytes(UTF_8));
@@ -195,7 +195,7 @@ public class StompSubframeDecoderTest {
     }
 
     @Test
-    public void testNotValidFrameWithEmptyHeaderName() {
+    public void testNotValidFrameWithEmptyHeaderName() throws Exception {
         channel = new EmbeddedChannel(new StompSubframeDecoder(true));
 
         ByteBuf invalidIncoming = Unpooled.wrappedBuffer(FRAME_WITH_EMPTY_HEADER_NAME.getBytes(UTF_8));
@@ -209,7 +209,7 @@ public class StompSubframeDecoderTest {
     }
 
     @Test
-    public void testUtf8FrameDecoding() {
+    public void testUtf8FrameDecoding() throws Exception {
         channel = new EmbeddedChannel(new StompSubframeDecoder(true));
 
         ByteBuf incoming = Unpooled.wrappedBuffer(SEND_FRAME_UTF8.getBytes(UTF_8));
@@ -228,7 +228,7 @@ public class StompSubframeDecoderTest {
     }
 
     @Test
-    void testFrameWithContentLengthAndWithoutNullEnding() {
+    void testFrameWithContentLengthAndWithoutNullEnding() throws Exception {
         channel = new EmbeddedChannel(new StompSubframeDecoder(true));
 
         ByteBuf incoming = Unpooled.wrappedBuffer(FRAME_WITHOUT_NULL_ENDING.getBytes(UTF_8));
@@ -246,7 +246,7 @@ public class StompSubframeDecoderTest {
     }
 
     @Test
-    void testUnescapeHeaders() {
+    void testUnescapeHeaders() throws Exception {
         channel = new EmbeddedChannel(new StompSubframeDecoder(true));
 
         ByteBuf incoming = Unpooled.wrappedBuffer(StompTestConstants.ESCAPED_MESSAGE_FRAME.getBytes(UTF_8));
@@ -270,7 +270,7 @@ public class StompSubframeDecoderTest {
     }
 
     @Test
-    void testNotUnescapeHeadersForConnectCommand() {
+    void testNotUnescapeHeadersForConnectCommand() throws Exception {
         String expectedStompFrame = "CONNECT\n"
                 + "headerName-\\\\:headerValue-\\\\\n"
                 + "\n" + '\0';
@@ -294,7 +294,7 @@ public class StompSubframeDecoderTest {
     }
 
     @Test
-    void testNotUnescapeHeadersForConnectedCommand() {
+    void testNotUnescapeHeadersForConnectedCommand() throws Exception {
         String expectedStompFrame = "CONNECTED\n"
                 + "headerName-\\\\:headerValue-\\\\\n"
                 + "\n" + '\0';
@@ -318,7 +318,7 @@ public class StompSubframeDecoderTest {
     }
 
     @Test
-    void testInvalidEscapeHeadersSequence() {
+    void testInvalidEscapeHeadersSequence() throws Exception {
         channel = new EmbeddedChannel(new StompSubframeDecoder(true));
 
         ByteBuf incoming = Unpooled.wrappedBuffer(INVALID_ESCAPED_MESSAGE_FRAME.getBytes(UTF_8));

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeEncoderTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeEncoderTest.java
@@ -48,7 +48,7 @@ public class StompSubframeEncoderTest {
     }
 
     @Test
-    public void testFrameAndContentEncoding() {
+    public void testFrameAndContentEncoding() throws Exception {
         StompHeadersSubframe frame = new DefaultStompHeadersSubframe(StompCommand.CONNECT);
         StompHeaders headers = frame.headers();
         headers.set(StompHeaders.HOST, "stomp.github.org");
@@ -73,7 +73,7 @@ public class StompSubframeEncoderTest {
     }
 
     @Test
-    public void testUtf8FrameEncoding() {
+    public void testUtf8FrameEncoding() throws Exception {
         StompFrame frame = new DefaultStompFrame(StompCommand.SEND,
                                                  Unpooled.wrappedBuffer("body".getBytes(CharsetUtil.UTF_8)));
         StompHeaders incoming = frame.headers();
@@ -88,7 +88,7 @@ public class StompSubframeEncoderTest {
     }
 
     @Test
-    public void testOneBufferForStompFrameWithEmptyContent() {
+    public void testOneBufferForStompFrameWithEmptyContent() throws Exception {
         StompFrame connectedFrame = new DefaultStompFrame(StompCommand.CONNECTED);
         connectedFrame.headers().set(StompHeaders.VERSION, "1.2");
 
@@ -103,7 +103,7 @@ public class StompSubframeEncoderTest {
     }
 
     @Test
-    void testEscapeStompHeaders() {
+    void testEscapeStompHeaders() throws Exception {
         StompFrame messageFrame = new DefaultStompFrame(StompCommand.MESSAGE);
         messageFrame.headers()
                   .add(StompHeaders.MESSAGE_ID, "100")
@@ -124,7 +124,7 @@ public class StompSubframeEncoderTest {
     }
 
     @Test
-    void testNotEscapeStompHeadersForConnectCommand() {
+    void testNotEscapeStompHeadersForConnectCommand() throws Exception {
         String expectedStompFrame = "CONNECT\n"
                 + "colonHeaderName-::colonHeaderValue-:\n"
                 + '\n' + '\0';
@@ -143,7 +143,7 @@ public class StompSubframeEncoderTest {
     }
 
     @Test
-    void testNotEscapeStompHeadersForConnectedCommand() {
+    void testNotEscapeStompHeadersForConnectedCommand() throws Exception {
         String expectedStompFrame = "CONNECTED\n"
                                     + "colonHeaderName-::colonHeaderValue-:\n"
                                     + '\n' + '\0';

--- a/codec-xml/src/test/java/io/netty/handler/codec/xml/XmlDecoderTest.java
+++ b/codec-xml/src/test/java/io/netty/handler/codec/xml/XmlDecoderTest.java
@@ -68,7 +68,7 @@ public class XmlDecoderTest {
      * This test feeds basic XML and verifies the resulting messages
      */
     @Test
-    public void shouldDecodeRequestWithSimpleXml() {
+    public void shouldDecodeRequestWithSimpleXml() throws Exception {
         Object temp;
 
         write(XML1);
@@ -229,7 +229,7 @@ public class XmlDecoderTest {
      * This test checks for different attributes in XML header
      */
     @Test
-    public void shouldDecodeXmlHeader() {
+    public void shouldDecodeXmlHeader() throws Exception {
         Object temp;
 
         write(XML3);
@@ -264,7 +264,7 @@ public class XmlDecoderTest {
      * This test checks for no XML header
      */
     @Test
-    public void shouldDecodeWithoutHeader() {
+    public void shouldDecodeWithoutHeader() throws Exception {
         Object temp;
 
         write(XML4);
@@ -295,7 +295,7 @@ public class XmlDecoderTest {
         assertNull(temp);
     }
 
-    private void write(String content) {
+    private void write(String content) throws Exception {
         assertTrue(channel.writeInbound(Unpooled.copiedBuffer(content, CharsetUtil.UTF_8)));
     }
 }

--- a/codec-xml/src/test/java/io/netty/handler/codec/xml/XmlFrameDecoderTest.java
+++ b/codec-xml/src/test/java/io/netty/handler/codec/xml/XmlFrameDecoderTest.java
@@ -36,8 +36,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class XmlFrameDecoderTest {
@@ -75,36 +77,39 @@ public class XmlFrameDecoderTest {
     public void testDecodeWithFrameExceedingMaxLength() {
         XmlFrameDecoder decoder = new XmlFrameDecoder(3);
         final EmbeddedChannel ch = new EmbeddedChannel(decoder);
-        assertThrows(TooLongFrameException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 ch.writeInbound(Unpooled.copiedBuffer("<v/>", CharsetUtil.UTF_8));
             }
         });
+        assertInstanceOf(TooLongFrameException.class, cause.getCause();
     }
 
     @Test
     public void testDecodeWithInvalidInput() {
         XmlFrameDecoder decoder = new XmlFrameDecoder(1048576);
         final EmbeddedChannel ch = new EmbeddedChannel(decoder);
-        assertThrows(CorruptedFrameException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 ch.writeInbound(Unpooled.copiedBuffer("invalid XML", CharsetUtil.UTF_8));
             }
         });
+        assertInstanceOf(CorruptedFrameException.class, cause.getCause());
     }
 
     @Test
     public void testDecodeWithInvalidContentBeforeXml() {
         XmlFrameDecoder decoder = new XmlFrameDecoder(1048576);
         final EmbeddedChannel ch = new EmbeddedChannel(decoder);
-        assertThrows(CorruptedFrameException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
                 ch.writeInbound(Unpooled.copiedBuffer("invalid XML<foo/>", CharsetUtil.UTF_8));
             }
         });
+        assertInstanceOf(CorruptedFrameException.class, cause.getCause());
     }
 
     @Test

--- a/codec-xml/src/test/java/io/netty/handler/codec/xml/XmlFrameDecoderTest.java
+++ b/codec-xml/src/test/java/io/netty/handler/codec/xml/XmlFrameDecoderTest.java
@@ -83,7 +83,7 @@ public class XmlFrameDecoderTest {
                 ch.writeInbound(Unpooled.copiedBuffer("<v/>", CharsetUtil.UTF_8));
             }
         });
-        assertInstanceOf(TooLongFrameException.class, cause.getCause();
+        assertInstanceOf(TooLongFrameException.class, cause.getCause());
     }
 
     @Test

--- a/codec-xml/src/test/java/io/netty/handler/codec/xml/XmlFrameDecoderTest.java
+++ b/codec-xml/src/test/java/io/netty/handler/codec/xml/XmlFrameDecoderTest.java
@@ -36,10 +36,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CompletionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class XmlFrameDecoderTest {
@@ -77,69 +75,54 @@ public class XmlFrameDecoderTest {
     public void testDecodeWithFrameExceedingMaxLength() {
         XmlFrameDecoder decoder = new XmlFrameDecoder(3);
         final EmbeddedChannel ch = new EmbeddedChannel(decoder);
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                ch.writeInbound(Unpooled.copiedBuffer("<v/>", CharsetUtil.UTF_8));
-            }
-        });
-        assertInstanceOf(TooLongFrameException.class, cause.getCause());
+        assertThrows(TooLongFrameException.class,
+                () -> ch.writeInbound(Unpooled.copiedBuffer("<v/>", CharsetUtil.UTF_8)));
     }
 
     @Test
     public void testDecodeWithInvalidInput() {
         XmlFrameDecoder decoder = new XmlFrameDecoder(1048576);
         final EmbeddedChannel ch = new EmbeddedChannel(decoder);
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                ch.writeInbound(Unpooled.copiedBuffer("invalid XML", CharsetUtil.UTF_8));
-            }
-        });
-        assertInstanceOf(CorruptedFrameException.class, cause.getCause());
+        assertThrows(CorruptedFrameException.class,
+                () -> ch.writeInbound(Unpooled.copiedBuffer("invalid XML", CharsetUtil.UTF_8)));
     }
 
     @Test
     public void testDecodeWithInvalidContentBeforeXml() {
         XmlFrameDecoder decoder = new XmlFrameDecoder(1048576);
         final EmbeddedChannel ch = new EmbeddedChannel(decoder);
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                ch.writeInbound(Unpooled.copiedBuffer("invalid XML<foo/>", CharsetUtil.UTF_8));
-            }
-        });
-        assertInstanceOf(CorruptedFrameException.class, cause.getCause());
+        assertThrows(CorruptedFrameException.class,
+                () -> ch.writeInbound(Unpooled.copiedBuffer("invalid XML<foo/>", CharsetUtil.UTF_8)));
     }
 
     @Test
-    public void testDecodeShortValidXml() {
+    public void testDecodeShortValidXml() throws Exception {
         testDecodeWithXml("<xxx/>", "<xxx/>");
     }
 
     @Test
-    public void testDecodeShortValidXmlWithLeadingWhitespace01() {
+    public void testDecodeShortValidXmlWithLeadingWhitespace01() throws Exception {
         testDecodeWithXml("   <xxx/>", "<xxx/>");
     }
 
     @Test
-    public void testDecodeShortValidXmlWithLeadingWhitespace02() {
+    public void testDecodeShortValidXmlWithLeadingWhitespace02() throws Exception {
         testDecodeWithXml("  \n\r \t<xxx/>\t", "<xxx/>");
     }
 
     @Test
-    public void testDecodeShortValidXmlWithLeadingWhitespace02AndTrailingGarbage() {
+    public void testDecodeShortValidXmlWithLeadingWhitespace02AndTrailingGarbage() throws Exception {
         testDecodeWithXml("  \n\r \t<xxx/>\ttrash", "<xxx/>", CorruptedFrameException.class);
     }
 
     @Test
-    public void testDecodeInvalidXml() {
+    public void testDecodeInvalidXml() throws Exception {
         testDecodeWithXml("<a></", new Object[0]);
         testDecodeWithXml("<a></a", new Object[0]);
     }
 
     @Test
-    public void testDecodeWithCDATABlock() {
+    public void testDecodeWithCDATABlock() throws Exception {
         final String xml = "<book>" +
                 "<![CDATA[K&R, a.k.a. Kernighan & Ritchie]]>" +
                 "</book>";
@@ -147,7 +130,7 @@ public class XmlFrameDecoderTest {
     }
 
     @Test
-    public void testDecodeWithCDATABlockContainingNestedUnbalancedXml() {
+    public void testDecodeWithCDATABlockContainingNestedUnbalancedXml() throws Exception {
         // <br> isn't closed, also <a> should have been </a>
         final String xml = "<info>" +
                 "<![CDATA[Copyright 2012-2013,<br><a href=\"http://www.acme.com\">ACME Inc.<a>]]>" +
@@ -156,7 +139,7 @@ public class XmlFrameDecoderTest {
     }
 
     @Test
-    public void testDecodeWithMultipleMessages() {
+    public void testDecodeWithMultipleMessages() throws Exception {
         final String input = "<root xmlns=\"http://www.acme.com/acme\" status=\"loginok\" " +
                 "timestamp=\"1362410583776\"/>\n\n" +
                 "<root xmlns=\"http://www.acme.com/acme\" status=\"start\" time=\"0\" " +
@@ -174,18 +157,18 @@ public class XmlFrameDecoderTest {
     }
 
     @Test
-    public void testFraming() {
+    public void testFraming() throws Exception {
         testDecodeWithXml(Arrays.asList("<abc", ">123</a", "bc>"), "<abc>123</abc>");
     }
 
     @Test
-    public void testDecodeWithSampleXml() {
+    public void testDecodeWithSampleXml() throws Exception {
         for (final String xmlSample : xmlSamples) {
             testDecodeWithXml(xmlSample, xmlSample);
         }
     }
 
-    private static void testDecodeWithXml(List<String> xmlFrames, Object... expected) {
+    private static void testDecodeWithXml(List<String> xmlFrames, Object... expected) throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new XmlFrameDecoder(1048576));
         Exception cause = null;
         try {
@@ -218,7 +201,7 @@ public class XmlFrameDecoderTest {
         }
     }
 
-    private static void testDecodeWithXml(String xml, Object... expected) {
+    private static void testDecodeWithXml(String xml, Object... expected) throws Exception {
         testDecodeWithXml(Collections.singletonList(xml), expected);
     }
 

--- a/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
@@ -16,7 +16,6 @@
 package io.netty.util.concurrent;
 
 import io.netty.util.internal.InternalThreadLocalMap;
-import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.ThrowableUtil;
@@ -710,11 +709,10 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
         if (cause == null) {
             return;
         }
-
-        if (!(cause instanceof CancellationException) && cause.getSuppressed().length == 0) {
-            cause.addSuppressed(new CompletionException("Rethrowing promise failure cause", null));
+        if (cause instanceof CancellationException) {
+            throw (CancellationException) cause;
         }
-        PlatformDependent.throwException(cause);
+        throw new CompletionException(cause);
     }
 
     private boolean await0(long timeoutNanos, boolean interruptable) throws InterruptedException {

--- a/common/src/main/java/io/netty/util/concurrent/FailedFuture.java
+++ b/common/src/main/java/io/netty/util/concurrent/FailedFuture.java
@@ -16,7 +16,8 @@
 package io.netty.util.concurrent;
 
 import io.netty.util.internal.ObjectUtil;
-import io.netty.util.internal.PlatformDependent;
+
+import java.util.concurrent.CompletionException;
 
 /**
  * The {@link CompleteFuture} which is failed already.  It is
@@ -50,14 +51,12 @@ public class FailedFuture<V> extends CompleteFuture<V> {
 
     @Override
     public Future<V> sync() {
-        PlatformDependent.throwException(cause);
-        return this;
+        throw new CompletionException(cause);
     }
 
     @Override
     public Future<V> syncUninterruptibly() {
-        PlatformDependent.throwException(cause);
-        return this;
+        throw new CompletionException(cause);
     }
 
     @Override

--- a/common/src/main/java/io/netty/util/concurrent/Future.java
+++ b/common/src/main/java/io/netty/util/concurrent/Future.java
@@ -16,6 +16,7 @@
 package io.netty.util.concurrent;
 
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 
 
@@ -64,13 +65,13 @@ public interface Future<V> extends java.util.concurrent.Future<V> {
 
     /**
      * Waits for this future until it is done, and rethrows the cause of the failure if this future
-     * failed.
+     * failed wrapped in a {@link CompletionException}
      */
     Future<V> sync() throws InterruptedException;
 
     /**
      * Waits for this future until it is done, and rethrows the cause of the failure if this future
-     * failed.
+     * failed wrapped in a {@link CompletionException}
      */
     Future<V> syncUninterruptibly();
 

--- a/common/src/test/java/io/netty/util/concurrent/SingleThreadEventExecutorTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/SingleThreadEventExecutorTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.function.Executable;
 
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -34,6 +35,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -264,12 +266,13 @@ public class SingleThreadEventExecutorTest {
         executorService.shutdownNow();
         executeShouldFail(executor);
         executeShouldFail(executor);
-        assertThrows(RejectedExecutionException.class, new Executable() {
+        Throwable wrapped = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 executor.shutdownGracefully().syncUninterruptibly();
             }
-        });
+        }).getCause();
+        assertInstanceOf(RejectedExecutionException.class, wrapped);
         assertTrue(executor.isShutdown());
     }
 

--- a/handler/src/test/java/io/netty/handler/address/DynamicAddressConnectHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/address/DynamicAddressConnectHandlerTest.java
@@ -34,7 +34,7 @@ public class DynamicAddressConnectHandlerTest {
     private static final SocketAddress REMOTE = new SocketAddress() { };
     private static final SocketAddress REMOTE_NEW = new SocketAddress() { };
     @Test
-    public void testReplaceAddresses() {
+    public void testReplaceAddresses() throws Exception {
 
         EmbeddedChannel channel = new EmbeddedChannel(new ChannelOutboundHandler() {
             @Override
@@ -69,16 +69,16 @@ public class DynamicAddressConnectHandlerTest {
     }
 
     @Test
-    public void testLocalAddressThrows() {
+    public void testLocalAddressThrows() throws Exception {
         testThrows0(true);
     }
 
     @Test
-    public void testRemoteAddressThrows() {
+    public void testRemoteAddressThrows() throws Exception {
         testThrows0(false);
     }
 
-    private static void testThrows0(final boolean localThrows) {
+    private static void testThrows0(final boolean localThrows) throws Exception {
         final IllegalStateException exception = new IllegalStateException();
 
         EmbeddedChannel channel = new EmbeddedChannel(new DynamicAddressConnectHandler() {

--- a/handler/src/test/java/io/netty/handler/flush/FlushConsolidationHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/flush/FlushConsolidationHandlerTest.java
@@ -22,10 +22,12 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -140,12 +142,13 @@ public class FlushConsolidationHandlerTest {
         assertEquals(1, flushCount.get());
         assertEquals(1L, (Long) channel.readOutbound());
         assertNull(channel.readOutbound());
-        assertThrows(IllegalStateException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
                 channel.finish();
             }
         });
+        assertInstanceOf(IllegalStateException.class, cause.getCause());
     }
 
     @Test

--- a/handler/src/test/java/io/netty/handler/flush/FlushConsolidationHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/flush/FlushConsolidationHandlerTest.java
@@ -20,14 +20,11 @@ import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelOutboundHandler;
 import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -36,7 +33,7 @@ public class FlushConsolidationHandlerTest {
     private static final int EXPLICIT_FLUSH_AFTER_FLUSHES = 3;
 
     @Test
-    public void testFlushViaScheduledTask() {
+    public void testFlushViaScheduledTask() throws Exception {
         final AtomicInteger flushCount = new AtomicInteger();
         EmbeddedChannel channel = newChannel(flushCount,  true);
         // Flushes should not go through immediately, as they're scheduled as an async task
@@ -52,7 +49,7 @@ public class FlushConsolidationHandlerTest {
     }
 
     @Test
-    public void testFlushViaThresholdOutsideOfReadLoop() {
+    public void testFlushViaThresholdOutsideOfReadLoop() throws Exception {
         final AtomicInteger flushCount = new AtomicInteger();
         EmbeddedChannel channel = newChannel(flushCount, true);
         // After a given threshold, the async task should be bypassed and a flush should be triggered immediately
@@ -65,7 +62,7 @@ public class FlushConsolidationHandlerTest {
     }
 
     @Test
-    public void testImmediateFlushOutsideOfReadLoop() {
+    public void testImmediateFlushOutsideOfReadLoop() throws Exception {
         final AtomicInteger flushCount = new AtomicInteger();
         EmbeddedChannel channel = newChannel(flushCount, false);
         channel.flush();
@@ -74,7 +71,7 @@ public class FlushConsolidationHandlerTest {
     }
 
     @Test
-    public void testFlushViaReadComplete() {
+    public void testFlushViaReadComplete() throws Exception {
         final AtomicInteger flushCount = new AtomicInteger();
         EmbeddedChannel channel = newChannel(flushCount, false);
         // Flush should go through as there is no read loop in progress.
@@ -101,7 +98,7 @@ public class FlushConsolidationHandlerTest {
     }
 
     @Test
-    public void testFlushViaClose() {
+    public void testFlushViaClose() throws Exception {
         final AtomicInteger flushCount = new AtomicInteger();
         EmbeddedChannel channel = newChannel(flushCount, false);
         // Simulate read loop;
@@ -116,7 +113,7 @@ public class FlushConsolidationHandlerTest {
     }
 
     @Test
-    public void testFlushViaDisconnect() {
+    public void testFlushViaDisconnect() throws Exception {
         final AtomicInteger flushCount = new AtomicInteger();
         EmbeddedChannel channel = newChannel(flushCount, false);
         // Simulate read loop;
@@ -142,17 +139,11 @@ public class FlushConsolidationHandlerTest {
         assertEquals(1, flushCount.get());
         assertEquals(1L, (Long) channel.readOutbound());
         assertNull(channel.readOutbound());
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                channel.finish();
-            }
-        });
-        assertInstanceOf(IllegalStateException.class, cause.getCause());
+        assertThrows(IllegalStateException.class, channel::finish);
     }
 
     @Test
-    public void testFlushViaRemoval() {
+    public void testFlushViaRemoval() throws Exception {
         final AtomicInteger flushCount = new AtomicInteger();
         EmbeddedChannel channel = newChannel(flushCount, false);
         // Simulate read loop;

--- a/handler/src/test/java/io/netty/handler/ipfilter/IpSubnetFilterTest.java
+++ b/handler/src/test/java/io/netty/handler/ipfilter/IpSubnetFilterTest.java
@@ -137,7 +137,7 @@ public class IpSubnetFilterTest {
     }
 
     @Test
-    public void testUniqueIpFilterHandler() {
+    public void testUniqueIpFilterHandler() throws Exception {
         UniqueIpFilter handler = new UniqueIpFilter();
 
         EmbeddedChannel ch1 = newEmbeddedInetChannel("91.92.93.1", handler);

--- a/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
@@ -58,6 +58,7 @@ import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
 import java.net.SocketAddress;
 import java.net.SocketException;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -66,6 +67,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -444,12 +446,8 @@ public class PcapWriteHandlerTest {
             assertEquals(24, pcapBuffer.readableBytes());
 
             // Verify thrown exception
-            try {
-                embeddedChannel.checkException();
-                fail();
-            } catch (Throwable t) {
-                assertSame(exception, t);
-            }
+            Throwable cause = assertThrows(CompletionException.class, embeddedChannel::checkException);
+            assertSame(exception, cause.getCause());
 
             assertFalse(embeddedChannel.finishAndReleaseAll());
         } finally {
@@ -867,14 +865,10 @@ public class PcapWriteHandlerTest {
         assertEquals(0, tcpPacket.readUnsignedShort()); // Urgent Pointer
 
         // Verify thrown exception
-        try {
-            embeddedChannel.checkException();
-            fail();
-        } catch (Throwable t) {
-            assertSame(exception, t);
-        } finally {
-            pcapBuffer.release();
-        }
+        // Verify thrown exception
+        Throwable cause = assertThrows(CompletionException.class, embeddedChannel::checkException);
+        assertSame(exception, cause.getCause());
+        pcapBuffer.release();
 
         assertFalse(embeddedChannel.finishAndReleaseAll());
     }

--- a/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/pcap/PcapWriteHandlerTest.java
@@ -57,8 +57,6 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
 import java.net.SocketAddress;
-import java.net.SocketException;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -69,7 +67,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class PcapWriteHandlerTest {
 
@@ -151,7 +148,7 @@ public class PcapWriteHandlerTest {
     }
 
     @Test
-    public void embeddedUdp() {
+    public void embeddedUdp() throws Exception {
         final ByteBuf pcapBuffer = Unpooled.buffer();
         final ByteBuf payload = Unpooled.wrappedBuffer("Meow".getBytes());
 
@@ -189,7 +186,7 @@ public class PcapWriteHandlerTest {
     }
 
     @Test
-    public void udpMixedAddress() throws SocketException {
+    public void udpMixedAddress() throws Exception {
         final ByteBuf pcapBuffer = Unpooled.buffer();
         final ByteBuf payload = Unpooled.wrappedBuffer("Meow".getBytes());
 
@@ -219,7 +216,7 @@ public class PcapWriteHandlerTest {
     }
 
     @Test
-    public void udpLargeByteBufPayload() {
+    public void udpLargeByteBufPayload() throws Exception {
         final ByteBuf pcapBuffer = Unpooled.buffer();
         //Create payload 1 byte larger than maximum
         String payloadString = new String(new char[65507 + 1]).replace('\0', 'X');
@@ -250,7 +247,7 @@ public class PcapWriteHandlerTest {
     }
 
     @Test
-    public void udpLargeDatagramPayload() {
+    public void udpLargeDatagramPayload() throws Exception {
         InetSocketAddress serverAddr = new InetSocketAddress("1.1.1.1", 1234);
         InetSocketAddress clientAddr = new InetSocketAddress("2.2.2.2", 3456);
 
@@ -281,7 +278,7 @@ public class PcapWriteHandlerTest {
     }
 
     @Test
-    public void udpZeroLengthByteBufCaptured() {
+    public void udpZeroLengthByteBufCaptured() throws Exception {
         final ByteBuf pcapBuffer = Unpooled.buffer();
         final ByteBuf payload = Unpooled.buffer();
 
@@ -317,7 +314,7 @@ public class PcapWriteHandlerTest {
     }
 
     @Test
-    public void udpZeroLengthByteBufDiscarded() {
+    public void udpZeroLengthByteBufDiscarded() throws Exception {
         final ByteBuf pcapBuffer = Unpooled.buffer();
         final ByteBuf payload = Unpooled.buffer();
 
@@ -351,7 +348,7 @@ public class PcapWriteHandlerTest {
     }
 
     @Test
-    public void udpZeroLengthDatagramCaptured() {
+    public void udpZeroLengthDatagramCaptured() throws Exception {
         final ByteBuf pcapBuffer = Unpooled.buffer();
         final ByteBuf payload = Unpooled.buffer();
         InetSocketAddress serverAddr = new InetSocketAddress("1.1.1.1", 1234);
@@ -389,7 +386,7 @@ public class PcapWriteHandlerTest {
     }
 
     @Test
-    public void udpZeroLengthDatagramDiscarded() {
+    public void udpZeroLengthDatagramDiscarded() throws Exception {
         final ByteBuf pcapBuffer = Unpooled.buffer();
         final ByteBuf payload = Unpooled.buffer();
         InetSocketAddress serverAddr = new InetSocketAddress("1.1.1.1", 1234);
@@ -425,7 +422,7 @@ public class PcapWriteHandlerTest {
     }
 
     @Test
-    public void udpExceptionCaught() {
+    public void udpExceptionCaught() throws Exception {
         final ByteBuf pcapBuffer = Unpooled.buffer();
         try {
             final RuntimeException exception = new RuntimeException();
@@ -446,8 +443,8 @@ public class PcapWriteHandlerTest {
             assertEquals(24, pcapBuffer.readableBytes());
 
             // Verify thrown exception
-            Throwable cause = assertThrows(CompletionException.class, embeddedChannel::checkException);
-            assertSame(exception, cause.getCause());
+            Exception cause = assertThrows(Exception.class, embeddedChannel::checkException);
+            assertSame(exception, cause);
 
             assertFalse(embeddedChannel.finishAndReleaseAll());
         } finally {
@@ -594,7 +591,7 @@ public class PcapWriteHandlerTest {
     }
 
     @Test
-    public void embeddedTcpClient() {
+    public void embeddedTcpClient() throws Exception {
         final ByteBuf pcapBuffer = Unpooled.buffer();
         //Differing size payloads so that sequence numbers and ack numbers are different
         final ByteBuf readPayload = Unpooled.wrappedBuffer("Read".getBytes());
@@ -645,7 +642,7 @@ public class PcapWriteHandlerTest {
     }
 
     @Test
-    public void embeddedTcpServer() {
+    public void embeddedTcpServer() throws Exception {
         final ByteBuf pcapBuffer = Unpooled.buffer();
         //Differing size payloads so that sequence numbers and ack numbers are different
         final ByteBuf readPayload = Unpooled.wrappedBuffer("Read".getBytes());
@@ -696,7 +693,7 @@ public class PcapWriteHandlerTest {
     }
 
     @Test
-    public void tcpLargePayload() {
+    public void tcpLargePayload() throws Exception {
         final ByteBuf pcapBuffer = Unpooled.buffer();
         String payloadString = new String(new char[65495 + 1]).replace('\0', 'X');
         final ByteBuf payload = Unpooled.wrappedBuffer(payloadString.getBytes());
@@ -737,7 +734,7 @@ public class PcapWriteHandlerTest {
     }
 
     @Test
-    public void tcpZeroByteCaptured() {
+    public void tcpZeroByteCaptured() throws Exception {
         final ByteBuf pcapBuffer = Unpooled.buffer();
         final ByteBuf payload = Unpooled.buffer();
 
@@ -785,7 +782,7 @@ public class PcapWriteHandlerTest {
     }
 
     @Test
-    public void tcpZeroByteDiscarded() {
+    public void tcpZeroByteDiscarded() throws Exception {
         final ByteBuf pcapBuffer = Unpooled.buffer();
         final ByteBuf payload = Unpooled.buffer();
 
@@ -823,7 +820,7 @@ public class PcapWriteHandlerTest {
     }
 
     @Test
-    public void tcpExceptionCaught() {
+    public void tcpExceptionCaught() throws Exception {
         final ByteBuf pcapBuffer = Unpooled.buffer();
         final RuntimeException exception = new RuntimeException();
 
@@ -865,16 +862,15 @@ public class PcapWriteHandlerTest {
         assertEquals(0, tcpPacket.readUnsignedShort()); // Urgent Pointer
 
         // Verify thrown exception
-        // Verify thrown exception
-        Throwable cause = assertThrows(CompletionException.class, embeddedChannel::checkException);
-        assertSame(exception, cause.getCause());
+        Exception cause = assertThrows(Exception.class, embeddedChannel::checkException);
+        assertSame(exception, cause);
         pcapBuffer.release();
 
         assertFalse(embeddedChannel.finishAndReleaseAll());
     }
 
     @Test
-    public void writePcapGreaterThan4Gb() {
+    public void writePcapGreaterThan4Gb() throws Exception {
         InetSocketAddress serverAddr = new InetSocketAddress("1.1.1.1", 1234);
         InetSocketAddress clientAddr = new InetSocketAddress("2.2.2.2", 3456);
 

--- a/handler/src/test/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandlerTest.java
@@ -23,13 +23,10 @@ import io.netty.channel.ChannelShutdownType;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.DecoderException;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLHandshakeException;
-import java.security.NoSuchAlgorithmException;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -37,7 +34,6 @@ import static io.netty.handler.ssl.CloseNotifyTest.assertCloseNotify;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -46,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class ApplicationProtocolNegotiationHandlerTest {
 
     @Test
-    public void testRemoveItselfIfNoSslHandlerPresent() throws NoSuchAlgorithmException {
+    public void testRemoveItselfIfNoSslHandlerPresent() throws Exception {
         ChannelHandler alpnHandler = new ApplicationProtocolNegotiationHandler(ApplicationProtocolNames.HTTP_1_1) {
             @Override
             protected void configurePipeline(ChannelHandlerContext ctx, String protocol) {
@@ -73,7 +69,7 @@ public class ApplicationProtocolNegotiationHandlerTest {
     }
 
     @Test
-    public void testHandshakeFailure() {
+    public void testHandshakeFailure() throws Exception {
         ChannelHandler alpnHandler = new ApplicationProtocolNegotiationHandler(ApplicationProtocolNames.HTTP_1_1) {
             @Override
             protected void configurePipeline(ChannelHandlerContext ctx, String protocol) {
@@ -91,16 +87,16 @@ public class ApplicationProtocolNegotiationHandlerTest {
     }
 
     @Test
-    public void testHandshakeSuccess() throws NoSuchAlgorithmException {
+    public void testHandshakeSuccess() throws Exception {
         testHandshakeSuccess0(false);
     }
 
     @Test
-    public void testHandshakeSuccessWithSslHandlerAddedLater() throws NoSuchAlgorithmException {
+    public void testHandshakeSuccessWithSslHandlerAddedLater() throws Exception {
         testHandshakeSuccess0(true);
     }
 
-    private static void testHandshakeSuccess0(boolean addLater) throws NoSuchAlgorithmException {
+    private static void testHandshakeSuccess0(boolean addLater) throws Exception {
         final AtomicBoolean configureCalled = new AtomicBoolean(false);
         ChannelHandler alpnHandler = new ApplicationProtocolNegotiationHandler(ApplicationProtocolNames.HTTP_1_1) {
             @Override
@@ -144,13 +140,7 @@ public class ApplicationProtocolNegotiationHandlerTest {
         final EmbeddedChannel channel = new EmbeddedChannel(alpnHandler);
         channel.pipeline().fireUserEventTriggered(SslHandshakeCompletionEvent.SUCCESS);
         assertNull(channel.pipeline().context(alpnHandler));
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                channel.finishAndReleaseAll();
-            }
-        });
-        assertInstanceOf(IllegalStateException.class, cause.getCause());
+        assertThrows(IllegalStateException.class, channel::finishAndReleaseAll);
     }
 
     @Test

--- a/handler/src/test/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandlerTest.java
@@ -29,6 +29,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLHandshakeException;
 import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -36,6 +37,7 @@ import static io.netty.handler.ssl.CloseNotifyTest.assertCloseNotify;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -142,12 +144,13 @@ public class ApplicationProtocolNegotiationHandlerTest {
         final EmbeddedChannel channel = new EmbeddedChannel(alpnHandler);
         channel.pipeline().fireUserEventTriggered(SslHandshakeCompletionEvent.SUCCESS);
         assertNull(channel.pipeline().context(alpnHandler));
-        assertThrows(IllegalStateException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
                 channel.finishAndReleaseAll();
             }
         });
+        assertInstanceOf(IllegalStateException.class, cause.getCause());
     }
 
     @Test

--- a/handler/src/test/java/io/netty/handler/ssl/CloseNotifyTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/CloseNotifyTest.java
@@ -183,14 +183,14 @@ public class CloseNotifyTest {
         );
     }
 
-    private static void forwardData(EmbeddedChannel from, EmbeddedChannel to) {
+    private static void forwardData(EmbeddedChannel from, EmbeddedChannel to) throws Exception {
         ByteBuf in;
         while ((in = from.readOutbound()) != null) {
             to.writeInbound(in);
         }
     }
 
-    private static void forwardAllWithCloseNotify(EmbeddedChannel from, EmbeddedChannel to) {
+    private static void forwardAllWithCloseNotify(EmbeddedChannel from, EmbeddedChannel to) throws Exception {
         ByteBuf cumulation = EMPTY_BUFFER;
         ByteBuf in, closeNotify = null;
         while ((in = from.readOutbound()) != null) {

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslCertificateCompressionTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslCertificateCompressionTest.java
@@ -42,8 +42,10 @@ import org.junit.jupiter.api.function.Executable;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -183,12 +185,13 @@ public class OpenSslCertificateCompressionTest {
                         .build()
         );
 
-        Assertions.assertThrows(SSLHandshakeException.class, new Executable() {
+        Throwable cause = Assertions.assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
                 runCertCompressionTest(clientSslContext, serverSslContext);
             }
         });
+        assertInstanceOf(SSLHandshakeException.class, cause.getCause());
     }
 
     @Test
@@ -212,12 +215,13 @@ public class OpenSslCertificateCompressionTest {
                         .build()
         );
 
-        Assertions.assertThrows(SSLHandshakeException.class, new Executable() {
+        Throwable cause = Assertions.assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
                 runCertCompressionTest(clientSslContext, serverSslContext);
             }
         });
+        assertInstanceOf(SSLHandshakeException.class, cause.getCause());
     }
 
     @Test

--- a/handler/src/test/java/io/netty/handler/ssl/SniClientTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniClientTest.java
@@ -40,12 +40,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.TrustManagerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -80,12 +82,13 @@ public class SniClientTest {
     @MethodSource("parameters")
     public void testSniSNIMatcherDoesNotMatchClient(
             final SslProvider serverProvider, final SslProvider clientProvider) {
-        assertThrows(SSLException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
                 SniClientJava8TestUtil.testSniClient(serverProvider, clientProvider, false);
             }
         });
+        assertInstanceOf(SSLException.class, cause.getCause());
     }
 
     @ParameterizedTest(name = PARAMETERIZED_NAME)

--- a/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -169,12 +170,12 @@ public class SniHandlerTest {
                 final byte[] bytes = new byte[1024];
                 bytes[0] = SslUtils.SSL_CONTENT_TYPE_ALERT;
 
-                DecoderException e = assertThrows(DecoderException.class, new Executable() {
+                DecoderException e = (DecoderException) assertThrows(CompletionException.class, new Executable() {
                     @Override
                     public void execute() throws Throwable {
                         ch.writeInbound(Unpooled.wrappedBuffer(bytes));
                     }
-                });
+                }).getCause();
                 assertInstanceOf(NotSslRecordException.class, e.getCause());
                 assertFalse(ch.finish());
             } finally {
@@ -286,12 +287,13 @@ public class SniHandlerTest {
                 // that isn't ASCII as per RFC 6066 - https://tools.ietf.org/html/rfc6066#page-6
                 ch.writeInbound(Unpooled.wrappedBuffer(StringUtil.decodeHexDump(tlsHandshakeMessageHex1)));
 
-                assertThrows(DecoderException.class, new Executable() {
+                Throwable cause = assertThrows(CompletionException.class, new Executable() {
                     @Override
                     public void execute() throws Throwable {
                         ch.writeInbound(Unpooled.wrappedBuffer(StringUtil.decodeHexDump(tlsHandshakeMessageHex)));
                     }
                 });
+                assertInstanceOf(DecoderException.class, cause.getCause());
             } finally {
                 ch.finishAndReleaseAll();
             }
@@ -739,12 +741,13 @@ public class SniHandlerTest {
         buffer.writeMedium(0xFFFFFF); // Length
         buffer.writeShort((short) 0x0303); // TLS 1.2
 
-        assertThrows(TooLongFrameException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
                 ch.writeInbound(buffer);
             }
         });
+        assertInstanceOf(TooLongFrameException.class, cause.getCause());
         try {
             while (completionEventRef.get() == null) {
                 Thread.sleep(100);

--- a/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
@@ -20,14 +20,12 @@ import java.io.File;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLException;
 
 import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
@@ -67,7 +65,6 @@ import io.netty.util.internal.ResourcesUtil;
 import io.netty.util.internal.StringUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -170,12 +167,8 @@ public class SniHandlerTest {
                 final byte[] bytes = new byte[1024];
                 bytes[0] = SslUtils.SSL_CONTENT_TYPE_ALERT;
 
-                DecoderException e = (DecoderException) assertThrows(CompletionException.class, new Executable() {
-                    @Override
-                    public void execute() throws Throwable {
-                        ch.writeInbound(Unpooled.wrappedBuffer(bytes));
-                    }
-                }).getCause();
+                DecoderException e = assertThrows(DecoderException.class,
+                        () -> ch.writeInbound(Unpooled.wrappedBuffer(bytes)));
                 assertInstanceOf(NotSslRecordException.class, e.getCause());
                 assertFalse(ch.finish());
             } finally {
@@ -287,13 +280,8 @@ public class SniHandlerTest {
                 // that isn't ASCII as per RFC 6066 - https://tools.ietf.org/html/rfc6066#page-6
                 ch.writeInbound(Unpooled.wrappedBuffer(StringUtil.decodeHexDump(tlsHandshakeMessageHex1)));
 
-                Throwable cause = assertThrows(CompletionException.class, new Executable() {
-                    @Override
-                    public void execute() throws Throwable {
-                        ch.writeInbound(Unpooled.wrappedBuffer(StringUtil.decodeHexDump(tlsHandshakeMessageHex)));
-                    }
-                });
-                assertInstanceOf(DecoderException.class, cause.getCause());
+                assertThrows(DecoderException.class, () -> ch.writeInbound(
+                        Unpooled.wrappedBuffer(StringUtil.decodeHexDump(tlsHandshakeMessageHex))));
             } finally {
                 ch.finishAndReleaseAll();
             }
@@ -674,7 +662,7 @@ public class SniHandlerTest {
     }
 
     private static List<ByteBuf> clientHelloInMultipleFragments(
-            SslProvider provider, String hostname, int maxTlsPlaintextSize) throws SSLException {
+            SslProvider provider, String hostname, int maxTlsPlaintextSize) throws Exception {
         final EmbeddedChannel client = new EmbeddedChannel();
         final SslContext ctx = SslContextBuilder.forClient()
                 .sslProvider(provider)
@@ -741,13 +729,7 @@ public class SniHandlerTest {
         buffer.writeMedium(0xFFFFFF); // Length
         buffer.writeShort((short) 0x0303); // TLS 1.2
 
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                ch.writeInbound(buffer);
-            }
-        });
-        assertInstanceOf(TooLongFrameException.class, cause.getCause());
+        assertThrows(TooLongFrameException.class, () -> ch.writeInbound(buffer));
         try {
             while (completionEventRef.get() == null) {
                 Thread.sleep(100);

--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -1679,7 +1679,7 @@ public class SslHandlerTest {
         buf.writeByte(0xfe);
         buf.writeByte(0x87);
         buf.writeByte(0x2);
-        DecoderException e = (DecoderException) assertThrows(DecoderException.class, () -> channel.writeInbound(buf));
+        DecoderException e = assertThrows(DecoderException.class, () -> channel.writeInbound(buf));
         assertInstanceOf(NotSslRecordException.class, e.getCause());
         assertTrue(channel.finishAndReleaseAll());
     }

--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -79,6 +79,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -208,23 +209,25 @@ public class SslHandlerTest {
     @Test
     @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
     public void testClientHandshakeTimeout() throws Exception {
-        assertThrows(SslHandshakeTimeoutException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
                 testHandshakeTimeout(true);
             }
         });
+        assertInstanceOf(SslHandshakeTimeoutException.class, cause.getCause());
     }
 
     @Test
     @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
     public void testServerHandshakeTimeout() throws Exception {
-        assertThrows(SslHandshakeTimeoutException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
                 testHandshakeTimeout(false);
             }
         });
+        assertInstanceOf(SslHandshakeTimeoutException.class, cause.getCause());
     }
 
     private static SSLEngine newServerModeSSLEngine() throws NoSuchAlgorithmException {
@@ -316,13 +319,14 @@ public class SslHandlerTest {
         // Should decode nothing yet.
         assertNull(ch.readInbound());
 
-        DecoderException e = assertThrows(DecoderException.class, new Executable() {
+        DecoderException e = (DecoderException) assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
                 // Push the second part of the 5-byte handshake message.
                 ch.writeInbound(wrappedBuffer(new byte[]{2, 0, 0, 1, 0}));
             }
-        });
+        }).getCause();
+
         // Be sure we cleanup the channel and release any pending messages that may have been generated because
         // of an alert.
         // See https://github.com/netty/netty/issues/6057.
@@ -364,12 +368,13 @@ public class SslHandlerTest {
         SSLEngine engine = newServerModeSSLEngine();
         final EmbeddedChannel ch = new EmbeddedChannel(new SslHandler(engine));
 
-        assertThrows(UnsupportedMessageTypeException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
                 ch.writeOutbound(new Object());
             }
         });
+        assertInstanceOf(UnsupportedMessageTypeException.class, cause.getCause());
         ch.finishAndReleaseAll();
     }
 
@@ -1693,12 +1698,12 @@ public class SslHandlerTest {
         buf.writeByte(0xfe);
         buf.writeByte(0x87);
         buf.writeByte(0x2);
-        DecoderException e = assertThrows(DecoderException.class, new Executable() {
+        DecoderException e = (DecoderException) assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 channel.writeInbound(buf);
             }
-        });
+        }).getCause();
         assertInstanceOf(NotSslRecordException.class, e.getCause());
         assertTrue(channel.finishAndReleaseAll());
     }

--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -79,6 +79,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -207,14 +208,16 @@ public class SslHandlerTest {
 
     @Test
     @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
-    public void testClientHandshakeTimeout() throws Exception {
-        assertThrows(SslHandshakeTimeoutException.class, () -> testHandshakeTimeout(true));
+    public void testClientHandshakeTimeout() {
+        CompletionException e = assertThrows(CompletionException.class, () -> testHandshakeTimeout(true));
+        assertInstanceOf(SslHandshakeTimeoutException.class, e.getCause());
     }
 
     @Test
     @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
-    public void testServerHandshakeTimeout() throws Exception {
-        assertThrows(SslHandshakeTimeoutException.class, () -> testHandshakeTimeout(false));
+    public void testServerHandshakeTimeout() {
+        CompletionException e = assertThrows(CompletionException.class, () -> testHandshakeTimeout(false));
+        assertInstanceOf(SslHandshakeTimeoutException.class, e.getCause());
     }
 
     private static SSLEngine newServerModeSSLEngine() throws NoSuchAlgorithmException {

--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -79,7 +79,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -115,7 +114,7 @@ public class SslHandlerTest {
 
     @Test
     @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
-    public void testNonApplicationDataFailureFailsQueuedWrites() throws NoSuchAlgorithmException, InterruptedException {
+    public void testNonApplicationDataFailureFailsQueuedWrites() throws Exception {
         final CountDownLatch writeLatch = new CountDownLatch(1);
         final Queue<CompletionHandler<Void>> writesToFail = new ConcurrentLinkedQueue<>();
         SSLEngine engine = newClientModeSSLEngine();
@@ -209,25 +208,13 @@ public class SslHandlerTest {
     @Test
     @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
     public void testClientHandshakeTimeout() throws Exception {
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                testHandshakeTimeout(true);
-            }
-        });
-        assertInstanceOf(SslHandshakeTimeoutException.class, cause.getCause());
+        assertThrows(SslHandshakeTimeoutException.class, () -> testHandshakeTimeout(true));
     }
 
     @Test
     @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
     public void testServerHandshakeTimeout() throws Exception {
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                testHandshakeTimeout(false);
-            }
-        });
-        assertInstanceOf(SslHandshakeTimeoutException.class, cause.getCause());
+        assertThrows(SslHandshakeTimeoutException.class, () -> testHandshakeTimeout(false));
     }
 
     private static SSLEngine newServerModeSSLEngine() throws NoSuchAlgorithmException {
@@ -319,13 +306,10 @@ public class SslHandlerTest {
         // Should decode nothing yet.
         assertNull(ch.readInbound());
 
-        DecoderException e = (DecoderException) assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                // Push the second part of the 5-byte handshake message.
-                ch.writeInbound(wrappedBuffer(new byte[]{2, 0, 0, 1, 0}));
-            }
-        }).getCause();
+        DecoderException e = assertThrows(DecoderException.class, () -> {
+            // Push the second part of the 5-byte handshake message.
+            ch.writeInbound(wrappedBuffer(new byte[]{2, 0, 0, 1, 0}));
+        });
 
         // Be sure we cleanup the channel and release any pending messages that may have been generated because
         // of an alert.
@@ -368,18 +352,12 @@ public class SslHandlerTest {
         SSLEngine engine = newServerModeSSLEngine();
         final EmbeddedChannel ch = new EmbeddedChannel(new SslHandler(engine));
 
-        Throwable cause = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                ch.writeOutbound(new Object());
-            }
-        });
-        assertInstanceOf(UnsupportedMessageTypeException.class, cause.getCause());
+        assertThrows(UnsupportedMessageTypeException.class, () -> ch.writeOutbound(new Object()));
         ch.finishAndReleaseAll();
     }
 
     @Test
-    public void testIncompleteWriteDoesNotCompletePromisePrematurely() throws NoSuchAlgorithmException {
+    public void testIncompleteWriteDoesNotCompletePromisePrematurely() throws Exception {
         SSLEngine engine = newServerModeSSLEngine();
         EmbeddedChannel ch = new EmbeddedChannel(new SslHandler(engine));
 
@@ -1684,7 +1662,7 @@ public class SslHandlerTest {
     }
 
     @Test
-    public void testIncorrectLength() throws SSLException {
+    public void testIncorrectLength() throws Exception {
         final SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
         final EmbeddedChannel channel = new EmbeddedChannel();
         channel.pipeline().addLast(
@@ -1698,12 +1676,7 @@ public class SslHandlerTest {
         buf.writeByte(0xfe);
         buf.writeByte(0x87);
         buf.writeByte(0x2);
-        DecoderException e = (DecoderException) assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() {
-                channel.writeInbound(buf);
-            }
-        }).getCause();
+        DecoderException e = (DecoderException) assertThrows(DecoderException.class, () -> channel.writeInbound(buf));
         assertInstanceOf(NotSslRecordException.class, e.getCause());
         assertTrue(channel.finishAndReleaseAll());
     }

--- a/handler/src/test/java/io/netty/handler/stream/ChunkedWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/stream/ChunkedWriteHandlerTest.java
@@ -38,6 +38,7 @@ import java.io.RandomAccessFile;
 import java.nio.channels.Channels;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.FileChannel;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -494,13 +495,13 @@ public class ChunkedWriteHandlerTest {
         final ThrowingChunkedInput input = new ThrowingChunkedInput(error);
         final EmbeddedChannel ch = new EmbeddedChannel(new ChunkedWriteHandler());
 
-        Exception e = assertThrows(Exception.class, new Executable() {
+        Exception e = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
                 ch.writeOutbound(input);
             }
         });
-        assertEquals(error, e);
+        assertEquals(error, e.getCause());
 
         assertTrue(input.isClosed());
         assertFalse(ch.finish());

--- a/handler/src/test/java/io/netty/handler/stream/ChunkedWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/stream/ChunkedWriteHandlerTest.java
@@ -38,7 +38,6 @@ import java.io.RandomAccessFile;
 import java.nio.channels.Channels;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.FileChannel;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -73,7 +72,7 @@ public class ChunkedWriteHandlerTest {
 
     // See #310
     @Test
-    public void testChunkedStream() {
+    public void testChunkedStream() throws Exception {
         check(new ChunkedStream(new ByteArrayInputStream(BYTES)));
 
         check(new ChunkedStream(new ByteArrayInputStream(BYTES)),
@@ -82,7 +81,7 @@ public class ChunkedWriteHandlerTest {
     }
 
     @Test
-    public void testChunkedNioStream() {
+    public void testChunkedNioStream() throws Exception {
         check(new ChunkedNioStream(Channels.newChannel(new ByteArrayInputStream(BYTES))));
 
         check(new ChunkedNioStream(Channels.newChannel(new ByteArrayInputStream(BYTES))),
@@ -91,21 +90,21 @@ public class ChunkedWriteHandlerTest {
     }
 
     @Test
-    public void testChunkedFile() throws IOException {
+    public void testChunkedFile() throws Exception {
         check(new ChunkedFile(TMP));
 
         check(new ChunkedFile(TMP), new ChunkedFile(TMP), new ChunkedFile(TMP));
     }
 
     @Test
-    public void testChunkedNioFile() throws IOException {
+    public void testChunkedNioFile() throws Exception {
         check(new ChunkedNioFile(TMP));
 
         check(new ChunkedNioFile(TMP), new ChunkedNioFile(TMP), new ChunkedNioFile(TMP));
     }
 
     @Test
-    public void testChunkedNioFileLeftPositionUnchanged() throws IOException {
+    public void testChunkedNioFileLeftPositionUnchanged() throws Exception {
         FileChannel in = null;
         final long expectedPosition = 10;
         try {
@@ -145,7 +144,7 @@ public class ChunkedWriteHandlerTest {
     }
 
     @Test
-    public void testUnchunkedData() throws IOException {
+    public void testUnchunkedData() throws Exception {
         check(Unpooled.wrappedBuffer(BYTES));
 
         check(Unpooled.wrappedBuffer(BYTES), Unpooled.wrappedBuffer(BYTES), Unpooled.wrappedBuffer(BYTES));
@@ -154,7 +153,7 @@ public class ChunkedWriteHandlerTest {
     // Test case which shows that there is not a bug like stated here:
     // https://stackoverflow.com/a/10426305
     @Test
-    public void testListenerNotifiedWhenIsEnd() {
+    public void testListenerNotifiedWhenIsEnd() throws Exception {
         ByteBuf buffer = Unpooled.copiedBuffer("Test", CharsetUtil.ISO_8859_1);
 
         ChunkedInput<ByteBuf> input = new ChunkedInput<ByteBuf>() {
@@ -216,7 +215,7 @@ public class ChunkedWriteHandlerTest {
     }
 
     @Test
-    public void testChunkedMessageInput() {
+    public void testChunkedMessageInput() throws Exception {
 
         ChunkedInput<Object> input = new ChunkedInput<Object>() {
             private boolean done;
@@ -266,55 +265,55 @@ public class ChunkedWriteHandlerTest {
     }
 
     @Test
-    public void testWriteFailureChunkedStream() throws IOException {
+    public void testWriteFailureChunkedStream() throws Exception {
         checkFirstFailed(new ChunkedStream(new ByteArrayInputStream(BYTES)));
     }
 
     @Test
-    public void testWriteFailureChunkedNioStream() throws IOException {
+    public void testWriteFailureChunkedNioStream() throws Exception {
         checkFirstFailed(new ChunkedNioStream(Channels.newChannel(new ByteArrayInputStream(BYTES))));
     }
 
     @Test
-    public void testWriteFailureChunkedFile() throws IOException {
+    public void testWriteFailureChunkedFile() throws Exception {
         checkFirstFailed(new ChunkedFile(TMP));
     }
 
     @Test
-    public void testWriteFailureChunkedNioFile() throws IOException {
+    public void testWriteFailureChunkedNioFile() throws Exception {
         checkFirstFailed(new ChunkedNioFile(TMP));
     }
 
     @Test
-    public void testWriteFailureUnchunkedData() throws IOException {
+    public void testWriteFailureUnchunkedData() throws Exception {
         checkFirstFailed(Unpooled.wrappedBuffer(BYTES));
     }
 
     @Test
-    public void testSkipAfterFailedChunkedStream() throws IOException {
+    public void testSkipAfterFailedChunkedStream() throws Exception {
         checkSkipFailed(new ChunkedStream(new ByteArrayInputStream(BYTES)),
                         new ChunkedStream(new ByteArrayInputStream(BYTES)));
     }
 
     @Test
-    public void testSkipAfterFailedChunkedNioStream() throws IOException {
+    public void testSkipAfterFailedChunkedNioStream() throws Exception {
         checkSkipFailed(new ChunkedNioStream(Channels.newChannel(new ByteArrayInputStream(BYTES))),
                         new ChunkedNioStream(Channels.newChannel(new ByteArrayInputStream(BYTES))));
     }
 
     @Test
-    public void testSkipAfterFailedChunkedFile() throws IOException {
+    public void testSkipAfterFailedChunkedFile() throws Exception {
         checkSkipFailed(new ChunkedFile(TMP), new ChunkedFile(TMP));
     }
 
     @Test
-    public void testSkipAfterFailedChunkedNioFile() throws IOException {
+    public void testSkipAfterFailedChunkedNioFile() throws Exception {
         checkSkipFailed(new ChunkedNioFile(TMP), new ChunkedFile(TMP));
     }
 
     // See https://github.com/netty/netty/issues/8700.
     @Test
-    public void testFailureWhenLastChunkFailed() throws IOException {
+    public void testFailureWhenLastChunkFailed() throws Exception {
         ChannelOutboundHandler failLast = new ChannelOutboundHandler() {
             private int passedWrites;
 
@@ -351,7 +350,7 @@ public class ChunkedWriteHandlerTest {
     }
 
     @Test
-    public void testDiscardPendingWritesOnInactive() throws IOException {
+    public void testDiscardPendingWritesOnInactive() throws Exception {
 
         final AtomicBoolean closeWasCalled = new AtomicBoolean(false);
 
@@ -413,7 +412,7 @@ public class ChunkedWriteHandlerTest {
 
     // See https://github.com/netty/netty/issues/8700.
     @Test
-    public void testStopConsumingChunksWhenFailed() {
+    public void testStopConsumingChunksWhenFailed() throws Exception {
         final ByteBuf buffer = Unpooled.copiedBuffer("Test", CharsetUtil.ISO_8859_1);
         final AtomicInteger chunks = new AtomicInteger(0);
 
@@ -472,7 +471,7 @@ public class ChunkedWriteHandlerTest {
     }
 
     @Test
-    public void testCloseSuccessfulChunkedInput() {
+    public void testCloseSuccessfulChunkedInput() throws Exception {
         int chunks = 10;
         TestChunkedInput input = new TestChunkedInput(chunks);
         EmbeddedChannel ch = new EmbeddedChannel(new ChunkedWriteHandler());
@@ -490,18 +489,13 @@ public class ChunkedWriteHandlerTest {
     }
 
     @Test
-    public void testCloseFailedChunkedInput() {
+    public void testCloseFailedChunkedInput() throws Exception {
         Exception error = new Exception("Unable to produce a chunk");
         final ThrowingChunkedInput input = new ThrowingChunkedInput(error);
         final EmbeddedChannel ch = new EmbeddedChannel(new ChunkedWriteHandler());
 
-        Exception e = assertThrows(CompletionException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                ch.writeOutbound(input);
-            }
-        });
-        assertEquals(error, e.getCause());
+        Exception e = assertThrows(Exception.class, () -> ch.writeOutbound(input));
+        assertEquals(error, e);
 
         assertTrue(input.isClosed());
         assertFalse(ch.finish());
@@ -573,7 +567,7 @@ public class ChunkedWriteHandlerTest {
     }
 
     @Test
-    public void testEndOfInputWhenChannelIsClosedwhenWrite() {
+    public void testEndOfInputWhenChannelIsClosedwhenWrite() throws Exception {
         ChunkedInput<ByteBuf> input = new ChunkedInput<ByteBuf>() {
 
             @Override
@@ -644,7 +638,7 @@ public class ChunkedWriteHandlerTest {
         assertFalse(ch.finish());
     }
 
-    private static void check(Object... inputs) {
+    private static void check(Object... inputs) throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new ChunkedWriteHandler());
 
         for (Object input: inputs) {
@@ -673,7 +667,7 @@ public class ChunkedWriteHandlerTest {
         assertEquals(BYTES.length * inputs.length, read);
     }
 
-    private static void checkFirstFailed(Object input) {
+    private static void checkFirstFailed(Object input) throws Exception {
         ChannelOutboundHandler noOpWrites = new ChannelOutboundHandler() {
             @Override
             public void write(ChannelHandlerContext ctx, Object msg, CompletionHandler<Void> handler) {
@@ -690,7 +684,7 @@ public class ChunkedWriteHandlerTest {
         assertTrue(r.cause() instanceof RuntimeException);
     }
 
-    private static void checkSkipFailed(Object input1, Object input2) {
+    private static void checkSkipFailed(Object input1, Object input2) throws Exception {
         ChannelOutboundHandler failFirst = new ChannelOutboundHandler() {
             private boolean alreadyFailed;
 

--- a/microbench/src/main/java/io/netty/microbench/http/HttpFragmentedRequestDecoderBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/http/HttpFragmentedRequestDecoderBenchmark.java
@@ -110,7 +110,7 @@ public class HttpFragmentedRequestDecoderBenchmark extends AbstractMicrobenchmar
 
     @Benchmark
     @CompilerControl(Mode.DONT_INLINE)
-    public void testDecodeWholeRequestInMultipleStepsMixedDelimiters() {
+    public void testDecodeWholeRequestInMultipleStepsMixedDelimiters() throws Exception {
         final EmbeddedChannel channel = this.channel;
         for (ByteBuf buf : this.fragmentedRequest) {
             buf.resetReaderIndex();

--- a/microbench/src/main/java/io/netty/microbench/http/HttpPipelinedRequestDecoderBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/http/HttpPipelinedRequestDecoderBenchmark.java
@@ -89,7 +89,7 @@ public class HttpPipelinedRequestDecoderBenchmark extends AbstractMicrobenchmark
 
     @Benchmark
     @CompilerControl(Mode.DONT_INLINE)
-    public void testDecodeWholePipelinedRequestMixedDelimiters() {
+    public void testDecodeWholePipelinedRequestMixedDelimiters() throws Exception {
         final EmbeddedChannel channel = this.channel;
         final ByteBuf batch = this.pipelinedRequest;
         final int refCnt = batch.refCnt();

--- a/microbench/src/main/java/io/netty/microbench/http/HttpRequestResponseBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/http/HttpRequestResponseBenchmark.java
@@ -267,7 +267,7 @@ public class HttpRequestResponseBenchmark extends AbstractMicrobenchmark {
     }
 
     @Benchmark
-    public Object netty() {
+    public Object netty() throws Exception {
         GET.setIndex(readerIndex, writeIndex);
         nettyChannel.writeInbound(GET);
         return nettyChannel.outboundMessages().poll();

--- a/microbench/src/main/java/io/netty/microbench/websocket/WebSocketFrame08DecoderBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/websocket/WebSocketFrame08DecoderBenchmark.java
@@ -65,7 +65,7 @@ public class WebSocketFrame08DecoderBenchmark extends AbstractMicrobenchmark {
     public boolean masking;
 
     @Setup(Level.Trial)
-    public void setUp() {
+    public void setUp() throws Exception {
         byte[] bytes = new byte[contentLength];
         ThreadLocalRandom.current().nextBytes(bytes);
         ByteBufAllocator allocator = pooledAllocator? PooledByteBufAllocator.DEFAULT : UnpooledByteBufAllocator.DEFAULT;

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -100,7 +100,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Queue;
 import java.util.Set;
-import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -772,30 +772,28 @@ public class DnsNameResolverTest {
     }
 
     private static UnknownHostException resolveNonExistentDomain(DnsNameResolver resolver) {
-        try {
-            resolver.resolve("non-existent.netty.io").sync();
-            fail();
-            return null;
-        } catch (Exception e) {
-            assertInstanceOf(UnknownHostException.class, e);
 
-            TestRecursiveCacheDnsQueryLifecycleObserverFactory lifecycleObserverFactory =
-                    (TestRecursiveCacheDnsQueryLifecycleObserverFactory) resolver.dnsQueryLifecycleObserverFactory();
-            TestDnsQueryLifecycleObserver observer = lifecycleObserverFactory.observers.poll();
-            if (observer != null) {
-                Object o = observer.events.poll();
-                if (o instanceof QueryCancelledEvent) {
-                    assertTrue(observer.question.type() == CNAME || observer.question.type() == AAAA,
+        Throwable cause = assertThrows(CompletionException.class,
+                () -> resolver.resolve("non-existent.netty.io").sync());
+
+        UnknownHostException e = assertInstanceOf(UnknownHostException.class, cause.getCause());
+
+        TestRecursiveCacheDnsQueryLifecycleObserverFactory lifecycleObserverFactory =
+                (TestRecursiveCacheDnsQueryLifecycleObserverFactory) resolver.dnsQueryLifecycleObserverFactory();
+        TestDnsQueryLifecycleObserver observer = lifecycleObserverFactory.observers.poll();
+        if (observer != null) {
+            Object o = observer.events.poll();
+            if (o instanceof QueryCancelledEvent) {
+                assertTrue(observer.question.type() == CNAME || observer.question.type() == AAAA,
                         "unexpected type: " + observer.question);
-                } else if (o instanceof QueryWrittenEvent) {
-                    QueryFailedEvent failedEvent = (QueryFailedEvent) observer.events.poll();
-                } else if (!(o instanceof QueryFailedEvent)) {
-                    fail("unexpected event type: " + o);
-                }
-                assertTrue(observer.events.isEmpty());
+            } else if (o instanceof QueryWrittenEvent) {
+                QueryFailedEvent failedEvent = (QueryFailedEvent) observer.events.poll();
+            } else if (!(o instanceof QueryFailedEvent)) {
+                fail("unexpected event type: " + o);
             }
-            return (UnknownHostException) e;
+            assertTrue(observer.events.isEmpty());
         }
+        return e;
     }
 
     @ParameterizedTest

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -2020,12 +2020,13 @@ public class DnsNameResolverTest {
     @ParameterizedTest
     @EnumSource(DnsNameResolverChannelStrategy.class)
     public void testRRNameContainsDifferentSearchDomainNoDomains(final DnsNameResolverChannelStrategy strategy) {
-        assertThrows(UnknownHostException.class, new Executable() {
+        CompletionException e = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
                 testRRNameContainsDifferentSearchDomain(strategy, Collections.<String>emptyList(), "netty");
             }
         });
+        assertInstanceOf(UnknownHostException.class, e.getCause());
     }
 
     @ParameterizedTest
@@ -2724,24 +2725,18 @@ public class DnsNameResolverTest {
     @EnumSource(DnsNameResolverChannelStrategy.class)
     public void testSearchDomainQueryFailureForSingleAddressTypeCompletes(
             final DnsNameResolverChannelStrategy strategy) {
-        assertThrows(UnknownHostException.class, new Executable() {
-            @Override
-            public void execute() {
-                testSearchDomainQueryFailureCompletes(strategy, ResolvedAddressTypes.IPV4_ONLY);
-            }
-        });
+        CompletionException e = assertThrows(CompletionException.class,
+                () -> testSearchDomainQueryFailureCompletes(strategy, ResolvedAddressTypes.IPV4_ONLY));
+        assertInstanceOf(UnknownHostException.class, e.getCause());
     }
 
     @ParameterizedTest
     @EnumSource(DnsNameResolverChannelStrategy.class)
     public void testSearchDomainQueryFailureForMultipleAddressTypeCompletes(
             final DnsNameResolverChannelStrategy strategy) {
-        assertThrows(UnknownHostException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                testSearchDomainQueryFailureCompletes(strategy, ResolvedAddressTypes.IPV4_PREFERRED);
-            }
-        });
+        CompletionException e = assertThrows(CompletionException.class,
+                () -> testSearchDomainQueryFailureCompletes(strategy, ResolvedAddressTypes.IPV4_PREFERRED));
+        assertInstanceOf(UnknownHostException.class, e.getCause());
     }
 
     private void testSearchDomainQueryFailureCompletes(
@@ -4180,13 +4175,10 @@ public class DnsNameResolverTest {
                 final DnsNameResolver resolver = newResolver(strategy)
                         .localAddress(datagramSocket.getLocalSocketAddress()).build();
                 try {
-                    Throwable cause = assertThrows(UnknownHostException.class, new Executable() {
-                        @Override
-                        public void execute() throws Throwable {
-                            resolver.resolve("netty.io").sync();
-                        }
-                    });
-                    assertInstanceOf(BindException.class, cause.getCause());
+                    Throwable cause = assertThrows(CompletionException.class,
+                            () -> resolver.resolve("netty.io").sync());
+                    assertInstanceOf(UnknownHostException.class, cause.getCause());
+                    assertInstanceOf(BindException.class, cause.getCause().getCause());
                 } finally {
                     resolver.close();
                 }

--- a/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/CodecCompressionTest.java
+++ b/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/CodecCompressionTest.java
@@ -31,16 +31,16 @@ import static org.junit.jupiter.api.Assertions.*;
 public class CodecCompressionTest {
 
     @Test
-    public void testBrotli4j() {
+    public void testBrotli4j() throws Exception {
         testCompress(new BrotliEncoder());
     }
 
     @Test
-    public void testZstd() {
+    public void testZstd() throws Exception {
         testCompress(new ZstdEncoder());
     }
 
-    public void testCompress(MessageToByteEncoder<ByteBuf> encoder) {
+    public void testCompress(MessageToByteEncoder<ByteBuf> encoder) throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(encoder);
         ByteBuf data = Unpooled.copiedBuffer("some-string", StandardCharsets.UTF_8);
         assertTrue(channel.writeOutbound(data));

--- a/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/CodecHaProxyTest.java
+++ b/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/CodecHaProxyTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class CodecHaProxyTest {
 
     @Test
-    public void testDecoder() {
+    public void testDecoder() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(HAProxyMessageEncoder.INSTANCE);
         HAProxyMessage message = new HAProxyMessage(
                 HAProxyProtocolVersion.V1, HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP4,

--- a/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/CodecMemcacheTest.java
+++ b/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/CodecMemcacheTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class CodecMemcacheTest {
 
     @Test
-    public void testEncoder() {
+    public void testEncoder() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new BinaryMemcacheRequestEncoder());
         BinaryMemcacheRequest request = new DefaultBinaryMemcacheRequest();
         assertTrue(channel.writeOutbound(request));

--- a/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/CodecMqttTest.java
+++ b/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/CodecMqttTest.java
@@ -43,7 +43,7 @@ public class CodecMqttTest {
     private static final int KEEP_ALIVE_SECONDS = 600;
 
     @Test
-    public void testCodec() {
+    public void testCodec() throws Exception {
         MqttConnectMessage msg = MqttMessageBuilders.connect()
                 .clientId(CLIENT_ID)
                 .protocolVersion(MqttVersion.MQTT_3_1)

--- a/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/CodecProtobufTest.java
+++ b/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/CodecProtobufTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 public class CodecProtobufTest {
 
     @Test
-    public void testDecoder() {
+    public void testDecoder() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new ProtobufVarint32FrameDecoder());
         byte[] b = { 4, 1, 1, 1, 1 };
         assertFalse(ch.writeInbound(wrappedBuffer(b, 0, 1)));

--- a/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/CodecRedisTest.java
+++ b/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/CodecRedisTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class CodecRedisTest {
 
     @Test
-    public void testEncoder() {
+    public void testEncoder() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new RedisEncoder());
         assertTrue(channel.writeOutbound(new InlineCommandRedisMessage("ping")));
         assertTrue(channel.finish());

--- a/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/CodecSmtpTest.java
+++ b/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/CodecSmtpTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class CodecSmtpTest {
 
     @Test
-    public void testEncoder() {
+    public void testEncoder() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new SmtpRequestEncoder());
         assertTrue(channel.writeOutbound(SmtpRequests.ehlo("localhost")));
         assertTrue(channel.finish());

--- a/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/CodecSocksTest.java
+++ b/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/CodecSocksTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class CodecSocksTest {
 
     @Test
-    public void testEncoder() {
+    public void testEncoder() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new SocksMessageEncoder());
         assertTrue(channel.writeOutbound(new SocksCmdRequest(SocksCmdType.BIND,
                 SocksAddressType.IPv4, "54.54.111.253", 1)));

--- a/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/CodecStompTest.java
+++ b/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/CodecStompTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 public class CodecStompTest {
 
     @Test
-    public void testEncoder() {
+    public void testEncoder() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new StompSubframeEncoder());
         StompHeadersSubframe frame = new DefaultStompHeadersSubframe(StompCommand.CONNECT);
         StompHeaders headers = frame.headers();

--- a/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/CodecXmlTest.java
+++ b/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/CodecXmlTest.java
@@ -37,7 +37,7 @@ public class CodecXmlTest {
             "<name ";
 
     @Test
-    public void testDecoder() {
+    public void testDecoder() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new XmlDecoder());
         try {
             assertTrue(channel.writeInbound(Unpooled.copiedBuffer(XML1, CharsetUtil.UTF_8)));

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketChannelNotYetConnectedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketChannelNotYetConnectedTest.java
@@ -36,11 +36,12 @@ import org.junit.jupiter.api.Timeout;
 import java.net.SocketException;
 import java.nio.channels.NotYetConnectedException;
 import java.util.List;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SocketChannelNotYetConnectedTest extends AbstractClientSocketTest {
     @Test
@@ -58,19 +59,13 @@ public class SocketChannelNotYetConnectedTest extends AbstractClientSocketTest {
         SocketChannel ch = (SocketChannel) cb.handler(new ChannelInboundHandler() { })
                 .bind(newSocketAddress()).get();
         try {
-            try {
-                ch.shutdown(ChannelShutdownType.newInbound()).syncUninterruptibly();
-                fail();
-            } catch (Throwable cause) {
-                checkThrowable(cause);
-            }
+            Throwable cause = assertThrows(CompletionException.class,
+                    () -> ch.shutdown(ChannelShutdownType.newInbound()).syncUninterruptibly());
+            checkThrowable(cause.getCause());
 
-            try {
-                ch.shutdown(ChannelShutdownType.newOutbound()).syncUninterruptibly();
-                fail();
-            } catch (Throwable cause) {
-                checkThrowable(cause);
-            }
+            cause = assertThrows(CompletionException.class,
+                    () -> ch.shutdown(ChannelShutdownType.newOutbound()).syncUninterruptibly());
+            checkThrowable(cause.getCause());
         } finally {
             ch.close().syncUninterruptibly();
         }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketShutdownOutputBySelfTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketShutdownOutputBySelfTest.java
@@ -39,6 +39,7 @@ import java.net.SocketException;
 import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -47,8 +48,8 @@ import static io.netty.testsuite.transport.TestsuitePermutation.randomBufferType
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
 
@@ -128,18 +129,14 @@ public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
             s = ss.accept();
 
             ch.close().syncUninterruptibly();
-            try {
-                ch.shutdown(ChannelShutdownType.newOutbound()).syncUninterruptibly();
-                fail();
-            } catch (Throwable cause) {
-                checkThrowable(cause);
-            }
-            try {
-                ch.shutdown(ChannelShutdownType.newOutbound()).syncUninterruptibly();
-                fail();
-            } catch (Throwable cause) {
-                checkThrowable(cause);
-            }
+            Throwable cause = assertThrows(CompletionException.class,
+                    () -> ch.shutdown(ChannelShutdownType.newOutbound()).syncUninterruptibly());
+            checkThrowable(cause.getCause());
+
+            ch.close().syncUninterruptibly();
+            cause = assertThrows(CompletionException.class,
+                    () -> ch.shutdown(ChannelShutdownType.newOutbound()).syncUninterruptibly());
+            checkThrowable(cause.getCause());
         } finally {
             if (s != null) {
                 s.close();
@@ -198,13 +195,11 @@ public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
             assertFalse(h.ch.isShutdown(ChannelShutdownDirection.Inbound));
             assertTrue(h.ch.isShutdown(ChannelShutdownDirection.Outbound));
 
-            try {
-                // If half-closed, the local endpoint shouldn't be able to write
-                ch.writeAndFlush(randomBufferType(ch.alloc(), new byte[]{ 2 }, 0 , 2)).sync();
-                fail();
-            } catch (Throwable cause) {
-                checkThrowable(cause);
-            }
+            // If half-closed, the local endpoint shouldn't be able to write
+            final Channel fch = ch;
+            Throwable cause = assertThrows(CompletionException.class,
+                    () -> fch.writeAndFlush(randomBufferType(fch.alloc(), new byte[]{ 2 }, 0 , 2)).sync());
+            checkThrowable(cause.getCause());
             assertNull(h.writabilityQueue.poll());
         } finally {
             if (s != null) {

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainDatagramPathTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainDatagramPathTest.java
@@ -28,12 +28,11 @@ import org.junit.jupiter.api.TestInfo;
 
 import java.io.FileNotFoundException;
 import java.util.List;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 class EpollDomainDatagramPathTest extends AbstractClientSocketTest {
 
@@ -54,17 +53,14 @@ class EpollDomainDatagramPathTest extends AbstractClientSocketTest {
     void testWriteReceiverPathDoesNotExist(TestInfo testInfo) throws Throwable {
         run(testInfo, new Runner<Bootstrap>() {
             @Override
-            public void run(Bootstrap bootstrap) {
-                try {
-                    Channel ch = bootstrap.handler(new ChannelInboundHandler() { })
-                                          .bind(EpollSocketTestPermutation.newDomainSocketAddress()).get();
-                    ch.writeAndFlush(new DatagramPacket(
-                            Unpooled.copiedBuffer("test", CharsetUtil.US_ASCII),
-                            EpollSocketTestPermutation.newDomainSocketAddress())).sync();
-                    fail("Expected FileNotFoundException");
-                } catch (Exception e) {
-                    assertTrue(e instanceof FileNotFoundException);
-                }
+            public void run(Bootstrap bootstrap) throws Exception {
+                Channel ch = bootstrap.handler(new ChannelInboundHandler() { })
+                        .bind(EpollSocketTestPermutation.newDomainSocketAddress()).get();
+                CompletionException e = assertThrows(CompletionException.class,
+                        () -> ch.writeAndFlush(
+                                new DatagramPacket(Unpooled.copiedBuffer("test", CharsetUtil.US_ASCII),
+                        EpollSocketTestPermutation.newDomainSocketAddress())).sync());
+                assertInstanceOf(FileNotFoundException.class, e.getCause());
             }
         });
     }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollReuseAddrTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollReuseAddrTest.java
@@ -39,6 +39,7 @@ import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -46,8 +47,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class EpollReuseAddrTest {
@@ -104,12 +106,9 @@ public class EpollReuseAddrTest {
             throws Exception {
         bootstrap.handler(new LoggingHandler(LogLevel.ERROR));
         Channel ch = bootstrap.bind().get();
-        try {
-            bootstrap.bind(ch.localAddress()).syncUninterruptibly();
-            fail();
-        } catch (Exception e) {
-            assertTrue(e instanceof IOException);
-        }
+        CompletionException e = assertThrows(CompletionException.class,
+                () -> bootstrap.bind(ch.localAddress()).syncUninterruptibly());
+        assertInstanceOf(IOException.class, e.getCause());
         ch.close().syncUninterruptibly();
     }
 

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainDatagramPathTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainDatagramPathTest.java
@@ -28,9 +28,10 @@ import org.junit.jupiter.api.TestInfo;
 
 import java.io.FileNotFoundException;
 import java.util.List;
+import java.util.concurrent.CompletionException;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class KQueueDomainDatagramPathTest extends AbstractClientSocketTest {
 
@@ -39,13 +40,10 @@ class KQueueDomainDatagramPathTest extends AbstractClientSocketTest {
         run(testInfo, new Runner<Bootstrap>() {
             @Override
             public void run(Bootstrap bootstrap) {
-                try {
-                    bootstrap.handler(new ChannelInboundHandler() { })
-                             .connect(KQueueSocketTestPermutation.newSocketAddress()).get();
-                    fail("Expected FileNotFoundException");
-                } catch (Exception e) {
-                    assertTrue(e instanceof FileNotFoundException);
-                }
+                CompletionException e = assertThrows(CompletionException.class,
+                        () -> bootstrap.handler(new ChannelInboundHandler() { })
+                        .connect(KQueueSocketTestPermutation.newSocketAddress()).get());
+                assertInstanceOf(FileNotFoundException.class, e.getCause());
             }
         });
     }
@@ -54,17 +52,13 @@ class KQueueDomainDatagramPathTest extends AbstractClientSocketTest {
     void testWriteReceiverPathDoesNotExist(TestInfo testInfo) throws Throwable {
         run(testInfo, new Runner<Bootstrap>() {
             @Override
-            public void run(Bootstrap bootstrap) {
-                try {
-                    Channel ch = bootstrap.handler(new ChannelInboundHandler() { })
-                                          .bind(KQueueSocketTestPermutation.newSocketAddress()).get();
-                    ch.writeAndFlush(new DatagramPacket(
-                            Unpooled.copiedBuffer("test", CharsetUtil.US_ASCII),
-                            KQueueSocketTestPermutation.newSocketAddress())).sync();
-                    fail("Expected FileNotFoundException");
-                } catch (Exception e) {
-                    assertTrue(e instanceof FileNotFoundException);
-                }
+            public void run(Bootstrap bootstrap) throws Exception {
+                Channel ch = bootstrap.handler(new ChannelInboundHandler() { })
+                        .bind(KQueueSocketTestPermutation.newSocketAddress()).get();
+                CompletionException e = assertThrows(CompletionException.class, () -> ch.writeAndFlush(
+                        new DatagramPacket(Unpooled.copiedBuffer("test", CharsetUtil.US_ASCII),
+                        KQueueSocketTestPermutation.newSocketAddress())).sync());
+                assertInstanceOf(FileNotFoundException.class, e.getCause());
             }
         });
     }

--- a/transport-sctp/src/test/java/io/netty/handler/codec/sctp/SctpMessageCompletionHandlerTest.java
+++ b/transport-sctp/src/test/java/io/netty/handler/codec/sctp/SctpMessageCompletionHandlerTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class SctpMessageCompletionHandlerTest {
 
     @Test
-    public void testFragmentsReleased() {
+    public void testFragmentsReleased() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new SctpMessageCompletionHandler());
         ByteBuf buffer = Unpooled.wrappedBuffer(new byte[] { 1, 2, 3, 4 });
         ByteBuf buffer2 = Unpooled.wrappedBuffer(new byte[] { 1, 2, 3, 4 });

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
@@ -943,7 +943,8 @@ public class EmbeddedChannel extends AbstractChannel {
     }
 
     /**
-     * Check if there was any {@link Throwable} received and if so rethrow it.
+     * Check if there was any {@link Throwable} received and if so rethrow it wrapped in a
+     * {@link java.util.concurrent.CompletionException}.
      */
     public void checkException() {
         Promise<Void> promise = newPromise();

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
@@ -412,7 +412,7 @@ public class EmbeddedChannel extends AbstractChannel {
      *
      * @see #flushOutbound()
      */
-    public EmbeddedChannel flushInbound() throws Exception{
+    public EmbeddedChannel flushInbound() throws Exception {
         flushInbound(true);
         return this;
     }
@@ -543,7 +543,7 @@ public class EmbeddedChannel extends AbstractChannel {
      *
      * @return bufferReadable returns {@code true} if any of the used buffers has something left to read
      */
-    public boolean finish() throws Exception{
+    public boolean finish() throws Exception {
         return finish(false);
     }
 
@@ -563,7 +563,7 @@ public class EmbeddedChannel extends AbstractChannel {
      * @param releaseAll if {@code true} all pending message in the inbound and outbound buffer are released.
      * @return bufferReadable returns {@code true} if any of the used buffers has something left to read
      */
-    private boolean finish(boolean releaseAll) throws Exception{
+    private boolean finish(boolean releaseAll) throws Exception {
         executingStackCnt++;
         try {
             close();
@@ -976,7 +976,7 @@ public class EmbeddedChannel extends AbstractChannel {
     /**
      * Ensure the {@link Channel} is open and if not throw an exception.
      */
-    protected final void ensureOpen() throws Exception{
+    protected final void ensureOpen() throws Exception {
         if (!checkOpen(true)) {
             checkException();
         }

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
@@ -354,7 +354,7 @@ public class EmbeddedChannel extends AbstractChannel {
      *
      * @return {@code true} if the write operation did add something to the inbound buffer
      */
-    public boolean writeInbound(Object... msgs) {
+    public boolean writeInbound(Object... msgs) throws Exception {
         ensureOpen();
         if (msgs.length == 0) {
             return isNotEmpty(inboundMessages);
@@ -412,12 +412,12 @@ public class EmbeddedChannel extends AbstractChannel {
      *
      * @see #flushOutbound()
      */
-    public EmbeddedChannel flushInbound() {
+    public EmbeddedChannel flushInbound() throws Exception{
         flushInbound(true);
         return this;
     }
 
-    private void flushInbound(boolean recordException) {
+    private void flushInbound(boolean recordException) throws Exception {
         executingStackCnt++;
         try {
             if (checkOpen(recordException)) {
@@ -437,7 +437,7 @@ public class EmbeddedChannel extends AbstractChannel {
      * @param msgs              the messages to be written
      * @return bufferReadable   returns {@code true} if the write operation did add something to the outbound buffer
      */
-    public boolean writeOutbound(Object... msgs) {
+    public boolean writeOutbound(Object... msgs) throws Exception {
         ensureOpen();
         if (msgs.length == 0) {
             return isNotEmpty(outboundMessages);
@@ -516,7 +516,7 @@ public class EmbeddedChannel extends AbstractChannel {
      *
      * @see #flushInbound()
      */
-    public EmbeddedChannel flushOutbound() {
+    public EmbeddedChannel flushOutbound() throws Exception {
         executingStackCnt++;
         try {
             if (checkOpen(true)) {
@@ -543,7 +543,7 @@ public class EmbeddedChannel extends AbstractChannel {
      *
      * @return bufferReadable returns {@code true} if any of the used buffers has something left to read
      */
-    public boolean finish() {
+    public boolean finish() throws Exception{
         return finish(false);
     }
 
@@ -553,7 +553,7 @@ public class EmbeddedChannel extends AbstractChannel {
      *
      * @return bufferReadable returns {@code true} if any of the used buffers has something left to read
      */
-    public boolean finishAndReleaseAll() {
+    public boolean finishAndReleaseAll() throws Exception {
         return finish(true);
     }
 
@@ -563,7 +563,7 @@ public class EmbeddedChannel extends AbstractChannel {
      * @param releaseAll if {@code true} all pending message in the inbound and outbound buffer are released.
      * @return bufferReadable returns {@code true} if any of the used buffers has something left to read
      */
-    private boolean finish(boolean releaseAll) {
+    private boolean finish(boolean releaseAll) throws Exception{
         executingStackCnt++;
         try {
             close();
@@ -943,13 +943,15 @@ public class EmbeddedChannel extends AbstractChannel {
     }
 
     /**
-     * Check if there was any {@link Throwable} received and if so rethrow it wrapped in a
-     * {@link java.util.concurrent.CompletionException}.
+     * Check if there was any {@link Throwable} received and if so rethrow it.
      */
-    public void checkException() {
+    public void checkException() throws Exception {
         Promise<Void> promise = newPromise();
         checkException(promise);
-        promise.syncUninterruptibly();
+        Throwable cause = promise.awaitUninterruptibly().cause();
+        if (cause != null) {
+            PlatformDependent.throwException(cause);
+        }
     }
 
     /**
@@ -974,7 +976,7 @@ public class EmbeddedChannel extends AbstractChannel {
     /**
      * Ensure the {@link Channel} is open and if not throw an exception.
      */
-    protected final void ensureOpen() {
+    protected final void ensureOpen() throws Exception{
         if (!checkOpen(true)) {
             checkException();
         }

--- a/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
@@ -55,6 +55,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
@@ -90,12 +91,13 @@ public class BootstrapTest {
                 .handler(new ChannelInboundHandler() { })
                 .register();
 
-        assertThrows(UnsupportedOperationException.class, new  Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new  Executable() {
             @Override
             public void execute() throws Throwable {
                 cf.syncUninterruptibly();
             }
         });
+        assertInstanceOf(UnsupportedOperationException.class, cause.getCause());
     }
 
     @Test
@@ -222,12 +224,14 @@ public class BootstrapTest {
             bootstrapA.group(group);
             bootstrapA.channel(LocalChannel.class);
             bootstrapA.handler(dummyHandler);
-            assertThrows(ConnectException.class, new Executable() {
+            Throwable cause = assertThrows(CompletionException.class, new Executable() {
                 @Override
                 public void execute() {
                     bootstrapA.connect(LocalAddress.ANY).syncUninterruptibly();
                 }
             });
+
+            assertInstanceOf(ConnectException.class, cause.getCause());
         } finally {
             group.shutdownGracefully();
         }

--- a/transport/src/test/java/io/netty/bootstrap/ServerBootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/ServerBootstrapTest.java
@@ -39,13 +39,14 @@ import org.junit.jupiter.api.function.Executable;
 import java.net.SocketAddress;
 import java.util.UUID;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -65,12 +66,13 @@ public class ServerBootstrapTest {
                     .childHandler(new ChannelInboundHandler() { })
                     .register();
 
-            assertThrows(UnsupportedOperationException.class, new Executable() {
+            Throwable cause = assertThrows(CompletionException.class, new Executable() {
                 @Override
                 public void execute() throws Throwable {
                     cf.syncUninterruptibly();
                 }
             });
+            assertInstanceOf(UnsupportedOperationException.class, cause.getCause());
         } finally {
             group.shutdownGracefully();
         }

--- a/transport/src/test/java/io/netty/channel/AbstractChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/AbstractChannelTest.java
@@ -91,7 +91,7 @@ public class AbstractChannelTest {
         final EventLoop eventLoop = mock(EventLoop.class);
         // This allows us to have a single-threaded test
         when(eventLoop.inEventLoop()).thenReturn(true);
-        when(eventLoop.newPromise()).thenReturn(new DefaultPromise(eventLoop));
+        doAnswer(m -> new DefaultPromise<>(eventLoop)).when(eventLoop).newPromise();
         doAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocationOnMock) {

--- a/transport/src/test/java/io/netty/channel/AbstractCoalescingBufferQueueTest.java
+++ b/transport/src/test/java/io/netty/channel/AbstractCoalescingBufferQueueTest.java
@@ -38,17 +38,17 @@ public class AbstractCoalescingBufferQueueTest {
 
     // See https://github.com/netty/netty/issues/10286
     @Test
-    public void testDecrementAllWhenWriteAndRemoveAll() {
+    public void testDecrementAllWhenWriteAndRemoveAll() throws Exception {
         testDecrementAll(true);
     }
 
     // See https://github.com/netty/netty/issues/10286
     @Test
-    public void testDecrementAllWhenReleaseAndFailAll() {
+    public void testDecrementAllWhenReleaseAndFailAll() throws Exception {
         testDecrementAll(false);
     }
 
-    private static void testDecrementAll(boolean write) {
+    private static void testDecrementAll(boolean write) throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new ChannelOutboundHandler() {
             @Override
             public void write(ChannelHandlerContext ctx, Object msg, CompletionHandler<Void> handler) {

--- a/transport/src/test/java/io/netty/channel/ChannelInitializerTest.java
+++ b/transport/src/test/java/io/netty/channel/ChannelInitializerTest.java
@@ -210,16 +210,16 @@ public class ChannelInitializerTest {
     }
 
     @Test
-    public void testAddFirstChannelInitializer() {
+    public void testAddFirstChannelInitializer() throws Exception {
         testAddChannelInitializer(true);
     }
 
     @Test
-    public void testAddLastChannelInitializer() {
+    public void testAddLastChannelInitializer() throws Exception {
         testAddChannelInitializer(false);
     }
 
-    private static void testAddChannelInitializer(final boolean first) {
+    private static void testAddChannelInitializer(final boolean first) throws Exception {
         final AtomicBoolean called = new AtomicBoolean();
         EmbeddedChannel channel = new EmbeddedChannel(new ChannelInitializer<Channel>() {
             @Override

--- a/transport/src/test/java/io/netty/channel/ChannelOutboundBufferTest.java
+++ b/transport/src/test/java/io/netty/channel/ChannelOutboundBufferTest.java
@@ -17,7 +17,6 @@ package io.netty.channel;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
-import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
 import io.netty.util.concurrent.CompletionHandler;
 import io.netty.util.concurrent.ImmediateEventExecutor;
@@ -244,17 +243,6 @@ public class ChannelOutboundBufferTest {
         @Override
         public <T> Promise<T> newPromise() {
             return new DefaultPromise<T>(executor());
-        }
-    }
-
-    private static void safeClose(EmbeddedChannel ch) {
-        ch.finish();
-        for (;;) {
-            ByteBuf m = ch.readOutbound();
-            if (m == null) {
-                break;
-            }
-            m.release();
         }
     }
 }

--- a/transport/src/test/java/io/netty/channel/CoalescingBufferQueueTest.java
+++ b/transport/src/test/java/io/netty/channel/CoalescingBufferQueueTest.java
@@ -65,7 +65,7 @@ public class CoalescingBufferQueueTest {
     }
 
     @AfterEach
-    public void finish() {
+    public void finish() throws Exception {
         assertFalse(channel.finish());
     }
 

--- a/transport/src/test/java/io/netty/channel/CombinedChannelDuplexHandlerTest.java
+++ b/transport/src/test/java/io/netty/channel/CombinedChannelDuplexHandlerTest.java
@@ -239,7 +239,7 @@ public class CombinedChannelDuplexHandlerTest {
 
     @Test
     @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
-    public void testPromisesPassed() throws Exception{
+    public void testPromisesPassed() throws Exception {
         OutboundEventHandler outboundHandler = new OutboundEventHandler();
         EmbeddedChannel ch = new EmbeddedChannel(outboundHandler,
                 new CombinedChannelDuplexHandler<ChannelInboundHandler, ChannelOutboundHandler>(

--- a/transport/src/test/java/io/netty/channel/CombinedChannelDuplexHandlerTest.java
+++ b/transport/src/test/java/io/netty/channel/CombinedChannelDuplexHandlerTest.java
@@ -26,7 +26,6 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.ArrayDeque;
 import java.util.Queue;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -130,7 +129,7 @@ public class CombinedChannelDuplexHandlerTest {
     }
 
     @Test
-    public void testInboundEvents() {
+    public void testInboundEvents() throws Exception {
         InboundEventHandler inboundHandler = new InboundEventHandler();
 
         CombinedChannelDuplexHandler<ChannelInboundHandler, ChannelOutboundHandler> handler =
@@ -153,15 +152,15 @@ public class CombinedChannelDuplexHandlerTest {
         // Should have not received any more events as it was removed before via removeInboundHandler()
         assertNull(inboundHandler.pollEvent());
 
-        Throwable cause = assertThrows(CompletionException.class, channel::checkException);
-        assertSame(CAUSE, cause.getCause());
+        Throwable cause = assertThrows(Throwable.class, channel::checkException);
+        assertSame(CAUSE, cause);
 
         assertTrue(channel.finish());
         assertNull(inboundHandler.pollEvent());
     }
 
     @Test
-    public void testOutboundEvents() {
+    public void testOutboundEvents() throws Exception {
         ChannelInboundHandler inboundHandler = new ChannelInboundHandler() { };
         OutboundEventHandler outboundHandler = new OutboundEventHandler();
 
@@ -240,7 +239,7 @@ public class CombinedChannelDuplexHandlerTest {
 
     @Test
     @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
-    public void testPromisesPassed() {
+    public void testPromisesPassed() throws Exception{
         OutboundEventHandler outboundHandler = new OutboundEventHandler();
         EmbeddedChannel ch = new EmbeddedChannel(outboundHandler,
                 new CombinedChannelDuplexHandler<ChannelInboundHandler, ChannelOutboundHandler>(

--- a/transport/src/test/java/io/netty/channel/CombinedChannelDuplexHandlerTest.java
+++ b/transport/src/test/java/io/netty/channel/CombinedChannelDuplexHandlerTest.java
@@ -26,6 +26,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.ArrayDeque;
 import java.util.Queue;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -34,7 +35,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class CombinedChannelDuplexHandlerTest {
 
@@ -152,12 +152,9 @@ public class CombinedChannelDuplexHandlerTest {
 
         // Should have not received any more events as it was removed before via removeInboundHandler()
         assertNull(inboundHandler.pollEvent());
-        try {
-            channel.checkException();
-            fail();
-        } catch (Throwable cause) {
-            assertSame(CAUSE, cause);
-        }
+
+        Throwable cause = assertThrows(CompletionException.class, channel::checkException);
+        assertSame(CAUSE, cause.getCause());
 
         assertTrue(channel.finish());
         assertNull(inboundHandler.pollEvent());

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
@@ -1384,7 +1384,7 @@ public class DefaultChannelPipelineTest {
     }
 
     @Test
-    public void testSkipHandlerMethodsIfAnnotated() {
+    public void testSkipHandlerMethodsIfAnnotated() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(true);
         ChannelPipeline pipeline = channel.pipeline();
 

--- a/transport/src/test/java/io/netty/channel/DefaultMaxMessagesRecvByteBufAllocatorTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultMaxMessagesRecvByteBufAllocatorTest.java
@@ -38,7 +38,7 @@ public class DefaultMaxMessagesRecvByteBufAllocatorTest {
     }
 
     @Test
-    public void testRespectReadBytes() {
+    public void testRespectReadBytes() throws Exception {
         DefaultMaxMessagesRecvByteBufAllocator allocator = newAllocator(false);
         RecvByteBufAllocator.Handle handle = allocator.newHandle();
 
@@ -56,7 +56,7 @@ public class DefaultMaxMessagesRecvByteBufAllocatorTest {
     }
 
     @Test
-    public void testIgnoreReadBytes() {
+    public void testIgnoreReadBytes() throws Exception {
         DefaultMaxMessagesRecvByteBufAllocator allocator = newAllocator(true);
         RecvByteBufAllocator.Handle handle = allocator.newHandle();
 

--- a/transport/src/test/java/io/netty/channel/PendingWriteQueueTest.java
+++ b/transport/src/test/java/io/netty/channel/PendingWriteQueueTest.java
@@ -28,11 +28,9 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CompletionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -42,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class PendingWriteQueueTest {
 
     @Test
-    public void testRemoveAndWrite() {
+    public void testRemoveAndWrite() throws Exception{
         assertWrite(new TestHandler() {
             @Override
             public void flush(ChannelHandlerContext ctx) {
@@ -54,7 +52,7 @@ public class PendingWriteQueueTest {
     }
 
     @Test
-    public void testRemoveAndWriteAll() {
+    public void testRemoveAndWriteAll() throws Exception {
         assertWrite(new TestHandler() {
             @Override
             public void flush(ChannelHandlerContext ctx) {
@@ -66,7 +64,7 @@ public class PendingWriteQueueTest {
     }
 
     @Test
-    public void testRemoveAndFail() {
+    public void testRemoveAndFail() throws Exception {
         assertWriteFails(new TestHandler() {
 
             @Override
@@ -78,7 +76,7 @@ public class PendingWriteQueueTest {
     }
 
     @Test
-    public void testRemoveAndFailAll() {
+    public void testRemoveAndFailAll() throws Exception {
         assertWriteFails(new TestHandler() {
             @Override
             public void flush(ChannelHandlerContext ctx) {
@@ -88,7 +86,7 @@ public class PendingWriteQueueTest {
         }, 3);
     }
 
-    private static void assertWrite(ChannelHandler handler, int count) {
+    private static void assertWrite(ChannelHandler handler, int count) throws Exception {
         final ByteBuf buffer = Unpooled.copiedBuffer("Test", CharsetUtil.US_ASCII);
         final EmbeddedChannel channel = new EmbeddedChannel(handler);
         channel.config().setWriteBufferWaterMark(new WriteBufferWaterMark(1, 3));
@@ -121,15 +119,14 @@ public class PendingWriteQueueTest {
         assertNull(queue.current());
     }
 
-    private static void assertWriteFails(ChannelHandler handler, int count) {
+    private static void assertWriteFails(ChannelHandler handler, int count) throws Exception {
         final ByteBuf buffer = Unpooled.copiedBuffer("Test", CharsetUtil.US_ASCII);
         final EmbeddedChannel channel = new EmbeddedChannel(handler);
         ByteBuf[] buffers = new ByteBuf[count];
         for (int i = 0; i < buffers.length; i++) {
             buffers[i] = buffer.retainedDuplicate();
         }
-        Throwable cause = assertThrows(CompletionException.class, () -> channel.writeOutbound(buffers));
-        assertInstanceOf(TestException.class, cause.getCause());
+        assertThrows(TestException.class, () -> channel.writeOutbound(buffers));
         assertFalse(channel.finish());
         channel.closeFuture().syncUninterruptibly();
 
@@ -143,7 +140,7 @@ public class PendingWriteQueueTest {
     }
 
     @Test
-    public void testRemoveAndFailAllReentrantFailAll() {
+    public void testRemoveAndFailAllReentrantFailAll() throws Exception {
         EmbeddedChannel channel = newChannel();
         final PendingWriteQueue queue = new PendingWriteQueue(channel.pipeline().firstContext());
 
@@ -162,7 +159,7 @@ public class PendingWriteQueueTest {
     }
 
     @Test
-    public void testRemoveAndWriteAllReentrantWrite() {
+    public void testRemoveAndWriteAllReentrantWrite() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new ChannelOutboundHandler() {
             @Override
             public void write(ChannelHandlerContext ctx, Object msg, CompletionHandler<Void> handler) {
@@ -194,7 +191,7 @@ public class PendingWriteQueueTest {
     }
 
     @Test
-    public void testRemoveAndFailAllReentrantWrite() {
+    public void testRemoveAndFailAllReentrantWrite() throws Exception {
         final List<Integer> failOrder = Collections.synchronizedList(new ArrayList<Integer>());
         EmbeddedChannel channel = newChannel();
         final PendingWriteQueue queue = new PendingWriteQueue(channel.pipeline().firstContext());
@@ -225,7 +222,7 @@ public class PendingWriteQueueTest {
     }
 
     @Test
-    public void testRemoveAndWriteAllReentrance() {
+    public void testRemoveAndWriteAllReentrance() throws Exception {
         EmbeddedChannel channel = newChannel();
         final PendingWriteQueue queue = new PendingWriteQueue(channel.pipeline().firstContext());
 

--- a/transport/src/test/java/io/netty/channel/PendingWriteQueueTest.java
+++ b/transport/src/test/java/io/netty/channel/PendingWriteQueueTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class PendingWriteQueueTest {
 
     @Test
-    public void testRemoveAndWrite() throws Exception{
+    public void testRemoveAndWrite() throws Exception {
         assertWrite(new TestHandler() {
             @Override
             public void flush(ChannelHandlerContext ctx) {

--- a/transport/src/test/java/io/netty/channel/PendingWriteQueueTest.java
+++ b/transport/src/test/java/io/netty/channel/PendingWriteQueueTest.java
@@ -28,14 +28,16 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class PendingWriteQueueTest {
 
@@ -126,12 +128,8 @@ public class PendingWriteQueueTest {
         for (int i = 0; i < buffers.length; i++) {
             buffers[i] = buffer.retainedDuplicate();
         }
-        try {
-            assertFalse(channel.writeOutbound(buffers));
-            fail();
-        } catch (Exception e) {
-            assertTrue(e instanceof TestException);
-        }
+        Throwable cause = assertThrows(CompletionException.class, () -> channel.writeOutbound(buffers));
+        assertInstanceOf(TestException.class, cause.getCause());
         assertFalse(channel.finish());
         channel.closeFuture().syncUninterruptibly();
 

--- a/transport/src/test/java/io/netty/channel/ReentrantChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/ReentrantChannelTest.java
@@ -33,12 +33,13 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class ReentrantChannelTest extends BaseChannelTest {
 
@@ -348,13 +349,9 @@ public class ReentrantChannelTest extends BaseChannelTest {
             }
         });
 
-        try {
-            clientChannel.writeAndFlush(createTestBuf(2000)).sync();
-            fail();
-        } catch (Exception e) {
-            // FIXME:  shouldn't this contain the "intentional failure" exception?
-            assertThat(e).isInstanceOf(ClosedChannelException.class);
-        }
+        Throwable cause = assertThrows(CompletionException.class,
+                () -> clientChannel.writeAndFlush(createTestBuf(2000)).sync());
+        assertThat(cause.getCause()).isInstanceOf(ClosedChannelException.class);
 
         clientChannel.closeFuture().sync();
 

--- a/transport/src/test/java/io/netty/channel/SimpleUserEventChannelHandlerTest.java
+++ b/transport/src/test/java/io/netty/channel/SimpleUserEventChannelHandlerTest.java
@@ -42,7 +42,7 @@ public class SimpleUserEventChannelHandlerTest {
     }
 
     @Test
-    public void testTypeMatch() {
+    public void testTypeMatch() throws Exception {
         FooEvent fooEvent = new FooEvent();
         channel.pipeline().fireUserEventTriggered(fooEvent);
         assertEquals(1, fooEventCatcher.caughtEvents.size());
@@ -52,7 +52,7 @@ public class SimpleUserEventChannelHandlerTest {
     }
 
     @Test
-    public void testTypeMismatch() {
+    public void testTypeMismatch() throws Exception {
         BarEvent barEvent = new BarEvent();
         channel.pipeline().fireUserEventTriggered(barEvent);
         assertEquals(0, fooEventCatcher.caughtEvents.size());

--- a/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.Timeout;
 import java.nio.channels.ClosedChannelException;
 import java.util.ArrayDeque;
 import java.util.Queue;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -48,8 +49,10 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -79,12 +82,9 @@ public class EmbeddedChannelTest {
     public void testRegistered() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(true, false);
         assertTrue(channel.isRegistered());
-        try {
-            channel.register().sync();
-            fail();
-        } catch (IllegalStateException expected) {
-            // This is expected the channel is registered already on an EventLoop.
-        }
+
+        Throwable cause = assertThrows(CompletionException.class, () -> channel.register().sync());
+        assertInstanceOf(IllegalStateException.class, cause.getCause());
         assertFalse(channel.finish());
     }
 
@@ -530,19 +530,11 @@ public class EmbeddedChannelTest {
         EmbeddedChannel channel = new EmbeddedChannel();
         channel.close().syncUninterruptibly();
 
-        try {
-            channel.writeOutbound("Hello, Netty!");
-            fail("This should have failed with a ClosedChannelException");
-        } catch (Exception expected) {
-            assertTrue(expected instanceof ClosedChannelException);
-        }
+        Throwable cause = assertThrows(CompletionException.class, () -> channel.writeOutbound("Hello, Netty!"));
+        assertInstanceOf(ClosedChannelException.class, cause.getCause());
 
-        try {
-            channel.writeInbound("Hello, Netty!");
-            fail("This should have failed with a ClosedChannelException");
-        } catch (Exception expected) {
-            assertTrue(expected instanceof ClosedChannelException);
-        }
+        cause = assertThrows(CompletionException.class, () -> channel.writeInbound("Hello, Netty!"));
+        assertInstanceOf(ClosedChannelException.class, cause.getCause());
     }
 
     @Test

--- a/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
@@ -59,7 +59,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class EmbeddedChannelTest {
 
     @Test
-    public void testParent() {
+    public void testParent() throws Exception {
         EmbeddedChannel parent = new EmbeddedChannel();
         EmbeddedChannel channel = new EmbeddedChannel(parent, EmbeddedChannelId.INSTANCE, true, false);
         assertSame(parent, channel.parent());
@@ -98,7 +98,7 @@ public class EmbeddedChannelTest {
     }
 
     @Test
-    public void testConstructWithChannelInitializer() {
+    public void testConstructWithChannelInitializer() throws Exception {
         final Integer first = 1;
         final Integer second = 2;
 
@@ -183,7 +183,7 @@ public class EmbeddedChannelTest {
     }
 
     @Test
-    public void testConstructWithOutHandler() {
+    public void testConstructWithOutHandler() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel();
         assertTrue(channel.writeInbound(1));
         assertTrue(channel.writeOutbound(2));
@@ -303,7 +303,7 @@ public class EmbeddedChannelTest {
     }
 
     @Test
-    public void testFinishAndReleaseAll() {
+    public void testFinishAndReleaseAll() throws Exception {
         ByteBuf in = Unpooled.buffer();
         ByteBuf out = Unpooled.buffer();
         try {
@@ -326,7 +326,7 @@ public class EmbeddedChannelTest {
     }
 
     @Test
-    public void testReleaseInbound() {
+    public void testReleaseInbound() throws Exception {
         ByteBuf in = Unpooled.buffer();
         ByteBuf out = Unpooled.buffer();
         try {
@@ -355,7 +355,7 @@ public class EmbeddedChannelTest {
     }
 
     @Test
-    public void testReleaseOutbound() {
+    public void testReleaseOutbound() throws Exception {
         ByteBuf in = Unpooled.buffer();
         ByteBuf out = Unpooled.buffer();
         try {
@@ -384,7 +384,7 @@ public class EmbeddedChannelTest {
     }
 
     @Test
-    public void testWriteLater() {
+    public void testWriteLater() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new ChannelOutboundHandler() {
             @Override
             public void write(
@@ -406,7 +406,7 @@ public class EmbeddedChannelTest {
     }
 
     @Test
-    public void testWriteScheduled() throws InterruptedException {
+    public void testWriteScheduled() throws Exception {
         final int delay = 500;
         EmbeddedChannel channel = new EmbeddedChannel(new ChannelOutboundHandler() {
             @Override
@@ -430,7 +430,7 @@ public class EmbeddedChannelTest {
     }
 
     @Test
-    public void testFlushInbound() throws InterruptedException {
+    public void testFlushInbound() throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
         EmbeddedChannel channel = new EmbeddedChannel(new ChannelInboundHandler() {
             @Override
@@ -478,7 +478,7 @@ public class EmbeddedChannelTest {
     }
 
     @Test
-    public void testFlushOutbound() throws InterruptedException {
+    public void testFlushOutbound() throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
         EmbeddedChannel channel = new EmbeddedChannel(new ChannelOutboundHandler() {
             @Override
@@ -530,11 +530,9 @@ public class EmbeddedChannelTest {
         EmbeddedChannel channel = new EmbeddedChannel();
         channel.close().syncUninterruptibly();
 
-        Throwable cause = assertThrows(CompletionException.class, () -> channel.writeOutbound("Hello, Netty!"));
-        assertInstanceOf(ClosedChannelException.class, cause.getCause());
+        assertThrows(ClosedChannelException.class, () -> channel.writeOutbound("Hello, Netty!"));
 
-        cause = assertThrows(CompletionException.class, () -> channel.writeInbound("Hello, Netty!"));
-        assertInstanceOf(ClosedChannelException.class, cause.getCause());
+        assertThrows(ClosedChannelException.class, () -> channel.writeInbound("Hello, Netty!"));
     }
 
     @Test
@@ -556,7 +554,7 @@ public class EmbeddedChannelTest {
     }
 
     @Test
-    public void testHandleOutboundMessage() throws InterruptedException {
+    public void testHandleOutboundMessage() throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
 
         EmbeddedChannel channel = new EmbeddedChannel() {
@@ -788,7 +786,7 @@ public class EmbeddedChannelTest {
     }
 
     @Test
-    void testReentrantClose() {
+    void testReentrantClose() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel();
         channel.pipeline().addLast(new ChannelInboundHandler() {
             boolean runningRead;

--- a/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.function.Executable;
 
 import java.net.ConnectException;
 import java.nio.channels.ClosedChannelException;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -166,17 +167,16 @@ public class LocalChannelTest {
 
             // Close the channel and write something.
             cc.close().sync();
-            try {
-                cc.writeAndFlush(new Object()).sync();
-                fail("must raise a ClosedChannelException");
-            } catch (Exception e) {
-                assertInstanceOf(ClosedChannelException.class, e);
-                // Ensure that the actual write attempt on a closed channel was never made by asserting that
-                // the ClosedChannelException has been created by AbstractUnsafe rather than transport implementations.
-                if (e.getStackTrace().length > 0) {
-                   assertEquals(AbstractChannel.class.getName() +
-                           "$IoTransportImpl", e.getStackTrace()[0].getClassName());
-                }
+            final Channel fcc = cc;
+            Throwable cause = assertThrows(CompletionException.class, () -> fcc.writeAndFlush(new Object()).sync());
+
+            Throwable e = cause.getCause();
+            assertInstanceOf(ClosedChannelException.class, e);
+            // Ensure that the actual write attempt on a closed channel was never made by asserting that
+            // the ClosedChannelException has been created by AbstractUnsafe rather than transport implementations.
+            if (e.getStackTrace().length > 0) {
+                assertEquals(AbstractChannel.class.getName() +
+                        "$IoTransportImpl", e.getStackTrace()[0].getClassName());
             }
         } finally {
             closeChannel(cc);
@@ -843,12 +843,13 @@ public class LocalChannelTest {
         sb.group(group1)
         .channel(LocalChannel.class)
         .handler(new TestHandler());
-        assertThrows(ConnectException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() {
                 sb.connect(LocalAddress.ANY).syncUninterruptibly();
             }
         });
+        assertInstanceOf(ConnectException.class, cause.getCause());
     }
 
     private static final class LatchChannelFutureListener extends CountDownLatch implements FutureListener<Void> {

--- a/transport/src/test/java/io/netty/channel/pool/AbstractChannelPoolMapTest.java
+++ b/transport/src/test/java/io/netty/channel/pool/AbstractChannelPoolMapTest.java
@@ -30,12 +30,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
 import java.net.ConnectException;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 
 import static io.netty.channel.pool.ChannelPoolTestUtils.getLocalAddrId;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -74,12 +76,13 @@ public class AbstractChannelPoolMapTest {
         assertFalse(poolMap.iterator().hasNext());
         assertEquals(0, poolMap.size());
 
-        assertThrows(ConnectException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
                 pool.acquire().syncUninterruptibly();
             }
         });
+        assertInstanceOf(ConnectException.class, cause.getCause());
         poolMap.close();
     }
 

--- a/transport/src/test/java/io/netty/channel/pool/FixedChannelPoolTest.java
+++ b/transport/src/test/java/io/netty/channel/pool/FixedChannelPoolTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -47,6 +48,7 @@ import static io.netty.channel.pool.ChannelPoolTestUtils.getLocalAddrId;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -117,12 +119,13 @@ public class FixedChannelPoolTest {
 
         Channel channel = pool.acquire().get();
         final Future<Channel> future = pool.acquire();
-        assertThrows(TimeoutException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
                 future.syncUninterruptibly();
             }
         });
+        assertInstanceOf(TimeoutException.class, cause.getCause());
         sc.close().syncUninterruptibly();
         channel.close().syncUninterruptibly();
         pool.close();
@@ -184,12 +187,13 @@ public class FixedChannelPoolTest {
         Future<Channel> future = pool.acquire();
         assertFalse(future.isDone());
 
-        assertThrows(IllegalStateException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
                 pool.acquire().syncUninterruptibly();
             }
         });
+        assertInstanceOf(IllegalStateException.class, cause.getCause());
         sc.close().syncUninterruptibly();
         channel.close().syncUninterruptibly();
         pool.close();
@@ -207,12 +211,13 @@ public class FixedChannelPoolTest {
 
         final Channel channel = pool.acquire().get();
 
-        assertThrows(IllegalArgumentException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
                 pool2.release(channel).syncUninterruptibly();
             }
         });
+        assertInstanceOf(IllegalArgumentException.class, cause.getCause());
         sc.close().syncUninterruptibly();
         channel.close().syncUninterruptibly();
         pool.close();
@@ -236,12 +241,13 @@ public class FixedChannelPoolTest {
                 // NOOP
             }
         }).syncUninterruptibly();
-        assertThrows(IllegalStateException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
                 pool.release(channel).syncUninterruptibly();
             }
         });
+        assertInstanceOf(IllegalStateException.class, cause.getCause());
         // Since the pool is closed, the Channel should have been closed as well.
         channel.closeFuture().syncUninterruptibly();
         assertFalse(channel.isOpen());
@@ -306,11 +312,8 @@ public class FixedChannelPoolTest {
             }
         }, 2);
 
-        try {
-            pool.acquire().sync();
-        } catch (NullPointerException e) {
-            assertSame(e, exception);
-        }
+        Throwable cause = assertThrows(CompletionException.class, () -> pool.acquire().sync());
+        assertSame(exception, cause.getCause());
 
         sc.close().sync();
         pool.close();

--- a/transport/src/test/java/io/netty/channel/pool/SimpleChannelPoolTest.java
+++ b/transport/src/test/java/io/netty/channel/pool/SimpleChannelPoolTest.java
@@ -31,12 +31,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
 import java.util.Queue;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import static io.netty.channel.pool.ChannelPoolTestUtils.getLocalAddrId;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -79,12 +81,13 @@ public class SimpleChannelPoolTest {
         pool.release(channel2).syncUninterruptibly();
 
         // Should fail on multiple release calls.
-        assertThrows(IllegalArgumentException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
                 pool.release(channel2).syncUninterruptibly();
             }
         });
+        assertInstanceOf(IllegalArgumentException.class, cause.getCause());
         assertFalse(channel.isActive());
 
         assertEquals(2, handler.acquiredCount());
@@ -136,12 +139,13 @@ public class SimpleChannelPoolTest {
         final Channel channel2 = pool.acquire().get();
 
         pool.release(channel).get();
-        assertThrows(IllegalStateException.class, new Executable() {
+        Throwable cause = assertThrows(CompletionException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
                 pool.release(channel2).syncUninterruptibly();
             }
         });
+        assertInstanceOf(IllegalStateException.class, cause.getCause());
         channel2.close().sync();
 
         assertEquals(2, handler.channelCount());
@@ -387,11 +391,8 @@ public class SimpleChannelPoolTest {
             }
         });
 
-        try {
-            pool.acquire().sync();
-        } catch (NullPointerException e) {
-            assertSame(e, exception);
-        }
+        Throwable cause = assertThrows(CompletionException.class, () -> pool.acquire().sync());
+        assertSame(cause.getCause(), exception);
 
         sc.close().sync();
         pool.close();


### PR DESCRIPTION
…tion

Motivation:

We should wrap the error in a CompletionException before rethrowing as otherwise we might produce exceptions that are not expected.

Modification:

- Rethrow by wrapping into CompletionException
- Fix tests

Result:

More correct implementation of sync*()