### PR TITLE
codec-http: make the default header key and value validators public

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -82,7 +82,7 @@ public class DefaultHttp2Headers
         }
     };
 
-    private static final ValueValidator<CharSequence> VALUE_VALIDATOR = new ValueValidator<CharSequence>() {
+    static final ValueValidator<CharSequence> VALUE_VALIDATOR = new ValueValidator<CharSequence>() {
         @Override
         public void validate(CharSequence value) {
             int index = HttpHeaderValidationUtil.validateValidHeaderValue(value);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Headers.java
@@ -15,6 +15,7 @@
 
 package io.netty.handler.codec.http2;
 
+import io.netty.handler.codec.DefaultHeaders;
 import io.netty.handler.codec.Headers;
 import io.netty.util.AsciiString;
 
@@ -287,4 +288,18 @@ public interface Http2Headers extends Headers<CharSequence, CharSequence, Http2H
      * otherwise a case sensitive compare is run to compare values.
      */
     boolean contains(CharSequence name, CharSequence value, boolean caseInsensitive);
+
+    /**
+     * Default {@link io.netty.handler.codec.DefaultHeaders.NameValidator} used for HTTP/2.
+     */
+    static DefaultHeaders.NameValidator<CharSequence> defaultHtt2NameValidator() {
+        return DefaultHttp2Headers.HTTP2_NAME_VALIDATOR;
+    }
+
+    /**
+     * Default {@link io.netty.handler.codec.DefaultHeaders.ValueValidator} used for HTTP/2.
+     */
+    static DefaultHeaders.ValueValidator<CharSequence> defaultHttp2ValueValidator() {
+        return DefaultHttp2Headers.VALUE_VALIDATOR;
+    }
 }


### PR DESCRIPTION
Motivation:

These are handy for people implementing their own Http2 types.

Modifications:

Make them public and also massage the names.

See #16197 for 4.2 branch PR.