### PR TITLE
Support more branch freedom for auto-porting

### DIFF
--- a/.github/workflows/autoport-41.yml
+++ b/.github/workflows/autoport-41.yml
@@ -1,4 +1,4 @@
-name: Auto Backport to 4.1
+name: Auto-port to 4.1
 on:
   pull_request_target:
     types:
@@ -6,10 +6,11 @@ on:
       - labeled
     branches:
       - '4.2'
+      - '5.0'
 
 jobs:
-  backport:
-    name: "Backporting to 4.1"
+  autoport:
+    name: "Auto-porting to 4.1"
     concurrency:
       group: port-41-${{ github.event.pull_request.number }}
       cancel-in-progress: true
@@ -28,15 +29,15 @@ jobs:
           git config --global user.email "netty-project-bot@users.noreply.github.com"
           git config --global user.name "Netty Project Bot"
 
-      - name: Create backport PR branch and cherry-pick
+      - name: Create auto-port PR branch and cherry-pick
         id: cherry-pick
         run: |
           MERGE_COMMIT="${{ github.event.pull_request.merge_commit_sha }}"
-          echo "Backporting commit: $MERGE_COMMIT"
+          echo "Auto-porting commit: $MERGE_COMMIT"
           
-          BACKPORT_BRANCH="backport-pr-${{ github.event.pull_request.number }}-to-4.1"
+          PORT_BRANCH="auto-port-pr-${{ github.event.pull_request.number }}-to-4.1"
           git fetch origin 4.1:4.1
-          git checkout -b "$BACKPORT_BRANCH" 4.1
+          git checkout -b "$PORT_BRANCH" 4.1
           
           if git cherry-pick -x "$MERGE_COMMIT"; then
             echo "Cherry-pick successful"
@@ -45,14 +46,14 @@ jobs:
             git cherry-pick --abort
             exit 1
           fi
-          echo "branch=$BACKPORT_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "branch=$PORT_BRANCH" >> "$GITHUB_OUTPUT"
 
-      - name: Push backport branch
+      - name: Push auto-port branch
         id: push
         if: steps.cherry-pick.outcome == 'success'
         run: |
           if ! git push origin "${{ steps.cherry-pick.outputs.branch }}"; then
-            echo "Backport branch push failed"
+            echo "Auto-port branch push failed"
             exit 1
           fi
           
@@ -66,19 +67,19 @@ jobs:
             const { data: pr } = await github.rest.pulls.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `Backport 4.1: ${context.payload.pull_request.title}`,
+              title: `Auto-port 4.1: ${context.payload.pull_request.title}`,
               head: '${{ steps.cherry-pick.outputs.branch }}',
               base: '4.1',
-              body: `Backport of #${context.payload.pull_request.number} to 4.1\n` +
+              body: `Auto-port of #${context.payload.pull_request.number} to 4.1\n` +
                     `Cherry-picked commit: ${context.payload.pull_request.merge_commit_sha}\n\n---\n` +
                     `${context.payload.pull_request.body || ''}`
             });
-            console.log(`Created backport PR: ${pr.html_url}`);
+            console.log(`Created auto-port PR: ${pr.html_url}`);
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              body: `Backport PR for 4.1: #${pr.number}`
+              body: `Auto-port PR for 4.1: #${pr.number}`
             });
 
       # Important: This script MUST run with the default GITHUB_TOKEN to avoid triggering other actions.
@@ -104,10 +105,10 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              body: `Could not create automatic backport PR.\nGot conflicts when cherry-picking onto 4.1.`
+              body: `Could not create auto-port PR.\nGot conflicts when cherry-picking onto 4.1.`
             });
 
-      - name: Report backport branch push failure
+      - name: Report auto-port branch push failure
         if: failure() && steps.push.outcome == 'failure'
         uses: actions/github-script@v8
         with:
@@ -117,7 +118,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              body: `Could not create automatic backport PR.\n`+
+              body: `Could not create auto-port PR.\n`+
                     `I could cherry-pick onto 4.1 just fine, but pushing the new branch failed.`
             });
 

--- a/.github/workflows/autoport-42.yml
+++ b/.github/workflows/autoport-42.yml
@@ -1,19 +1,20 @@
-name: Auto Forward port to 5.0
+name: Auto-port to 4.2
 on:
   pull_request_target:
     types:
       - closed
       - labeled
     branches:
-      - '4.2'
+      - '4.1'
+      - '5.0'
 
 jobs:
-  backport:
-    name: "Forward porting to 5.0"
+  autoport:
+    name: "Auto-porting to 4.2"
     concurrency:
-      group: port-50-${{ github.event.pull_request.number }}
+      group: port-42-${{ github.event.pull_request.number }}
       cancel-in-progress: true
