### PR TITLE
IoUring: Fix io_uring writev infinite loop on kernels without SENDMSG_ZC support

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
@@ -160,6 +160,9 @@ public final class IoUringSocketChannel extends AbstractIoUringStreamChannel imp
 
         @Override
         protected ChannelOutboundBuffer.MessageProcessor filterWriteMultiple(IovArray iovArray) {
+            if (!IoUring.isSendmsgZcSupported()) {
+                return super.filterWriteMultiple(iovArray);
+            }
             IoUringSocketChannelConfig ioUringSocketChannelConfig = (IoUringSocketChannelConfig) config();
             return new ChannelOutboundBuffer.MessageProcessor() {
                 @Override


### PR DESCRIPTION

Motivation:

When IoUringChannelOption.IO_URING_WRITE_ZERO_COPY_THRESHOLD is configured but the Linux kernel does not support IORING_OP_SENDMSG_ZC, writing buffers exceeding the zero-copy threshold causes an infinite loop and no data is transmitted.

`IoUringSocketChannel.IoUringSocketUnsafe#scheduleWriteMultiple` falls back to the writev path when the kernel does not support IORING_OP_SENDMSG_ZC. However, `IoUringSocketChannel.IoUringSocketUnsafe#filterWriteMultiple` does not check whether IORING_OP_SENDMSG_ZC is supported, and still rejects buffers exceeding the zero-copy threshold from being added to the IovArray. This results in an empty writev submission (0 iov entries). The kernel returns res=0 immediately, and `writeComplete` interprets this as writtenAll=true, re-scheduling the write and forming an infinite loop.

```
IoUringSocketChannel.scheduleWriteMultiple()
  → isSendmsgZcSupported() = false → skip ZC branch
  → super.scheduleWriteMultiple()          // fallback to normal writev
    → filterWriteMultiple()
      → shouldWriteZeroCopy = true → return false   // buffer rejected
    → iovArrayLength = 0 → submit empty writev
→ Kernel CQE: op=WRITEV, res=0
→ writeComplete()
  → removeBytes(0) → no-op, writtenAll = true
  → clear WRITE_SCHEDULED → scheduleWriteIfNeeded()
    → scheduleWriteMultiple()              // loop restarts ♻️
```

Modification:
Add an isSendmsgZcSupported() guard in `io.netty.channel.uring.IoUringSocketChannel.IoUringSocketUnsafe#filterWriteMultiple` when the kernel does not support ZC, skip the buffer size filter and allow large buffers to be sent via the normal writev path.

Result:

Fix io_uring writev infinite loop on kernels without SENDMSG_ZC support
