### PR TITLE
Fix UnsupportedOperationException in readTrailingHeaders (#16412)

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -875,7 +875,6 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             return LastHttpContent.EMPTY_LAST_CONTENT;
         }
 
-        CharSequence lastHeader = null;
         if (trailer == null) {
             trailer = this.trailer = new DefaultLastHttpContent(Unpooled.EMPTY_BUFFER, trailersFactory);
         }
@@ -883,29 +882,19 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             final byte[] lineContent = line.array();
             final int startLine = line.arrayOffset() + line.readerIndex();
             final byte firstChar = lineContent[startLine];
-            if (lastHeader != null && (firstChar == ' ' || firstChar == '\t')) {
-                List<String> current = trailer.trailingHeaders().getAll(lastHeader);
-                if (!current.isEmpty()) {
-                    int lastPos = current.size() - 1;
-                    //please do not make one line from below code
-                    //as it breaks +XX:OptimizeStringConcat optimization
-                    String lineTrimmed = langAsciiString(lineContent, startLine, line.readableBytes()).trim();
-                    String currentLastPos = current.get(lastPos);
-                    current.set(lastPos, currentLastPos + lineTrimmed);
-                }
+            if (name != null && (firstChar == ' ' || firstChar == '\t')) {
+                //please do not make one line from below code
+                //as it breaks +XX:OptimizeStringConcat optimization
+                String trimmedLine = langAsciiString(lineContent, startLine, lineLength).trim();
+                String valueStr = value;
+                value = valueStr + ' ' + trimmedLine;
             } else {
-                splitHeader(lineContent, startLine, lineLength);
-                AsciiString headerName = name;
-                if (!HttpHeaderNames.CONTENT_LENGTH.contentEqualsIgnoreCase(headerName) &&
-                        !HttpHeaderNames.TRANSFER_ENCODING.contentEqualsIgnoreCase(headerName) &&
-                        !HttpHeaderNames.TRAILER.contentEqualsIgnoreCase(headerName)) {
-                    trailer.trailingHeaders().add(headerName, value);
+                if (name != null && isPermittedTrailingHeader(name)) {
+                    trailer.trailingHeaders().add(name, value);
                 }
-                lastHeader = name;
-                // reset name and value fields
-                name = null;
-                value = null;
+                splitHeader(lineContent, startLine, lineLength);
             }
+
             line = headerParser.parse(buffer, defaultStrictCRLFCheck);
             if (line == null) {
                 return null;
@@ -913,8 +902,26 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             lineLength = line.readableBytes();
         }
 
+        // Add the last trailer
+        if (name != null && isPermittedTrailingHeader(name)) {
+            trailer.trailingHeaders().add(name, value);
+        }
+
+        // reset name and value fields
+        name = null;
+        value = null;
+
         this.trailer = null;
         return trailer;
+    }
+
+    /**
+     * Checks whether the given trailer field name is permitted per RFC 9110 section 6.5
+     */
+    private static boolean isPermittedTrailingHeader(final AsciiString name) {
+        return !HttpHeaderNames.CONTENT_LENGTH.contentEqualsIgnoreCase(name) &&
+               !HttpHeaderNames.TRANSFER_ENCODING.contentEqualsIgnoreCase(name) &&
+               !HttpHeaderNames.TRAILER.contentEqualsIgnoreCase(name);
     }
 
     protected abstract boolean isDecodingRequest();

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -270,6 +270,92 @@ public class HttpRequestDecoderTest {
     }
 
     @Test
+    public void testSingleTrailingHeader() throws Exception {
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
+        String request = "POST / HTTP/1.1\r\n" +
+                "Host: localhost\r\n" +
+                "Transfer-Encoding: chunked\r\n" +
+                "\r\n" +
+                "5\r\n" +
+                "hello\r\n" +
+                "0\r\n" +
+                "X-Checksum: abc123\r\n" +
+                "\r\n";
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(request, CharsetUtil.US_ASCII)));
+        HttpRequest req = channel.readInbound();
+        assertFalse(req.decoderResult().isFailure());
+        HttpContent body = channel.readInbound();
+        body.release();
+        LastHttpContent last = channel.readInbound();
+        assertFalse(last.decoderResult().isFailure());
+        assertEquals("abc123", last.trailingHeaders().get(of("X-Checksum")));
+        last.release();
+        assertFalse(channel.finish());
+    }
+
+    @Test
+    public void testMultiLineTrailingHeader() throws Exception {
+        // Regression: folded trailer values previously threw UnsupportedOperationException
+        // because trailingHeaders().getAll() returns an AbstractList that does not implement set().
+        // Note: obs-fold in trailers is permitted as trailers are field-lines per
+        // https://www.rfc-editor.org/rfc/rfc9112#section-5.2
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
+        String request = "POST / HTTP/1.1\r\n" +
+                "Host: localhost\r\n" +
+                "Transfer-Encoding: chunked\r\n" +
+                "\r\n" +
+                "5\r\n" +
+                "hello\r\n" +
+                "0\r\n" +
+                "X-Long: part1\r\n" +
+                "        part2\r\n" +
+                "\t\t\t  part3\r\n" +
+                "X-Short: value\r\n" +
+                "\r\n";
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(request, CharsetUtil.US_ASCII)));
+        HttpRequest req = channel.readInbound();
+        assertFalse(req.decoderResult().isFailure());
+        HttpContent body = channel.readInbound();
+        body.release();
+        LastHttpContent last = channel.readInbound();
+        assertFalse(last.decoderResult().isFailure());
+        assertEquals("part1 part2 part3", last.trailingHeaders().get(of("X-Long")));
+        assertEquals("value", last.trailingHeaders().get(of("X-Short")));
+        last.release();
+        assertFalse(channel.finish());
+    }
+
+    @Test
+    public void testForbiddenTrailingHeadersAreDropped() throws Exception {
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
+        String request = "POST / HTTP/1.1\r\n" +
+                "Host: localhost\r\n" +
+                "Transfer-Encoding: chunked\r\n" +
+                "\r\n" +
+                "5\r\n" +
+                "hello\r\n" +
+                "0\r\n" +
+                HttpHeaderNames.CONTENT_LENGTH + ": 5\r\n" +
+                HttpHeaderNames.TRANSFER_ENCODING + ": chunked\r\n" +
+                "X-Custom: keep\r\n" +
+                HttpHeaderNames.TRAILER + ": X-Checksum\r\n" + // covering post-loop flush path
+                "\r\n";
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(request, CharsetUtil.US_ASCII)));
+        HttpRequest req = channel.readInbound();
+        assertFalse(req.decoderResult().isFailure());
+        HttpContent body = channel.readInbound();
+        body.release();
+        LastHttpContent last = channel.readInbound();
+        assertFalse(last.decoderResult().isFailure());
+        assertNull(last.trailingHeaders().get(HttpHeaderNames.CONTENT_LENGTH));
+        assertNull(last.trailingHeaders().get(HttpHeaderNames.TRANSFER_ENCODING));
+        assertNull(last.trailingHeaders().get(HttpHeaderNames.TRAILER));
+        assertEquals("keep", last.trailingHeaders().get(of("X-Custom")));
+        last.release();
+        assertFalse(channel.finish());
+    }
+
+    @Test
     public void test100Continue() throws Exception {
         HttpRequestDecoder decoder = new HttpRequestDecoder();
         EmbeddedChannel channel = new EmbeddedChannel(decoder);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
@@ -667,6 +667,64 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
+    public void testMultiLineTrailingHeader() throws Exception {
+        // Regression: folded trailer values previously threw UnsupportedOperationException
+        // because trailingHeaders().getAll() returns an AbstractList that does not implement set().
+        // Note: obs-fold in trailers is permitted as trailers are field-lines per
+        // https://www.rfc-editor.org/rfc/rfc9112#section-5.2
+        EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder());
+        String response = "HTTP/1.1 200 OK\r\n" +
+                "Transfer-Encoding: chunked\r\n" +
+                "\r\n" +
+                "0\r\n" +
+                "X-Long: part1\r\n" +
+                "        part2\r\n" +
+                "\t\t\t  part3\r\n" +
+                "X-Short: value\r\n" +
+                "\r\n";
+        assertTrue(ch.writeInbound(Unpooled.copiedBuffer(response, CharsetUtil.US_ASCII)));
+        HttpResponse res = ch.readInbound();
+        assertFalse(res.decoderResult().isFailure());
+        assertSame(HttpVersion.HTTP_1_1, res.protocolVersion());
+        assertEquals(HttpResponseStatus.OK, res.status());
+
+        LastHttpContent last = ch.readInbound();
+        assertFalse(last.decoderResult().isFailure());
+        assertEquals("part1 part2 part3", last.trailingHeaders().get(of("X-Long")));
+        assertEquals("value", last.trailingHeaders().get(of("X-Short")));
+        last.release();
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testForbiddenTrailingHeadersAreDropped() throws Exception {
+        EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder());
+        String response = "HTTP/1.1 200 OK\r\n" +
+                "Transfer-Encoding: chunked\r\n" +
+                "\r\n" +
+                "0\r\n" +
+                HttpHeaderNames.CONTENT_LENGTH + ": 5\r\n" +
+                HttpHeaderNames.TRANSFER_ENCODING + ": chunked\r\n" +
+                "X-Custom: keep\r\n" +
+                HttpHeaderNames.TRAILER + ": X-Checksum\r\n" + // covering post-loop flush path
+                "\r\n";
+        assertTrue(ch.writeInbound(Unpooled.copiedBuffer(response, CharsetUtil.US_ASCII)));
+        HttpResponse res = ch.readInbound();
+        assertFalse(res.decoderResult().isFailure());
+        assertSame(HttpVersion.HTTP_1_1, res.protocolVersion());
+        assertEquals(HttpResponseStatus.OK, res.status());
+
+        LastHttpContent last = ch.readInbound();
+        assertFalse(last.decoderResult().isFailure());
+        assertNull(last.trailingHeaders().get(HttpHeaderNames.CONTENT_LENGTH));
+        assertNull(last.trailingHeaders().get(HttpHeaderNames.TRANSFER_ENCODING));
+        assertNull(last.trailingHeaders().get(HttpHeaderNames.TRAILER));
+        assertEquals("keep", last.trailingHeaders().get(of("X-Custom")));
+        last.release();
+        assertFalse(ch.finish());
+    }
+
+    @Test
     public void testResponseWithContentLength() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder());
         ch.writeInbound(Unpooled.copiedBuffer(


### PR DESCRIPTION
Motivation:

When a chunked HTTP message contains a trailer field with a folded value (obs-fold continuation line starting with SP or HT), readTrailingHeaders threw UnsupportedOperationException. This happened because the folding logic called List.set() on the list returned by
trailingHeaders().getAll(), which is an AbstractList implementation that does not override set().

Modifications:

Changed readTrailingHeaders in HttpObjectDecoder to accumulate folded continuation lines into the instance-level `value` field, mirroring the pattern already used by readHeaders. The previous header is now flushed via trailingHeaders().add() only once its complete value is assembled, eliminating the need to mutate the list returned by getAll(). Forbidden trailer fields (Content-Length, Transfer-Encoding, Trailer) are filtered at flush time, consistent with the previous behaviour.

Added tests to HttpRequestDecoderTest and HttpResponseDecoderTest covering:
- A single trailer field
- A folded trailer field with multiple SP and HT continuation lines, followed by a non-folded trailer to verify isolation between fields
- Forbidden trailer fields interleaved with a valid one, with a forbidden field placed last to exercise the post-loop flush path

Result:

Chunked HTTP messages with folded trailer values are now decoded correctly instead of throwing UnsupportedOperationException.

(cherry picked from commit 9a85f9f25cd580e4f971deb6ea19f7b8af1c6e0d)
