### PR TITLE
Swap conditions to avoid native calls in ReferenceCountedOpenSslEngine.rejectRemoteInitiatedRenegotiation

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -1447,8 +1447,8 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
     private void rejectRemoteInitiatedRenegotiation() throws SSLHandshakeException {
         // Avoid NPE: SSL.getHandshakeCount(ssl) must not be called if destroyed.
         // TLS 1.3 forbids renegotiation by spec.
-        if (destroyed || SslProtocols.TLS_v1_3.equals(session.getProtocol())
-                || handshakeState != HandshakeState.FINISHED) {
+        if (destroyed || handshakeState != HandshakeState.FINISHED
+                || SslProtocols.TLS_v1_3.equals(session.getProtocol())) {
             return;
         }
 


### PR DESCRIPTION
Motivation:

When ssl handshake is not yet done, the `protocol` field is not set, and thus a native call is made within a sync block of `DefaultOpenSslSession.getProtocol()` method. It could often be avoided as `handshakeState != HandshakeState.FINISHED` returns true.

<img width="586" height="225" alt="image" src="https://github.com/user-attachments/assets/4feac474-29ea-478d-9b4e-b4012641c594" />

Modification:

Swap conditions in ReferenceCountedOpenSslEngine.rejectRemoteInitiatedRenegotiation

Result:

One native call less in some flows.
