### PR TITLE
QUIC: Don'l leak memory when context is detroyed

### DIFF
--- a/codec-native-quic/src/main/c/netty_quic_boringssl.c
+++ b/codec-native-quic/src/main/c/netty_quic_boringssl.c
@@ -1190,6 +1190,9 @@ static void netty_boringssl_SSLContext_free(JNIEnv* env, jclass clazz, jlong ctx
     }
 
     alpn_data* data = SSL_CTX_get_ex_data(ssl_ctx, alpn_data_idx);
+    if (data != NULL) {
+        OPENSSL_free(data->proto_data);
+    }
     OPENSSL_free(data);
 
     jobject sessionTicketCallbackRef = SSL_CTX_get_ex_data(ssl_ctx, sessionTicketCallbackIdx);


### PR DESCRIPTION
Motivation:

We need to ensure we release all previous malloced memory as otherwise we will leak. alpn->proto_data was never freed and so we leaked memory

Modifications:

Correclty free proto_data before we free the alpn itself.

Result:

No more memory leak
