### PR TITLE
Make the build run faster

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
@@ -2335,7 +2335,7 @@ public abstract class AbstractByteBufTest {
     }
 
     @Test
-    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(60)
     public void testCopyMultipleThreads0() throws Throwable {
         byte[] bytes = new byte[8];
         random.nextBytes(bytes);

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
@@ -16,32 +16,20 @@
 package io.netty.buffer;
 
 import io.netty.util.NettyRuntime;
-import io.netty.util.concurrent.FastThreadLocalThread;
 import io.netty.util.test.DisabledForSlowLeakDetection;
-import jdk.jfr.consumer.RecordedEvent;
-import jdk.jfr.consumer.RecordingStream;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.RepetitionInfo;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.lang.reflect.Array;
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Deque;
-import java.util.List;
 import java.util.SplittableRandom;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.FutureTask;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -222,175 +210,6 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
         if (throwable != null) {
             fail("Expected no exception, but got", throwable);
         }
-    }
-
-    @SuppressWarnings("Since15")
-    @Test
-    @EnabledForJreRange(min = JRE.JAVA_17) // RecordingStream
-    @Timeout(10)
-    public void jfrChunkAllocation() throws Exception {
-        try (RecordingStream stream = new RecordingStream()) {
-            CompletableFuture<RecordedEvent> allocateFuture = new CompletableFuture<>();
-
-            stream.enable(AllocateChunkEvent.class);
-            stream.onEvent(AllocateChunkEvent.NAME, allocateFuture::complete);
-            stream.startAsync();
-
-            AdaptiveByteBufAllocator alloc = new AdaptiveByteBufAllocator(true, false);
-            alloc.directBuffer(128).release();
-
-            RecordedEvent allocate = allocateFuture.get();
-            assertEquals(AdaptivePoolingAllocator.MIN_CHUNK_SIZE, allocate.getInt("capacity"));
-            assertTrue(allocate.getBoolean("pooled"));
-            assertFalse(allocate.getBoolean("threadLocal"));
-            assertTrue(allocate.getBoolean("direct"));
-        }
-    }
-
-    @SuppressWarnings("Since15")
-    @Test
-    @EnabledForJreRange(min = JRE.JAVA_17) // RecordingStream
-    @Timeout(10)
-    public void shouldCreateTwoChunks() throws Exception {
-        try (RecordingStream stream = new RecordingStream()) {
-            final CountDownLatch eventsFlushed = new CountDownLatch(2);
-            stream.enable(AllocateChunkEvent.class);
-            stream.onEvent(AllocateChunkEvent.NAME,
-                           event -> {
-                                eventsFlushed.countDown();
-                           });
-            stream.startAsync();
-            ByteBufAllocator allocator = newAllocator(false);
-            int bufSize = 16896;
-            int minSegmentsPerChunk = 32; // See AdaptivePoolingAllocator.SizeClassChunkController.
-            int bufsToAllocate = 1 + minSegmentsPerChunk;
-            List<ByteBuf> buffers = new ArrayList<>(bufsToAllocate);
-            for (int i = 0; i < bufsToAllocate; ++i) {
-                buffers.add(allocator.heapBuffer(bufSize, bufSize));
-            }
-            // release all buffers
-            for (ByteBuf buffer : buffers) {
-                buffer.release();
-            }
-            buffers.clear();
-            eventsFlushed.await();
-            assertEquals(0, eventsFlushed.getCount());
-        }
-    }
-
-    @SuppressWarnings("Since15")
-    @Test
-    @EnabledForJreRange(min = JRE.JAVA_17) // RecordingStream
-    @Timeout(10)
-    public void shouldReuseTheSameChunk() throws Exception {
-        try (RecordingStream stream = new RecordingStream()) {
-            final CountDownLatch eventsFlushed = new CountDownLatch(1);
-            final AtomicInteger chunksAllocations = new AtomicInteger();
-            stream.enable(AllocateChunkEvent.class);
-            stream.onEvent(AllocateChunkEvent.NAME,
-                           event -> {
-                               chunksAllocations.incrementAndGet();
-                               eventsFlushed.countDown();
-                           });
-            stream.startAsync();
-            int bufSize = 16896;
-            ByteBufAllocator allocator = newAllocator(false);
-            List<ByteBuf> buffers = new ArrayList<>(32);
-            for (int i = 0; i < 30; ++i) {
-                buffers.add(allocator.heapBuffer(bufSize, bufSize));
-            }
-            // we still have 2 available segments in the chunk, so we should not allocate a new one
-            for (int i = 0; i < 128; ++i) {
-                allocator.heapBuffer(bufSize, bufSize).release();
-            }
-            // release all buffers
-            for (ByteBuf buffer : buffers) {
-                buffer.release();
-            }
-            buffers.clear();
-            eventsFlushed.await();
-            assertEquals(1, chunksAllocations.get());
-        }
-    }
-
-    @SuppressWarnings("Since15")
-    @Test
-    @EnabledForJreRange(min = JRE.JAVA_17) // RecordingStream
-    @Timeout(10)
-    public void jfrBufferAllocation() throws Exception {
-        try (RecordingStream stream = new RecordingStream()) {
-            CompletableFuture<RecordedEvent> allocateFuture = new CompletableFuture<>();
-            CompletableFuture<RecordedEvent> releaseFuture = new CompletableFuture<>();
-
-            stream.enable(AllocateBufferEvent.class);
-            stream.onEvent(AllocateBufferEvent.NAME, allocateFuture::complete);
-            stream.enable(FreeBufferEvent.class);
-            stream.onEvent(FreeBufferEvent.NAME, releaseFuture::complete);
-            stream.startAsync();
-
-            AdaptiveByteBufAllocator alloc = new AdaptiveByteBufAllocator(true, false);
-            alloc.directBuffer(128).release();
-
-            RecordedEvent allocate = allocateFuture.get();
-            assertEquals(128, allocate.getInt("size"));
-            assertEquals(128, allocate.getInt("maxFastCapacity"));
-            assertEquals(Integer.MAX_VALUE, allocate.getInt("maxCapacity"));
-            assertTrue(allocate.getBoolean("chunkPooled"));
-            assertFalse(allocate.getBoolean("chunkThreadLocal"));
-            assertTrue(allocate.getBoolean("direct"));
-
-            RecordedEvent release = releaseFuture.get();
-            assertEquals(128, release.getInt("size"));
-            assertEquals(128, release.getInt("maxFastCapacity"));
-            assertEquals(Integer.MAX_VALUE, release.getInt("maxCapacity"));
-            assertTrue(release.getBoolean("direct"));
-        }
-    }
-
-    @SuppressWarnings("Since15")
-    @Test
-    @EnabledForJreRange(min = JRE.JAVA_17) // RecordingStream
-    @Timeout(10)
-    public void jfrBufferAllocationThreadLocal() throws Exception {
-        ByteBufAllocator alloc = new AdaptiveByteBufAllocator(true, true);
-
-        Callable<Void> allocateAndRelease = () -> {
-            try (RecordingStream stream = new RecordingStream()) {
-                CompletableFuture<RecordedEvent> allocateFuture = new CompletableFuture<>();
-                CompletableFuture<RecordedEvent> releaseFuture = new CompletableFuture<>();
-
-                // Prime the cache.
-                alloc.directBuffer(128).release();
-
-                stream.enable(AllocateBufferEvent.class);
-                stream.onEvent(AllocateBufferEvent.NAME, allocateFuture::complete);
-                stream.enable(FreeBufferEvent.class);
-                stream.onEvent(FreeBufferEvent.NAME, releaseFuture::complete);
-                stream.startAsync();
-
-                // Allocate out of the cache.
-                alloc.directBuffer(128).release();
-
-                RecordedEvent allocate = allocateFuture.get();
-                assertEquals(128, allocate.getInt("size"));
-                assertEquals(128, allocate.getInt("maxFastCapacity"));
-                assertEquals(Integer.MAX_VALUE, allocate.getInt("maxCapacity"));
-                assertTrue(allocate.getBoolean("chunkPooled"));
-                assertTrue(allocate.getBoolean("chunkThreadLocal"));
-                assertTrue(allocate.getBoolean("direct"));
-
-                RecordedEvent release = releaseFuture.get();
-                assertEquals(128, release.getInt("size"));
-                assertEquals(128, release.getInt("maxFastCapacity"));
-                assertEquals(Integer.MAX_VALUE, release.getInt("maxCapacity"));
-                assertTrue(release.getBoolean("direct"));
-                return null;
-            }
-        };
-        FutureTask<Void> task = new FutureTask<>(allocateAndRelease);
-        FastThreadLocalThread thread = new FastThreadLocalThread(task);
-        thread.start();
-        task.get();
     }
 
     @DisabledForSlowLeakDetection

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
@@ -17,6 +17,7 @@ package io.netty.buffer;
 
 import io.netty.util.NettyRuntime;
 import io.netty.util.concurrent.FastThreadLocalThread;
