### PR TITLE
Remove unnecessary null check in WebSocketServerExtensionHandler (#16201)

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketExtensionUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketExtensionUtil.java
@@ -77,7 +77,7 @@ public final class WebSocketExtensionUtil {
         List<WebSocketExtensionData> userDefinedExtensions =
           userDefinedHeaderValue != null ?
             extractExtensions(userDefinedHeaderValue) :
-            Collections.<WebSocketExtensionData>emptyList();
+            Collections.emptyList();
 
         for (WebSocketExtensionData userDefined: userDefinedExtensions) {
             WebSocketExtensionData matchingExtra = null;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandler.java
@@ -56,8 +56,7 @@ public class WebSocketServerExtensionHandler implements ChannelInboundHandler, C
 
     private final List<WebSocketServerExtensionHandshaker> extensionHandshakers;
 
-    private final Queue<List<WebSocketServerExtension>> validExtensions =
-            new ArrayDeque<List<WebSocketServerExtension>>(4);
+    private final Queue<List<WebSocketServerExtension>> validExtensions = new ArrayDeque<>(4);
 
     /**
      * Constructor
@@ -223,7 +222,7 @@ public class WebSocketServerExtensionHandler implements ChannelInboundHandler, C
             if (validExtensionsList != null && !validExtensionsList.isEmpty()) {
                 String headerValue = headers.getAsString(HttpHeaderNames.SEC_WEBSOCKET_EXTENSIONS);
                 List<WebSocketExtensionData> extraExtensions =
-                  new ArrayList<WebSocketExtensionData>(extensionHandshakers.size());
+                  new ArrayList<>(extensionHandshakers.size());
                 for (WebSocketServerExtension extension : validExtensionsList) {
                     extraExtensions.add(extension.newReponseData());
                 }
@@ -242,9 +241,7 @@ public class WebSocketServerExtensionHandler implements ChannelInboundHandler, C
                     }
                 });
 
-                if (newHeaderValue != null) {
-                    headers.set(HttpHeaderNames.SEC_WEBSOCKET_EXTENSIONS, newHeaderValue);
-                }
+                headers.set(HttpHeaderNames.SEC_WEBSOCKET_EXTENSIONS, newHeaderValue);
             }
 
             future.addListener(f -> {


### PR DESCRIPTION
Motivation:

`WebSocketExtensionUtil.computeMergeExtensionsHeaderValue` always
returns `StringBuilder.toString()`, which can't be null.

Modification:

Remove unnecessary null check in WebSocketServerExtensionHandler +
cleanup

Result:

No more unnecessary check + small cleanup.

Co-authored-by: Norman Maurer <norman_maurer@apple.com>