### PR TITLE
Allocate one large segment and slice for each MsgHdrMemory (#16234)

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemory.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemory.java
@@ -20,11 +20,15 @@ import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.socket.SocketProtocolFamily;
 import io.netty.channel.unix.Buffer;
 import io.netty.util.internal.CleanableDirectBuffer;
+import io.netty.util.internal.PlatformDependent;
 
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 final class MsgHdrMemory {
+    public static final int MSG_HDR_SIZE =
+            Native.SIZEOF_MSGHDR + Native.SIZEOF_SOCKADDR_STORAGE + Native.SIZEOF_IOVEC + Native.CMSG_SPACE;
     private static final byte[] EMPTY_SOCKADDR_STORAGE = new byte[Native.SIZEOF_SOCKADDR_STORAGE];
     // It is not possible to have a zero length buffer in sendFd,
     // so we use a 1 byte buffer here.
@@ -44,17 +48,30 @@ final class MsgHdrMemory {
     private final short idx;
     private final int cmsgDataOffset;
 
-    MsgHdrMemory(short idx) {
+    MsgHdrMemory(short idx, ByteBuffer msgHdrMemoryArray) {
         this.idx = idx;
-        msgHdrMemoryCleanable = Buffer.allocateDirectBufferWithNativeOrder(Native.SIZEOF_MSGHDR);
-        socketAddrMemoryCleanable = Buffer.allocateDirectBufferWithNativeOrder(Native.SIZEOF_SOCKADDR_STORAGE);
-        iovMemoryCleanable = Buffer.allocateDirectBufferWithNativeOrder(Native.SIZEOF_IOVEC);
-        cmsgDataMemoryCleanable = Buffer.allocateDirectBufferWithNativeOrder(Native.CMSG_SPACE);
-
-        msgHdrMemory = msgHdrMemoryCleanable.buffer();
-        socketAddrMemory = socketAddrMemoryCleanable.buffer();
-        iovMemory = iovMemoryCleanable.buffer();
-        cmsgDataMemory = cmsgDataMemoryCleanable.buffer();
+        this.msgHdrMemoryCleanable = null;
+        this.socketAddrMemoryCleanable = null;
+        this.iovMemoryCleanable = null;
+        this.cmsgDataMemoryCleanable = null;
+        int offset = idx * MSG_HDR_SIZE;
+        // ByteBuffer.slice(int, int) / duplicate() are specified to produce BIG_ENDIAN byte buffers.
+        // Set native order explicitly so native structs written via putInt/putLong use the expected endianness.
+        this.msgHdrMemory = PlatformDependent.offsetSlice(
+                msgHdrMemoryArray, offset, Native.SIZEOF_MSGHDR
+        ).order(ByteOrder.nativeOrder());
+        offset += Native.SIZEOF_MSGHDR;
+        this.socketAddrMemory = PlatformDependent.offsetSlice(
+                msgHdrMemoryArray, offset, Native.SIZEOF_SOCKADDR_STORAGE
+        ).order(ByteOrder.nativeOrder());
+        offset += Native.SIZEOF_SOCKADDR_STORAGE;
+        this.iovMemory = PlatformDependent.offsetSlice(
+                msgHdrMemoryArray, offset, Native.SIZEOF_IOVEC
+        ).order(ByteOrder.nativeOrder());
+        offset += Native.SIZEOF_IOVEC;
+        this.cmsgDataMemory = PlatformDependent.offsetSlice(
+                msgHdrMemoryArray, offset, Native.CMSG_SPACE
+        ).order(ByteOrder.nativeOrder());
 
         msgHdrMemoryAddress = Buffer.memoryAddress(msgHdrMemory);
 
@@ -161,11 +178,17 @@ final class MsgHdrMemory {
     }
 
     void release() {
-        msgHdrMemoryCleanable.clean();
+        if (msgHdrMemoryCleanable != null) {
+            msgHdrMemoryCleanable.clean();
+        }
         if (socketAddrMemoryCleanable != null) {
             socketAddrMemoryCleanable.clean();
         }
-        iovMemoryCleanable.clean();
-        cmsgDataMemoryCleanable.clean();
+        if (iovMemoryCleanable != null) {
+            iovMemoryCleanable.clean();
+        }
+        if (cmsgDataMemoryCleanable != null) {
+            cmsgDataMemoryCleanable.clean();
+        }
     }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemoryArray.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemoryArray.java
@@ -15,6 +15,10 @@
  */
 package io.netty.channel.uring;
 
+import io.netty.channel.unix.Buffer;
+import io.netty.util.internal.CleanableDirectBuffer;
+
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 final class MsgHdrMemoryArray {
@@ -23,6 +27,7 @@ final class MsgHdrMemoryArray {
     private final MsgHdrMemory[] hdrs;
     private final int capacity;
     private final long[] ids;
+    private final CleanableDirectBuffer msgHdrMemoryArrayMemoryCleanable;
     private boolean released;
     private int idx;
 
@@ -31,8 +36,11 @@ final class MsgHdrMemoryArray {
         this.capacity = capacity;
         hdrs = new MsgHdrMemory[capacity];
         ids = new long[capacity];
+        int total = MsgHdrMemory.MSG_HDR_SIZE * capacity;
+        this.msgHdrMemoryArrayMemoryCleanable = Buffer.allocateDirectBufferWithNativeOrder(total);
+        ByteBuffer msgHdrMemoryArrayMemory = msgHdrMemoryArrayMemoryCleanable.buffer();
         for (int i = 0; i < hdrs.length; i++) {
-            hdrs[i] = new MsgHdrMemory((short) i);
+            hdrs[i] = new MsgHdrMemory((short) i, msgHdrMemoryArrayMemory);
             ids[i] = NO_ID;
         }
     }
@@ -80,6 +88,7 @@ final class MsgHdrMemoryArray {
         for (MsgHdrMemory hdr: hdrs) {
             hdr.release();
         }
+        msgHdrMemoryArrayMemoryCleanable.clean();
     }
 
     int capacity() {


### PR DESCRIPTION
Motivation:

IoUringIoHandler.msgHdrMemoryArray has 1024 MsgHdrMemory instances, each allocating 4 CleanableDirectBuffers. On JDK 25, each clean() closes a shared Arena, so shutdown performs 1024 * 4 closeScope0 calls, i.e., excessive handshakes.

Modification:

Reimplement MsgHdrMemoryArray to allocate one large segment and slice for each MsgHdrMemory.
collapses 4096 shared closes into a single close.

Result:

Fixes #16174