-    if: github.event.pull_request.merged && contains(github.event.pull_request.labels.*.name, 'needs-cherry-pick-5.0')
+    if: github.event.pull_request.merged && contains(github.event.pull_request.labels.*.name, 'needs-cherry-pick-4.2')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -28,15 +29,15 @@ jobs:
           git config --global user.email "netty-project-bot@users.noreply.github.com"
           git config --global user.name "Netty Project Bot"
 
-      - name: Create forward port PR branch and cherry-pick
+      - name: Create auto-port PR branch and cherry-pick
         id: cherry-pick
         run: |
           MERGE_COMMIT="${{ github.event.pull_request.merge_commit_sha }}"
-          echo "Forward porting commit: $MERGE_COMMIT"
+          echo "Auto-porting commit: $MERGE_COMMIT"
           
-          FORWARDPORT_BRANCH="forwardport-pr-${{ github.event.pull_request.number }}-to-5.0"
-          git fetch origin 5.0:5.0
-          git checkout -b "$FORWARDPORT_BRANCH" 5.0
+          PORT_BRANCH="auto-port-pr-${{ github.event.pull_request.number }}-to-4.2"
+          git fetch origin 4.2:4.2
+          git checkout -b "$PORT_BRANCH" 4.2
           
           if git cherry-pick -x "$MERGE_COMMIT"; then
             echo "Cherry-pick successful"
@@ -45,14 +46,14 @@ jobs:
             git cherry-pick --abort
             exit 1
           fi
-          echo "branch=$FORWARDPORT_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "branch=$PORT_BRANCH" >> "$GITHUB_OUTPUT"
 
-      - name: Push backport branch
+      - name: Push auto-port branch
         id: push
         if: steps.cherry-pick.outcome == 'success'
         run: |
           if ! git push origin "${{ steps.cherry-pick.outputs.branch }}"; then
-            echo "Backport branch push failed"
+            echo "Auto-port branch push failed"
             exit 1
           fi
           
@@ -66,19 +67,19 @@ jobs:
             const { data: pr } = await github.rest.pulls.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `Forward port 5.0: ${context.payload.pull_request.title}`,
+              title: `Auto-port 4.2: ${context.payload.pull_request.title}`,
               head: '${{ steps.cherry-pick.outputs.branch }}',
-              base: '5.0',
-              body: `Forward port of #${context.payload.pull_request.number} to 5.0\n` +
+              base: '4.2',
+              body: `Auto-port of #${context.payload.pull_request.number} to 4.2\n` +
                     `Cherry-picked commit: ${context.payload.pull_request.merge_commit_sha}\n\n---\n` +
                     `${context.payload.pull_request.body || ''}`
             });
-            console.log(`Created forward port PR: ${pr.html_url}`);
+            console.log(`Created auto-port PR: ${pr.html_url}`);
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              body: `Forward port PR for 5.0: #${pr.number}`
+              body: `Auto-port PR for 4.2: #${pr.number}`
             });
 
       # Important: This script MUST run with the default GITHUB_TOKEN to avoid triggering other actions.
@@ -91,7 +92,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              name: 'needs-cherry-pick-5.0'
+              name: 'needs-cherry-pick-4.2'
             });
 
       - name: Report cherry-pick conflicts
@@ -104,10 +105,10 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              body: `Could not create automatic backport PR.\nGot conflicts when cherry-picking onto 5.0.`
+              body: `Could not create auto-port PR.\nGot conflicts when cherry-picking onto 4.2.`
             });
 
-      - name: Report backport branch push failure
+      - name: Report auto-port branch push failure
         if: failure() && steps.push.outcome == 'failure'
         uses: actions/github-script@v8
         with:
@@ -117,8 +118,8 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              body: `Could not create automatic backport PR.\n`+
-                    `I could cherry-pick onto 5.0 just fine, but pushing the new branch failed.`
+              body: `Could not create auto-port PR.\n`+
+                    `I could cherry-pick onto 4.2 just fine, but pushing the new branch failed.`
             });
 
       - name: Remove branch on PR create failure

--- a/.github/workflows/autoport-50.yml
+++ b/.github/workflows/autoport-50.yml
@@ -1,19 +1,20 @@
-name: Auto Backport to 4.2
+name: Auto-port to 5.0
 on:
   pull_request_target:
     types:
       - closed
       - labeled
     branches:
-      - '5.0'
+      - '4.1'
+      - '4.2'
 
 jobs:
-  backport:
-    name: "Backporting to 4.2"
+  autoport:
+    name: "Auto-porting to 5.0"
     concurrency:
