### PR TITLE
Avoid loosing original read exception

### DIFF
--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
@@ -118,7 +118,11 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
             if (byteBuf != null) {
                 if (byteBuf.isReadable()) {
                     readPending = false;
-                    pipeline.fireChannelRead(byteBuf);
+                    try {
+                        pipeline.fireChannelRead(byteBuf);
+                    } catch (Exception e) {
+                        cause.addSuppressed(e);
+                    }
                 } else {
                     byteBuf.release();
                 }


### PR DESCRIPTION
Motivation:
If we are handling an exception from `read` but we did manage to read something, then we should not lose track of the original exception if `fireChannelRead` also throws.

Modification:
Add any exception from `fireChannelRead` to the original as a suppressed exception, in `handleReadException`.

Result:
We now send the correct exception through `fireExceptionCaught`.