### PR TITLE
Capture why threads get stuck in testCopyMultipleThreads0

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
@@ -2330,6 +2330,11 @@ public abstract class AbstractByteBufTest {
             thread.start();
         }
 
+        joinAllAndReportErrors(threads, errorRef);
+    }
+
+    private static void joinAllAndReportErrors(List<Thread> threads, AtomicReference<Throwable> errorRef)
+            throws Throwable {
         try {
             for (Thread thread : threads) {
                 thread.join();
@@ -2362,7 +2367,7 @@ public abstract class AbstractByteBufTest {
     static void testCopyMultipleThreads0(final ByteBuf buffer) throws Throwable {
         final ByteBuf expected = buffer.copy();
         try {
-            final AtomicInteger counter = new AtomicInteger(30000);
+            final CyclicBarrier startBarrier = new CyclicBarrier(10);
             final AtomicReference<Throwable> errorRef = new AtomicReference<Throwable>();
             List<Thread> threads = new ArrayList<Thread>();
             for (int i = 0; i < 10; i++) {
@@ -2370,7 +2375,9 @@ public abstract class AbstractByteBufTest {
                     @Override
                     public void run() {
                         try {
-                            while (errorRef.get() == null && counter.decrementAndGet() > 0) {
+                            startBarrier.await(10, TimeUnit.SECONDS);
+                            int counter = 3000;
+                            while (errorRef.get() == null && counter-- > 0) {
                                 ByteBuf copy = buffer.copy();
                                 try {
                                     assertEquals(expected, copy);
@@ -2389,14 +2396,7 @@ public abstract class AbstractByteBufTest {
                 thread.start();
             }
 
-            for (Thread thread : threads) {
-                thread.join();
-            }
-
-            Throwable error = errorRef.get();
-            if (error != null) {
-                throw error;
-            }
+            joinAllAndReportErrors(threads, errorRef);
         } finally {
             expected.release();
         }


### PR DESCRIPTION
Motivation:
We often see timeouts of this test in CI.

Modification:
Apply a similar change to this test, to what we did to `testToStringMultipleThreads` in https://github.com/netty/netty/pull/16380

Result:
If it fails again we'll know what the worker threads are doing.
