### PR TITLE
Fix pooled arena accounting tests 

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -30,6 +30,7 @@ import java.util.Queue;
 import java.util.Random;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.FutureTask;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -417,7 +418,7 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
 
     @Test
     @Timeout(value = 3000, unit = MILLISECONDS)
-    public void testNumThreadCachesWithNoDirectArenas() throws InterruptedException {
+    public void testNumThreadCachesWithNoDirectArenas() throws Exception {
         int numHeapArenas = 1;
         final PooledByteBufAllocator allocator =
             new PooledByteBufAllocator(numHeapArenas, 0, 8192, 1);
@@ -437,7 +438,7 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
 
     @Test
     @Timeout(value = 3000, unit = MILLISECONDS)
-    public void testNumThreadCachesAccountForDirectAndHeapArenas() throws InterruptedException {
+    public void testNumThreadCachesAccountForDirectAndHeapArenas() throws Exception {
         int numHeapArenas = 1;
         final PooledByteBufAllocator allocator =
                 new PooledByteBufAllocator(numHeapArenas, 0, 8192, 1);
@@ -457,7 +458,7 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
 
     @Test
     @Timeout(value = 3000, unit = MILLISECONDS)
-    public void testThreadCacheToArenaMappings() throws InterruptedException {
+    public void testThreadCacheToArenaMappings() throws Exception {
         int numArenas = 2;
         final PooledByteBufAllocator allocator =
             new PooledByteBufAllocator(numArenas, numArenas, 8192, 1);
@@ -500,8 +501,7 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
             throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         final CountDownLatch cacheLatch = new CountDownLatch(1);
-        final Thread t = new FastThreadLocalThread(new Runnable() {
-
+        FutureTask<Void> task = new FutureTask<>(new Runnable() {
             @Override
             public void run() {
                 final ByteBuf buf;
@@ -527,7 +527,8 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
 
                 FastThreadLocal.removeAll();
             }
-        });
+        }, null);
+        final Thread t = new FastThreadLocalThread(task);
         t.start();
 
         // Wait until we allocated a buffer and so be sure the thread was started and the cache exists.
@@ -535,15 +536,26 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
 
         return new ThreadCache() {
             @Override
-            public void destroy() throws InterruptedException {
+            public void destroy() throws Exception {
                 latch.countDown();
-                t.join();
+                try {
+                    task.get();
+                    t.join();
+                } catch (InterruptedException e) {
+                    StackTraceElement[] stackTrace = t.getStackTrace();
+                    InterruptedException asyncIE = new InterruptedException(
+                            "Asynchronous interruption: " + t);
+                    t.interrupt();
+                    asyncIE.setStackTrace(stackTrace);
+                    e.addSuppressed(asyncIE);
+                    throw e;
+                }
             }
         };
     }
 
     private interface ThreadCache {
-        void destroy() throws InterruptedException;
+        void destroy() throws Exception;
     }
 
     @Test

--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -417,7 +417,7 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
     }
 
     @Test
-    @Timeout(value = 3000, unit = MILLISECONDS)
+    @Timeout(10)
     public void testNumThreadCachesWithNoDirectArenas() throws Exception {
         int numHeapArenas = 1;
         final PooledByteBufAllocator allocator =
@@ -437,11 +437,11 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
     }
 
     @Test
-    @Timeout(value = 3000, unit = MILLISECONDS)
+    @Timeout(10)
     public void testNumThreadCachesAccountForDirectAndHeapArenas() throws Exception {
-        int numHeapArenas = 1;
+        int numArenas = 1;
         final PooledByteBufAllocator allocator =
-                new PooledByteBufAllocator(numHeapArenas, 0, 8192, 1);
+                new PooledByteBufAllocator(numArenas, numArenas, 8192, 1);
 
         ThreadCache tcache0 = createNewThreadCache(allocator, false);
         assertEquals(1, allocator.metric().numThreadLocalCaches());
@@ -457,7 +457,7 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
     }
 
     @Test
-    @Timeout(value = 3000, unit = MILLISECONDS)
+    @Timeout(10)
     public void testThreadCacheToArenaMappings() throws Exception {
         int numArenas = 2;
         final PooledByteBufAllocator allocator =


### PR DESCRIPTION
Motivation:
These tests were often running into timeouts.

Modification:

Capture the stack trace of the spawned thread, and include it in the tests own InterruptedException. Also capture any exceptions thrown in the thread, by wrapping the work in a FutureTask.
This makes diagnosing these issues easier.

Extend the timeouts to 10 seconds.

Give the pool a direct arena since it allocates direct buffers.
Without a direct arena, it would allocate unpooled buffers, which bear the cost of deallocation directly in ByteBuf.release.

Result:
More stable build.