### PR TITLE
AdaptivePoolingAllocator: Fix assertion for size class multiple of 32

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -175,7 +175,7 @@ final class AdaptivePoolingAllocator {
         for (int i = 0; i < SIZE_CLASSES_COUNT; i++) {
             int sizeClass = SIZE_CLASSES[i];
             //noinspection ConstantValue
-            assert (sizeClass & 5) == 0 : "Size class must be a multiple of 32";
+            assert (sizeClass & 31) == 0 : "Size class must be a multiple of 32";
             int sizeIndex = sizeIndexOf(sizeClass);
             Arrays.fill(SIZE_INDEXES, lastIndex + 1, sizeIndex + 1, (byte) i);
             lastIndex = sizeIndex;


### PR DESCRIPTION
Motivation:

The assertion validating `SIZE_CLASSES` is a multiple of 32 used the wrong bit-mask: `(sizeClass & 5) == 0`, so values like 10 will pass the assertion. 

Modification:

Changed to `(sizeClass & 31) == 0`.

Result:

Invalid size class can now correctly caught in assertion environment.