### PR TITLE
LocalChannel: Remove dependency on SingleThreadEventExecutor

### DIFF
--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -521,13 +521,18 @@ public class LocalChannel extends AbstractChannel {
                     }
                 });
             }
-            ((SingleThreadEventExecutor) eventLoop()).addShutdownHook(shutdownHook);
+            EventLoop loop = eventLoop();
+            if (!(loop instanceof IoEventLoop) && loop instanceof SingleThreadEventExecutor) {
+                ((SingleThreadEventExecutor) eventLoop()).addShutdownHook(shutdownHook);
+            }
         }
 
         @Override
         public void unregistered() {
-            // Just remove the shutdownHook as this Channel may be closed later or registered to another EventLoop
-            ((SingleThreadEventExecutor) eventLoop()).removeShutdownHook(shutdownHook);
+            EventLoop loop = eventLoop();
+            if (!(loop instanceof IoEventLoop) && loop instanceof SingleThreadEventExecutor) {
+                ((SingleThreadEventExecutor) eventLoop()).removeShutdownHook(shutdownHook);
+            }
         }
 
         @Override

--- a/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
@@ -89,7 +89,7 @@ public class LocalServerChannel extends AbstractServerChannel {
     @Override
     protected boolean isCompatible(EventLoop loop) {
         return loop instanceof SingleThreadEventLoop ||
-                (loop instanceof IoEventLoopGroup && ((IoEventLoopGroup) loop).isCompatible(LocalServerUnsafe.class));
+                (loop instanceof IoEventLoop && ((IoEventLoop) loop).isCompatible(LocalServerUnsafe.class));
     }
 
     @Override
@@ -238,12 +238,18 @@ public class LocalServerChannel extends AbstractServerChannel {
 
         @Override
         public void registered() {
-            ((SingleThreadEventExecutor) eventLoop()).addShutdownHook(shutdownHook);
+            EventLoop loop = eventLoop();
+            if (!(loop instanceof IoEventLoop) && loop instanceof SingleThreadEventExecutor) {
+                ((SingleThreadEventExecutor) eventLoop()).addShutdownHook(shutdownHook);
+            }
         }
 
         @Override
         public void unregistered() {
-            ((SingleThreadEventExecutor) eventLoop()).removeShutdownHook(shutdownHook);
+            EventLoop loop = eventLoop();
+            if (!(loop instanceof IoEventLoop) && loop instanceof SingleThreadEventExecutor) {
+                ((SingleThreadEventExecutor) eventLoop()).removeShutdownHook(shutdownHook);
+            }
         }
 
         @Override


### PR DESCRIPTION
Motivation:

LocalChannel had a hard dependency on SingleThreadEventExecutor which is not needed if an IoEventLoop is used.

Modifications:

Remove hard dependency

Result:

LocalChannels can be used with all IoEventLoop implementations
