### PR TITLE
Reduce allocations in WebSocketServerHandshaker13

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13.java
@@ -23,10 +23,12 @@ import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import io.netty.util.CharsetUtil;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 
 import static io.netty.handler.codec.http.HttpMethod.GET;
-import static io.netty.handler.codec.http.HttpVersion.*;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
 /**
  * <p>
@@ -37,6 +39,7 @@ import static io.netty.handler.codec.http.HttpVersion.*;
 public class WebSocketServerHandshaker13 extends WebSocketServerHandshaker {
 
     public static final String WEBSOCKET_13_ACCEPT_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+    private static final byte[] GUID_BYTES = WEBSOCKET_13_ACCEPT_GUID.getBytes(StandardCharsets.US_ASCII);
 
     /**
      * Constructor specifying the destination web socket location
@@ -152,7 +155,7 @@ public class WebSocketServerHandshaker13 extends WebSocketServerHandshaker {
                     "not a WebSocket request: a |Upgrade| header must containing the value 'websocket'", req);
         }
 
-        CharSequence key = reqHeaders.get(HttpHeaderNames.SEC_WEBSOCKET_KEY);
+        String key = reqHeaders.get(HttpHeaderNames.SEC_WEBSOCKET_KEY);
         if (key == null) {
             throw new WebSocketServerHandshakeException("not a WebSocket request: missing key", req);
         }
@@ -163,9 +166,10 @@ public class WebSocketServerHandshaker13 extends WebSocketServerHandshaker {
             res.headers().add(headers);
         }
 
-        String acceptSeed = key + WEBSOCKET_13_ACCEPT_GUID;
-        byte[] sha1 = WebSocketUtil.sha1(acceptSeed.getBytes(CharsetUtil.US_ASCII));
-        String accept = WebSocketUtil.base64(sha1);
+        MessageDigest digestSha1 = WebSocketUtil.sha1();
+        digestSha1.update(key.getBytes(StandardCharsets.US_ASCII));
+        digestSha1.update(GUID_BYTES);
+        String accept = WebSocketUtil.base64(digestSha1.digest());
 
         if (logger.isDebugEnabled()) {
             logger.debug("WebSocket version 13 server handshake key: {}, response: {}", key, accept);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketUtil.java
@@ -68,6 +68,12 @@ final class WebSocketUtil {
         return digest(MD5, data);
     }
 
+    static MessageDigest sha1() {
+        MessageDigest digest = SHA1.get();
+        digest.reset();
+        return digest;
+    }
+
     /**
      * Performs a SHA-1 hash on the specified data
      *


### PR DESCRIPTION
Motivation:

<img width="695" height="207" alt="image" src="https://github.com/user-attachments/assets/30a86363-3805-4414-a40b-ed3cfbea39cc" />


Currently, `WebSocketServerHandshaker13` does multiple different allocations in `newHandshakeResponse()` method, some of which could be avoided.

Modification:

Replaced the concat operation with multiple `digest.update()` calls.

Result:

No more String allocation on the concat operation. Also, as a bonus key.getBytes() now allocates ~2 times smaller byte array than a concatenated string would.


```
Benchmark                                                                              (key)  Mode  Cnt     Score     Error   Units
WebSocketServerHandshakeBenchmark.original                          dGhlIHNhbXBsZSBub25jZQ==  avgt   16   200.463 ±  66.739   ns/op
WebSocketServerHandshakeBenchmark.original:gc.alloc.rate            dGhlIHNhbXBsZSBub25jZQ==  avgt   16  1686.895 ± 565.204  MB/sec
WebSocketServerHandshakeBenchmark.original:gc.alloc.rate.norm       dGhlIHNhbXBsZSBub25jZQ==  avgt   16   320.001 ±   0.001    B/op
WebSocketServerHandshakeBenchmark.new                     dGhlIHNhbXBsZSBub25jZQ==  avgt   16   164.732 ±  43.825   ns/op
WebSocketServerHandshakeBenchmark.new:gc.alloc.rate       dGhlIHNhbXBsZSBub25jZQ==  avgt   16  1220.335 ± 269.482  MB/sec
WebSocketServerHandshakeBenchmark.new:gc.alloc.rate.norm  dGhlIHNhbXBsZSBub25jZQ==  avgt   16   200.001 ±   0.001    B/op
```