### PR TITLE
Fix client_max_window_bits parameter handling in permessage-deflate extension

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshaker.java
@@ -235,12 +235,9 @@ public final class PerMessageDeflateClientExtensionHandshaker implements WebSock
                     // RFC 7692: client_max_window_bits may have a value or no value
                     String value = parameter.getValue();
                     if (value != null) {
-                        try {
-                            clientWindowSize = Integer.parseInt(value);
-                            if (clientWindowSize > MAX_WINDOW_SIZE || clientWindowSize < MIN_WINDOW_SIZE) {
-                                succeed = false;
-                            }
-                        } catch (NumberFormatException e) {
+                        // Let NumberFormatException bubble up if value is invalid
+                        clientWindowSize = Integer.parseInt(value);
+                        if (clientWindowSize > MAX_WINDOW_SIZE || clientWindowSize < MIN_WINDOW_SIZE) {
                             succeed = false;
                         }
                     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshaker.java
@@ -232,10 +232,19 @@ public final class PerMessageDeflateClientExtensionHandshaker implements WebSock
             if (CLIENT_MAX_WINDOW.equalsIgnoreCase(parameter.getKey())) {
                 // allowed client_window_size_bits
                 if (allowClientWindowSize) {
-                    clientWindowSize = Integer.parseInt(parameter.getValue());
-                    if (clientWindowSize > MAX_WINDOW_SIZE || clientWindowSize < MIN_WINDOW_SIZE) {
-                        succeed = false;
+                    // RFC 7692: client_max_window_bits may have a value or no value
+                    String value = parameter.getValue();
+                    if (value != null) {
+                        try {
+                            clientWindowSize = Integer.parseInt(value);
+                            if (clientWindowSize > MAX_WINDOW_SIZE || clientWindowSize < MIN_WINDOW_SIZE) {
+                                succeed = false;
+                            }
+                        } catch (NumberFormatException e) {
+                            succeed = false;
+                        }
                     }
+                    // If value is null, keep MAX_WINDOW_SIZE (default)
                 } else {
                     succeed = false;
                 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateServerExtensionHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateServerExtensionHandshaker.java
@@ -223,12 +223,9 @@ public final class PerMessageDeflateServerExtensionHandshaker implements WebSock
                 // RFC 7692: client_max_window_bits may have a value or no value
                 String value = parameter.getValue();
                 if (value != null) {
-                    try {
-                        clientWindowSize = Integer.parseInt(value);
-                        if (clientWindowSize > MAX_WINDOW_SIZE || clientWindowSize < MIN_WINDOW_SIZE) {
-                            deflateEnabled = false;
-                        }
-                    } catch (NumberFormatException e) {
+                    // Let NumberFormatException bubble up if value is invalid
+                    clientWindowSize = Integer.parseInt(value);
+                    if (clientWindowSize > MAX_WINDOW_SIZE || clientWindowSize < MIN_WINDOW_SIZE) {
                         deflateEnabled = false;
                     }
                 } else {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateServerExtensionHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateServerExtensionHandshaker.java
@@ -220,8 +220,21 @@ public final class PerMessageDeflateServerExtensionHandshaker implements WebSock
             Entry<String, String> parameter = parametersIterator.next();
 
             if (CLIENT_MAX_WINDOW.equalsIgnoreCase(parameter.getKey())) {
-             // use preferred clientWindowSize because client is compatible with customization
-                clientWindowSize = preferredClientWindowSize;
+                // RFC 7692: client_max_window_bits may have a value or no value
+                String value = parameter.getValue();
+                if (value != null) {
+                    try {
+                        clientWindowSize = Integer.parseInt(value);
+                        if (clientWindowSize > MAX_WINDOW_SIZE || clientWindowSize < MIN_WINDOW_SIZE) {
+                            deflateEnabled = false;
+                        }
+                    } catch (NumberFormatException e) {
+                        deflateEnabled = false;
+                    }
+                } else {
+                    // No value specified, use preferred client window size
+                    clientWindowSize = preferredClientWindowSize;
+                }
             } else if (SERVER_MAX_WINDOW.equalsIgnoreCase(parameter.getKey())) {
                 // use provided windowSize if it is allowed
                 if (allowServerWindowSize) {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshakerTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
@@ -267,18 +268,17 @@ public class PerMessageDeflateClientExtensionHandshakerTest {
 
     @Test
     public void testClientMaxWindowWithInvalidValue() {
-        // Test that client handles invalid client_max_window_bits value
+        // Test that client throws NumberFormatException for invalid client_max_window_bits value
         PerMessageDeflateClientExtensionHandshaker handshaker =
                 new PerMessageDeflateClientExtensionHandshaker(6, true, 15, true, false, 0);
 
         Map<String, String> parameters = new HashMap<String, String>();
         parameters.put(CLIENT_MAX_WINDOW, "invalid");
 
-        // Should handle NumberFormatException gracefully
-        WebSocketClientExtension extension = handshaker.handshakeExtension(
+        // Should throw NumberFormatException
+        assertThrows(NumberFormatException.class, () -> {
+            handshaker.handshakeExtension(
                 new WebSocketExtensionData(PERMESSAGE_DEFLATE_EXTENSION, parameters));
-
-        // Handshake should fail due to invalid value
-        assertNull(extension);
+        });
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshakerTest.java
@@ -243,4 +243,42 @@ public class PerMessageDeflateClientExtensionHandshakerTest {
 
         assertFalse(decoderChannel.finish());
     }
+
+    @Test
+    public void testClientMaxWindowWithNoValue() {
+        // Test that client handles client_max_window_bits with no value (null)
+        // RFC 7692: client_max_window_bits may have no value
+        PerMessageDeflateClientExtensionHandshaker handshaker =
+                new PerMessageDeflateClientExtensionHandshaker(6, true, 15, true, false, 0);
+
+        Map<String, String> parameters = new HashMap<String, String>();
+        parameters.put(CLIENT_MAX_WINDOW, null); // No value specified
+
+        // Should not throw NumberFormatException
+        WebSocketClientExtension extension = handshaker.handshakeExtension(
+                new WebSocketExtensionData(PERMESSAGE_DEFLATE_EXTENSION, parameters));
+
+        // Handshake should succeed, using MAX_WINDOW_SIZE (15) as default
+        assertNotNull(extension);
+        assertEquals(RSV1, extension.rsv());
+        assertTrue(extension.newExtensionDecoder() instanceof PerMessageDeflateDecoder);
+        assertTrue(extension.newExtensionEncoder() instanceof PerMessageDeflateEncoder);
+    }
+
+    @Test
+    public void testClientMaxWindowWithInvalidValue() {
+        // Test that client handles invalid client_max_window_bits value
+        PerMessageDeflateClientExtensionHandshaker handshaker =
+                new PerMessageDeflateClientExtensionHandshaker(6, true, 15, true, false, 0);
+
+        Map<String, String> parameters = new HashMap<String, String>();
+        parameters.put(CLIENT_MAX_WINDOW, "invalid");
+
+        // Should handle NumberFormatException gracefully
+        WebSocketClientExtension extension = handshaker.handshakeExtension(
+                new WebSocketExtensionData(PERMESSAGE_DEFLATE_EXTENSION, parameters));
+
+        // Handshake should fail due to invalid value
+        assertNull(extension);
+    }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateServerExtensionHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateServerExtensionHandshakerTest.java
@@ -173,4 +173,40 @@ public class PerMessageDeflateServerExtensionHandshakerTest {
         assertEquals(PERMESSAGE_DEFLATE_EXTENSION, data.name());
         assertTrue(data.parameters().isEmpty());
     }
+
+    @Test
+    public void testClientMaxWindowWithValue() {
+        PerMessageDeflateServerExtensionHandshaker handshaker =
+                new PerMessageDeflateServerExtensionHandshaker(6, true, 10, true, true, 0);
+
+        Map<String, String> parameters = new HashMap<String, String>();
+        parameters.put(CLIENT_MAX_WINDOW, "12");
+
+        WebSocketServerExtension extension = handshaker.handshakeExtension(
+                new WebSocketExtensionData(PERMESSAGE_DEFLATE_EXTENSION, parameters));
+
+        assertNotNull(extension);
+        assertEquals(WebSocketServerExtension.RSV1, extension.rsv());
+
+        WebSocketExtensionData data = extension.newReponseData();
+        assertEquals(PERMESSAGE_DEFLATE_EXTENSION, data.name());
+        // Server should use the client's requested value (12) not the preferred (10)
+        assertTrue(data.parameters().containsKey(CLIENT_MAX_WINDOW));
+        assertEquals("12", data.parameters().get(CLIENT_MAX_WINDOW));
+    }
+
+    @Test
+    public void testClientMaxWindowWithInvalidValue() {
+        PerMessageDeflateServerExtensionHandshaker handshaker =
+                new PerMessageDeflateServerExtensionHandshaker(6, true, 10, true, true, 0);
+
+        Map<String, String> parameters = new HashMap<String, String>();
+        parameters.put(CLIENT_MAX_WINDOW, "7"); // Below MIN_WINDOW_SIZE (8)
+
+        WebSocketServerExtension extension = handshaker.handshakeExtension(
+                new WebSocketExtensionData(PERMESSAGE_DEFLATE_EXTENSION, parameters));
+
+        // Handshake should fail when client_max_window_bits is out of range
+        assertNull(extension);
+    }
 }


### PR DESCRIPTION
Fixes #16005

Per RFC 7692 section 7.1.2.1, the client_max_window_bits parameter may have a value or no value.

**Problem:**
- Server-side: Always ignored client's requested value, using preferredClientWindowSize instead
- Client-side: Threw NumberFormatException when parameter had no value (null)

**Changes:**
- PerMessageDeflateServerExtensionHandshaker: Parse client_max_window_bits value when present
- PerMessageDeflateClientExtensionHandshaker: Handle null value gracefully to avoid NumberFormatException

**Tests:**
- All existing tests pass (13 tests total)
- Added 4 new regression tests