### PR TITLE
Native transports: Fix possible fd leak when fcntl fails.

### DIFF
--- a/transport-native-unix-common/src/main/c/netty_unix_socket.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_socket.c
@@ -699,8 +699,10 @@ static jint netty_unix_socket_accept(JNIEnv* env, jclass clazz, jint fd, jbyteAr
     if (accept4)  {
         return socketFd;
     }
+    // accept4 was not present so need two more sys-calls ...
     if (fcntl(socketFd, F_SETFD, FD_CLOEXEC) == -1 || fcntl(socketFd, F_SETFL, O_NONBLOCK) == -1) {
-        // accept4 was not present so need two more sys-calls ...
+        // close the fd before report the error so we don't leak it.
+        close(socketFd);
         return -errno;
     }
     return socketFd;


### PR DESCRIPTION
Motivation:

When accept4(...) is not present on the platform we fallback to using normal accept(...) syscall. In this case we also need two extra syscalls (fcntl). If one of the fcntl calls failed we did not close the previous accepted fd and so leaked it.

Modifications:

Call close(...) before returning early

Result:

No more fd leak in case of fcntl failure