+import io.netty.util.test.DisabledForSlowLeakDetection;
 import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.consumer.RecordingStream;
 import org.junit.jupiter.api.RepeatedTest;
@@ -392,6 +393,7 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
         task.get();
     }
 
+    @DisabledForSlowLeakDetection
     @RepeatedTest(100)
     void buddyAllocationConsistency(RepetitionInfo info) {
         SplittableRandom rng = new SplittableRandom(info.getCurrentRepetition());

--- a/buffer/src/test/java/io/netty/buffer/JfrEventsTest.java
+++ b/buffer/src/test/java/io/netty/buffer/JfrEventsTest.java
@@ -1,0 +1,371 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import io.netty.util.concurrent.FastThreadLocalThread;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Timeout(10)
+@EnabledForJreRange(min = JRE.JAVA_17) // RecordingStream
+@Isolated
+public class JfrEventsTest {
+    PooledByteBufAllocator newPooledAllocator(boolean preferDirect) {
+        return new PooledByteBufAllocator(preferDirect);
+    }
+
+    AdaptiveByteBufAllocator newAdaptiveAllocator(boolean preferDirect) {
+        return new AdaptiveByteBufAllocator(preferDirect);
+    }
+
+    @SuppressWarnings("Since15")
+    @Test
+    public void pooledJfrChunkAllocation() throws Exception {
+        try (RecordingStream stream = new RecordingStream()) {
+            CompletableFuture<RecordedEvent> allocateFuture = new CompletableFuture<>();
+
+            stream.enable(AllocateChunkEvent.class);
+            stream.onEvent(AllocateChunkEvent.NAME, allocateFuture::complete);
+            stream.startAsync();
+
+            PooledByteBufAllocator alloc = newPooledAllocator(true);
+            alloc.directBuffer(128).release();
+
+            RecordedEvent allocate = allocateFuture.get();
+            assertEquals(alloc.metric().chunkSize(), allocate.getInt("capacity"));
+            assertTrue(allocate.getBoolean("pooled"));
+            assertFalse(allocate.getBoolean("threadLocal"));
+            assertTrue(allocate.getBoolean("direct"));
+        }
+    }
+
+    @SuppressWarnings("Since15")
+    @Test
+    public void pooledShouldCreateTwoChunks() throws Exception {
+        try (RecordingStream stream = new RecordingStream()) {
+            final CountDownLatch eventsFlushed = new CountDownLatch(2);
+            stream.enable(AllocateChunkEvent.class);
+            stream.onEvent(AllocateChunkEvent.NAME,
+                    event -> {
+                        eventsFlushed.countDown();
+                    });
+            stream.startAsync();
+            PooledByteBufAllocator allocator = newPooledAllocator(false);
+            int bufSize = 16896;
+            int bufsToAllocate = 1 + allocator.metric().chunkSize() / bufSize;
+            List<ByteBuf> buffers = new ArrayList<>(bufsToAllocate);
+            for (int i = 0; i < bufsToAllocate; ++i) {
+                buffers.add(allocator.heapBuffer(bufSize, bufSize));
+            }
+            // release all buffers
+            for (ByteBuf buffer : buffers) {
+                buffer.release();
+            }
+            buffers.clear();
+            eventsFlushed.await();
+            assertEquals(0, eventsFlushed.getCount());
+        }
+    }
+
+    @SuppressWarnings("Since15")
+    @Test
+    public void pooledShouldReuseTheSameChunk() throws Exception {
+        try (RecordingStream stream = new RecordingStream()) {
+            final CountDownLatch eventsFlushed = new CountDownLatch(1);
+            final AtomicInteger chunksAllocations = new AtomicInteger();
+            stream.enable(AllocateChunkEvent.class);
+            stream.onEvent(AllocateChunkEvent.NAME,
+                    event -> {
+                        chunksAllocations.incrementAndGet();
+                        eventsFlushed.countDown();
+                    });
+            stream.startAsync();
+            int bufSize = 16896;
+            PooledByteBufAllocator allocator = newPooledAllocator(false);
+            ByteBuf buf = allocator.heapBuffer(bufSize, bufSize);
+            int bufPin = Math.toIntExact(allocator.pinnedHeapMemory());
+            buf.release();
+            int bufsPerChunk = allocator.metric().chunkSize() / bufPin;
+            List<ByteBuf> buffers = new ArrayList<>(bufsPerChunk);
+            for (int i = 0; i < bufsPerChunk - 2; ++i) {
+                buffers.add(allocator.heapBuffer(bufSize, bufSize));
+            }
+            // we still have 2 available segments in the chunk, so we should not allocate a new one
+            for (int i = 0; i < 128; ++i) {
+                allocator.heapBuffer(bufSize, bufSize).release();
+            }
+            // release all buffers
+            for (ByteBuf buffer : buffers) {
+                buffer.release();
+            }
+            buffers.clear();
+            eventsFlushed.await();
+            assertEquals(1, chunksAllocations.get());
+        }
+    }
+
+    @SuppressWarnings("Since15")
+    @Test
+    public void pooledJfrBufferAllocation() throws Exception {
+        try (RecordingStream stream = new RecordingStream()) {
+            CompletableFuture<RecordedEvent> allocateFuture = new CompletableFuture<>();
+            CompletableFuture<RecordedEvent> releaseFuture = new CompletableFuture<>();
+
+            stream.enable(AllocateBufferEvent.class);
+            stream.onEvent(AllocateBufferEvent.NAME, allocateFuture::complete);
+            stream.enable(FreeBufferEvent.class);
+            stream.onEvent(FreeBufferEvent.NAME, releaseFuture::complete);
+            stream.startAsync();
+
+            PooledByteBufAllocator alloc = newPooledAllocator(true);
+            alloc.directBuffer(128).release();
+
+            RecordedEvent allocate = allocateFuture.get();
+            assertEquals(128, allocate.getInt("size"));
+            assertEquals(128, allocate.getInt("maxFastCapacity"));
+            assertEquals(Integer.MAX_VALUE, allocate.getInt("maxCapacity"));
+            assertTrue(allocate.getBoolean("chunkPooled"));
+            assertFalse(allocate.getBoolean("chunkThreadLocal"));
+            assertTrue(allocate.getBoolean("direct"));
+
+            RecordedEvent release = releaseFuture.get();
+            assertEquals(128, release.getInt("size"));
+            assertEquals(128, release.getInt("maxFastCapacity"));
+            assertEquals(Integer.MAX_VALUE, release.getInt("maxCapacity"));
+            assertTrue(release.getBoolean("direct"));
+        }
+    }
+
+    @SuppressWarnings("Since15")
+    @Test
+    public void pooledJfrBufferAllocationThreadLocal() throws Exception {
+        ByteBufAllocator alloc = newPooledAllocator(true);
+
+        Callable<Void> allocateAndRelease = () -> {
+            try (RecordingStream stream = new RecordingStream()) {
+                CompletableFuture<RecordedEvent> allocateFuture = new CompletableFuture<>();
+                CompletableFuture<RecordedEvent> releaseFuture = new CompletableFuture<>();
+
+                // Prime the cache.
+                alloc.directBuffer(128).release();
+
+                stream.enable(AllocateBufferEvent.class);
+                stream.onEvent(AllocateBufferEvent.NAME, allocateFuture::complete);
+                stream.enable(FreeBufferEvent.class);
+                stream.onEvent(FreeBufferEvent.NAME, releaseFuture::complete);
+                stream.startAsync();
+
+                // Allocate out of the cache.
+                alloc.directBuffer(128).release();
+
+                RecordedEvent allocate = allocateFuture.get();
+                assertEquals(128, allocate.getInt("size"));
+                assertEquals(128, allocate.getInt("maxFastCapacity"));
+                assertEquals(Integer.MAX_VALUE, allocate.getInt("maxCapacity"));
+                assertTrue(allocate.getBoolean("chunkPooled"));
+                assertTrue(allocate.getBoolean("chunkThreadLocal"));
+                assertTrue(allocate.getBoolean("direct"));
+
+                RecordedEvent release = releaseFuture.get();
+                assertEquals(128, release.getInt("size"));
+                assertEquals(128, release.getInt("maxFastCapacity"));
+                assertEquals(Integer.MAX_VALUE, release.getInt("maxCapacity"));
+                assertTrue(release.getBoolean("direct"));
+                return null;
+            }
+        };
+        FutureTask<Void> task = new FutureTask<>(allocateAndRelease);
+        FastThreadLocalThread thread = new FastThreadLocalThread(task);
+        thread.start();
+        task.get();
+    }
+
+    @SuppressWarnings("Since15")
+    @Test
+    public void adaptiveJfrChunkAllocation() throws Exception {
+        try (RecordingStream stream = new RecordingStream()) {
+            CompletableFuture<RecordedEvent> allocateFuture = new CompletableFuture<>();
+
+            stream.enable(AllocateChunkEvent.class);
+            stream.onEvent(AllocateChunkEvent.NAME, allocateFuture::complete);
+            stream.startAsync();
+
+            AdaptiveByteBufAllocator alloc = new AdaptiveByteBufAllocator(true, false);
+            alloc.directBuffer(128).release();
+
+            RecordedEvent allocate = allocateFuture.get();
+            assertEquals(AdaptivePoolingAllocator.MIN_CHUNK_SIZE, allocate.getInt("capacity"));
+            assertTrue(allocate.getBoolean("pooled"));
+            assertFalse(allocate.getBoolean("threadLocal"));
+            assertTrue(allocate.getBoolean("direct"));
+        }
+    }
+
+    @SuppressWarnings("Since15")
+    @Test
+    public void adaptiveShouldCreateTwoChunks() throws Exception {
+        try (RecordingStream stream = new RecordingStream()) {
+            final CountDownLatch eventsFlushed = new CountDownLatch(2);
+            stream.enable(AllocateChunkEvent.class);
+            stream.onEvent(AllocateChunkEvent.NAME,
+                    event -> {
+                        eventsFlushed.countDown();
+                    });
+            stream.startAsync();
+            ByteBufAllocator allocator = newAdaptiveAllocator(false);
+            int bufSize = 16896;
+            int minSegmentsPerChunk = 32; // See AdaptivePoolingAllocator.SizeClassChunkController.
+            int bufsToAllocate = 1 + minSegmentsPerChunk;
+            List<ByteBuf> buffers = new ArrayList<>(bufsToAllocate);
+            for (int i = 0; i < bufsToAllocate; ++i) {
+                buffers.add(allocator.heapBuffer(bufSize, bufSize));
+            }
+            // release all buffers
+            for (ByteBuf buffer : buffers) {
+                buffer.release();
+            }
+            buffers.clear();
+            eventsFlushed.await();
+            assertEquals(0, eventsFlushed.getCount());
+        }
+    }
+
+    @SuppressWarnings("Since15")
+    @Test
+    public void adaptiveShouldReuseTheSameChunk() throws Exception {
+        try (RecordingStream stream = new RecordingStream()) {
+            final CountDownLatch eventsFlushed = new CountDownLatch(1);
+            final AtomicInteger chunksAllocations = new AtomicInteger();
+            stream.enable(AllocateChunkEvent.class);
+            stream.onEvent(AllocateChunkEvent.NAME,
+                    event -> {
+                        chunksAllocations.incrementAndGet();
+                        eventsFlushed.countDown();
+                    });
+            stream.startAsync();
+            int bufSize = 16896;
+            ByteBufAllocator allocator = newAdaptiveAllocator(false);
+            List<ByteBuf> buffers = new ArrayList<>(32);
+            for (int i = 0; i < 30; ++i) {
+                buffers.add(allocator.heapBuffer(bufSize, bufSize));
+            }
+            // we still have 2 available segments in the chunk, so we should not allocate a new one
+            for (int i = 0; i < 128; ++i) {
+                allocator.heapBuffer(bufSize, bufSize).release();
+            }
+            // release all buffers
+            for (ByteBuf buffer : buffers) {
+                buffer.release();
+            }
+            buffers.clear();
+            eventsFlushed.await();
+            assertEquals(1, chunksAllocations.get());
+        }
+    }
+
+    @SuppressWarnings("Since15")
+    @Test
+    public void adaptiveJfrBufferAllocation() throws Exception {
+        try (RecordingStream stream = new RecordingStream()) {
+            CompletableFuture<RecordedEvent> allocateFuture = new CompletableFuture<>();
+            CompletableFuture<RecordedEvent> releaseFuture = new CompletableFuture<>();
+
+            stream.enable(AllocateBufferEvent.class);
+            stream.onEvent(AllocateBufferEvent.NAME, allocateFuture::complete);
+            stream.enable(FreeBufferEvent.class);
+            stream.onEvent(FreeBufferEvent.NAME, releaseFuture::complete);
+            stream.startAsync();
+
+            AdaptiveByteBufAllocator alloc = new AdaptiveByteBufAllocator(true, false);
+            alloc.directBuffer(128).release();
+
+            RecordedEvent allocate = allocateFuture.get();
+            assertEquals(128, allocate.getInt("size"));
+            assertEquals(128, allocate.getInt("maxFastCapacity"));
+            assertEquals(Integer.MAX_VALUE, allocate.getInt("maxCapacity"));
+            assertTrue(allocate.getBoolean("chunkPooled"));
+            assertFalse(allocate.getBoolean("chunkThreadLocal"));
+            assertTrue(allocate.getBoolean("direct"));
+
+            RecordedEvent release = releaseFuture.get();
+            assertEquals(128, release.getInt("size"));
+            assertEquals(128, release.getInt("maxFastCapacity"));
+            assertEquals(Integer.MAX_VALUE, release.getInt("maxCapacity"));
+            assertTrue(release.getBoolean("direct"));
+        }
+    }
+
+    @SuppressWarnings("Since15")
+    @Test
+    public void adaptiveJfrBufferAllocationThreadLocal() throws Exception {
+        ByteBufAllocator alloc = new AdaptiveByteBufAllocator(true, true);
+
+        Callable<Void> allocateAndRelease = () -> {
+            try (RecordingStream stream = new RecordingStream()) {
+                CompletableFuture<RecordedEvent> allocateFuture = new CompletableFuture<>();
+                CompletableFuture<RecordedEvent> releaseFuture = new CompletableFuture<>();
+
+                // Prime the cache.
+                alloc.directBuffer(128).release();
+
+                stream.enable(AllocateBufferEvent.class);
+                stream.onEvent(AllocateBufferEvent.NAME, allocateFuture::complete);
+                stream.enable(FreeBufferEvent.class);
+                stream.onEvent(FreeBufferEvent.NAME, releaseFuture::complete);
+                stream.startAsync();
+
+                // Allocate out of the cache.
+                alloc.directBuffer(128).release();
+
+                RecordedEvent allocate = allocateFuture.get();
+                assertEquals(128, allocate.getInt("size"));
+                assertEquals(128, allocate.getInt("maxFastCapacity"));
+                assertEquals(Integer.MAX_VALUE, allocate.getInt("maxCapacity"));
+                assertTrue(allocate.getBoolean("chunkPooled"));
+                assertTrue(allocate.getBoolean("chunkThreadLocal"));
+                assertTrue(allocate.getBoolean("direct"));
+
+                RecordedEvent release = releaseFuture.get();
+                assertEquals(128, release.getInt("size"));
+                assertEquals(128, release.getInt("maxFastCapacity"));
+                assertEquals(Integer.MAX_VALUE, release.getInt("maxCapacity"));
+                assertTrue(release.getBoolean("direct"));
+                return null;
+            }
+        };
+        FutureTask<Void> task = new FutureTask<>(allocateAndRelease);
+        FastThreadLocalThread thread = new FastThreadLocalThread(task);
+        thread.start();
+        task.get();
+    }
+}

--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -20,26 +20,18 @@ import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.concurrent.FastThreadLocalThread;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SystemPropertyUtil;
-import jdk.jfr.consumer.RecordedEvent;
-import jdk.jfr.consumer.RecordingStream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
 import java.util.Random;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.FutureTask;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
@@ -990,177 +982,5 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
                 buffer.release();
             }
         }
