### PR TITLE
Avoid allocation in HttpObjectEncoder.addEncodedLengthHex method (#16241)

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectEncoder.java
@@ -550,11 +550,22 @@ public abstract class HttpObjectEncoder<H extends HttpMessage> extends MessageTo
     }
 
     private static void addEncodedLengthHex(ChannelHandlerContext ctx, long contentLength, List<Object> out) {
-        String lengthHex = Long.toHexString(contentLength);
-        ByteBuf buf = ctx.alloc().buffer(lengthHex.length() + 2);
-        buf.writeCharSequence(lengthHex, CharsetUtil.US_ASCII);
+        // logic is from Long.toHexString() but we want to avoid creating a String
+        int hexLen = contentLength == 0 ? 1 : (Long.SIZE - Long.numberOfLeadingZeros(contentLength) + 3) >>> 2;
+        ByteBuf buf = ctx.alloc().buffer(hexLen + 2); // +2 for CRLF
+        writeHexAscii(buf, contentLength, hexLen);
         ByteBufUtil.writeShortBE(buf, CRLF_SHORT);
         out.add(buf);
+    }
+
+    private static final byte[] HEX = {
+            '0', '1', '2', '3', '4', '5', '6', '7',
+            '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
+    };
+    private static void writeHexAscii(ByteBuf out, long contentLength, int hexLen) {
+        for (int shift = (hexLen - 1) << 2; shift >= 0; shift -= 4) {
+            out.writeByte(HEX[(int) ((contentLength >>> shift) & 0xF)]);
+        }
     }
 
     /**


### PR DESCRIPTION
Motivation:

`HttpObjectEncoder.addEncodedLengthHex` allocates a hex string, which could be easily avoided with manual code.

<img width="626" height="187" alt="image"
src="https://github.com/user-attachments/assets/0ae41145-1ff8-48c4-b850-688e574674e3" />

Modification:

Replaced `Long.toHexString(contentLength)` with custom utility method `writeHexAscii` that writes byte by byte into output buffer

Result:

No more string allocation `HttpObjectEncoder.addEncodedLengthHex` method.

(cherry picked from commit ee12997f3829f68f24cb5d57b46f58ad049f3d9e)