### PR TITLE
Kqueue: Correctly use KqueueIoOps.data() when update change list

### DIFF
--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoHandler.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoHandler.java
@@ -455,10 +455,11 @@ public final class KQueueIoHandler implements IoHandler {
             short filter = kQueueIoOps.filter();
             short flags = kQueueIoOps.flags();
             int fflags = kQueueIoOps.fflags();
+            long data = kQueueIoOps.data();
             if (executor.isExecutorThread(Thread.currentThread())) {
-                evSet(filter, flags, fflags);
+                evSet(filter, flags, fflags, data);
             } else {
-                executor.execute(() -> evSet(filter, flags, fflags));
+                executor.execute(() -> evSet(filter, flags, fflags, data));
             }
             return 0;
         }
@@ -472,12 +473,12 @@ public final class KQueueIoHandler implements IoHandler {
             handle.handle(this, event);
         }
 
-        private void evSet(short filter, short flags, int fflags) {
+        private void evSet(short filter, short flags, int fflags, long data) {
             if (cancellationPending) {
                 // This registration was already cancelled but not removed from the map yet, just ignore.
                 return;
             }
-            changeList.evSet(handle.ident(), filter, flags, fflags, 0, id);
+            changeList.evSet(handle.ident(), filter, flags, fflags, data, id);
         }
 
         @Override


### PR DESCRIPTION
Motivation:

We did miss to pass the correct data value to the change list. While this is not a problem in our usage (as data is always 0) this might be a problem if people use KQueueIoHandler with their own KqueueHandle implementation

Modifications:

Correctly use data

Result:

Correct use values passed as KqueueIoOps
