### PR TITLE
Fix high-order bit aliasing in HttpUtil.validateToken

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
@@ -717,8 +717,10 @@ public final class HttpUtil {
      */
     private static int validateCharSequenceToken(CharSequence token) {
         for (int i = 0, len = token.length(); i < len; i++) {
-            byte value = (byte) token.charAt(i);
-            if (!isValidTokenChar(value)) {
+            int value = token.charAt(i);
+            // 1. Check for truncation (anything above 255)
+            // 2. Check against the BitSet (isValidTokenChar handles 128-255 via bit < 0)
+            if (value > 0xFF || !isValidTokenChar((byte) value)) {
                 return i;
             }
         }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpUtilTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpUtilTest.java
@@ -535,4 +535,22 @@ public class HttpUtilTest {
         assertEquals(2, validateToken(asciiStringToken));
         assertEquals(2, validateToken(token));
     }
+
+    @ParameterizedTest
+    @ValueSource(chars = {
+            // High-bit Truncation Candidates (verifying > 0xFF check)
+            // These characters are chosen because their lower 8 bits
+            // alias to valid US-ASCII 'tchar' values.
+            '\u0161', // 0x0161 truncates to 0x61 ('a')
+            '\u0121', // 0x0121 truncates to 0x21 ('!')
+            '\u0231', // 0x0231 truncates to 0x31 ('1')
+            '\u0361'  // 0x0361 truncates to 0x61 ('a')
+    })
+    public void testInvalidTokenCharsOutsideAsciiRange(char invalidChar) {
+        // We use a String here because AsciiString would truncate
+        // the char to a byte during construction.
+        String token = "GE" + invalidChar + 'T';
+        assertEquals(2, validateToken(token),
+            String.format("Character U+%04X should be invalid", (int) invalidChar));
+    }
 }


### PR DESCRIPTION
Motivation:

The goal of this PR is to fix a character validation bypass in HttpUtil.validateToken.

Prior to this change, the validateCharSequenceToken method was susceptible to "high-order bit aliasing." Because the logic performed a direct cast from a 16-bit char to an 8-bit byte, any Unicode character whose lower 8 bits matched a valid RFC 7230 tchar would be incorrectly validated.

For example, the character 'Š' (U+0161) has the bit pattern 00000001 01100001. A narrow cast to byte strips the high-order bits, leaving 01100001, which is the ASCII value for 'a'. Since 'a' is a valid token character, the validator would return -1 (valid), violating the strictness required by RFC 7230.

Modification:

* Modified validateCharSequenceToken(CharSequence token) to store the character in an int variable to prevent multiple charAt lookups and maintain consistency with Netty's internal coding style.
* Introduced an explicit range check (value > 0xFF) to catch high-order characters before they are cast to byte.
* Updated HttpUtilTest with a new parameterized test testInvalidTokenCharsHighOrderBitAliasing that specifically tests Unicode characters known to alias into the valid tchar range (U+0161, U+0121, U+0231, U+0361).

Result:

This change ensures that HttpUtil correctly rejects non-ASCII and multi-byte characters that were previously able to bypass the token validation logic.
