### PR TITLE
Local transport: shutdown hook should call closeNow to be conistent with what LocalIoHandler will call

### DIFF
--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -74,13 +74,6 @@ public class LocalChannel extends AbstractChannel {
         }
     };
 
-    private final Runnable shutdownHook = new Runnable() {
-        @Override
-        public void run() {
-            unsafe().close(unsafe().voidPromise());
-        }
-    };
-
     private final Runnable finishReadTask = new Runnable() {
         @Override
         public void run() {
@@ -477,6 +470,8 @@ public class LocalChannel extends AbstractChannel {
     }
 
     private class LocalUnsafe extends AbstractUnsafe implements LocalIoHandle {
+
+        private final Runnable shutdownHook = this::closeNow;
 
         @Override
         public void close() {

--- a/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
@@ -44,12 +44,6 @@ public class LocalServerChannel extends AbstractServerChannel {
     private final ChannelConfig config =
             new DefaultChannelConfig(this, new ServerChannelRecvByteBufAllocator()) { };
     private final Queue<Object> inboundBuffer = new ArrayDeque<Object>();
-    private final Runnable shutdownHook = new Runnable() {
-        @Override
-        public void run() {
-            unsafe().close(unsafe().voidPromise());
-        }
-    };
 
     private IoRegistration registration;
 
@@ -221,6 +215,8 @@ public class LocalServerChannel extends AbstractServerChannel {
     }
 
     private class LocalServerUnsafe extends AbstractUnsafe implements LocalIoHandle {
+        private final Runnable shutdownHook = this::closeNow;
+
         @Override
         public void close() {
             close(voidPromise());


### PR DESCRIPTION
Motivation:

When LocalIoHandler is used it will call closeNow() to handle the close of the Local*Channel when destroyed. We should use the the same method when using a shutdown hook to do the same to make things consistent.

Modifications:
- Move shutdownHook to inner class as it is where it is used.
- call closeNow to make it conistent

Result:

Cleanup
