### PR TITLE
Avoid unpooled allocator in `CloseWebSocketFrame`

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/CloseWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/CloseWebSocketFrame.java
@@ -16,7 +16,9 @@
 package io.netty.handler.codec.http.websocketx;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
+import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.StringUtil;
 
@@ -41,6 +43,17 @@ public class CloseWebSocketFrame extends WebSocketFrame {
      */
     public CloseWebSocketFrame(WebSocketCloseStatus status) {
         this(requireValidStatusCode(status.code()), status.reasonText());
+    }
+
+    /**
+     * Creates a new empty close frame with closing status code and reason text, using the provided ByteBuf allocator.
+     *
+     * @param status
+     *            Status code as per <a href="https://tools.ietf.org/html/rfc6455#section-7.4">RFC 6455</a>. For
+     *            example, <tt>1000</tt> indicates normal closure.
+     */
+    public CloseWebSocketFrame(WebSocketCloseStatus status, ByteBufAllocator allocator) {
+        this(true, 0, allocator, requireValidStatusCode(status.code()), status.reasonText());
     }
 
     /**
@@ -95,15 +108,35 @@ public class CloseWebSocketFrame extends WebSocketFrame {
      *            Reason text. Set to null if no text.
      */
     public CloseWebSocketFrame(boolean finalFragment, int rsv, int statusCode, String reasonText) {
-        super(finalFragment, rsv, newBinaryData(requireValidStatusCode(statusCode), reasonText));
+        this(finalFragment, rsv, UnpooledByteBufAllocator.DEFAULT, statusCode, reasonText);
     }
 
-    private static ByteBuf newBinaryData(int statusCode, String reasonText) {
+    /**
+     * Creates a new close frame with closing status code and reason text
+     *
+     * @param finalFragment
+     *            flag indicating if this frame is the final fragment
+     * @param rsv
+     *            reserved bits used for protocol extensions
+     * @param allocator
+     *            the ByteBuf allocator to use to build the binary data.
+     * @param statusCode
+     *            Integer status code as per <a href="https://tools.ietf.org/html/rfc6455#section-7.4">RFC 6455</a>. For
+     *            example, <tt>1000</tt> indicates normal closure.
+     * @param reasonText
+     *            Reason text. Set to null if no text.
+     */
+    public CloseWebSocketFrame(boolean finalFragment, int rsv, ByteBufAllocator allocator,
+                               int statusCode, String reasonText) {
+        super(finalFragment, rsv, newBinaryData(allocator, requireValidStatusCode(statusCode), reasonText));
+    }
+
+    private static ByteBuf newBinaryData(ByteBufAllocator allocator, int statusCode, String reasonText) {
         if (reasonText == null) {
             reasonText = StringUtil.EMPTY_STRING;
         }
 
-        ByteBuf binaryData = Unpooled.buffer(2 + reasonText.length());
+        ByteBuf binaryData = allocator.buffer(2 + reasonText.length());
         binaryData.writeShort(statusCode);
         if (!reasonText.isEmpty()) {
             binaryData.writeCharSequence(reasonText, CharsetUtil.UTF_8);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/CloseWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/CloseWebSocketFrame.java
@@ -108,7 +108,7 @@ public class CloseWebSocketFrame extends WebSocketFrame {
      *            Reason text. Set to null if no text.
      */
     public CloseWebSocketFrame(boolean finalFragment, int rsv, int statusCode, String reasonText) {
-        this(finalFragment, rsv, UnpooledByteBufAllocator.DEFAULT, statusCode, reasonText);
+        this(finalFragment, rsv, null, statusCode, reasonText);
     }
 
     /**
@@ -120,6 +120,7 @@ public class CloseWebSocketFrame extends WebSocketFrame {
      *            reserved bits used for protocol extensions
      * @param allocator
      *            the ByteBuf allocator to use to build the binary data.
+     *            <code>null</code> indicates to use an unpooled heap buffer.
      * @param statusCode
      *            Integer status code as per <a href="https://tools.ietf.org/html/rfc6455#section-7.4">RFC 6455</a>. For
      *            example, <tt>1000</tt> indicates normal closure.
@@ -136,7 +137,10 @@ public class CloseWebSocketFrame extends WebSocketFrame {
             reasonText = StringUtil.EMPTY_STRING;
         }
 
-        ByteBuf binaryData = allocator.buffer(2 + reasonText.length());
+        int bufferInitialCapacity = 2 + reasonText.length();
+        ByteBuf binaryData = allocator == null
+                ? Unpooled.buffer(bufferInitialCapacity)
+                : allocator.buffer(bufferInitialCapacity);
         binaryData.writeShort(statusCode);
         if (!reasonText.isEmpty()) {
             binaryData.writeCharSequence(reasonText, CharsetUtil.UTF_8);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/CloseWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/CloseWebSocketFrame.java
@@ -108,7 +108,7 @@ public class CloseWebSocketFrame extends WebSocketFrame {
      *            Reason text. Set to null if no text.
      */
     public CloseWebSocketFrame(boolean finalFragment, int rsv, int statusCode, String reasonText) {
-        this(finalFragment, rsv, null, statusCode, reasonText);
+        this(finalFragment, rsv, UnpooledByteBufAllocator.DEFAULT, statusCode, reasonText);
     }
 
     /**
@@ -120,7 +120,6 @@ public class CloseWebSocketFrame extends WebSocketFrame {
      *            reserved bits used for protocol extensions
      * @param allocator
      *            the ByteBuf allocator to use to build the binary data.
-     *            <code>null</code> indicates to use an unpooled heap buffer.
      * @param statusCode
      *            Integer status code as per <a href="https://tools.ietf.org/html/rfc6455#section-7.4">RFC 6455</a>. For
      *            example, <tt>1000</tt> indicates normal closure.
@@ -137,10 +136,7 @@ public class CloseWebSocketFrame extends WebSocketFrame {
             reasonText = StringUtil.EMPTY_STRING;
         }
 
-        int bufferInitialCapacity = 2 + reasonText.length();
-        ByteBuf binaryData = allocator == null
-                ? Unpooled.buffer(bufferInitialCapacity)
-                : allocator.buffer(bufferInitialCapacity);
+        ByteBuf binaryData = allocator.buffer(2 + reasonText.length());
         binaryData.writeShort(statusCode);
         if (!reasonText.isEmpty()) {
             binaryData.writeCharSequence(reasonText, CharsetUtil.UTF_8);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketProtocolHandler.java
@@ -94,7 +94,7 @@ abstract class WebSocketProtocolHandler extends MessageToMessageDecoder<WebSocke
             ctx.close(promise);
         } else {
             if (closeSent == null) {
-                write(ctx, new CloseWebSocketFrame(closeStatus), ctx.newPromise());
+                write(ctx, new CloseWebSocketFrame(closeStatus, ctx.alloc()), ctx.newPromise());
             }
             flush(ctx);
             applyCloseSentTimeout(ctx);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandlerTest.java
@@ -393,8 +393,10 @@ public class WebSocketServerProtocolHandlerTest {
         assertFalse(server.isOpen());
 
         CloseWebSocketFrame closeMessage = decode(server.<ByteBuf>readOutbound(), CloseWebSocketFrame.class);
-        assertEquals(closeMessage, new CloseWebSocketFrame(WebSocketCloseStatus.NORMAL_CLOSURE));
+        CloseWebSocketFrame expectedFrame = new CloseWebSocketFrame(WebSocketCloseStatus.NORMAL_CLOSURE);
+        assertEquals(expectedFrame, closeMessage);
         closeMessage.release();
+        expectedFrame.release();
 
         assertFalse(client.finishAndReleaseAll());
         assertFalse(server.finishAndReleaseAll());


### PR DESCRIPTION
Motivation:

The `CloseWebSocketFrame.newBinaryData` method produces garbage that can be optimized using a pooled heap/direct buffers.
This would reduce the GC pressure, boosting the performance. We are facing a lot of allocations:
<img width="701" height="401" alt="image" src="https://github.com/user-attachments/assets/0aa8812f-4866-4ae3-833c-3659d93dd223" />

Modification:

Introduced a new `CloseWebSocketFrame` constructor that accepts `ByteBufAllocator`, and uses it in `newBinaryData` to allocate the buffer.
Also, updated the `WebSocketProtocolHandler` handler code to use the new constructor.

Result:

Fixes #16485. 