### PR TITLE
Update some dependencies (#16198) (#16215)

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/UnpooledTest.java
+++ b/buffer/src/test/java/io/netty/buffer/UnpooledTest.java
@@ -476,7 +476,7 @@ public class UnpooledTest {
         } catch (UnsupportedOperationException e) {
             // Expected
         }
-        Mockito.verifyZeroInteractions(inputStream);
+        Mockito.verifyNoInteractions(inputStream);
 
         ScatteringByteChannel scatteringByteChannel = Mockito.mock(ScatteringByteChannel.class);
         try {
@@ -485,7 +485,7 @@ public class UnpooledTest {
         } catch (UnsupportedOperationException e) {
             // Expected
         }
-        Mockito.verifyZeroInteractions(scatteringByteChannel);
+        Mockito.verifyNoInteractions(scatteringByteChannel);
         buf.release();
     }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyFrameDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyFrameDecoderTest.java
@@ -31,7 +31,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 public class SpdyFrameDecoderTest {
 
@@ -841,7 +841,7 @@ public class SpdyFrameDecoderTest {
         buf.writeLong(RANDOM.nextLong());
 
         decoder.decode(buf);
-        verifyZeroInteractions(delegate);
+        verifyNoInteractions(delegate);
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -856,7 +856,7 @@ public class SpdyFrameDecoderTest {
         encodeControlFrameHeader(buf, type, flags, length);
 
         decoder.decode(buf);
-        verifyZeroInteractions(delegate);
+        verifyNoInteractions(delegate);
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -878,7 +878,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(header);
         decoder.decode(segment1);
         decoder.decode(segment2);
-        verifyZeroInteractions(delegate);
+        verifyNoInteractions(delegate);
         assertFalse(header.isReadable());
         assertFalse(segment1.isReadable());
         assertFalse(segment2.isReadable());

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
@@ -55,7 +55,7 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -146,7 +146,7 @@ public abstract class DefaultHttp2RemoteFlowControllerTest {
         assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_B));
         assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_C));
         assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_D));
-        verifyZeroInteractions(listener);
+        verifyNoInteractions(listener);
     }
 
     @Test
@@ -157,7 +157,7 @@ public abstract class DefaultHttp2RemoteFlowControllerTest {
         assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_B));
         assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_C));
         assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_D));
-        verifyZeroInteractions(listener);
+        verifyNoInteractions(listener);
     }
 
     @Test
@@ -165,10 +165,10 @@ public abstract class DefaultHttp2RemoteFlowControllerTest {
         FakeFlowControlled data = new FakeFlowControlled(5);
         sendData(STREAM_A, data);
         data.assertNotWritten();
-        verifyZeroInteractions(listener);
+        verifyNoInteractions(listener);
         controller.writePendingBytes();
         data.assertFullyWritten();
-        verifyZeroInteractions(listener);
+        verifyNoInteractions(listener);
     }
 
     @Test
@@ -178,7 +178,7 @@ public abstract class DefaultHttp2RemoteFlowControllerTest {
         data.assertNotWritten();
         controller.writePendingBytes();
         data.assertFullyWritten();
-        verifyZeroInteractions(listener);
+        verifyNoInteractions(listener);
     }
 
     @Test
@@ -244,7 +244,7 @@ public abstract class DefaultHttp2RemoteFlowControllerTest {
         sendData(STREAM_A, moreData);
         controller.writePendingBytes();
         moreData.assertNotWritten();
-        verifyZeroInteractions(listener);
+        verifyNoInteractions(listener);
     }
 
     @Test
@@ -266,7 +266,7 @@ public abstract class DefaultHttp2RemoteFlowControllerTest {
         connection.stream(STREAM_A).close();
         data.assertError(Http2Error.STREAM_CLOSED);
         moreData.assertError(Http2Error.STREAM_CLOSED);
-        verifyZeroInteractions(listener);
+        verifyNoInteractions(listener);
     }
 
     @Test
@@ -754,7 +754,7 @@ public abstract class DefaultHttp2RemoteFlowControllerTest {
         verify(flowControlled, never()).writeComplete();
 
         assertEquals(90, windowBefore - window(STREAM_A));
-        verifyZeroInteractions(listener);
+        verifyNoInteractions(listener);
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -74,7 +74,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -706,7 +706,7 @@ public class Http2ConnectionHandlerTest {
         handler = newHandler();
         when(channel.isActive()).thenReturn(true);
         handler.close(ctx, CompletionHandler.ignore());
-        verifyZeroInteractions(frameWriter);
+        verifyNoInteractions(frameWriter);
     }
 
     @Test

--- a/handler/src/test/java/io/netty/handler/ssl/OptionalSslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OptionalSslHandlerTest.java
@@ -28,7 +28,7 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 public class OptionalSslHandlerTest {
@@ -115,7 +115,7 @@ public class OptionalSslHandlerTest {
         final ByteBuf payload = Unpooled.wrappedBuffer(new byte[] { 22, 3 });
         try {
             handler.decode(context, payload, null);
-            verifyZeroInteractions(pipeline);
+            verifyNoInteractions(pipeline);
         } finally {
             payload.release();
         }

--- a/pom.xml
+++ b/pom.xml
@@ -462,7 +462,7 @@
     <jni.classifier>${os.detected.name}-${os.detected.arch}</jni.classifier>
     <logging.config>${project.basedir}/../common/src/test/resources/logback-test.xml</logging.config>
     <logging.logLevel>warn</logging.logLevel>
-    <log4j2.version>2.23.1</log4j2.version>
+    <log4j2.version>2.25.3</log4j2.version>
     <enforcer.plugin.version>3.0.0</enforcer.plugin.version>
     <junit.version>5.12.1</junit.version>
     <skipTests>false</skipTests>
@@ -817,13 +817,13 @@
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
-        <version>3.18.0</version>
+        <version>3.27.7</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>3.6.28</version>
+        <version>4.11.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -857,7 +857,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
-        <version>1.26.0</version>
+        <version>1.28.0</version>
         <scope>test</scope>
       </dependency>
 
@@ -865,7 +865,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.14.0</version>
+        <version>2.20.0</version>
         <scope>test</scope>
       </dependency>
 


### PR DESCRIPTION
Motivation:
Some of our test dependencies are outdated and have vulnerabilities.

Modification:
Update some of our test/optional dependencies to newer but compatible versions.

Result:
More up to date dependencies.

Co-authored-by: Chris Vest <christianvest_hansen@apple.com>

(cherry picked from commit b91804287e0e06e8ca9da5e508f0490f9b7e4ad9)

Forward port of https://github.com/netty/netty/pull/16215