### PR TITLE
LocalChannel: Remove dependency on SingleThreadEventExecutor (#16393)

### DIFF
--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -32,7 +32,6 @@ import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.CompletionHandler;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
-import io.netty.util.concurrent.SingleThreadEventExecutor;
 import io.netty.util.internal.InternalThreadLocalMap;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.logging.InternalLogger;
@@ -462,12 +461,6 @@ public class LocalChannel extends AbstractChannel {
     }
 
     private final class LocalIoHandleImpl implements LocalIoHandle {
-        private final Runnable shutdownHook = new Runnable() {
-            @Override
-            public void run() {
-                closeNow();
-            }
-        };
 
         @Override
         public void close() {
@@ -509,13 +502,6 @@ public class LocalChannel extends AbstractChannel {
                     }
                 });
             }
-            ((SingleThreadEventExecutor) executor()).addShutdownHook(shutdownHook);
-        }
-
-        @Override
-        public void unregistered() {
-            // Just remove the shutdownHook as this Channel may be closed later or registered to another EventLoop
-            ((SingleThreadEventExecutor) executor()).removeShutdownHook(shutdownHook);
         }
 
         @Override

--- a/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
@@ -30,7 +30,6 @@ import io.netty.channel.ServerChannel;
 import io.netty.channel.ServerChannelRecvByteBufAllocator;
 import io.netty.util.concurrent.CompletionHandler;
 import io.netty.util.concurrent.Promise;
-import io.netty.util.concurrent.SingleThreadEventExecutor;
 
 import java.net.SocketAddress;
 import java.util.ArrayDeque;
@@ -220,16 +219,6 @@ public class LocalServerChannel extends AbstractServerChannel {
         @Override
         public void handle(IoRegistration registration, IoEvent event) {
             // NOOP
-        }
-
-        @Override
-        public void registered() {
-            ((SingleThreadEventExecutor) executor()).addShutdownHook(shutdownHook);
-        }
-
-        @Override
-        public void unregistered() {
-            ((SingleThreadEventExecutor) executor()).removeShutdownHook(shutdownHook);
         }
 
         @Override


### PR DESCRIPTION
Motivation:

LocalChannel had a hard dependency on SingleThreadEventExecutor which is not needed if an IoEventLoop is used.

Modifications:

Remove hard dependency

Result:

LocalChannels can be used with all IoEventLoop implementations