### PR TITLE
Fix Incorrect nanos-to-millis conversion in epoll_wait EINTR retry loop

### DIFF
--- a/transport-native-epoll/src/main/c/netty_epoll_native.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_native.c
@@ -269,7 +269,7 @@ static inline jint netty_epoll_wait(JNIEnv* env, jint efd, struct epoll_event *e
             netty_unix_errors_throwRuntimeExceptionErrorNo(env, "clock_gettime() failed: ", errno);
             return -1;
         }
-        deadline = ts.tv_sec * 1000 + ts.tv_nsec / 1000 + timeout;
+        deadline = ts.tv_sec * 1000 + ts.tv_nsec / 1000000 + timeout;
 
         while ((rc = epoll_wait(efd, ev, len, timeout)) < 0) {
             if (errno != EINTR) {
@@ -281,7 +281,7 @@ static inline jint netty_epoll_wait(JNIEnv* env, jint efd, struct epoll_event *e
                 return -1;
             }
 
-            now = ts.tv_sec * 1000 + ts.tv_nsec / 1000;
+            now = ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
             if (now >= deadline) {
                 return 0;
             }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Timeout;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -47,11 +48,9 @@ public class EpollTest {
 
             assertEquals(0, ready);
             // Should have waited at least close to the timeout
-            assertTrue(elapsedMs >= timeoutMs - 20,
-                    "Elapsed " + elapsedMs + "ms, expected at least " + (timeoutMs - 20) + "ms");
+            assertThat(elapsedMs).isGreaterThanOrEqualTo(timeoutMs - 20);
             // Should not have waited vastly longer than the timeout
-            assertTrue(elapsedMs < timeoutMs + 200,
-                    "Elapsed " + elapsedMs + "ms, expected less than " + (timeoutMs + 200) + "ms");
+            assertThat(elapsedMs).isLessThan(timeoutMs + 200);
         } finally {
             eventArray.free();
             epoll.close();

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollTest.java
@@ -33,6 +33,31 @@ public class EpollTest {
         assertTrue(Epoll.isAvailable());
     }
 
+    @Test
+    @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+    public void testEpollWaitTimeoutAccuracy() throws Exception {
+        final int timeoutMs = 200;
+        final FileDescriptor epoll = Native.newEpollCreate();
+        final EpollEventArray eventArray = new EpollEventArray(8);
+        try {
+            long startNs = System.nanoTime();
+            // No fds registered, so this will just wait for the timeout.
+            int ready = Native.epollWait(epoll, eventArray, timeoutMs);
+            long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNs);
+
+            assertEquals(0, ready);
+            // Should have waited at least close to the timeout
+            assertTrue(elapsedMs >= timeoutMs - 20,
+                    "Elapsed " + elapsedMs + "ms, expected at least " + (timeoutMs - 20) + "ms");
+            // Should not have waited vastly longer than the timeout
+            assertTrue(elapsedMs < timeoutMs + 200,
+                    "Elapsed " + elapsedMs + "ms, expected less than " + (timeoutMs + 200) + "ms");
+        } finally {
+            eventArray.free();
+            epoll.close();
+        }
+    }
+
     // Testcase for https://github.com/netty/netty/issues/8444
     @Test
     @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)


### PR DESCRIPTION
Motivation:

See #16244

Modification:

Fix nanos to mills conversion.

Result:

Fixes #16244

If there is no issue then describe the changes introduced by this PR.
