### PR TITLE
Automatic backporting workflow from 4.1 to 4.2

### DIFF
--- a/.github/workflows/backport-41.yml
+++ b/.github/workflows/backport-41.yml
@@ -1,0 +1,114 @@
+name: Auto Backport to 4.1
+on:
+  pull_request:
+    types:
+      - closed
+      - labeled
+    branches:
+      - '4.2'
+
+jobs:
+  backport:
+    if: github.event.pull_request.merged && (
+      github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'needs-cherry-pick-4.1') ||
+      github.event.action == 'labeled' && contains(github.event.label.name, 'needs-cherry-pick-4.1'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: '0' # Cherry-pick needs full history
+          token: '${{ secrets.GITHUB_TOKEN }}'
+
+      - name: Setup git configuration
+        run: |
+          git config --global user.email "netty-project-bot@users.noreply.github.com"
+          git config --global user.name "Netty Project Bot"
+
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_PRIVATE_KEY_PEM }}
+          known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
+
+      - name: Create backport PR branch and cherry-pick
+        id: cherry-pick
+        run: |
+          MERGE_COMMIT="${{ github.event.pull_request.merge_commit_sha }}"
+          echo "Backporting commit: $MERGE_COMMIT"
+          
+          BACKPORT_BRANCH="backport-pr-${{ github.event.pull_request.number }}-to-4.1"
+          git fetch origin 4.1:4.1
+          git checkout -b "$BACKPORT_BRANCH" 4.1
+          
+          if git cherry-pick -x "$MERGE_COMMIT"; then
+            echo "Cherry-pick successful"
+            echo "success=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Cherry-pick failed - conflicts detected"
+            echo "success=false" >> "$GITHUB_OUTPUT"
+            git cherry-pick --abort
+            exit 1
+          fi
+          echo "branch=$BACKPORT_BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Push backport branch
+        id: push
+        if: steps.cherry-pick.outputs.success == 'true'
+        run: |
+          if ! git push origin "${{ steps.cherry-pick.outputs.branch }}"; then
+            echo "Backport branch push failed"
+            echo "push_failed=true" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+          
+      - name: Create pull request
+        if: steps.cherry-pick.outputs.success == 'true'
+        uses: actions/github-script@v8
+        with:
+          github-token: '${{ secrets.PAT_TOKEN_READ_WRITE_PR }}'
+          script: |
+            const { data: pr } = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Backport 4.1: ${context.payload.pull_request.title}`,
+              head: '${{ steps.cherry-pick.outputs.branch }}',
+              base: '4.1',
+              body: `Backport of #${context.payload.pull_request.number} to 4.1\n` +
+                    `Cherry-picked commit: ${context.payload.pull_request.merge_commit_sha}\n\n---\n` +
+                    `${context.payload.pull_request.body || ''}`
+            });
+            console.log(`Created backport PR: ${pr.html_url}`);
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `Backport PR for 4.1: #${pr.number}`
+            });
+
+      - name: Report cherry-pick conflicts
+        if: failure() && steps.cherry-pick.outputs.success == 'false'
+        uses: actions/github-script@v8
+        with:
+          github-token: '${{ secrets.PAT_TOKEN_READ_WRITE_PR }}'
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `Could not create automatic backport PR.\nGot conflicts when cherry-picking onto 4.1.`
+            });
+
+      - name: Report backport branch push failure
+        if: failure() && steps.push.outputs.push_failed == 'true'
+        uses: actions/github-script@v8
+        with:
+          github-token: '${{ secrets.PAT_TOKEN_READ_WRITE_PR }}'
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `Could not create automatic backport PR.\n`+
+                    `I could cherry-pick onto 4.1 just fine, but pushing the new branch failed.`
+            });

--- a/.github/workflows/backport-41.yml
+++ b/.github/workflows/backport-41.yml
@@ -1,6 +1,6 @@
 name: Auto Backport to 4.1
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
       - labeled

--- a/.github/workflows/backport-41.yml
+++ b/.github/workflows/backport-41.yml
@@ -22,18 +22,11 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: '0' # Cherry-pick needs full history
-          token: '${{ secrets.GITHUB_TOKEN }}'
 
       - name: Setup git configuration
         run: |
           git config --global user.email "netty-project-bot@users.noreply.github.com"
           git config --global user.name "Netty Project Bot"
-
-      - name: Install SSH key
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.SSH_PRIVATE_KEY_PEM }}
-          known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
 
       - name: Create backport PR branch and cherry-pick
         id: cherry-pick
@@ -70,7 +63,6 @@ jobs:
         if: steps.cherry-pick.outputs.success == 'true'
         uses: actions/github-script@v8
         with:
