### PR TITLE
codec-http2: move the accessors from Http2Headers to DefaultHttp2Headers

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -37,7 +37,7 @@ public class DefaultHttp2Headers
             return !isUpperCase(value);
         }
     };
-    static final NameValidator<CharSequence> HTTP2_NAME_VALIDATOR = new NameValidator<CharSequence>() {
+    private static final NameValidator<CharSequence> HTTP2_NAME_VALIDATOR = new NameValidator<CharSequence>() {
         @Override
         public void validateName(CharSequence name) {
             if (name == null || name.length() == 0) {
@@ -82,7 +82,7 @@ public class DefaultHttp2Headers
         }
     };
 
-    static final ValueValidator<CharSequence> VALUE_VALIDATOR = new ValueValidator<CharSequence>() {
+    private static final ValueValidator<CharSequence> VALUE_VALIDATOR = new ValueValidator<CharSequence>() {
         @Override
         public void validate(CharSequence value) {
             int index = HttpHeaderValidationUtil.validateValidHeaderValue(value);
@@ -298,5 +298,19 @@ public class DefaultHttp2Headers
             }
             super.remove();
         }
+    }
+
+    /**
+     * Default {@link io.netty.handler.codec.DefaultHeaders.NameValidator} used for HTTP/2.
+     */
+    public static NameValidator<CharSequence> defaultHtt2NameValidator() {
+        return HTTP2_NAME_VALIDATOR;
+    }
+
+    /**
+     * Default {@link io.netty.handler.codec.DefaultHeaders.ValueValidator} used for HTTP/2.
+     */
+    public static ValueValidator<CharSequence> defaultHttp2ValueValidator() {
+        return VALUE_VALIDATOR;
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Headers.java
@@ -288,18 +288,4 @@ public interface Http2Headers extends Headers<CharSequence, CharSequence, Http2H
      * otherwise a case sensitive compare is run to compare values.
      */
     boolean contains(CharSequence name, CharSequence value, boolean caseInsensitive);
-
-    /**
-     * Default {@link io.netty.handler.codec.DefaultHeaders.NameValidator} used for HTTP/2.
-     */
-    static DefaultHeaders.NameValidator<CharSequence> defaultHtt2NameValidator() {
-        return DefaultHttp2Headers.HTTP2_NAME_VALIDATOR;
-    }
-
-    /**
-     * Default {@link io.netty.handler.codec.DefaultHeaders.ValueValidator} used for HTTP/2.
-     */
-    static DefaultHeaders.ValueValidator<CharSequence> defaultHttp2ValueValidator() {
-        return DefaultHttp2Headers.VALUE_VALIDATOR;
-    }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/ReadOnlyHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/ReadOnlyHttp2Headers.java
@@ -140,7 +140,7 @@ public final class ReadOnlyHttp2Headers implements Http2Headers {
         final int otherHeadersEnd = otherHeaders.length - 1;
         for (int i = 0; i < otherHeadersEnd; i += 2) {
             AsciiString name = otherHeaders[i];
-            HTTP2_NAME_VALIDATOR.validateName(name);
+            defaultHtt2NameValidator().validateName(name);
             if (!seenNonPseudoHeader && !name.isEmpty() && name.byteAt(0) != PSEUDO_HEADER_TOKEN) {
                 seenNonPseudoHeader = true;
             } else if (seenNonPseudoHeader && !name.isEmpty() && name.byteAt(0) == PSEUDO_HEADER_TOKEN) {


### PR DESCRIPTION
 #### Motivation

These helpers might be better in the DefaultHttp2Headers object since they expose types from the DefaultHttpHeaders.

 #### Modifications

Move them.
