### PR TITLE
HTTP2: Pass the correct number of arguments when logging goaway

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -922,7 +922,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
                     if (logger.isDebugEnabled()) {
                         logger.debug("{} Sent GOAWAY: lastStreamId '{}', errorCode '{}', " +
                                      "debugData '{}'. Forcing shutdown of the connection.",
-                                     ctx.channel(), lastStreamId, errorCode, debugData.toString(UTF_8), future.cause());
+                                     ctx.channel(), lastStreamId, errorCode, debugData.toString(UTF_8));
                     }
                     ctx.close();
                 }


### PR DESCRIPTION
Motivation:

We did not use the correct number of arguments as future.cause() is null.

Modifications:

Remove future.cause() as argument

Result:

Fixes https://github.com/netty/netty/issues/16391