### PR TITLE
Fix flaky HTTP/2 test

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/LastInboundHandler.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/LastInboundHandler.java
@@ -109,7 +109,9 @@ public class LastInboundHandler extends ChannelDuplexHandler {
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-        queue.add(msg);
+        synchronized (queue) {
+            queue.add(msg);
+        }
     }
 
     @Override
@@ -119,7 +121,9 @@ public class LastInboundHandler extends ChannelDuplexHandler {
 
     @Override
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
-        queue.add(new UserEvent(evt));
+        synchronized (queue) {
+            queue.add(new UserEvent(evt));
+        }
     }
 
     @Override
@@ -142,11 +146,13 @@ public class LastInboundHandler extends ChannelDuplexHandler {
 
     @SuppressWarnings("unchecked")
     public <T> T readInbound() {
-        for (int i = 0; i < queue.size(); i++) {
-            Object o = queue.get(i);
-            if (!(o instanceof UserEvent)) {
-                queue.remove(i);
-                return (T) o;
+        synchronized (queue) {
+            for (int i = 0; i < queue.size(); i++) {
+                Object o = queue.get(i);
+                if (!(o instanceof UserEvent)) {
+                    queue.remove(i);
+                    return (T) o;
+                }
             }
         }
 
@@ -163,11 +169,13 @@ public class LastInboundHandler extends ChannelDuplexHandler {
 
     @SuppressWarnings("unchecked")
     public <T> T readUserEvent() {
-        for (int i = 0; i < queue.size(); i++) {
-            Object o = queue.get(i);
-            if (o instanceof UserEvent) {
-                queue.remove(i);
-                return (T) ((UserEvent) o).evt;
+        synchronized (queue) {
+            for (int i = 0; i < queue.size(); i++) {
+                Object o = queue.get(i);
+                if (o instanceof UserEvent) {
+                    queue.remove(i);
+                    return (T) ((UserEvent) o).evt;
+                }
             }
         }
 
@@ -179,14 +187,16 @@ public class LastInboundHandler extends ChannelDuplexHandler {
      */
     @SuppressWarnings("unchecked")
     public <T> T readInboundMessageOrUserEvent() {
-        if (queue.isEmpty()) {
-            return null;
+        synchronized (queue) {
+            if (queue.isEmpty()) {
+                return null;
+            }
+            Object o = queue.remove(0);
+            if (o instanceof UserEvent) {
+                return (T) ((UserEvent) o).evt;
+            }
+            return (T) o;
         }
-        Object o = queue.remove(0);
-        if (o instanceof UserEvent) {
-            return (T) ((UserEvent) o).evt;
-        }
-        return (T) o;
     }
 
     public void writeOutbound(Object... msgs) throws Exception {


### PR DESCRIPTION
Motivation:
The `LastInboundHandler.queue` is a plain `ArrayList`, but tests access and modify it from both within event loops and test methods.

Modification:
Put all accesses in `synchronized` blocks.

Result:
Accesses to the queue is now thread-safe.
No more flaky test failures from unsafe concurrent access to the queue.

I considered changing it to a concurrent or blocking queue. However, the logic around `UserEvents` makes this difficult to do while preserving the exact behavior that tests might expect.