### PR TITLE
Whitelist JMH annotation processing in microbench module

### DIFF
--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -241,6 +241,13 @@
           <excludes>
             <exclude>**/Http2FrameWriterBenchmark.java</exclude>
           </excludes>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.openjdk.jmh</groupId>
+              <artifactId>jmh-generator-annprocess</artifactId>
+              <version>${jmh.version}</version>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Motivation:

Starting from JDK 23, the annotation processing was disabled by default, see:
https://bugs.java.com/bugdatabase/JDK-8321314/description
https://mail.openjdk.org/pipermail/jdk-dev/2024-May/009028.html

This change breaks the `microbench` module because it relies on JMH annotation processors to generate benchmark code. For instance, when building with JDK 25, run the following command within the `microbench` module:

> mvn clean install -Dcheckstyle.skip -Pbenchmark-jar

Then run the generated JAR(`java -jar target/microbenchmarks.jar`), and it results in the following error:

> Error: Unable to access jarfile microbenchmarks.jar
> Exception in thread "main" java.lang.RuntimeException: ERROR: Unable to find the resource: /META-INF/BenchmarkList
>         at org.openjdk.jmh.runner.AbstractResourceReader.getReaders(AbstractResourceReader.java:98)
>         at org.openjdk.jmh.runner.BenchmarkList.find(BenchmarkList.java:124)
>         at org.openjdk.jmh.runner.Runner.internalRun(Runner.java:253)
>         at org.openjdk.jmh.runner.Runner.run(Runner.java:209)
>         at org.openjdk.jmh.Main.main(Main.java:71) 

Modification:

Whitelist the `jmh-generator-annprocess` in the `microbench/pom.xml`, with `annotationProcessorPaths` configuration, see:
https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#annotationProcessorPaths

Result:

Properly process the JMH annotation.
