### PR TITLE
Use headers.setInt() in HttpObjectAggregator instead of set() and use concrete version of String.valueOf in CharSequenceValueConverter

### DIFF
--- a/codec-base/src/main/java/io/netty/handler/codec/CharSequenceValueConverter.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/CharSequenceValueConverter.java
@@ -37,17 +37,17 @@ public class CharSequenceValueConverter implements ValueConverter<CharSequence> 
 
     @Override
     public CharSequence convertInt(int value) {
-        return String.valueOf(value);
+        return Integer.toString(value);
     }
 
     @Override
     public CharSequence convertLong(long value) {
-        return String.valueOf(value);
+        return Long.toString(value);
     }
 
     @Override
     public CharSequence convertDouble(double value) {
-        return String.valueOf(value);
+        return Double.toString(value);
     }
 
     @Override
@@ -62,7 +62,7 @@ public class CharSequenceValueConverter implements ValueConverter<CharSequence> 
 
     @Override
     public CharSequence convertFloat(float value) {
-        return String.valueOf(value);
+        return Float.toString(value);
     }
 
     @Override
@@ -72,7 +72,7 @@ public class CharSequenceValueConverter implements ValueConverter<CharSequence> 
 
     @Override
     public CharSequence convertByte(byte value) {
-        return String.valueOf(value);
+        return Integer.toString(value);
     }
 
     @Override
@@ -90,7 +90,7 @@ public class CharSequenceValueConverter implements ValueConverter<CharSequence> 
 
     @Override
     public CharSequence convertShort(short value) {
-        return String.valueOf(value);
+        return Integer.toString(value);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
@@ -96,10 +96,10 @@ public class HttpObjectAggregator
         HttpVersion.HTTP_1_1, HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE, Unpooled.EMPTY_BUFFER);
 
     static {
-        EXPECTATION_FAILED.headers().set(CONTENT_LENGTH, 0);
-        TOO_LARGE.headers().set(CONTENT_LENGTH, 0);
+        EXPECTATION_FAILED.headers().setInt(CONTENT_LENGTH, 0);
+        TOO_LARGE.headers().setInt(CONTENT_LENGTH, 0);
 
-        TOO_LARGE_CLOSE.headers().set(CONTENT_LENGTH, 0);
+        TOO_LARGE_CLOSE.headers().setInt(CONTENT_LENGTH, 0);
         TOO_LARGE_CLOSE.headers().set(CONNECTION, HttpHeaderValues.CLOSE);
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
@@ -232,9 +232,9 @@ public class HttpObjectAggregator
         //
         // See rfc2616 14.13 Content-Length
         if (!HttpUtil.isContentLengthSet(aggregated)) {
-            aggregated.headers().set(
+            aggregated.headers().setInt(
                     CONTENT_LENGTH,
-                    String.valueOf(aggregated.content().readableBytes()));
+                    aggregated.content().readableBytes());
         }
     }
 


### PR DESCRIPTION
Motivation:

`HttpHeaders.setInt()` is a bit more efficient than `HttpHeaders.set()`, as it does fewer checks.

Modification:

- Use `HttpHeaders.setInt()` instead of `HttpHeaders.set()` in `HttpObjectAggregator.finishAggregation` method.
- Replace `String.valueOf` in `CharSequenceValueConverter` with concrete versions: `Integer.toString()`, `Float.toString()`, etc. Could save some time for JIT.

Result:

`HttpHeaders.setInt()` is used instead of `HttpHeaders.set()` in `HttpObjectAggregator`