### PR TITLE
Epoll / IoUring: setTcpMg5Sig(...) might overflow

### DIFF
--- a/transport-native-epoll/src/main/c/netty_epoll_linuxsocket.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_linuxsocket.c
@@ -541,8 +541,13 @@ static void netty_epoll_linuxsocket_setTcpMd5Sig(JNIEnv* env, jclass clazz, jint
     }
 
     if (key != NULL) {
-        md5sig.tcpm_keylen = (*env)->GetArrayLength(env, key);
-        (*env)->GetByteArrayRegion(env, key, 0, md5sig.tcpm_keylen, (void *) &md5sig.tcpm_key);
+        jint keylen = (*env)->GetArrayLength(env, key);
+        if (keylen > TCP_MD5SIG_MAXKEYLEN) {
+            netty_unix_errors_throwIOException(env, "key is too long");
+            return;
+       }
+        md5sig.tcpm_keylen = (u_int16_t) keylen;
+        (*env)->GetByteArrayRegion(env, key, 0, keylen, (void *) &md5sig.tcpm_key);
         if ((*env)->ExceptionCheck(env) == JNI_TRUE) {
             return;
         }

--- a/transport-native-io_uring/src/main/c/netty_io_uring_linuxsocket.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_linuxsocket.c
@@ -439,8 +439,13 @@ static void netty_io_uring_linuxsocket_setTcpMd5Sig(JNIEnv* env, jclass clazz, j
     }
 
     if (key != NULL) {
-        md5sig.tcpm_keylen = (*env)->GetArrayLength(env, key);
-        (*env)->GetByteArrayRegion(env, key, 0, md5sig.tcpm_keylen, (void *) &md5sig.tcpm_key);
+        jint keylen = (*env)->GetArrayLength(env, key);
+        if (keylen > TCP_MD5SIG_MAXKEYLEN) {
+            netty_unix_errors_throwIOException(env, "key is too long");
+            return;
+        }
+        md5sig.tcpm_keylen = (u_int16_t) keylen;
+        (*env)->GetByteArrayRegion(env, key, 0, keylen, (void *) &md5sig.tcpm_key);
         if ((*env)->ExceptionCheck(env) == JNI_TRUE) {
             return;
         }


### PR DESCRIPTION
Motivation:

We did not check that the provided byte[] will fin into tcpm_key and so might overflow

Modifications:

Add length check and if it does not fit throw

Result:

No risk of overflow
