### PR TITLE
Avoid loosing original read exception (#16199)

### DIFF
--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
@@ -30,6 +30,7 @@ import io.netty.channel.socket.ChannelInputShutdownEvent;
 import io.netty.channel.socket.ChannelInputShutdownReadComplete;
 import io.netty.channel.socket.SocketChannelConfig;
 import io.netty.util.internal.StringUtil;
+import io.netty.util.internal.ThrowableUtil;
 
 import java.io.IOException;
 import java.nio.channels.SelectableChannel;
@@ -115,7 +116,11 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
             if (byteBuf != null) {
                 if (byteBuf.isReadable()) {
                     readPending = false;
-                    pipeline.fireChannelRead(byteBuf);
+                    try {
+                        pipeline.fireChannelRead(byteBuf);
+                    } catch (Exception e) {
+                        ThrowableUtil.addSuppressed(cause, e);
+                    }
                 } else {
                     byteBuf.release();
                 }


### PR DESCRIPTION
Motivation:
If we are handling an exception from `read` but we did manage to read something, then we should not lose track of the original exception if `fireChannelRead` also throws.

Modification:
Add any exception from `fireChannelRead` to the original as a suppressed exception, in `handleReadException`.

Result:
We now send the correct exception through `fireExceptionCaught`.

(cherry picked from commit dffcb418b9b6709579d3f80956d11a3a3e2c7d75)
