### PR TITLE
AdaptivePoolingAllocator: call `unreserveMatchingBuddy(...)` if `byteBuf` initialization failed

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -1408,6 +1408,7 @@ final class AdaptivePoolingAllocator {
                 chunk = null;
             } finally {
                 if (chunk != null) {
+                    unreserveMatchingBuddy(1, startingCapacity, startIndex, 0);
                     // If chunk is not null we know that buf.init(...) failed and so we need to manually release
                     // the chunk again as we retained it before calling buf.init(...).
                     chunk.release();


### PR DESCRIPTION
Motivation:
In `BuddyChunk.readInitInto(...)`, we should call `unreserveMatchingBuddy(...)` if the `byteBuf` initialization failed, to unreserve the memory.

Modification:
Call `unreserveMatchingBuddy(...)` in the `finally` block.

Result:
Better memory utilization.