### PR TITLE
Update to gcc for arm 10.3-2021.07 (#16255)

### DIFF
--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 centos:7.6.1810
 
 ARG java_version=25-zulu
-ARG gcc_version=10.2-2020.11
+ARG gcc_version=10.3-2021.07
 ENV GCC_VERSION $gcc_version
 ENV SOURCE_DIR /root/source
 

--- a/docker/docker-compose.centos-7.cross.yaml
+++ b/docker/docker-compose.centos-7.cross.yaml
@@ -8,7 +8,7 @@ services:
       context: ../
       dockerfile: docker/Dockerfile.cross_compile_aarch64
       args:
-        gcc_version: "10.2-2020.11"
+        gcc_version: "10.3-2021.07"
         java_version: "8.0.462-zulu"
 
   cross-compile-aarch64-common: &cross-compile-aarch64-common


### PR DESCRIPTION
Motivation:

gcc released a new version which also contains security fixes

Modifications:

Update to version of 10.3-2021.07

Result:

More optimized builds for aarch64