### PR TITLE
Fix io_uring datagram channel read buffer leak

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -748,13 +748,12 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
 
             boolean multishot = numOutstandingReads == -1;
             boolean rearm = (flags & Native.IORING_CQE_F_MORE) == 0;
-            if (rearm) {
-                // Reset READ_SCHEDULED if there is nothing more to handle and so we need to re-arm. This works for
-                // multi-shot and non multi-shot variants.
-                ioState &= ~READ_SCHEDULED;
-            }
             boolean pending = readPending;
             if (multishot) {
+                if (rearm) {
+                    // Reset READ_SCHEDULED if there is nothing more to handle and so we need to re-arm.
+                    ioState &= ~READ_SCHEDULED;
+                }
                 // Reset readPending so we can still keep track if we might need to cancel the multi-shot read or
                 // not.
                 readPending = false;

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
@@ -643,6 +643,7 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
         @Override
         public void unregistered() {
             super.unregistered();
+            assert readBuffer == null;
             sendmsgHdrs.release();
             recvmsgHdrs.release();
         }


### PR DESCRIPTION
Motivation:

For single-shot datagram reads, multiple recvmsg operations can be outstanding simultaneously. The rearm flag was prematurely clearing READ_SCHEDULED on the first completion, causing subsequent completions to see ioState == 0 with an unregistered channel, triggering early registration cancel before all completions arrived. This left the readBuffer unreleased.

Modifications:

- Only use the rearm flag to clear READ_SCHEDULED for multishot reads
- For single-shot reads, clear READ_SCHEDULED only when all outstanding completions (numOutstandingReads == 0) have been received
- Add assert readBuffer == null in IoUringDatagramChannel.unregistered()

Result:

No more ByteBuf leak when datagram channels are deregistered with outstanding single-shot reads.