### PR TITLE
Fix autoport fetching into the existing branch

### DIFF
--- a/.github/workflows/autoport-41.yml
+++ b/.github/workflows/autoport-41.yml
@@ -36,7 +36,9 @@ jobs:
           echo "Auto-porting commit: $MERGE_COMMIT"
           
           PORT_BRANCH="auto-port-pr-${{ github.event.pull_request.number }}-to-4.1"
-          git fetch origin 4.1:4.1
+          if $(git branch --show-current) != '4.1'; then
+            git fetch origin 4.1:4.1
+          fi
           git checkout -b "$PORT_BRANCH" 4.1
           
           if git cherry-pick -x "$MERGE_COMMIT"; then

--- a/.github/workflows/autoport-42.yml
+++ b/.github/workflows/autoport-42.yml
@@ -36,7 +36,9 @@ jobs:
           echo "Auto-porting commit: $MERGE_COMMIT"
           
           PORT_BRANCH="auto-port-pr-${{ github.event.pull_request.number }}-to-4.2"
-          git fetch origin 4.2:4.2
+          if $(git branch --show-current) != '4.2'; then
+            git fetch origin 4.2:4.2
+          fi
           git checkout -b "$PORT_BRANCH" 4.2
           
           if git cherry-pick -x "$MERGE_COMMIT"; then

--- a/.github/workflows/autoport-50.yml
+++ b/.github/workflows/autoport-50.yml
@@ -36,7 +36,9 @@ jobs:
           echo "Auto-porting commit: $MERGE_COMMIT"
           
           PORT_BRANCH="auto-port-pr-${{ github.event.pull_request.number }}-to-5.0"
-          git fetch origin 5.0:5.0
+          if $(git branch --show-current) != '5.0'; then
+            git fetch origin 5.0:5.0
+          fi
           git checkout -b "$PORT_BRANCH" 5.0
           
           if git cherry-pick -x "$MERGE_COMMIT"; then


### PR DESCRIPTION
Motivation:
There's no need to specifically fetch and create the target port branch if that is already the default branch of the checkout. Doing so will just make the fetch fail.

Modification:
Only fetch the target branch if it is different from the current branch.

Result:
We can now autoport into the default branch.