### PR TITLE
Make RefCntOpenSslContext.deallocate more robust

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -150,10 +150,13 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
 
         @Override
         protected void deallocate() {
-            destroy();
-            if (leak != null) {
-                boolean closed = leak.close(ReferenceCountedOpenSslContext.this);
-                assert closed;
+            try {
+                destroy();
+            } finally {
+                if (leak != null) {
+                    boolean closed = leak.close(ReferenceCountedOpenSslContext.this);
+                    assert closed;
+                }
             }
         }
     };


### PR DESCRIPTION
Motivation:
We should always close the leak detector even if the destroy method throws. A failed destroy() call will be propagated and there isn't anything the leak detector can add to that.

Modification:
Wrap the destroy() call in a try-finally and always close the leak tracker.

Result:
More robust deallocate method.