### PR TITLE
remove duplicated SSL.getSniHostname(ssl) call in ExtendedOpenSslSession (#16209)

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -256,16 +256,11 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                                 requestedServerNames = Collections.emptyList();
                             } else {
                                 String name = SSL.getSniHostname(ssl);
-                                if (name == null) {
-                                    requestedServerNames = Collections.emptyList();
-                                } else {
-                                    // Convert to bytes as we do not want to do any strict validation of the
-                                    // SNIHostName while creating it.
-                                    byte[] hostname = SSL.getSniHostname(ssl).getBytes(CharsetUtil.UTF_8);
-                                    requestedServerNames = hostname.length == 0 ?
-                                            Collections.emptyList() :
-                                            Collections.singletonList(new SNIHostName(hostname));
-                                }
+                                requestedServerNames = (name == null || name.isEmpty()) ?
+                                        Collections.emptyList() :
+                                        // Convert to bytes as we do not want to do any strict validation of the
+                                        // SNIHostName while creating it.
+                                        Collections.singletonList(new SNIHostName(name.getBytes(CharsetUtil.UTF_8)));
                             }
                         }
                         return requestedServerNames;


### PR DESCRIPTION
Motivation:

`ExtendedOpenSslSession.getRequestedServerNames` may call
`SSL.getSniHostname(ssl)` 2 times while it's not necessary.

Modification:

Remove duplicated `SSL.getSniHostname(ssl)` call + cleanup.

Result:

1 less `SSL.getSniHostname(ssl)` call.

---------

Co-authored-by: Norman Maurer <norman_maurer@apple.com>