### PR TITLE
Kqueue: Correctly handle registrations

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractSocketReuseFdTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractSocketReuseFdTest.java
@@ -142,7 +142,12 @@ public abstract class AbstractSocketReuseFdTest extends AbstractSocketTest {
         public void channelActive(ChannelHandlerContext ctx) {
             channel = ctx.channel();
             if (client) {
-                ctx.writeAndFlush(Unpooled.copiedBuffer(EXPECTED_PAYLOAD, CharsetUtil.US_ASCII));
+                ctx.writeAndFlush(Unpooled.copiedBuffer(EXPECTED_PAYLOAD, CharsetUtil.US_ASCII))
+                        .addListener(f -> {
+                            if (!f.isSuccess()) {
+                                donePromise.tryFailure(f.cause());
+                            }
+                        });
             }
         }
 
@@ -157,7 +162,12 @@ public abstract class AbstractSocketReuseFdTest extends AbstractSocketTest {
                     if (client) {
                         ctx.close();
                     } else {
-                        ctx.writeAndFlush(Unpooled.copiedBuffer(EXPECTED_PAYLOAD, CharsetUtil.US_ASCII));
+                        ctx.writeAndFlush(Unpooled.copiedBuffer(EXPECTED_PAYLOAD, CharsetUtil.US_ASCII))
+                                .addListener(f -> {
+                                    if (!f.isSuccess()) {
+                                        donePromise.tryFailure(f.cause());
+                                    }
+                                });
                     }
                 }
             }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
@@ -179,6 +179,11 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
     }
 
     private void submit(KQueueIoOps ops) {
+        if (!isOpen()) {
+            // If the channel was closed in the meantime we should just drop the ops as otherwise we might end up
+            // affected another channel that re-used the fd.
+            return;
+        }
         try {
             registration.submit(ops);
         } catch (Exception e) {


### PR DESCRIPTION
Motivation:

When refactoring our Kqueue transport to use the new IO transport concept we introduced a regression which could lead to submitting IoOps that ended up be used for re-used FDs.

Modifications:

Correctly guards submits as it was before in 4.1

Result:

No more failures due FD reused and submitting of ops