### PR TITLE
Some polishing of the porting workflows

### DIFF
--- a/.github/workflows/backport-41.yml
+++ b/.github/workflows/backport-41.yml
@@ -81,10 +81,24 @@ jobs:
               body: `Backport PR for 4.1: #${pr.number}`
             });
 
-      - name: Report cherry-pick conflicts
-        if: failure() && steps.cherry-pick.outcome != 'success'
+      # Important: This script MUST run with the default GITHUB_TOKEN to avoid triggering other actions.
+      - name: Remove triggering label
+        if: steps.create-pr.outcome == 'success'
         uses: actions/github-script@v8
         with:
+          script: |
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              name: 'needs-cherry-pick-4.1'
+            });
+
+      - name: Report cherry-pick conflicts
+        if: failure() && steps.cherry-pick.outcome == 'failure'
+        uses: actions/github-script@v8
+        with:
+          github-token: '${{ secrets.PAT_TOKEN_READ_WRITE_PR }}'
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -94,9 +108,10 @@ jobs:
             });
 
       - name: Report backport branch push failure
-        if: failure() && steps.push.outcome != 'success'
+        if: failure() && steps.push.outcome == 'failure'
         uses: actions/github-script@v8
         with:
+          github-token: '${{ secrets.PAT_TOKEN_READ_WRITE_PR }}'
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -107,6 +122,6 @@ jobs:
             });
 
       - name: Remove branch on PR create failure
-        if: failure() && steps.create-pr.outcome != 'success'
+        if: failure() && steps.cherry-pick.outputs.branch
         run: |
           git push -d origin "${{ steps.cherry-pick.outputs.branch }}"

--- a/.github/workflows/backport-42.yml
+++ b/.github/workflows/backport-42.yml
@@ -81,10 +81,24 @@ jobs:
               body: `Backport PR for 4.2: #${pr.number}`
             });
 
-      - name: Report cherry-pick conflicts
-        if: failure() && steps.cherry-pick.outcome != 'success'
+      # Important: This script MUST run with the default GITHUB_TOKEN to avoid triggering other actions.
+      - name: Remove triggering label
+        if: steps.create-pr.outcome == 'success'
         uses: actions/github-script@v8
         with:
+          script: |
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              name: 'needs-cherry-pick-4.2'
+            });
+
+      - name: Report cherry-pick conflicts
+        if: failure() && steps.cherry-pick.outcome == 'failure'
+        uses: actions/github-script@v8
+        with:
+          github-token: '${{ secrets.PAT_TOKEN_READ_WRITE_PR }}'
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -94,9 +108,10 @@ jobs:
             });
 
       - name: Report backport branch push failure
-        if: failure() && steps.push.outcome != 'success'
+        if: failure() && steps.push.outcome == 'failure'
         uses: actions/github-script@v8
         with:
+          github-token: '${{ secrets.PAT_TOKEN_READ_WRITE_PR }}'
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -107,6 +122,6 @@ jobs:
             });
 
       - name: Remove branch on PR create failure
-        if: failure() && steps.create-pr.outcome != 'success'
+        if: failure() && steps.cherry-pick.outputs.branch
         run: |
           git push -d origin "${{ steps.cherry-pick.outputs.branch }}"

--- a/.github/workflows/forwardport-50.yml
+++ b/.github/workflows/forwardport-50.yml
@@ -81,10 +81,24 @@ jobs:
               body: `Forward port PR for 5.0: #${pr.number}`
             });
 
-      - name: Report cherry-pick conflicts
-        if: failure() && steps.cherry-pick.outcome != 'success'
+      # Important: This script MUST run with the default GITHUB_TOKEN to avoid triggering other actions.
+      - name: Remove triggering label
+        if: steps.create-pr.outcome == 'success'
         uses: actions/github-script@v8
         with:
+          script: |
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              name: 'needs-cherry-pick-5.0'
+            });
+
+      - name: Report cherry-pick conflicts
+        if: failure() && steps.cherry-pick.outcome == 'failure'
+        uses: actions/github-script@v8
+        with:
+          github-token: '${{ secrets.PAT_TOKEN_READ_WRITE_PR }}'
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -94,9 +108,10 @@ jobs:
             });
 
       - name: Report backport branch push failure
-        if: failure() && steps.push.outcome != 'success'
+        if: failure() && steps.push.outcome == 'failure'
         uses: actions/github-script@v8
         with:
+          github-token: '${{ secrets.PAT_TOKEN_READ_WRITE_PR }}'
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -107,6 +122,6 @@ jobs:
             });
 
       - name: Remove branch on PR create failure
-        if: failure() && steps.create-pr.outcome != 'success'
+        if: failure() && steps.cherry-pick.outputs.branch
         run: |
           git push -d origin "${{ steps.cherry-pick.outputs.branch }}"


### PR DESCRIPTION
Motivation:
Step failures should be reported by the netty project bot instead of the github actions bot. We should also prevent steps from triggering from future label changes by having the workflows remove their triggering label once they're done.

Modification:
- Make errors be reported through the PAT token so they show as being from the netty project bot.
- Make the workflow remove the triggering label if it succeeds in creating a back/forward port PR.
- Only attempt to delete the porting branch on failure, if a porting branch was created.
- Only report errors for steps that actually failed, i.e. don't report errors for steps that were skipped due to earlier failures.

Result:
More robust experience with automated backporting.