### PR TITLE
Remove unnecessary null check in WebSocketServerExtensionHandler

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketExtensionUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketExtensionUtil.java
@@ -77,7 +77,7 @@ public final class WebSocketExtensionUtil {
         List<WebSocketExtensionData> userDefinedExtensions =
           userDefinedHeaderValue != null ?
             extractExtensions(userDefinedHeaderValue) :
-            Collections.<WebSocketExtensionData>emptyList();
+            Collections.emptyList();
 
         for (WebSocketExtensionData userDefined: userDefinedExtensions) {
             WebSocketExtensionData matchingExtra = null;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandler.java
@@ -53,8 +53,7 @@ public class WebSocketServerExtensionHandler extends ChannelDuplexHandler {
 
     private final List<WebSocketServerExtensionHandshaker> extensionHandshakers;
 
-    private final Queue<List<WebSocketServerExtension>> validExtensions =
-            new ArrayDeque<List<WebSocketServerExtension>>(4);
+    private final Queue<List<WebSocketServerExtension>> validExtensions = new ArrayDeque<>(4);
 
     /**
      * Constructor
@@ -216,7 +215,7 @@ public class WebSocketServerExtensionHandler extends ChannelDuplexHandler {
             if (validExtensionsList != null && !validExtensionsList.isEmpty()) {
                 String headerValue = headers.getAsString(HttpHeaderNames.SEC_WEBSOCKET_EXTENSIONS);
                 List<WebSocketExtensionData> extraExtensions =
-                  new ArrayList<WebSocketExtensionData>(extensionHandshakers.size());
+                  new ArrayList<>(extensionHandshakers.size());
                 for (WebSocketServerExtension extension : validExtensionsList) {
                     extraExtensions.add(extension.newReponseData());
                 }
@@ -235,9 +234,7 @@ public class WebSocketServerExtensionHandler extends ChannelDuplexHandler {
                     }
                 });
 
-                if (newHeaderValue != null) {
-                    headers.set(HttpHeaderNames.SEC_WEBSOCKET_EXTENSIONS, newHeaderValue);
-                }
+                headers.set(HttpHeaderNames.SEC_WEBSOCKET_EXTENSIONS, newHeaderValue);
             }
 
             promise.addListener(future -> {


### PR DESCRIPTION
Motivation:

`WebSocketExtensionUtil.computeMergeExtensionsHeaderValue` always returns `StringBuilder.toString()`, which can't be null.

Modification:

Remove unnecessary null check in WebSocketServerExtensionHandler + cleanup

Result:

No more unnecessary check + small cleanup.