### PR TITLE
IoUring: Correctly handle return value of sys_io_uring_register(...) while register und unregister buffer ring

### DIFF
--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -439,8 +439,7 @@ static jlong netty_io_uring_register_buf_ring(JNIEnv* env, jclass clazz,
     reg.flags |= (__u16) flags;
 
     int registerRes = sys_io_uring_register(ringFd, IORING_REGISTER_PBUF_RING, &reg, 1);
-
-    if (registerRes) {
+    if (registerRes < 0) {
         munmap(br, ring_size);
         return registerRes;
     }
@@ -457,7 +456,7 @@ static jint netty_io_uring_unregister_buf_ring(JNIEnv* env, jclass clazz,
                                         jint nentries, jshort bgid) {
     struct io_uring_buf_reg reg = { .bgid = (__u16) bgid };
     int registerRes = sys_io_uring_register(ringFd, IORING_UNREGISTER_PBUF_RING, &reg, 1);
-    if (registerRes) {
+    if (registerRes < 0) {
         return registerRes;
     }
     size_t ring_size = nentries * sizeof(struct io_uring_buf);


### PR DESCRIPTION
Motivation:

As stated in the manpage sys_io_uring_register will return a negative value on failure so we need to respect this

Modifications:

Correctly handle negative value

Result:

Correctly handle failures of sys_io_uring_register when trying to register and unregister the buffer ring
