### PR TITLE
Avoid unnecessary Long.toString() allocation in HttpObjectDecoder

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -797,7 +797,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             if (contentLength != -1) {
                 String lengthValue = contentLengthFields.get(0).trim();
                 if (contentLengthFields.size() > 1 || // don't unnecessarily re-order headers
-                        !isLengthEqual(lengthValue)) {
+                        !isLengthEqual(lengthValue, contentLength)) {
                     headers.set(HttpHeaderNames.CONTENT_LENGTH, contentLength);
                 }
             }
@@ -827,7 +827,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
         return State.READ_VARIABLE_LENGTH_CONTENT;
     }
 
-    private boolean isLengthEqual(String lengthValue) {
+    private static boolean isLengthEqual(String lengthValue, long contentLength) {
         try {
             return Long.parseLong(lengthValue) == contentLength;
         } catch (NumberFormatException e) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -797,7 +797,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             if (contentLength != -1) {
                 String lengthValue = contentLengthFields.get(0).trim();
                 if (contentLengthFields.size() > 1 || // don't unnecessarily re-order headers
-                        !lengthValue.equals(Long.toString(contentLength))) {
+                        !isLengthEqual(lengthValue)) {
                     headers.set(HttpHeaderNames.CONTENT_LENGTH, contentLength);
                 }
             }
@@ -825,6 +825,14 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             return State.READ_FIXED_LENGTH_CONTENT;
         }
         return State.READ_VARIABLE_LENGTH_CONTENT;
+    }
+
+    private boolean isLengthEqual(String lengthValue) {
+        try {
+            return Long.parseLong(lengthValue) == contentLength;
+        } catch (NumberFormatException e) {
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
Motivation:

`HttpObjectDecoder.readHeaders()` calls `Long.toString()` to compare with another string, we can use `Long.parseLong()` instead to compare 2 longs, it will avoid allocation and should be faster for valid content-type input.

<img width="606" height="147" alt="image" src="https://github.com/user-attachments/assets/78fd07ae-82fd-4fb8-93e8-6d4daf1180ae" />


Modification:

Introduced a method `isLengthEqual` that does `Long.parseLong()` and catches exception in case of invalid input to preserve current behaivour.

Result:

Fewer allocations in `HttpObjectDecoder.readHeaders()`.
