### PR TITLE
Make unpooled buffers avoid shared arenas

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptiveByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptiveByteBufAllocator.java
@@ -111,9 +111,7 @@ public final class AdaptiveByteBufAllocator extends AbstractByteBufAllocator
 
         @Override
         public AbstractByteBuf allocate(int initialCapacity, int maxCapacity) {
-            return PlatformDependent.hasUnsafe() ?
-                    UnsafeByteBufUtil.newUnsafeDirectByteBuf(allocator, initialCapacity, maxCapacity) :
-                    new UnpooledDirectByteBuf(allocator, initialCapacity, maxCapacity);
+            return UnsafeByteBufUtil.newDirectByteBuf(allocator, initialCapacity, maxCapacity);
         }
     }
 }

--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -764,7 +764,7 @@ abstract class PoolArena<T> implements PoolArenaMetric {
         }
 
         private static CleanableDirectBuffer allocateDirect(int capacity) {
-            return PlatformDependent.allocateDirect(capacity);
+            return PlatformDependent.allocateDirect(capacity, true);
         }
 
         @Override

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -402,9 +402,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
         if (directArena != null) {
             buf = directArena.allocate(cache, initialCapacity, maxCapacity);
         } else {
-            buf = PlatformDependent.hasUnsafe() ?
-                    UnsafeByteBufUtil.newUnsafeDirectByteBuf(this, initialCapacity, maxCapacity) :
-                    new UnpooledDirectByteBuf(this, initialCapacity, maxCapacity);
+            buf = UnsafeByteBufUtil.newDirectByteBuf(this, initialCapacity, maxCapacity);
             onAllocateBuffer(buf, false, false);
         }
         return toLeakAwareBuffer(buf);

--- a/buffer/src/main/java/io/netty/buffer/UnpooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledByteBufAllocator.java
@@ -189,6 +189,12 @@ public final class UnpooledByteBufAllocator extends AbstractByteBufAllocator imp
         }
 
         @Override