-      group: port-42-${{ github.event.pull_request.number }}
+      group: port-50-${{ github.event.pull_request.number }}
       cancel-in-progress: true
-    if: github.event.pull_request.merged && contains(github.event.pull_request.labels.*.name, 'needs-cherry-pick-4.2')
+    if: github.event.pull_request.merged && contains(github.event.pull_request.labels.*.name, 'needs-cherry-pick-5.0')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -28,15 +29,15 @@ jobs:
           git config --global user.email "netty-project-bot@users.noreply.github.com"
           git config --global user.name "Netty Project Bot"
 
-      - name: Create backport PR branch and cherry-pick
+      - name: Create auto-port PR branch and cherry-pick
         id: cherry-pick
         run: |
           MERGE_COMMIT="${{ github.event.pull_request.merge_commit_sha }}"
-          echo "Backporting commit: $MERGE_COMMIT"
+          echo "Auto-porting commit: $MERGE_COMMIT"
           
-          BACKPORT_BRANCH="backport-pr-${{ github.event.pull_request.number }}-to-4.2"
-          git fetch origin 4.2:4.2
-          git checkout -b "$BACKPORT_BRANCH" 4.2
+          PORT_BRANCH="auto-port-pr-${{ github.event.pull_request.number }}-to-5.0"
+          git fetch origin 5.0:5.0
+          git checkout -b "$PORT_BRANCH" 5.0
           
           if git cherry-pick -x "$MERGE_COMMIT"; then
             echo "Cherry-pick successful"
@@ -45,14 +46,14 @@ jobs:
             git cherry-pick --abort
             exit 1
           fi
-          echo "branch=$BACKPORT_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "branch=$PORT_BRANCH" >> "$GITHUB_OUTPUT"
 
-      - name: Push backport branch
+      - name: Push auto-port branch
         id: push
         if: steps.cherry-pick.outcome == 'success'
         run: |
           if ! git push origin "${{ steps.cherry-pick.outputs.branch }}"; then
-            echo "Backport branch push failed"
+            echo "Auto-port branch push failed"
             exit 1
           fi
           
@@ -66,19 +67,19 @@ jobs:
             const { data: pr } = await github.rest.pulls.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `Backport 4.2: ${context.payload.pull_request.title}`,
+              title: `Auto-port 5.0: ${context.payload.pull_request.title}`,
               head: '${{ steps.cherry-pick.outputs.branch }}',
-              base: '4.2',
-              body: `Backport of #${context.payload.pull_request.number} to 4.2\n` +
+              base: '5.0',
+              body: `Auto-port of #${context.payload.pull_request.number} to 5.0\n` +
                     `Cherry-picked commit: ${context.payload.pull_request.merge_commit_sha}\n\n---\n` +
                     `${context.payload.pull_request.body || ''}`
             });
-            console.log(`Created backport PR: ${pr.html_url}`);
+            console.log(`Created auto-port PR: ${pr.html_url}`);
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              body: `Backport PR for 4.2: #${pr.number}`
+              body: `Auto-port PR for 5.0: #${pr.number}`
             });
 
       # Important: This script MUST run with the default GITHUB_TOKEN to avoid triggering other actions.
@@ -91,7 +92,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              name: 'needs-cherry-pick-4.2'
+              name: 'needs-cherry-pick-5.0'
             });
 
       - name: Report cherry-pick conflicts
@@ -104,10 +105,10 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              body: `Could not create automatic backport PR.\nGot conflicts when cherry-picking onto 4.2.`
+              body: `Could not create auto-port PR.\nGot conflicts when cherry-picking onto 5.0.`
             });
 
-      - name: Report backport branch push failure
+      - name: Report auto-port branch push failure
         if: failure() && steps.push.outcome == 'failure'
         uses: actions/github-script@v8
         with:
@@ -117,8 +118,8 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              body: `Could not create automatic backport PR.\n`+
-                    `I could cherry-pick onto 4.2 just fine, but pushing the new branch failed.`
+              body: `Could not create auto-port PR.\n`+
+                    `I could cherry-pick onto 5.0 just fine, but pushing the new branch failed.`
             });
 
       - name: Remove branch on PR create failure


### PR DESCRIPTION
Motivation:
The automatic porting workflows are not strictly tied to the branch they're porting from - only the branch they're porting to. So we can allow them to run from any source branch, in principle, but let's focus on only the supported mainline branches.

Modification:

- Make the porting workflows be triggered by the other (non-target) mainline branches, rather than just one fixed branch.
- Rename things to be more generic, so we call it auto-porting, rather than back- or forward-porting.

Result:
The auto-porting workflows now work from more source branches, e.g. we can now auto-port from 4.1 to 4.2, or even 5.0 to 4.1, provided the cherry-pick succeeds.
