### PR TITLE
Epoll: Fix excessive CPU usage when Channel is only registered but no…

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -66,6 +66,8 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
 abstract class AbstractEpollChannel extends AbstractChannel implements UnixChannel {
     private static final ChannelMetadata METADATA = new ChannelMetadata(false);
     protected final LinuxSocket socket;
+    private final EpollIoOps inital;
+
     /**
      * The future of the current connection attempt.  If not null, subsequent
      * connection attempts will fail.
@@ -79,7 +81,6 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
     private IoRegistration registration;
     boolean inputClosedSeenErrorOnRead;
     private EpollIoOps ops;
-    private EpollIoOps inital;
 
     protected volatile boolean active;
 
@@ -93,6 +94,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
             this.local = fd.localAddress();
             this.remote = fd.remoteAddress();
         }
+        this.inital = initialOps;
         this.ops = initialOps;
     }
 
@@ -104,6 +106,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
         // See https://github.com/netty/netty/issues/2359
         this.remote = remote;
         this.local = fd.localAddress();
+        this.inital = initialOps;
         this.ops = initialOps;
     }
 
@@ -296,8 +299,10 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
         ((IoEventLoop) eventLoop()).register((AbstractEpollUnsafe) unsafe()).addListener(f -> {
             if (f.isSuccess()) {
                 registration = (IoRegistration) f.getNow();
-                registration.submit(ops);
-                inital = ops;
+                if (isActive()) {
+                    // The channel is active, register with current ops now as we are ready to start receiving events.
+                    submitCurrentOps();
+                }
                 promise.setSuccess();
             } else {
                 promise.setFailure(f.cause());
@@ -699,6 +704,9 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
             }
             active = true;
 
+            // The channel is active, register with current ops now as we are ready to start receiving events.
+            submitCurrentOps();
+
             // Get the state as trySuccess() may trigger an ChannelFutureListener that will close the Channel.
             // We still need to ensure we call fireChannelActive() in this case.
             boolean active = isActive();
@@ -835,6 +843,11 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
                 doClose();
             }
         }
+    }
+
+    final void submitCurrentOps() {
+        IoRegistration registration = registration();
+        registration.submit(ops);
     }
 
     @Override

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -347,6 +347,18 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
     }
 
     @Override
+    protected void doRegister(ChannelPromise promise) {
+        super.doRegister(promise);
+        promise.addListener(f -> {
+            if (f.isSuccess() && isRegistered()) {
+                // As Datagram is connection-less we can submit the current ops once the registration itself was
+                // successful.
+                submitCurrentOps();
+            }
+        });
+    }
+
+    @Override
     protected void doBind(SocketAddress localAddress) throws Exception {
         if (localAddress instanceof InetSocketAddress) {
             InetSocketAddress socketAddress = (InetSocketAddress) localAddress;

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainDatagramChannel.java
@@ -21,6 +21,7 @@ import io.netty.channel.AddressedEnvelope;
 import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultAddressedEnvelope;
 import io.netty.channel.unix.DomainDatagramChannel;
 import io.netty.channel.unix.DomainDatagramChannelConfig;
@@ -227,7 +228,7 @@ public final class EpollDomainDatagramChannel extends AbstractEpollChannel imple
 
                 ByteBuf content = (ByteBuf) e.content();
                 return UnixChannelUtil.isBufferCopyNeededForWrite(content) ?
-                        new DefaultAddressedEnvelope<ByteBuf, DomainSocketAddress>(
+                        new DefaultAddressedEnvelope<>(
                                 newDirectBuffer(e, content), (DomainSocketAddress) e.recipient()) : e;
             }
         }
@@ -264,6 +265,18 @@ public final class EpollDomainDatagramChannel extends AbstractEpollChannel imple
     @Override
     protected AbstractEpollUnsafe newUnsafe() {
         return new EpollDomainDatagramChannelUnsafe();
+    }
+
+    @Override
+    protected void doRegister(ChannelPromise promise) {
+        super.doRegister(promise);
+        promise.addListener(f -> {
+            if (f.isSuccess() && isRegistered()) {
+                // As Datagram is connection-less we can submit the current ops once the registration itself was
+                // successful.
+                submitCurrentOps();
+            }
+        });
     }
 
     /**

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
@@ -229,8 +229,6 @@ public class EpollIoHandler implements IoHandler {
     private enum RegistrationState {
         // Was not added via EPOLL_CTL_ADD
         Pending,
-        // Is about to be added via EPOLL_CTL_ADD
-        ToBeAdded,
         // Was added via EPOLL_CTL_ADD
         Added,
         // Was canceled an so removed via EPOLL_CTL_DEL

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
@@ -43,7 +43,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static java.lang.Math.min;
 
@@ -238,13 +237,13 @@ public class EpollIoHandler implements IoHandler {
         Cancelled
     }
 
-    private final class DefaultEpollIoRegistration extends AtomicReference<RegistrationState>
+    private final class DefaultEpollIoRegistration
             implements IoRegistration {
         private final ThreadAwareExecutor executor;
+        private RegistrationState state = RegistrationState.Pending;
         final EpollIoHandle handle;
 
         DefaultEpollIoRegistration(ThreadAwareExecutor executor, EpollIoHandle handle) {
-            super(RegistrationState.Pending);
             this.executor = executor;
             this.handle = handle;
         }
@@ -259,27 +258,13 @@ public class EpollIoHandler implements IoHandler {
         public long submit(IoOps ops) {
             EpollIoOps epollIoOps = cast(ops);
             try {
-                for (;;) {
-                    RegistrationState oldState = get();
-                    switch (oldState) {
+                synchronized (this) {
+                    switch (state) {
                         case Cancelled:
                             return -1;
-                        case ToBeAdded:
-                            // Just fetch again, another thread is about to add the fd via EPOLL_CTL_ADD
-                            break;
                         case Pending:
-                            if (compareAndSet(oldState, RegistrationState.ToBeAdded)) {
-                                Native.epollCtlAdd(epollFd.intValue(), handle.fd().intValue(), epollIoOps.value);
-                                if (compareAndSet(RegistrationState.ToBeAdded, RegistrationState.Added)) {
-                                    return epollIoOps.value;
-                                }
-                                // If this is happening someone else already cancelled, let's call cancel as well
-                                // so we are sure we not end up with a fd registered.
-                                cancel();
-                                return -1;
-                            }
-                            // Try again.
-                            break;
+                            Native.epollCtlAdd(epollFd.intValue(), handle.fd().intValue(), epollIoOps.value);
+                            state = RegistrationState.Added;
                         case Added:
                             Native.epollCtlMod(epollFd.intValue(), handle.fd().intValue(), epollIoOps.value);
                             return epollIoOps.value;
@@ -288,20 +273,22 @@ public class EpollIoHandler implements IoHandler {
                     }
                 }
             } catch (IOException e) {
-                cancel();
                 throw new UncheckedIOException(e);
             }
         }
 
         @Override
-        public boolean isValid() {
-            return get() != RegistrationState.Cancelled;
+        public synchronized boolean isValid() {
+            return state != RegistrationState.Cancelled;
         }
 
         @Override
         public boolean cancel() {
-            if (getAndSet(RegistrationState.Cancelled) == RegistrationState.Cancelled) {
-                return false;
+            synchronized (this) {
+                if (state == RegistrationState.Cancelled) {
+                    return false;
+                }
+                state = RegistrationState.Cancelled;
             }
             if (executor.isExecutorThread(Thread.currentThread())) {
                 cancel0();

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
@@ -42,11 +42,10 @@ import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static java.lang.Math.min;
-import static java.lang.System.nanoTime;
 
 /**
  * {@link IoHandler} which uses epoll under the covers. Only works on Linux!
@@ -228,12 +227,24 @@ public class EpollIoHandler implements IoHandler {
         }
     }
 
-    private final class DefaultEpollIoRegistration implements IoRegistration {
+    private enum RegistrationState {
+        // Was not added via EPOLL_CTL_ADD
+        Pending,
+        // Is about to be added via EPOLL_CTL_ADD
+        ToBeAdded,
+        // Was added via EPOLL_CTL_ADD
+        Added,
+        // Was canceled an so removed via EPOLL_CTL_DEL
+        Cancelled
+    }
+
+    private final class DefaultEpollIoRegistration extends AtomicReference<RegistrationState>
+            implements IoRegistration {
         private final ThreadAwareExecutor executor;
-        private final AtomicBoolean canceled = new AtomicBoolean();
         final EpollIoHandle handle;
 
         DefaultEpollIoRegistration(ThreadAwareExecutor executor, EpollIoHandle handle) {
+            super(RegistrationState.Pending);
             this.executor = executor;
             this.handle = handle;
         }
@@ -248,24 +259,48 @@ public class EpollIoHandler implements IoHandler {
         public long submit(IoOps ops) {
             EpollIoOps epollIoOps = cast(ops);
             try {
-                if (!isValid()) {
-                    return -1;
+                for (;;) {
+                    RegistrationState oldState = get();
+                    switch (oldState) {
+                        case Cancelled:
+                            return -1;
+                        case ToBeAdded:
+                            // Just fetch again, another thread is about to add the fd via EPOLL_CTL_ADD
+                            break;
+                        case Pending:
+                            if (compareAndSet(oldState, RegistrationState.ToBeAdded)) {
+                                Native.epollCtlAdd(epollFd.intValue(), handle.fd().intValue(), epollIoOps.value);
+                                if (compareAndSet(RegistrationState.ToBeAdded, RegistrationState.Added)) {
+                                    return epollIoOps.value;
+                                }
+                                // If this is happening someone else already cancelled, let's call cancel as well
+                                // so we are sure we not end up with a fd registered.
+                                cancel();
+                                return -1;
+                            }
+                            // Try again.
+                            break;
+                        case Added:
+                            Native.epollCtlMod(epollFd.intValue(), handle.fd().intValue(), epollIoOps.value);
+                            return epollIoOps.value;
+                        default:
+                            throw new IllegalStateException();
+                    }
                 }
-                Native.epollCtlMod(epollFd.intValue(), handle.fd().intValue(), epollIoOps.value);
-                return epollIoOps.value;
             } catch (IOException e) {
+                cancel();
                 throw new UncheckedIOException(e);
             }
         }
 
         @Override
         public boolean isValid() {
-            return !canceled.get();
+            return get() != RegistrationState.Cancelled;
         }
 
         @Override
         public boolean cancel() {
-            if (!canceled.compareAndSet(false, true)) {
+            if (getAndSet(RegistrationState.Cancelled) == RegistrationState.Cancelled) {
                 return false;
             }
             if (executor.isExecutorThread(Thread.currentThread())) {
@@ -324,7 +359,6 @@ public class EpollIoHandler implements IoHandler {
         final EpollIoHandle epollHandle = cast(handle);
         DefaultEpollIoRegistration registration = new DefaultEpollIoRegistration(executor, epollHandle);
         int fd = epollHandle.fd().intValue();
-        Native.epollCtlAdd(epollFd.intValue(), fd, EpollIoOps.EPOLLERR.value);
         DefaultEpollIoRegistration old = registrations.put(fd, registration);
 
         // We either expect to have no registration in the map with the same FD or that the FD of the old registration

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerDomainSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerDomainSocketChannel.java
@@ -71,6 +71,8 @@ public final class EpollServerDomainSocketChannel extends AbstractEpollServerCha
         socket.listen(config.getBacklog());
         local = (DomainSocketAddress) localAddress;
         active = true;
+        // We now listen for new connections, submit the ops so we receive events.
+        submitCurrentOps();
     }
 
     @Override

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
@@ -84,6 +84,8 @@ public final class EpollServerSocketChannel extends AbstractEpollServerChannel i
         }
         socket.listen(config.getBacklog());
         active = true;
+        // We now listen for new connections, submit the ops so we receive events.
+        submitCurrentOps();
     }
 
     @Override

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollIoHandlerTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollIoHandlerTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.epoll;
+
+import io.netty.channel.IoEvent;
+import io.netty.channel.IoHandler;
+import io.netty.channel.IoHandlerContext;
+import io.netty.channel.IoHandlerFactory;
+import io.netty.channel.IoRegistration;
+import io.netty.channel.unix.FileDescriptor;
+import io.netty.util.concurrent.ThreadAwareExecutor;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class EpollIoHandlerTest {
+    @Test
+    public void testRegisterWillNotTriggerEvent() throws Exception {
+        IoHandlerFactory ioHandlerFactory = EpollIoHandler.newFactory();
+        IoHandler handler = ioHandlerFactory.newHandler(new ThreadAwareExecutor() {
+
+            @Override
+            public boolean isExecutorThread(Thread thread) {
+                return true;
+            }
+
+            @Override
+            public void execute(Runnable command) {
+                command.run();
+            }
+        });
+        handler.initialize();
+
+        LinuxSocket socket = LinuxSocket.newSocketStream();
+        AtomicReference<IoEvent> eventRef = new AtomicReference<>();
+        IoRegistration registration = handler.register(new EpollIoHandle() {
+            @Override
+            public FileDescriptor fd() {
+                return socket;
+            }
+
+            @Override
+            public void handle(IoRegistration registration, IoEvent ioEvent) {
+                eventRef.set(ioEvent);
+            }
+
+            @Override
+            public void close() {
+            }
+        });
+        handler.run(new IoHandlerContext() {
+            @Override
+            public boolean canBlock() {
+                return false;
+            }
+
+            @Override
+            public long delayNanos(long currentTimeNanos) {
+                return 0;
+            }
+
+            @Override
+            public long deadlineNanos() {
+                return 0;
+            }
+        });
+        assertTrue(registration.cancel());
+        handler.prepareToDestroy();
+        handler.destroy();
+        socket.close();
+        assertNull(eventRef.get());
+    }
+}


### PR DESCRIPTION
…t bound / connected

Motivation:

We should only add a fd (Channel) to epoll onec it is considered active (connected) as otherwise we will receive EPOLLHUP events until it is active. This can lead to excessive CPU usage.

Modifications:

Delay adding of fd to epoll until it is considered active / connected.

Result:

Fixes https://github.com/netty/netty/issues/16240