### PR TITLE
SSL test: Don't depend on property value in test (#16346)

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -50,7 +50,6 @@ import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
-import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.conscrypt.OpenSSLProvider;
@@ -4499,11 +4498,9 @@ public abstract class SSLEngineTest {
          * The JDK SSL engine master key retrieval relies on being able to set field access to true.
          * That is not available in JDK9+
          */
-        assumeFalse(sslServerProvider() == SslProvider.JDK && PlatformDependent.javaVersion() > 8);
-
-        String originalSystemPropertyValue = SystemPropertyUtil.get(SslMasterKeyHandler.SYSTEM_PROP_KEY);
-        System.setProperty(SslMasterKeyHandler.SYSTEM_PROP_KEY, Boolean.TRUE.toString());
-
+        if (sslServerProvider() == SslProvider.JDK) {
+            assumeTrue(SslMasterKeyHandler.isSunSslEngineAvailable());
+        }
         SelfSignedCertificate ssc = CachedSelfSignedCertificate.getCachedCertificate();
         serverSslCtx = wrapContext(param, SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
                 .sslProvider(sslServerProvider())
@@ -4530,6 +4527,12 @@ public abstract class SSLEngineTest {
 
                     ch.pipeline().addLast(sslHandler);
                     ch.pipeline().addLast(new SslMasterKeyHandler() {
+
+                        @Override
+                        protected boolean masterKeyHandlerEnabled() {
+                            return true;
+                        }
+
                         @Override
                         protected void accept(SecretKey masterKey, SSLSession session) {
                             promise.setSuccess(masterKey);
@@ -4553,11 +4556,6 @@ public abstract class SSLEngineTest {
             assertEquals(48, key.getEncoded().length, "AES secret key must be 48 bytes");
         } finally {
             closeQuietly(socket);
-            if (originalSystemPropertyValue != null) {
-                System.setProperty(SslMasterKeyHandler.SYSTEM_PROP_KEY, originalSystemPropertyValue);
-            } else {
-                System.clearProperty(SslMasterKeyHandler.SYSTEM_PROP_KEY);
-            }
         }
     }
 


### PR DESCRIPTION
Motivation:

We should not depend on modify a system property in a test when running
tests concurrently as it might fail due races.

Modifications:

Just override the method in SslMasterKeyHandler and not depend on the
property at all.

Result:

Less flaky tests
