### PR TITLE
codec-http2: make the default header key and value validators public

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -37,7 +37,7 @@ public class DefaultHttp2Headers
             return !isUpperCase(value);
         }
     };
-    static final NameValidator<CharSequence> HTTP2_NAME_VALIDATOR = new NameValidator<CharSequence>() {
+    private static final NameValidator<CharSequence> HTTP2_NAME_VALIDATOR = new NameValidator<CharSequence>() {
         @Override
         public void validateName(CharSequence name) {
             if (name == null || name.length() == 0) {
@@ -298,5 +298,19 @@ public class DefaultHttp2Headers
             }
             super.remove();
         }
+    }
+
+    /**
+     * Default {@link io.netty.handler.codec.DefaultHeaders.NameValidator} used for HTTP/2.
+     */
+    public static NameValidator<CharSequence> defaultHtt2NameValidator() {
+        return HTTP2_NAME_VALIDATOR;
+    }
+
+    /**
+     * Default {@link io.netty.handler.codec.DefaultHeaders.ValueValidator} used for HTTP/2.
+     */
+    public static ValueValidator<CharSequence> defaultHttp2ValueValidator() {
+        return VALUE_VALIDATOR;
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/ReadOnlyHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/ReadOnlyHttp2Headers.java
@@ -140,7 +140,7 @@ public final class ReadOnlyHttp2Headers implements Http2Headers {
         final int otherHeadersEnd = otherHeaders.length - 1;
         for (int i = 0; i < otherHeadersEnd; i += 2) {
             AsciiString name = otherHeaders[i];
-            HTTP2_NAME_VALIDATOR.validateName(name);
+            defaultHtt2NameValidator().validateName(name);
             if (!seenNonPseudoHeader && !name.isEmpty() && name.byteAt(0) != PSEUDO_HEADER_TOKEN) {
                 seenNonPseudoHeader = true;
             } else if (seenNonPseudoHeader && !name.isEmpty() && name.byteAt(0) == PSEUDO_HEADER_TOKEN) {


### PR DESCRIPTION
Motivation:

These are handy for people implementing their own Http2 types.

Modifications:

Make them public and also massage the names.
