### PR TITLE
Allow to set destination connection id when creating a client side QuicheChannel (#16286)

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicChannelBootstrap.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicChannelBootstrap.java
@@ -48,7 +48,8 @@ public final class QuicChannelBootstrap {
 
     private SocketAddress local;
     private SocketAddress remote;
-    private QuicConnectionAddress connectionAddress = QuicConnectionAddress.EPHEMERAL;
+    private QuicConnectionAddress localAddress = QuicConnectionAddress.EPHEMERAL;
+    private QuicConnectionAddress remoteAddress = QuicConnectionAddress.EPHEMERAL;
     private ChannelHandler handler;
     private ChannelHandler streamHandler;
 
@@ -176,9 +177,35 @@ public final class QuicChannelBootstrap {
      *
      * @param connectionAddress     the {@link QuicConnectionAddress} to use.
      * @return                      this instance.
+     * @deprecated                  use {@link #localConnectionAddress(QuicConnectionAddress)}.
      */
+    @Deprecated
     public QuicChannelBootstrap connectionAddress(QuicConnectionAddress connectionAddress) {
-        this.connectionAddress = ObjectUtil.checkNotNull(connectionAddress, "connectionAddress");
+        this.localAddress = ObjectUtil.checkNotNull(connectionAddress, "connectionAddress");
+        return this;
+    }
+
+    /**
+     * Set the {@link QuicConnectionAddress} to use. If none is specified a random address is generated on your
+     * behalf.
+     *
+     * @param localConnectionAddress     the {@link QuicConnectionAddress} to use.
+     * @return                      this instance.
+     */
+    public QuicChannelBootstrap localConnectionAddress(QuicConnectionAddress localConnectionAddress) {
+        this.localAddress = ObjectUtil.checkNotNull(localConnectionAddress, "localConnectionAddress");
+        return this;
+    }
+
+    /**
+     * Set the {@link QuicConnectionAddress} to use. If none is specified a random address is generated on your
+     * behalf.
+     *
+     * @param remoteConnectionAddress     the {@link QuicConnectionAddress} to use.
+     * @return                            this instance.
+     */
+    public QuicChannelBootstrap remoteConnectionAddress(QuicConnectionAddress remoteConnectionAddress) {
+        this.remoteAddress = ObjectUtil.checkNotNull(remoteConnectionAddress, "remoteConnectionAddress");
         return this;
     }
 
@@ -218,7 +245,8 @@ public final class QuicChannelBootstrap {
             throw new IllegalStateException("remote not set");
         }
 
-        final QuicConnectionAddress address = connectionAddress;
+        final QuicConnectionAddress localaddress = localAddress;
+        final QuicConnectionAddress remoteaddress = remoteAddress;
         QuicChannel channel = QuicheQuicChannel.forClient(parent, (InetSocketAddress)  local,
                 (InetSocketAddress) remote,
                 streamHandler, Quic.toOptionsArray(streamOptions), Quic.toAttributesArray(streamAttrs));
@@ -229,7 +257,7 @@ public final class QuicChannelBootstrap {
             if (cause != null) {
                 promise.setFailure(cause);
             } else {
-                channel.connect(address).addListener(f -> {
+                channel.connect(remoteaddress, localaddress).addListener(f -> {
                     Throwable error = f.cause();
                     if (error != null) {
                         promise.setFailure(error);

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/Quiche.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/Quiche.java
@@ -279,6 +279,9 @@ final class Quiche {
     static final int QUICHE_ERR_CRYPTO_BUFFER_EXCEEDED =
             QuicheNativeStaticallyReferencedJniMethods.quiche_err_crypto_buffer_exceeded();
 
+    static final int QUICHE_ERR_INVALID_DCID_INITIALIZATION =
+            QuicheNativeStaticallyReferencedJniMethods.quiche_err_invalid_dcid_initialization();
+
     /**
      * See <a href="https://github.com/cloudflare/quiche/blob/0.6.0/include/quiche.h#L176">
      *     QUICHE_CC_RENO</a>.
@@ -339,6 +342,11 @@ final class Quiche {
                                                 long localAddr, int localLen,
                                                 long peerAddr, int peerLen,
                                                 long configAddr, long ssl, boolean isServer);
+
+    static native long quiche_conn_new_with_tls_and_client_dcid(long scidAddr, int scidLen, long odcidAddr,
+                                                                int odcidLen, long localAddr, int localLen,
+                                                                long peerAddr, int peerLen,
+                                                                long configAddr, long ssl);
 
     /**
      * See <a href="https://github.com/cloudflare/quiche/blob/master/include/quiche.h#L248">
@@ -903,6 +911,8 @@ final class Quiche {
                 new QuicTransportErrorHolder(QuicTransportError.PROTOCOL_VIOLATION, "QUICHE_ERR_STREAM_STOPPED"));
         ERROR_MAPPINGS.put(QUICHE_ERR_OUT_OF_IDENTIFIERS,
                 new QuicTransportErrorHolder(QuicTransportError.PROTOCOL_VIOLATION, "QUICHE_ERR_OUT_OF_IDENTIFIERS"));
+        ERROR_MAPPINGS.put(QUICHE_ERR_INVALID_DCID_INITIALIZATION, new QuicTransportErrorHolder(
+                QuicTransportError.PROTOCOL_VIOLATION, "QUICHE_ERR_INVALID_DCID_INITIALIZATION"));
     }
 
     static Exception convertToException(int result) {

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheNativeStaticallyReferencedJniMethods.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheNativeStaticallyReferencedJniMethods.java
@@ -42,6 +42,7 @@ final class QuicheNativeStaticallyReferencedJniMethods {
     static native int quiche_err_out_of_identifiers();
     static native int quiche_err_key_update();
     static native int quiche_err_crypto_buffer_exceeded();
+    static native int quiche_err_invalid_dcid_initialization();
     static native int quiche_cc_reno();
     static native int quiche_cc_cubic();
     static native int quiche_cc_bbr();

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicChannel.java
@@ -141,7 +141,8 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
     private ByteBuf finBuffer;
     private ByteBuf outErrorCodeBuffer;
     private Promise<Void> connectPromise;
-    private QuicConnectionAddress connectAddress;
+    private QuicConnectionAddress connectLocalAddress;
+    private QuicConnectionAddress connectRemoteAddress;
     private CloseData closeData;
     private QuicConnectionCloseEvent connectionCloseEvent;
     private QuicConnectionStats statsAtClose;
@@ -339,17 +340,19 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
         this.sslTaskExecutor = sslTaskExecutor;
         this.freeTask = freeTask;
 
-        QuicConnectionAddress address = this.connectAddress;
+        QuicConnectionAddress connectLocalAddress = this.connectLocalAddress;
 
-        if (address == QuicConnectionAddress.EPHEMERAL) {
-            address = QuicConnectionAddress.random(localConnIdLength);
+        if (connectLocalAddress == QuicConnectionAddress.EPHEMERAL) {
+            connectLocalAddress = QuicConnectionAddress.random(localConnIdLength);
         }
-        ByteBuffer connectId = address.id();
-        if (connectId.remaining() != localConnIdLength) {
+        ByteBuffer localConnectId = connectLocalAddress.id();
+        if (localConnectId.remaining() != localConnIdLength) {
             failConnectPromiseAndThrow(new IllegalArgumentException("connectionAddress has length "
-                    + connectId.remaining()
+                    + localConnectId.remaining()
                     + " instead of " + localConnIdLength));
         }
+        QuicConnectionAddress connectRemoteAddress = this.connectRemoteAddress;
+
         QuicSslEngine engine = engineProvider.apply(this);
         if (!(engine instanceof QuicheQuicSslEngine)) {
             failConnectPromiseAndThrow(new IllegalArgumentException("QuicSslEngine is not of type "
@@ -360,16 +363,37 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
             failConnectPromiseAndThrow(new IllegalArgumentException("QuicSslEngine is not create in client mode"));
         }
         QuicheQuicSslEngine quicheEngine = (QuicheQuicSslEngine) engine;
-        ByteBuf idBuffer = alloc().directBuffer(connectId.remaining()).writeBytes(connectId.duplicate());
+        ByteBuf localIdBuffer = alloc().directBuffer(localConnectId.remaining()).writeBytes(localConnectId.duplicate());
+        ByteBuf remoteIdBuffer;
+        if (connectRemoteAddress != QuicConnectionAddress.EPHEMERAL) {
+            ByteBuffer remoteId = connectRemoteAddress.id();
+            remoteIdBuffer = alloc().directBuffer(remoteId.remaining()).writeBytes(remoteId.duplicate());
+        } else {
+            remoteIdBuffer = null;
+        }
         try {
             int fromSockaddrLen = SockaddrIn.setAddress(fromSockaddrMemory, local);
             int toSockaddrLen = SockaddrIn.setAddress(toSockaddrMemory, remote);
-            QuicheQuicConnection connection = quicheEngine.createConnection(ssl ->
-                    Quiche.quiche_conn_new_with_tls(Quiche.readerMemoryAddress(idBuffer),
-                            idBuffer.readableBytes(), -1, -1,
+            QuicheQuicConnection connection = quicheEngine.createConnection(ssl -> {
+                long localIdMemoryAddress = Quiche.readerMemoryAddress(localIdBuffer);
+                int localIdLength = localIdBuffer.readableBytes();
+
+                final long remoteIdMemoryAddress;
+                final int remoteIdLength;
+                if (remoteIdBuffer == null) {
+                    return Quiche.quiche_conn_new_with_tls(localIdMemoryAddress, localIdLength,
+                            -1, -1,
                             Quiche.memoryAddressWithPosition(fromSockaddrMemory), fromSockaddrLen,
                             Quiche.memoryAddressWithPosition(toSockaddrMemory), toSockaddrLen,
-                            configAddr, ssl, false));
+                            configAddr, ssl, false);
+                } else {
+                    return Quiche.quiche_conn_new_with_tls_and_client_dcid(localIdMemoryAddress, localIdLength,
+                            Quiche.readerMemoryAddress(remoteIdBuffer), remoteIdBuffer.readableBytes(),
+                            Quiche.memoryAddressWithPosition(fromSockaddrMemory), fromSockaddrLen,
+                            Quiche.memoryAddressWithPosition(toSockaddrMemory), toSockaddrLen,
+                            configAddr, ssl);
+                }
+            });
             if (connection == null) {
                 failConnectPromiseAndThrow(new ConnectException());
                 return;
@@ -384,9 +408,12 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                 }
             }
             this.supportsDatagram = supportsDatagram;
-            sourceConnectionIds.add(connectId);
+            sourceConnectionIds.add(localConnectId);
         } finally {
-            idBuffer.release();
+            localIdBuffer.release();
+            if (remoteIdBuffer != null) {
+                remoteIdBuffer.release();
+            }
         }
     }
 
@@ -1488,7 +1515,8 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                 return;
             }
 
-            connectAddress = (QuicConnectionAddress) remote;
+            connectLocalAddress = (QuicConnectionAddress) local;
+            connectRemoteAddress = (QuicConnectionAddress) remote;
             connectPromise = channelPromise;
 
             parent().connect(new QuicheQuicChannelAddress(QuicheQuicChannel.this))

--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -60,7 +60,7 @@
     <quicheHomeIncludeDir>${quicheHomeDir}/quiche/include</quicheHomeIncludeDir>
     <quicheRepository>https://github.com/cloudflare/quiche</quicheRepository>
     <quicheBranch>master</quicheBranch>
-    <quicheCommitSha>c9d3e85f0f2acda30acbe186033bf534faeba7f3</quicheCommitSha>
+    <quicheCommitSha>4f347477006bf7f928335d28f05056013f70b87e</quicheCommitSha>
     <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
     <templateDir>${project.build.directory}/template</templateDir>
     <cargoTarget />
@@ -820,7 +820,7 @@
                       <equals arg1="${platform}" arg2="android" />
                       <then>
                         <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
-                          <arg line="ndk ${cargoTarget} -p ${androidNdkVersion} -- build -p quiche --features &quot;ffi qlog&quot; --release" />
+                          <arg line="ndk ${cargoTarget} --platform ${androidNdkVersion} -- build -p quiche --features &quot;ffi qlog custom-client-dcid&quot; --release" />
                           <env key="CFLAGS" value="${extraCflags}" />
                           <env key="CXXFLAGS" value="${extraCxxflags}" />
                           <env key="QUICHE_BSSL_PATH" value="${boringsslHomeDir}/" />
@@ -831,7 +831,7 @@
                           <equals arg1="${os.detected.name}" arg2="windows" />
                           <then>
                             <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
-                              <arg line="build -p quiche --features &quot;ffi qlog&quot; --release" />
+                              <arg line="build -p quiche --features &quot;ffi qlog custom-client-dcid&quot; --release" />
                               <arg value="${cargoTarget}" />
                               <!-- See https://github.com/cloudflare/quiche/blob/0.7.0/src/build.rs#L73 -->
                               <env key="DEBUG" value="true" />
@@ -843,7 +843,7 @@
                             <equals arg1="${crossCompile}" arg2="linux" />
                             <then>
                               <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
-                                <arg line="build -p quiche --features &quot;ffi qlog&quot; --release" />
+                                <arg line="build -p quiche --features &quot;ffi qlog custom-client-dcid&quot; --release" />
                                 <arg value="${cargoTarget}" />
                                 <env key="QUICHE_BSSL_PATH" value="${boringsslHomeDir}/" />
                                 <!-- Lets enable frame-pointers so we can profile better -->
@@ -856,7 +856,7 @@
                             <equals arg1="${crossCompile}" arg2="mac" />
                             <then>
                               <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
-                                <arg line="build -p quiche --features &quot;ffi qlog&quot; --release" />
+                                <arg line="build -p quiche --features &quot;ffi qlog custom-client-dcid&quot; --release" />
                                 <env key="CFLAGS" value="${extraCflags}" />
                                 <env key="CXXFLAGS" value="${extraCxxflags}" />
                                 <arg value="${cargoTarget}" />
@@ -869,7 +869,7 @@
                           </elseif>
                           <else>
                             <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
-                              <arg line="build -p quiche --features &quot;ffi qlog&quot; --release" />
+                              <arg line="build -p quiche --features &quot;ffi qlog custom-client-dcid&quot; --release" />
                               <env key="CFLAGS" value="${extraCflags}" />
                               <env key="CXXFLAGS" value="${extraCxxflags}" />
                               <env key="QUICHE_BSSL_PATH" value="${boringsslHomeDir}/" />

--- a/codec-native-quic/src/main/c/netty_quic_quiche.c
+++ b/codec-native-quic/src/main/c/netty_quic_quiche.c
@@ -311,6 +311,10 @@ static jint netty_quiche_err_crypto_buffer_exceeded(JNIEnv* env, jclass clazz) {
     return QUICHE_ERR_CRYPTO_BUFFER_EXCEEDED;
 }
 
+static jint netty_quiche_err_invalid_dcid_initialization(JNIEnv* env, jclass clazz) {
+    return QUICHE_ERR_INVALID_DCID_INITIALIZATION;
+}
+
 static jint netty_quiche_cc_reno(JNIEnv* env, jclass clazz) {
     return QUICHE_CC_RENO;
 }
@@ -320,7 +324,7 @@ static jint netty_quiche_cc_cubic(JNIEnv* env, jclass clazz) {
 }
 
 static jint netty_quiche_cc_bbr(JNIEnv* env, jclass clazz) {
-    return QUICHE_CC_BBR;
+    return QUICHE_CC_BBR2_GCONGESTION;
 }
 
 static jint netty_quiche_path_event_type_new(JNIEnv* env, jclass clazz) {
@@ -396,6 +400,24 @@ static jlong netty_quiche_conn_new_with_tls(JNIEnv* env, jclass clazz, jlong sci
                                  local_pointer, (socklen_t) local_len,
                                  peer_pointer, (socklen_t) peer_len,
                                  (quiche_config *) config, (void*) ssl, isServer == JNI_TRUE ? true : false);
+    if (conn == NULL) {
+        return -1;
+    }
+    return (jlong) conn;
+}
+
+static jlong netty_quiche_conn_new_with_tls_and_client_dcid(JNIEnv* env, jclass clazz, jlong scid, jint scid_len, jlong odcid, jint odcid_len, jlong local, jint local_len, jlong peer, jint peer_len, jlong config, jlong ssl) {
+    const uint8_t * odcid_pointer = NULL;
+    if (odcid_len != -1) {
+        odcid_pointer = (const uint8_t *) odcid;
+    }
+    const struct sockaddr *local_pointer = (const struct sockaddr*) local;
+    const struct sockaddr *peer_pointer = (const struct sockaddr*) peer;
+    quiche_conn *conn = quiche_conn_new_with_tls_and_client_dcid((const uint8_t *) scid, (size_t) scid_len,
+                                 odcid_pointer, (size_t) odcid_len,
+                                 local_pointer, (socklen_t) local_len,
+                                 peer_pointer, (socklen_t) peer_len,
+                                 (quiche_config *) config, (void*) ssl);
     if (conn == NULL) {
         return -1;
     }
@@ -1155,6 +1177,7 @@ static const JNINativeMethod statically_referenced_fixed_method_table[] = {
   { "quiche_err_out_of_identifiers", "()I", (void *) netty_quiche_err_out_of_identifiers },
   { "quiche_err_key_update", "()I", (void *) netty_quiche_err_key_update },
   { "quiche_err_crypto_buffer_exceeded", "()I", (void *) netty_quiche_err_crypto_buffer_exceeded },
+  { "quiche_err_invalid_dcid_initialization", "()I", (void *) netty_quiche_err_invalid_dcid_initialization },
   { "quiche_cc_reno", "()I", (void *) netty_quiche_cc_reno },
   { "quiche_cc_cubic", "()I", (void *) netty_quiche_cc_cubic },
   { "quiche_cc_bbr", "()I", (void *) netty_quiche_cc_bbr },
@@ -1178,6 +1201,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "quiche_conn_source_id", "(J)[B", (void *) netty_quiche_conn_source_id },
   { "quiche_conn_destination_id", "(J)[B", (void *) netty_quiche_conn_destination_id },
   { "quiche_conn_new_with_tls", "(JIJIJIJIJJZ)J", (void *) netty_quiche_conn_new_with_tls },
+  { "quiche_conn_new_with_tls_and_client_dcid", "(JIJIJIJIJJ)J", (void *) netty_quiche_conn_new_with_tls_and_client_dcid },
   { "quiche_conn_recv", "(JJIJ)I", (void *) netty_quiche_conn_recv },
   { "quiche_conn_send", "(JJIJ)I", (void *) netty_quiche_conn_send },
   { "quiche_conn_free", "(J)V", (void *) netty_quiche_conn_free },


### PR DESCRIPTION
Motivation:

Sometimes it might be benefitial to be able to specify which destination
connection (ODCID) should be used if known in advance

Modifications:

Add new method which allows to pass the ODCID

Result:

More flexible way to create client side channels. Port of
https://github.com/netty/netty-incubator-codec-quic/pull/833

Co-authored-by: Chris Vest <christianvest_hansen@apple.com>
