### PR TITLE
AbstractByteBuf._internalNioBuffer() might throw exception

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -1498,6 +1498,6 @@ public abstract class AbstractByteBuf extends ByteBuf {
     }
 
     ByteBuffer _internalNioBuffer() {
-        return internalNioBuffer(0, maxFastWritableBytes());
+        return internalNioBuffer(0, capacity());
     }
 }

--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
@@ -75,6 +75,7 @@ import static io.netty.buffer.Unpooled.unreleasableBuffer;
 import static io.netty.buffer.Unpooled.wrappedBuffer;
 import static io.netty.util.internal.EmptyArrays.EMPTY_BYTES;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -6474,4 +6475,22 @@ public abstract class AbstractByteBufTest {
         assertNotSame(capacity, buffer.capacity());
         buffer.release();
     }
+
+    @Test
+    public void test_internalNioBuffer() {
+        ByteBuf buf = buffer(8, 16);
+        ByteBuf buffer = buf;
+        if (buf instanceof SimpleLeakAwareByteBuf) {
+            buffer = buf.unwrap();
+        }
+        assumeThat(buffer).isInstanceOf(AbstractByteBuf.class);
+        try {
+            ByteBuffer nioBuffer = ((AbstractByteBuf) buffer)._internalNioBuffer();
+            assertEquals(0, nioBuffer.position());
+            assertThat(nioBuffer.remaining()).isGreaterThanOrEqualTo(8);
+        } finally {
+            buf.release();
+        }
+    }
+
 }


### PR DESCRIPTION
Motivation:

https://github.com/netty/netty/commit/5fe1eea9257b796405f55361202765d8f3184491 introduced a change which could lead to an IndexOutOfBoundsException in some states.

Modifications:

- Correctly use capacity() when generating the ByteBuffer
- Add unit test

Result:

Fixes https://github.com/netty/netty/issues/16413