### PR TITLE
Remove more AccessController usage

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/BouncyCastleAlpnSslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/BouncyCastleAlpnSslUtils.java
@@ -24,8 +24,6 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
-import java.security.AccessController;
-import java.security.PrivilegedExceptionAction;
 import java.security.SecureRandom;
 import java.util.List;
 import java.util.function.BiFunction;
@@ -74,58 +72,28 @@ final class BouncyCastleAlpnSslUtils {
 
             final SSLParameters bcSslParameters = engine.getSSLParameters();
             final Class<?> bCSslParametersClass = bcSslParameters.getClass();
-            setApplicationProtocols = AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
-                @Override
-                public Method run() throws Exception {
-                    return bCSslParametersClass.getMethod("setApplicationProtocols", String[].class);
-                }
-            });
+            setApplicationProtocols = bCSslParametersClass.getMethod("setApplicationProtocols", String[].class);
             setApplicationProtocols.invoke(bcSslParameters, new Object[]{EmptyArrays.EMPTY_STRINGS});
 
-            getApplicationProtocol = AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
-                @Override
-                public Method run() throws Exception {
-                    return bcEngineClass.getMethod("getApplicationProtocol");
-                }
-            });
+            getApplicationProtocol = bcEngineClass.getMethod("getApplicationProtocol");
             getApplicationProtocol.invoke(engine);
 
-            getHandshakeApplicationProtocol = AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
-                @Override
-                public Method run() throws Exception {
-                    return bcEngineClass.getMethod("getHandshakeApplicationProtocol");
-                }
-            });
+            getHandshakeApplicationProtocol = bcEngineClass.getMethod("getHandshakeApplicationProtocol");
             getHandshakeApplicationProtocol.invoke(engine);
 
             final Class<?> testBCApplicationProtocolSelector = Class.forName(
                     "org.bouncycastle.jsse.BCApplicationProtocolSelector", true, engineClass.getClassLoader());
             bcApplicationProtocolSelector = testBCApplicationProtocolSelector;
 
-            bcApplicationProtocolSelectorSelect = AccessController.doPrivileged(
-                    new PrivilegedExceptionAction<Method>() {
-                        @Override
-                        public Method run() throws Exception {
-                            return testBCApplicationProtocolSelector.getMethod("select", Object.class, List.class);
-                        }
-                    });
+            bcApplicationProtocolSelectorSelect =
+                    testBCApplicationProtocolSelector.getMethod("select", Object.class, List.class);
 
             setHandshakeApplicationProtocolSelector =
-                    AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
-                        @Override
-                        public Method run() throws Exception {
-                            return bcEngineClass.getMethod("setBCHandshakeApplicationProtocolSelector",
-                                    testBCApplicationProtocolSelector);
-                        }
-                    });
+                    bcEngineClass.getMethod("setBCHandshakeApplicationProtocolSelector",
+                            testBCApplicationProtocolSelector);
 
             getHandshakeApplicationProtocolSelector =
-                    AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
-                        @Override
-                        public Method run() throws Exception {
-                            return bcEngineClass.getMethod("getBCHandshakeApplicationProtocolSelector");
-                        }
-                    });
+                    bcEngineClass.getMethod("getBCHandshakeApplicationProtocolSelector");
             getHandshakeApplicationProtocolSelector.invoke(engine);
             supported = true;
         } catch (Throwable t) {

--- a/transport/src/main/java/io/netty/channel/ChannelHandlerMask.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandlerMask.java
@@ -28,8 +28,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Method;
 import java.net.SocketAddress;
-import java.security.AccessController;
-import java.security.PrivilegedExceptionAction;
 import java.util.Map;
 import java.util.WeakHashMap;
 
@@ -183,22 +181,17 @@ final class ChannelHandlerMask {
 
     private static boolean isSkippable(
             final Class<?> handlerType, final String methodName, final Class<?>... paramTypes) throws Exception {
-        return AccessController.doPrivileged(new PrivilegedExceptionAction<Boolean>() {
-            @Override
-            public Boolean run() throws Exception {
-                Method m;
-                try {
-                    m = handlerType.getMethod(methodName, paramTypes);
-                } catch (NoSuchMethodException e) {
-                    if (logger.isDebugEnabled()) {
-                        logger.debug(
-                            "Class {} missing method {}, assume we can not skip execution", handlerType, methodName, e);
-                    }
-                    return false;
-                }
-                return m.isAnnotationPresent(Skip.class);
+        Method m;
+        try {
+            m = handlerType.getMethod(methodName, paramTypes);
+        } catch (NoSuchMethodException e) {
+            if (logger.isDebugEnabled()) {
+                logger.debug(
+                        "Class {} missing method {}, assume we can not skip execution", handlerType, methodName, e);
             }
-        });
+            return false;
+        }
+        return m.isAnnotationPresent(Skip.class);
     }
 
     private ChannelHandlerMask() { }


### PR DESCRIPTION
Motivation:
The AccessController and PrivilegedAction APIs are deprecated for removal.

Modification:
Remove more remaining usages of these APIs.

Result:
The only usages left are removed by other PRs.
