### PR TITLE
ByteBufAllocatorAllocPatternBenchmark: Fix case sensitivity in benchmark method name check

### DIFF
--- a/microbench/src/main/java/io/netty/microbench/buffer/ByteBufAllocatorAllocPatternBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/ByteBufAllocatorAllocPatternBenchmark.java
@@ -179,7 +179,7 @@ public class ByteBufAllocatorAllocPatternBenchmark extends AbstractMicrobenchmar
             return;
         }
 
-        final boolean directAllocation = params.getBenchmark().contains("Direct");
+        final boolean directAllocation = params.getBenchmark().contains("direct");
 
         int perThreadIterations = pollutionIterations / 2;
 


### PR DESCRIPTION
Motivation:

The `String.contains()` method in Java is case-sensitive. In `ByteBufAllocatorAllocPatternBenchmark`, the benchmark name check used `"Direct"` (capitalized) to determine whether direct memory allocation should be enabled, but the benchmark name uses lowercase `"direct"`, the condition would silently evaluate to `false` to `directAllocation`.

Modification:

Changed the string literal in the `contains()` check from `"Direct"` to `"direct"` to correctly match the actual benchmark naming.

```java
// Before
final boolean directAllocation = params.getBenchmark().contains("Direct");

// After
final boolean directAllocation = params.getBenchmark().contains("direct");
```

Result:

The `directAllocation` flag is now correctly resolved based on the benchmark name.

