### PR TITLE
IoUring: Use correct errno value in exception

### DIFF
--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -350,7 +350,7 @@ static jlongArray netty_io_uring_setup(JNIEnv *env, jclass clazz, jint entries, 
     if (ret != 0) {
         // Close ring fd before return.
         close(ring_fd);
-        netty_unix_errors_throwRuntimeExceptionErrorNo(env, "failed to mmap io_uring ring buffer: ", ret);
+        netty_unix_errors_throwRuntimeExceptionErrorNo(env, "failed to mmap io_uring ring buffer: ", -ret);
         return NULL;
     }
 


### PR DESCRIPTION
Motivation:
io_uring_mmap() returns -errno on failure so we need to negating it

Modifications:
- Changed ret to -ret

Result:
Since io_uring_mmap() returns -errno on failure, negating it recovers the positive errno value that throwRuntimeExceptionErrorNo expects for a meaningful error message.
