### PR TITLE
IoUring: Don't use RDHUP for non stream Channel implementations

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
@@ -435,8 +435,14 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
 
                 ChannelFuture future = cc.writeAndFlush(
                         buf.retain().duplicate()).awaitUninterruptibly();
-                assertTrue(future.cause() instanceof NotYetConnectedException,
-                        "NotYetConnectedException expected, got: " + future.cause());
+                assertInstanceOf(NotYetConnectedException.class, future.cause());
+
+                // Connect again and try to write.
+                cc.connect(addr).sync();
+
+                ChannelFuture f = write(cc, buf, wrapType);
+                cc.flush();
+                f.sync();
             }
         } finally {
             // release as we used buf.retain() before

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -411,6 +411,8 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         pollRdhupId = schedulePollAdd(POLL_RDHUP_SCHEDULED, Native.POLLRDHUP, false);
     }
 
+    protected abstract boolean isStreamSocket();
+
     private long schedulePollAdd(int ioMask, int mask, boolean multishot) {
         assert (ioState & ioMask) == 0;
         int fd = fd().intValue();
@@ -670,8 +672,10 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
             }
             computeRemote();
 
-            // Register POLLRDHUP
-            schedulePollRdHup();
+            if (isStreamSocket()) {
+                // Register POLLRDHUP
+                schedulePollRdHup();
+            }
 
             // Get the state as trySuccess() may trigger an ChannelFutureListener that will close the Channel.
             // We still need to ensure we call fireChannelActive() in this case.

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringServerChannel.java
@@ -90,6 +90,11 @@ abstract class AbstractIoUringServerChannel extends AbstractIoUringChannel imple
     }
 
     @Override
+    protected final boolean isStreamSocket() {
+        return true;
+    }
+
+    @Override
     public final ChannelMetadata metadata() {
         return METADATA;
     }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -59,6 +59,11 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
     }
 
     @Override
+    protected final boolean isStreamSocket() {
+        return true;
+    }
+
+    @Override
     public ChannelMetadata metadata() {
         return METADATA;
     }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
@@ -128,6 +128,11 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
     }
 
     @Override
+    protected boolean isStreamSocket() {
+        return false;
+    }
+
+    @Override
     public InetSocketAddress remoteAddress() {
         return (InetSocketAddress) super.remoteAddress();
     }


### PR DESCRIPTION
    
Motivation:
    
We did not have any testing that ensured that it is actually possible to connect a DatagramChannel again after it was disconnected.
    
Modifications:
    
- Fix IoUring to only register RDHUP for stream channels and so fix assert error
- Adjust testcase to cover this scenario
    
Result:
    
More complete testing of DatagramChannel implementations and fix for IoUring
