### PR TITLE
Fix riscv64 build for Netty 5

### DIFF
--- a/.github/workflows/ci-build-riscv64.yml
+++ b/.github/workflows/ci-build-riscv64.yml
@@ -65,7 +65,7 @@ jobs:
         id: runcmd
         with:
           arch: riscv64
-          distro: ubuntu20.04
+          distro: ubuntu24.04
 
           # Not required, but speeds up builds by storing container images in
           # a GitHub package registry.
@@ -78,11 +78,11 @@ jobs:
           # Install dependencies
           install: |
             apt-get update -q -y
-            apt-get install -q -y openjdk-11-jdk autoconf automake libtool make tar maven git
+            apt-get install -q -y openjdk-25-jdk autoconf automake libtool make tar maven git
 
           # Compile native code and the modules it depend on and run NativeLoadingTest. This is enough to ensure
           # we can load the native module on riscv64
           #
           # Use tcnative.classifier that is empty as we don't support using the shared lib version on ubuntu.
           run: |
-            JAVA_HOME=/usr/lib/jvm/java-11-openjdk-riscv64 ./mvnw -V -B -ntp -pl testsuite-native -am clean package -DskipTests=true -Dcheckstyle.skip=true -DskipNativeTestsuite=false -Dtcnative.classifier=
+            JAVA_HOME=/usr/lib/jvm/java-25-openjdk-riscv64 ./mvnw -V -B -ntp -pl testsuite-native -am clean package -DskipTests=true -Dcheckstyle.skip=true -DskipNativeTestsuite=false -Dtcnative.classifier=


### PR DESCRIPTION
Motivation:
The build failed because it was installing Java 11 but this branch needs Java 25 now.

Modification:
Update the ubuntu base image and install OpenJDK 25.

Result:
Build should now work again.
