### PR TITLE
Epoll: Fix excessive CPU usage when Channel is only registered but no…

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -60,8 +60,10 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 abstract class AbstractEpollChannel extends AbstractChannel implements UnixChannel {
     protected final LinuxSocket socket;
+    private final EpollIoOps inital;
     private final EpollIoHandleImpl ioHandle = new  EpollIoHandleImpl();
     private Promise<Void> connectPromise;
+
     private SocketAddress requestedRemoteAddress;
     private volatile SocketAddress local;
     private volatile SocketAddress remote;
@@ -69,7 +71,6 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
     private IoRegistration registration;
     boolean inputClosedSeenErrorOnRead;
     private EpollIoOps ops;
-    private EpollIoOps inital;
 
     protected volatile boolean active;
 
@@ -84,6 +85,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
             this.local = fd.localAddress();
             this.remote = fd.remoteAddress();
         }
+        this.inital = initialOps;
         this.ops = initialOps;
     }
 
@@ -96,6 +98,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
         // See https://github.com/netty/netty/issues/2359
         this.remote = remote;
         this.local = fd.localAddress();
+        this.inital = initialOps;
         this.ops = initialOps;
     }
 
@@ -279,8 +282,10 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
         executor().register(ioHandle).addListener(f -> {
             if (f.isSuccess()) {
                 registration = (IoRegistration) f.getNow();
-                registration.submit(ops);
-                inital = ops;
+                if (isActive()) {
+                    // The channel is active, register with current ops now as we are ready to start receiving events.
+                    submitCurrentOps();
+                }
                 promise.setSuccess(null);
             } else {
                 promise.setFailure(f.cause());
@@ -655,6 +660,9 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
             requestedRemoteAddress = null;
             active = true;
 
+            // The channel is active, register with current ops now as we are ready to start receiving events.
+            submitCurrentOps();
+
             return true;
         }
         setFlag(Native.EPOLLOUT);
@@ -706,6 +714,8 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
             remote = remoteSocketAddr == null ?
                     remoteAddress : computeRemoteAddr(remoteSocketAddr, (InetSocketAddress) socket.remoteAddress());
             active = true;
+            // The channel is active, register with current ops now as we are ready to start receiving events.
+            submitCurrentOps();
         }
         // We always need to set the localAddress even if not connected yet as the bind already took place.
         //
@@ -728,6 +738,11 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
                 doClose(newPromise());
             }
         }
+    }
+
+    final void submitCurrentOps() {
+        IoRegistration registration = registration();
+        registration.submit(ops);
     }
 
     @Override

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -306,6 +306,18 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
     }
 
     @Override
