### PR TITLE
Fix flaky RenegotiateTest

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/RenegotiateTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/RenegotiateTest.java
@@ -97,7 +97,7 @@ public abstract class RenegotiateTest {
                             });
                         }
                     });
-            Channel channel = sb.bind(new LocalAddress("RenegotiateTest")).syncUninterruptibly().channel();
+            Channel channel = sb.bind(new LocalAddress(getClass())).syncUninterruptibly().channel();
 
             final SslContext clientContext = SslContextBuilder.forClient()
                     .trustManager(InsecureTrustManagerFactory.INSTANCE)


### PR DESCRIPTION
Motivation:
The `OpenSslRenegotiateTest` and the `JdkSslRenegotiateTest` may run concurrently.

Modification:
Make sure they use different LocalAddresses, so the tests don't conflict with each other if they run at the same time.

Result:
Stable `RenegotiateTest`