### PR TITLE
Allocate less in QueryStringDecoder.addParam for typical use case

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringDecoder.java
@@ -248,7 +248,7 @@ public class QueryStringDecoder {
         if (s.charAt(from) == '?') {
             from++;
         }
-        Map<String, List<String>> params = new LinkedHashMap<String, List<String>>();
+        Map<String, List<String>> params = new LinkedHashMap<>();
         int nameStart = from;
         int valueStart = -1;
         int i;
@@ -298,10 +298,15 @@ public class QueryStringDecoder {
         String value = decodeComponent(s, valueStart, valueEnd, charset, htmlQueryDecoding);
         List<String> values = params.get(name);
         if (values == null) {
-            values = new ArrayList<String>(1);  // Often there's only 1 value.
-            params.put(name, values);
+            params.put(name, Collections.singletonList(value));
+        } else if (values instanceof ArrayList) {
+            values.add(value);
+        } else {
+            List<String> newValues = new ArrayList<>(2);
+            newValues.add(values.get(0));
+            newValues.add(value);
+            params.put(name, newValues);
         }
-        values.add(value);
         return true;
     }
 


### PR DESCRIPTION
Motivation:

Typically, query parameters have only one value, so for this use case we can allocate less.

<img width="541" height="79" alt="image" src="https://github.com/user-attachments/assets/57c2d6b1-c0b1-46e4-b543-241bb9a0eb48" />


https://github.com/netty/netty/pull/16526 follow-up.

Modification:

- Replaced new ArrayList(1) in `QueryStringDecoder.addParam` with `Collections.singletonList(value)`

Result:

Less allocations for the typical single-value query parameter.
