### PR TITLE
Support QuicheQuicSslEngine hostname identification algorithm.

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicSslContextBuilder.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicSslContextBuilder.java
@@ -26,6 +26,7 @@ import org.jetbrains.annotations.Nullable;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509ExtendedKeyManager;
@@ -174,9 +175,15 @@ public final class QuicSslContextBuilder {
     private Boolean earlyData;
     private BoringSSLKeylog keylog;
     private Mapping<? super String, ? extends QuicSslContext> mapping;
+    private String endpointIdentificationAlgorithm;
 
     private QuicSslContextBuilder(boolean forServer) {
         this.forServer = forServer;
+        if (!forServer) {
+            // Todo : initialize like we do for regular context
+            // but this requires exposing package private SslUtils
+            // this.endpointIdentificationAlgorithm = SslUtils.defaultEndpointVerificationAlgorithm;
+        }
     }
 
     /**
@@ -410,6 +417,21 @@ public final class QuicSslContextBuilder {
     }
 
     /**
+     * Specify the endpoint identification algorithm (aka. hostname verification algorithm) that clients will use as
+     * part of authenticating servers.
+     * <p>
+     * See <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#jssenames">
+     *     Java Security Standard Names</a> for a list of supported algorithms.
+     *
+     * @param algorithm either {@code "HTTPS"}, {@code "LDAPS"}, or {@code null} (disables hostname verification).
+     * @see SSLParameters#setEndpointIdentificationAlgorithm(String)
+     */
+    public QuicSslContextBuilder endpointIdentificationAlgorithm(String algorithm) {
+        endpointIdentificationAlgorithm = algorithm;
+        return this;
+    }
+
+    /**
      * Create new {@link QuicSslContext} instance with configured settings that can be used for {@code QUIC}.
      *
      */
@@ -417,11 +439,11 @@ public final class QuicSslContextBuilder {
         if (forServer) {
             return new QuicheQuicSslContext(true, sessionTimeout, sessionCacheSize, clientAuth, trustManagerFactory,
                     keyManagerFactory, keyPassword, mapping, earlyData, keylog,
-                    applicationProtocols, toArray(options.entrySet(), EMPTY_ENTRIES));
+                    applicationProtocols, null, toArray(options.entrySet(), EMPTY_ENTRIES));
         } else {
             return new QuicheQuicSslContext(false, sessionTimeout, sessionCacheSize, clientAuth, trustManagerFactory,
                     keyManagerFactory, keyPassword, mapping, earlyData, keylog,
-                    applicationProtocols, toArray(options.entrySet(), EMPTY_ENTRIES));
+                    applicationProtocols, endpointIdentificationAlgorithm, toArray(options.entrySet(), EMPTY_ENTRIES));
         }
     }
 

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicSslContextBuilder.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicSslContextBuilder.java
@@ -180,9 +180,7 @@ public final class QuicSslContextBuilder {
     private QuicSslContextBuilder(boolean forServer) {
         this.forServer = forServer;
         if (!forServer) {
-            // Todo : initialize like we do for regular context
-            // but this requires exposing package private SslUtils
-            // this.endpointIdentificationAlgorithm = SslUtils.defaultEndpointVerificationAlgorithm;
+             this.endpointIdentificationAlgorithm = QuicheQuicSslContext.defaultEndpointVerificationAlgorithm;
         }
     }
 

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicSslContext.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicSslContext.java
@@ -18,6 +18,7 @@ package io.netty.handler.codec.quic;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.ssl.ApplicationProtocolNegotiator;
 import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextOption;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.AbstractReferenceCounted;
@@ -68,6 +69,8 @@ final class QuicheQuicSslContext extends QuicSslContext {
     // See https://www.java.com/en/configure_crypto.html for ordering
     private static final String[] DEFAULT_NAMED_GROUPS = { "x25519", "secp256r1", "secp384r1", "secp521r1" };
     private static final String[] NAMED_GROUPS;
+
+    static final String defaultEndpointVerificationAlgorithm = SslContext.defaultEndpointVerificationAlgorithm;
 
     static {
         String[] namedGroups = DEFAULT_NAMED_GROUPS;

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicSslContext.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicSslContext.java
@@ -139,6 +139,7 @@ final class QuicheQuicSslContext extends QuicSslContext {
 
     final ClientAuth clientAuth;
     private final boolean server;
+    private final String endpointIdentificationAlgorithm;
     @SuppressWarnings("deprecation")
     private final ApplicationProtocolNegotiator apn;
     private long sessionCacheSize;
@@ -156,9 +157,11 @@ final class QuicheQuicSslContext extends QuicSslContext {
                          @Nullable KeyManagerFactory keyManagerFactory, String password,
                          @Nullable Mapping<? super String, ? extends QuicSslContext> mapping,
                          @Nullable Boolean earlyData, @Nullable BoringSSLKeylog keylog,
-                         String[] applicationProtocols, Map.Entry<SslContextOption<?>, Object>... ctxOptions) {
+                         String[] applicationProtocols, String endpointIdentificationAlgorithm,
+                         Map.Entry<SslContextOption<?>, Object>... ctxOptions) {
         Quic.ensureAvailability();
         this.server = server;
+        this.endpointIdentificationAlgorithm = endpointIdentificationAlgorithm;
         this.clientAuth = server ? checkNotNull(clientAuth, "clientAuth") : ClientAuth.NONE;
         final X509TrustManager trustManager;
         if (trustManagerFactory == null) {
@@ -412,12 +415,12 @@ final class QuicheQuicSslContext extends QuicSslContext {
 
     @Override
     public QuicSslEngine newEngine(ByteBufAllocator alloc) {
-        return new QuicheQuicSslEngine(this, null, -1);
+        return new QuicheQuicSslEngine(this, null, -1, endpointIdentificationAlgorithm);
     }
 
     @Override
     public QuicSslEngine newEngine(ByteBufAllocator alloc, String peerHost, int peerPort) {
-        return new QuicheQuicSslEngine(this, peerHost, peerPort);
+        return new QuicheQuicSslEngine(this, peerHost, peerPort, endpointIdentificationAlgorithm);
     }
 
     @Override

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicSslEngine.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicSslEngine.java
@@ -48,6 +48,7 @@ final class QuicheQuicSslEngine extends QuicSslEngine {
     QuicheQuicSslContext ctx;
     private final String peerHost;
     private final int peerPort;
+    private final String endpointIdentificationAlgorithm;
     private final QuicheQuicSslSession session = new QuicheQuicSslSession();
     private volatile Certificate[] localCertificateChain;
     private List<SNIServerName> sniHostNames;
@@ -59,10 +60,12 @@ final class QuicheQuicSslEngine extends QuicSslEngine {
 
     volatile Consumer<String> sniSelectedCallback;
 
-    QuicheQuicSslEngine(QuicheQuicSslContext ctx, @Nullable String peerHost, int peerPort) {
+    QuicheQuicSslEngine(QuicheQuicSslContext ctx, @Nullable String peerHost, int peerPort,
+                        String endpointIdentificationAlgorithm) {
         this.ctx = ctx;
         this.peerHost = peerHost;
         this.peerPort = peerPort;
+        this.endpointIdentificationAlgorithm = endpointIdentificationAlgorithm;
         // Use SNI if peerHost was specified and a valid hostname
         // See https://github.com/netty/netty/issues/4746
         if (ctx.isClient() && isValidHostNameForSNI(peerHost)) {
@@ -109,6 +112,9 @@ final class QuicheQuicSslEngine extends QuicSslEngine {
     public SSLParameters getSSLParameters() {
         SSLParameters parameters = super.getSSLParameters();
         parameters.setServerNames(sniHostNames);
+        if (endpointIdentificationAlgorithm != null) {
+            parameters.setEndpointIdentificationAlgorithm(endpointIdentificationAlgorithm);
+        }
         return parameters;
     }
 

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicChannelConnectTest.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicChannelConnectTest.java
@@ -1209,10 +1209,13 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
                 new ChannelInboundHandlerAdapter());
         InetSocketAddress address = (InetSocketAddress) server.localAddress();
 
+        QuicSslContext clientSslContext = QuicSslContextBuilder.forClient()
+                .trustManager(QuicTestUtils.SELF_SIGNED_CERTIFICATE.certificate())
+                .applicationProtocols(QuicTestUtils.PROTOS).build();
         Channel channel = QuicTestUtils.newClient(QuicTestUtils.newQuicClientBuilder(executor,
-                QuicSslContextBuilder.forClient()
-                        .trustManager(QuicTestUtils.SELF_SIGNED_CERTIFICATE.certificate())
-                        .applicationProtocols(QuicTestUtils.PROTOS).build()));
+                        clientSslContext)
+                        .sslEngineProvider(ch ->
+                                clientSslContext.newEngine(ch.alloc(), "localhost", address.getPort())));
         try {
             ChannelActiveVerifyHandler clientQuicChannelHandler = new ChannelActiveVerifyHandler();
             QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicSslContextTest.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicSslContextTest.java
@@ -20,6 +20,8 @@ import io.netty.util.internal.EmptyArrays;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSessionContext;
 import javax.net.ssl.X509ExtendedKeyManager;
 
@@ -34,7 +36,11 @@ public class QuicSslContextTest {
 
     @Test
     public void testSessionContextSettingsForClient() {
-        testSessionContextSettings(QuicSslContextBuilder.forClient(), 20, 50);
+        QuicSslContextBuilder builder = QuicSslContextBuilder
+                .forClient()
+                .endpointIdentificationAlgorithm("HTTPS");
+        testSessionContextSettings(builder, 20, 50,
+                "HTTPS");
     }
 
     @Test
@@ -72,10 +78,11 @@ public class QuicSslContextTest {
             public PrivateKey getPrivateKey(String alias) {
                 return null;
             }
-        }, null), 20, 50);
+        }, null), 20, 50, null);
     }
 
-    private void testSessionContextSettings(QuicSslContextBuilder builder, int size, int timeout) {
+    private void testSessionContextSettings(QuicSslContextBuilder builder, int size, int timeout,
+                                            String endpointIdentificationAlgorithm) {
         SslContext context = builder.sessionCacheSize(size).sessionTimeout(timeout).build();
         assertEquals(size, context.sessionCacheSize());
         assertEquals(timeout, context.sessionTimeout());
@@ -90,5 +97,9 @@ public class QuicSslContextTest {
         int newTimeout = timeout / 2;
         sessionContext.setSessionTimeout(newTimeout);
         assertEquals(newTimeout, sessionContext.getSessionTimeout());
+
+        SSLEngine engine = context.newEngine(null);
+        SSLParameters sslParameters = engine.getSSLParameters();
+        assertEquals(endpointIdentificationAlgorithm, sslParameters.getEndpointIdentificationAlgorithm());
     }
 }

--- a/handler/src/main/java/io/netty/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContext.java
@@ -29,6 +29,9 @@ import io.netty.util.AttributeMap;
 import io.netty.util.DefaultAttributeMap;
 import io.netty.util.concurrent.ImmediateExecutor;
 import io.netty.util.internal.EmptyArrays;
+import io.netty.util.internal.SystemPropertyUtil;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -94,6 +97,22 @@ import javax.net.ssl.TrustManagerFactory;
  * </pre>
  */
 public abstract class SslContext {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(SslContext.class);
+
+    private static final String DEFAULT_ENDPOINT_VERIFICATION_ALGORITHM_PROPERTY =
+            "io.netty.handler.ssl.defaultEndpointVerificationAlgorithm";
+
+    /**
+     * Endpoint verification is enabled by default from Netty 4.2 onward, but it wasn't in Netty 4.1 and earlier.
+     * The {@value #DEFAULT_ENDPOINT_VERIFICATION_ALGORITHM_PROPERTY} can be set to one of the following
+     * values to control this behavior:
+     * <ul>
+     *     <li>{@code "HTTPS"} — verify subject by DNS hostnames; this is the Netty 4.2 default.</li>
+     *     <li>{@code "LDAP"} — verify subject by LDAP identity.</li>
+     *     <li>{@code "NONE"} — don't enable endpoint verification by default; this is the Netty 4.1 behavior.</li>
+     * </ul>
+     */
+    protected static final String defaultEndpointVerificationAlgorithm;
     static final String ALIAS = "key";
 
     static final CertificateFactory X509_CERT_FACTORY;
@@ -102,6 +121,22 @@ public abstract class SslContext {
             X509_CERT_FACTORY = CertificateFactory.getInstance("X.509");
         } catch (CertificateException e) {
             throw new IllegalStateException("unable to instance X.509 CertificateFactory", e);
+        }
+
+        String defaultEndpointVerification = SystemPropertyUtil.get(DEFAULT_ENDPOINT_VERIFICATION_ALGORITHM_PROPERTY);
+        if ("LDAP".equalsIgnoreCase(defaultEndpointVerification)) {
+            defaultEndpointVerificationAlgorithm = "LDAP";
+        } else if ("NONE".equalsIgnoreCase(defaultEndpointVerification)) {
+            logger.info("Default SSL endpoint verification has been disabled:  -D{}=\"{}\"",
+                    DEFAULT_ENDPOINT_VERIFICATION_ALGORITHM_PROPERTY, defaultEndpointVerification);
+            defaultEndpointVerificationAlgorithm = null;
+        } else {
+            if (defaultEndpointVerification != null && !"HTTPS".equalsIgnoreCase(defaultEndpointVerification)) {
+                logger.warn("Unknown default SSL endpoint verification algorithm: -D{}=\"{}\", " +
+                                "will use \"HTTPS\" instead.",
+                        DEFAULT_ENDPOINT_VERIFICATION_ALGORITHM_PROPERTY, defaultEndpointVerification);
+            }
+            defaultEndpointVerificationAlgorithm = "HTTPS";
         }
     }
 
@@ -816,7 +851,7 @@ public abstract class SslContext {
                                             keyPassword, keyManagerFactory, ciphers, cipherFilter,
                                             apn, null, sessionCacheSize, sessionTimeout, false,
                                             null, KeyStore.getDefaultType(),
-                                            SslUtils.defaultEndpointVerificationAlgorithm,
+                                            defaultEndpointVerificationAlgorithm,
                                             Collections.emptyList(), null, null);
         } catch (Exception e) {
             if (e instanceof SSLException) {

--- a/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
@@ -222,7 +222,7 @@ public final class SslContextBuilder {
     private SslContextBuilder(boolean forServer) {
         this.forServer = forServer;
         if (!forServer) {
-            endpointIdentificationAlgorithm = SslUtils.defaultEndpointVerificationAlgorithm;
+            endpointIdentificationAlgorithm = SslContext.defaultEndpointVerificationAlgorithm;
         }
         serverNames = forServer ? null : new ArrayList<>(2); // Only for clients.
     }

--- a/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
@@ -63,20 +63,6 @@ final class SslUtils {
     static final short DTLS_1_3 = (short) 0xFEFC;
     static final short DTLS_RECORD_HEADER_LENGTH = 13;
 
-    private static final String DEFAULT_ENDPOINT_VERIFICATION_ALGORITHM_PROPERTY =
-            "io.netty.handler.ssl.defaultEndpointVerificationAlgorithm";
-    /**
-     * Endpoint verification is enabled by default from Netty 4.2 onward, but it wasn't in Netty 4.1 and earlier.
-     * The {@value #DEFAULT_ENDPOINT_VERIFICATION_ALGORITHM_PROPERTY} can be set to one of the following
-     * values to control this behavior:
-     * <ul>
-     *     <li>{@code "HTTPS"} — verify subject by DNS hostnames; this is the Netty 4.2 default.</li>
-     *     <li>{@code "LDAP"} — verify subject by LDAP identity.</li>
-     *     <li>{@code "NONE"} — don't enable endpoint verification by default; this is the Netty 4.1 behavior.</li>
-     * </ul>
-     */
-    static final String defaultEndpointVerificationAlgorithm;
-
     /**
      * GMSSL Protocol Version
      */
@@ -199,22 +185,6 @@ final class SslUtils {
         Collections.addAll(defaultCiphers, DEFAULT_TLSV13_CIPHER_SUITES);
 
         DEFAULT_CIPHER_SUITES = defaultCiphers.toArray(EmptyArrays.EMPTY_STRINGS);
-
-        String defaultEndpointVerification = SystemPropertyUtil.get(DEFAULT_ENDPOINT_VERIFICATION_ALGORITHM_PROPERTY);
-        if ("LDAP".equalsIgnoreCase(defaultEndpointVerification)) {
-            defaultEndpointVerificationAlgorithm = "LDAP";
-        } else if ("NONE".equalsIgnoreCase(defaultEndpointVerification)) {
-            logger.info("Default SSL endpoint verification has been disabled:  -D{}=\"{}\"",
-                    DEFAULT_ENDPOINT_VERIFICATION_ALGORITHM_PROPERTY, defaultEndpointVerification);
-            defaultEndpointVerificationAlgorithm = null;
-        } else {
-            if (defaultEndpointVerification != null && !"HTTPS".equalsIgnoreCase(defaultEndpointVerification)) {
-                logger.warn("Unknown default SSL endpoint verification algorithm: -D{}=\"{}\", " +
-                                "will use \"HTTPS\" instead.",
-                        DEFAULT_ENDPOINT_VERIFICATION_ALGORITHM_PROPERTY, defaultEndpointVerification);
-            }
-            defaultEndpointVerificationAlgorithm = "HTTPS";
-        }
     }
 
     /**


### PR DESCRIPTION
Motivation:

QuicheQuicSslEngine does not currently support hostname identification algorithm.

Changes:

- add configuration for hostname identification algorithm in QuicSslContextBuilder
- configure QuicheQuicSslEngine ssl parameters, those parameters are used by X509ExtendedTrustManager#checkTrusted to enforce the algorithm, this is called by BoringSSLCertificateVerifyCallback

Results:

Hostname verificiation algorithm is configurable and enforced.
