### PR TITLE
Enforce io.netty.maxDirectMemory accounting on all Java versions (#16489)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/UnpooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledByteBufAllocator.java
@@ -68,7 +68,7 @@ public final class UnpooledByteBufAllocator extends AbstractByteBufAllocator imp
      * @param disableLeakDetector {@code true} if the leak-detection should be disabled completely for this
      *                            allocator. This can be useful if the user just want to depend on the GC to handle
      *                            direct buffers when not explicit released.
-     * @param tryNoCleaner {@code true} if we should try to use {@link PlatformDependent#allocateDirectNoCleaner(int)}
+     * @param tryNoCleaner {@code true} if we should try to use {@link PlatformDependent#allocateDirect(int)}
      *                            to allocate direct memory.
      */
     public UnpooledByteBufAllocator(boolean preferDirect, boolean disableLeakDetector, boolean tryNoCleaner) {
@@ -195,10 +195,11 @@ public final class UnpooledByteBufAllocator extends AbstractByteBufAllocator imp
         }
 
         @Override
-        CleanableDirectBuffer reallocateDirect(CleanableDirectBuffer oldBuffer, int initialCapacity) {
-            int capacity = oldBuffer.buffer().capacity();
-            CleanableDirectBuffer buffer = super.reallocateDirect(oldBuffer, initialCapacity);
-            return new DecrementingCleanableDirectBuffer(alloc(), buffer, buffer.buffer().capacity() - capacity);
+        CleanableDirectBuffer reallocateDirect(CleanableDirectBuffer oldBuffer, int newCapacity) {
+            int oldCapacity = oldBuffer.buffer().capacity();
+            CleanableDirectBuffer buffer = super.reallocateDirect(oldBuffer, newCapacity);
+            return new DecrementingCleanableDirectBuffer(
+                    alloc(), buffer, buffer.buffer().capacity() - oldCapacity);
         }
     }
 

--- a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeNoCleanerDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeNoCleanerDirectByteBuf.java
@@ -26,22 +26,12 @@ class UnpooledUnsafeNoCleanerDirectByteBuf extends UnpooledUnsafeDirectByteBuf {
     }
 
     @Override
-    protected CleanableDirectBuffer allocateDirectBuffer(int capacity) {
-        return PlatformDependent.allocateDirectBufferNoCleaner(capacity);
-    }
-
-    @Override
-    protected CleanableDirectBuffer allocateDirectBuffer(int capacity, boolean ignorePermitExpensiveClean) {
-        return PlatformDependent.allocateDirectBufferNoCleaner(capacity);
-    }
-
-    @Override
     protected ByteBuffer allocateDirect(int initialCapacity) {
         throw new UnsupportedOperationException();
     }
 
-    CleanableDirectBuffer reallocateDirect(CleanableDirectBuffer oldBuffer, int initialCapacity) {
-        return PlatformDependent.reallocateDirectBufferNoCleaner(oldBuffer, initialCapacity);
+    CleanableDirectBuffer reallocateDirect(CleanableDirectBuffer oldBuffer, int newCapacity) {
+        return PlatformDependent.reallocateDirect(oldBuffer, newCapacity);
     }
 
     @Override

--- a/common/src/main/java/io/netty/util/internal/Cleaner.java
+++ b/common/src/main/java/io/netty/util/internal/Cleaner.java
@@ -31,6 +31,26 @@ interface Cleaner {
     CleanableDirectBuffer allocate(int capacity);
 
     /**
+     * Reallocate a direct buffer with a new capacity. The old buffer is consumed and
+     * must not be used after this call.
+     * <p>
+     * The default implementation allocates a new buffer, copies the data, and frees the old one.
+     * Implementations may override this to provide more efficient reallocation (e.g. via
+     * {@code Unsafe.reallocateMemory}).
+     */
+    default CleanableDirectBuffer reallocate(CleanableDirectBuffer old, int newCapacity) {
+        CleanableDirectBuffer newBuf = allocate(newCapacity);
+        ByteBuffer oldBB = old.buffer();
+        ByteBuffer newBB = newBuf.buffer();
+        int bytesToCopy = Math.min(oldBB.capacity(), newCapacity);
+        oldBB.position(0).limit(bytesToCopy);
+        newBB.position(0).limit(bytesToCopy);
+        newBB.put(oldBB).clear();
+        old.clean();
+        return newBuf;
+    }
+
+    /**
      * Free a direct {@link ByteBuffer} if possible
      *
      * @deprecated Instead allocate buffers from {@link #allocate(int)}

--- a/common/src/main/java/io/netty/util/internal/CleanerJava24Linker.java
+++ b/common/src/main/java/io/netty/util/internal/CleanerJava24Linker.java
@@ -236,11 +236,19 @@ public class CleanerJava24Linker implements Cleaner {
         private final long memoryAddress;
 
         private CleanableDirectBufferImpl(int capacity) {
-            long addr = malloc(capacity);
+            PlatformDependent.incrementMemoryCounter(capacity);
+            long addr;
+            try {
+                addr = malloc(capacity);
+            } catch (Throwable e) {
+                PlatformDependent.decrementMemoryCounter(capacity);
+                throw e;
+            }
             try {
                 memoryAddress = addr;
                 buffer = (ByteBuffer) INVOKE_CREATE_BYTEBUFFER.invokeExact(addr, (long) capacity);
             } catch (Throwable throwable) {
+                PlatformDependent.decrementMemoryCounter(capacity);
                 Error error = new Error(throwable);
                 try {
                     free(addr);
@@ -258,7 +266,9 @@ public class CleanerJava24Linker implements Cleaner {
 
         @Override
         public void clean() {
+            int capacity = buffer.capacity();
             free(memoryAddress);
+            PlatformDependent.decrementMemoryCounter(capacity);
         }
 
         @Override

--- a/common/src/main/java/io/netty/util/internal/CleanerJava25.java
+++ b/common/src/main/java/io/netty/util/internal/CleanerJava25.java
@@ -169,11 +169,14 @@ final class CleanerJava25 implements Cleaner {
     @SuppressWarnings("OverlyStrongTypeCast") // The cast is needed for 'invokeExact' semantics.
     @Override
     public CleanableDirectBuffer allocate(int capacity) {
+        PlatformDependent.incrementMemoryCounter(capacity);
         try {
             return (CleanableDirectBufferImpl) INVOKE_ALLOCATOR.invokeExact(capacity);
         } catch (RuntimeException e) {
+            PlatformDependent.decrementMemoryCounter(capacity);
             throw e; // Propagate the runtime exceptions that the Arena would normally throw.
         } catch (Throwable e) {
+            PlatformDependent.decrementMemoryCounter(capacity);
             throw new IllegalStateException("Unexpected allocation exception", e);
         }
     }
@@ -209,12 +212,15 @@ final class CleanerJava25 implements Cleaner {
 
         @Override
         public void clean() {
+            int capacity = buffer.capacity();
             try {
                 closeable.close();
             } catch (RuntimeException e) {
                 throw e; // Propagate the runtime exceptions that Arena would normally throw.
             } catch (Exception e) {
                 throw new IllegalStateException("Unexpected close exception", e);
+            } finally {
+                PlatformDependent.decrementMemoryCounter(capacity);
             }
         }
 

--- a/common/src/main/java/io/netty/util/internal/CleanerJava9.java
+++ b/common/src/main/java/io/netty/util/internal/CleanerJava9.java
@@ -97,6 +97,7 @@ final class CleanerJava9 implements Cleaner {
 
         private CleanableDirectBufferImpl(ByteBuffer buffer) {
             this.buffer = buffer;
+            PlatformDependent.incrementMemoryCounter(buffer.capacity());
         }
 
         @Override
@@ -106,7 +107,9 @@ final class CleanerJava9 implements Cleaner {
 
         @Override
         public void clean() {
+            int capacity = buffer.capacity();
             freeDirectBufferStatic(buffer);
+            PlatformDependent.decrementMemoryCounter(capacity);
         }
     }
 }

--- a/common/src/main/java/io/netty/util/internal/DirectCleaner.java
+++ b/common/src/main/java/io/netty/util/internal/DirectCleaner.java
@@ -20,12 +20,27 @@ import java.nio.ByteBuffer;
 final class DirectCleaner implements Cleaner {
     @Override
     public CleanableDirectBuffer allocate(int capacity) {
-        return new CleanableDirectBufferImpl(PlatformDependent.allocateDirectNoCleaner(capacity));
+        return new CleanableDirectBufferImpl(capacity);
+    }
+
+    @Override
+    public CleanableDirectBuffer reallocate(CleanableDirectBuffer old, int newCapacity) {
+        int oldCapacity = old.buffer().capacity();
+        int delta = newCapacity - oldCapacity;
+        PlatformDependent.incrementMemoryCounter(delta);
+        try {
+            ByteBuffer newBuffer = PlatformDependent0.reallocateDirectNoCleaner(
+                    old.buffer(), newCapacity);
+            return new CleanableDirectBufferImpl(newBuffer);
+        } catch (Throwable e) {
+            PlatformDependent.decrementMemoryCounter(delta);
+            throw e;
+        }
     }
 
     @Override
     public void freeDirectBuffer(ByteBuffer buffer) {
-        PlatformDependent.freeDirectNoCleaner(buffer);
+        PlatformDependent0.freeMemory(PlatformDependent0.directBufferAddress(buffer));
     }
 
     @Override
@@ -33,15 +48,22 @@ final class DirectCleaner implements Cleaner {
         return false;
     }
 
-    CleanableDirectBuffer reallocate(CleanableDirectBuffer buffer, int capacity) {
-        ByteBuffer newByteBuffer = PlatformDependent.reallocateDirectNoCleaner(buffer.buffer(), capacity);
-        return new CleanableDirectBufferImpl(newByteBuffer);
-    }
-
     private static final class CleanableDirectBufferImpl implements CleanableDirectBuffer {
         private final ByteBuffer buffer;
 
-        private CleanableDirectBufferImpl(ByteBuffer buffer) {
+        // Used for normal allocation — allocates memory and increments counter
+        CleanableDirectBufferImpl(int capacity) {
+            PlatformDependent.incrementMemoryCounter(capacity);
+            try {
+                this.buffer = PlatformDependent0.allocateDirectNoCleaner(capacity);
+            } catch (Throwable e) {
+                PlatformDependent.decrementMemoryCounter(capacity);
+                throw e;
+            }
+        }
+
+        // Used for reallocation — memory already allocated, counter already adjusted
+        CleanableDirectBufferImpl(ByteBuffer buffer) {
             this.buffer = buffer;
         }
 
@@ -52,7 +74,9 @@ final class DirectCleaner implements Cleaner {
 
         @Override
         public void clean() {
-            PlatformDependent.freeDirectNoCleaner(buffer);
+            int capacity = buffer.capacity();
+            PlatformDependent0.freeMemory(PlatformDependent0.directBufferAddress(buffer));
+            PlatformDependent.decrementMemoryCounter(capacity);
         }
     }
 }

--- a/common/src/main/java/io/netty/util/internal/OutOfDirectMemoryError.java
+++ b/common/src/main/java/io/netty/util/internal/OutOfDirectMemoryError.java
@@ -18,7 +18,7 @@ package io.netty.util.internal;
 import java.nio.ByteBuffer;
 
 /**
- * {@link OutOfMemoryError} that is throws if {@link PlatformDependent#allocateDirectNoCleaner(int)} can not allocate
+ * {@link OutOfMemoryError} that is throws if {@link PlatformDependent#allocateDirect(int)} can not allocate
  * a new {@link ByteBuffer} due memory restrictions.
  */
 public final class OutOfDirectMemoryError extends OutOfMemoryError {

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -116,11 +116,9 @@ public final class PlatformDependent {
     private static final boolean IS_IVKVM_DOT_NET = isIkvmDotNet0();
 
     private static final int ADDRESS_SIZE = addressSize0();
-    private static final boolean USE_DIRECT_BUFFER_NO_CLEANER;
     private static final AtomicLong DIRECT_MEMORY_COUNTER;
     private static final long DIRECT_MEMORY_LIMIT;
     private static final Cleaner CLEANER;
-    private static final Cleaner DIRECT_CLEANER;
     private static final Cleaner LEGACY_CLEANER;
     private static final boolean HAS_ALLOCATE_UNINIT_ARRAY;
     private static final String LINUX_ID_PREFIX = "ID=";
@@ -181,23 +179,19 @@ public final class PlatformDependent {
         //           (note: that JDK's direct memory limit is independent of this).
         long maxDirectMemory = SystemPropertyUtil.getLong("io.netty.maxDirectMemory", -1);
 
-        if (maxDirectMemory == 0 || !hasUnsafe() || !PlatformDependent0.hasDirectBufferNoCleanerConstructor()) {
-            USE_DIRECT_BUFFER_NO_CLEANER = false;
-            DIRECT_CLEANER = NOOP;
+        // Initialize the direct memory counter independently of Unsafe availability,
+        // so that io.netty.maxDirectMemory is enforced even when Unsafe is not available (e.g. Java 25+).
+        if (maxDirectMemory == 0) {
             DIRECT_MEMORY_COUNTER = null;
-        } else {
-            USE_DIRECT_BUFFER_NO_CLEANER = true;
-            DIRECT_CLEANER = new DirectCleaner();
-            if (maxDirectMemory < 0) {
-                maxDirectMemory = MAX_DIRECT_MEMORY;
-                if (maxDirectMemory <= 0) {
-                    DIRECT_MEMORY_COUNTER = null;
-                } else {
-                    DIRECT_MEMORY_COUNTER = new AtomicLong();
-                }
+        } else if (maxDirectMemory < 0) {
+            maxDirectMemory = MAX_DIRECT_MEMORY;
+            if (maxDirectMemory <= 0) {
+                DIRECT_MEMORY_COUNTER = null;
             } else {
                 DIRECT_MEMORY_COUNTER = new AtomicLong();
             }
+        } else {
+            DIRECT_MEMORY_COUNTER = new AtomicLong();
         }
         logger.debug("-Dio.netty.maxDirectMemory: {} bytes", maxDirectMemory);
         DIRECT_MEMORY_LIMIT = maxDirectMemory >= 1 ? maxDirectMemory : MAX_DIRECT_MEMORY;
@@ -228,7 +222,11 @@ public final class PlatformDependent {
         } else {
             LEGACY_CLEANER = NOOP;
         }
-        CLEANER = USE_DIRECT_BUFFER_NO_CLEANER ? DIRECT_CLEANER : LEGACY_CLEANER;
+        if (maxDirectMemory != 0 && hasUnsafe() && PlatformDependent0.hasDirectBufferNoCleanerConstructor()) {
+            CLEANER = new DirectCleaner();
+        } else {
+            CLEANER = LEGACY_CLEANER;
+        }
 
         EXPLICIT_NO_PREFER_DIRECT = SystemPropertyUtil.getBoolean("io.netty.noPreferDirect", false);
         // We should always prefer direct buffers by default if we can use a Cleaner to release direct buffers.
@@ -625,6 +623,18 @@ public final class PlatformDependent {
     }
 
     /**
+     * Reallocate a direct buffer with the given new capacity.
+     * The old buffer is invalidated and must not be used after this call.
+     *
+     * @param buffer The old buffer to reallocate.
+     * @param newCapacity The desired new capacity.
+     * @return The new {@link CleanableDirectBuffer} with the given capacity.
+     */
+    public static CleanableDirectBuffer reallocateDirect(CleanableDirectBuffer buffer, int newCapacity) {
+        return CLEANER.reallocate(buffer, newCapacity);
+    }
+
+    /**
      * Try to deallocate the specified direct {@link ByteBuffer}. Please note this method does nothing if
      * the current platform does not support this operation or the specified buffer is not a direct buffer.
      *
@@ -632,8 +642,6 @@ public final class PlatformDependent {
      */
     @Deprecated
     public static void freeDirectBuffer(ByteBuffer buffer) {
-        // Use the LEGACY_CLEANER reference to avoid using the DIRECT_CLEANER implementation
-        // that just calls #freeDirectNoCleaner(ByteBuffer).
         LEGACY_CLEANER.freeDirectBuffer(buffer);
     }
 
@@ -1020,75 +1028,6 @@ public final class PlatformDependent {
         PlatformDependent0.setMemory(address, bytes, value);
     }
 
-    /**
-     * Allocate a new {@link ByteBuffer} with the given {@code capacity}. {@link ByteBuffer}s allocated with
-     * this method <strong>MUST</strong> be deallocated via {@link #freeDirectNoCleaner(ByteBuffer)}.
-     */
-    public static ByteBuffer allocateDirectNoCleaner(int capacity) {
-        assert USE_DIRECT_BUFFER_NO_CLEANER;
-
-        incrementMemoryCounter(capacity);
-        try {
-            return PlatformDependent0.allocateDirectNoCleaner(capacity);
-        } catch (Throwable e) {
-            decrementMemoryCounter(capacity);
-            throwException(e);
-            return null;
-        }
-    }
-
-    /**
-     * Allocate a new {@link ByteBuffer} with the given {@code capacity}, inside a {@link CleanableDirectBuffer}.
-     * The {@link ByteBuffer} <strong>MUST</strong> be deallocated via the {@link CleanableDirectBuffer#clean()}
-     * of the returned {@link CleanableDirectBuffer} object.
-     */
-    public static CleanableDirectBuffer allocateDirectBufferNoCleaner(int capacity) {
-        assert USE_DIRECT_BUFFER_NO_CLEANER;
-        return DIRECT_CLEANER.allocate(capacity);
-    }
-
-    /**
-     * Reallocate a new {@link ByteBuffer} with the given {@code capacity}. {@link ByteBuffer}s reallocated with
-     * this method <strong>MUST</strong> be deallocated via {@link #freeDirectNoCleaner(ByteBuffer)}.
-     */
-    public static ByteBuffer reallocateDirectNoCleaner(ByteBuffer buffer, int capacity) {
-        assert USE_DIRECT_BUFFER_NO_CLEANER;
-
-        int len = capacity - buffer.capacity();
-        incrementMemoryCounter(len);
-        try {
-            return PlatformDependent0.reallocateDirectNoCleaner(buffer, capacity);
-        } catch (Throwable e) {
-            decrementMemoryCounter(len);
-            throwException(e);
-            return null;
-        }
-    }
-
-    /**
-     * Reallocate a new {@link ByteBuffer} with the given {@code capacity}.
-     * The {@link ByteBuffer} is given as wrapped in its associated {@link CleanableDirectBuffer},
-     * and a new {@link CleanableDirectBuffer} instance will be returned.
-     * The {@link ByteBuffer}s reallocated with this method <strong>MUST</strong> be deallocated
-     * via the {@link CleanableDirectBuffer#clean()} method on the returned object.
-     */
-    public static CleanableDirectBuffer reallocateDirectBufferNoCleaner(CleanableDirectBuffer buffer, int capacity) {
-        assert USE_DIRECT_BUFFER_NO_CLEANER;
-        return ((DirectCleaner) DIRECT_CLEANER).reallocate(buffer, capacity);
-    }
-
-    /**
-     * This method <strong>MUST</strong> only be called for {@link ByteBuffer}s that were allocated via
-     * {@link #allocateDirectNoCleaner(int)}.
-     */
-    public static void freeDirectNoCleaner(ByteBuffer buffer) {
-        assert USE_DIRECT_BUFFER_NO_CLEANER;
-
-        int capacity = buffer.capacity();
-        PlatformDependent0.freeMemory(PlatformDependent0.directBufferAddress(buffer));
-        decrementMemoryCounter(capacity);
-    }
-
     public static boolean hasAlignDirectByteBuffer() {
         return hasUnsafe() || PlatformDependent0.hasAlignSliceMethod();
     }
@@ -1144,7 +1083,7 @@ public final class PlatformDependent {
         }
     }
 
-    private static void incrementMemoryCounter(int capacity) {
+    static void incrementMemoryCounter(int capacity) {
         if (DIRECT_MEMORY_COUNTER != null) {
             long newUsedMemory = DIRECT_MEMORY_COUNTER.addAndGet(capacity);
             if (newUsedMemory > DIRECT_MEMORY_LIMIT) {
@@ -1156,7 +1095,7 @@ public final class PlatformDependent {
         }
     }
 
-    private static void decrementMemoryCounter(int capacity) {
+    static void decrementMemoryCounter(int capacity) {
         if (DIRECT_MEMORY_COUNTER != null) {
             long usedMemory = DIRECT_MEMORY_COUNTER.addAndGet(-capacity);
             assert usedMemory >= 0;
@@ -1164,7 +1103,7 @@ public final class PlatformDependent {
     }
 
     public static boolean useDirectBufferNoCleaner() {
-        return USE_DIRECT_BUFFER_NO_CLEANER;
+        return CLEANER instanceof DirectCleaner;
     }
 
     /**

--- a/common/src/test/java/io/netty/util/internal/PlatformDependentTest.java
+++ b/common/src/test/java/io/netty/util/internal/PlatformDependentTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
-import java.nio.ByteBuffer;
 import java.util.Random;
 
 import static io.netty.util.internal.PlatformDependent.hashCodeAscii;
@@ -155,10 +154,10 @@ public class PlatformDependentTest {
     @Test
     public void testAllocateWithCapacity0() {
         assumeTrue(PlatformDependent.hasDirectBufferNoCleanerConstructor());
-        ByteBuffer buffer = PlatformDependent.allocateDirectNoCleaner(0);
-        assertNotEquals(0, PlatformDependent.directBufferAddress(buffer));
-        assertEquals(0, buffer.capacity());
-        PlatformDependent.freeDirectNoCleaner(buffer);
+        CleanableDirectBuffer buffer = PlatformDependent.allocateDirect(0);
+        assertNotEquals(0, PlatformDependent.directBufferAddress(buffer.buffer()));
+        assertEquals(0, buffer.buffer().capacity());
+        buffer.clean();
     }
 
     @EnabledForJreRange(min = JRE.JAVA_25)


### PR DESCRIPTION
**Motivation**:

Netty selects a Cleaner implementation based on the Java version and whether `sun.misc.Unsafe` is available. The selection matrix is:
```
  Java version   | Unsafe available | Cleaner selected
  ───────────────|──────────────────|─────────────────────
  6-8            | Yes              | DirectCleaner
  9-23           | Yes              | DirectCleaner
  24             | Yes (warnings)   | DirectCleaner
  24             | No, native access| CleanerJava24Linker
  25+            | No, native access| CleanerJava24Linker
  25+            | No               | CleanerJava25
```
Before this change, direct memory accounting (`incrementMemoryCounter` / `decrementMemoryCounter`) was coupled to `USE_DIRECT_BUFFER_NO_CLEANER`, which was only true when Unsafe was available. This had two consequences:

1. `DIRECT_MEMORY_COUNTER` was only initialized inside the `USE_DIRECT_BUFFER_NO_CLEANER=true` branch, so on any Java version without Unsafe the counter was always null even if the user explicitly set `io.netty.maxDirectMemory`.

2. The accounting calls themselves lived only in PlatformDependent's legacy NoCleaner methods (`allocateDirectNoCleaner`, `reallocateDirectNoCleaner`, `freeDirectNoCleaner`), which were only called by DirectCleaner. The other Cleaner implementations (`CleanerJava9`, `CleanerJava6`, `CleanerJava24Linker`, `CleanerJava25`) never called these methods and performed no accounting.

The combined effect was that the configured limit was silently ignored on every path that didn't go through DirectCleaner:
```
  Java version   | Unsafe | Cleaner             | Counter init | Accounting
  ───────────────|────────|─────────────────────|──────────────|───────────
  6-8            | Yes    | DirectCleaner       | Yes          | Yes ✓
  9-23           | Yes    | DirectCleaner       | Yes          | Yes ✓
  24             | Yes    | DirectCleaner       | Yes          | Yes ✓
  24             | No     | CleanerJava24Linker | No           | No  ✗
  25+            | No     | CleanerJava24Linker | No           | No  ✗
  25+            | No     | CleanerJava25       | No           | No  ✗
```
On Java 25+, where Unsafe is disabled by default, this means `io.netty.maxDirectMemory` has no effect at all.

**Modifications**:

- Decouple `DIRECT_MEMORY_COUNTER` initialization from Unsafe availability. The counter is now created based solely on the value of `io.netty.maxDirectMemory`, independent of
`USE_DIRECT_BUFFER_NO_CLEANER`.

- Move accounting into each Cleaner's `CleanableDirectBufferImpl` so that every allocation/deallocation pair tracks memory regardless of which Cleaner is active:
- `DirectCleaner`: increment in `CleanableDirectBufferImpl(int capacity)` constructor, decrement in `clean()`.
  - `CleanerJava9`: increment in constructor, decrement in `clean()`.
  - `CleanerJava6`: increment in constructor, decrement in `clean()`.
- `CleanerJava24Linker`: increment before `malloc()`, decrement in `clean()`, with rollback on allocation failure.
- `CleanerJava25`: increment in `allocate()` before MethodHandle invoke, decrement in `clean()` via finally block.

- Change `incrementMemoryCounter`/`decrementMemoryCounter` from private to package-private so Cleaner implementations (same package) can call them directly.

- Add a default `reallocate(CleanableDirectBuffer, int)` method to the Cleaner interface with an allocate-copy-free fallback. DirectCleaner overrides this with in-place `Unsafe.reallocateMemory`, adjusting the counter by the delta.

- Add `PlatformDependent.reallocateDirect()` as the unified public entry point for reallocation.

- Remove the legacy NoCleaner API surface from PlatformDependent: `allocateDirectNoCleaner`, `allocateDirectBufferNoCleaner`, `reallocateDirectNoCleaner`, `reallocateDirectBufferNoCleaner`, and `freeDirectNoCleaner`.

- Remove `USE_DIRECT_BUFFER_NO_CLEANER` and `DIRECT_CLEANER` fields. `CLEANER` is now the single entry point; `useDirectBufferNoCleaner()` returns whether `CLEANER` is an instance of DirectCleaner.

- Update `UnpooledUnsafeNoCleanerDirectByteBuf` to use the new unified API: remove the `allocateDirectBuffer()` override (parent's impl now does the right thing via `PlatformDependent.allocateDirect()`), and delegate `reallocateDirect()` to `PlatformDependent.reallocateDirect()`.

- Update `PlatformDependentTest.testAllocateWithCapacity0()` to use the new CleanableDirectBuffer-based API.

**Result**:

After this change, the accounting matrix becomes:
```
  Java version   | Unsafe | Cleaner             | Counter init | Accounting
  ───────────────|────────|─────────────────────|──────────────|───────────
  6-8            | Yes    | DirectCleaner       | Yes          | Yes ✓
  9-23           | Yes    | DirectCleaner       | Yes          | Yes ✓
  24             | Yes    | DirectCleaner       | Yes          | Yes ✓
  24             | No     | CleanerJava24Linker | Yes          | Yes ✓
  25+            | No     | CleanerJava24Linker | Yes          | Yes ✓
  25+            | No     | CleanerJava25       | Yes          | Yes ✓
```
`io.netty.maxDirectMemory` is now enforced on all Java versions and all Cleaner implementations. The legacy raw-ByteBuffer NoCleaner API surface is eliminated, and each `CleanableDirectBuffer` is responsible for its own accounting.

---------

Co-authored-by: Chris Vest <mr.chrisvest@gmail.com>

(cherry picked from commit 7937553d8f49e17b064f57b1414907aed8e3be3d)