### PR TITLE
Use recommanded finalize chain pattern when override finalize() method

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -344,9 +344,9 @@ final class AdaptivePoolingAllocator {
     @Override
     protected void finalize() throws Throwable {
         try {
-            super.finalize();
-        } finally {
             free();
+        } finally {
+            super.finalize();
         }
     }
 

--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -640,10 +640,10 @@ abstract class PoolArena<T> implements PoolArenaMetric {
     @Override
     protected final void finalize() throws Throwable {
         try {
-            super.finalize();
-        } finally {
             destroyPoolSubPages(smallSubpagePools);
             destroyPoolChunkLists(qInit, q000, q025, q050, q075, q100);
+        } finally {
+            super.finalize();
         }
     }
 

--- a/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
@@ -484,8 +484,6 @@ final class PoolThreadCache {
         @Override
         protected void finalize() throws Throwable {
             try {
-                super.finalize();
-            } finally {
                 PoolThreadCache cache = this.cache;
                 // this can race with a non-finalizer thread calling free: regardless who wins, the cache will be
                 // null out
@@ -493,6 +491,8 @@ final class PoolThreadCache {
                 if (cache != null) {
                     cache.free(true);
                 }
+            } finally {
+                super.finalize();
             }
         }
     }

--- a/common/src/main/java/io/netty/util/HashedWheelTimer.java
+++ b/common/src/main/java/io/netty/util/HashedWheelTimer.java
@@ -322,13 +322,13 @@ public class HashedWheelTimer implements Timer {
     @Override
     protected void finalize() throws Throwable {
         try {
-            super.finalize();
-        } finally {
             // This object is going to be GCed and it is assumed the ship has sailed to do a proper shutdown. If
             // we have not yet shutdown then we want to make sure we decrement the active instance count.
             if (WORKER_STATE_UPDATER.getAndSet(this, WORKER_STATE_SHUTDOWN) != WORKER_STATE_SHUTDOWN) {
                 INSTANCE_COUNTER.decrementAndGet();
             }
+        } finally {
+            super.finalize();
         }
     }
 

--- a/common/src/test/java/io/netty/util/RecyclerFastThreadLocalTest.java
+++ b/common/src/test/java/io/netty/util/RecyclerFastThreadLocalTest.java
@@ -56,8 +56,11 @@ public class RecyclerFastThreadLocalTest extends RecyclerTest {
         }) {
             @Override
             protected void finalize() throws Throwable {
-                super.finalize();
-                collected.set(true);
+                try {
+                    collected.set(true);
+                } finally {
+                    super.finalize();
+                }
             }
         };
         assertFalse(collected.get());

--- a/common/src/test/java/io/netty/util/RecyclerTest.java
+++ b/common/src/test/java/io/netty/util/RecyclerTest.java
@@ -185,8 +185,11 @@ public class RecyclerTest {
         }) {
             @Override
             protected void finalize() throws Throwable {
-                super.finalize();
-                collected.set(true);
+                try {
+                    collected.set(true);
+                } finally {
+                    super.finalize();
+                }
             }
         };
         assertFalse(collected.get());

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
@@ -60,7 +60,10 @@ public abstract class OpenSslContext extends ReferenceCountedOpenSslContext {
     @Override
     @SuppressWarnings("FinalizeDeclaration")
     protected final void finalize() throws Throwable {
-        super.finalize();
-        OpenSsl.releaseIfNeeded(this);
+        try {
+            OpenSsl.releaseIfNeeded(this);
+        } finally {
+            super.finalize();
+        }
     }
 }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
@@ -39,7 +39,10 @@ public final class OpenSslEngine extends ReferenceCountedOpenSslEngine {
     @Override
     @SuppressWarnings("FinalizeDeclaration")
     protected void finalize() throws Throwable {
-        super.finalize();
-        OpenSsl.releaseIfNeeded(this);
+        try {
+            OpenSsl.releaseIfNeeded(this);
+        } finally {
+            super.finalize();
+        }
     }
 }


### PR DESCRIPTION
According to the java docs of [Object.finalize()](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Object.html#finalize()), when override `finalize()` method, the `super.finalize()` should be placed in the `finally` block:

> Finalizer invocations are not automatically chained, unlike constructors. If a subclass overrides finalize it must invoke the superclass finalizer explicitly. To guard against exceptions prematurely terminating the finalize chain, the subclass should use a try-finally block to ensure super.finalize() is always invoked. For example,

```
     @Override
     protected void finalize() throws Throwable {
         try {
             ... // cleanup subclass state
         } finally {
             super.finalize();
         }
     }
```

As we know, the [constructor chaining](https://docs.oracle.com/javase/tutorial/java/IandI/super.html) order is: First the superclass constructor, then the subclass constructor.

The destruction order has not been explained well in java docs, but we can take C++ docs as reference:
https://isocpp.org/wiki/faq/dtors#order-dtors-for-members

So when doing finalize(), the order should be reversed: First the subclass, then the superclass.

This pattern has also been stated in the book [<Effective Java, 2nd Edition>](https://www.oreilly.com/library/view/effective-java-2nd/9780137150021/)(Item 7):

> You should finalize the subclass in a try block and invoke the superclass finalizer in the corresponding finally block.

By doing so, it should make the code less error prone, for example:
https://issues.apache.org/jira/browse/AXIS2-4163
