### PR TITLE
Cleanup: Fix typo in method name

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -653,7 +653,7 @@ public final class PlatformDependent {
      * otherwise {@code false}.
      */
     public static boolean hasDirectByteBufferAddress(ByteBuffer buffer) {
-        return PlatformDependent0.hasDirectByteBufferAdderss(buffer);
+        return PlatformDependent0.hasDirectByteBufferAddress(buffer);
     }
 
     /**

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -792,7 +792,7 @@ final class PlatformDependent0 {
         }
     }
 
-    static boolean hasDirectByteBufferAdderss(ByteBuffer buffer) {
+    static boolean hasDirectByteBufferAddress(ByteBuffer buffer) {
         return buffer.isDirect() && (hasUnsafe() || hasMemorySegmentAddressOfBuffer());
     }
 


### PR DESCRIPTION
Motivation:

There was a typo in a method name.

Modifications:

Fix typo

Result:

Cleanup