### PR TITLE
AdaptivePoolingAllocator: assign a more explicit value to BuddyChunk.freeListCapacity

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -1373,7 +1373,7 @@ final class AdaptivePoolingAllocator {
             int tree = (capFactor << 1) - 1;
             int maxShift = Integer.numberOfTrailingZeros(capFactor);
             assert maxShift <= 30; // The top 2 bits are used for marking.
-            freeListCapacity = tree >> 1;
+            freeListCapacity = capFactor;
             freeList = MpscIntQueue.create(freeListCapacity, -1); // At most half of tree (all leaf nodes) can be freed.
             buddies = new byte[1 + tree];
 

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -1368,14 +1368,11 @@ final class AdaptivePoolingAllocator {
 
         BuddyChunk(AbstractByteBuf delegate, Magazine magazine) {
             super(delegate, magazine, true);
-            int capacity = delegate.capacity();
-            int capFactor = capacity / MIN_BUDDY_SIZE;
-            int tree = (capFactor << 1) - 1;
-            int maxShift = Integer.numberOfTrailingZeros(capFactor);
+            freeListCapacity = delegate.capacity() / MIN_BUDDY_SIZE;
+            int maxShift = Integer.numberOfTrailingZeros(freeListCapacity);
             assert maxShift <= 30; // The top 2 bits are used for marking.
-            freeListCapacity = capFactor;
             freeList = MpscIntQueue.create(freeListCapacity, -1); // At most half of tree (all leaf nodes) can be freed.
-            buddies = new byte[1 + tree];
+            buddies = new byte[freeListCapacity << 1];
 
             // Generate the buddies entries.
             int index = 1;


### PR DESCRIPTION
Motivation:

Currently, the value of `BuddyChunk.freeListCapacity` is less than the real max size of the `freeList`.
1. It may lead to the `freeList.drain(freeListCapacity, this)` can not drain all the elements at once.
2. When calling `MpscIntQueue.create(freeListCapacity, -1)`, we rely on `MpscIntQueue` implicitly calling `MathUtil.safeFindNextPositivePowerOfTwo(freeListCapacity)` to set the proper max size. This makes the code less explicit.
3. Semantically, `freeListCapacity` should be equal to the value of `capFactor`, if I understand correctly.
4. In addition, use `freeListCapacity = capFactor` eliminates a bit-shift operation.

Modification:

Use `freeListCapacity = capFactor;` instead of `freeListCapacity = tree >> 1;`.

Result:

More clean code.
