### PR TITLE
Fix unit conversion error in epoll wait routine

### DIFF
--- a/transport-native-epoll/src/main/c/netty_epoll_native.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_native.c
@@ -269,7 +269,7 @@ static inline jint netty_epoll_wait(JNIEnv* env, jint efd, struct epoll_event *e
             netty_unix_errors_throwRuntimeExceptionErrorNo(env, "clock_gettime() failed: ", errno);
             return -1;
         }
-        deadline = ts.tv_sec * 1000 + ts.tv_nsec / 1000 + timeout;
+        deadline = ts.tv_sec * 1000 + ts.tv_nsec / 1000000 + timeout;
 
         while ((rc = epoll_wait(efd, ev, len, timeout)) < 0) {
             if (errno != EINTR) {
@@ -281,7 +281,7 @@ static inline jint netty_epoll_wait(JNIEnv* env, jint efd, struct epoll_event *e
                 return -1;
             }
 
-            now = ts.tv_sec * 1000 + ts.tv_nsec / 1000;
+            now = ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
             if (now >= deadline) {
                 return 0;
             }
@@ -827,7 +827,7 @@ static JNINativeMethod* createDynamicMethodsTable(const char* packagePrefix) {
     }
     memset(dynamicMethods, 0, size);
     memcpy(dynamicMethods, fixed_method_table, sizeof(fixed_method_table));
-    
+
     JNINativeMethod* dynamicMethod = &dynamicMethods[fixed_method_table_size];
     NETTY_JNI_UTIL_PREPEND(packagePrefix, "io/netty/channel/epoll/NativeDatagramPacketArray$NativeDatagramPacket;II)I", dynamicTypeName, error);
     NETTY_JNI_UTIL_PREPEND("(IZ[L", dynamicTypeName,  dynamicMethod->signature, error);


### PR DESCRIPTION
Motivation:

There is a unit conversion bug in Netty's native epoll wait routine which causes system clock nanoseconds to be mistakenly converted to microseconds instead of milliseconds when added to a millisecond value. This erroneous value is used only when the thread is interrupted. Because the nanosecond value rotates from 1 second back to 0, if the initial deadline is computed prior to this rotation and the interrupt occurs after, the resulting timeout may be arbitrarily high (up to ~16 minutes), causing the event loop to hang indefinitely.

This affects EpollEventLoop and is most apparent in event loops that have very little activity, as new tasks will force the epoll wait to wakeup. This bug is present in Netty versions 4.1, 4.2 and 5.0. This PR targets 4.1 as this is the oldest affected version, but this fix will need to be cherry-picked to other affected versions.

Modification:

Fix the unit conversion bug by converting nanoseconds to milliseconds in netty_epoll_wait.

Result:

No issue tracked for this, see above.