### PR TITLE
IoUring: Reduce unnecessary io_uring_enter syscalls on non-blocking path

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -207,10 +207,10 @@ public final class IoUringIoHandler implements IoHandler {
                         completionQueue.ringEntries);
             }
             if (p == 0) {
-                if (needSubmit(sqFlags)) {
-                    submitAndClearNow0(submissionQueue);
+                if (!needSubmit(sqFlags)) {
+                    break;
                 }
-                break;
+                submitAndClearNow0(submissionQueue);
             }
             processed += p;
         }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -188,6 +188,12 @@ public final class IoUringIoHandler implements IoHandler {
         return processed;
     }
 
+    private boolean needSubmit(int sqFlags) {
+        SubmissionQueue submissionQueue = ringBuffer.ioUringSubmissionQueue();
+        return submissionQueue.count() > 0
+                || (sqFlags & (Native.IORING_SQ_CQ_OVERFLOW | Native.IORING_SQ_TASKRUN)) != 0;
+    }
+
     private int processCompletionsAndHandleOverflow(SubmissionQueue submissionQueue, CompletionQueue completionQueue,
                                          CompletionCallback callback) {
         int processed = 0;
@@ -195,16 +201,15 @@ public final class IoUringIoHandler implements IoHandler {
         // 128 here is just some sort of bound and another number might be ok as well.
         for (int i = 0; i < 128; i++) {
             int p = completionQueue.process(callback);
-            if ((submissionQueue.flags() & Native.IORING_SQ_CQ_OVERFLOW) != 0) {
+            int sqFlags = submissionQueue.flags();
+            if ((sqFlags & Native.IORING_SQ_CQ_OVERFLOW) != 0) {
                 logger.warn("CompletionQueue overflow detected, consider increasing size: {} ",
                         completionQueue.ringEntries);
-                submitAndClearNow(submissionQueue);
-            } else if (p == 0 &&
-                    // Check if there are any more submissions pending, if not break the loop.
-                    (submissionQueue.count() == 0 ||
-                    // Let's try to submit again and check if there are new completions to handle.
-                    // Only break the loop if there was nothing submitted and there are no new completions.
-                    (submitAndClearNow(submissionQueue) == 0 && !completionQueue.hasCompletions()))) {
+            }
+            if (p == 0) {
+                if (needSubmit(sqFlags)) {
+                    submitAndClearNow0(submissionQueue);
+                }
                 break;
             }
             processed += p;
@@ -213,6 +218,14 @@ public final class IoUringIoHandler implements IoHandler {
     }
 
     private int submitAndClearNow(SubmissionQueue submissionQueue) {
+        if (needSubmit(submissionQueue.flags())) {
+            return submitAndClearNow0(submissionQueue);
+        }
+        return 0;
+    }
+
+    private int submitAndClearNow0(SubmissionQueue submissionQueue) {
+
         int submitted = submissionQueue.submitAndGetNow();
 
         // Clear the iovArray as we can re-use it now as things are considered stable after submission:

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -228,6 +228,7 @@ final class Native {
     static final int IORING_SETUP_SUBMIT_ALL = 1 << 7;
     static final int IORING_SETUP_CQE32 = 1 << 11;
 
+    static final int IORING_SETUP_TASKRUN_FLAG = 1 << 9;
     static final int IORING_SETUP_SINGLE_ISSUER = 1 << 12;
     static final int IORING_SETUP_DEFER_TASKRUN = 1 << 13;
     static final int IORING_SETUP_NO_SQARRAY = 1 << 16;
@@ -375,6 +376,7 @@ final class Native {
             // IORING_SETUP_DEFER_TASKRUN also requires IORING_SETUP_SINGLE_ISSUER.
             if (IoUring.isSetupDeferTaskrunSupported()) {
                 flags |= Native.IORING_SETUP_DEFER_TASKRUN;
+                flags |= Native.IORING_SETUP_TASKRUN_FLAG;
             }
         }
         // liburing uses IORING_SETUP_NO_SQARRAY by default these days, we should do the same by default if possible.


### PR DESCRIPTION

Motivation:

In `IoUringIoHandler.run()`, the non-blocking path unconditionally calls `io_uring_enter` via `submitAndClearNow()` even when there are no pending SQEs and no deferred task work to flush.

Modification:

- Enable `IORING_SETUP_TASKRUN_FLAG` when `IORING_SETUP_DEFER_TASKRUN` is set,
  so the kernel signals `IORING_SQ_TASKRUN` when deferred completions are pending.

Result:

Fixes #16247.

No regression under high concurrency load. Under IO-idle non-blocking
path scenario, `io_uring_enter` calls reduced from 486 to 65 (-86.6%).
