### PR TITLE
Fix flaky PooledByteBufAllocatorTest

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -349,13 +349,13 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
     }
 
     @Test
-    @Timeout(value = 10, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+    @Timeout(value = 20, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
     public void testThreadCacheDestroyedByThreadCleaner() throws InterruptedException {
         testThreadCacheDestroyed(false);
     }
 
     @Test
-    @Timeout(value = 10, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+    @Timeout(value = 20, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
     public void testThreadCacheDestroyedAfterExitRun() throws InterruptedException {
         testThreadCacheDestroyed(true);
     }
@@ -408,7 +408,6 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
         while (allocator.metric().numThreadLocalCaches() > 0) {
             // Signal we want to have a GC run to ensure we can process our ThreadCleanerReference
             System.gc();
-            System.runFinalization();
             LockSupport.parkNanos(MILLISECONDS.toNanos(100));
         }
 


### PR DESCRIPTION
Motivation:
We observed the testThreadCacheDestroyedByThreadCleaner test failing due to timing out after 10 seconds, while in the `runFinalization` call.

After analyzing the code, I've determined that the most likely cause is that the `runFinalization` call itself is very slow, because it waits for the processing of _all_ eligible finalizers, rather than just the one we care about.

Modification:
- Remove the call to `runFinalization` and instead rely on the background reference processing thread.
- Increase the timeout from 10 to 20 seconds, to account for a busier runtime environment now that we run all the buffer tests in parallel.

Result:
More stable build, hopefully.