### PR TITLE
fix: the precedence of + is higher than >> (#16312)

### DIFF
--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventArray.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventArray.java
@@ -97,7 +97,7 @@ final class KQueueEventArray {
      */
     void realloc(boolean throwIfFail) {
         // Double the capacity while it is "sufficiently small", and otherwise increase by 50%.
-        int newLength = capacity <= 65536 ? capacity << 1 : capacity + capacity >> 1;
+        int newLength = capacity <= 65536 ? capacity << 1 : capacity + (capacity >> 1);
 
         try {
             ByteBuffer buffer = Buffer.allocateDirectWithNativeOrder(calculateBufferCapacity(newLength));

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/NativeLongArray.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/NativeLongArray.java
@@ -85,7 +85,7 @@ final class NativeLongArray {
     private void reallocIfNeeded() {
         if (size == capacity) {
             // Double the capacity while it is "sufficiently small", and otherwise increase by 50%.
-            int newLength = capacity <= 65536 ? capacity << 1 : capacity + capacity >> 1;
+            int newLength = capacity <= 65536 ? capacity << 1 : capacity + (capacity >> 1);
             ByteBuffer buffer = Buffer.allocateDirectWithNativeOrder(calculateBufferCapacity(newLength));
             // Copy over the old content of the memory and reset the position as we always act on the buffer as if
             // the position was never increased.


### PR DESCRIPTION
Motivation:
Code does not take operator precedence into account.

Modification:
Add parenthesis to force operator precedence to match the comments.

Result:
Array size increments works as intended.

(cherry picked from commit e855de52f5f87eb67ae29a4dad71bb4ff160cbcc)