### PR TITLE
IoUring: Don't use RDHUP for non stream Channel implementations

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
@@ -435,8 +435,14 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
 
                 Future<Void> future = cc.writeAndFlush(
                         buf.retain().duplicate()).awaitUninterruptibly();
-                assertTrue(future.cause() instanceof NotYetConnectedException,
-                        "NotYetConnectedException expected, got: " + future.cause());
+                assertInstanceOf(NotYetConnectedException.class, future.cause());
+
+                // Connect again and try to write.
+                cc.connect(addr).sync();
+
+                Future<Void> f = write(cc, buf, wrapType);
+                cc.flush();
+                f.sync();
             }
         } finally {
             // release as we used buf.retain() before

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -145,6 +145,8 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         this.local = fd.localAddress();
     }
 
+    protected abstract boolean isStreamSocket();
+
     // Called once a Channel changed from AUTO_READ=true to AUTO_READ=false
     final void autoReadCleared() {
         if (!isRegistered()) {
@@ -850,8 +852,10 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
                 }
                 computeRemote();
 
-                // Register POLLRDHUP
-                schedulePollRdHup();
+                if (isStreamSocket()) {
+                    // Register POLLRDHUP
+                    schedulePollRdHup();
+                }
 
                 promise.setSuccess(null);
             } else {
@@ -972,7 +976,10 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
                 computeRemote();
 
                 // Register POLLRDHUP
-                schedulePollRdHup();
+                if (isStreamSocket()) {
+                    // Register POLLRDHUP
+                    schedulePollRdHup();
+                }
 
                 promise.setSuccess(null);
                 if (readPending) {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
@@ -126,6 +126,11 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
     }
 
     @Override
+    protected boolean isStreamSocket() {
+        return false;
+    }
+
+    @Override
     protected void doShutdown(ChannelShutdownType type, Promise<Void> promise) {
         promise.setFailure(new UnsupportedOperationException());
     }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringServerSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringServerSocketChannel.java
@@ -119,6 +119,11 @@ public final class IoUringServerSocketChannel extends AbstractIoUringChannel imp
     }
 
     @Override
+    protected boolean isStreamSocket() {
+        return true;
+    }
+
+    @Override
     protected void doShutdown(ChannelShutdownType type, Promise<Void> promise) {
         promise.setFailure(new UnsupportedOperationException());
     }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
@@ -91,6 +91,11 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
     }
 
     @Override
+    protected boolean isStreamSocket() {
+        return true;
+    }
+
+    @Override
     public ServerSocketChannel parent() {
         return (ServerSocketChannel) super.parent();
     }

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -127,6 +127,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             if (connectPromise != null) {
                 // Use tryFailure() instead of setFailure() to avoid the race against cancel().
                 connectPromise.tryFailure(new ClosedChannelException());
+                this.connectPromise = null;
             }
 
             Future<?> future = connectTimeoutFuture;
@@ -676,6 +677,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                 // Reset remoteAddress and localAddress
                 remoteAddress = null;
                 localAddress = null;
+                connectPromise = null;
                 if (wasActive && !isActive()) {
                     invokeLater(new Runnable() {
                         @Override


### PR DESCRIPTION
Motivation:

We did not have any testing that ensured that it is actually possible to connect a DatagramChannel again after it was disconnected.

Modifications:

- Fix IoUring to only register RDHUP for stream channels and so fix assert error
- Adjust testcase to cover this scenario

Result:

More complete testing of DatagramChannel implementations and fix for IoUring