### PR TITLE
IoUring: Add NULL check for GetStringUTFChars(...)

### DIFF
--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -471,8 +471,10 @@ static jint netty_io_uring_unregister_buf_ring(JNIEnv* env, jclass clazz,
 
 static jint netty_create_file(JNIEnv *env, jclass class, jstring filename) {
     const char *file = (*env)->GetStringUTFChars(env, filename, 0);
-
-    int fd =  open(file, O_RDWR | O_TRUNC | O_CREAT, 0644);
+    if (file == NULL) {
+        return -1;
+    }
+    int fd = open(file, O_RDWR | O_TRUNC | O_CREAT, 0644);
     (*env)->ReleaseStringUTFChars(env, filename, file);
     return fd;
 }


### PR DESCRIPTION
Motivation:

We need to check if NULL is returned by GetStringUTFChars(...) as otherwise we might call open(...) with NULL which is undefined behavior

Modifications:

Add NULL check

Result:

No undefined behavior
