### PR TITLE
Epoll: Fix support for IP_RECVORIGDSTADDR

### DIFF
--- a/transport-native-epoll/src/main/c/netty_epoll_native.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_native.c
@@ -615,7 +615,7 @@ static jint netty_epoll_native_recvmmsg0(JNIEnv* env, jclass clazz, jint fd, jbo
 #ifdef IP_RECVORIGDSTADDR
     int readLocalAddr = 0;
     if (netty_unix_socket_getOption(env, fd, IPPROTO_IP, IP_RECVORIGDSTADDR,
-            &readLocalAddr, sizeof(readLocalAddr)) < 0) {
+            &readLocalAddr, sizeof(readLocalAddr)) != -1 && readLocalAddr != 0) {
         cntrlbuf = malloc(sizeof(char) * storageSize * len);
     }
 #endif // IP_RECVORIGDSTADDR


### PR DESCRIPTION
Motivation:

We incorrectly used the return value of netty_unix_socket_getOption(...,IP_RECVORIGDSTADDR) and so did not correctly support IP_RECVORIGDSTADDR when using recvmmsg.

Modifications:

- Correctly use the return value and also validate that the socket option is actually set before allocating the control message buffer.

Result:

Fix support of IP_RECVORIGDSTADDR when using recvmmsg
