### PR TITLE
Fix IDE warnings in SslHandler

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1374,14 +1374,6 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         }
     }
 
-    private void decodeNonJdkCompatible(ChannelHandlerContext ctx, ByteBuf in) {
-        try {
-            unwrap(ctx, in, in.readableBytes());
-        } catch (Throwable cause) {
-            handleUnwrapThrowable(ctx, cause);
-        }
-    }
-
     private void handleUnwrapThrowable(ChannelHandlerContext ctx, Throwable cause) {
         try {
             // We should attempt to notify the handshake failure before writing any pending data. If we are in unwrap
@@ -1416,7 +1408,11 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         if (jdkCompatibilityMode) {
             decodeJdkCompatible(ctx, in);
         } else {
-            decodeNonJdkCompatible(ctx, in);
+            try {
+                unwrap(ctx, in, in.readableBytes());
+            } catch (Throwable cause) {
+                handleUnwrapThrowable(ctx, cause);
+            }
         }
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1374,6 +1374,14 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         }
     }
 
+    private void decodeNonJdkCompatible(ChannelHandlerContext ctx, ByteBuf in) {
+        try {
+            unwrap(ctx, in, in.readableBytes());
+        } catch (Throwable cause) {
+            handleUnwrapThrowable(ctx, cause);
+        }
+    }
+
     private void handleUnwrapThrowable(ChannelHandlerContext ctx, Throwable cause) {
         try {
             // We should attempt to notify the handshake failure before writing any pending data. If we are in unwrap
@@ -1408,11 +1416,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         if (jdkCompatibilityMode) {
             decodeJdkCompatible(ctx, in);
         } else {
-            try {
-                unwrap(ctx, in, in.readableBytes());
-            } catch (Throwable cause) {
-                handleUnwrapThrowable(ctx, cause);
-            }
+            decodeNonJdkCompatible(ctx, in);
         }
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -301,27 +301,26 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
             SSLEngineResult unwrap(SslHandler handler, ByteBuf in, int len, ByteBuf out) throws SSLException {
                 int writerIndex = out.writerIndex();
                 ByteBuffer inNioBuffer = getUnwrapInputBuffer(handler, toByteBuffer(in, in.readerIndex(), len));
+                int position = inNioBuffer.position();
                 final SSLEngineResult result = handler.engine.unwrap(inNioBuffer,
-                    toByteBuffer(out, writerIndex, out.writableBytes()));
+                        toByteBuffer(out, writerIndex, out.writableBytes()));
                 out.writerIndex(writerIndex + result.bytesProduced());
-                return result;
-            }
 
-            private ByteBuffer getUnwrapInputBuffer(SslHandler handler, ByteBuffer inNioBuffer) {
-                int javaVersion = PlatformDependent.javaVersion();
-                if (javaVersion >= 22 && javaVersion < 25 && inNioBuffer.isDirect()) {
-                    // Work-around for https://bugs.openjdk.org/browse/JDK-8357268
-                    int remaining = inNioBuffer.remaining();
-                    ByteBuffer copy = handler.unwrapInputCopy;
-                    if (copy == null || copy.capacity() < remaining) {
-                        handler.unwrapInputCopy = copy = ByteBuffer.allocate(remaining);
-                    } else {
-                        copy.clear();
+                // This is a workaround for a bug in Android 5.0. Android 5.0 does not correctly update the
+                // SSLEngineResult.bytesConsumed() in some cases and just return 0.
+                //
+                // See:
+                //     - https://android-review.googlesource.com/c/platform/external/conscrypt/+/122080
+                //     - https://github.com/netty/netty/issues/7758
+                if (result.bytesConsumed() == 0) {
+                    int consumed = inNioBuffer.position() - position;
+                    if (consumed != result.bytesConsumed()) {
+                        // Create a new SSLEngineResult with the correct bytesConsumed().
+                        return new SSLEngineResult(
+                                result.getStatus(), result.getHandshakeStatus(), consumed, result.bytesProduced());
                     }
-                    copy.put(inNioBuffer).flip();
-                    return copy;
                 }
-                return inNioBuffer;
+                return result;
             }
 
             @Override

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -314,7 +314,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                 //     - https://github.com/netty/netty/issues/7758
                 if (result.bytesConsumed() == 0) {
                     int consumed = inNioBuffer.position() - position;
-                    if (consumed != result.bytesConsumed()) {
+                    if (consumed != 0) {
                         // Create a new SSLEngineResult with the correct bytesConsumed().
                         return new SSLEngineResult(
                                 result.getStatus(), result.getHandshakeStatus(), consumed, result.bytesProduced());

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -314,7 +314,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                 //     - https://github.com/netty/netty/issues/7758
                 if (result.bytesConsumed() == 0) {
                     int consumed = inNioBuffer.position() - position;
-                    if (consumed != 0) {
+                    if (consumed != result.bytesConsumed()) {
                         // Create a new SSLEngineResult with the correct bytesConsumed().
                         return new SSLEngineResult(
                                 result.getStatus(), result.getHandshakeStatus(), consumed, result.bytesProduced());

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -301,25 +301,9 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
             SSLEngineResult unwrap(SslHandler handler, ByteBuf in, int len, ByteBuf out) throws SSLException {
                 int writerIndex = out.writerIndex();
                 ByteBuffer inNioBuffer = getUnwrapInputBuffer(handler, toByteBuffer(in, in.readerIndex(), len));
-                int position = inNioBuffer.position();
                 final SSLEngineResult result = handler.engine.unwrap(inNioBuffer,
                     toByteBuffer(out, writerIndex, out.writableBytes()));
                 out.writerIndex(writerIndex + result.bytesProduced());
-
-                // This is a workaround for a bug in Android 5.0. Android 5.0 does not correctly update the
-                // SSLEngineResult.bytesConsumed() in some cases and just return 0.
-                //
-                // See:
-                //     - https://android-review.googlesource.com/c/platform/external/conscrypt/+/122080
-                //     - https://github.com/netty/netty/issues/7758
-                if (result.bytesConsumed() == 0) {
-                    int consumed = inNioBuffer.position() - position;
-                    if (consumed != result.bytesConsumed()) {
-                        // Create a new SSLEngineResult with the correct bytesConsumed().
-                        return new SSLEngineResult(
-                                result.getStatus(), result.getHandshakeStatus(), consumed, result.bytesProduced());
-                    }
-                }
                 return result;
             }
 
@@ -681,12 +665,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         if (ctx.executor().inEventLoop()) {
             closeOutbound0(promise);
         } else {
-            ctx.executor().execute(new Runnable() {
-                @Override
-                public void run() {
-                    closeOutbound0(promise);
-                }
-            });
+            ctx.executor().execute(() -> closeOutbound0(promise));
         }
         return promise;
     }
@@ -1063,12 +1042,6 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                 // Check if did not produce any bytes and if so break out of the loop, but only if we did not process
                 // a task as last action. It's fine to not produce any data as part of executing a task.
                 if (result.bytesProduced() == 0 && status != HandshakeStatus.NEED_TASK) {
-                    break;
-                }
-
-                // It should not consume empty buffers when it is not handshaking
-                // Fix for Android, where it was encrypting empty buffers even when not handshaking
-                if (result.bytesConsumed() == 0 && result.getHandshakeStatus() == HandshakeStatus.NOT_HANDSHAKING) {
                     break;
                 }
             }
@@ -1637,12 +1610,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
 
     private void executeNotifyClosePromise(final ChannelHandlerContext ctx) {
         try {
-            ctx.executor().execute(new Runnable() {
-                @Override
-                public void run() {
-                    notifyClosePromise(null);
-                }
-            });
+            ctx.executor().execute(() -> notifyClosePromise(null));
         } catch (RejectedExecutionException e) {
             notifyClosePromise(e);
         }
@@ -1650,12 +1618,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
 
     private void executeChannelRead(final ChannelHandlerContext ctx, final ByteBuf decodedOut) {
         try {
-            ctx.executor().execute(new Runnable() {
-                @Override
-                public void run() {
-                    ctx.fireChannelRead(decodedOut);
-                }
-            });
+            ctx.executor().execute(() -> ctx.fireChannelRead(decodedOut));
         } catch (RejectedExecutionException e) {
             decodedOut.release();
             throw e;
@@ -1770,12 +1733,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
      */
     private final class SslTasksRunner implements Runnable {
         private final boolean inUnwrap;
-        private final Runnable runCompleteTask = new Runnable() {
-            @Override
-            public void run() {
-                runComplete();
-            }
-        };
+        private final Runnable runCompleteTask = this::runComplete;
 
         SslTasksRunner(boolean inUnwrap) {
             this.inUnwrap = inUnwrap;
@@ -1930,12 +1888,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
             // decoding.
             //
             // See https://github.com/netty/netty-tcnative/issues/680
-            executor.execute(new Runnable() {
-                @Override
-                public void run() {
-                    resumeOnEventExecutor();
-                }
-            });
+            executor.execute(this::resumeOnEventExecutor);
         }
 
         @Override
@@ -1965,12 +1918,9 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                 safeExceptionCaught(cause);
             } else {
                 try {
-                    executor.execute(new Runnable() {
-                        @Override
-                        public void run() {
-                            clearState(STATE_PROCESS_TASK);
-                            safeExceptionCaught(cause);
-                        }
+                    executor.execute(() -> {
+                        clearState(STATE_PROCESS_TASK);
+                        safeExceptionCaught(cause);
                     });
                 } catch (RejectedExecutionException ignore) {
                     clearState(STATE_PROCESS_TASK);
@@ -2201,7 +2151,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
             throw new IllegalStateException();
         }
 
-        return renegotiate(ctx.executor().<Channel>newPromise());
+        return renegotiate(ctx.executor().newPromise());
     }
 
     /**
@@ -2217,12 +2167,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
 
         EventExecutor executor = ctx.executor();
         if (!executor.inEventLoop()) {
-            executor.execute(new Runnable() {
-                @Override
-                public void run() {
-                    renegotiateOnEventLoop(promise);
-                }
-            });
+            executor.execute(() -> renegotiateOnEventLoop(promise));
             return promise;
         }
 
@@ -2287,21 +2232,18 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
             return;
         }
 
-        final Future<?> timeoutFuture = ctx.executor().schedule(new Runnable() {
-            @Override
-            public void run() {
-                if (localHandshakePromise.isDone()) {
-                    return;
+        final Future<?> timeoutFuture = ctx.executor().schedule(() -> {
+            if (localHandshakePromise.isDone()) {
+                return;
+            }
+            SSLException exception =
+                    new SslHandshakeTimeoutException("handshake timed out after " + handshakeTimeoutMillis + "ms");
+            try {
+                if (localHandshakePromise.tryFailure(exception)) {
+                    SslUtils.handleHandshakeFailure(ctx, exception, true);
                 }
-                SSLException exception =
-                        new SslHandshakeTimeoutException("handshake timed out after " + handshakeTimeoutMillis + "ms");
-                try {
-                    if (localHandshakePromise.tryFailure(exception)) {
-                        SslUtils.handleHandshakeFailure(ctx, exception, true);
-                    }
-                } finally {
-                    releaseAndFailAll(ctx, exception);
-                }
+            } finally {
+                releaseAndFailAll(ctx, exception);
             }
         }, handshakeTimeoutMillis, TimeUnit.MILLISECONDS);
 
@@ -2345,15 +2287,12 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
             long closeNotifyTimeout = closeNotifyFlushTimeoutMillis;
             if (closeNotifyTimeout > 0) {
                 // Force-close the connection if close_notify is not fully sent in time.
-                timeoutFuture = ctx.executor().schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        // May be done in the meantime as cancel(...) is only best effort.
-                        if (!flushFuture.isDone()) {
-                            logger.warn("{} Last write attempt timed out; force-closing the connection.",
-                                    ctx.channel());
-                            addCloseListener(ctx.close(ctx.newPromise()), promise);
-                        }
+                timeoutFuture = ctx.executor().schedule(() -> {
+                    // May be done in the meantime as cancel(...) is only best effort.
+                    if (!flushFuture.isDone()) {
+                        logger.warn("{} Last write attempt timed out; force-closing the connection.",
+                                ctx.channel());
+                        addCloseListener(ctx.close(ctx.newPromise()), promise);
                     }
                 }, closeNotifyTimeout, TimeUnit.MILLISECONDS);
             } else {
@@ -2377,17 +2316,14 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                 final Future<?> closeNotifyReadTimeoutFuture;
 
                 if (!sslClosePromise.isDone()) {
-                    closeNotifyReadTimeoutFuture = ctx.executor().schedule(new Runnable() {
-                        @Override
-                        public void run() {
-                            if (!sslClosePromise.isDone()) {
-                                logger.debug(
-                                        "{} did not receive close_notify in {}ms; force-closing the connection.",
-                                        ctx.channel(), closeNotifyReadTimeout);
+                    closeNotifyReadTimeoutFuture = ctx.executor().schedule(() -> {
+                        if (!sslClosePromise.isDone()) {
+                            logger.debug(
+                                    "{} did not receive close_notify in {}ms; force-closing the connection.",
+                                    ctx.channel(), closeNotifyReadTimeout);
 
-                                // Do the close now...
-                                addCloseListener(ctx.close(ctx.newPromise()), promise);
-                            }
+                            // Do the close now...
+                            addCloseListener(ctx.close(ctx.newPromise()), promise);
                         }
                     }, closeNotifyReadTimeout, TimeUnit.MILLISECONDS);
                 } else {

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -303,7 +303,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                 ByteBuffer inNioBuffer = getUnwrapInputBuffer(handler, toByteBuffer(in, in.readerIndex(), len));
                 int position = inNioBuffer.position();
                 final SSLEngineResult result = handler.engine.unwrap(inNioBuffer,
-                        toByteBuffer(out, writerIndex, out.writableBytes()));
+                    toByteBuffer(out, writerIndex, out.writableBytes()));
                 out.writerIndex(writerIndex + result.bytesProduced());
 
                 // This is a workaround for a bug in Android 5.0. Android 5.0 does not correctly update the
@@ -321,6 +321,23 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                     }
                 }
                 return result;
+            }
+
+            private ByteBuffer getUnwrapInputBuffer(SslHandler handler, ByteBuffer inNioBuffer) {
+                int javaVersion = PlatformDependent.javaVersion();
+                if (javaVersion >= 22 && javaVersion < 25 && inNioBuffer.isDirect()) {
+                    // Work-around for https://bugs.openjdk.org/browse/JDK-8357268
+                    int remaining = inNioBuffer.remaining();
+                    ByteBuffer copy = handler.unwrapInputCopy;
+                    if (copy == null || copy.capacity() < remaining) {
+                        handler.unwrapInputCopy = copy = ByteBuffer.allocate(remaining);
+                    } else {
+                        copy.clear();
+                    }
+                    copy.put(inNioBuffer).flip();
+                    return copy;
+                }
+                return inNioBuffer;
             }
 
             @Override


### PR DESCRIPTION
Motivation:

Make code cleaner and easier to read.

Modification:

- Use lambdas/method references when possible
- Removed unreachable condition `result.bytesConsumed() == 0 && result.getHandshakeStatus() == HandshakeStatus.NOT_HANDSHAKING` as previously in the code there is a switch that returns true for `NOT_HANDSHAKING` status
- Remove unnecessary `result.bytesConsumed()` call

Result:

Less IDE warnings, easier to read code
