### PR TITLE
Epoll: Add null checks for safety reasons

### DIFF
--- a/transport-native-epoll/src/main/c/netty_epoll_native.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_native.c
@@ -487,6 +487,11 @@ static jint netty_epoll_native_sendmmsg0(JNIEnv* env, jclass clazz, jint fd, jbo
 
     for (i = 0; i < len; i++) {
         jobject packet = (*env)->GetObjectArrayElement(env, packets, i + offset);
+        if (packet == NULL) {
+            // This should never happen but just handle it and return early. This way if GetObjectArrayElement(...)
+            // did put an exception on the stack we will see it and not crash.
+            return -1;
+        }
         jbyteArray address = (jbyteArray) (*env)->GetObjectField(env, packet, packetRecipientAddrFieldId);
         jint addrLen = (*env)->GetIntField(env, packet, packetRecipientAddrLenFieldId);
         jint packetSegmentSize = (*env)->GetIntField(env, packet, packetSegmentSizeFieldId);
@@ -624,6 +629,11 @@ static jint netty_epoll_native_recvmmsg0(JNIEnv* env, jclass clazz, jint fd, jbo
 
     for (i = 0; i < len; i++) {
         jobject packet = (*env)->GetObjectArrayElement(env, packets, i + offset);
+        if (packet == NULL) {
+            // This should never happen but just handle it and return early. This way if GetObjectArrayElement(...)
+            // did put an exception on the stack we will see it and not crash.
+            return -1;
+        }
         msg[i].msg_hdr.msg_iov = (struct iovec*) (intptr_t) (*env)->GetLongField(env, packet, packetMemoryAddressFieldId);
         msg[i].msg_hdr.msg_iovlen = (*env)->GetIntField(env, packet, packetCountFieldId);
 


### PR DESCRIPTION
Motivation:

We did not check for NULL when calling GetObjectArrayElement which could be returned if we try to access an element that is out of bounds. While this should never happen we should better still guard against it to make the code less error-prone.

Modifications:

Add NULL check

Result:

More correct code
