### PR TITLE
codec-http: make the default header key and value validators public

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -37,7 +37,12 @@ public class DefaultHttp2Headers
             return !isUpperCase(value);
         }
     };
-    static final NameValidator<CharSequence> HTTP2_NAME_VALIDATOR = new NameValidator<CharSequence>() {
+
+    /**
+     * Default {@link io.netty.handler.codec.DefaultHeaders.NameValidator} used for HTTP/2.
+     */
+    public static final NameValidator<CharSequence> DEFAULT_HTTP2_NAME_VALIDATOR =
+            new NameValidator<CharSequence>() {
         @Override
         public void validateName(CharSequence name) {
             if (name == null || name.length() == 0) {
@@ -82,7 +87,11 @@ public class DefaultHttp2Headers
         }
     };
 
-    private static final ValueValidator<CharSequence> VALUE_VALIDATOR = new ValueValidator<CharSequence>() {
+    /**
+     * Default {@link io.netty.handler.codec.DefaultHeaders.ValueValidator} used for HTTP/2.
+     */
+    public static final ValueValidator<CharSequence> DEFAULT_HEADER_VALUE_VALIDATOR =
+            new ValueValidator<CharSequence>() {
         @Override
         public void validate(CharSequence value) {
             int index = HttpHeaderValidationUtil.validateValidHeaderValue(value);
@@ -116,7 +125,7 @@ public class DefaultHttp2Headers
         // headers.
         super(CASE_SENSITIVE_HASHER,
               CharSequenceValueConverter.INSTANCE,
-              validate ? HTTP2_NAME_VALIDATOR : NameValidator.NOT_NULL);
+              validate ? DEFAULT_HTTP2_NAME_VALIDATOR : NameValidator.NOT_NULL);
     }
 
     /**
@@ -133,7 +142,7 @@ public class DefaultHttp2Headers
         // headers.
         super(CASE_SENSITIVE_HASHER,
               CharSequenceValueConverter.INSTANCE,
-              validate ? HTTP2_NAME_VALIDATOR : NameValidator.NOT_NULL,
+              validate ? DEFAULT_HTTP2_NAME_VALIDATOR : NameValidator.NOT_NULL,
               arraySizeHint);
     }
 
@@ -154,15 +163,16 @@ public class DefaultHttp2Headers
         // headers.
         super(CASE_SENSITIVE_HASHER,
                 CharSequenceValueConverter.INSTANCE,
-                validate ? HTTP2_NAME_VALIDATOR : NameValidator.NOT_NULL,
+                validate ? DEFAULT_HTTP2_NAME_VALIDATOR : NameValidator.NOT_NULL,
                 arraySizeHint,
-                validateValues ? VALUE_VALIDATOR : (ValueValidator<CharSequence>) ValueValidator.NO_VALIDATION);
+                validateValues ? DEFAULT_HEADER_VALUE_VALIDATOR :
+                        (ValueValidator<CharSequence>) ValueValidator.NO_VALIDATION);
     }
 
     @Override
     protected void validateName(NameValidator<CharSequence> validator, boolean forAdd, CharSequence name) {
         super.validateName(validator, forAdd, name);
-        if (nameValidator() == HTTP2_NAME_VALIDATOR && forAdd && hasPseudoHeaderFormat(name)) {
+        if (nameValidator() == DEFAULT_HTTP2_NAME_VALIDATOR && forAdd && hasPseudoHeaderFormat(name)) {
             if (contains(name)) {
                 PlatformDependent.throwException(connectionError(
                         PROTOCOL_ERROR, "Duplicate HTTP/2 pseudo-header '%s' encountered.", name));
@@ -176,7 +186,7 @@ public class DefaultHttp2Headers
         super.validateValue(validator, name, value);
         // https://datatracker.ietf.org/doc/html/rfc9113#section-8.3.1
         // pseudo headers must not be empty
-        if (nameValidator() == HTTP2_NAME_VALIDATOR && (value == null || value.length() == 0) &&
+        if (nameValidator() == DEFAULT_HTTP2_NAME_VALIDATOR && (value == null || value.length() == 0) &&
                 hasPseudoHeaderFormat(name)) {
             PlatformDependent.throwException(connectionError(
                     PROTOCOL_ERROR, "HTTP/2 pseudo-header '%s' must not be empty.", name));

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -37,12 +37,7 @@ public class DefaultHttp2Headers
             return !isUpperCase(value);
         }
     };
-
-    /**
-     * Default {@link io.netty.handler.codec.DefaultHeaders.NameValidator} used for HTTP/2.
-     */
-    public static final NameValidator<CharSequence> DEFAULT_HTTP2_NAME_VALIDATOR =
-            new NameValidator<CharSequence>() {
+    static final NameValidator<CharSequence> HTTP2_NAME_VALIDATOR = new NameValidator<CharSequence>() {
         @Override
         public void validateName(CharSequence name) {
             if (name == null || name.length() == 0) {
@@ -87,11 +82,7 @@ public class DefaultHttp2Headers
         }
     };
 
-    /**
-     * Default {@link io.netty.handler.codec.DefaultHeaders.ValueValidator} used for HTTP/2.
-     */
-    public static final ValueValidator<CharSequence> DEFAULT_HEADER_VALUE_VALIDATOR =
-            new ValueValidator<CharSequence>() {
+    static final ValueValidator<CharSequence> VALUE_VALIDATOR = new ValueValidator<CharSequence>() {
         @Override
         public void validate(CharSequence value) {
             int index = HttpHeaderValidationUtil.validateValidHeaderValue(value);
@@ -125,7 +116,7 @@ public class DefaultHttp2Headers
         // headers.
         super(CASE_SENSITIVE_HASHER,
               CharSequenceValueConverter.INSTANCE,
-              validate ? DEFAULT_HTTP2_NAME_VALIDATOR : NameValidator.NOT_NULL);
+              validate ? HTTP2_NAME_VALIDATOR : NameValidator.NOT_NULL);
     }
 
     /**
@@ -142,7 +133,7 @@ public class DefaultHttp2Headers
         // headers.
         super(CASE_SENSITIVE_HASHER,
               CharSequenceValueConverter.INSTANCE,
-              validate ? DEFAULT_HTTP2_NAME_VALIDATOR : NameValidator.NOT_NULL,
+              validate ? HTTP2_NAME_VALIDATOR : NameValidator.NOT_NULL,
               arraySizeHint);
     }
 
@@ -163,16 +154,15 @@ public class DefaultHttp2Headers
         // headers.
         super(CASE_SENSITIVE_HASHER,
                 CharSequenceValueConverter.INSTANCE,
-                validate ? DEFAULT_HTTP2_NAME_VALIDATOR : NameValidator.NOT_NULL,
+                validate ? HTTP2_NAME_VALIDATOR : NameValidator.NOT_NULL,
                 arraySizeHint,
-                validateValues ? DEFAULT_HEADER_VALUE_VALIDATOR :
-                        (ValueValidator<CharSequence>) ValueValidator.NO_VALIDATION);
+                validateValues ? VALUE_VALIDATOR : (ValueValidator<CharSequence>) ValueValidator.NO_VALIDATION);
     }
 
     @Override
     protected void validateName(NameValidator<CharSequence> validator, boolean forAdd, CharSequence name) {
         super.validateName(validator, forAdd, name);
-        if (nameValidator() == DEFAULT_HTTP2_NAME_VALIDATOR && forAdd && hasPseudoHeaderFormat(name)) {
+        if (nameValidator() == HTTP2_NAME_VALIDATOR && forAdd && hasPseudoHeaderFormat(name)) {
             if (contains(name)) {
                 PlatformDependent.throwException(connectionError(
                         PROTOCOL_ERROR, "Duplicate HTTP/2 pseudo-header '%s' encountered.", name));
@@ -186,7 +176,7 @@ public class DefaultHttp2Headers
         super.validateValue(validator, name, value);
         // https://datatracker.ietf.org/doc/html/rfc9113#section-8.3.1
         // pseudo headers must not be empty
-        if (nameValidator() == DEFAULT_HTTP2_NAME_VALIDATOR && (value == null || value.length() == 0) &&
+        if (nameValidator() == HTTP2_NAME_VALIDATOR && (value == null || value.length() == 0) &&
                 hasPseudoHeaderFormat(name)) {
             PlatformDependent.throwException(connectionError(
                     PROTOCOL_ERROR, "HTTP/2 pseudo-header '%s' must not be empty.", name));

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Headers.java
@@ -15,6 +15,7 @@
 
 package io.netty.handler.codec.http2;
 
+import io.netty.handler.codec.DefaultHeaders;
 import io.netty.handler.codec.Headers;
 import io.netty.util.AsciiString;
 
@@ -287,4 +288,18 @@ public interface Http2Headers extends Headers<CharSequence, CharSequence, Http2H
      * otherwise a case sensitive compare is run to compare values.
      */
     boolean contains(CharSequence name, CharSequence value, boolean caseInsensitive);
+
+    /**
+     * Default {@link io.netty.handler.codec.DefaultHeaders.NameValidator} used for HTTP/2.
+     */
+    static DefaultHeaders.NameValidator<CharSequence> defaultHtt2NameValidator() {
+        return DefaultHttp2Headers.HTTP2_NAME_VALIDATOR;
+    }
+
+    /**
+     * Default {@link io.netty.handler.codec.DefaultHeaders.ValueValidator} used for HTTP/2.
+     */
+    static DefaultHeaders.ValueValidator<CharSequence> defaultHttp2ValueValidator() {
+        return DefaultHttp2Headers.VALUE_VALIDATOR;
+    }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/ReadOnlyHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/ReadOnlyHttp2Headers.java
@@ -140,7 +140,7 @@ public final class ReadOnlyHttp2Headers implements Http2Headers {
         final int otherHeadersEnd = otherHeaders.length - 1;
         for (int i = 0; i < otherHeadersEnd; i += 2) {
             AsciiString name = otherHeaders[i];
-            DEFAULT_HTTP2_NAME_VALIDATOR.validateName(name);
+            HTTP2_NAME_VALIDATOR.validateName(name);
             if (!seenNonPseudoHeader && !name.isEmpty() && name.byteAt(0) != PSEUDO_HEADER_TOKEN) {
                 seenNonPseudoHeader = true;
             } else if (seenNonPseudoHeader && !name.isEmpty() && name.byteAt(0) == PSEUDO_HEADER_TOKEN) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/ReadOnlyHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/ReadOnlyHttp2Headers.java
@@ -140,7 +140,7 @@ public final class ReadOnlyHttp2Headers implements Http2Headers {
         final int otherHeadersEnd = otherHeaders.length - 1;
         for (int i = 0; i < otherHeadersEnd; i += 2) {
             AsciiString name = otherHeaders[i];
-            HTTP2_NAME_VALIDATOR.validateName(name);
+            DEFAULT_HTTP2_NAME_VALIDATOR.validateName(name);
             if (!seenNonPseudoHeader && !name.isEmpty() && name.byteAt(0) != PSEUDO_HEADER_TOKEN) {
                 seenNonPseudoHeader = true;
             } else if (seenNonPseudoHeader && !name.isEmpty() && name.byteAt(0) == PSEUDO_HEADER_TOKEN) {


### PR DESCRIPTION
 #### Motivation

These are handy for people implementing their own Http2 types.

 #### Modifications

Make them public and also massage the names.

Motivation:

Explain here the context, and why you're making that change.
What is the problem you're trying to solve.
