### PR TITLE
Remove duplicated contains calls in WebSockets

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13.java
@@ -142,8 +142,7 @@ public class WebSocketServerHandshaker13 extends WebSocketServerHandshaker {
         }
 
         HttpHeaders reqHeaders = req.headers();
-        if (!reqHeaders.contains(HttpHeaderNames.CONNECTION) ||
-            !reqHeaders.containsValue(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE, true)) {
+        if (!reqHeaders.containsValue(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE, true)) {
             throw new WebSocketServerHandshakeException(
                     "not a WebSocket request: a |Connection| header must includes a token 'Upgrade'", req);
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketExtensionUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketExtensionUtil.java
@@ -39,21 +39,20 @@ public final class WebSocketExtensionUtil {
     static boolean isWebsocketUpgrade(HttpHeaders headers) {
         //this contains check does not allocate an iterator, and most requests are not upgrades
         //so we do the contains check first before checking for specific values
-        return headers.contains(HttpHeaderNames.UPGRADE) &&
-                headers.containsValue(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE, true) &&
-                headers.contains(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET, true);
+        return headers.contains(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET, true) &&
+               headers.containsValue(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE, true);
     }
 
     public static List<WebSocketExtensionData> extractExtensions(String extensionHeader) {
         String[] rawExtensions = extensionHeader.split(EXTENSION_SEPARATOR);
         if (rawExtensions.length > 0) {
-            List<WebSocketExtensionData> extensions = new ArrayList<WebSocketExtensionData>(rawExtensions.length);
+            List<WebSocketExtensionData> extensions = new ArrayList<>(rawExtensions.length);
             for (String rawExtension : rawExtensions) {
                 String[] extensionParameters = rawExtension.split(PARAMETER_SEPARATOR);
                 String name = extensionParameters[0].trim();
                 Map<String, String> parameters;
                 if (extensionParameters.length > 1) {
-                    parameters = new LinkedHashMap<String, String>(extensionParameters.length - 1);
+                    parameters = new LinkedHashMap<>(extensionParameters.length - 1);
                     for (int i = 1; i < extensionParameters.length; i++) {
                         String parameter = extensionParameters[i].trim();
                         Matcher parameterMatcher = PARAMETER.matcher(parameter);
@@ -93,7 +92,7 @@ public final class WebSocketExtensionUtil {
                 extraExtensions.add(userDefined);
             } else {
                 // merge with higher precedence to user defined parameters
-                Map<String, String> mergedParameters = new LinkedHashMap<String, String>(matchingExtra.parameters());
+                Map<String, String> mergedParameters = new LinkedHashMap<>(matchingExtra.parameters());
                 mergedParameters.putAll(userDefined.parameters());
                 extraExtensions.set(i, new WebSocketExtensionData(matchingExtra.name(), mergedParameters));
             }

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -1447,8 +1447,8 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
     private void rejectRemoteInitiatedRenegotiation() throws SSLHandshakeException {
         // Avoid NPE: SSL.getHandshakeCount(ssl) must not be called if destroyed.
         // TLS 1.3 forbids renegotiation by spec.
-        if (destroyed || SslProtocols.TLS_v1_3.equals(session.getProtocol())
-                || handshakeState != HandshakeState.FINISHED) {
+        if (destroyed || handshakeState != HandshakeState.FINISHED
+                || SslProtocols.TLS_v1_3.equals(session.getProtocol())) {
             return;
         }
 

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -1447,8 +1447,8 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
     private void rejectRemoteInitiatedRenegotiation() throws SSLHandshakeException {
         // Avoid NPE: SSL.getHandshakeCount(ssl) must not be called if destroyed.
         // TLS 1.3 forbids renegotiation by spec.
-        if (destroyed || handshakeState != HandshakeState.FINISHED
-                || SslProtocols.TLS_v1_3.equals(session.getProtocol())) {
+        if (destroyed || SslProtocols.TLS_v1_3.equals(session.getProtocol())
+                || handshakeState != HandshakeState.FINISHED) {
             return;
         }
 


### PR DESCRIPTION
Motivation:

As of today, `DefaultHttpHeaders.containsValue` and `DefaultHttpHeaders.contains` no longer allocate an iterator, so we can remove duplicated `contains()` calls, which were added to avoid iterator allocation.

Modification:

Removed unnecessary `DefaultHttpHeaders.contains` calls in Websockets.

Result:

Fewer unnecessary calls.
