### PR TITLE
IoUring: Only complete deregistration promise once we received all completions

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -101,6 +101,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
     private Promise<Void> delayedClose;
     private boolean inputClosedSeenErrorOnRead;
     private boolean socketIsEmpty;
+    private Promise<Void> deregisterPromise;
 
     /**
      * The future of the current connection attempt.  If not null, subsequent connection attempts will fail.
@@ -504,7 +505,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
             // was a close that needs to be done now.
             handleDelayedClosed();
 
-            if (ioState == 0 && closed) {
+            if (ioState == 0 && (closed || deregisterPromise != null)) {
                 // Cancel the registration now.
                 registration.cancel();
             }
@@ -515,6 +516,13 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
             freeMsgHdrArray();
             freeRemoteAddressMemory();
             AbstractIoUringChannel.this.unregistered();
+
+            // Check if we need to notify about the deregistration.
+            if (deregisterPromise != null) {
+                Promise<Void> promise = deregisterPromise;
+                deregisterPromise = null;
+                promise.setSuccess(null);
+            }
         }
 
         @Override
@@ -564,37 +572,46 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         }
     }
 
-    private void cancelOps(boolean cancelConnect) {
+    private boolean cancelOps(boolean cancelConnect) {
         if (registration == null || !registration.isValid()) {
-            return;
+            return false;
         }
+        boolean cancelled = false;
         byte flags = (byte) 0;
         if ((ioState & POLL_RDHUP_SCHEDULED) != 0 && pollRdhupId != 0) {
             long id = registration.submit(
                     IoUringIoOps.newAsyncCancel(flags, pollRdhupId, Native.IORING_OP_POLL_ADD));
             assert id != 0;
             pollRdhupId = 0;
+            cancelled = true;
         }
         if ((ioState & POLL_IN_SCHEDULED) != 0 && pollInId != 0) {
             long id = registration.submit(
                     IoUringIoOps.newAsyncCancel(flags, pollInId, Native.IORING_OP_POLL_ADD));
             assert id != 0;
             pollInId = 0;
+            cancelled = true;
         }
         if ((ioState & POLL_OUT_SCHEDULED) != 0 && pollOutId != 0) {
             long id = registration.submit(
                     IoUringIoOps.newAsyncCancel(flags, pollOutId, Native.IORING_OP_POLL_ADD));
             assert id != 0;
             pollOutId = 0;
+            cancelled = true;
         }
         if (cancelConnect && connectId != 0) {
             // Best effort to cancel the already submitted connect request.
             long id = registration.submit(IoUringIoOps.newAsyncCancel(flags, connectId, Native.IORING_OP_CONNECT));
             assert id != 0;
             connectId = 0;
+            cancelled = true;
+        }
+        if (numOutstandingReads != 0 || numOutstandingWrites != 0) {
+            cancelled = true;
         }
         cancelOutstandingReads(registration, numOutstandingReads);
         cancelOutstandingWrites(registration, numOutstandingWrites);
+        return cancelled;
     }
 
     private boolean canCloseNow() {
@@ -1097,7 +1114,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         EventLoop eventLoop = executor();
         eventLoop.register(ioHandle).addListener(f -> {
             if (f.isSuccess()) {
-                registration = (IoRegistration) f.getNow();
+                registration = f.getNow();
                 promise.setSuccess(null);
             } else {
                 promise.setFailure(f.cause());
@@ -1107,9 +1124,24 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
 
     @Override
     protected final void doDeregister(Promise<Void> promise) {
+        if (deregisterPromise != null) {
+            deregisterPromise.addHandler(promise);
+            return;
+        } else if (!isRegistered()) {
+            promise.setSuccess(null);
+            return;
+        }
         // Cancel all previous submitted ops.
-        cancelOps(connectPromise != null);
-        promise.setSuccess(null);
+        if (!cancelOps(connectPromise != null)) {
+            // It's possible that we never registered anything and so we did not submit any ASYNC_CANCEL.
+            // In this case directly call cancel as we will not receive any completion at all.
+            if (registration != null) {
+                registration.cancel();
+            }
+            promise.setSuccess(null);
+        } else {
+            deregisterPromise = promise;
+        }
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringRegisterTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringRegisterTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelInboundHandler;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.testsuite.transport.TestsuitePermutation;
+import io.netty.testsuite.transport.socket.AbstractSocketTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IoUringRegisterTest extends AbstractSocketTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IoUring.isAvailable());
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IoUringSocketTestPermutation.INSTANCE.socket();
+    }
+
+    @Test
+    @Timeout(value = 300000, unit = TimeUnit.MILLISECONDS)
+    public void testDeregisterRegisterSameEventLoop(TestInfo testInfo) throws Throwable {
+        run(testInfo, new Runner<ServerBootstrap, Bootstrap>() {
+            @Override
+            public void run(ServerBootstrap serverBootstrap, Bootstrap bootstrap) throws Throwable {
+                testDeregisterRegister(serverBootstrap, bootstrap);
+            }
+        });
+    }
+
+    private void testDeregisterRegister(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+        Channel serverChannel = null;
+        Channel clientChannel = null;
+        try {
+            serverChannel = sb.childHandler(new ChannelInboundHandler() {
+            }).bind().get();
+            if (!(serverChannel instanceof NioServerSocketChannel)) {
+                serverChannel.close();
+                return;
+            }
+            clientChannel = cb.handler(new ChannelInboundHandler() { })
+                    .connect(serverChannel.localAddress()).get();
+            clientChannel.deregister().sync();
+            clientChannel.register().sync();
+        } finally {
+            if (clientChannel != null) {
+                clientChannel.close().syncUninterruptibly();
+            }
+            if (serverChannel != null) {
+                serverChannel.close().syncUninterruptibly();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

We need to ensure we only notify about the completion of the deregistration once we handled all completions. Otherwise we might produce assertion failures. Beside this we also need to ensure we always cancel the registration on deregistration even if there are no ops scheduled.

Modifications:

- Only notify promise once everything is handled
- Always cancel registration.
- Add unit test

Result:

Fixes #16307
