### PR TITLE
HttpObjectDecoder: Detect TLS ClientHello on plaintext HTTP connections

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -20,6 +20,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.ByteToMessageDecoder;
+import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.PrematureChannelClosureException;
 import io.netty.handler.codec.TooLongFrameException;
@@ -168,6 +169,12 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             throw new InvalidLineSeparatorException();
         }
     };
+
+    /**
+     * TLS record content type for Handshake (ClientHello), as defined in
+     * <a href="https://tools.ietf.org/html/rfc5246#section-6.2.1">RFC 5246, Section 6.2.1</a>.
+     */
+    private static final byte TLS_CONTENT_TYPE_HANDSHAKE = 0x16;
 
     private final int maxChunkSize;
     private final boolean chunkedSupported;
@@ -1263,6 +1270,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
 
         private boolean skipControlChars(ByteBuf buffer, int readableBytes, int readerIndex) {
             assert currentState == State.SKIP_CONTROL_CHARS;
+            checkForTlsHandshake(buffer, readerIndex);
             final int maxToSkip = Math.min(maxLength, readableBytes);
             final int firstNonControlIndex = buffer.forEachByte(readerIndex, maxToSkip, SKIP_CONTROL_CHARS_BYTES);
             if (firstNonControlIndex == -1) {
@@ -1304,4 +1312,15 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
     private static boolean isControlOrWhitespaceAsciiChar(byte b) {
         return ISO_CONTROL_OR_WHITESPACE[128 + b];
     }
+
+    private static void checkForTlsHandshake(final ByteBuf buffer, final int readerIndex) {
+        if (buffer.getByte(readerIndex) == TLS_CONTENT_TYPE_HANDSHAKE) {
+            throw new DecoderException(
+                    "Received a TLS/SSL ClientHello (0x" + Integer.toHexString(TLS_CONTENT_TYPE_HANDSHAKE) + ") while " +
+                            "parsing control chars, this indicates a client attempting to connect via HTTPS on a " +
+                            "plaintext HTTP port");
+        }
+    }
+
+
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -20,6 +20,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
@@ -487,6 +488,27 @@ public class HttpRequestDecoderTest {
         assertEquals("/some/path", req.uri());
         assertEquals(HttpVersion.HTTP_1_1, req.protocolVersion());
         assertTrue(channel.finishAndReleaseAll());
+    }
+
+    @Test
+    public void testTlsClientHelloOnPlaintextConnection() {
+        assertTlsOnPlaintext(new byte[] {0x16, 0x03, 0x01, 0x00, 0x05});
+    }
+
+    @Test
+    public void testTlsClientHelloSingleByteOnPlaintextConnection() {
+        assertTlsOnPlaintext(new byte[] {0x16});
+    }
+
+    private static void assertTlsOnPlaintext(final byte[] input) {
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
+        assertTrue(channel.writeInbound(Unpooled.wrappedBuffer(input)));
+        HttpRequest request = channel.readInbound();
+        assertTrue(request.decoderResult().isFailure());
+        assertInstanceOf(DecoderException.class, request.decoderResult().cause());
+        assertThat(request.decoderResult().cause().getMessage())
+                .startsWith("Received a TLS/SSL ClientHello (0x16) while parsing control chars");
+        assertFalse(channel.finish());
     }
 
     @Test

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
@@ -18,6 +18,7 @@ package io.netty.handler.codec.http;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.PrematureChannelClosureException;
 import io.netty.util.CharsetUtil;
@@ -1287,6 +1288,21 @@ public class HttpResponseDecoderTest {
         assertInstanceOf(IllegalArgumentException.class, response.decoderResult().cause());
         assertTrue(response.decoderResult().isFailure());
         ReferenceCountUtil.release(response);
+        assertFalse(channel.finish());
+    }
+
+    @Test
+    public void testTlsRecordOnPlaintextConnection() {
+        // this case is very unlikely, but to ensure parity with the request decoder
+        // we keep one regression test in here.
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseDecoder());
+        byte[] clientHelloStart = {0x16, 0x03, 0x01, 0x00, 0x05};
+        assertTrue(channel.writeInbound(Unpooled.wrappedBuffer(clientHelloStart)));
+        HttpResponse response = channel.readInbound();
+        assertTrue(response.decoderResult().isFailure());
+        assertInstanceOf(DecoderException.class, response.decoderResult().cause());
+        assertThat(response.decoderResult().cause().getMessage())
+                .startsWith("Received a TLS/SSL ClientHello (0x16) while parsing control chars");
         assertFalse(channel.finish());
     }
 }


### PR DESCRIPTION
Motivation:

When a client accidentally connects via HTTPS to a plaintext HTTP port, the SKIP_CONTROL_CHARS phase silently skips the TLS record header bytes (0x16, 0x03, 0x01) because they are ISO control characters. The decoder then attempts to parse the remaining TLS handshake payload as an HTTP start-line, producing misleading/confusing errors such as InvalidLineSeparatorException. This makes it difficult to diagnose the actual problem.

Modification:

Added a check in LineParser.skipControlChars() that detects byte 0x16 (TLS Handshake content type, per RFC 5246) at the buffer's reader index before control characters are skipped. When detected, a DecoderException is thrown with a descriptive message indicating a TLS/SSL ClientHello was received on a non-TLS HTTP connection. Added tests in both HttpRequestDecoderTest and HttpResponseDecoderTest.

Result:

Operators now get a clear, actionable error message when a TLS client connects to a plaintext HTTP port instead of a confusing parse failure.