### PR TITLE
Fix flaky RenegotiateTest (#16351)

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/RenegotiateTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/RenegotiateTest.java
@@ -99,7 +99,7 @@ public abstract class RenegotiateTest {
                             });
                         }
                     });
-            Channel channel = sb.bind(new LocalAddress("RenegotiateTest")).get();
+            Channel channel = sb.bind(new LocalAddress(getClass())).get();
 
             final SslContext clientContext = SslContextBuilder.forClient()
                     .trustManager(InsecureTrustManagerFactory.INSTANCE)


### PR DESCRIPTION
Motivation:
The `OpenSslRenegotiateTest` and the `JdkSslRenegotiateTest` may run concurrently.

Modification:
Make sure they use different LocalAddresses, so the tests don't conflict with each other if they run at the same time.

Result:
Stable `RenegotiateTest`

(cherry picked from commit 471de0d22db9538b1ed835117d86893d2fa689ca)