+    protected void doRegister(Promise<Void> promise) {
+        super.doRegister(promise);
+        promise.addListener(f -> {
+            if (f.isSuccess() && isRegistered()) {
+                // As Datagram is connection-less we can submit the current ops once the registration itself was
+                // successful.
+                submitCurrentOps();
+            }
+        });
+    }
+
+    @Override
     protected void doBind(SocketAddress localAddress, Promise<Void> promise) {
         if (localAddress instanceof InetSocketAddress) {
             InetSocketAddress socketAddress = (InetSocketAddress) localAddress;

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
@@ -38,11 +38,9 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static java.lang.Math.min;
-import static java.lang.System.nanoTime;
 
 /**
  * {@link IoHandler} which uses epoll under the covers. Only works on Linux!
@@ -222,9 +220,19 @@ public class EpollIoHandler implements IoHandler {
         }
     }
 
-    private final class DefaultEpollIoRegistration implements IoRegistration {
+    private enum RegistrationState {
+        // Was not added via EPOLL_CTL_ADD
+        Pending,
+        // Was added via EPOLL_CTL_ADD
+        Added,
+        // Was canceled an so removed via EPOLL_CTL_DEL
+        Cancelled
+    }
+
+    private final class DefaultEpollIoRegistration
+            implements IoRegistration {
         private final ThreadAwareExecutor executor;
-        private final AtomicBoolean canceled = new AtomicBoolean();
+        private RegistrationState state = RegistrationState.Pending;
         final EpollIoHandle handle;
 
         DefaultEpollIoRegistration(ThreadAwareExecutor executor, EpollIoHandle handle) {
@@ -242,25 +250,37 @@ public class EpollIoHandler implements IoHandler {
         public long submit(IoOps ops) {
             EpollIoOps epollIoOps = cast(ops);
             try {
-                if (!isValid()) {
-                    return -1;
+                synchronized (this) {
+                    switch (state) {
+                        case Cancelled:
+                            return -1;
+                        case Pending:
+                            Native.epollCtlAdd(epollFd.intValue(), handle.fd().intValue(), epollIoOps.value);
+                            state = RegistrationState.Added;
+                        case Added:
+                            Native.epollCtlMod(epollFd.intValue(), handle.fd().intValue(), epollIoOps.value);
+                            return epollIoOps.value;
+                        default:
+                            throw new IllegalStateException();
+                    }
                 }
-                Native.epollCtlMod(epollFd.intValue(), handle.fd().intValue(), epollIoOps.value);
-                return epollIoOps.value;
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
         }
 
         @Override
-        public boolean isValid() {
-            return !canceled.get();
+        public synchronized boolean isValid() {
+            return state != RegistrationState.Cancelled;
         }
 
         @Override
         public boolean cancel() {
-            if (!canceled.compareAndSet(false, true)) {
-                return false;
+            synchronized (this) {
+                if (state == RegistrationState.Cancelled) {
+                    return false;
+                }
+                state = RegistrationState.Cancelled;
             }
             if (executor.isExecutorThread(Thread.currentThread())) {
                 cancel0();
@@ -316,7 +336,6 @@ public class EpollIoHandler implements IoHandler {
         final EpollIoHandle epollHandle = cast(handle);
         DefaultEpollIoRegistration registration = new DefaultEpollIoRegistration(executor, epollHandle);
         int fd = epollHandle.fd().intValue();
-        Native.epollCtlAdd(epollFd.intValue(), fd, EpollIoOps.EPOLLERR.value);
         DefaultEpollIoRegistration old = registrations.put(fd, registration);
 
         // We either expect to have no registration in the map with the same FD or that the FD of the old registration

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
@@ -183,6 +183,9 @@ public final class EpollServerSocketChannel extends AbstractEpollChannel impleme
                     }
                     socket.listen(config.getBacklog());
                     active = true;
+
+                    // We now listen for new connections, submit the ops so we receive events.
+                    submitCurrentOps();
                 } catch (Throwable cause) {
                     promise.setFailure(cause);
                     return;

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollIoHandlerTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollIoHandlerTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.epoll;
+
+import io.netty.channel.IoEvent;
+import io.netty.channel.IoHandler;
+import io.netty.channel.IoHandlerContext;
+import io.netty.channel.IoHandlerFactory;
+import io.netty.channel.IoRegistration;
+import io.netty.channel.unix.FileDescriptor;
+import io.netty.util.concurrent.ThreadAwareExecutor;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class EpollIoHandlerTest {
+    @Test
+    public void testRegisterWillNotTriggerEvent() throws Exception {
+        IoHandlerFactory ioHandlerFactory = EpollIoHandler.newFactory();
+        IoHandler handler = ioHandlerFactory.newHandler(new ThreadAwareExecutor() {
+
+            @Override
+            public boolean isExecutorThread(Thread thread) {
+                return true;
+            }
+
+            @Override
+            public void execute(Runnable command) {
+                command.run();
+            }
+        });
+        handler.initialize();
+
+        LinuxSocket socket = LinuxSocket.newSocketStream();
+        AtomicReference<IoEvent> eventRef = new AtomicReference<>();
+        IoRegistration registration = handler.register(new EpollIoHandle() {
+            @Override
+            public FileDescriptor fd() {
+                return socket;
+            }
+
+            @Override
+            public void handle(IoRegistration registration, IoEvent ioEvent) {
+                eventRef.set(ioEvent);
+            }
+
+            @Override
+            public void close() {
+            }
+        });
+        handler.run(new IoHandlerContext() {
+            @Override
+            public boolean canBlock() {
+                return false;
+            }
+
+            @Override
+            public long delayNanos(long currentTimeNanos) {
+                return 0;
+            }
+
+            @Override
+            public long deadlineNanos() {
+                return 0;
+            }
+        });
+        assertTrue(registration.cancel());
+        handler.prepareToDestroy();
+        handler.destroy();
+        socket.close();
+        assertNull(eventRef.get());
+    }
+}


### PR DESCRIPTION
…… (#16250)

…t bound / connected

Motivation:

We should only add a fd (Channel) to epoll onec it is considered active (connected) as otherwise we will receive EPOLLHUP events until it is active. This can lead to excessive CPU usage.

Modifications:

Delay adding of fd to epoll until it is considered active / connected.

Result:

Fixes https://github.com/netty/netty/issues/16240