### PR TITLE
Fix possible ClassCastException when using ReadOnlyAbstractByteBuf

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyAbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyAbstractByteBuf.java
@@ -23,6 +23,7 @@ final class ReadOnlyAbstractByteBuf extends ReadOnlyByteBuf {
 
     ReadOnlyAbstractByteBuf(AbstractByteBuf buffer) {
         super(buffer);
+        assert buffer.unwrap() == null || buffer.unwrap() instanceof AbstractByteBuf;
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/Unpooled.java
+++ b/buffer/src/main/java/io/netty/buffer/Unpooled.java
@@ -702,7 +702,10 @@ public final class Unpooled {
     }
 
     private static ReadOnlyByteBuf newReadyOnlyBuffer(ByteBuf buffer) {
-        return buffer instanceof AbstractByteBuf ?
+        // We can only use ReadOnlyAbstractByteBuf if we either have nothing to unwrap or the unwrapped buffer is of
+        // type AbstractByteBuf. Otherwise we will produce a CCE later.
+        return buffer instanceof AbstractByteBuf && (
+                buffer.unwrap() == null || buffer.unwrap() instanceof AbstractByteBuf) ?
                 new ReadOnlyAbstractByteBuf((AbstractByteBuf) buffer) :
                 new ReadOnlyByteBuf(buffer);
     }

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyByteBufTest.java
@@ -62,6 +62,11 @@ public class ReadOnlyByteBufTest {
     }
 
     @Test
+    public void testUnmodifiableBufferDoesNotThrowClassCastException() {
+        unmodifiableBuffer(new DuplicatedByteBuf(mock(ByteBuf.class)));
+    }
+
+    @Test
     public void testUnwrap() {
         ByteBuf buf = buffer(1);
         assertSame(buf, unmodifiableBuffer(buf).unwrap());


### PR DESCRIPTION
Motivation:

https://github.com/netty/netty/pull/15413 introduced a change that reduced bound checks. Unfortunally this change also introduced a bug that can cause ClassCastExceptions in some rare-cases (mostly when people write their own ByteBuf implementation.

Modifications:

- Ensure the wrapped buffer will really be of type AbstractByteBuf
- Add unit test

Result:

Fixes rare ClassCastException
