### PR TITLE
Native transports: Fix undefined behaviour when GetStringUTFChars fails while open FD

### DIFF
--- a/transport-native-unix-common/src/main/c/netty_unix_filedescriptor.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_filedescriptor.c
@@ -97,6 +97,9 @@ static jint netty_unix_filedescriptor_close(JNIEnv* env, jclass clazz, jint fd) 
 
 static jint netty_unix_filedescriptor_open(JNIEnv* env, jclass clazz, jstring path) {
     const char* f_path = (*env)->GetStringUTFChars(env, path, 0);
+    if (f_path == NULL) {
+        return -ENOMEN;
+    }
 
     int res = open(f_path, O_WRONLY | O_CREAT | O_TRUNC, 0666);
     (*env)->ReleaseStringUTFChars(env, path, f_path);

--- a/transport-native-unix-common/src/main/c/netty_unix_filedescriptor.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_filedescriptor.c
@@ -98,7 +98,7 @@ static jint netty_unix_filedescriptor_close(JNIEnv* env, jclass clazz, jint fd) 
 static jint netty_unix_filedescriptor_open(JNIEnv* env, jclass clazz, jstring path) {
     const char* f_path = (*env)->GetStringUTFChars(env, path, 0);
     if (f_path == NULL) {
-        return -ENOMEN;
+        return -ENOMEM;
     }
 
     int res = open(f_path, O_WRONLY | O_CREAT | O_TRUNC, 0666);


### PR DESCRIPTION
Motivation:

We need to handle the case of GetStringUTFChars returning NULL as otherwise we run into undefined behavior which will most likely cause a crash

Modifications:

Return -ENOMEM in case of failure

Result:

No more undef behavior
