### PR TITLE
QUIC: Correctly handle malloc errors during ssl context creation

### DIFF
--- a/codec-native-quic/src/main/c/netty_quic_boringssl.c
+++ b/codec-native-quic/src/main/c/netty_quic_boringssl.c
@@ -1014,7 +1014,8 @@ static jlong netty_boringssl_SSLContext_new0(JNIEnv* env, jclass clazz, jboolean
     jobject sessionCallbackRef = NULL;
     jobject privateKeyMethodRef = NULL;
     jobject sessionTicketCallbackRef = NULL;
-
+    SSL_CTX *ctx = NULL;
+    alpn_data* alpn = NULL;
     if ((handshakeCompleteCallbackRef = (*env)->NewGlobalRef(env, handshakeCompleteCallback)) == NULL) {
         goto error;
     }
@@ -1054,7 +1055,7 @@ static jlong netty_boringssl_SSLContext_new0(JNIEnv* env, jclass clazz, jboolean
         goto error;
     }
 
-    SSL_CTX *ctx = SSL_CTX_new(TLS_with_buffers_method());
+     ctx = SSL_CTX_new(TLS_with_buffers_method());
     // When using BoringSSL we want to use CRYPTO_BUFFER to reduce memory usage and minimize overhead as we do not need
     // X509* at all and just need the raw bytes of the certificates to construct our Java X509Certificate.
     //
@@ -1113,6 +1114,10 @@ static jlong netty_boringssl_SSLContext_new0(JNIEnv* env, jclass clazz, jboolean
         if (alpn != NULL) {
             // Fill the alpn_data struct
             alpn->proto_data = OPENSSL_malloc(alpn_length);
+            if (alpn->proto_data == NULL) {
+                // malloc failed, most likely OOM.
+                goto error;
+            }
             alpn->proto_len = alpn_length;
             (*env)->GetByteArrayRegion(env, alpn_protos, 0, alpn_length, (jbyte*) alpn->proto_data);
 
@@ -1122,10 +1127,20 @@ static jlong netty_boringssl_SSLContext_new0(JNIEnv* env, jclass clazz, jboolean
             } else {
                 SSL_CTX_set_alpn_protos(ctx, alpn->proto_data, alpn->proto_len);
             }
+        } else {
+           // malloc failed, most likely OOM.
+           goto error;
         }
     }
     return (jlong) ctx;
 error:
+    if (ctx != NULL) {
+        SSL_CTX_free(ctx);
+    }
+    if (alpn != NULL) {
+        OPENSSL_free(alpn->proto_data);
+        OPENSSL_free(alpn);
+    }
     if (handshakeCompleteCallbackRef != NULL) {
         (*env)->DeleteGlobalRef(env, handshakeCompleteCallbackRef);
     }


### PR DESCRIPTION
Motivation:

In case if malloc fails we need to correctly handle the case and release all previous allocated memory. We missed this and so leaked memory.

Modifications:

Correctly handle malloc errors and ensure we free all previous allocated memory

Result:

No more memory leak in case of malloc error
