### PR TITLE
Decrease Long allocations and map.put calls in ReferenceCountedOpenSllEngine in handshake() method

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -419,6 +419,9 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
         // object so we need to retain a reference to the parent context.
         parentContext = context;
 
+        // Adding the OpenSslEngine to the OpenSslEngineMap so it can be used in the AbstractCertificateVerifier.
+        engines.put(ssl, this);
+
         // Only create the leak after everything else was executed and so ensure we don't produce a false-positive for
         // the ResourceLeakDetector.
         leak = leakDetection ? leakDetector.track(this) : null;
@@ -1967,9 +1970,6 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
             }
             return handshakeException();
         }
-
-        // Adding the OpenSslEngine to the OpenSslEngineMap so it can be used in the AbstractCertificateVerifier.
-        engines.put(sslPointer(), this);
 
         if (!sessionSet) {
             if (!parentContext.sessionContext().setSessionFromCache(ssl, session, getPeerHost(), getPeerPort())) {


### PR DESCRIPTION
Motivation:

`ReferenceCountedOpenSslEngine.ssl` field is initialized in the constructor and never changes after that (except on shutdown). `ReferenceCountedOpenSslEngine.engines` map, puts `ReferenceCountedOpenSslEngine.ssl` field on every` handshake()` call with wrap/unwrap state, which could be called multiple times during the connection. We can move `map.put` in the constructor and call it once per `ReferenceCountedOpenSslEngine` instance.

<img width="1543" height="292" alt="image" src="https://github.com/user-attachments/assets/926f9176-11e4-42a5-a800-bc1212b3157a" />


Modification:

Moved  `engines.put(sslPointer(), this);` from handshake() method to `ReferenceCountedOpenSslEngine` constructor.

Result:

Fewer `Long` allocations, and fewer `concurrentMap.put` operations when multiple handshakes are called during the connection.
