### PR TITLE
Enable OpenSslCachingKeyMaterialProvider to evict stale entries after cert rotation

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslCachingKeyMaterialProvider.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslCachingKeyMaterialProvider.java
@@ -19,22 +19,41 @@ import io.netty.buffer.ByteBufAllocator;
 
 import javax.net.ssl.X509KeyManager;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 /**
  * {@link OpenSslKeyMaterialProvider} that will cache the {@link OpenSslKeyMaterial} to reduce the overhead
  * of parsing the chain and the key for generation of the material.
+ *
+ * When new material is loaded on a cache miss, stale entries (whose alias is no longer owned by the
+ * {@link X509KeyManager}) are evicted before inserting the new material. This keeps memory bounded to only the aliases that are
+ * currently valid in the key manager.
  */
 final class OpenSslCachingKeyMaterialProvider extends OpenSslKeyMaterialProvider {
 
     private final int maxCachedEntries;
-    private volatile boolean full;
     private final ConcurrentMap<String, OpenSslKeyMaterial> cache = new ConcurrentHashMap<String, OpenSslKeyMaterial>();
 
     OpenSslCachingKeyMaterialProvider(X509KeyManager keyManager, String password, int maxCachedEntries) {
         super(keyManager, password);
         this.maxCachedEntries = maxCachedEntries;
+    }
+
+    /**
+     * Removes cached entries whose alias is no longer recognized by the key manager.
+     * Called on cache miss to reclaim memory before potentially inserting a new entry.
+     */
+    private void evictStaleEntries() {
+        Iterator<Map.Entry<String, OpenSslKeyMaterial>> iterator = cache.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<String, OpenSslKeyMaterial> entry = iterator.next();
+            if (keyManager().getCertificateChain(entry.getKey()) == null) {
+                iterator.remove();
+                entry.getValue().release();
+            }
+        }
     }
 
     @Override
@@ -47,11 +66,10 @@ final class OpenSslCachingKeyMaterialProvider extends OpenSslKeyMaterialProvider
                 return null;
             }
 
-            if (full) {
-                return material;
-            }
+            // Evict stale entries before inserting new material to reclaim memory.
+            evictStaleEntries();
+
             if (cache.size() > maxCachedEntries) {
-                full = true;
                 // Do not cache...
                 return material;
             }
@@ -63,6 +81,10 @@ final class OpenSslCachingKeyMaterialProvider extends OpenSslKeyMaterialProvider
         }
         // We need to call retain() as we want to always have at least a refCnt() of 1 before destroy() was called.
         return material.retain();
+    }
+
+    int cacheSize() {
+        return cache.size();
     }
 
     @Override

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslCachingKeyMaterialProvider.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslCachingKeyMaterialProvider.java
@@ -27,9 +27,8 @@ import java.util.concurrent.ConcurrentMap;
  * {@link OpenSslKeyMaterialProvider} that will cache the {@link OpenSslKeyMaterial} to reduce the overhead
  * of parsing the chain and the key for generation of the material.
  *
