### PR TITLE
AdaptiveByteBufAllocator: make sure byteBuf.capacity() not greater th…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -1611,12 +1611,12 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
 
         @Override
         public ByteBuf capacity(int newCapacity) {
+            checkNewCapacity(newCapacity);
             if (length <= newCapacity && newCapacity <= maxFastCapacity) {
                 ensureAccessible();
                 length = newCapacity;
                 return this;
             }
-            checkNewCapacity(newCapacity);
             if (newCapacity < capacity()) {
                 length = newCapacity;
                 trimIndicesToCapacity(newCapacity);

--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufAllocatorTest.java
@@ -17,6 +17,7 @@ package io.netty.buffer;
 
 import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
@@ -26,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.abort;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -194,6 +196,27 @@ public abstract class AbstractByteBufAllocatorTest<T extends AbstractByteBufAllo
         assertThat(allocAfter - allocBefore)
                 .as("allocated MB: %.3f", (allocAfter - allocBefore) / 1024.0 / 1024.0)
                 .isLessThan(8 * 1024 * 1024);
+    }
+
+    @Test
+    public void testCapacityNotGreaterThanMaxCapacity() {
+        testCapacityNotGreaterThanMaxCapacity(true);
+        testCapacityNotGreaterThanMaxCapacity(false);
+    }
+
+    private void testCapacityNotGreaterThanMaxCapacity(boolean preferDirect) {
+        final int maxSize = 100000;
+        final ByteBuf buf = newAllocator(preferDirect).newDirectBuffer(maxSize, maxSize);
+        try {
+            assertThrows(IllegalArgumentException.class, new Executable() {
+                @Override
+                public void execute() throws Throwable {
+                    buf.capacity(maxSize + 1);
+                }
+            });
+        } finally {
+            buf.release();
+        }
     }
 
     protected long expectedUsedMemory(T allocator, int capacity) {


### PR DESCRIPTION
…an byteBuf.maxCapacity() (#16309)

Motivation:

According to the docs of `ByteBuf.maxCapacity()`:

https://github.com/netty/netty/blob/d9336245a2fe3dfec4d0d1e489135bbf7ed03160/buffer/src/main/java/io/netty/buffer/ByteBuf.java#L265-L269

The `byteBuf.capacity()` should always <= `byteBuf.maxCapacity()`.

But if we run the following code:
```
public static void main(String[] args) {
    int maxSize = 100000;
    AdaptiveByteBufAllocator alloc = new AdaptiveByteBufAllocator();
    ByteBuf buf = alloc.newDirectBuffer(maxSize, maxSize);
    System.out.println("Before reallocation: buf.capacity(): " + buf.capacity());
    System.out.println("Before reallocation: buf.maxCapacity(): " + buf.maxCapacity());
    buf = buf.capacity(maxSize + 1); // Should not be allowed.
    System.out.println("After reallocation: buf.capacity(): " + buf.capacity());
    System.out.println("After reallocation: buf.maxCapacity(): " + buf.maxCapacity());
    //assert buf.capacity() <= buf.maxCapacity();
}
```
The output:

> Before reallocation: buf.capacity(): 100000
> Before reallocation: buf.maxCapacity(): 100000
> After reallocation: buf.capacity(): 100001
> After reallocation: buf.maxCapacity(): 100000

We can see after reallocation, the `buf.capacity()` is greater than `buf.maxCapacity()`, which should not happen.

Modification:

Adjust the check in `AdaptivePoolingAllocator.capacity(int newCapacity)`, to make sure the constrain hold.

Result:

Make sure `byteBuf.capacity()` not greater than `byteBuf.maxCapacity()`.

---------

Co-authored-by: lao <none>

(cherry picked from commit a78ea77c12d2c18dcab4a99f19d75d7e3b518b6a)