-    }
-
-    @SuppressWarnings("Since15")
-    @Test
-    @EnabledForJreRange(min = JRE.JAVA_17) // RecordingStream
-    @Timeout(10)
-    public void jfrChunkAllocation() throws Exception {
-        try (RecordingStream stream = new RecordingStream()) {
-            CompletableFuture<RecordedEvent> allocateFuture = new CompletableFuture<>();
-
-            stream.enable(AllocateChunkEvent.class);
-            stream.onEvent(AllocateChunkEvent.NAME, allocateFuture::complete);
-            stream.startAsync();
-
-            PooledByteBufAllocator alloc = newAllocator(true);
-            alloc.directBuffer(128).release();
-
-            RecordedEvent allocate = allocateFuture.get();
-            assertEquals(alloc.metric().chunkSize(), allocate.getInt("capacity"));
-            assertTrue(allocate.getBoolean("pooled"));
-            assertFalse(allocate.getBoolean("threadLocal"));
-            assertTrue(allocate.getBoolean("direct"));
-        }
-    }
-
-    @SuppressWarnings("Since15")
-    @Test
-    @EnabledForJreRange(min = JRE.JAVA_17) // RecordingStream
-    @Timeout(10)
-    public void shouldCreateTwoChunks() throws Exception {
-        try (RecordingStream stream = new RecordingStream()) {
-            final CountDownLatch eventsFlushed = new CountDownLatch(2);
-            stream.enable(AllocateChunkEvent.class);
-            stream.onEvent(AllocateChunkEvent.NAME,
-                           event -> {
-                                eventsFlushed.countDown();
-                           });
-            stream.startAsync();
-            PooledByteBufAllocator allocator = newAllocator(false);
-            int bufSize = 16896;
-            int bufsToAllocate = 1 + allocator.metric().chunkSize() / bufSize;
-            List<ByteBuf> buffers = new ArrayList<>(bufsToAllocate);
-            for (int i = 0; i < bufsToAllocate; ++i) {
-                buffers.add(allocator.heapBuffer(bufSize, bufSize));
-            }
-            // release all buffers
-            for (ByteBuf buffer : buffers) {
-                buffer.release();
-            }
-            buffers.clear();
-            eventsFlushed.await();
-            assertEquals(0, eventsFlushed.getCount());
-        }
-    }
-
-    @SuppressWarnings("Since15")
-    @Test
-    @EnabledForJreRange(min = JRE.JAVA_17) // RecordingStream
-    @Timeout(10)
-    public void shouldReuseTheSameChunk() throws Exception {
-        try (RecordingStream stream = new RecordingStream()) {
-            final CountDownLatch eventsFlushed = new CountDownLatch(1);
-            final AtomicInteger chunksAllocations = new AtomicInteger();
-            stream.enable(AllocateChunkEvent.class);
-            stream.onEvent(AllocateChunkEvent.NAME,
-                           event -> {
-                               chunksAllocations.incrementAndGet();
-                               eventsFlushed.countDown();
-                           });
-            stream.startAsync();
-            int bufSize = 16896;
-            PooledByteBufAllocator allocator = newAllocator(false);
-            ByteBuf buf = allocator.heapBuffer(bufSize, bufSize);
-            int bufPin = Math.toIntExact(allocator.pinnedHeapMemory());
-            buf.release();
-            int bufsPerChunk = allocator.metric().chunkSize() / bufPin;
-            List<ByteBuf> buffers = new ArrayList<>(bufsPerChunk);
-            for (int i = 0; i < bufsPerChunk - 2; ++i) {
-                buffers.add(allocator.heapBuffer(bufSize, bufSize));
-            }
-            // we still have 2 available segments in the chunk, so we should not allocate a new one
-            for (int i = 0; i < 128; ++i) {
-                allocator.heapBuffer(bufSize, bufSize).release();
-            }
-            // release all buffers
-            for (ByteBuf buffer : buffers) {
-                buffer.release();
-            }
-            buffers.clear();
-            eventsFlushed.await();
-            assertEquals(1, chunksAllocations.get());
-        }
-    }
-
-    @SuppressWarnings("Since15")
-    @Test
-    @EnabledForJreRange(min = JRE.JAVA_17) // RecordingStream
-    @Timeout(10)
-    public void jfrBufferAllocation() throws Exception {
-        try (RecordingStream stream = new RecordingStream()) {
-            CompletableFuture<RecordedEvent> allocateFuture = new CompletableFuture<>();
-            CompletableFuture<RecordedEvent> releaseFuture = new CompletableFuture<>();
-
-            stream.enable(AllocateBufferEvent.class);
-            stream.onEvent(AllocateBufferEvent.NAME, allocateFuture::complete);
-            stream.enable(FreeBufferEvent.class);
-            stream.onEvent(FreeBufferEvent.NAME, releaseFuture::complete);
-            stream.startAsync();
-
-            PooledByteBufAllocator alloc = newAllocator(true);
-            alloc.directBuffer(128).release();
-
-            RecordedEvent allocate = allocateFuture.get();
-            assertEquals(128, allocate.getInt("size"));
-            assertEquals(128, allocate.getInt("maxFastCapacity"));
-            assertEquals(Integer.MAX_VALUE, allocate.getInt("maxCapacity"));
-            assertTrue(allocate.getBoolean("chunkPooled"));
-            assertFalse(allocate.getBoolean("chunkThreadLocal"));
-            assertTrue(allocate.getBoolean("direct"));
-
-            RecordedEvent release = releaseFuture.get();
-            assertEquals(128, release.getInt("size"));
-            assertEquals(128, release.getInt("maxFastCapacity"));
-            assertEquals(Integer.MAX_VALUE, release.getInt("maxCapacity"));
-            assertTrue(release.getBoolean("direct"));
-        }
-    }
-
-    @SuppressWarnings("Since15")
-    @Test
-    @EnabledForJreRange(min = JRE.JAVA_17) // RecordingStream
-    @Timeout(10)
-    public void jfrBufferAllocationThreadLocal() throws Exception {
-        ByteBufAllocator alloc = newAllocator(true);
-
-        Callable<Void> allocateAndRelease = () -> {
-            try (RecordingStream stream = new RecordingStream()) {
-                CompletableFuture<RecordedEvent> allocateFuture = new CompletableFuture<>();
-                CompletableFuture<RecordedEvent> releaseFuture = new CompletableFuture<>();
-
-                // Prime the cache.
-                alloc.directBuffer(128).release();
-
-                stream.enable(AllocateBufferEvent.class);
-                stream.onEvent(AllocateBufferEvent.NAME, allocateFuture::complete);
-                stream.enable(FreeBufferEvent.class);
-                stream.onEvent(FreeBufferEvent.NAME, releaseFuture::complete);
-                stream.startAsync();
-
-                // Allocate out of the cache.
-                alloc.directBuffer(128).release();
-
-                RecordedEvent allocate = allocateFuture.get();
-                assertEquals(128, allocate.getInt("size"));
-                assertEquals(128, allocate.getInt("maxFastCapacity"));
-                assertEquals(Integer.MAX_VALUE, allocate.getInt("maxCapacity"));
-                assertTrue(allocate.getBoolean("chunkPooled"));
-                assertTrue(allocate.getBoolean("chunkThreadLocal"));
-                assertTrue(allocate.getBoolean("direct"));
-
-                RecordedEvent release = releaseFuture.get();
-                assertEquals(128, release.getInt("size"));
-                assertEquals(128, release.getInt("maxFastCapacity"));
-                assertEquals(Integer.MAX_VALUE, release.getInt("maxCapacity"));
-                assertTrue(release.getBoolean("direct"));
-                return null;
-            }
-        };
-        FutureTask<Void> task = new FutureTask<>(allocateAndRelease);
-        FastThreadLocalThread thread = new FastThreadLocalThread(task);
-        thread.start();
-        task.get();
     }
 }

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
@@ -597,7 +597,7 @@ public class ReadOnlyDirectByteBufferBufTest {
     }
 
     @Test
