### PR TITLE
DnsNameResolver: Skip test if we can not bind TCP and UDP to the same port

### DIFF
--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -68,6 +68,7 @@ import org.apache.directory.server.dns.store.DnsAttribute;
 import org.apache.directory.server.dns.store.RecordStore;
 import org.apache.mina.core.buffer.IoBuffer;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -3490,8 +3491,8 @@ public class DnsNameResolverTest {
                 serverSocket.close();
                 if (i == 10) {
                     // We tried 10 times without success
-                    throw new IllegalStateException(
-                            "Unable to bind TestDnsServer and ServerSocket to the same address", e);
+                    Assumptions.abort("Unable to bind TestDnsServer and ServerSocket to the same address: " +
+                            e.getMessage());
                 }
                 // We could not start the DnsServer which is most likely because the localAddress was already used,
                 // let's retry


### PR DESCRIPTION
Motivation:

On windows we sometimes see failures when we try to bind TCP and UDP to the same port for our tests even after we retried multiple times. To make the CI less stable we should just skip the test in this case.

Modifications:

Just abort the test via an Assumption if we can't bind

Result:

More stable CI
