### PR TITLE
Remove unnecessary protobuf imports

### DIFF
--- a/codec-protobuf/src/main/java/io/netty/handler/codec/protobuf/ProtobufDecoder.java
+++ b/codec-protobuf/src/main/java/io/netty/handler/codec/protobuf/ProtobufDecoder.java
@@ -15,7 +15,6 @@
  */
 package io.netty.handler.codec.protobuf;
 
-import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.ExtensionRegistryLite;
 import com.google.protobuf.Message;
 import com.google.protobuf.MessageLite;
@@ -89,10 +88,6 @@ public class ProtobufDecoder extends MessageToMessageDecoder<ByteBuf> {
      */
     public ProtobufDecoder(MessageLite prototype) {
         this(prototype, null);
-    }
-
-    public ProtobufDecoder(MessageLite prototype, ExtensionRegistry extensionRegistry) {
-        this(prototype, (ExtensionRegistryLite) extensionRegistry);
     }
 
     public ProtobufDecoder(MessageLite prototype, ExtensionRegistryLite extensionRegistry) {

--- a/codec-protobuf/src/main/java/io/netty/handler/codec/protobuf/ProtobufEncoder.java
+++ b/codec-protobuf/src/main/java/io/netty/handler/codec/protobuf/ProtobufEncoder.java
@@ -15,7 +15,6 @@
  */
 package io.netty.handler.codec.protobuf;
 
-import com.google.protobuf.Message;
 import com.google.protobuf.MessageLite;
 import com.google.protobuf.MessageLiteOrBuilder;
 import io.netty.buffer.ByteBuf;


### PR DESCRIPTION
ExternalRegistry extends ExternalRegistryLite so that overload is unnecessary.

Motivation:

Remove unnecessary imports on protobuf, since protobuf-lite support has been added. This change should allow clients using only protobuf-lite without the full protobuf dependency.