-          github-token: '${{ secrets.PAT_TOKEN_READ_WRITE_PR }}'
           script: |
             const { data: pr } = await github.rest.pulls.create({
               owner: context.repo.owner,
@@ -94,7 +86,6 @@ jobs:
         if: failure() && steps.cherry-pick.outputs.success == 'false'
         uses: actions/github-script@v8
         with:
-          github-token: '${{ secrets.PAT_TOKEN_READ_WRITE_PR }}'
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -107,7 +98,6 @@ jobs:
         if: failure() && steps.push.outputs.push_failed == 'true'
         uses: actions/github-script@v8
         with:
-          github-token: '${{ secrets.PAT_TOKEN_READ_WRITE_PR }}'
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/.github/workflows/backport-41.yml
+++ b/.github/workflows/backport-41.yml
@@ -11,7 +11,7 @@ jobs:
   backport:
     name: "Backporting to 4.1"
     concurrency:
-      group: backporting-${{ github.head_ref }}
+      group: backporting-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     if: github.event.pull_request.merged && (
       github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'needs-cherry-pick-4.1') ||

--- a/.github/workflows/backport-41.yml
+++ b/.github/workflows/backport-41.yml
@@ -13,9 +13,7 @@ jobs:
     concurrency:
       group: backporting-${{ github.event.pull_request.number }}
       cancel-in-progress: true
-    if: github.event.pull_request.merged && (
-      github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'needs-cherry-pick-4.1') ||
-      github.event.action == 'labeled' && contains(github.event.label.name, 'needs-cherry-pick-4.1'))
+    if: github.event.pull_request.merged && contains(github.event.pull_request.labels.*.name, 'needs-cherry-pick-4.1')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/backport-41.yml
+++ b/.github/workflows/backport-41.yml
@@ -19,6 +19,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY_PEM }}
+          ssh-known-hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
           fetch-depth: '0' # Cherry-pick needs full history
 
       - name: Setup git configuration

--- a/.github/workflows/backport-41.yml
+++ b/.github/workflows/backport-41.yml
@@ -9,6 +9,10 @@ on:
 
 jobs:
   backport:
+    name: "Backporting to 4.1"
+    concurrency:
+      group: backporting-${{ github.head_ref }}
+      cancel-in-progress: true
     if: github.event.pull_request.merged && (
       github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'needs-cherry-pick-4.1') ||
       github.event.action == 'labeled' && contains(github.event.label.name, 'needs-cherry-pick-4.1'))

--- a/.github/workflows/backport-41.yml
+++ b/.github/workflows/backport-41.yml
@@ -40,10 +40,8 @@ jobs:
           
           if git cherry-pick -x "$MERGE_COMMIT"; then
             echo "Cherry-pick successful"
-            echo "success=true" >> "$GITHUB_OUTPUT"
           else
             echo "Cherry-pick failed - conflicts detected"
-            echo "success=false" >> "$GITHUB_OUTPUT"
             git cherry-pick --abort
             exit 1
           fi
@@ -51,16 +49,15 @@ jobs:
 
       - name: Push backport branch
         id: push
-        if: steps.cherry-pick.outputs.success == 'true'
+        if: steps.cherry-pick.outcome == 'success'
         run: |
           if ! git push origin "${{ steps.cherry-pick.outputs.branch }}"; then
             echo "Backport branch push failed"
-            echo "push_failed=true" >> "$GITHUB_OUTPUT"
             exit 1
           fi
           
       - name: Create pull request
-        if: steps.cherry-pick.outputs.success == 'true'
+        if: steps.cherry-pick.outcome == 'success'
         uses: actions/github-script@v8
         with:
           script: |
@@ -83,7 +80,7 @@ jobs:
             });
 
       - name: Report cherry-pick conflicts
-        if: failure() && steps.cherry-pick.outputs.success == 'false'
+        if: failure() && steps.cherry-pick.outcome != 'success'
         uses: actions/github-script@v8
         with:
           script: |
@@ -95,7 +92,7 @@ jobs:
             });
 
       - name: Report backport branch push failure
-        if: failure() && steps.push.outputs.push_failed == 'true'
+        if: failure() && steps.push.outcome != 'success'
         uses: actions/github-script@v8
         with:
           script: |


### PR DESCRIPTION
Motivation:
We often backport PRs from 4.2 to 4.1.
Because these branches are very similar, cherry-picking often applies cleanly.

Modification:
Add a workflow that triggers when a is PRs merged into 4.2 with the `needs-cherry-pick-4.1` label, or when a merged PR is labelled with `needs-cherry-pick-4.1`.
The workflow triggers on `pull_request_target` so that it runs in the context of the base branch, rather than the PR, which gives it access to repository secrets – this is safe because we're not running any code that's been added or modified by the PR in question.
The workflow checks out the full git history, and tries to cherry-pick the merge commit onto `4.1` and create a pull-request. Finally, the workflow adds a comment to the original PR, linking the backport PR if the cherry-pick succeeded, or reporting failure if it didn't.
The back port branch are pushed back to the netty/netty repository using the same SSH key we use to push release tags.

Result:
Easier to keep 4.1 up to date with bug fixes we do in 4.2.
This PR attempts to fix the issues encountered with https://github.com/netty/netty/pull/16269 and https://github.com/netty/netty/pull/16271