- * When new material is loaded on a cache miss, stale entries (whose alias is no longer owned by the
- * {@link X509KeyManager}) are evicted before inserting the new material. This keeps memory bounded to only the aliases that are
- * currently valid in the key manager.
+ * When the cache is full on a cache miss, stale entries (whose alias is no longer owned by the
+ * {@link X509KeyManager}) are evicted to make room before inserting new material.
  */
 final class OpenSslCachingKeyMaterialProvider extends OpenSslKeyMaterialProvider {
 
@@ -43,7 +42,7 @@ final class OpenSslCachingKeyMaterialProvider extends OpenSslKeyMaterialProvider
 
     /**
      * Removes cached entries whose alias is no longer recognized by the key manager.
-     * Called on cache miss to reclaim memory before potentially inserting a new entry.
+     * Called when the cache is full to reclaim memory from stale entries before giving up on caching.
      */
     private void evictStaleEntries() {
         Iterator<Map.Entry<String, OpenSslKeyMaterial>> iterator = cache.entrySet().iterator();
@@ -66,12 +65,13 @@ final class OpenSslCachingKeyMaterialProvider extends OpenSslKeyMaterialProvider
                 return null;
             }
 
-            // Evict stale entries before inserting new material to reclaim memory.
-            evictStaleEntries();
-
-            if (cache.size() > maxCachedEntries) {
-                // Do not cache...
-                return material;
+            if (cache.size() >= maxCachedEntries) {
+                // Cache is full; try to evict stale entries to make room.
+                evictStaleEntries();
+                if (cache.size() >= maxCachedEntries) {
+                    // Still full after eviction, do not cache.
+                    return material;
+                }
             }
             OpenSslKeyMaterial old = cache.putIfAbsent(alias, material);
             if (old != null) {

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslCachingKeyMaterialProvider.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslCachingKeyMaterialProvider.java
@@ -16,168 +16,99 @@
 package io.netty.handler.ssl;
 
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.IllegalReferenceCountException;
 
 import javax.net.ssl.X509KeyManager;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * {@link OpenSslKeyMaterialProvider} that will cache the
- * {@link OpenSslKeyMaterial} to reduce the overhead of parsing the chain
- * and the key for generation of the material.
+ * {@link OpenSslKeyMaterialProvider} that will cache the {@link OpenSslKeyMaterial} to reduce the overhead
+ * of parsing the chain and the key for generation of the material.
  * <p>
- * All cache operations that access or evict entries perform retain/release
- * atomically via {@link ConcurrentHashMap}'s per-bucket locking.
- * When the cache is full on a cache miss, stale entries (whose alias is no
- * longer owned by the {@link X509KeyManager}) are evicted to make room
- * before inserting new material.
+ * Cache reads are lock-free ({@link ConcurrentHashMap#get} + {@code retain()});
+ * if a concurrent eviction releases the material in between, {@code retain()}
+ * detects the dead reference count and the read falls back to a cache miss.
+ * Mutations (insert, evict, destroy) use {@link ConcurrentHashMap#compute} /
+ * {@link ConcurrentHashMap#computeIfPresent} for atomicity.
  */
 final class OpenSslCachingKeyMaterialProvider extends OpenSslKeyMaterialProvider {
 
-    /**
-     * A cache that performs retain/release atomically with map operations,
-     * using {@link ConcurrentHashMap}'s per-bucket locking to prevent
-     * use-after-free races between concurrent reads and evictions.
-     */
-    private static final class KeyMaterialCache {
-
-        /**
-         * Backing store for cached key materials.
-         */
-        private final ConcurrentHashMap<String, OpenSslKeyMaterial> map =
-                new ConcurrentHashMap<String, OpenSslKeyMaterial>();
-
-        /**
-         * Returns the material for the given alias with its reference count
-         * incremented, or {@code null} if absent.
-         *
-         * @param alias the alias to look up
-         * @return the retained material, or {@code null} if not cached
-         */
-        OpenSslKeyMaterial getAndRetain(final String alias) {
-            final OpenSslKeyMaterial[] result = {null};
-            map.computeIfPresent(alias, (final String k, final OpenSslKeyMaterial v) -> {
-                v.retain();
-                result[0] = v;
-                return v;
-            });
-            return result[0];
-        }
-
-        /**
-         * Inserts {@code material} if absent and returns it retained. If a
-         * concurrent insert won, returns the existing entry retained instead;
-         * the caller must then release {@code material}.
-         *
-         * @param alias    the alias to insert under
-         * @param material the material to insert
-         * @return the retained material now in the cache
-         */
-        OpenSslKeyMaterial putIfAbsentAndRetain(final String alias, final OpenSslKeyMaterial material) {
-            final OpenSslKeyMaterial[] result = {null};
-            map.compute(alias, (final String k, final OpenSslKeyMaterial existing) -> {
-                if (existing != null) {
-                    existing.retain();
-                    result[0] = existing;
-                    return existing;
-                }
-                // Retain for the caller; the map holds the original reference.
-                material.retain();
-                result[0] = material;
-                return material;
-            });
-            return result[0];
-        }
-
-        /**
-         * Removes and releases the entry for the given alias, if present.
-         *
-         * @param alias the alias whose entry should be removed and released
-         */
-        void removeAndRelease(final String alias) {
-            map.computeIfPresent(alias, (final String k, final OpenSslKeyMaterial v) -> {
-                v.release();
-                return null;
-            });
-        }
-
-        /**
-         * Returns the number of entries in the cache.
-         *
-         * @return the cache size
-         */
-        int size() {
-            return map.size();
-        }
-
-        /**
-         * Returns {@code true} if the cache contains no entries.
-         *
-         * @return {@code true} if empty
-         */
-        boolean isEmpty() {
-            return map.isEmpty();
-        }
-
-        /**
-         * Returns a view of the aliases currently in the cache.
-         *
-         * @return the set of aliases
-         */
-        Iterable<String> aliases() {
-            return map.keySet();
-        }
-    }
-
-    /**
-     * Maximum number of entries to hold in the cache.
-     */
     private final int maxCachedEntries;
+    private final ConcurrentHashMap<String, OpenSslKeyMaterial> cache =
+            new ConcurrentHashMap<String, OpenSslKeyMaterial>();
 
-    /**
-     * The key material cache.
-     */
-    private final KeyMaterialCache cache = new KeyMaterialCache();
-
-    OpenSslCachingKeyMaterialProvider(final X509KeyManager keyManager, final String password, final int maxEntries) {
+    OpenSslCachingKeyMaterialProvider(X509KeyManager keyManager, String password, int maxEntries) {
         super(keyManager, password);
         maxCachedEntries = maxEntries;
     }
 
     /**
-     * Removes cached entries whose alias is no longer recognized by the key
-     * manager. Evicting only when full avoids per-insert overhead, which is
-     * acceptable for most cases where {@code maxCachedEntries} is reasonably
-     * sized.
+     * Lock-free cache lookup. If a concurrent eviction releases the material between
+     * {@code get} and {@code retain}, the dead reference count is detected and treated
+     * as a cache miss.
      */
+    private OpenSslKeyMaterial getAndRetain(String alias) {
+        OpenSslKeyMaterial m = cache.get(alias);
+        if (m != null) {
+            try {
+                return m.retain();
+            } catch (IllegalReferenceCountException e) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Atomically inserts material if absent, or retains the existing entry.
+     */
+    private OpenSslKeyMaterial putIfAbsentAndRetain(String alias, OpenSslKeyMaterial material) {
+        return cache.compute(alias, (k, existing) -> {
+            if (existing != null) {
+                existing.retain();
+                return existing;
+            }
+            material.retain();
+            return material;
+        });
+    }
+
+    /**
+     * Atomically removes and releases the entry for the given alias.
+     */
+    private void removeAndRelease(String alias) {
+        cache.computeIfPresent(alias, (k, v) -> {
+            v.release();
+            return null;
+        });
+    }
+
     private void evictStaleEntries() {
-        for (String alias : cache.aliases()) {
+        for (String alias : cache.keySet()) {
             if (keyManager().getCertificateChain(alias) == null) {
-                cache.removeAndRelease(alias);
+                removeAndRelease(alias);
             }
         }
     }
 
     @Override
-    OpenSslKeyMaterial chooseKeyMaterial(final ByteBufAllocator allocator, final String alias) throws Exception {
-        OpenSslKeyMaterial material = cache.getAndRetain(alias);
+    OpenSslKeyMaterial chooseKeyMaterial(ByteBufAllocator allocator, String alias) throws Exception {
+        OpenSslKeyMaterial material = getAndRetain(alias);
         if (material == null) {
             material = super.chooseKeyMaterial(allocator, alias);
             if (material == null) {
-                // No keymaterial should be used.
                 return null;
             }
 
             if (cache.size() >= maxCachedEntries) {
-                // Cache is full; try to evict stale entries to make room.
                 evictStaleEntries();
                 if (cache.size() >= maxCachedEntries) {
-                    // Still full after eviction, do not cache.
                     return material;
                 }
             }
-            OpenSslKeyMaterial old = cache.putIfAbsentAndRetain(alias, material);
+            // Returns the newly created material, or an existing entry if another thread inserted first.
+            OpenSslKeyMaterial old = putIfAbsentAndRetain(alias, material);
             if (old != material) {
-                // Another operation inserted first; release our copy.
                 material.release();
                 material = old;
             }
@@ -191,10 +122,9 @@ final class OpenSslCachingKeyMaterialProvider extends OpenSslKeyMaterialProvider
 
     @Override
     void destroy() {
-        // Remove and release all entries.
         do {
-            for (String alias : cache.aliases()) {
-                cache.removeAndRelease(alias);
+            for (String alias : cache.keySet()) {
+                removeAndRelease(alias);
             }
         } while (!cache.isEmpty());
     }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslCachingKeyMaterialProvider.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslCachingKeyMaterialProvider.java
@@ -18,46 +18,148 @@ package io.netty.handler.ssl;
 import io.netty.buffer.ByteBufAllocator;
 
 import javax.net.ssl.X509KeyManager;
-import java.util.Iterator;
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 /**
- * {@link OpenSslKeyMaterialProvider} that will cache the {@link OpenSslKeyMaterial} to reduce the overhead
- * of parsing the chain and the key for generation of the material.
- *
- * When the cache is full on a cache miss, stale entries (whose alias is no longer owned by the
- * {@link X509KeyManager}) are evicted to make room before inserting new material.
+ * {@link OpenSslKeyMaterialProvider} that will cache the
+ * {@link OpenSslKeyMaterial} to reduce the overhead of parsing the chain
+ * and the key for generation of the material.
+ * <p>
+ * All cache operations that access or evict entries perform retain/release
+ * atomically via {@link ConcurrentHashMap}'s per-bucket locking.
+ * When the cache is full on a cache miss, stale entries (whose alias is no
+ * longer owned by the {@link X509KeyManager}) are evicted to make room
+ * before inserting new material.
  */
 final class OpenSslCachingKeyMaterialProvider extends OpenSslKeyMaterialProvider {
 
-    private final int maxCachedEntries;
-    private final ConcurrentMap<String, OpenSslKeyMaterial> cache = new ConcurrentHashMap<String, OpenSslKeyMaterial>();
+    /**
+     * A cache that performs retain/release atomically with map operations,
+     * using {@link ConcurrentHashMap}'s per-bucket locking to prevent
+     * use-after-free races between concurrent reads and evictions.
+     */
+    private static final class KeyMaterialCache {
 
-    OpenSslCachingKeyMaterialProvider(X509KeyManager keyManager, String password, int maxCachedEntries) {
-        super(keyManager, password);
-        this.maxCachedEntries = maxCachedEntries;
+        /**
+         * Backing store for cached key materials.
+         */
+        private final ConcurrentHashMap<String, OpenSslKeyMaterial> map =
+                new ConcurrentHashMap<String, OpenSslKeyMaterial>();
+
+        /**
+         * Returns the material for the given alias with its reference count
+         * incremented, or {@code null} if absent.
+         *
+         * @param alias the alias to look up
+         * @return the retained material, or {@code null} if not cached
+         */
+        OpenSslKeyMaterial getAndRetain(final String alias) {
+            final OpenSslKeyMaterial[] result = {null};
+            map.computeIfPresent(alias, (final String k, final OpenSslKeyMaterial v) -> {
+                v.retain();
+                result[0] = v;
+                return v;
+            });
+            return result[0];
+        }
+
+        /**
+         * Inserts {@code material} if absent and returns it retained. If a
+         * concurrent insert won, returns the existing entry retained instead;
+         * the caller must then release {@code material}.
+         *
+         * @param alias    the alias to insert under
+         * @param material the material to insert
+         * @return the retained material now in the cache
+         */
+        OpenSslKeyMaterial putIfAbsentAndRetain(final String alias, final OpenSslKeyMaterial material) {
+            final OpenSslKeyMaterial[] result = {null};
+            map.compute(alias, (final String k, final OpenSslKeyMaterial existing) -> {
+                if (existing != null) {
+                    existing.retain();
+                    result[0] = existing;
+                    return existing;
+                }
+                // Retain for the caller; the map holds the original reference.
+                material.retain();
+                result[0] = material;
+                return material;
+            });
+            return result[0];
+        }
+
+        /**
+         * Removes and releases the entry for the given alias, if present.
+         *
+         * @param alias the alias whose entry should be removed and released
+         */
+        void removeAndRelease(final String alias) {
+            map.computeIfPresent(alias, (final String k, final OpenSslKeyMaterial v) -> {
+                v.release();
+                return null;
+            });
+        }
+
+        /**
+         * Returns the number of entries in the cache.
+         *
+         * @return the cache size
+         */
+        int size() {
+            return map.size();
+        }
+
+        /**
+         * Returns {@code true} if the cache contains no entries.
+         *
+         * @return {@code true} if empty
+         */
+        boolean isEmpty() {
+            return map.isEmpty();
+        }
+
+        /**
+         * Returns a view of the aliases currently in the cache.
+         *
+         * @return the set of aliases
+         */
+        Iterable<String> aliases() {
+            return map.keySet();
+        }
     }
 
     /**
-     * Removes cached entries whose alias is no longer recognized by the key manager.
-     * Called when the cache is full to reclaim memory from stale entries before giving up on caching.
+     * Maximum number of entries to hold in the cache.
+     */
+    private final int maxCachedEntries;
+
+    /**
+     * The key material cache.
+     */
+    private final KeyMaterialCache cache = new KeyMaterialCache();
+
+    OpenSslCachingKeyMaterialProvider(final X509KeyManager keyManager, final String password, final int maxEntries) {
+        super(keyManager, password);
+        maxCachedEntries = maxEntries;
+    }
+
+    /**
+     * Removes cached entries whose alias is no longer recognized by the key
+     * manager. Evicting only when full avoids per-insert overhead, which is
+     * acceptable for most cases where {@code maxCachedEntries} is reasonably
+     * sized.
      */
     private void evictStaleEntries() {
-        Iterator<Map.Entry<String, OpenSslKeyMaterial>> iterator = cache.entrySet().iterator();
-        while (iterator.hasNext()) {
-            Map.Entry<String, OpenSslKeyMaterial> entry = iterator.next();
-            if (keyManager().getCertificateChain(entry.getKey()) == null) {
-                iterator.remove();
-                entry.getValue().release();
+        for (String alias : cache.aliases()) {
+            if (keyManager().getCertificateChain(alias) == null) {
+                cache.removeAndRelease(alias);
             }
         }
     }
 
     @Override
-    OpenSslKeyMaterial chooseKeyMaterial(ByteBufAllocator allocator, String alias) throws Exception {
-        OpenSslKeyMaterial material = cache.get(alias);
+    OpenSslKeyMaterial chooseKeyMaterial(final ByteBufAllocator allocator, final String alias) throws Exception {
+        OpenSslKeyMaterial material = cache.getAndRetain(alias);
         if (material == null) {
             material = super.chooseKeyMaterial(allocator, alias);
             if (material == null) {
@@ -73,14 +175,14 @@ final class OpenSslCachingKeyMaterialProvider extends OpenSslKeyMaterialProvider
                     return material;
                 }
             }
-            OpenSslKeyMaterial old = cache.putIfAbsent(alias, material);
-            if (old != null) {
+            OpenSslKeyMaterial old = cache.putIfAbsentAndRetain(alias, material);
+            if (old != material) {
+                // Another operation inserted first; release our copy.
                 material.release();
                 material = old;
             }
         }
-        // We need to call retain() as we want to always have at least a refCnt() of 1 before destroy() was called.
-        return material.retain();
+        return material;
     }
 
     int cacheSize() {
@@ -90,11 +192,9 @@ final class OpenSslCachingKeyMaterialProvider extends OpenSslKeyMaterialProvider
     @Override
     void destroy() {
         // Remove and release all entries.
-        do  {
-            Iterator<OpenSslKeyMaterial> iterator = cache.values().iterator();
-            while (iterator.hasNext()) {
-                iterator.next().release();
-                iterator.remove();
+        do {
+            for (String alias : cache.aliases()) {
+                cache.removeAndRelease(alias);
             }
         } while (!cache.isEmpty());
     }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslCachingKeyMaterialProvider.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslCachingKeyMaterialProvider.java
@@ -36,6 +36,7 @@ final class OpenSslCachingKeyMaterialProvider extends OpenSslKeyMaterialProvider
     private final int maxCachedEntries;
     private final ConcurrentHashMap<String, OpenSslKeyMaterial> cache =
             new ConcurrentHashMap<String, OpenSslKeyMaterial>();
+    private volatile boolean destroyed;
 
     OpenSslCachingKeyMaterialProvider(X509KeyManager keyManager, String password, int maxEntries) {
         super(keyManager, password);
@@ -111,6 +112,9 @@ final class OpenSslCachingKeyMaterialProvider extends OpenSslKeyMaterialProvider
             if (old != material) {
                 material.release();
                 material = old;
+            } else if (destroyed) {
+                // We may have inserted an entry after the provider has been destroyed. Help with the cleanup.
+                removeAndReleaseAllEntries();
             }
         }
         return material;
@@ -122,15 +126,19 @@ final class OpenSslCachingKeyMaterialProvider extends OpenSslKeyMaterialProvider
 
     @Override
     void destroy() {
+        destroyed = true;
         try {
-            // Remove and release all entries.
-            do  {
-                for (String alias : cache.keySet()) {
-                    removeAndRelease(alias);
-                }
-            } while (!cache.isEmpty());
+            removeAndReleaseAllEntries();
         } finally {
             super.destroy();
         }
+    }
+
+    private void removeAndReleaseAllEntries() {
+        do  {
+            for (String alias : cache.keySet()) {
+                removeAndRelease(alias);
+            }
+        } while (!cache.isEmpty());
     }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslCachingKeyMaterialProviderTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslCachingKeyMaterialProviderTest.java
@@ -95,7 +95,7 @@ public class OpenSslCachingKeyMaterialProviderTest extends OpenSslKeyMaterialPro
     }
 
     @Test
-    public void testStaleEntriesEvictedOnCacheMiss() throws Exception {
+    public void testStaleEntriesEvictedWhenCacheFull() throws Exception {
         final X509KeyManager delegate = ReferenceCountedOpenSslContext.chooseX509KeyManager(
                 newKeyManagerFactory().getKeyManagers());
 
@@ -134,7 +134,7 @@ public class OpenSslCachingKeyMaterialProviderTest extends OpenSslKeyMaterialPro
 
         RotatableKeyManager rotatableKeyManager = new RotatableKeyManager();
         OpenSslCachingKeyMaterialProvider provider =
-                new OpenSslCachingKeyMaterialProvider(rotatableKeyManager, PASSWORD, Integer.MAX_VALUE);
+                new OpenSslCachingKeyMaterialProvider(rotatableKeyManager, PASSWORD, 1);
 
         // Populate the cache with the old alias.
         OpenSslKeyMaterial material = provider.chooseKeyMaterial(UnpooledByteBufAllocator.DEFAULT, "old-key");
@@ -145,7 +145,7 @@ public class OpenSslCachingKeyMaterialProviderTest extends OpenSslKeyMaterialPro
         // Simulate cert rotation: old alias is gone, new alias takes over.
         rotatableKeyManager.rotate();
 
-        // Cache miss for the new alias triggers evictStaleEntries(), which removes "old-key".
+        // Cache is full; loading "new-key" triggers evictStaleEntries(), which removes "old-key".
         OpenSslKeyMaterial newMaterial = provider.chooseKeyMaterial(UnpooledByteBufAllocator.DEFAULT, "new-key");
         assertNotNull(newMaterial);
         assertEquals(1, provider.cacheSize()); // old evicted, new-key inserted

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslCachingKeyMaterialProviderTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslCachingKeyMaterialProviderTest.java
@@ -19,6 +19,11 @@ import io.netty.buffer.UnpooledByteBufAllocator;
 import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.X509KeyManager;
+import java.net.Socket;
+import java.security.Principal;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -26,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class OpenSslCachingKeyMaterialProviderTest extends OpenSslKeyMaterialProviderTest {
 
@@ -86,5 +92,65 @@ public class OpenSslCachingKeyMaterialProviderTest extends OpenSslKeyMaterialPro
                 super.newKeyManagerFactory("PKIX"));
         OpenSslKeyMaterialProvider provider = factory.newProvider(PASSWORD);
         assertThat(provider).isNotInstanceOf(OpenSslCachingKeyMaterialProvider.class);
+    }
+
+    @Test
+    public void testStaleEntriesEvictedOnCacheMiss() throws Exception {
+        final X509KeyManager delegate = ReferenceCountedOpenSslContext.chooseX509KeyManager(
+                newKeyManagerFactory().getKeyManagers());
+
+        class RotatableKeyManager implements X509KeyManager {
+            private String currentAlias = "old-key";
+
+            void rotate() {
+                currentAlias = "new-key";
+            }
+
+            @Override
+            public X509Certificate[] getCertificateChain(String alias) {
+                return currentAlias.equals(alias) ? delegate.getCertificateChain(EXISTING_ALIAS) : null;
+            }
+            @Override
+            public PrivateKey getPrivateKey(String alias) {
+                return currentAlias.equals(alias) ? delegate.getPrivateKey(EXISTING_ALIAS) : null;
+            }
+            @Override
+            public String[] getClientAliases(String keyType, Principal[] issuers) {
+                return delegate.getClientAliases(keyType, issuers);
+            }
+            @Override
+            public String chooseClientAlias(String[] keyType, Principal[] issuers, Socket socket) {
+                return delegate.chooseClientAlias(keyType, issuers, socket);
+            }
+            @Override
+            public String[] getServerAliases(String keyType, Principal[] issuers) {
+                return delegate.getServerAliases(keyType, issuers);
+            }
+            @Override
+            public String chooseServerAlias(String keyType, Principal[] issuers, Socket socket) {
+                return delegate.chooseServerAlias(keyType, issuers, socket);
+            }
+        }
+
+        RotatableKeyManager rotatableKeyManager = new RotatableKeyManager();
+        OpenSslCachingKeyMaterialProvider provider =
+                new OpenSslCachingKeyMaterialProvider(rotatableKeyManager, PASSWORD, Integer.MAX_VALUE);
+
+        // Populate the cache with the old alias.
+        OpenSslKeyMaterial material = provider.chooseKeyMaterial(UnpooledByteBufAllocator.DEFAULT, "old-key");
+        assertNotNull(material);
+        assertEquals(1, provider.cacheSize());
+        material.release();
+
+        // Simulate cert rotation: old alias is gone, new alias takes over.
+        rotatableKeyManager.rotate();
+
+        // Cache miss for the new alias triggers evictStaleEntries(), which removes "old-key".
+        OpenSslKeyMaterial newMaterial = provider.chooseKeyMaterial(UnpooledByteBufAllocator.DEFAULT, "new-key");
+        assertNotNull(newMaterial);
+        assertEquals(1, provider.cacheSize()); // old evicted, new-key inserted
+        newMaterial.release();
+
+        provider.destroy();
     }
 }


### PR DESCRIPTION
### Motivation: 

The current `OpenSslCachingKeyMaterialProvider` does not evict stale entries after a cert rotation. 
This is related to a performance concern when using grpc-java (grpc/grpc-java#12670)

###  Modification:
Added `evictStaleEntries()`, which removes cached entries whose alias is no longer recognized by the `X509KeyManager`. It is called on a cache miss when new material is successfully loaded, so stale entries from rotated credentials are pruned before inserting the new one.

 ### Result:
Better support for cert rotation. 
  Related discussion:
  https://github.com/grpc/grpc-java/pull/12686
  https://github.com/grpc/grpc-java/issues/12670