### PR TITLE
Epoll: Remove outdated docs about usage of edge-triggered (#16478)

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -56,8 +56,7 @@ import java.nio.channels.UnresolvedAddressException;
 import static io.netty.channel.epoll.LinuxSocket.newSocketDgram;
 
 /**
- * {@link DatagramChannel} implementation that uses linux EPOLL Edge-Triggered Mode for
- * maximal performance.
+ * {@link DatagramChannel} implementation that uses linux EPOLL.
  */
 public final class EpollDatagramChannel extends AbstractEpollChannel implements DatagramChannel {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(EpollDatagramChannel.class);

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
@@ -45,8 +45,7 @@ import static io.netty.channel.unix.NativeInetAddress.address;
 import static io.netty.channel.unix.Socket.isIPv6Preferred;
 
 /**
- * {@link ServerSocketChannel} implementation that uses linux EPOLL Edge-Triggered Mode for
- * maximal performance.
+ * {@link ServerSocketChannel} implementation that uses linux EPOLL.
  */
 public final class EpollServerSocketChannel extends AbstractEpollChannel implements ServerSocketChannel {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannel.java
@@ -63,8 +63,7 @@ import static io.netty.channel.internal.ChannelUtils.WRITE_STATUS_SNDBUF_FULL;
 import static io.netty.util.internal.StringUtil.className;
 
 /**
- * {@link SocketChannel} implementation that uses linux EPOLL Edge-Triggered Mode for
- * maximal performance.
+ * {@link SocketChannel} implementation that uses linux EPOLL.
  */
 public final class EpollSocketChannel extends AbstractEpollChannel implements SocketChannel {
 

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/package-info.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/package-info.java
@@ -15,7 +15,6 @@
  */
 
 /**
- * Optimized transport for linux which uses <a href="https://en.wikipedia.org/wiki/Epoll">EPOLL Edge-Triggered Mode</a>
- * for maximal performance.
+ * Optimized transport for linux which uses <a href="https://en.wikipedia.org/wiki/Epoll">EPOLL</a>.
  */
 package io.netty.channel.epoll;


### PR DESCRIPTION
Motivation:

These days we only use level-triggered mode with EPOLL but missed to also reflect this in the docs

Modifications:

Update docs to remove incorrect references to edge-triggered mode

Result:

Fixes https://github.com/netty/netty/issues/16427

(cherry picked from commit d5d6baeff88407307c7938bfb35ced9a6bb72e07)