### PR TITLE
Improve multi-byte access performance when UNALIGNED availability is unknown (#16207)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -74,6 +74,7 @@ public final class ByteBufUtil {
 
     static final int WRITE_CHUNK_SIZE = 8192;
     static final ByteBufAllocator DEFAULT_ALLOCATOR;
+    private static final boolean SWAR_UNALIGNED = PlatformDependent.canUnalignedAccess();
 
     static {
         String allocType = SystemPropertyUtil.get(
@@ -576,10 +577,10 @@ public final class ByteBufUtil {
         }
         final int length = toIndex - fromIndex;
         buffer.checkIndex(fromIndex, length);
-        if (!PlatformDependent.isUnaligned()) {
+        if (!SWAR_UNALIGNED) {
             return linearFirstIndexOf(buffer, fromIndex, toIndex, value);
         }
-        assert PlatformDependent.isUnaligned();
+        assert SWAR_UNALIGNED;
         int offset = fromIndex;
         final int byteCount = length & 7;
         if (byteCount > 0) {
@@ -729,7 +730,7 @@ public final class ByteBufUtil {
         }
         final int length = fromIndex - toIndex;
         buffer.checkIndex(toIndex, length);
-        if (!PlatformDependent.isUnaligned()) {
+        if (!SWAR_UNALIGNED) {
             return linearLastIndexOf(buffer, fromIndex, toIndex, value);
         }
         final int longCount = length >>> 3;

--- a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeDirectByteBuf.java
@@ -31,6 +31,8 @@ import java.nio.ByteBuffer;
  */
 public class UnpooledUnsafeDirectByteBuf extends UnpooledDirectByteBuf {
 
+    private static final boolean USE_VAR_HANDLE = PlatformDependent.useVarHandleForMultiByteAccess();
+
     long memoryAddress;
 
     /**
@@ -126,11 +128,17 @@ public class UnpooledUnsafeDirectByteBuf extends UnpooledDirectByteBuf {
 
     @Override
     protected short _getShort(int index) {
+        if (USE_VAR_HANDLE) {
+            return VarHandleByteBufferAccess.getShortBE(buffer, index);
+        }
         return UnsafeByteBufUtil.getShort(addr(index));
     }
 
     @Override
     protected short _getShortLE(int index) {
+        if (USE_VAR_HANDLE) {
+            return VarHandleByteBufferAccess.getShortLE(buffer, index);
+        }
         return UnsafeByteBufUtil.getShortLE(addr(index));
     }
 
@@ -158,11 +166,17 @@ public class UnpooledUnsafeDirectByteBuf extends UnpooledDirectByteBuf {
 
     @Override
     protected int _getInt(int index) {
+        if (USE_VAR_HANDLE) {
+            return VarHandleByteBufferAccess.getIntBE(buffer, index);
+        }
         return UnsafeByteBufUtil.getInt(addr(index));
     }
 
     @Override
     protected int _getIntLE(int index) {
+        if (USE_VAR_HANDLE) {
+            return VarHandleByteBufferAccess.getIntLE(buffer, index);
+        }
         return UnsafeByteBufUtil.getIntLE(addr(index));
     }
 
@@ -174,11 +188,17 @@ public class UnpooledUnsafeDirectByteBuf extends UnpooledDirectByteBuf {
 
     @Override
     protected long _getLong(int index) {
+        if (USE_VAR_HANDLE) {
+            return VarHandleByteBufferAccess.getLongBE(buffer, index);
+        }
         return UnsafeByteBufUtil.getLong(addr(index));
     }
 
     @Override
     protected long _getLongLE(int index) {
+        if (USE_VAR_HANDLE) {
+            return VarHandleByteBufferAccess.getLongLE(buffer, index);
+        }
         return UnsafeByteBufUtil.getLongLE(addr(index));
     }
 
@@ -219,11 +239,19 @@ public class UnpooledUnsafeDirectByteBuf extends UnpooledDirectByteBuf {
 
     @Override
     protected void _setShort(int index, int value) {
+        if (USE_VAR_HANDLE) {
+            VarHandleByteBufferAccess.setShortBE(buffer, index, value);
+            return;
+        }
         UnsafeByteBufUtil.setShort(addr(index), value);
     }
 
     @Override
     protected void _setShortLE(int index, int value) {
+        if (USE_VAR_HANDLE) {
+            VarHandleByteBufferAccess.setShortLE(buffer, index, value);
+            return;
+        }
         UnsafeByteBufUtil.setShortLE(addr(index), value);
     }
 
@@ -253,11 +281,19 @@ public class UnpooledUnsafeDirectByteBuf extends UnpooledDirectByteBuf {
 
     @Override
     protected void _setInt(int index, int value) {
+        if (USE_VAR_HANDLE) {
+            VarHandleByteBufferAccess.setIntBE(buffer, index, value);
+            return;
+        }
         UnsafeByteBufUtil.setInt(addr(index), value);
     }
 
     @Override
     protected void _setIntLE(int index, int value) {
+        if (USE_VAR_HANDLE) {
+            VarHandleByteBufferAccess.setIntLE(buffer, index, value);
+            return;
+        }
         UnsafeByteBufUtil.setIntLE(addr(index), value);
     }
 
@@ -270,11 +306,19 @@ public class UnpooledUnsafeDirectByteBuf extends UnpooledDirectByteBuf {
 
     @Override
     protected void _setLong(int index, long value) {
+        if (USE_VAR_HANDLE) {
+            VarHandleByteBufferAccess.setLongBE(buffer, index, value);
+            return;
+        }
         UnsafeByteBufUtil.setLong(addr(index), value);
     }
 
     @Override
     protected void _setLongLE(int index, long value) {
+        if (USE_VAR_HANDLE) {
+            VarHandleByteBufferAccess.setLongLE(buffer, index, value);
+            return;
+        }
         UnsafeByteBufUtil.setLongLE(addr(index), value);
     }
 

--- a/buffer/src/main/java/io/netty/buffer/UnsafeByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/UnsafeByteBufUtil.java
@@ -33,6 +33,7 @@ import static io.netty.util.internal.PlatformDependent.BIG_ENDIAN_NATIVE_ORDER;
  */
 final class UnsafeByteBufUtil {
     private static final boolean UNALIGNED = PlatformDependent.isUnaligned();
+    private static final boolean USE_VAR_HANDLE = PlatformDependent.useVarHandleForMultiByteAccess();
     private static final byte ZERO = 0;
     private static final int MAX_HAND_ROLLED_SET_ZERO_BYTES = 64;
 
@@ -237,6 +238,9 @@ final class UnsafeByteBufUtil {
             short v = PlatformDependent.getShort(array, index);
             return BIG_ENDIAN_NATIVE_ORDER ? v : Short.reverseBytes(v);
         }
+        if (USE_VAR_HANDLE) {
+            return VarHandleByteBufferAccess.getShortBE(array, index);
+        }
         return (short) (PlatformDependent.getByte(array, index) << 8 |
                        PlatformDependent.getByte(array, index + 1) & 0xff);
     }
@@ -245,6 +249,9 @@ final class UnsafeByteBufUtil {
         if (UNALIGNED) {
             short v = PlatformDependent.getShort(array, index);
             return BIG_ENDIAN_NATIVE_ORDER ? Short.reverseBytes(v) : v;
+        }
+        if (USE_VAR_HANDLE) {
+            return VarHandleByteBufferAccess.getShortLE(array, index);
         }
         return (short) (PlatformDependent.getByte(array, index) & 0xff |
                        PlatformDependent.getByte(array, index + 1) << 8);
@@ -278,6 +285,9 @@ final class UnsafeByteBufUtil {
             int v = PlatformDependent.getInt(array, index);
             return BIG_ENDIAN_NATIVE_ORDER ? v : Integer.reverseBytes(v);
         }
+        if (USE_VAR_HANDLE) {
+            return VarHandleByteBufferAccess.getIntBE(array, index);
+        }
         return PlatformDependent.getByte(array, index) << 24 |
                (PlatformDependent.getByte(array, index + 1) & 0xff) << 16 |
                (PlatformDependent.getByte(array, index + 2) & 0xff) <<  8 |
@@ -289,6 +299,9 @@ final class UnsafeByteBufUtil {
             int v = PlatformDependent.getInt(array, index);
             return BIG_ENDIAN_NATIVE_ORDER ? Integer.reverseBytes(v) : v;
         }
+        if (USE_VAR_HANDLE) {
+            return VarHandleByteBufferAccess.getIntLE(array, index);
+        }
         return PlatformDependent.getByte(array, index)      & 0xff        |
                (PlatformDependent.getByte(array, index + 1) & 0xff) <<  8 |
                (PlatformDependent.getByte(array, index + 2) & 0xff) << 16 |
@@ -299,6 +312,9 @@ final class UnsafeByteBufUtil {
         if (UNALIGNED) {
             long v = PlatformDependent.getLong(array, index);
             return BIG_ENDIAN_NATIVE_ORDER ? v : Long.reverseBytes(v);
+        }
+        if (USE_VAR_HANDLE) {
+            return VarHandleByteBufferAccess.getLongBE(array, index);
         }
         return ((long) PlatformDependent.getByte(array, index)) << 56 |
                (PlatformDependent.getByte(array, index + 1) & 0xffL) << 48 |
@@ -314,6 +330,9 @@ final class UnsafeByteBufUtil {
         if (UNALIGNED) {
             long v = PlatformDependent.getLong(array, index);
             return BIG_ENDIAN_NATIVE_ORDER ? Long.reverseBytes(v) : v;
+        }
+        if (USE_VAR_HANDLE) {
+            return VarHandleByteBufferAccess.getLongLE(array, index);
         }
         return PlatformDependent.getByte(array, index)      & 0xffL        |
                (PlatformDependent.getByte(array, index + 1) & 0xffL) <<  8 |
@@ -333,6 +352,8 @@ final class UnsafeByteBufUtil {
         if (UNALIGNED) {
             PlatformDependent.putShort(array, index,
                                        BIG_ENDIAN_NATIVE_ORDER ? (short) value : Short.reverseBytes((short) value));
+        } else if (USE_VAR_HANDLE) {
+            VarHandleByteBufferAccess.setShortBE(array, index, value);
         } else {
             PlatformDependent.putByte(array, index, (byte) (value >>> 8));
             PlatformDependent.putByte(array, index + 1, (byte) value);
@@ -343,6 +364,8 @@ final class UnsafeByteBufUtil {
         if (UNALIGNED) {
             PlatformDependent.putShort(array, index,
                                        BIG_ENDIAN_NATIVE_ORDER ? Short.reverseBytes((short) value) : (short) value);
+        } else if (USE_VAR_HANDLE) {
+            VarHandleByteBufferAccess.setShortLE(array, index, value);
         } else {
             PlatformDependent.putByte(array, index, (byte) value);
             PlatformDependent.putByte(array, index + 1, (byte) (value >>> 8));
@@ -376,6 +399,8 @@ final class UnsafeByteBufUtil {
     static void setInt(byte[] array, int index, int value) {
         if (UNALIGNED) {
             PlatformDependent.putInt(array, index, BIG_ENDIAN_NATIVE_ORDER ? value : Integer.reverseBytes(value));
+        } else if (USE_VAR_HANDLE) {
+            VarHandleByteBufferAccess.setIntBE(array, index, value);
         } else {
             PlatformDependent.putByte(array, index, (byte) (value >>> 24));
             PlatformDependent.putByte(array, index + 1, (byte) (value >>> 16));
@@ -387,6 +412,8 @@ final class UnsafeByteBufUtil {
     static void setIntLE(byte[] array, int index, int value) {
         if (UNALIGNED) {
             PlatformDependent.putInt(array, index, BIG_ENDIAN_NATIVE_ORDER ? Integer.reverseBytes(value) : value);
+        } else if (USE_VAR_HANDLE) {
+            VarHandleByteBufferAccess.setIntLE(array, index, value);
         } else {
             PlatformDependent.putByte(array, index, (byte) value);
             PlatformDependent.putByte(array, index + 1, (byte) (value >>> 8));
@@ -398,6 +425,8 @@ final class UnsafeByteBufUtil {
     static void setLong(byte[] array, int index, long value) {
         if (UNALIGNED) {
             PlatformDependent.putLong(array, index, BIG_ENDIAN_NATIVE_ORDER ? value : Long.reverseBytes(value));
+        } else if (USE_VAR_HANDLE) {
+            VarHandleByteBufferAccess.setLongBE(array, index, value);
         } else {
             PlatformDependent.putByte(array, index, (byte) (value >>> 56));
             PlatformDependent.putByte(array, index + 1, (byte) (value >>> 48));
@@ -413,6 +442,8 @@ final class UnsafeByteBufUtil {
     static void setLongLE(byte[] array, int index, long value) {
         if (UNALIGNED) {
             PlatformDependent.putLong(array, index, BIG_ENDIAN_NATIVE_ORDER ? Long.reverseBytes(value) : value);
+        } else if (USE_VAR_HANDLE) {
+            VarHandleByteBufferAccess.setLongLE(array, index, value);
         } else {
             PlatformDependent.putByte(array, index, (byte) value);
             PlatformDependent.putByte(array, index + 1, (byte) (value >>> 8));

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -258,7 +258,7 @@ public final class PlatformDependent {
     }
 
     private static boolean initializeVarHandle() {
-        if (UNSAFE_UNAVAILABILITY_CAUSE == null || PlatformDependent0.isNativeImage()) {
+        if (PlatformDependent0.isNativeImage()) {
             return false;
         }
         boolean varHandleAvailable = false;
@@ -618,6 +618,26 @@ public final class PlatformDependent {
 
     public static boolean hasVarHandle() {
         return VAR_HANDLE;
+    }
+
+    /**
+     * {@code true} if {@code VarHandle} should be used for multi-byte access.
+     *
+     * The multi-byte access strategy is determined as follows:
+     * 1) If the platform supports unaligned access natively, use {@code Unsafe} as the fastest option.
+     * 2) Otherwise, if {@code VarHandle} is available, use it as a fallback.
+     * 3) Otherwise, fall back to manual byte-by-byte access.
+     */
+    public static boolean useVarHandleForMultiByteAccess() {
+        return !isUnaligned() && VAR_HANDLE;
+    }
+
+    /**
+     * {@code true} if multi-byte access at arbitrary offsets is possible, either natively through {@code Unsafe}
+     * or via {@code VarHandle} where the JVM handles alignment and byte ordering internally.
+     */
+    public static boolean canUnalignedAccess() {
+        return isUnaligned() || VAR_HANDLE;
     }
 
     public static VarHandle findVarHandleOfIntField(MethodHandles.Lookup lookup, Class<?> type, String fieldName) {

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -271,13 +271,18 @@ final class PlatformDependent0 {
             LONG_ARRAY_BASE_OFFSET = UNSAFE.arrayBaseOffset(long[].class);
             LONG_ARRAY_INDEX_SCALE = UNSAFE.arrayIndexScale(long[].class);
             Boolean unaligned = null;
+            String unalignedProperty = SystemPropertyUtil.get("io.netty.unalignedAccess", "").trim();
             // using a known type to avoid loading new classes
             final AtomicLong maybeMaxMemory = new AtomicLong(-1);
             try {
                 Class<?> bitsClass =
                         Class.forName("java.nio.Bits", false, getSystemClassLoader());
                 int version = javaVersion();
-                if (version >= 9) {
+                if ("true".equalsIgnoreCase(unalignedProperty)) {
+                    unaligned = Boolean.TRUE;
+                } else if ("false".equalsIgnoreCase(unalignedProperty)) {
+                    unaligned = Boolean.FALSE;
+                } else if (version >= 9) {
                     // Java9/10 use all lowercase and later versions all uppercase.
                     String fieldName = version >= 11? "MAX_MEMORY" : "maxMemory";
                     // On Java9 and later we try to directly access the field as we can do this without

--- a/microbench/src/main/java/io/netty/buffer/VarHandleAccessBenchmark.java
+++ b/microbench/src/main/java/io/netty/buffer/VarHandleAccessBenchmark.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class VarHandleAccessBenchmark extends AbstractMicrobenchmark {
+
+    private ByteBuf unsafeDirect;
+    private ByteBuf unsafeHeap;
+
+    @Setup
+    public void setup() {
+        unsafeDirect = new UnpooledUnsafeDirectByteBuf(ByteBufAllocator.DEFAULT, 8, 8);
+        unsafeHeap = new UnpooledUnsafeHeapByteBuf(ByteBufAllocator.DEFAULT, 8, 8);
+        unsafeDirect.setLong(0, 1L);
+        unsafeHeap.setLong(0, 1L);
+    }
+
+    @TearDown
+    public void tearDown() {
+        unsafeDirect.release();
+        unsafeHeap.release();
+    }
+
+    // UNALIGNED = false: should use VarHandle for multi-byte access
+    @Benchmark
+    @Fork(value = 1, jvmArgsAppend = "-Dio.netty.unalignedAccess=false")
+    public long getLongDirectFalse() {
+        return unsafeDirect.getLong(0);
+    }
+
+    @Benchmark
+    @Fork(value = 1, jvmArgsAppend = "-Dio.netty.unalignedAccess=false")
+    public long getLongHeapFalse() {
+        return unsafeHeap.getLong(0);
+    }
+}

--- a/microbench/src/main/java/io/netty/microbench/search/UnalignedIndexOfBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/search/UnalignedIndexOfBenchmark.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.search;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
+@Fork(value = 1, jvmArgsAppend = "-Dio.netty.unalignedAccess=false")
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class UnalignedIndexOfBenchmark extends AbstractMicrobenchmark {
+
+    @Param({ "256", "2048" })
+    public int haystackSize;
+
+    private ByteBuf needle;
+    private ByteBuf haystack;
+    private byte[] needleBytes;
+    private byte[] haystackBytes;
+
+    @Setup
+    public void setup() {
+        Random rnd = new Random(123);
+        needleBytes = new byte[] { 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h' };
+        haystackBytes = randomBytes(rnd, haystackSize, ' ', 127);
+        needle = Unpooled.wrappedBuffer(needleBytes);
+        haystack = Unpooled.wrappedBuffer(haystackBytes);
+    }
+
+    @TearDown
+    public void tearDown() {
+        needle.release();
+        haystack.release();
+    }
+
+    @Benchmark
+    public int indexOf() {
+        return ByteBufUtil.indexOf(needle, haystack);
+    }
+
+    private static byte[] randomBytes(Random rnd, int size, int from, int to) {
+        byte[] bytes = new byte[size];
+        for (int i = 0; i < size; i++) {
+            bytes[i] = (byte) (from + rnd.nextInt(to - from + 1));
+        }
+        return bytes;
+    }
+}


### PR DESCRIPTION
Motivation:
When the JVM cannot report UNALIGNED support (e.g., on some ARM platforms or in restricted environments), Netty falls back to an architecture-based guess. If that guess yields UNALIGNED = false, multi-byte reads (getLong,
getInt, getShort) degrade to byte-by-byte access (8× getByte) even though the JIT could still optimize at runtime. There is currently no distinction between "the platform is known to not support unaligned access" and "we
simply don't know."
Modification:
Introduce UNALIGNED_AVAILABLE flag to distinguish whether UNALIGNED info came from the runtime (true) or from an architecture-based guess (false). When unaligned info is unavailable, use VarHandle instead of 8× getByte so
HotSpot can emit the optimal access strategy at runtime.
- PlatformDependent0: add UNALIGNED_AVAILABLE flag; add io.netty.unalignedAccess=true|false|unavailable system property.
- PlatformDependent: expose isUnalignedAvailable(); allow VarHandle initialization even when Unsafe is available.
- UnsafeByteBufUtil: use `VarHandle` for multi-byte `byte[]` operations (`getShort/getInt/getLong`, `setShort/setInt/setLong` and their LE variants) when unaligned info is unavailable.
- UnpooledUnsafeDirectByteBuf: use `VarHandle` for multi-byte `ByteBuffer` operations (`_getShort/_getInt/_getLong`, `_setShort/_setInt/_setLong` and their LE variants) when unaligned info is unavailable.
- ByteBufUtil: enable SWAR indexOf/lastIndexOf via VarHandle when unaligned info is unavailable.
Three-tier access strategy:

| Condition | Strategy | Path |
|---------|---------|------|
| UNALIGNED = true (known supported) | Unsafe direct access | single `Unsafe.getLong()` |
| UNALIGNED info unavailable (unknown) | VarHandle | JIT chooses optimal access |
| UNALIGNED = false (known unsupported) | 8× getByte | safe byte-wise assembly |

---
Result:
Fixes #15781.
Benchmark (JDK 24.0.1, Apple Silicon, JMH 1.36):
### Benchmark Summary

| Benchmark | false (8× getByte) | unavailable (VarHandle) | Improvement |

|----------|--------------------|--------------------------|-------------| | getLongDirect | 2.144 ns/op | 1.764 ns/op | 17.7% faster | | getLongHeap | 2.152 ns/op | 1.119 ns/op | 48.0% faster |

Sorry for the delay in submitting this PR.
If anything looks incorrect or needs adjustment, I will update it promptly.
Thanks for the review.

---------

Co-authored-by: Norman Maurer <norman_maurer@apple.com>
Co-authored-by: Chris Vest <christianvest_hansen@apple.com>

(cherry picked from commit 0ee9723d48e36165fb464d62be8cb1f9efc3783e)