### PR TITLE
Mark LoggingHandlerTest with @Isolated to fix flaky build

### DIFF
--- a/handler/src/test/java/io/netty/handler/logging/LoggingHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/logging/LoggingHandlerTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.mockito.ArgumentMatcher;
 import org.slf4j.LoggerFactory;
 
@@ -54,6 +55,7 @@ import static org.slf4j.Logger.ROOT_LOGGER_NAME;
 /**
  * Verifies the correct functionality of the {@link LoggingHandler}.
  */
+@Isolated
 public class LoggingHandlerTest {
 
     private static final String LOGGER_NAME = LoggingHandler.class.getName();


### PR DESCRIPTION
Motivation:

As LoggingHandlerTest depends on static state we should better mark it as `@Isolated` so we not mess up the state sometimes by running test concurrently. Failing to do so can cause issues like:

```
2026-02-21T04:13:33.0279489Z [ERROR] io.netty.handler.logging.LoggingHandlerTest -- Time elapsed: 0.095 s <<< ERROR!
2026-02-21T04:13:33.0281038Z java.lang.ExceptionInInitializerError
2026-02-21T04:13:33.0282266Z 	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
2026-02-21T04:13:33.0284143Z 	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
2026-02-21T04:13:33.0285193Z 	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
2026-02-21T04:13:33.0286182Z 	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
2026-02-21T04:13:33.0287200Z 	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
2026-02-21T04:13:33.0288167Z 	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
2026-02-21T04:13:33.0289364Z 	Suppressed: java.lang.NoClassDefFoundError: Could not initialize class io.netty.handler.logging.LoggingHandlerTest
2026-02-21T04:13:33.0290429Z 		at java.base/java.lang.reflect.Method.invoke(Method.java:566)
2026-02-21T04:13:33.0291123Z 		at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
2026-02-21T04:13:33.0291996Z 		at java.base/java.util.Collections$UnmodifiableCollection.forEach(Collections.java:1085)
2026-02-21T04:13:33.0292740Z 		... 5 more
2026-02-21T04:13:33.0294696Z Caused by: java.lang.ClassCastException: class org.slf4j.helpers.SubstituteLogger cannot be cast to class ch.qos.logback.classic.Logger (org.slf4j.helpers.SubstituteLogger and ch.qos.logback.classic.Logger are in unnamed module of loader 'app')
2026-02-21T04:13:33.0296729Z 	at io.netty.handler.logging.LoggingHandlerTest.<clinit>(LoggingHandlerTest.java:61)
2026-02-21T04:13:33.0297699Z 	... 6 more
```

Modifications:

Add `@Isolated` annotation to test class

Result:

No more test-failures
