### PR TITLE
Kqueue: Fix undefined behaviour when GetStringUTFChars fails and SO_ACCEPTFILTER is supported

### DIFF
--- a/transport-native-kqueue/src/main/c/netty_kqueue_bsdsocket.c
+++ b/transport-native-kqueue/src/main/c/netty_kqueue_bsdsocket.c
@@ -145,10 +145,20 @@ static void netty_kqueue_bsdsocket_setAcceptFilter(JNIEnv* env, jclass clazz, ji
     af.af_name[0] = af.af_arg[0] ='\0';
 
     tmpString = (*env)->GetStringUTFChars(env, afName, NULL);
+    if (tmpString == NULL) {
+       // if NULL is returned it failed due OOME
+       netty_unix_errors_throwChannelExceptionErrorNo(env, "setsockopt() failed: ", ENOMEM);
+       return;
+    }
     strncat(af.af_name, tmpString, sizeof(af.af_name) / sizeof(af.af_name[0]));
     (*env)->ReleaseStringUTFChars(env, afName, tmpString);
 
     tmpString = (*env)->GetStringUTFChars(env, afArg, NULL);
+    if (tmpString == NULL) {
+        // if NULL is returned it failed due OOME
+        netty_unix_errors_throwChannelExceptionErrorNo(env, "setsockopt() failed: ", ENOMEM);
+        return;
+    }
     strncat(af.af_arg, tmpString, sizeof(af.af_arg) / sizeof(af.af_arg[0]));
     (*env)->ReleaseStringUTFChars(env, afArg, tmpString);
 


### PR DESCRIPTION
Motivation:

We did miss some NULL checks which could cause undefined behaviour which most likely would cause a crash. As this only happens when SO_ACCEPTFILTER is supported and when GetStringUTFChars fails it was not possible to reach this on MacOS.

Modifications:

Add missing NULL checks

Result:

No more undef behaviour
