### PR TITLE
Fix RunInFastThreadLocalThreadExtension

### DIFF
--- a/common/src/test/java/io/netty/util/RunInFastThreadLocalThreadExtension.java
+++ b/common/src/test/java/io/netty/util/RunInFastThreadLocalThreadExtension.java
@@ -16,6 +16,7 @@
 package io.netty.util;
 
 import io.netty.util.concurrent.FastThreadLocalThread;
+import org.junit.jupiter.api.extension.DynamicTestInvocationContext;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.InvocationInterceptor;
 import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
@@ -37,6 +38,26 @@ public class RunInFastThreadLocalThreadExtension implements InvocationIntercepto
             final Invocation<Void> invocation,
             final ReflectiveInvocationContext<Method> invocationContext,
             final ExtensionContext extensionContext) throws Throwable {
+        proceed(invocation);
+    }
+
+    @Override
+    public void interceptTestTemplateMethod(
+            Invocation<Void> invocation,
+            ReflectiveInvocationContext<Method> invocationContext,
+            ExtensionContext extensionContext) throws Throwable {
+        proceed(invocation);
+    }
+
+    @Override
+    public void interceptDynamicTest(
+            Invocation<Void> invocation,
+            DynamicTestInvocationContext invocationContext,
+            ExtensionContext extensionContext) throws Throwable {
+        proceed(invocation);
+    }
+
+    private static void proceed(Invocation<Void> invocation) throws Throwable {
         final AtomicReference<Throwable> throwable = new AtomicReference<Throwable>();
         Thread thread = new FastThreadLocalThread(new Runnable() {
             @Override

--- a/common/src/test/java/io/netty/util/RunInFastThreadLocalThreadExtensionTest.java
+++ b/common/src/test/java/io/netty/util/RunInFastThreadLocalThreadExtensionTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util;
+
+import io.netty.util.concurrent.FastThreadLocalThread;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(RunInFastThreadLocalThreadExtension.class)
+public class RunInFastThreadLocalThreadExtensionTest {
+    @Test
+    void normalTest() {
+        assertTrue(FastThreadLocalThread.currentThreadHasFastThreadLocal());
+    }
+
+    @RepeatedTest(1)
+    void repeatedTest() {
+        assertTrue(FastThreadLocalThread.currentThreadHasFastThreadLocal());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = 1)
+    void parameterizedTest(int ignoreParameter) {
+        assertTrue(FastThreadLocalThread.currentThreadHasFastThreadLocal());
+    }
+}


### PR DESCRIPTION
Motivation:
This JUnit extension is meant to run all the tests in FastThreadLocalThreads. However, it did not intercept repeated or parameterized test invocations.

Modification:
Make the extension also intercept templated tests and dynamic tests.

Result:
Repeated and parameterized tests now also run in FastThreadLocalThreads when using this extension.