### PR TITLE
IoUring: Only complete deregistration promise once we received all co…

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -1187,11 +1187,18 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
             if (deregisterPromise != null) {
                 // A deregistration is already in progress.
                 PromiseNotifier.cascade(deregisterPromise, promise);
+            } else if (!isRegistered()) {
+                promise.setSuccess();
             } else {
                 // We need to store a reference to the original promise as we should only notify it once we
                 // have handles all pending completions.
                 deregisterPromise = promise;
-                super.deregister(newPromise());
+                super.deregister(newPromise().addListener(f -> {
+                    if (!f.isSuccess()) {
+                        this.deregisterPromise = null;
+                        promise.setFailure(f.cause());
+                    }
+                }));
             }
         }
     }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -433,6 +433,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         private IoUringRecvByteAllocatorHandle allocHandle;
         private boolean closed;
         private boolean socketIsEmpty;
+        private ChannelPromise deregisterPromise;
 
         /**
          * Schedule the write of multiple messages in the {@link ChannelOutboundBuffer} and returns the number of
@@ -498,7 +499,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
             // was a close that needs to be done now.
             handleDelayedClosed();
 
-            if (ioState == 0 && closed) {
+            if (ioState == 0 && (closed || !isRegistered())) {
                 // Cancel the registration now.
                 registration.cancel();
             }
@@ -508,6 +509,13 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         public void unregistered() {
             freeMsgHdrArray();
             freeRemoteAddressMemory();
+
+            // Check if we need to notify about the deregistration.
+            if (deregisterPromise != null) {
+                ChannelPromise promise = deregisterPromise;
+                deregisterPromise = null;
+                promise.setSuccess();
+            }
         }
 
         private void handleDelayedClosed() {
@@ -573,37 +581,46 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
             }
         }
 
-        private void cancelOps(boolean cancelConnect) {
+        private boolean cancelOps(boolean cancelConnect) {
             if (registration == null || !registration.isValid()) {
-                return;
+                return false;
             }
+            boolean cancelled = false;
             byte flags = (byte) 0;
             if ((ioState & POLL_RDHUP_SCHEDULED) != 0 && pollRdhupId != 0) {
                 long id = registration.submit(
                         IoUringIoOps.newAsyncCancel(flags, pollRdhupId, Native.IORING_OP_POLL_ADD));
                 assert id != 0;
                 pollRdhupId = 0;
+                cancelled = true;
             }
             if ((ioState & POLL_IN_SCHEDULED) != 0 && pollInId != 0) {
                 long id = registration.submit(
                         IoUringIoOps.newAsyncCancel(flags, pollInId, Native.IORING_OP_POLL_ADD));
                 assert id != 0;
                 pollInId = 0;
+                cancelled = true;
             }
             if ((ioState & POLL_OUT_SCHEDULED) != 0 && pollOutId != 0) {
                 long id = registration.submit(
                         IoUringIoOps.newAsyncCancel(flags, pollOutId, Native.IORING_OP_POLL_ADD));
                 assert id != 0;
                 pollOutId = 0;
+                cancelled = true;
             }
             if (cancelConnect && connectId != 0) {
                 // Best effort to cancel the already submitted connect request.
                 long id = registration.submit(IoUringIoOps.newAsyncCancel(flags, connectId, Native.IORING_OP_CONNECT));
                 assert id != 0;
                 connectId = 0;
+                cancelled = true;
+            }
+            if (numOutstandingReads != 0 || numOutstandingWrites != 0) {
+                cancelled = true;
             }
             cancelOutstandingReads(registration, numOutstandingReads);
             cancelOutstandingWrites(registration, numOutstandingWrites);
+            return cancelled;
         }
 
         private boolean canCloseNow() {
@@ -1164,6 +1181,19 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
                 }
             });
         }
+
+        @Override
+        public final void deregister(ChannelPromise promise) {
+            if (deregisterPromise != null) {
+                // A deregistration is already in progress.
+                PromiseNotifier.cascade(deregisterPromise, promise);
+            } else {
+                // We need to store a reference to the original promise as we should only notify it once we
+                // have handles all pending completions.
+                deregisterPromise = promise;
+                super.deregister(newPromise());
+            }
+        }
     }
 
     private void submitConnect(InetSocketAddress inetSocketAddress) {
@@ -1223,7 +1253,13 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
     @Override
     protected final void doDeregister() {
         // Cancel all previous submitted ops.
-        ioUringUnsafe().cancelOps(connectPromise != null);
+        if (!ioUringUnsafe().cancelOps(connectPromise != null)) {
+            // It's possible that we never registered anything and so we did not submit any ASYNC_CANCEL.
+            // In this case directly call cancel as we will not receive any completion at all.
+            if (registration != null) {
+                registration.cancel();
+            }
+        }
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringRegisterTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringRegisterTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.EventLoop;
+import io.netty.testsuite.transport.TestsuitePermutation;
+import io.netty.testsuite.transport.socket.AbstractSocketTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IoUringRegisterTest extends AbstractSocketTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IoUring.isAvailable());
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IoUringSocketTestPermutation.INSTANCE.socket();
+    }
+
+    @Test
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testDeregisterRegisterSameEventLoop(TestInfo testInfo) throws Throwable {
+        run(testInfo, new Runner<ServerBootstrap, Bootstrap>() {
+            @Override
+            public void run(ServerBootstrap serverBootstrap, Bootstrap bootstrap) throws Throwable {
+                testDeregisterRegister(serverBootstrap, bootstrap, true);
+            }
+        });
+    }
+
+    @Test
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void testDeregisterRegisterDifferentEventLoop(TestInfo testInfo) throws Throwable {
+        run(testInfo, new Runner<ServerBootstrap, Bootstrap>() {
+            @Override
+            public void run(ServerBootstrap serverBootstrap, Bootstrap bootstrap) throws Throwable {
+                testDeregisterRegister(serverBootstrap, bootstrap, false);
+            }
+        });
+    }
+
+    private void testDeregisterRegister(ServerBootstrap sb, Bootstrap cb, boolean sameLoop) throws Throwable {
+        Channel serverChannel = null;
+        Channel clientChannel = null;
+        try {
+            serverChannel = sb.childHandler(new ChannelInboundHandlerAdapter()).bind().syncUninterruptibly().channel();
+            clientChannel = cb.handler(new ChannelInboundHandlerAdapter() { })
+                    .connect(serverChannel.localAddress()).syncUninterruptibly().channel();
+            EventLoop loop = clientChannel.eventLoop();
+            if (!sameLoop) {
+                for (;;) {
+                    EventLoop next = loop.parent().next();
+                    if (next != loop) {
+                        loop = next;
+                        break;
+                    }
+                }
+            }
+            clientChannel.deregister().sync();
+            loop.register(clientChannel).sync();
+        } finally {
+            if (clientChannel != null) {
+                clientChannel.close().syncUninterruptibly();
+            }
+            if (serverChannel != null) {
+                serverChannel.close().syncUninterruptibly();
+            }
+        }
+    }
+}

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -639,7 +639,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         }
 
         @Override
-        public final void deregister(final ChannelPromise promise) {
+        public void deregister(final ChannelPromise promise) {
             assertEventLoop();
 
             deregister(promise, false);


### PR DESCRIPTION
…mpletions

Motivation:

We need to ensure we only notify about the completion of the deregistration once we handled all completions. Otherwise we might produce assertion failures. Beside this we also need to ensure we always cancel the registration on deregistration even if there are no ops scheduled.

Modifications:

- Only notify promise once everything is handled
- Always cancel registration.
- Add unit test

Result:

Fixes https://github.com/netty/netty/issues/16307