### PR TITLE
Fix HTTP/2 push frame test (#16343)

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2PushPromiseFrameTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2PushPromiseFrameTest.java
@@ -29,6 +29,7 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.util.CharsetUtil;
+import io.netty.util.NetUtil;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
 import org.junit.jupiter.api.AfterEach;
@@ -67,7 +68,7 @@ public class DefaultHttp2PushPromiseFrameTest {
                     }
                 });
 
-        Future<Channel> channelFuture = serverBootstrap.bind(0).sync();
+        Future<Channel> channelFuture = serverBootstrap.bind(NetUtil.LOCALHOST, 0).sync();
 
         final Bootstrap bootstrap = new Bootstrap()
                 .group(eventLoopGroup)


### PR DESCRIPTION
Motivation:
The test fails on macOS because the server gets bound to the "any" address, and then returns that as its local address, which is correct but not something the client can connect to directly.

Modification:
Make the server only bind to localhost, which clients _can_ connect to directly. This also prevents the test from temporarily exposing a port to the local network.

Result:
Test now passing on macOS.

(cherry picked from commit bb5f61bd4c0b4d58352a0a02da9da0805ff07a73)