### PR TITLE
Fix flaky AbstractSingleThreadEventLoopTest

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/AbstractSingleThreadEventLoopTest.java
@@ -373,14 +373,18 @@ public abstract class AbstractSingleThreadEventLoopTest {
             assertNotNull(suspendedLoop, "Could not find a suspended executor to test.");
 
             // Submit a task directly to the suspended loop, this should trigger the wake-up mechanism.
-            Future<?> future = suspendedLoop.submit(() -> { });
-            future.syncUninterruptibly();
+            int i = 0;
+            boolean isSuspended;
+            do {
+                Future<?> future = suspendedLoop.submit(() -> { });
+                future.sync();
+            } while ((isSuspended = suspendedLoop.isSuspended()) && i++ < 10);
 
-            assertFalse(suspendedLoop.isSuspended(), "Executor should wake up after task submission.");
+            assertFalse(isSuspended, "Executor should wake up after task submission.");
             assertEquals(SCALING_MAX_THREADS, countActiveExecutors(group),
                          "Active executor count should increase after wake-up.");
         } finally {
-            group.shutdownGracefully().syncUninterruptibly();
+            group.shutdownGracefully().sync();
         }
     }
 


### PR DESCRIPTION
Motivation:
The test has an inherent Time-Of-Check-Time-Of-Use data race with the utilization monitor. We expect that submitting a task to an event loop will wake it up if it has been suspended. Afterward we check that the event loop is no longer suspended. However, this races with the utilization monitor, which is trying to keep the event loop group down to some number of threads – it may choose to suspend some other event loop, or it may try to suspend the event loop we just woke up.

Modification:
Do the task submission and suspension check in a loop up to 10 times, greatly reducing the probability of this data race failing the test – we'd have to have an unlucky race 10 times in a row, which I suspect is astronomically unlikely.

Result:
More stable build.
