### PR TITLE
Fix docker image for cross-compiling

### DIFF
--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -13,9 +13,6 @@ ENV PROJECT_DIR=/root/workspace/project
 # Update to use the vault
 RUN sed -i -e 's/^mirrorlist/#mirrorlist/g' -e 's/^#baseurl=http:\/\/mirror.centos.org\/centos\/$releasever\//baseurl=https:\/\/linuxsoft.cern.ch\/centos-vault\/\/7.9.2009\//g' /etc/yum.repos.d/CentOS-Base.repo
 
-# We want to have git 2.x for the maven scm plugin and also for boringssl
-RUN yum install -y https://opensource.blueoptima.com/centos/6/git/x86_64/wandisco-git-release-6-1.noarch.rpm
-
 RUN yum -y install epel-release
 
 # Install requirements


### PR DESCRIPTION
Motivation:

Downloading a different git version failed and we actually don't need it at all so just remove it.

Modifications:

Remove custom git

Result:

Docker image build should pass again