+        protected CleanableDirectBuffer allocateDirectBuffer(int capacity, boolean permitExpensiveClean) {
+            CleanableDirectBuffer buffer = super.allocateDirectBuffer(capacity, permitExpensiveClean);
+            return new DecrementingCleanableDirectBuffer(alloc(), buffer);
+        }
+
+        @Override
         CleanableDirectBuffer reallocateDirect(CleanableDirectBuffer oldBuffer, int initialCapacity) {
             int capacity = oldBuffer.buffer().capacity();
             CleanableDirectBuffer buffer = super.reallocateDirect(oldBuffer, initialCapacity);
@@ -205,6 +211,12 @@ public final class UnpooledByteBufAllocator extends AbstractByteBufAllocator imp
         @Override
         protected CleanableDirectBuffer allocateDirectBuffer(int capacity) {
             CleanableDirectBuffer buffer = super.allocateDirectBuffer(capacity);
+            return new DecrementingCleanableDirectBuffer(alloc(), buffer);
+        }
+
+        @Override
+        protected CleanableDirectBuffer allocateDirectBuffer(int capacity, boolean permitExpensiveClean) {
+            CleanableDirectBuffer buffer = super.allocateDirectBuffer(capacity, permitExpensiveClean);
             return new DecrementingCleanableDirectBuffer(alloc(), buffer);
         }
 
@@ -228,6 +240,12 @@ public final class UnpooledByteBufAllocator extends AbstractByteBufAllocator imp
         @Override
         protected CleanableDirectBuffer allocateDirectBuffer(int initialCapacity) {
             CleanableDirectBuffer buffer = super.allocateDirectBuffer(initialCapacity);
+            return new DecrementingCleanableDirectBuffer(alloc(), buffer);
+        }
+
+        @Override
+        protected CleanableDirectBuffer allocateDirectBuffer(int initialCapacity, boolean permitExpensiveClean) {
+            CleanableDirectBuffer buffer = super.allocateDirectBuffer(initialCapacity, permitExpensiveClean);
             return new DecrementingCleanableDirectBuffer(alloc(), buffer);
         }
 

--- a/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
@@ -122,7 +122,7 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     protected CleanableDirectBuffer allocateDirectBuffer(int capacity) {
-        return allocateDirectBuffer(capacity, false);
+        return PlatformDependent.allocateDirect(capacity, false);
     }
 
     protected CleanableDirectBuffer allocateDirectBuffer(int capacity, boolean permitExpensiveClean) {

--- a/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
@@ -125,7 +125,7 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
         return PlatformDependent.allocateDirect(capacity, false);
     }
 
-    protected CleanableDirectBuffer allocateDirectBuffer(int capacity, boolean permitExpensiveClean) {
+    CleanableDirectBuffer allocateDirectBuffer(int capacity, boolean permitExpensiveClean) {
         return PlatformDependent.allocateDirect(capacity, permitExpensiveClean);
     }
 

--- a/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
@@ -53,6 +53,10 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
      * @param maxCapacity     the maximum capacity of the underlying direct buffer
      */
     public UnpooledDirectByteBuf(ByteBufAllocator alloc, int initialCapacity, int maxCapacity) {
+        this(alloc, initialCapacity, maxCapacity, false);
+    }
+
+    UnpooledDirectByteBuf(ByteBufAllocator alloc, int initialCapacity, int maxCapacity, boolean permitExpensiveClean) {
         super(maxCapacity);
         ObjectUtil.checkNotNull(alloc, "alloc");
         checkPositiveOrZero(initialCapacity, "initialCapacity");
@@ -63,7 +67,7 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
         }
 
         this.alloc = alloc;
-        setByteBuffer(allocateDirectBuffer(initialCapacity), false);
+        setByteBuffer(allocateDirectBuffer(initialCapacity, permitExpensiveClean), false);
     }
 
     /**
@@ -118,7 +122,11 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     protected CleanableDirectBuffer allocateDirectBuffer(int capacity) {
-        return PlatformDependent.allocateDirect(capacity);
+        return allocateDirectBuffer(capacity, false);
+    }
+
+    protected CleanableDirectBuffer allocateDirectBuffer(int capacity, boolean permitExpensiveClean) {
+        return PlatformDependent.allocateDirect(capacity, permitExpensiveClean);
     }
 
     void setByteBuffer(CleanableDirectBuffer cleanableDirectBuffer, boolean tryFree) {

--- a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeDirectByteBuf.java
@@ -45,6 +45,11 @@ public class UnpooledUnsafeDirectByteBuf extends UnpooledDirectByteBuf {
         super(alloc, initialCapacity, maxCapacity);
     }
 
+    UnpooledUnsafeDirectByteBuf(ByteBufAllocator alloc, int initialCapacity, int maxCapacity,
+                                boolean permitExpensiveClean) {
+        super(alloc, initialCapacity, maxCapacity, permitExpensiveClean);
+    }
+
     /**
      * Creates a new direct buffer by wrapping the specified initial buffer.
      *

--- a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeNoCleanerDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeNoCleanerDirectByteBuf.java
@@ -31,6 +31,11 @@ class UnpooledUnsafeNoCleanerDirectByteBuf extends UnpooledUnsafeDirectByteBuf {
     }
 
     @Override
+    protected CleanableDirectBuffer allocateDirectBuffer(int capacity, boolean ignorePermitExpensiveClean) {
+        return PlatformDependent.allocateDirectBufferNoCleaner(capacity);
+    }
+
+    @Override
     protected ByteBuffer allocateDirect(int initialCapacity) {
         throw new UnsupportedOperationException();
     }

--- a/buffer/src/main/java/io/netty/buffer/UnsafeByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/UnsafeByteBufUtil.java
@@ -719,14 +719,21 @@ final class UnsafeByteBufUtil {
         return toZero;
     }
 
-    static UnpooledUnsafeDirectByteBuf newUnsafeDirectByteBuf(
-            ByteBufAllocator alloc, int initialCapacity, int maxCapacity) {
-        if (PlatformDependent.useDirectBufferNoCleaner()) {
-            return new UnpooledUnsafeNoCleanerDirectByteBuf(
-                    alloc, initialCapacity, maxCapacity);
+    /**
+     * Allocates direct buffers for chunks used in the pooling allocators.
+     * @param alloc The allocator we're creating a chunk for.
+     * @param initialCapacity The initial capacity.
+     * @param maxCapacity The max capacity.
+     * @return The {@link UnpooledDirectByteBuf} with the chunk memory.
+     */
+    static UnpooledDirectByteBuf newDirectByteBuf(ByteBufAllocator alloc, int initialCapacity, int maxCapacity) {
+        if (PlatformDependent.hasUnsafe()) {
+            if (PlatformDependent.useDirectBufferNoCleaner()) {
+                return new UnpooledUnsafeNoCleanerDirectByteBuf(alloc, initialCapacity, maxCapacity);
+            }
+            return new UnpooledUnsafeDirectByteBuf(alloc, initialCapacity, maxCapacity, true);
         }
-        return new UnpooledUnsafeDirectByteBuf(
-                alloc, initialCapacity, maxCapacity);
+        return new UnpooledDirectByteBuf(alloc, initialCapacity, maxCapacity, true);
     }
 
     private UnsafeByteBufUtil() { }

--- a/common/src/main/java/io/netty/util/internal/Cleaner.java
+++ b/common/src/main/java/io/netty/util/internal/Cleaner.java
@@ -45,7 +45,5 @@ interface Cleaner {
      * @return {@code true} if this Cleaner has an expensive clean
      * (i.e. {@link CleanableDirectBuffer#clean()}) operation.
      */
-    default boolean hasExpensiveClean() {
-        return false;
-    }
+    boolean hasExpensiveClean();
 }

--- a/common/src/main/java/io/netty/util/internal/Cleaner.java
+++ b/common/src/main/java/io/netty/util/internal/Cleaner.java
@@ -38,4 +38,14 @@ interface Cleaner {
      */
     @Deprecated
     void freeDirectBuffer(ByteBuffer buffer);
+
+    /**
+     * Check if the clean operation is "relatively expensive".
+     * Expensive clean operations are fine for pooling allocators, but should be avoided for unpooled buffers.
+     * @return {@code true} if this Cleaner has an expensive clean
+     * (i.e. {@link CleanableDirectBuffer#clean()}) operation.
+     */
+    default boolean hasExpensiveClean() {
+        return false;
+    }
 }

--- a/common/src/main/java/io/netty/util/internal/CleanerJava24Linker.java
+++ b/common/src/main/java/io/netty/util/internal/CleanerJava24Linker.java
@@ -203,6 +203,11 @@ public class CleanerJava24Linker implements Cleaner {
         throw new UnsupportedOperationException("Cannot clean arbitrary ByteBuffer instances");
     }
 
+    @Override
+    public boolean hasExpensiveClean() {
+        return false;
+    }
+
     static long malloc(int capacity) {
         final long addr;
         try {

--- a/common/src/main/java/io/netty/util/internal/CleanerJava25.java
+++ b/common/src/main/java/io/netty/util/internal/CleanerJava25.java
@@ -183,6 +183,13 @@ final class CleanerJava25 implements Cleaner {
         throw new UnsupportedOperationException("Cannot clean arbitrary ByteBuffer instances");
     }
 
+    @Override
+    public boolean hasExpensiveClean() {
+        // Closing shared arenas can be fairly expensive if we do it a lot,
+        // because it relies on inter-thread handshakes.
+        return true;
+    }
+
     private static final class CleanableDirectBufferImpl implements CleanableDirectBuffer {
         private final AutoCloseable closeable;
         private final ByteBuffer buffer;

--- a/common/src/main/java/io/netty/util/internal/CleanerJava6.java
+++ b/common/src/main/java/io/netty/util/internal/CleanerJava6.java
@@ -110,6 +110,11 @@ final class CleanerJava6 implements Cleaner {
         freeDirectBufferStatic(buffer);
     }
 
+    @Override
+    public boolean hasExpensiveClean() {
+        return false;
+    }
+
     private static void freeDirectBufferStatic(ByteBuffer buffer) {
         if (!buffer.isDirect()) {
             return;

--- a/common/src/main/java/io/netty/util/internal/CleanerJava9.java
+++ b/common/src/main/java/io/netty/util/internal/CleanerJava9.java
@@ -92,6 +92,11 @@ final class CleanerJava9 implements Cleaner {
         freeDirectBufferStatic(buffer);
     }
 
+    @Override
+    public boolean hasExpensiveClean() {
+        return false;
+    }
+
     private static void freeDirectBufferStatic(ByteBuffer buffer) {
         // Try to minimize overhead when there is no SecurityManager present.
         // See https://bugs.openjdk.java.net/browse/JDK-8191053.

--- a/common/src/main/java/io/netty/util/internal/DirectCleaner.java
+++ b/common/src/main/java/io/netty/util/internal/DirectCleaner.java
@@ -28,6 +28,11 @@ final class DirectCleaner implements Cleaner {
         PlatformDependent.freeDirectNoCleaner(buffer);
     }
 
+    @Override
+    public boolean hasExpensiveClean() {
+        return false;
+    }
+
     CleanableDirectBuffer reallocate(CleanableDirectBuffer buffer, int capacity) {
         ByteBuffer newByteBuffer = PlatformDependent.reallocateDirectNoCleaner(buffer.buffer(), capacity);
         return new CleanableDirectBufferImpl(newByteBuffer);

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -597,6 +597,22 @@ public final class PlatformDependent {
      * @return The {@link CleanableDirectBuffer} instance that contain the buffer and its deallocation mechanism.
      */
     public static CleanableDirectBuffer allocateDirect(int capacity) {
+        return allocateDirect(capacity, false);
+    }
+
+    /**
+     * Allocate a direct {@link ByteBuffer} of the given capacity, and return it alongside its deallocation mechanism.
+     * @param capacity The desired capacity of the direct byte buffer.
+     * @param permitExpensiveClean Whether to allow expensive clean operations or not. If expensive clean operations
+     * are not permitted ({@code false}), then the buffer cleaning may instead be delegated to the GC and reference
+     * processing. Pooling allocators would typically permit expensive clean operations, while unpooled buffers
+     * would not.
+     * @return The {@link CleanableDirectBuffer} instance that contain the buffer and its deallocation mechanism.
+     */
+    public static CleanableDirectBuffer allocateDirect(int capacity, boolean permitExpensiveClean) {
+        if (!permitExpensiveClean && CLEANER.hasExpensiveClean()) {
+            return NOOP.allocate(capacity);
+        }
         return CLEANER.allocate(capacity);
     }
 

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -128,6 +128,8 @@ public final class PlatformDependent {
     private static final String LINUX_ID_PREFIX = "ID=";
     private static final String LINUX_ID_LIKE_PREFIX = "ID_LIKE=";
     public static final boolean BIG_ENDIAN_NATIVE_ORDER = ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN;
+    private static final boolean IGNORE_EXPENSIVE_CLEAN =
+            SystemPropertyUtil.getBoolean("io.netty.ignoreExpensiveClean", false);
 
     private static final boolean JFR;
     private static final boolean VAR_HANDLE;
@@ -625,7 +627,7 @@ public final class PlatformDependent {
      * @return The {@link CleanableDirectBuffer} instance that contain the buffer and its deallocation mechanism.
      */
     public static CleanableDirectBuffer allocateDirect(int capacity, boolean permitExpensiveClean) {
-        if (!permitExpensiveClean && CLEANER.hasExpensiveClean()) {
+        if (!IGNORE_EXPENSIVE_CLEAN && !permitExpensiveClean && CLEANER.hasExpensiveClean()) {
             return NOOP.allocate(capacity);
         }
         return CLEANER.allocate(capacity);

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -147,6 +147,16 @@ public final class PlatformDependent {
                 public void clean() {
                     // NOOP
                 }
+
+                @Override
+                public boolean hasMemoryAddress() {
+                    return hasDirectByteBufferAddress(byteBuffer);
+                }
+
+                @Override
+                public long memoryAddress() {
+                    return directBufferAddress(byteBuffer);
+                }
             };
         }
 
@@ -629,6 +639,21 @@ public final class PlatformDependent {
         LEGACY_CLEANER.freeDirectBuffer(buffer);
     }
 
+    /**
+     * Check if it is possible to call {@link #directBufferAddress(ByteBuffer)} on the given buffer.
+     * @param buffer The specific buffer instance to check for.
+     * @return {@code true} if {@link #directBufferAddress(ByteBuffer)} can be called on the given buffer,
+     * otherwise {@code false}.
+     */
+    public static boolean hasDirectByteBufferAddress(ByteBuffer buffer) {
+        return PlatformDependent0.hasDirectByteBufferAdderss(buffer);
+    }
+
+    /**
+     * Obtain the native memory address of the given direct byte buffer, or throw an exception if it's not possible.
+     * @param buffer The buffer to get the native memory address for.
+     * @return The native memory address of the give buffer.
+     */
     public static long directBufferAddress(ByteBuffer buffer) {
         return PlatformDependent0.directBufferAddress(buffer);
     }

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -164,6 +164,11 @@ public final class PlatformDependent {
         public void freeDirectBuffer(ByteBuffer buffer) {
             // NOOP
         }
+
+        @Override
+        public boolean hasExpensiveClean() {
+            return false;
+        }
     };
 
     static {

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -52,6 +52,7 @@ final class PlatformDependent0 {
     private static final MethodHandle OFFSET_SLICE;
     private static final MethodHandle ABSOLUTE_PUT_BUFFER;
     private static final MethodHandle ABSOLUTE_PUT_ARRAY;
+    private static final MethodHandle MEMORY_SEGMENT_ADDRESS_OF_BUFFER;
     private static final boolean IS_ANDROID = isAndroid0();
     private static final int JAVA_VERSION = javaVersion0();
     private static final Throwable EXPLICIT_NO_UNSAFE_CAUSE = explicitNoUnsafeCause0();
@@ -540,6 +541,28 @@ final class PlatformDependent0 {
         } else {
             ABSOLUTE_PUT_ARRAY = null;
         }
+        if (javaVersion() >= 22) {
+            MEMORY_SEGMENT_ADDRESS_OF_BUFFER = (MethodHandle) AccessController.doPrivileged(new PrivilegedAction<Object>() {
+                @Override
+                public Object run() {
+                    try {
+                        // We're recreating the following code snippet:
+                        // (long) MemorySegment.ofBuffer((Buffer) arg1).address();
+                        Class<?> memsegCls = Class.forName("java.lang.foreign.MemorySegment");
+                        MethodType ofBufferType = methodType(memsegCls, Buffer.class);
+                        MethodType addressType = methodType(long.class);
+                        MethodHandles.Lookup lookup = MethodHandles.publicLookup();
+                        MethodHandle ofBuffer = lookup.findStatic(memsegCls, "ofBuffer", ofBufferType);
+                        MethodHandle address = lookup.findVirtual(memsegCls, "address", addressType);
+                        return MethodHandles.filterArguments(address, 0, ofBuffer);
+                    } catch (Throwable e) {
+                        return null;
+                    }
+                }
+            });
+        } else {
+            MEMORY_SEGMENT_ADDRESS_OF_BUFFER = null;
+        }
 
         logger.debug("java.nio.DirectByteBuffer.<init>(long, {int,long}): {}",
                 DIRECT_BUFFER_CONSTRUCTOR != null ? "available" : "unavailable");
@@ -649,6 +672,10 @@ final class PlatformDependent0 {
 
     static Throwable getUnsafeUnavailabilityCause() {
         return UNSAFE_UNAVAILABILITY_CAUSE;
+    }
+
+    static boolean hasMemorySegmentAddressOfBuffer() {
+        return MEMORY_SEGMENT_ADDRESS_OF_BUFFER != null;
     }
 
     static boolean unalignedAccess() {
@@ -764,8 +791,25 @@ final class PlatformDependent0 {
         }
     }
 
+    static boolean hasDirectByteBufferAdderss(ByteBuffer buffer) {
+        return buffer.isDirect() && (hasUnsafe() || hasMemorySegmentAddressOfBuffer());
+    }
+
     static long directBufferAddress(ByteBuffer buffer) {
-        return getLong(buffer, ADDRESS_FIELD_OFFSET);
+        if (hasUnsafe()) {
+            return getLong(buffer, ADDRESS_FIELD_OFFSET);
+
+        }
+        if (hasMemorySegmentAddressOfBuffer()) {
+            try {
+                return (long) MEMORY_SEGMENT_ADDRESS_OF_BUFFER.invokeExact((Buffer) buffer);
+            } catch (Throwable e) {
+                LinkageError error = new LinkageError("Failed to call MemorySegment.ofBuffer(arg1).address()");
+                error.initCause(e);
+                throw error;
+            }
+        }
+        throw new IllegalStateException("No address access method");
     }
 
     static long byteArrayBaseOffset() {

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -542,7 +542,8 @@ final class PlatformDependent0 {
             ABSOLUTE_PUT_ARRAY = null;
         }
         if (javaVersion() >= 22) {
-            MEMORY_SEGMENT_ADDRESS_OF_BUFFER = (MethodHandle) AccessController.doPrivileged(new PrivilegedAction<Object>() {
+            MEMORY_SEGMENT_ADDRESS_OF_BUFFER = (MethodHandle) AccessController.doPrivileged(
+                    new PrivilegedAction<Object>() {
                 @Override
                 public Object run() {
                     try {
@@ -798,7 +799,6 @@ final class PlatformDependent0 {
     static long directBufferAddress(ByteBuffer buffer) {
         if (hasUnsafe()) {
             return getLong(buffer, ADDRESS_FIELD_OFFSET);
-
         }
         if (hasMemorySegmentAddressOfBuffer()) {
             try {


### PR DESCRIPTION
Motivation:
Shared arenas can be expensive to close if we do it a lot, for instance in cases when we use the UnpooledByteBufAllocator.

Modification:
Make Unpooled buffers avoid shared arenas and instead fall back to GC/reference processing buffer cleaning. Make the pooling allocators explicitly state that they permit "expensive" clean operations to that they use shared arenas.

Result:
Greatly improves system-wide performance and scalability when allocating a lot of unpooled buffers, at the cost of delayed cleaning/deallocation and in turn higher memory usage.

This should also address a number of flaky test failures we see, that are caused by timeouts due to increased time we were spending in closing shared arenas.

If the use GC and reference counting causes adverse performance effects, e.g. performance regressions or poor GC behavior, then the previous behavior (letting unpooled buffers use shared memory segment arenas) can be restored by setting the `io.netty.ignoreExpensiveClean=true` system property.