### PR TITLE
QUIC: Correctly handle selection of alpn protos

### DIFF
--- a/codec-native-quic/src/main/c/netty_quic_boringssl.c
+++ b/codec-native-quic/src/main/c/netty_quic_boringssl.c
@@ -725,7 +725,8 @@ int BoringSSL_callback_alpn_select_proto(SSL* ssl, const unsigned char **out, un
         }
 
         // increment len and pointers.
-        i += target_proto_len;
+        // +1 accounts for the one-byte length prefix that was consumed above via ++supported_protos.
+        i += target_proto_len + 1;
         supported_protos += target_proto_len;
     }
     return SSL_TLSEXT_ERR_NOACK;


### PR DESCRIPTION
Motivation:

We did miss to increment by 1 which could lead to reading out of bounds and so is a undefined behavior

Modifications:

Correctly increment by 1 as well

Result:

No more undefined behavior during alpn selection by more then 2 protocols.
