### PR TITLE
Fix adaptive allocator bug from not noticing failed allocation

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -309,7 +309,8 @@ final class AdaptivePoolingAllocator {
         Chunk chunk = new Chunk(innerChunk, magazine, false, chunkSize -> true);
         chunkRegistry.add(chunk);
         try {
-            chunk.readInitInto(buf, size, size, maxCapacity);
+            boolean success = chunk.readInitInto(buf, size, size, maxCapacity);
+            assert success: "Failed to initialize ByteBuf with dedicated chunk";
         } finally {
             // As the chunk is an one-off we need to always call release explicitly as readInitInto(...)
             // will take care of retain once when successful. Once The AdaptiveByteBuf is released it will
@@ -749,9 +750,10 @@ final class AdaptivePoolingAllocator {
             int remainingCapacity = curr.remainingCapacity();
             int startingCapacity = chunkController.computeBufferCapacity(
                     size, maxCapacity, true /* never update stats as we don't hold the magazine lock */);
-            if (remainingCapacity >= size) {
-                curr.readInitInto(buf, size, Math.min(remainingCapacity, startingCapacity), maxCapacity);
+            if (remainingCapacity >= size &&
+                    curr.readInitInto(buf, size, Math.min(remainingCapacity, startingCapacity), maxCapacity)) {
                 allocated = true;
+                remainingCapacity = curr.remainingCapacity();
             }
             try {
                 if (remainingCapacity >= RETIRE_CAPACITY) {


### PR DESCRIPTION
Motivation:
Allocations out of magazines and chunks can fail for various reasons. The allocator as a whole needs to handle this gracefully everywhere.

Modification:
Fix a bug where the lockless allocation path didn't check if an allocation succeeded or not, and just assumed success. This led to all sorts of weird and difficult to diagnose problems later, when buffers were used but not bound to a chunk, or bound to a previously used chunk, or not expanded from `ensureWritable`, etc.

Result:
We should see fewer weird test failures now.

Fixes https://github.com/netty/netty/issues/16139