### PR TITLE
Epoll: Remove outdated docs about usage of edge-triggered

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollChannelConfig.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollChannelConfig.java
@@ -180,10 +180,7 @@ public class EpollChannelConfig extends DefaultChannelConfig {
     }
 
     /**
-     * Return the {@link EpollMode} used. Default is
-     * {@link EpollMode#EDGE_TRIGGERED}. If you want to use {@link #isAutoRead()} {@code false} or
-     * {@link #getMaxMessagesPerRead()} and have an accurate behaviour you should use
-     * {@link EpollMode#LEVEL_TRIGGERED}.
+     * Return the {@link EpollMode} used.
      *
      * @deprecated Netty always uses level-triggered mode and so this method is just a no-op.
      */
@@ -194,8 +191,6 @@ public class EpollChannelConfig extends DefaultChannelConfig {
 
     /**
      * Set the {@link EpollMode} used. Default is
-     * {@link EpollMode#EDGE_TRIGGERED}. If you want to use {@link #isAutoRead()} {@code false} or
-     * {@link #getMaxMessagesPerRead()} and have an accurate behaviour you should use
      * {@link EpollMode#LEVEL_TRIGGERED}.
      *
      * <strong>Be aware this config setting can only be adjusted before the channel was registered.</strong>

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -55,8 +55,7 @@ import java.nio.channels.UnresolvedAddressException;
 import static io.netty.channel.epoll.LinuxSocket.newSocketDgram;
 
 /**
- * {@link DatagramChannel} implementation that uses linux EPOLL Edge-Triggered Mode for
- * maximal performance.
+ * {@link DatagramChannel} implementation that uses linux EPOLL.
  */
 public final class EpollDatagramChannel extends AbstractEpollChannel implements DatagramChannel {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(EpollDatagramChannel.class);

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
@@ -33,8 +33,7 @@ import static io.netty.channel.epoll.Native.IS_SUPPORTING_TCP_FASTOPEN_SERVER;
 import static io.netty.channel.unix.NativeInetAddress.address;
 
 /**
- * {@link ServerSocketChannel} implementation that uses linux EPOLL Edge-Triggered Mode for
- * maximal performance.
+ * {@link ServerSocketChannel} implementation that uses linux EPOLL.
  */
 public final class EpollServerSocketChannel extends AbstractEpollServerChannel implements ServerSocketChannel {
 

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannel.java
@@ -38,8 +38,7 @@ import static io.netty.channel.epoll.LinuxSocket.newSocketStream;
 import static io.netty.channel.epoll.Native.IS_SUPPORTING_TCP_FASTOPEN_CLIENT;
 
 /**
- * {@link SocketChannel} implementation that uses linux EPOLL Edge-Triggered Mode for
- * maximal performance.
+ * {@link SocketChannel} implementation that uses linux EPOLL.
  */
 public final class EpollSocketChannel extends AbstractEpollStreamChannel implements SocketChannel {
 

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/package-info.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/package-info.java
@@ -15,7 +15,6 @@
  */
 
 /**
- * Optimized transport for linux which uses <a href="https://en.wikipedia.org/wiki/Epoll">EPOLL Edge-Triggered Mode</a>
- * for maximal performance.
+ * Optimized transport for linux which uses <a href="https://en.wikipedia.org/wiki/Epoll">EPOLL</a>.
  */
 package io.netty.channel.epoll;


### PR DESCRIPTION
Motivation:

These days we only use level-triggered mode with EPOLL but missed to also reflect this in the docs

Modifications:

Update docs to remove incorrect references to edge-triggered mode

Result:

Fixes https://github.com/netty/netty/issues/16427