-    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(60)
     public void testCopyMultipleThreads() throws Throwable {
         final ByteBuf buffer = newRandomReadOnlyBuffer();
         try {

--- a/buffer/src/test/resources/junit-platform.properties
+++ b/buffer/src/test/resources/junit-platform.properties
@@ -1,0 +1,16 @@
+# Copyright 2026 The Netty Project
+#
+# The Netty Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.default = concurrent

--- a/buffer/src/test/resources/junit-platform.properties
+++ b/buffer/src/test/resources/junit-platform.properties
@@ -13,4 +13,4 @@
 # under the License.
 
 junit.jupiter.execution.parallel.enabled = true
-junit.jupiter.execution.parallel.mode.classes.default = concurrent
+junit.jupiter.execution.parallel.mode.default = concurrent

--- a/buffer/src/test/resources/junit-platform.properties
+++ b/buffer/src/test/resources/junit-platform.properties
@@ -13,4 +13,4 @@
 # under the License.
 
 junit.jupiter.execution.parallel.enabled = true
-junit.jupiter.execution.parallel.mode.default = concurrent
+junit.jupiter.execution.parallel.mode.classes.default = concurrent

--- a/common/src/main/java/io/netty/util/LeakPresenceDetector.java
+++ b/common/src/main/java/io/netty/util/LeakPresenceDetector.java
@@ -262,7 +262,7 @@ public class LeakPresenceDetector<T> extends ResourceLeakDetector<T> {
         final LongAdder openResourceCounter = new LongAdder();
         final Map<PresenceTracker<?>, Throwable> creationStacks =
                 TRACK_CREATION_STACK ? new ConcurrentHashMap<>() : null;
-        boolean closed;
+        int closed;
 
         /**
          * Create a new scope.
@@ -271,10 +271,11 @@ public class LeakPresenceDetector<T> extends ResourceLeakDetector<T> {
          */
         public ResourceScope(String name) {
             this.name = name;
+            closed = 1;
         }
 
         void checkOpen() {
-            if (closed) {
+            if (closed == 0) {
                 throw new AllocationProhibitedException("Resource scope '" + name + "' already closed");
             }
         }
@@ -323,8 +324,16 @@ public class LeakPresenceDetector<T> extends ResourceLeakDetector<T> {
          */
         @Override
         public void close() {
-            closed = true;
-            check();
+            if (--closed == 0) {
+                check();
+            }
+        }
+
+        public void retain() {
+            if (closed == 0) {
+                throw new IllegalStateException("Scope already closed");
+            }
+            closed++;
         }
     }
 

--- a/handler/src/test/resources/junit-platform.properties
+++ b/handler/src/test/resources/junit-platform.properties
@@ -1,0 +1,16 @@
+# Copyright 2026 The Netty Project
+#
+# The Netty Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.classes.default = concurrent

--- a/testsuite-common/src/main/java/io/netty/util/test/LeakPresenceExtension.java
+++ b/testsuite-common/src/main/java/io/netty/util/test/LeakPresenceExtension.java
@@ -55,8 +55,10 @@ public final class LeakPresenceExtension
     @Override
     public void beforeAll(ExtensionContext context) {
         ExtensionContext.Store store = context.getStore(ExtensionContext.Namespace.GLOBAL);
-        if (store.get(SCOPE_KEY) != null) {
-            throw new IllegalStateException("Weird context lifecycle");
+        LeakPresenceDetector.ResourceScope existingScope = (LeakPresenceDetector.ResourceScope) store.get(SCOPE_KEY);
+        if (existingScope != null) {
+            existingScope.retain();
+            return;
         }
         LeakPresenceDetector.ResourceScope scope = new LeakPresenceDetector.ResourceScope(context.getDisplayName());
         store.put(SCOPE_KEY, scope);


### PR DESCRIPTION
Motivation:

It's annoying to have to wait for a long build to complete.
But arguably even worse: we have a limited number of build agents, and longer builds increases their utilization and reduces their responsiveness to new PRs, in turn adding a lengthy delay before builds for new PRs even start.

Modification:

- Disable the `buddyAllocationConsistency` test when the leak detector is enabled. This test took up to seven minutes to complete when the paranoid leak detector was enabled - and we ran it twice!
- Make the buffer tests run in parallel. Locally this cuts the build time for the buffer module in half.
- Isolate the JFR event tests because they're inherently inspecting static mutable state.
- Make the handler tests run in parallel per class. This allows the many, fairly slow SSL engine tests to run in parallel.

Result:

Much faster build - especially when the paranoid leak detector is enabled.