### PR TITLE
HTTP2: Correctly account for padding when decompress

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingDecompressorFrameListener.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingDecompressorFrameListener.java
@@ -361,6 +361,10 @@ public class DelegatingDecompressorFrameListener extends Http2FrameListenerDecor
                         buf.release();
                         return;
                     }
+
+                    // Also take padding into account.
+                    incrementDecompressedBytes(padding);
+
                     incrementDecompressedBytes(buf.readableBytes());
                     // Immediately return the bytes back to the flow controller. ConsumedBytesConverter will convert
                     // from the decompressed amount which the user knows about to the compressed amount which flow

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
@@ -39,7 +39,8 @@ import io.netty.util.concurrent.Future;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
@@ -50,6 +51,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_PRIORITY_WEIGHT;
 import static io.netty.handler.codec.http2.Http2TestUtil.runInChannel;
@@ -89,6 +91,7 @@ public class DataCompressionHttp2Test {
     private Http2Connection clientConnection;
     private Http2ConnectionHandler clientHandler;
     private ByteArrayOutputStream serverOut;
+    private final AtomicReference<Throwable> serverException = new AtomicReference<Throwable>();
 
     @BeforeAll
     public static void beforeAllTests() throws Throwable {
@@ -148,8 +151,9 @@ public class DataCompressionHttp2Test {
         clientGroup.sync();
     }
 
-    @Test
-    public void justHeadersNoData() throws Exception {
+    @ParameterizedTest
+    @ValueSource(ints = { 0, 10 })
+    public void justHeadersNoData(final int padding) throws Exception {
         bootstrapEnv(0);
         final Http2Headers headers = new DefaultHttp2Headers().method(GET).path(PATH)
                 .set(HttpHeaderNames.CONTENT_ENCODING, HttpHeaderValues.GZIP);
@@ -157,17 +161,18 @@ public class DataCompressionHttp2Test {
         runInChannel(clientChannel, new Http2Runnable() {
             @Override
             public void run() throws Http2Exception {
-                clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, true, newPromiseClient());
+                clientEncoder.writeHeaders(ctxClient(), 3, headers, padding, true, newPromiseClient());
                 clientHandler.flush(ctxClient());
             }
         });
         awaitServer();
         verify(serverListener).onHeadersRead(any(ChannelHandlerContext.class), eq(3), eq(headers), eq(0),
-                eq(DEFAULT_PRIORITY_WEIGHT), eq(false), eq(0), eq(true));
+                eq(DEFAULT_PRIORITY_WEIGHT), eq(false), eq(padding), eq(true));
     }
 
-    @Test
-    public void gzipEncodingSingleEmptyMessage() throws Exception {
+    @ParameterizedTest
+    @ValueSource(ints = { 0, 10 })
+    public void gzipEncodingSingleEmptyMessage(final int padding) throws Exception {
         final String text = "";
         final ByteBuf data = Unpooled.copiedBuffer(text.getBytes());
         bootstrapEnv(data.readableBytes());
@@ -178,8 +183,8 @@ public class DataCompressionHttp2Test {
             runInChannel(clientChannel, new Http2Runnable() {
                 @Override
                 public void run() throws Http2Exception {
-                    clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false, newPromiseClient());
-                    clientEncoder.writeData(ctxClient(), 3, data.retain(), 0, true, newPromiseClient());
+                    clientEncoder.writeHeaders(ctxClient(), 3, headers, padding, false, newPromiseClient());
+                    clientEncoder.writeData(ctxClient(), 3, data.retain(), padding, true, newPromiseClient());
                     clientHandler.flush(ctxClient());
                 }
             });
@@ -190,8 +195,9 @@ public class DataCompressionHttp2Test {
         }
     }
 
-    @Test
-    public void gzipEncodingSingleMessage() throws Exception {
+    @ParameterizedTest
+    @ValueSource(ints = { 0, 10 })
+    public void gzipEncodingSingleMessage(final int padding) throws Exception {
         final String text = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbccccccccccccccccccccccc";
         final ByteBuf data = Unpooled.copiedBuffer(text.getBytes());
         bootstrapEnv(data.readableBytes());
@@ -202,8 +208,8 @@ public class DataCompressionHttp2Test {
             runInChannel(clientChannel, new Http2Runnable() {
                 @Override
                 public void run() throws Http2Exception {
-                    clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false, newPromiseClient());
-                    clientEncoder.writeData(ctxClient(), 3, data.retain(), 0, true, newPromiseClient());
+                    clientEncoder.writeHeaders(ctxClient(), 3, headers, padding, false, newPromiseClient());
+                    clientEncoder.writeData(ctxClient(), 3, data.retain(), padding, true, newPromiseClient());
                     clientHandler.flush(ctxClient());
                 }
             });
@@ -214,8 +220,9 @@ public class DataCompressionHttp2Test {
         }
     }
 
-    @Test
-    public void gzipEncodingMultipleMessages() throws Exception {
+    @ParameterizedTest
+    @ValueSource(ints = { 0, 10 })
+    public void gzipEncodingMultipleMessages(final int padding) throws Exception {
         final String text1 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbccccccccccccccccccccccc";
         final String text2 = "dddddddddddddddddddeeeeeeeeeeeeeeeeeeeffffffffffffffffffff";
         final ByteBuf data1 = Unpooled.copiedBuffer(text1.getBytes());
@@ -228,9 +235,9 @@ public class DataCompressionHttp2Test {
             runInChannel(clientChannel, new Http2Runnable() {
                 @Override
                 public void run() throws Http2Exception {
-                    clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false, newPromiseClient());
-                    clientEncoder.writeData(ctxClient(), 3, data1.retain(), 0, false, newPromiseClient());
-                    clientEncoder.writeData(ctxClient(), 3, data2.retain(), 0, true, newPromiseClient());
+                    clientEncoder.writeHeaders(ctxClient(), 3, headers, padding, false, newPromiseClient());
+                    clientEncoder.writeData(ctxClient(), 3, data1.retain(), padding, false, newPromiseClient());
+                    clientEncoder.writeData(ctxClient(), 3, data2.retain(), padding, true, newPromiseClient());
                     clientHandler.flush(ctxClient());
                 }
             });
@@ -242,8 +249,9 @@ public class DataCompressionHttp2Test {
         }
     }
 
-    @Test
-    public void brotliEncodingSingleEmptyMessage() throws Exception {
+    @ParameterizedTest
+    @ValueSource(ints = { 0, 10 })
+    public void brotliEncodingSingleEmptyMessage(final int padding) throws Exception {
         final String text = "";
         final ByteBuf data = Unpooled.copiedBuffer(text.getBytes());
         bootstrapEnv(data.readableBytes());
@@ -254,8 +262,8 @@ public class DataCompressionHttp2Test {
             runInChannel(clientChannel, new Http2Runnable() {
                 @Override
                 public void run() throws Http2Exception {
-                    clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false, newPromiseClient());
-                    clientEncoder.writeData(ctxClient(), 3, data.retain(), 0, true, newPromiseClient());
+                    clientEncoder.writeHeaders(ctxClient(), 3, headers, padding, false, newPromiseClient());
+                    clientEncoder.writeData(ctxClient(), 3, data.retain(), padding, true, newPromiseClient());
                     clientHandler.flush(ctxClient());
                 }
             });
@@ -266,8 +274,9 @@ public class DataCompressionHttp2Test {
         }
     }
 
-    @Test
-    public void brotliEncodingSingleMessage() throws Exception {
+    @ParameterizedTest
+    @ValueSource(ints = { 0, 10 })
+    public void brotliEncodingSingleMessage(final int padding) throws Exception {
         final String text = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbccccccccccccccccccccccc";
         final ByteBuf data = Unpooled.copiedBuffer(text.getBytes(CharsetUtil.UTF_8.name()));
         bootstrapEnv(data.readableBytes());
@@ -278,8 +287,8 @@ public class DataCompressionHttp2Test {
             runInChannel(clientChannel, new Http2Runnable() {
                 @Override
                 public void run() throws Http2Exception {
-                    clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false, newPromiseClient());
-                    clientEncoder.writeData(ctxClient(), 3, data.retain(), 0, true, newPromiseClient());
+                    clientEncoder.writeHeaders(ctxClient(), 3, headers, padding, false, newPromiseClient());
+                    clientEncoder.writeData(ctxClient(), 3, data.retain(), padding, true, newPromiseClient());
                     clientHandler.flush(ctxClient());
                 }
             });
@@ -290,8 +299,9 @@ public class DataCompressionHttp2Test {
         }
     }
 
-    @Test
-    public void zstdEncodingSingleEmptyMessage() throws Exception {
+    @ParameterizedTest
+    @ValueSource(ints = { 0, 10 })
+    public void zstdEncodingSingleEmptyMessage(final int padding) throws Exception {
         final String text = "";
         final ByteBuf data = Unpooled.copiedBuffer(text.getBytes());
         bootstrapEnv(data.readableBytes());
@@ -302,8 +312,8 @@ public class DataCompressionHttp2Test {
             runInChannel(clientChannel, new Http2Runnable() {
                 @Override
                 public void run() throws Http2Exception {
-                    clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false, newPromiseClient());
-                    clientEncoder.writeData(ctxClient(), 3, data.retain(), 0, true, newPromiseClient());
+                    clientEncoder.writeHeaders(ctxClient(), 3, headers, padding, false, newPromiseClient());
+                    clientEncoder.writeData(ctxClient(), 3, data.retain(), padding, true, newPromiseClient());
                     clientHandler.flush(ctxClient());
                 }
             });
@@ -314,8 +324,9 @@ public class DataCompressionHttp2Test {
         }
     }
 
-    @Test
-    public void zstdEncodingSingleMessage() throws Exception {
+    @ParameterizedTest
+    @ValueSource(ints = { 0, 10 })
+    public void zstdEncodingSingleMessage(final int padding) throws Exception {
         final String text = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbccccccccccccccccccccccc";
         final ByteBuf data = Unpooled.copiedBuffer(text.getBytes(CharsetUtil.UTF_8.name()));
         bootstrapEnv(data.readableBytes());
@@ -326,8 +337,8 @@ public class DataCompressionHttp2Test {
             runInChannel(clientChannel, new Http2Runnable() {
                 @Override
                 public void run() throws Http2Exception {
-                    clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false, newPromiseClient());
-                    clientEncoder.writeData(ctxClient(), 3, data.retain(), 0, true, newPromiseClient());
+                    clientEncoder.writeHeaders(ctxClient(), 3, headers, padding, false, newPromiseClient());
+                    clientEncoder.writeData(ctxClient(), 3, data.retain(), padding, true, newPromiseClient());
                     clientHandler.flush(ctxClient());
                 }
             });
@@ -338,8 +349,9 @@ public class DataCompressionHttp2Test {
         }
     }
 
-    @Test
-    public void snappyEncodingSingleEmptyMessage() throws Exception {
+    @ParameterizedTest
+    @ValueSource(ints = { 0, 10 })
+    public void snappyEncodingSingleEmptyMessage(final int padding) throws Exception {
         final String text = "";
         final ByteBuf data = Unpooled.copiedBuffer(text.getBytes(CharsetUtil.US_ASCII));
         bootstrapEnv(data.readableBytes());
@@ -350,8 +362,8 @@ public class DataCompressionHttp2Test {
             runInChannel(clientChannel, new Http2Runnable() {
                 @Override
                 public void run() throws Http2Exception {
-                    clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false, newPromiseClient());
-                    clientEncoder.writeData(ctxClient(), 3, data.retain(), 0, true, newPromiseClient());
+                    clientEncoder.writeHeaders(ctxClient(), 3, headers, padding, false, newPromiseClient());
+                    clientEncoder.writeData(ctxClient(), 3, data.retain(), padding, true, newPromiseClient());
                     clientHandler.flush(ctxClient());
                 }
             });
@@ -362,8 +374,9 @@ public class DataCompressionHttp2Test {
         }
     }
 
-    @Test
-    public void snappyEncodingSingleMessage() throws Exception {
+    @ParameterizedTest
+    @ValueSource(ints = { 0, 10 })
+    public void snappyEncodingSingleMessage(final int padding) throws Exception {
         final String text = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbccccccccccccccccccccccc";
         final ByteBuf data = Unpooled.copiedBuffer(text.getBytes(CharsetUtil.US_ASCII));
         bootstrapEnv(data.readableBytes());
@@ -374,8 +387,8 @@ public class DataCompressionHttp2Test {
             runInChannel(clientChannel, new Http2Runnable() {
                 @Override
                 public void run() throws Http2Exception {
-                    clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false, newPromiseClient());
-                    clientEncoder.writeData(ctxClient(), 3, data.retain(), 0, true, newPromiseClient());
+                    clientEncoder.writeHeaders(ctxClient(), 3, headers, padding, false, newPromiseClient());
+                    clientEncoder.writeData(ctxClient(), 3, data.retain(), padding, true, newPromiseClient());
                     clientHandler.flush(ctxClient());
                 }
             });
@@ -386,8 +399,9 @@ public class DataCompressionHttp2Test {
         }
     }
 
-    @Test
-    public void deflateEncodingWriteLargeMessage() throws Exception {
+    @ParameterizedTest
+    @ValueSource(ints = { 0, 10 })
+    public void deflateEncodingWriteLargeMessage(final int padding) throws Exception {
         final int BUFFER_SIZE = 1 << 12;
         final byte[] bytes = new byte[BUFFER_SIZE];
         new Random().nextBytes(bytes);
@@ -400,8 +414,8 @@ public class DataCompressionHttp2Test {
             runInChannel(clientChannel, new Http2Runnable() {
                 @Override
                 public void run() throws Http2Exception {
-                    clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false, newPromiseClient());
-                    clientEncoder.writeData(ctxClient(), 3, data.retain(), 0, true, newPromiseClient());
+                    clientEncoder.writeHeaders(ctxClient(), 3, headers, padding, false, newPromiseClient());
+                    clientEncoder.writeData(ctxClient(), 3, data.retain(), padding, true, newPromiseClient());
                     clientHandler.flush(ctxClient());
                 }
             });
@@ -417,6 +431,7 @@ public class DataCompressionHttp2Test {
         final CountDownLatch prefaceWrittenLatch = new CountDownLatch(1);
         serverOut = new ByteArrayOutputStream(serverOutSize);
         serverLatch = new CountDownLatch(1);
+        serverException.set(null);
         sb = new ServerBootstrap();
         cb = new Bootstrap();
 
@@ -466,7 +481,18 @@ public class DataCompressionHttp2Test {
                 Http2ConnectionDecoder decoder =
                         new DefaultHttp2ConnectionDecoder(serverConnection, encoder, new DefaultHttp2FrameReader());
                 Http2ConnectionHandler connectionHandler = new Http2ConnectionHandlerBuilder()
-                        .frameListener(new DelegatingDecompressorFrameListener(serverConnection, serverListener, 0))
+                        .frameListener(new DelegatingDecompressorFrameListener(serverConnection, serverListener, 0) {
+                            @Override
+                            public int onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data,
+                                                  int padding, boolean endOfStream) throws Http2Exception {
+                                try {
+                                    return super.onDataRead(ctx, streamId, data, padding, endOfStream);
+                                } catch (Http2Exception e) {
+                                    serverException.set(e);
+                                    throw e;
+                                }
+                            }
+                        })
                         .codec(decoder, encoder).build();
                 p.addLast(connectionHandler);
                 serverChannelLatch.countDown();
@@ -521,6 +547,10 @@ public class DataCompressionHttp2Test {
     private void awaitServer() throws Exception {
         assertTrue(serverLatch.await(5, SECONDS));
         serverOut.flush();
+        Throwable cause = serverException.get();
+        if (cause != null) {
+            throw new AssertionError("Server-side decompression error", cause);
+        }
     }
 
     private ChannelHandlerContext ctxClient() {


### PR DESCRIPTION
Motivation:

https://github.com/netty/netty/commit/9d804c54ce962408ae6418255a83a13924f7145d introduced a regression which would cause the decompressing to fail if padding is used.

Modifications:

- Correctly handle padding
- Enhance unit tests

Result:

Fixes https://github.com/netty/netty/issues/16252
