### PR TITLE
HTTP2: Ensure preface is flushed in all cases 

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -260,13 +260,6 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         public void channelActive(ChannelHandlerContext ctx) throws Exception {
             // The channel just became active - send the connection preface to the remote endpoint.
             sendPreface(ctx);
-
-            if (flushPreface) {
-                // As we don't know if any channelReadComplete() events will be triggered at all we need to ensure we
-                // also flush. Otherwise the remote peer might never see the preface / settings frame.
-                // See https://github.com/netty/netty/issues/12089
-                ctx.flush();
-            }
         }
 
         @Override
@@ -384,11 +377,20 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
             encoder.writeSettings(ctx, initialSettings, ctx.newPromise()).addListener(
                     ChannelFutureListener.CLOSE_ON_FAILURE);
 
-            if (isClient) {
-                // If this handler is extended by the user and we directly fire the userEvent from this context then
-                // the user will not see the event. We should fire the event starting with this handler so this class
-                // (and extending classes) have a chance to process the event.
-                userEventTriggered(ctx, Http2ConnectionPrefaceAndSettingsFrameWrittenEvent.INSTANCE);
+            try {
+                if (isClient) {
+                    // If this handler is extended by the user and we directly fire the userEvent from this context then
+                    // the user will not see the event. We should fire the event starting with this handler so this
+                    // class (and extending classes) have a chance to process the event.
+                    userEventTriggered(ctx, Http2ConnectionPrefaceAndSettingsFrameWrittenEvent.INSTANCE);
+                }
+            } finally {
+                if (flushPreface) {
+                    // As we don't know if any channelReadComplete() events will be triggered at all we need to ensure
+                    // we also flush. Otherwise the remote peer might never see the preface / settings frame.
+                    // See https://github.com/netty/netty/issues/12089
+                    ctx.flush();
+                }
             }
         }
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -306,9 +306,11 @@ public class Http2ConnectionHandlerTest {
         when(connection.isServer()).thenReturn(false);
         when(channel.isActive()).thenReturn(false);
         handler = newHandler();
+        verify(ctx, never()).flush();
         when(channel.isActive()).thenReturn(true);
         handler.channelActive(ctx);
         verify(ctx).write(eq(connectionPrefaceBuf()));
+        verify(ctx).flush();
     }
 
     @Test
@@ -316,9 +318,29 @@ public class Http2ConnectionHandlerTest {
         when(connection.isServer()).thenReturn(true);
         when(channel.isActive()).thenReturn(false);
         handler = newHandler();
+        verify(ctx, never()).flush();
         when(channel.isActive()).thenReturn(true);
         handler.channelActive(ctx);
         verify(ctx, never()).write(eq(connectionPrefaceBuf()));
+        verify(ctx).flush();
+    }
+
+    @Test
+    public void clientShouldSendClientPrefaceStringWhenAddedAfterActive() throws Exception {
+        when(connection.isServer()).thenReturn(false);
+        when(channel.isActive()).thenReturn(true);
+        handler = newHandler();
+        verify(ctx).write(eq(connectionPrefaceBuf()));
+        verify(ctx).flush();
+    }
+
+    @Test
+    public void serverShouldNotSendClientPrefaceStringWhenAddedAfterActive() throws Exception {
+        when(connection.isServer()).thenReturn(true);
+        when(channel.isActive()).thenReturn(true);
+        handler = newHandler();
+        verify(ctx, never()).write(eq(connectionPrefaceBuf()));
+        verify(ctx).flush();
     }
 
     @Test
@@ -733,7 +755,8 @@ public class Http2ConnectionHandlerTest {
 
     @Test
     public void channelReadCompleteTriggersFlush() throws Exception {
-        handler = newHandler();
+        // Create the handler in a way that it will flush the preface by itself
+        handler = newHandler(false);
         handler.channelReadComplete(ctx);
         verify(ctx, times(1)).flush();
     }


### PR DESCRIPTION
Motivation:

We did miss to ensure we flushed the preface automatically in some cases which could have caused the remote peer to never see it if no data was ready to read.
Beside this we also sometimes flushed even if there was no data generated and so it it was not required.

Modifications:

- Ensure we always flush if we produce the preface
- Only flush if we really produce data
- Add tests

Result:

Preface is always flushed correctly