### PR TITLE
fix: the precedence of + is higher than >>

### DIFF
--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventArray.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventArray.java
@@ -99,7 +99,7 @@ final class KQueueEventArray {
      */
     void realloc(boolean throwIfFail) {
         // Double the capacity while it is "sufficiently small", and otherwise increase by 50%.
-        int newLength = capacity <= 65536 ? capacity << 1 : capacity + capacity >> 1;
+        int newLength = capacity <= 65536 ? capacity << 1 : capacity + (capacity >> 1);
 
         try {
             int newCapacity = calculateBufferCapacity(newLength);

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/NativeLongArray.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/NativeLongArray.java
@@ -88,7 +88,7 @@ final class NativeLongArray {
     private void reallocIfNeeded() {
         if (size == capacity) {
             // Double the capacity while it is "sufficiently small", and otherwise increase by 50%.
-            int newLength = capacity <= 65536 ? capacity << 1 : capacity + capacity >> 1;
+            int newLength = capacity <= 65536 ? capacity << 1 : capacity + (capacity >> 1);
             int newCapacity = calculateBufferCapacity(newLength);
             CleanableDirectBuffer buffer = Buffer.allocateDirectBufferWithNativeOrder(newCapacity);
             // Copy over the old content of the memory and reset the position as we always act on the buffer as if


### PR DESCRIPTION
Motivation:
Code does not take operator precedence into account.

Modification:
Add parenthesis to force operator precedence to match the comments.

Result:
Array size increments works as intended.