### PR TITLE
AdaptivePoolingAllocator: remove `ensureAccessible()` call in `capacity(int)` method

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -1667,7 +1667,6 @@ final class AdaptivePoolingAllocator {
         public ByteBuf capacity(int newCapacity) {
             checkNewCapacity(newCapacity);
             if (length <= newCapacity && newCapacity <= maxFastCapacity) {
-                ensureAccessible();
                 length = newCapacity;
                 return this;
             }


### PR DESCRIPTION
Motivation:

In `AdaptivePoolingAllocator.capacity(int)`, the call to `checkNewCapacity(newCapacity)` already invokes `ensureAccessible()` internally, making the explicit `ensureAccessible()` call redundant.

Modification:

Remove the redundant `ensureAccessible()` call from the `capacity(int)` method.

Result:

Reducing unnecessary overhead.