### PR TITLE
Automatic backporting workflow from 4.1 to 4.2

### DIFF
--- a/.github/workflows/backport-41.yml
+++ b/.github/workflows/backport-41.yml
@@ -34,19 +34,24 @@ jobs:
           
           if git cherry-pick -x "$MERGE_COMMIT"; then
             echo "Cherry-pick successful"
-            echo "success=true" >> $GITHUB_OUTPUT
+            echo "success=true" >> "$GITHUB_OUTPUT"
           else
             echo "Cherry-pick failed - conflicts detected"
-            echo "success=false" >> $GITHUB_OUTPUT
+            echo "success=false" >> "$GITHUB_OUTPUT"
             git cherry-pick --abort
             exit 1
           fi
-          echo "branch=$BACKPORT_BRANCH" >> $GITHUB_OUTPUT
+          echo "branch=$BACKPORT_BRANCH" >> "$GITHUB_OUTPUT"
 
       - name: Push backport branch
+        id: push
         if: steps.cherry-pick.outputs.success == 'true'
         run: |
-          git push origin "${{ steps.cherry-pick.outputs.branch }}"
+          if ! git push origin "${{ steps.cherry-pick.outputs.branch }}"; then
+            echo "Backport branch push failed"
+            echo "push_failed=true" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
           
       - name: Create pull request
         if: steps.cherry-pick.outputs.success == 'true'
@@ -81,4 +86,17 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
               body: `Could not create automatic backport PR.\nGot conflicts when cherry-picking onto 4.1.`
+            });
+
+      - name: Report backport branch push failure
+        if: failure() && steps.push.outputs.push_failed == 'true'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `Could not create automatic backport PR.\n`+
+                    `I could cherry-pick onto 4.1 just fine, but pushing the new branch failed.`
             });

--- a/.github/workflows/backport-41.yml
+++ b/.github/workflows/backport-41.yml
@@ -1,0 +1,84 @@
+name: Auto Backport to 4.1
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - '4.2'
+
+jobs:
+  backport:
+    if: github.event.pull_request.merged && contains(github.event.pull_request.labels.*.name, 'needs-cherry-pick-4.1')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: '0' # Cherry-pick needs full history
+          token: '${{ secrets.GITHUB_TOKEN }}'
+
+      - name: Setup git configuration
+        run: |
+          git config --global user.email "netty-project-bot@users.noreply.github.com"
+          git config --global user.name "Netty Project Bot"
+
+      - name: Create backport PR branch and cherry-pick
+        id: cherry-pick
+        run: |
+          MERGE_COMMIT="${{ github.event.pull_request.merge_commit_sha }}"
+          echo "Backporting commit: $MERGE_COMMIT"
+          
+          BACKPORT_BRANCH="backport-pr-${{ github.event.pull_request.number }}-to-4.1"
+          git fetch origin 4.1:4.1
+          git checkout -b "$BACKPORT_BRANCH" 4.1
+          
+          if git cherry-pick -x "$MERGE_COMMIT"; then
+            echo "Cherry-pick successful"
+            echo "success=true" >> $GITHUB_OUTPUT
+          else
+            echo "Cherry-pick failed - conflicts detected"
+            echo "success=false" >> $GITHUB_OUTPUT
+            git cherry-pick --abort
+            exit 1
+          fi
+          echo "branch=$BACKPORT_BRANCH" >> $GITHUB_OUTPUT
+
+      - name: Push backport branch
+        if: steps.cherry-pick.outputs.success == 'true'
+        run: |
+          git push origin "${{ steps.cherry-pick.outputs.branch }}"
+          
+      - name: Create pull request
+        if: steps.cherry-pick.outputs.success == 'true'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Backport 4.1: ${context.payload.pull_request.title}`,
+              head: '${{ steps.cherry-pick.outputs.branch }}',
+              base: '4.1',
+              body: `Backport of #${context.payload.pull_request.number} to 4.1\n` +
+                    `Cherry-picked commit: ${context.payload.pull_request.merge_commit_sha}\n\n---\n` +
+                    `${context.payload.pull_request.body || ''}`
+            });
+            console.log(`Created backport PR: ${pr.html_url}`);
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `Backport PR for 4.1: #${pr.number}`
+            });
+
+      - name: Report cherry-pick conflicts
+        if: failure() && steps.cherry-pick.outputs.success == 'false'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `Could not create automatic backport PR.\nGot conflicts when cherry-picking onto 4.1.`
+            });


### PR DESCRIPTION
Motivation:
We often backport PRs from 4.2 to 4.1.
Because these branches are very similar, cherry-picking often applies cleanly.

Modification:
Add a workflow that triggers on PRs merged into 4.2 with the `needs-cherry-pick-4.1` label, and tries to cherry-pick the merge commit onto 4.1 and create a pull-request. Finally, the workflow adds a comment to the original PR, linking the backport PR if the cherry-pick succeeded, or reporting failure if it didn't.

Result:
Easier to keep 4.1 up to date with bug fixes we do in 4.2.