### PR TITLE
AdaptiveByteBufAllocator: make sure byteBuf.capacity() not greater than byteBuf.maxCapacity()

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -1597,12 +1597,12 @@ final class AdaptivePoolingAllocator {
 
         @Override
         public ByteBuf capacity(int newCapacity) {
+            checkNewCapacity(newCapacity);
             if (length <= newCapacity && newCapacity <= maxFastCapacity) {
                 ensureAccessible();
                 length = newCapacity;
                 return this;
             }
-            checkNewCapacity(newCapacity);
             if (newCapacity < capacity()) {
                 length = newCapacity;
                 trimIndicesToCapacity(newCapacity);

--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufAllocatorTest.java
@@ -17,6 +17,7 @@ package io.netty.buffer;
 
 import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
@@ -27,6 +28,7 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.abort;
@@ -211,6 +213,27 @@ public abstract class AbstractByteBufAllocatorTest<T extends AbstractByteBufAllo
         assertThat(allocAfter - allocBefore)
                 .as("allocated MB: %.3f", (allocAfter - allocBefore) / 1024.0 / 1024.0)
                 .isLessThan(8 * 1024 * 1024);
+    }
+
+    @Test
+    public void testCapacityNotGreaterThanMaxCapacity() {
+        testCapacityNotGreaterThanMaxCapacity(true);
+        testCapacityNotGreaterThanMaxCapacity(false);
+    }
+
+    private void testCapacityNotGreaterThanMaxCapacity(boolean preferDirect) {
+        int maxSize = 100000;
+        ByteBuf buf = newAllocator(preferDirect).newDirectBuffer(maxSize, maxSize);
+        try {
+            assertThrows(IllegalArgumentException.class, new Executable() {
+                @Override
+                public void execute() throws Throwable {
+                    buf.capacity(maxSize + 1);
+                }
+            });
+        } finally {
+            buf.release();
+        }
     }
 
     protected long expectedUsedMemory(T allocator, int capacity) {

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
@@ -17,6 +17,7 @@ package io.netty.buffer;
 
 import io.netty.util.NettyRuntime;
 import io.netty.util.test.DisabledForSlowLeakDetection;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.RepetitionInfo;
 import org.junit.jupiter.api.Test;
@@ -210,6 +211,23 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
         if (throwable != null) {
             fail("Expected no exception, but got", throwable);
         }
+    }
+
+    @Test
+    public void testMaxFastCapacity() {
+        int maxSize = 100000;
+        AdaptiveByteBufAllocator alloc = new AdaptiveByteBufAllocator();
+        ByteBuf buf = alloc.newDirectBuffer(maxSize, maxSize);
+        final AtomicReference<Throwable> throwableAtomicReference = new AtomicReference<Throwable>();
+        try {
+            buf.capacity(maxSize + 1); // Should throw IllegalArgumentException.
+        } catch (Throwable t) {
+            throwableAtomicReference.set(t);
+        } finally {
+            buf.release();
+        }
+        Throwable throwable = throwableAtomicReference.get();
+        Assertions.assertInstanceOf(IllegalArgumentException.class, throwable);
     }
 
     @DisabledForSlowLeakDetection

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
@@ -17,7 +17,6 @@ package io.netty.buffer;
 
 import io.netty.util.NettyRuntime;
 import io.netty.util.test.DisabledForSlowLeakDetection;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.RepetitionInfo;
 import org.junit.jupiter.api.Test;
@@ -211,23 +210,6 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
         if (throwable != null) {
             fail("Expected no exception, but got", throwable);
         }
-    }
-
-    @Test
-    public void testMaxFastCapacity() {
-        int maxSize = 100000;
-        AdaptiveByteBufAllocator alloc = new AdaptiveByteBufAllocator();
-        ByteBuf buf = alloc.newDirectBuffer(maxSize, maxSize);
-        final AtomicReference<Throwable> throwableAtomicReference = new AtomicReference<Throwable>();
-        try {
-            buf.capacity(maxSize + 1); // Should throw IllegalArgumentException.
-        } catch (Throwable t) {
-            throwableAtomicReference.set(t);
-        } finally {
-            buf.release();
-        }
-        Throwable throwable = throwableAtomicReference.get();
-        Assertions.assertInstanceOf(IllegalArgumentException.class, throwable);
     }
 
     @DisabledForSlowLeakDetection


### PR DESCRIPTION
Motivation:

According to the docs of `ByteBuf.maxCapacity()`:
https://github.com/netty/netty/blob/d9336245a2fe3dfec4d0d1e489135bbf7ed03160/buffer/src/main/java/io/netty/buffer/ByteBuf.java#L265-L269

The `byteBuf.capacity()` should always <= `byteBuf.maxCapacity()`.

But if we run the following code:
```
public static void main(String[] args) {
    int maxSize = 100000;
    AdaptiveByteBufAllocator alloc = new AdaptiveByteBufAllocator();
    ByteBuf buf = alloc.newDirectBuffer(maxSize, maxSize);
    System.out.println("Before reallocation: buf.capacity(): " + buf.capacity());
    System.out.println("Before reallocation: buf.maxCapacity(): " + buf.maxCapacity());
    buf = buf.capacity(maxSize + 1); // Should not be allowed.
    System.out.println("After reallocation: buf.capacity(): " + buf.capacity());
    System.out.println("After reallocation: buf.maxCapacity(): " + buf.maxCapacity());
    //assert buf.capacity() <= buf.maxCapacity();
}
```
The output:

> Before reallocation: buf.capacity(): 100000
> Before reallocation: buf.maxCapacity(): 100000
> After reallocation: buf.capacity(): 100001
> After reallocation: buf.maxCapacity(): 100000

We can see after reallocation, the  `buf.capacity()` is greater than `buf.maxCapacity()`, which should not happen.

Modification:

Adjust the check in `AdaptivePoolingAllocator.capacity(int newCapacity)`, to make sure the constrain hold.

Result:

Make sure `byteBuf.capacity()` not greater than `byteBuf.maxCapacity()`.