### PR TITLE
Backport 4.1: Backport PRs must be created with personal access tokens

### DIFF
--- a/.github/workflows/backport-41.yml
+++ b/.github/workflows/backport-41.yml
@@ -60,6 +60,7 @@ jobs:
         if: steps.cherry-pick.outcome == 'success'
         uses: actions/github-script@v8
         with:
+          github-token: '${{ secrets.PAT_TOKEN_READ_WRITE_PR }}'
           script: |
             const { data: pr } = await github.rest.pulls.create({
               owner: context.repo.owner,


### PR DESCRIPTION
Backport of #16276 to 4.1
Cherry-picked commit: ca2564131d8870ac27fc684fecf231b46b996f30

---
Motivation:
When creating a PR using a workflow GITHUB_TOKEN, then no additional workflows are triggered. This means our CI build is not started on automatic backport PRs:
https://docs.github.com/en/actions/concepts/security/github_token#when-github_token-triggers-workflow-runs

Modification:
Use a personal access token when creating the backport PR, instead of GITHUB_TOKEN.

Result:
Backport PRs should now have CI triggered.