### PR TITLE
Remove the unpooled allocator from test permutations

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/TestsuitePermutation.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/TestsuitePermutation.java
@@ -21,7 +21,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
-import io.netty.buffer.UnpooledByteBufAllocator;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,7 +31,6 @@ public final class TestsuitePermutation {
 
     public static List<ByteBufAllocator> allocator() {
         List<ByteBufAllocator> allocators = new ArrayList<ByteBufAllocator>();
-        allocators.add(UnpooledByteBufAllocator.DEFAULT);
         allocators.add(PooledByteBufAllocator.DEFAULT);
         allocators.add(DEFAULT_ADAPTIVE_ALLOCATOR);
         return allocators;


### PR DESCRIPTION
Motivation:
The unpooled allocator will allocate and deallocate memory for each buffer, rather than pool the memory. On Java 25+, deallocating memory (in the form of shared memory segments) involves thread-local handshakes, and can have significant overhead to the point of causing frequent test timeouts. Additionally, having the unpooled allocator in the test permutations does not add very much to test coverage.

Modification:
Remove the unpooled allocator from the transport test permutation parameters.

Result:
Much faster builds, from removing the overhead of releasing millions of shared memory segments.