### PR TITLE
chore: Make HTTP/2 frameType a short

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DecoratingHttp2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DecoratingHttp2FrameWriter.java
@@ -95,7 +95,7 @@ public class DecoratingHttp2FrameWriter implements Http2FrameWriter {
     }
 
     @Override
-    public void writeFrame(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags,
+    public void writeFrame(ChannelHandlerContext ctx, short frameType, int streamId, Http2Flags flags,
                            ByteBuf payload, Promise<Void> promise) {
         delegate.writeFrame(ctx, frameType, streamId, flags, payload, promise);
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -614,7 +614,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
         }
 
         @Override
-        public void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags,
+        public void onUnknownFrame(ChannelHandlerContext ctx, short frameType, int streamId, Http2Flags flags,
                 ByteBuf payload) throws Http2Exception {
             Http2Stream stream = connection.stream(streamId);
             if (stream == null) {
@@ -790,7 +790,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
         }
 
         @Override
-        public void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags,
+        public void onUnknownFrame(ChannelHandlerContext ctx, short frameType, int streamId, Http2Flags flags,
                 ByteBuf payload) throws Http2Exception {
             verifyPrefaceReceived();
             internalFrameListener.onUnknownFrame(ctx, frameType, streamId, flags, payload);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
@@ -382,7 +382,7 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder, Ht
     }
 
     @Override
-    public void writeFrame(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags,
+    public void writeFrame(ChannelHandlerContext ctx, short frameType, int streamId, Http2Flags flags,
                            ByteBuf payload, Promise<Void> promise) {
         frameWriter.writeFrame(ctx, frameType, streamId, flags, payload, promise);
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameReader.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameReader.java
@@ -66,7 +66,7 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
      * renders the connection unusable.
      */
     private boolean readError;
-    private byte frameType;
+    private short frameType;
     private int streamId;
     private Http2Flags flags;
     private int payloadLength;
@@ -197,7 +197,7 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
             throw connectionError(FRAME_SIZE_ERROR, "Frame length: %d exceeds maximum: %d", payloadLength,
                                   maxFrameSize);
         }
-        frameType = in.readByte();
+        frameType = in.readUnsignedByte();
         flags = new Http2Flags(in.readUnsignedByte());
         streamId = readUnsignedInt(in);
         readingHeaders = false;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
@@ -469,7 +469,7 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
     }
 
     @Override
-    public void writeFrame(ChannelHandlerContext ctx, byte frameType, int streamId,
+    public void writeFrame(ChannelHandlerContext ctx, short frameType, int streamId,
                            Http2Flags flags, ByteBuf payload, Promise<Void> promise) {
         SimpleChannelPromiseAggregator promiseAggregator =
                 new SimpleChannelPromiseAggregator(promise, ctx.channel(), ctx.executor());

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2UnknownFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2UnknownFrame.java
@@ -21,15 +21,15 @@ import io.netty.buffer.Unpooled;
 import io.netty.util.internal.StringUtil;
 
 public final class DefaultHttp2UnknownFrame extends DefaultByteBufHolder implements Http2UnknownFrame {
-    private final byte frameType;
+    private final short frameType;
     private final Http2Flags flags;
     private Http2FrameStream stream;
 
-    public DefaultHttp2UnknownFrame(byte frameType, Http2Flags flags) {
+    public DefaultHttp2UnknownFrame(short frameType, Http2Flags flags) {
         this(frameType, flags, Unpooled.EMPTY_BUFFER);
     }
 
-    public DefaultHttp2UnknownFrame(byte frameType, Http2Flags flags, ByteBuf data) {
+    public DefaultHttp2UnknownFrame(short frameType, Http2Flags flags, ByteBuf data) {
         super(data);
         this.frameType = frameType;
         this.flags = flags;
@@ -47,7 +47,7 @@ public final class DefaultHttp2UnknownFrame extends DefaultByteBufHolder impleme
     }
 
     @Override
-    public byte frameType() {
+    public short frameType() {
         return frameType;
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
@@ -207,7 +207,7 @@ public final class Http2CodecUtil {
     /**
      * Writes an HTTP/2 frame header to the output buffer.
      */
-    public static void writeFrameHeader(ByteBuf out, int payloadLength, byte type,
+    public static void writeFrameHeader(ByteBuf out, int payloadLength, short type,
             Http2Flags flags, int streamId) {
         out.ensureWritable(FRAME_HEADER_LENGTH + payloadLength);
         writeFrameHeaderInternal(out, payloadLength, type, flags, streamId);
@@ -246,8 +246,7 @@ public final class Http2CodecUtil {
                 "allowed size (%d)", maxHeaderListSize);
     }
 
-    static void writeFrameHeaderInternal(ByteBuf out, int payloadLength, byte type,
-            Http2Flags flags, int streamId) {
+    static void writeFrameHeaderInternal(ByteBuf out, int payloadLength, short type, Http2Flags flags, int streamId) {
         out.writeMedium(payloadLength);
         out.writeByte(type);
         out.writeByte(flags.value());

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionEncoder.java
@@ -60,6 +60,6 @@ public interface Http2ConnectionEncoder extends Http2FrameWriter {
      * state checks on the connection/stream.
      */
     @Override
-    void writeFrame(ChannelHandlerContext ctx, byte frameType, int streamId,
+    void writeFrame(ChannelHandlerContext ctx, short frameType, int streamId,
                             Http2Flags flags, ByteBuf payload, Promise<Void> promise);
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2EventAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2EventAdapter.java
@@ -79,7 +79,7 @@ public class Http2EventAdapter implements Http2Connection.Listener, Http2FrameLi
     }
 
     @Override
-    public void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags,
+    public void onUnknownFrame(ChannelHandlerContext ctx, short frameType, int streamId, Http2Flags flags,
             ByteBuf payload) throws Http2Exception {
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameAdapter.java
@@ -82,7 +82,7 @@ public class Http2FrameAdapter implements Http2FrameListener {
     }
 
     @Override
-    public void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags,
+    public void onUnknownFrame(ChannelHandlerContext ctx, short frameType, int streamId, Http2Flags flags,
             ByteBuf payload) {
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
@@ -586,8 +586,8 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
     private final class FrameListener implements Http2FrameListener {
 
         @Override
-        public void onUnknownFrame(
-                ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags, ByteBuf payload) {
+    public void onUnknownFrame(
+            ChannelHandlerContext ctx, short frameType, int streamId, Http2Flags flags, ByteBuf payload) {
             if (streamId == 0) {
                 // Ignore unknown frames on connection stream, for example: HTTP/2 GREASE testing
                 return;
@@ -722,7 +722,7 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
     /**
      * Create a Http2UnknownFrame. The ownership of the {@link ByteBuf} is transferred.
      * */
-    protected Http2StreamFrame newHttp2UnknownFrame(byte frameType, int streamId, Http2Flags flags, ByteBuf payload) {
+    protected Http2StreamFrame newHttp2UnknownFrame(short frameType, int streamId, Http2Flags flags, ByteBuf payload) {
         return new DefaultHttp2UnknownFrame(frameType, flags, payload);
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameListener.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameListener.java
@@ -213,6 +213,6 @@ public interface Http2FrameListener {
      * @param flags the flags in the frame header.
      * @param payload the payload of the frame.
      */
-    void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags, ByteBuf payload)
+    void onUnknownFrame(ChannelHandlerContext ctx, short frameType, int streamId, Http2Flags flags, ByteBuf payload)
             throws Http2Exception;
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameListenerDecorator.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameListenerDecorator.java
@@ -96,7 +96,7 @@ public class Http2FrameListenerDecorator implements Http2FrameListener {
     }
 
     @Override
-    public void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags,
+    public void onUnknownFrame(ChannelHandlerContext ctx, short frameType, int streamId, Http2Flags flags,
             ByteBuf payload) throws Http2Exception {
         listener.onUnknownFrame(ctx, frameType, streamId, flags, payload);
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameLogger.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameLogger.java
@@ -154,7 +154,7 @@ public class Http2FrameLogger implements ChannelInboundHandler, ChannelOutboundH
         }
     }
 
-    public void logUnknownFrame(Direction direction, ChannelHandlerContext ctx, byte frameType, int streamId,
+    public void logUnknownFrame(Direction direction, ChannelHandlerContext ctx, short frameType, int streamId,
             Http2Flags flags, ByteBuf data) {
         if (isEnabled()) {
             logger.log(level, "{} {} UNKNOWN: frameType={} streamId={} flags={} length={} bytes={}", ctx.channel(),

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameWriter.java
@@ -178,7 +178,7 @@ public interface Http2FrameWriter extends Http2DataWriter, Closeable {
      * @param payload   the payload to write for this frame. This will be released by this method.
      * @param promise   the promise for the write.
      */
-    void writeFrame(ChannelHandlerContext ctx, byte frameType, int streamId,
+    void writeFrame(ChannelHandlerContext ctx, short frameType, int streamId,
                     Http2Flags flags, ByteBuf payload, Promise<Void> promise);
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2InboundFrameLogger.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2InboundFrameLogger.java
@@ -125,7 +125,7 @@ public class Http2InboundFrameLogger implements Http2FrameReader {
             }
 
             @Override
-            public void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId,
+            public void onUnknownFrame(ChannelHandlerContext ctx, short frameType, int streamId,
                     Http2Flags flags, ByteBuf payload) throws Http2Exception {
                 logger.logUnknownFrame(INBOUND, ctx, frameType, streamId, flags, payload);
                 listener.onUnknownFrame(ctx, frameType, streamId, flags, payload);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2OutboundFrameLogger.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2OutboundFrameLogger.java
@@ -118,7 +118,7 @@ public class Http2OutboundFrameLogger implements Http2FrameWriter {
     }
 
     @Override
-    public void writeFrame(ChannelHandlerContext ctx, byte frameType, int streamId,
+    public void writeFrame(ChannelHandlerContext ctx, short frameType, int streamId,
                            Http2Flags flags, ByteBuf payload, Promise<Void> promise) {
         logger.logUnknownFrame(OUTBOUND, ctx, frameType, streamId, flags, payload);
         writer.writeFrame(ctx, frameType, streamId, flags, payload, promise);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2UnknownFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2UnknownFrame.java
@@ -26,7 +26,7 @@ public interface Http2UnknownFrame extends Http2StreamFrame, ByteBufHolder {
     @Override
     Http2UnknownFrame stream(Http2FrameStream stream);
 
-    byte frameType();
+    short frameType();
 
     Http2Flags flags();
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameReaderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameReaderTest.java
@@ -174,7 +174,7 @@ public class DefaultHttp2FrameReaderTest {
             frameReader.readFrame(ctx, input, listener);
 
             verify(listener).onUnknownFrame(
-                    ctx, (byte) 0xff, 0, new Http2Flags(), payload.slice(0, 1));
+                    ctx, (short) 0xff, 0, new Http2Flags(), payload.slice(0, 1));
         } finally {
             payload.release();
             input.release();

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriterTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriterTest.java
@@ -296,7 +296,7 @@ public class DefaultHttp2FrameWriterTest {
 
     @Test
     public void writeFrameZeroPayload() throws Exception {
-        frameWriter.writeFrame(ctx, (byte) 0xf, 0, new Http2Flags(), Unpooled.EMPTY_BUFFER, promise);
+        frameWriter.writeFrame(ctx, (short) 0xf, 0, new Http2Flags(), Unpooled.EMPTY_BUFFER, promise);
 
         byte[] expectedFrameBytes = {
                 (byte) 0x00, (byte) 0x00, (byte) 0x00, // payload length
@@ -315,7 +315,7 @@ public class DefaultHttp2FrameWriterTest {
 
         // will auto release after frameWriter.writeFrame succeed
         ByteBuf payloadByteBuf = Unpooled.wrappedBuffer(payload);
-        frameWriter.writeFrame(ctx, (byte) 0xf, 0, new Http2Flags(), payloadByteBuf, promise);
+        frameWriter.writeFrame(ctx, (short) 0xf, 0, new Http2Flags(), payloadByteBuf, promise);
 
         byte[] expectedFrameHeaderBytes = {
                 (byte) 0x00, (byte) 0x00, (byte) 0x05, // payload length

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2DefaultFramesTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2DefaultFramesTest.java
@@ -29,7 +29,7 @@ public class Http2DefaultFramesTest {
         // in this case, 'goAwayFrame' and 'unknownFrame' will also have an EMPTY_BUFFER data
         // so we want to check that 'dflt' will not consider them equal.
         DefaultHttp2GoAwayFrame goAwayFrame = new DefaultHttp2GoAwayFrame(1);
-        DefaultHttp2UnknownFrame unknownFrame = new DefaultHttp2UnknownFrame((byte) 1, new Http2Flags((short) 1));
+        DefaultHttp2UnknownFrame unknownFrame = new DefaultHttp2UnknownFrame((short) 1, new Http2Flags((short) 1));
         DefaultByteBufHolder dflt = new DefaultByteBufHolder(Unpooled.EMPTY_BUFFER);
         try {
             // not using 'assertNotEquals' to be explicit about which object we are calling .equals() on

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
@@ -242,7 +242,7 @@ public class Http2FrameCodecTest {
         Http2ConnectionDecoder dec = new DefaultHttp2ConnectionDecoder(conn, enc, new DefaultHttp2FrameReader());
         new Http2FrameCodec(enc, dec, new Http2Settings(), false, true) {
             @Override
-            protected Http2StreamFrame newHttp2UnknownFrame(byte frameType,
+            protected Http2StreamFrame newHttp2UnknownFrame(short frameType,
                                                       int streamId,
                                                       Http2Flags flags,
                                                       ByteBuf payload) {
@@ -405,7 +405,7 @@ public class Http2FrameCodecTest {
         // handle the case where unknown frames are sent before a stream is created,
         // for example: HTTP/2 GREASE testing
         ByteBuf debugData = bb("debug");
-        frameInboundWriter.writeInboundFrame((byte) 0xb, 0, new Http2Flags(), debugData);
+        frameInboundWriter.writeInboundFrame((short) 0xb, 0, new Http2Flags(), debugData);
         channel.flush();
 
         assertEquals(0, debugData.refCnt());
@@ -415,7 +415,7 @@ public class Http2FrameCodecTest {
     @Test
     public void unknownFrameOnMissingStream() throws Exception {
         ByteBuf debugData = bb("debug");
-        frameInboundWriter.writeInboundFrame((byte) 0xb, 101, new Http2Flags(), debugData);
+        frameInboundWriter.writeInboundFrame((short) 0xb, 101, new Http2Flags(), debugData);
         channel.flush();
 
         assertEquals(0, debugData.refCnt());
@@ -450,7 +450,7 @@ public class Http2FrameCodecTest {
         frameInboundWriter.writeInboundSettings(new Http2Settings());
 
         ByteBuf debugData = bb("debug");
-        frameInboundWriter.writeInboundFrame((byte) 0xb, 101, new Http2Flags(), debugData);
+        frameInboundWriter.writeInboundFrame((short) 0xb, 101, new Http2Flags(), debugData);
 
         channel.pipeline().remove("combine");
         channel.flushInbound();
@@ -632,8 +632,8 @@ public class Http2FrameCodecTest {
         final Http2FrameStream stream = frameCodec.newStream();
 
         ByteBuf buffer = Unpooled.buffer().writeByte(1);
-        DefaultHttp2UnknownFrame unknownFrame = new DefaultHttp2UnknownFrame(
-                (byte) 20, new Http2Flags().ack(true), buffer);
+    DefaultHttp2UnknownFrame unknownFrame = new DefaultHttp2UnknownFrame(
+            (short) 20, new Http2Flags().ack(true), buffer);
         unknownFrame.stream(stream);
         channel.write(unknownFrame);
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameInboundWriter.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameInboundWriter.java
@@ -122,8 +122,7 @@ final class Http2FrameInboundWriter {
         promise.syncUninterruptibly();
     }
 
-    void writeInboundFrame(byte frameType, int streamId,
-                             Http2Flags flags, ByteBuf payload) {
+    void writeInboundFrame(short frameType, int streamId, Http2Flags flags, ByteBuf payload) {
         Promise<Void> promise = ctx.newPromise();
         writer.writeFrame(ctx, frameType, streamId, flags, payload, promise);
         promise.syncUninterruptibly();

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexTest.java
@@ -162,7 +162,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
             @Override
             public void channelActive(ChannelHandlerContext ctx) {
                 ctx.writeAndFlush(new DefaultHttp2HeadersFrame(new DefaultHttp2Headers()));
-                ctx.writeAndFlush(new DefaultHttp2UnknownFrame((byte) 99, new Http2Flags()));
+                ctx.writeAndFlush(new DefaultHttp2UnknownFrame((short) 99, new Http2Flags()));
                 ctx.fireChannelActive();
             }
         });
@@ -170,7 +170,7 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
 
         parentChannel.runPendingTasks();
 
-        verify(frameWriter).writeFrame(eq(codec.ctx), eq((byte) 99), eqStreamId(childChannel), any(Http2Flags.class),
+        verify(frameWriter).writeFrame(eq(codec.ctx), eq((short) 99), eqStreamId(childChannel), any(Http2Flags.class),
                 any(ByteBuf.class), any(Promise.class));
     }
 
@@ -204,7 +204,8 @@ public abstract class Http2MultiplexTest<C extends Http2FrameCodec> {
         LastInboundHandler handler = new LastInboundHandler();
 
         Http2StreamChannel channel = newInboundStream(3, true, handler);
-        frameInboundWriter.writeInboundFrame((byte) 99, channel.stream().id(), new Http2Flags(), Unpooled.EMPTY_BUFFER);
+        frameInboundWriter.writeInboundFrame((short) 99, channel.stream().id(), new Http2Flags(),
+            Unpooled.EMPTY_BUFFER);
 
         // header frame and unknown frame
         verifyFramesMultiplexedToCorrectChannel(channel, handler, 2);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
@@ -271,7 +271,7 @@ public final class Http2TestUtil {
         }
 
         @Override
-        public void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags,
+        public void onUnknownFrame(ChannelHandlerContext ctx, short frameType, int streamId, Http2Flags flags,
                 ByteBuf payload) throws Http2Exception {
             listener.onUnknownFrame(ctx, frameType, streamId, flags, payload);
             messageLatch.countDown();

--- a/example/src/main/java/io/netty/example/http2/helloworld/server/HelloWorldHttp2Handler.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/server/HelloWorldHttp2Handler.java
@@ -160,7 +160,7 @@ public final class HelloWorldHttp2Handler extends Http2ConnectionHandler impleme
     }
 
     @Override
-    public void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId,
+    public void onUnknownFrame(ChannelHandlerContext ctx, short frameType, int streamId,
                                Http2Flags flags, ByteBuf payload) {
     }
 }

--- a/testsuite-http2/src/main/java/io/netty/testsuite/http2/HelloWorldHttp2Handler.java
+++ b/testsuite-http2/src/main/java/io/netty/testsuite/http2/HelloWorldHttp2Handler.java
@@ -160,7 +160,7 @@ public final class HelloWorldHttp2Handler extends Http2ConnectionHandler impleme
     }
 
     @Override
-    public void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId,
+    public void onUnknownFrame(ChannelHandlerContext ctx, short frameType, int streamId,
                                Http2Flags flags, ByteBuf payload) {
     }
 }


### PR DESCRIPTION
Motivation:

refs: https://github.com/netty/netty/issues/14721

Modification:

Change frametype from byte to short
Result:

Fixes: https://github.com/netty/netty/issues/14721

was: https://github.com/netty/netty/pull/14796