### PR TITLE
Lazy init ArrayList in DefaultHeaders.getAll

### DIFF
--- a/codec-base/src/main/java/io/netty/handler/codec/DefaultHeaders.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/DefaultHeaders.java
@@ -16,11 +16,11 @@ package io.netty.handler.codec;
 
 import io.netty.util.HashingStrategy;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -222,17 +222,32 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
     public List<V> getAll(K name) {
         checkNotNull(name, "name");
 
-        LinkedList<V> values = new LinkedList<V>();
-
         int h = hashingStrategy.hashCode(name);
         int i = index(h);
+
+        ArrayList<V> values = null;
+
         HeaderEntry<K, V> e = entries[i];
         while (e != null) {
             if (e.hash == h && hashingStrategy.equals(name, e.key)) {
-                values.addFirst(e.getValue());
+                if (values == null) {
+                    //typically we have 0 or 1 entries. more than that is usually rare
+                    values = new ArrayList<>(2);
+                }
+                values.add(e.getValue());
             }
             e = e.next;
         }
+
+        if (values == null) {
+            return Collections.emptyList();
+        }
+
+        //we add this check, having 1 element here is most common
+        if (values.size() > 1) {
+            Collections.reverse(values);
+        }
+
         return values;
     }
 

--- a/codec-base/src/main/java/io/netty/handler/codec/DefaultHeaders.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/DefaultHeaders.java
@@ -226,27 +226,32 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
         int i = index(h);
 
         ArrayList<V> values = null;
-
+        V value = null;
         HeaderEntry<K, V> e = entries[i];
         while (e != null) {
             if (e.hash == h && hashingStrategy.equals(name, e.key)) {
-                if (values == null) {
-                    //typically we have 0 or 1 entries. more than that is usually rare
-                    values = new ArrayList<>(1);
+                if (value == null) {
+                    value = e.getValue();
+                } else {
+                    if (values == null) {
+                        values = new ArrayList<>(2);
+                        values.add(value);
+                    }
+                    values.add(e.getValue());
                 }
-                values.add(e.getValue());
             }
             e = e.next;
         }
 
         if (values == null) {
-            return Collections.emptyList();
+            if (value == null) {
+                return Collections.emptyList();
+            }
+            return Collections.singletonList(value);
         }
 
-        //we add this check, having 1 element here is most common
-        if (values.size() > 1) {
-            Collections.reverse(values);
-        }
+        assert values.size() > 1;
+        Collections.reverse(values);
 
         return values;
     }

--- a/codec-base/src/main/java/io/netty/handler/codec/DefaultHeaders.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/DefaultHeaders.java
@@ -232,7 +232,7 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
             if (e.hash == h && hashingStrategy.equals(name, e.key)) {
                 if (values == null) {
                     //typically we have 0 or 1 entries. more than that is usually rare
-                    values = new ArrayList<>(2);
+                    values = new ArrayList<>(1);
                 }
                 values.add(e.getValue());
             }

--- a/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdySessionHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdySessionHandlerTest.java
@@ -88,8 +88,7 @@ public class SpdySessionHandlerTest {
             List<CharSequence> expectedValues = headers.getAll(name);
             List<CharSequence> receivedValues = spdyHeadersFrame.headers().getAll(name);
             assertTrue(receivedValues.containsAll(expectedValues));
-            receivedValues.removeAll(expectedValues);
-            assertTrue(receivedValues.isEmpty());
+            assertEquals(expectedValues.size(), receivedValues.size());
             spdyHeadersFrame.headers().remove(name);
         }
         assertTrue(spdyHeadersFrame.headers().isEmpty());


### PR DESCRIPTION
Motivation:

In wecksockets flow, `content-length` is never there, but `DefaultHeaders.getAll()` allocates an empty `LinkedList` anyway.

<img width="764" height="180" alt="image" src="https://github.com/user-attachments/assets/58fd0071-c5d5-425b-9445-708ad312ee88" />
<img width="485" height="170" alt="image" src="https://github.com/user-attachments/assets/9c94c354-a334-45aa-a56d-190eb4f6f294" />

Modification:

- Replaced `LinkedList` with `ArrayList`. There is no actual need for `LinkedList` as it's a very rare event to have more than one param with the same name. Also, `LinkedList` typically allocates more per entry than `ArrayList` and slower in most cases.
- Added lazy init logic - init ArrayList only when we found a match
- Added default size for ArrayList of 1, as typically params have only 1 value
- Call `Collections.reserve()` only when we have more than 1 element (the most common use case)

Result:

No more LinkedList allocation for the WebSockets flow.

P.S. The only downside in this PR is returning `Collections.emptyList()` that may break some implementations that mutate the returned list. But I think it's unlikely to happen.
