### PR TITLE
Don't assume CertificateFactory is thread-safe

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/util/LazyX509Certificate.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/LazyX509Certificate.java
@@ -16,6 +16,7 @@
 package io.netty.handler.ssl.util;
 
 import io.netty.util.internal.ObjectUtil;
+import io.netty.util.internal.PlatformDependent;
 
 import java.io.ByteArrayInputStream;
 import java.math.BigInteger;
@@ -36,22 +37,16 @@ import java.security.cert.X509Certificate;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.Queue;
 import java.util.Set;
 import javax.security.auth.x500.X500Principal;
 
 public final class LazyX509Certificate extends X509Certificate {
 
-    static final CertificateFactory X509_CERT_FACTORY;
-    static {
-        try {
-            X509_CERT_FACTORY = CertificateFactory.getInstance("X.509");
-        } catch (CertificateException e) {
-            throw new ExceptionInInitializerError(e);
-        }
-    }
+    private static final Queue<CertificateFactory> CERT_FACTORY = PlatformDependent.newFixedMpmcQueue(64);
 
     private final byte[] bytes;
-    private X509Certificate wrapped;
+    private volatile X509Certificate wrapped;
 
     /**
      * Creates a new instance which will lazy parse the given bytes. Be aware that the bytes will not be cloned.
@@ -228,11 +223,20 @@ public final class LazyX509Certificate extends X509Certificate {
     private X509Certificate unwrap() {
         X509Certificate wrapped = this.wrapped;
         if (wrapped == null) {
+            CertificateFactory factory = CERT_FACTORY.poll();
             try {
-                wrapped = this.wrapped = (X509Certificate) X509_CERT_FACTORY.generateCertificate(
-                        new ByteArrayInputStream(bytes));
+                if (factory == null) {
+                    try {
+                        factory = CertificateFactory.getInstance("X.509");
+                    } catch (CertificateException e) {
+                        throw new ExceptionInInitializerError(e);
+                    }
+                }
+                wrapped = this.wrapped = (X509Certificate) factory.generateCertificate(new ByteArrayInputStream(bytes));
             } catch (CertificateException e) {
                 throw new IllegalStateException(e);
+            } finally {
+                CERT_FACTORY.offer(factory);
             }
         }
         return wrapped;

--- a/handler/src/main/java/io/netty/handler/ssl/util/LazyX509Certificate.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/LazyX509Certificate.java
@@ -16,7 +16,6 @@
 package io.netty.handler.ssl.util;
 
 import io.netty.util.internal.ObjectUtil;
-import io.netty.util.internal.PlatformDependent;
 
 import java.io.ByteArrayInputStream;
 import java.math.BigInteger;
@@ -37,13 +36,10 @@ import java.security.cert.X509Certificate;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
-import java.util.Queue;
 import java.util.Set;
 import javax.security.auth.x500.X500Principal;
 
 public final class LazyX509Certificate extends X509Certificate {
-
-    private static final Queue<CertificateFactory> CERT_FACTORY = PlatformDependent.newFixedMpmcQueue(64);
 
     private final byte[] bytes;
     private volatile X509Certificate wrapped;
@@ -223,20 +219,16 @@ public final class LazyX509Certificate extends X509Certificate {
     private X509Certificate unwrap() {
         X509Certificate wrapped = this.wrapped;
         if (wrapped == null) {
-            CertificateFactory factory = CERT_FACTORY.poll();
             try {
-                if (factory == null) {
-                    try {
-                        factory = CertificateFactory.getInstance("X.509");
-                    } catch (CertificateException e) {
-                        throw new ExceptionInInitializerError(e);
-                    }
+                CertificateFactory factory;
+                try {
+                    factory = CertificateFactory.getInstance("X.509");
+                } catch (CertificateException e) {
+                    throw new ExceptionInInitializerError(e);
                 }
                 wrapped = this.wrapped = (X509Certificate) factory.generateCertificate(new ByteArrayInputStream(bytes));
             } catch (CertificateException e) {
                 throw new IllegalStateException(e);
-            } finally {
-                CERT_FACTORY.offer(factory);
             }
         }
         return wrapped;

--- a/handler/src/main/java/io/netty/handler/ssl/util/LazyX509Certificate.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/LazyX509Certificate.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.ssl.util;
 
+import io.netty.util.Recycler;
 import io.netty.util.internal.ObjectUtil;
 
 import java.io.ByteArrayInputStream;
@@ -40,6 +41,34 @@ import java.util.Set;
 import javax.security.auth.x500.X500Principal;
 
 public final class LazyX509Certificate extends X509Certificate {
+    private static final Recycler<CertFactoryHandle> CERT_FACTORIES = new Recycler<CertFactoryHandle>() {
+        @Override
+        protected CertFactoryHandle newObject(Handle<CertFactoryHandle> handle) {
+            try {
+                return new CertFactoryHandle(CertificateFactory.getInstance("X.509"), handle);
+            } catch (CertificateException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+    };
+
+    private static final class CertFactoryHandle {
+        private final CertificateFactory factory;
+        private final Recycler.EnhancedHandle<CertFactoryHandle> handle;
+
+        private CertFactoryHandle(CertificateFactory factory, Recycler.Handle<CertFactoryHandle> handle) {
+            this.factory = factory;
+            this.handle = (Recycler.EnhancedHandle<CertFactoryHandle>) handle;
+        }
+
+        public X509Certificate generateCertificate(byte[] bytes) throws CertificateException {
+            return (X509Certificate) factory.generateCertificate(new ByteArrayInputStream(bytes));
+        }
+
+        public void recycle() {
+            handle.unguardedRecycle(this);
+        }
+    }
 
     private final byte[] bytes;
     private volatile X509Certificate wrapped;
@@ -219,16 +248,16 @@ public final class LazyX509Certificate extends X509Certificate {
     private X509Certificate unwrap() {
         X509Certificate wrapped = this.wrapped;
         if (wrapped == null) {
+            CertFactoryHandle factory = null;
             try {
-                CertificateFactory factory;
-                try {
-                    factory = CertificateFactory.getInstance("X.509");
-                } catch (CertificateException e) {
-                    throw new ExceptionInInitializerError(e);
-                }
-                wrapped = this.wrapped = (X509Certificate) factory.generateCertificate(new ByteArrayInputStream(bytes));
+                factory = CERT_FACTORIES.get();
+                wrapped = this.wrapped = factory.generateCertificate(bytes);
             } catch (CertificateException e) {
                 throw new IllegalStateException(e);
+            } finally {
+                if (factory != null) {
+                    factory.recycle();
+                }
             }
         }
         return wrapped;

--- a/handler/src/test/java/io/netty/handler/ssl/util/LazyX509CertificateTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/util/LazyX509CertificateTest.java
@@ -21,9 +21,15 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayInputStream;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class LazyX509CertificateTest {
 
@@ -79,7 +85,29 @@ public class LazyX509CertificateTest {
         assertArrayEquals(x509Certificate.getKeyUsage(), lazyX509Certificate.getKeyUsage());
         assertEquals(x509Certificate.getExtendedKeyUsage(), lazyX509Certificate.getExtendedKeyUsage());
         assertEquals(x509Certificate.getBasicConstraints(), lazyX509Certificate.getBasicConstraints());
-        assertEquals(x509Certificate.getSubjectAlternativeNames(), lazyX509Certificate.getSubjectAlternativeNames());
-        assertEquals(x509Certificate.getIssuerAlternativeNames(), lazyX509Certificate.getIssuerAlternativeNames());
+        assertEqualSans(x509Certificate.getSubjectAlternativeNames(), lazyX509Certificate.getSubjectAlternativeNames());
+        assertEqualSans(x509Certificate.getIssuerAlternativeNames(), lazyX509Certificate.getIssuerAlternativeNames());
+    }
+
+    private static void assertEqualSans(Collection<List<?>> expectedSans, Collection<List<?>> actualSans) {
+        Supplier<String> errMsgSans = () -> expectedSans + " != " + actualSans;
+        if (expectedSans == null) {
+            assertNull(actualSans, errMsgSans);
+            return;
+        }
+        assertEquals(expectedSans.size(), actualSans.size(), errMsgSans);
+        Iterator<List<?>> expectItr = expectedSans.iterator();
+        Iterator<List<?>> actualItr = actualSans.iterator();
+        while (expectItr.hasNext() && actualItr.hasNext()) {
+            List<?> expectedSan = expectItr.next();
+            List<?> actualSan = actualItr.next();
+            Supplier<String> errMsgSan = () -> expectedSan + " != " + actualSan;
+            assertEquals(2, expectedSan.size(), errMsgSan);
+            assertEquals(2, actualSan.size(), errMsgSan);
+            assertEquals(expectedSan.get(0), actualSan.get(0), errMsgSan);
+            assertEquals(expectedSan.get(1), actualSan.get(1), errMsgSan);
+        }
+        assertFalse(expectItr.hasNext(), errMsgSans);
+        assertFalse(actualItr.hasNext(), errMsgSans);
     }
 }


### PR DESCRIPTION
Motivation:
We cannot assume that `CertificateFactory` implementations are thread-safe, since they contain complicated parsing logic which may be implemented as stateful operations depending on the particular provider used at runtime.

Modification:
Remove the singleton instance and just create a new `CertificateFactory` every time.
Creating these factories should not be the most expensive thing, regardless of provider used.

Made the `wrapped` field volatile to ensure visibility across threads, effectively obtaining safe publication for the `X509Certificate` object. This is important because `X509Certificate`, just like the `CertificateFactory`, may have any number of implementations at runtime and there are no guarantees about their thread-safety or immutability.

Made the test dig into the SANs and compare the data directly, instead of relying on the `Collection.equals` implementation, which could be anything, just like with the other objects above.

Result:
`LazyX509Certificate` is now thread-safe.

Should fix weird flaky test failures, such as:

```
[ERROR] Failures:
[ERROR]   LazyX509CertificateTest.testLazyX509Certificate:83 expected: java.util.Collections$UnmodifiableCollection@757bd65c<[[2, www.foo.com]]> but was: java.util.Collections$UnmodifiableCollection@2c32b649<[[2, www.foo.com]]>
```