### PR TITLE
Quic: Fix global reference leak

### DIFF
--- a/codec-native-quic/src/main/c/netty_quic_boringssl.c
+++ b/codec-native-quic/src/main/c/netty_quic_boringssl.c
@@ -1193,7 +1193,7 @@ static void netty_boringssl_SSLContext_free(JNIEnv* env, jclass clazz, jlong ctx
     OPENSSL_free(data);
 
     jobject sessionTicketCallbackRef = SSL_CTX_get_ex_data(ssl_ctx, sessionTicketCallbackIdx);
-    if (sessionCallbackRef != NULL) {
+    if (sessionTicketCallbackRef != NULL) {
         (*env)->DeleteGlobalRef(env, sessionTicketCallbackRef);
     }
 


### PR DESCRIPTION
Motivation:

We did check the wrong variable for NULL and so leaked a global reference which means it can never be GC'ed. As this per QuicheQuicSslContext it is not super critical but still we shouldn't leak memory.

Modifications:

Fix NULL check

Result:

No more global reference leak
