### PR TITLE
Replace `ClosedChannelException` with `StacklessClosedChannelException` (#16506)

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -30,6 +30,7 @@ import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelOutboundHandler;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelShutdownType;
+import io.netty.channel.StacklessClosedChannelException;
 import io.netty.channel.unix.UnixChannel;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.DecoderException;
@@ -51,7 +52,6 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.channels.ClosedChannelException;
 import java.nio.channels.DatagramChannel;
 import java.nio.channels.SocketChannel;
 import java.security.cert.CertificateException;
@@ -1123,7 +1123,8 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         boolean handshakeFailed = handshakePromise.cause() != null;
 
         // Channel closed, we will generate 'ClosedChannelException' now.
-        ClosedChannelException exception = new ClosedChannelException();
+        StacklessClosedChannelException exception = StacklessClosedChannelException.newInstance(
+                SslHandler.class, "channelInactive(ChannelHandlerContext)");
 
         // Add a supressed exception if the handshake was not completed yet.
         if (isStateSet(STATE_HANDSHAKE_STARTED) && !handshakePromise.isDone()) {

--- a/transport/src/main/java/io/netty/channel/StacklessClosedChannelException.java
+++ b/transport/src/main/java/io/netty/channel/StacklessClosedChannelException.java
@@ -16,13 +16,15 @@
 package io.netty.channel;
 
 import io.netty.util.internal.ThrowableUtil;
+import io.netty.util.internal.UnstableApi;
 
 import java.nio.channels.ClosedChannelException;
 
 /**
  * Cheap {@link ClosedChannelException} that does not fill in the stacktrace.
  */
-final class StacklessClosedChannelException extends ClosedChannelException {
+@UnstableApi
+public final class StacklessClosedChannelException extends ClosedChannelException {
 
     private static final long serialVersionUID = -2214806025529435136L;
 
@@ -37,7 +39,7 @@ final class StacklessClosedChannelException extends ClosedChannelException {
     /**
      * Creates a new {@link StacklessClosedChannelException} which has the origin of the given {@link Class} and method.
      */
-    static StacklessClosedChannelException newInstance(Class<?> clazz, String method) {
+    public static StacklessClosedChannelException newInstance(Class<?> clazz, String method) {
         return ThrowableUtil.unknownStackTrace(new StacklessClosedChannelException(), clazz, method);
     }
 }


### PR DESCRIPTION
Motivation:

`SslHandler.channelInactive` allocates `ClosedChannelException`, which
collects the stacktrace.
In a high-load environment, with a large number of connections being
opened/closed, this introduces GC pressure:
<img width="1349" height="315" alt="Image"
src="https://github.com/user-attachments/assets/7d578905-e74c-4fd2-81c6-2af1083ece5b"
/>

Modification:

Replaced this exception with `StacklessClosedChannelException`, which
will reduce pressure by eliminating the allocation of the
`StackTraceElement[]` array for the stack trace.

Result:

Fixes #16504.
