### PR TITLE
AdaptivePoolingAllocator: assign a more explicit value to BuddyChunk.freeListCapacity (#16334)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -1396,7 +1396,8 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
             freeListCapacity = delegate.capacity() / MIN_BUDDY_SIZE;
             int maxShift = Integer.numberOfTrailingZeros(freeListCapacity);
             assert maxShift <= 30; // The top 2 bits are used for marking.
-            freeList = new MpscAtomicIntegerArrayQueue(freeListCapacity, -1); // At most half of tree (all leaf nodes) can be freed.
+            // At most half of tree (all leaf nodes) can be freed.
+            freeList = new MpscAtomicIntegerArrayQueue(freeListCapacity, -1);
             buddies = new byte[freeListCapacity << 1];
 
             // Generate the buddies entries.

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -1393,14 +1393,11 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
 
         BuddyChunk(AbstractByteBuf delegate, Magazine magazine) {
             super(delegate, magazine);
-            int capacity = delegate.capacity();
-            int capFactor = capacity / MIN_BUDDY_SIZE;
-            int tree = (capFactor << 1) - 1;
-            int maxShift = Integer.numberOfTrailingZeros(capFactor);
+            freeListCapacity = delegate.capacity() / MIN_BUDDY_SIZE;
+            int maxShift = Integer.numberOfTrailingZeros(freeListCapacity);
             assert maxShift <= 30; // The top 2 bits are used for marking.
-            freeListCapacity = tree >> 1; // At most half of tree (all leaf nodes) can be freed.
-            freeList = new MpscAtomicIntegerArrayQueue(freeListCapacity, -1);
-            buddies = new byte[1 + tree];
+            freeList = new MpscAtomicIntegerArrayQueue(freeListCapacity, -1); // At most half of tree (all leaf nodes) can be freed.
+            buddies = new byte[freeListCapacity << 1];
 
             // Generate the buddies entries.
             int index = 1;


### PR DESCRIPTION
Motivation:

Currently, the value of `BuddyChunk.freeListCapacity` is less than the real max size of the `freeList`.
1. It may lead to the `freeList.drain(freeListCapacity, this)` can not drain all the elements at once.
2. When calling `MpscIntQueue.create(freeListCapacity, -1)`, we rely on `MpscIntQueue` implicitly calling
`MathUtil.safeFindNextPositivePowerOfTwo(freeListCapacity)` to set the proper max size. This makes the code less explicit.
3. Semantically, `freeListCapacity` should be equal to the value of `capFactor`, if I understand correctly.
4. In addition, use `freeListCapacity = capFactor` eliminates a bit-shift operation.

Modification:

Use `freeListCapacity = capFactor;` instead of `freeListCapacity = tree
>> 1;`.

Result:

More clean code.

---------

Co-authored-by: lao <none>
Co-authored-by: Chris Vest <christianvest_hansen@apple.com>

(cherry picked from commit b7ec449fe6b83e2603e92b5fc0d9be7c85141533)