### PR TITLE
Stabilize AbstractByteBufTest.testToStringMultipleThreads

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
@@ -20,6 +20,7 @@ import io.netty.util.ByteProcessor;
 import io.netty.util.CharsetUtil;
 import io.netty.util.IllegalReferenceCountException;
 import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.ThrowableUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -2293,7 +2294,7 @@ public abstract class AbstractByteBufTest {
     }
 
     @Test
-    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(30)
     public void testToStringMultipleThreads() throws Throwable {
         buffer.clear();
         buffer.writeBytes("Hello, World!".getBytes(CharsetUtil.ISO_8859_1));
@@ -2303,7 +2304,7 @@ public abstract class AbstractByteBufTest {
     static void testToStringMultipleThreads0(final ByteBuf buffer) throws Throwable {
         final String expected = buffer.toString(CharsetUtil.ISO_8859_1);
 
-        final AtomicInteger counter = new AtomicInteger(30000);
+        final CyclicBarrier startBarrier = new CyclicBarrier(10);
         final AtomicReference<Throwable> errorRef = new AtomicReference<Throwable>();
         List<Thread> threads = new ArrayList<Thread>();
         for (int i = 0; i < 10; i++) {
@@ -2311,11 +2312,15 @@ public abstract class AbstractByteBufTest {
                 @Override
                 public void run() {
                     try {
-                        while (errorRef.get() == null && counter.decrementAndGet() > 0) {
+                        startBarrier.await(10, TimeUnit.SECONDS);
+                        int counter = 3000;
+                        while (errorRef.get() == null && counter-- > 0) {
                             assertEquals(expected, buffer.toString(CharsetUtil.ISO_8859_1));
                         }
                     } catch (Throwable cause) {
-                        errorRef.compareAndSet(null, cause);
+                        if (!errorRef.compareAndSet(null, cause)) {
+                            ThrowableUtil.addSuppressed(errorRef.get(), cause);
+                        }
                     }
                 }
             });
@@ -2325,13 +2330,22 @@ public abstract class AbstractByteBufTest {
             thread.start();
         }
 
-        for (Thread thread : threads) {
-            thread.join();
-        }
+        try {
+            for (Thread thread : threads) {
+                thread.join();
+            }
 
-        Throwable error = errorRef.get();
-        if (error != null) {
-            throw error;
+            Throwable error = errorRef.get();
+            if (error != null) {
+                throw error;
+            }
+        } catch (Throwable e) {
+            for (Thread thread : threads) {
+                if (thread.isAlive()) {
+                    ThrowableUtil.interruptAndAttachAsyncStackTrace(thread, e);
+                }
+            }
+            throw e;
         }
     }
 

--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -20,6 +20,7 @@ import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.concurrent.FastThreadLocalThread;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SystemPropertyUtil;
+import io.netty.util.internal.ThrowableUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -534,7 +535,7 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
         try {
             cacheLatch.await();
         } catch (InterruptedException e) {
-            attachAsyncStackTrace(e, t);
+            ThrowableUtil.interruptAndAttachAsyncStackTrace(t, e);
             throw e;
         }
 
@@ -546,20 +547,11 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
                     task.get();
                     t.join();
                 } catch (InterruptedException e) {
-                    attachAsyncStackTrace(e, t);
+                    ThrowableUtil.interruptAndAttachAsyncStackTrace(t, e);
                     throw e;
                 }
             }
         };
-    }
-
-    private static void attachAsyncStackTrace(Exception e, Thread thread) {
-        StackTraceElement[] stackTrace = thread.getStackTrace();
-        InterruptedException asyncIE = new InterruptedException(
-                "Asynchronous interruption: " + thread);
-        thread.interrupt();
-        asyncIE.setStackTrace(stackTrace);
-        e.addSuppressed(asyncIE);
     }
 
     private interface ThreadCache {

--- a/common/src/main/java/io/netty/util/internal/ThrowableUtil.java
+++ b/common/src/main/java/io/netty/util/internal/ThrowableUtil.java
@@ -80,4 +80,19 @@ public final class ThrowableUtil {
     public static Throwable[] getSuppressed(Throwable source) {
         return source.getSuppressed();
     }
+
+    /**
+     * Capture the stack trace of the given thread, interrupt it, and attach the stack trace as a suppressed exception
+     * to the given cause.
+     * @param thread The thread to interrupt.
+     * @param cause The cause to attach a stack trace to.
+     */
+    public static void interruptAndAttachAsyncStackTrace(Thread thread, Throwable cause) {
+        StackTraceElement[] stackTrace = thread.getStackTrace();
+        InterruptedException asyncIE = new InterruptedException(
+                "Asynchronous interruption: " + thread);
+        thread.interrupt();
+        asyncIE.setStackTrace(stackTrace);
+        addSuppressed(cause, asyncIE);
+    }
 }


### PR DESCRIPTION
Motivation:
In busy CI environments these tests could time out and cause build breakages.

Modification:

- Add a barrier for the start of the worker threads.
- Increase the timeout to 30 seconds.
- Capture more stack trace information if the test fails in the future.

Result:
Tests should be more stable now.
