### PR TITLE
Fire the QuicChannel datagram extension event before the channel becomes active

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicChannel.java
@@ -1953,9 +1953,9 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                     // We didn't notify before about channelActive... Update state and fire the event.
                     state = ChannelState.ACTIVE;
 
+                    fireDatagramExtensionEvent(conn);
                     pipeline().fireChannelActive();
                     notifyAboutHandshakeCompletionIfNeeded(conn, null);
-                    fireDatagramExtensionEvent(conn);
                 }
             } else if (connectPromise != null && Quiche.quiche_conn_is_established(conn.address())) {
                 ChannelPromise promise = connectPromise;
@@ -1963,9 +1963,9 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                 state = ChannelState.ACTIVE;
 
                 boolean promiseSet = promise.trySuccess();
+                fireDatagramExtensionEvent(conn);
                 pipeline().fireChannelActive();
                 notifyAboutHandshakeCompletionIfNeeded(conn, null);
-                fireDatagramExtensionEvent(conn);
                 if (!promiseSet) {
                     fireConnectCloseEventIfNeeded(conn);
                     this.close(this.voidPromise());

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicChannelDatagramTest.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicChannelDatagramTest.java
@@ -67,6 +67,15 @@ public class QuicChannelDatagramTest extends AbstractQuicTest {
         QuicChannelValidationHandler serverHandler = new QuicChannelValidationHandler() {
 
             @Override
+            public void channelActive(ChannelHandlerContext ctx) {
+                if (serverEventRef.get() == null) {
+                    exceptionCaught(ctx, new IllegalStateException("Expected to have received datagram extension" +
+                            " before channel was active"));
+                }
+                super.channelActive(ctx);
+            }
+
+            @Override
             public void channelRead(ChannelHandlerContext ctx, Object msg) {
                 if (msg instanceof ByteBuf) {
                     final ChannelFuture future;
@@ -107,6 +116,16 @@ public class QuicChannelDatagramTest extends AbstractQuicTest {
                 .datagram(10, 10));
 
         QuicChannelValidationHandler clientHandler = new QuicChannelValidationHandler() {
+
+            @Override
+            public void channelActive(ChannelHandlerContext ctx) {
+                if (clientEventRef.get() == null) {
+                    exceptionCaught(ctx, new IllegalStateException("Expected to have received datagram extension" +
+                            " before channel was active"));
+                }
+                super.channelActive(ctx);
+            }
+
             @Override
             public void channelRead(ChannelHandlerContext ctx, Object msg) {
                 if (!receivedBuffer.trySuccess((ByteBuf) msg)) {


### PR DESCRIPTION
Motivation:

The `QuicheQuicChannel` implementation fires the datagram extension event after the channel becomes active.

In addition this event is optional, implying there is no trival way to determine than the extension is available when the channel becomes active and is supposed to be functionnal at this moment.

Modification:

Fire the datagram extension event before the channel becomes active.

Result:

When the `QuicChannel` becomes active, handlers are fully aware whether the channel extension is available and will have the knowledge of the max datagram len.
