### PR TITLE
Delay getBytes() call in ReferenceCountedOpenSslServerContext

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -2284,10 +2284,10 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
         return endPointIdentificationAlgorithm != null && !endPointIdentificationAlgorithm.isEmpty();
     }
 
-    final boolean checkSniHostnameMatch(byte[] hostname) {
+    final boolean checkSniHostnameMatch(String hostname) {
         Collection<SNIMatcher> matchers = this.matchers;
         if (matchers != null && !matchers.isEmpty()) {
-            SNIHostName name = new SNIHostName(hostname);
+            SNIHostName name = new SNIHostName(hostname.getBytes(CharsetUtil.UTF_8));
             for (SNIMatcher matcher : matchers) {
                 // type 0 is for hostname
                 if (matcher.getType() == 0 && matcher.matches(name)) {

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslServerContext.java
@@ -302,7 +302,7 @@ public final class ReferenceCountedOpenSslServerContext extends ReferenceCounted
             ReferenceCountedOpenSslEngine engine = engines.get(ssl);
             if (engine != null) {
                 // TODO: In the next release of tcnative we should pass the byte[] directly in and not use a String.
-                return engine.checkSniHostnameMatch(hostname.getBytes(CharsetUtil.UTF_8));
+                return engine.checkSniHostnameMatch(hostname);
             }
             logger.warn("No ReferenceCountedOpenSslEngine found for SSL pointer: {}", ssl);
             return false;

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -1123,7 +1123,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
             SSLParameters parameters = new SSLParameters();
             Java8SslTestUtils.setSNIMatcher(parameters, name);
             engine.setSSLParameters(parameters);
-            assertFalse(unwrapEngine(engine).checkSniHostnameMatch("other".getBytes(CharsetUtil.UTF_8)));
+            assertFalse(unwrapEngine(engine).checkSniHostnameMatch("other"));
         } finally {
             cleanupServerSslEngine(engine);
         }


### PR DESCRIPTION
Motivation:

If sni matchers are empty, no need to call the unnecessary `String.getBytes()`, which allocates a byte array.

Modification:

Changed `ReferenceCountedOpenSslEngine.checkSniHostnameMatch` to accept `String` instead of `byte[]`

Result:

No more getBytes() call if sni matchers are empty.
