### PR TITLE
Avoid unnecessary SSL.getVersion() call and string allocation in ReferenceCountedOpenSslEngine

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -2085,6 +2085,9 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
     }
 
     private String toJavaCipherSuite(String openSslCipherSuite, String version) {
+        if (openSslCipherSuite == null) {
+            return null;
+        }
         String prefix = toJavaCipherSuitePrefix(version);
         return CipherSuiteConverter.toJava(openSslCipherSuite, prefix);
     }

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -2081,6 +2081,10 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
         }
 
         String version = SSL.getVersion(ssl);
+        return toJavaCipherSuite(openSslCipherSuite, version);
+    }
+
+    private String toJavaCipherSuite(String openSslCipherSuite, String version) {
         String prefix = toJavaCipherSuitePrefix(version);
         return CipherSuiteConverter.toJava(openSslCipherSuite, prefix);
     }
@@ -2549,7 +2553,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                         // did not set it earlier via setSessionDetails(...)
                         this.creationTime = lastAccessed = creationTime;
                     }
-                    this.cipher = toJavaCipherSuite(cipher);
+                    this.cipher = toJavaCipherSuite(cipher, protocol);
                     this.protocol = protocol;
 
                     if (clientMode) {


### PR DESCRIPTION
Motivation:

When ssl handshake is done `SSL.getVersion()` is called 2 times. Which also allocates a string with every call.

<img width="1548" height="196" alt="5f3d4238-7594-4890-b48c-881352788e1d" src="https://github.com/user-attachments/assets/99a743ca-9512-4dc7-8c69-1f692ae3e08e" />

Modification:

Added overloaded `toJavaCipherSuite()` method that accepts `String protocol` which we can pass when we have it already.

Result:

1 less JNI call, 1 less string allocation during SSL handshake.
