### PR TITLE
Log value of io.netty.ignoreExpensiveClean property during initialization

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -244,6 +244,8 @@ public final class PlatformDependent {
             logger.debug("-Dio.netty.noPreferDirect: {}", EXPLICIT_NO_PREFER_DIRECT);
         }
 
+        logger.debug("-Dio.netty.ignoreExpensiveClean: {}", IGNORE_EXPENSIVE_CLEAN);
+
         /*
          * We do not want to log this message if unsafe is explicitly disabled. Do not remove the explicit no unsafe
          * guard.


### PR DESCRIPTION
Motivation:

c79ce23a7b4e1be6985ad5e9127f0244f1052621 introduced a system property but we failed to log it's value during initialization.

Modifications:

Log property value in debug mode just as all the otehr properties

Result:

Log used value
