### PR TITLE
Merge commit from fork

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpChunkLineValidatingByteProcessor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpChunkLineValidatingByteProcessor.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http;
+
+import io.netty.util.ByteProcessor;
+
+import java.util.BitSet;
+
+/**
+ * Validates the chunk start line. That is, the chunk size and chunk extensions, until the CR LF pair.
+ * See <a href="https://www.rfc-editor.org/rfc/rfc9112#name-chunked-transfer-coding">RFC 9112 section 7.1</a>.
+ *
+ * <pre>{@code
+ *   chunked-body   = *chunk
+ *                    last-chunk
+ *                    trailer-section
+ *                    CRLF
+ *
+ *   chunk          = chunk-size [ chunk-ext ] CRLF
+ *                    chunk-data CRLF
+ *   chunk-size     = 1*HEXDIG
+ *   last-chunk     = 1*("0") [ chunk-ext ] CRLF
+ *
+ *   chunk-data     = 1*OCTET ; a sequence of chunk-size octets
+ *   chunk-ext      = *( BWS ";" BWS chunk-ext-name
+ *                       [ BWS "=" BWS chunk-ext-val ] )
+ *
+ *   chunk-ext-name = token
+ *   chunk-ext-val  = token / quoted-string
+ *   quoted-string  = DQUOTE *( qdtext / quoted-pair ) DQUOTE
+ *   qdtext         = HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text
+ *   quoted-pair    = "\" ( HTAB / SP / VCHAR / obs-text )
+ *   obs-text       = %x80-FF
+ *   OWS            = *( SP / HTAB )
+ *                  ; optional whitespace
+ *   BWS            = OWS
+ *                  ; "bad" whitespace
+ *   VCHAR          =  %x21-7E
+ *                  ; visible (printing) characters
+ * }</pre>
+ */
+final class HttpChunkLineValidatingByteProcessor implements ByteProcessor {
+    private static final int SIZE = 0;
+    private static final int CHUNK_EXT_NAME = 1;
+    private static final int CHUNK_EXT_VAL_START = 2;
+    private static final int CHUNK_EXT_VAL_QUOTED = 3;
+    private static final int CHUNK_EXT_VAL_QUOTED_ESCAPE = 4;
+    private static final int CHUNK_EXT_VAL_QUOTED_END = 5;
+    private static final int CHUNK_EXT_VAL_TOKEN = 6;
+
+    static final class Match extends BitSet {
+        private static final long serialVersionUID = 49522994383099834L;
+        private final int then;
+
+        Match(int then) {
+            super(256);
+            this.then = then;
+        }
+
+        Match chars(String chars) {
+            return chars(chars, true);
+        }
+
+        Match chars(String chars, boolean value) {
+            for (int i = 0, len = chars.length(); i < len; i++) {
+                set(chars.charAt(i), value);
+            }
+            return this;
+        }
+
+        Match range(int from, int to) {
+            return range(from, to, true);
+        }
+
+        Match range(int from, int to, boolean value) {
+            for (int i = from; i <= to; i++) {
+                set(i, value);
+            }
+            return this;
+        }
+    }
+
+    private enum State {
+        Size(
+                new Match(SIZE).chars("0123456789abcdefABCDEF \t"),
+                new Match(CHUNK_EXT_NAME).chars(";")),
+        ChunkExtName(
+                new Match(CHUNK_EXT_NAME)
+                        .range(0x21, 0x7E)
+                        .chars(" \t")
+                        .chars("(),/:<=>?@[\\]{}", false),
+                new Match(CHUNK_EXT_VAL_START).chars("=")),
+        ChunkExtValStart(
+                new Match(CHUNK_EXT_VAL_START).chars(" \t"),
+                new Match(CHUNK_EXT_VAL_QUOTED).chars("\""),
+                new Match(CHUNK_EXT_VAL_TOKEN)
+                        .range(0x21, 0x7E)
+                        .chars("(),/:<=>?@[\\]{}", false)),
+        ChunkExtValQuoted(
+                new Match(CHUNK_EXT_VAL_QUOTED_ESCAPE).chars("\\"),
+                new Match(CHUNK_EXT_VAL_QUOTED_END).chars("\""),
+                new Match(CHUNK_EXT_VAL_QUOTED)
+                        .chars("\t !")
+                        .range(0x23, 0x5B)
+                        .range(0x5D, 0x7E)
+                        .range(0x80, 0xFF)),
+        ChunkExtValQuotedEscape(
+                new Match(CHUNK_EXT_VAL_QUOTED)
+                        .chars("\t ")
+                        .range(0x21, 0x7E)
+                        .range(0x80, 0xFF)),
+        ChunkExtValQuotedEnd(
+                new Match(CHUNK_EXT_VAL_QUOTED_END).chars("\t "),
+                new Match(CHUNK_EXT_NAME).chars(";")),
+        ChunkExtValToken(
+                new Match(CHUNK_EXT_VAL_TOKEN)
+                        .range(0x21, 0x7E, true)
+                        .chars("(),/:<=>?@[\\]{}", false),
+                new Match(CHUNK_EXT_NAME).chars(";")),
+        ;
+
+        private final Match[] matches;
+
+        State(Match... matches) {
+            this.matches = matches;
+        }
+
+        State match(byte value) {
+            for (Match match : matches) {
+                if (match.get(value)) {
+                    return STATES_BY_ORDINAL[match.then];
+                }
+            }
+            if (this == Size) {
+                throw new NumberFormatException("Invalid chunk size");
+            } else {
+                throw new InvalidChunkExtensionException("Invalid chunk extension");
+            }
+        }
+    }
+
+    private static final State[] STATES_BY_ORDINAL = State.values();
+
+    private State state = State.Size;
+
+    @Override
+    public boolean process(byte value) {
+        state = state.match(value);
+        return true;
+    }
+
+    public void finish() {
+        if (state != State.Size && state != State.ChunkExtName && state != State.ChunkExtValQuotedEnd) {
+            throw new InvalidChunkExtensionException("Invalid chunk extension");
+        }
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -477,6 +477,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             if (line == null) {
                 return;
             }
+            checkChunkExtensions(line);
             int chunkSize = getChunkSize(line.array(), line.arrayOffset() + line.readerIndex(), line.readableBytes());
             this.chunkSize = chunkSize;
             if (chunkSize == 0) {
@@ -723,6 +724,16 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
         return current;
     }
 
+    private static void checkChunkExtensions(ByteBuf line) {
+        int extensionsStart = line.bytesBefore((byte) ';');
+        if (extensionsStart == -1) {
+            return;
+        }
+        HttpChunkLineValidatingByteProcessor processor = new HttpChunkLineValidatingByteProcessor();
+        line.forEachByte(processor);
+        processor.finish();
+    }
+
     private HttpContent invalidChunk(ByteBuf in, Exception cause) {
         currentState = State.BAD_MESSAGE;
         message = null;
@@ -941,7 +952,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
     }
 
     private static int getChunkSize(byte[] hex, int start, int length) {
-        // trim the leading bytes if white spaces, if any
+        // trim the leading bytes of white spaces, if any
         final int skipped = skipWhiteSpaces(hex, start, length);
         if (skipped == length) {
             // empty case

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
@@ -808,13 +808,13 @@ public final class HttpUtil {
     private static final long TOKEN_CHARS_HIGH = 0x57ffffffc7fffffeL;
     private static final long TOKEN_CHARS_LOW = 0x3ff6cfa00000000L;
 
-    private static boolean isValidTokenChar(byte bit) {
-        if (bit < 0) {
+    static boolean isValidTokenChar(byte octet) {
+        if (octet < 0) {
             return false;
         }
-        if (bit < 64) {
-            return 0 != (TOKEN_CHARS_LOW & 1L << bit);
+        if (octet < 64) {
+            return 0 != (TOKEN_CHARS_LOW & 1L << octet);
         }
-        return 0 != (TOKEN_CHARS_HIGH & 1L << bit - 64);
+        return 0 != (TOKEN_CHARS_HIGH & 1L << octet - 64);
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -33,7 +33,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import static io.netty.handler.codec.http.HttpHeaderNames.*;
+import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
 import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -778,6 +778,187 @@ public class HttpRequestDecoderTest {
         assertTrue(decoderResult.isFailure()); // But then parsing the chunk delimiter must fail.
         assertThat(decoderResult.cause()).isInstanceOf(InvalidChunkTerminationException.class);
         content.release();
+        assertFalse(channel.finish());
+    }
+
+    @Test
+    void mustParsedChunkExtensionsWithQuotedStrings() throws Exception {
+        // See full explanation: https://w4ke.info/2025/10/29/funky-chunks-2.html
+        String requestStr = "GET /one HTTP/1.1\r\n" +
+                "Host: localhost\r\n" +
+                "Transfer-Encoding: chunked\r\n\r\n" +
+                "1;a=\" ;\t\"\r\n" + // chunk extension quote end
+                "Y\r\n" +
+                "0\r\n" +
+                "\r\n";
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
+        HttpRequest request = channel.readInbound();
+        assertFalse(request.decoderResult().isFailure()); // We parse the headers just fine.
+        assertTrue(request.headers().names().contains("Transfer-Encoding"));
+        assertTrue(request.headers().contains("Transfer-Encoding", "chunked", false));
+        HttpContent content = channel.readInbound();
+        DecoderResult decoderResult = content.decoderResult();
+        assertFalse(decoderResult.isFailure()); // And we parse the chunk.
+        content.release();
+        LastHttpContent last = channel.readInbound();
+        assertEquals(0, last.content().readableBytes());
+        last.release();
+        assertFalse(channel.finish()); // And there are no other chunks parsed.
+    }
+
+    @Test
+    void mustRejectChunkExtensionsWithLineBreaksInQuotedStrings() throws Exception {
+        // See full explanation: https://w4ke.info/2025/10/29/funky-chunks-2.html
+        String requestStr = "GET /one HTTP/1.1\r\n" +
+                "Host: localhost\r\n" +
+                "Transfer-Encoding: chunked\r\n\r\n" +
+                "1;a=\"\r\n" + // chunk extension quote start
+                "X\r\n" +
+                "0\r\n\r\n" +
+                "GET /two HTTP/1.1\r\n" +
+                "Host: localhost\r\n" +
+                "Transfer-Encoding: chunked\r\n\r\n" +
+                "\"\r\n" + // chunk extension quote end
+                "Y\r\n" +
+                "0\r\n" +
+                "\r\n";
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
+        HttpRequest request = channel.readInbound();
+        assertFalse(request.decoderResult().isFailure()); // We parse the headers just fine.
+        assertTrue(request.headers().names().contains("Transfer-Encoding"));
+        assertTrue(request.headers().contains("Transfer-Encoding", "chunked", false));
+        HttpContent content = channel.readInbound();
+        DecoderResult decoderResult = content.decoderResult();
+        assertTrue(decoderResult.isFailure()); // Chunk extension is not allowed to contain line breaks.
+        assertThat(decoderResult.cause()).isInstanceOf(InvalidChunkExtensionException.class);
+        content.release();
+        assertFalse(channel.finish()); // And there are no other chunks parsed.
+    }
+
+    @Test
+    void mustParseChunkExtensionsWithQuotedStringsAndEscapes() throws Exception {
+        // See full explanation: https://w4ke.info/2025/10/29/funky-chunks-2.html
+        String requestStr = "GET /one HTTP/1.1\r\n" +
+                "Host: localhost\r\n" +
+                "Transfer-Encoding: chunked\r\n\r\n" +
+                "1;a=\" \\\";\t\"\r\n" +
+                "Y\r\n" +
+                "0\r\n" +
+                "\r\n";
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
+        HttpRequest request = channel.readInbound();
+        assertFalse(request.decoderResult().isFailure()); // We parse the headers just fine.
+        assertTrue(request.headers().names().contains("Transfer-Encoding"));
+        assertTrue(request.headers().contains("Transfer-Encoding", "chunked", false));
+        HttpContent content = channel.readInbound();
+        DecoderResult decoderResult = content.decoderResult();
+        assertFalse(decoderResult.isFailure()); // And we parse the chunk.
+        content.release();
+        LastHttpContent last = channel.readInbound();
+        assertEquals(0, last.content().readableBytes());
+        last.release();
+        assertFalse(channel.finish()); // And there are no other chunks parsed.
+    }
+
+    @Test
+    void mustRejectChunkExtensionsWithEscapedLineBreakInQuotedStrings() throws Exception {
+        // See full explanation: https://w4ke.info/2025/10/29/funky-chunks-2.html
+        String requestStr = "GET /one HTTP/1.1\r\n" +
+                "Host: localhost\r\n" +
+                "Transfer-Encoding: chunked\r\n\r\n" +
+                "1;a=\" \\\n;\t\"\r\n" +
+                "Y\r\n" +
+                "0\r\n" +
+                "\r\n";
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
+        HttpRequest request = channel.readInbound();
+        assertFalse(request.decoderResult().isFailure()); // We parse the headers just fine.
+        assertTrue(request.headers().names().contains("Transfer-Encoding"));
+        assertTrue(request.headers().contains("Transfer-Encoding", "chunked", false));
+        HttpContent content = channel.readInbound();
+        DecoderResult decoderResult = content.decoderResult();
+        assertTrue(decoderResult.isFailure()); // Chunk extension is not allowed to contain line breaks.
+        assertThat(decoderResult.cause()).isInstanceOf(InvalidChunkExtensionException.class);
+        content.release();
+        assertFalse(channel.finish()); // And there are no other chunks parsed.
+    }
+
+    @Test
+    void mustRejectChunkExtensionsWithEscapedCarriageReturnInQuotedStrings() throws Exception {
+        // See full explanation: https://w4ke.info/2025/10/29/funky-chunks-2.html
+        String requestStr = "GET /one HTTP/1.1\r\n" +
+                "Host: localhost\r\n" +
+                "Transfer-Encoding: chunked\r\n\r\n" +
+                "1;a=\" \\\r;\t\"\r\n" +
+                "Y\r\n" +
+                "0\r\n" +
+                "\r\n";
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
+        HttpRequest request = channel.readInbound();
+        assertFalse(request.decoderResult().isFailure()); // We parse the headers just fine.
+        assertTrue(request.headers().names().contains("Transfer-Encoding"));
+        assertTrue(request.headers().contains("Transfer-Encoding", "chunked", false));
+        HttpContent content = channel.readInbound();
+        DecoderResult decoderResult = content.decoderResult();
+        assertTrue(decoderResult.isFailure()); // Chunk extension is not allowed to contain carraige return.
+        assertThat(decoderResult.cause()).isInstanceOf(InvalidChunkExtensionException.class);
+        content.release();
+        assertFalse(channel.finish()); // And there are no other chunks parsed.
+    }
+
+    @Test
+    void lineLengthRestrictionMustNotApplyToChunkContents() throws Exception {
+        char[] chars = new char[10000];
+        Arrays.fill(chars, 'a');
+        String requestContent = new String(chars);
+        String requestStr = "POST /one HTTP/1.1\r\n" +
+                "Host: localhost\r\n" +
+                "Transfer-Encoding: chunked\r\n\r\n" +
+                Integer.toHexString(chars.length) + "\r\n" +
+                requestContent + "\r\n" +
+                "0\r\n\r\n";
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
+        HttpRequest request = channel.readInbound();
+        assertFalse(request.decoderResult().isFailure()); // We parse the headers just fine.
+        assertTrue(request.headers().names().contains("Transfer-Encoding"));
+        assertTrue(request.headers().contains("Transfer-Encoding", "chunked", false));
+        int contentLength = 0;
+        HttpContent content;
+        do {
+            content = channel.readInbound();
+            DecoderResult decoderResult = content.decoderResult();
+            if (decoderResult.cause() != null) {
+                throw new Exception(decoderResult.cause());
+            }
+            assertFalse(decoderResult.isFailure()); // And we parse the chunk.
+            contentLength += content.content().readableBytes();
+            content.release();
+        } while (!(content instanceof LastHttpContent));
+        assertEquals(chars.length, contentLength);
+        assertFalse(channel.finish()); // And there are no other chunks parsed.
+    }
+
+    @Test
+    void mustRejectChunkSizeWithNonHexadecimalCharacters() throws Exception {
+        String requestStr = "POST /one HTTP/1.1\r\n" +
+                "Host: localhost\r\n" +
+                "Transfer-Encoding: chunked\r\n" +
+                "\r\n" +
+                "test\r\n\r\n" + // chunk extension quote start
+                "\r\n";
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
+        HttpRequest request = channel.readInbound();
+        assertFalse(request.decoderResult().isFailure()); // We parse the headers
+        HttpContent content = channel.readInbound();
+        assertTrue(content.decoderResult().isFailure());
+        assertThat(content.decoderResult().cause()).isInstanceOf(NumberFormatException.class);
         assertFalse(channel.finish());
     }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
@@ -26,11 +26,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+
 import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -200,21 +201,6 @@ public class HttpResponseDecoderTest {
         assertEquals(data.length, content.content().readableBytes());
 
         byte[] decodedData = new byte[data.length];
-        content.content().readBytes(decodedData);
-        assertArrayEquals(data, decodedData);
-        content.release();
-
-        assertFalse(ch.writeInbound(Unpooled.copiedBuffer("\r\n", CharsetUtil.US_ASCII)));
-
-        // leading whitespace, trailing control char
-
-        assertFalse(ch.writeInbound(Unpooled.copiedBuffer("  " + Integer.toHexString(data.length) + "\0\r\n",
-                                                          CharsetUtil.US_ASCII)));
-        assertTrue(ch.writeInbound(Unpooled.copiedBuffer(data)));
-        content = ch.readInbound();
-        assertEquals(data.length, content.content().readableBytes());
-
-        decodedData = new byte[data.length];
         content.content().readBytes(decodedData);
         assertArrayEquals(data, decodedData);
         content.release();
@@ -1059,7 +1045,7 @@ public class HttpResponseDecoderTest {
     @Test
     void mustRejectImproperlyTerminatedChunkExtensions() throws Exception {
         // See full explanation: https://w4ke.info/2025/06/18/funky-chunks.html
-        String requestStr = "HTTP/1.1 200 OK\r\n" +
+        String responseStr = "HTTP/1.1 200 OK\r\n" +
                 "Transfer-Encoding: chunked\r\n" +
                 "\r\n" +
                 "2;\n" + // Chunk size followed by illegal single newline (not preceded by carraige return)
@@ -1070,7 +1056,7 @@ public class HttpResponseDecoderTest {
                 "Transfer-Encoding: chunked\r\n\r\n" +
                 "0\r\n\r\n";
         EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseDecoder());
-        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(responseStr, CharsetUtil.US_ASCII)));
         HttpResponse response = channel.readInbound();
         assertFalse(response.decoderResult().isFailure()); // We parse the headers just fine.
         assertTrue(response.headers().names().contains("Transfer-Encoding"));
@@ -1086,7 +1072,7 @@ public class HttpResponseDecoderTest {
     @Test
     void mustRejectImproperlyTerminatedChunkBodies() throws Exception {
         // See full explanation: https://w4ke.info/2025/06/18/funky-chunks.html
-        String requestStr = "HTTP/1.1 200 OK\r\n" +
+        String responseStr = "HTTP/1.1 200 OK\r\n" +
                 "Transfer-Encoding: chunked\r\n\r\n" +
                 "5\r\n" +
                 "AAAAXX" + // Chunk body contains extra (XX) bytes, and no CRLF terminator.
@@ -1096,7 +1082,7 @@ public class HttpResponseDecoderTest {
                 "Transfer-Encoding: chunked\r\n\r\n" +
                 "0\r\n\r\n";
         EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseDecoder());
-        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(responseStr, CharsetUtil.US_ASCII)));
         HttpResponse response = channel.readInbound();
         assertFalse(response.decoderResult().isFailure()); // We parse the headers just fine.
         assertTrue(response.headers().names().contains("Transfer-Encoding"));
@@ -1110,6 +1096,185 @@ public class HttpResponseDecoderTest {
         assertTrue(decoderResult.isFailure()); // But then parsing the chunk delimiter must fail.
         assertThat(decoderResult.cause()).isInstanceOf(InvalidChunkTerminationException.class);
         content.release();
+        assertFalse(channel.finish());
+    }
+
+    @Test
+    void mustParsedChunkExtensionsWithQuotedStrings() throws Exception {
+        // See full explanation: https://w4ke.info/2025/10/29/funky-chunks-2.html
+        String responseStr = "HTTP/1.1 200 OK\r\n" +
+                "Transfer-Encoding: chunked\r\n" +
+                "\r\n" +
+                "1;a=\" ;\t\"\r\n" +
+                "Y\r\n" +
+                "0\r\n" +
+                "\r\n";
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseDecoder());
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(responseStr, CharsetUtil.US_ASCII)));
+        HttpResponse response = channel.readInbound();
+        assertFalse(response.decoderResult().isFailure()); // We parse the headers just fine.
+        assertTrue(response.headers().names().contains("Transfer-Encoding"));
+        assertTrue(response.headers().contains("Transfer-Encoding", "chunked", false));
+        HttpContent content = channel.readInbound();
+        DecoderResult decoderResult = content.decoderResult();
+        assertFalse(decoderResult.isFailure()); // And we parse the chunk.
+        content.release();
+        LastHttpContent last = channel.readInbound();
+        assertEquals(0, last.content().readableBytes());
+        last.release();
+        assertFalse(channel.finish()); // And there are no other chunks parsed.
+    }
+
+    @Test
+    void mustRejectChunkExtensionsWithLineBreaksInQuotedStrings() throws Exception {
+        // See full explanation: https://w4ke.info/2025/10/29/funky-chunks-2.html
+        String responseStr = "HTTP/1.1 200 OK\r\n" +
+                "Transfer-Encoding: chunked\r\n" +
+                "\r\n" +
+                "1;a=\"\r\n" + // chunk extension quote start
+                "X\r\n" +
+                "0\r\n\r\n" +
+                "HTTP/1.1 200 OK\r\n" +
+                "Transfer-Encoding: chunked\r\n\r\n" +
+                "\"\r\n" + // chunk extension quote end
+                "Y\r\n" +
+                "0\r\n" +
+                "\r\n";
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseDecoder());
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(responseStr, CharsetUtil.US_ASCII)));
+        HttpResponse response = channel.readInbound();
+        assertFalse(response.decoderResult().isFailure()); // We parse the headers just fine.
+        assertTrue(response.headers().names().contains("Transfer-Encoding"));
+        assertTrue(response.headers().contains("Transfer-Encoding", "chunked", false));
+        HttpContent content = channel.readInbound();
+        DecoderResult decoderResult = content.decoderResult();
+        assertTrue(decoderResult.isFailure()); // Chunk extension is not allowed to contain line breaks.
+        assertThat(decoderResult.cause()).isInstanceOf(InvalidChunkExtensionException.class);
+        content.release();
+        assertFalse(channel.finish()); // And there are no other chunks parsed.
+    }
+
+    @Test
+    void mustParsedChunkExtensionsWithQuotedStringsAndEscapes() throws Exception {
+        // See full explanation: https://w4ke.info/2025/10/29/funky-chunks-2.html
+        String responseStr = "HTTP/1.1 200 OK\r\n" +
+                "Transfer-Encoding: chunked\r\n" +
+                "\r\n" +
+                "1;a=\" \\\";\t\"\r\n" +
+                "Y\r\n" +
+                "0\r\n" +
+                "\r\n";
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseDecoder());
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(responseStr, CharsetUtil.US_ASCII)));
+        HttpResponse response = channel.readInbound();
+        assertFalse(response.decoderResult().isFailure()); // We parse the headers just fine.
+        assertTrue(response.headers().names().contains("Transfer-Encoding"));
+        assertTrue(response.headers().contains("Transfer-Encoding", "chunked", false));
+        HttpContent content = channel.readInbound();
+        DecoderResult decoderResult = content.decoderResult();
+        assertFalse(decoderResult.isFailure()); // And we parse the chunk.
+        content.release();
+        LastHttpContent last = channel.readInbound();
+        assertEquals(0, last.content().readableBytes());
+        last.release();
+        assertFalse(channel.finish()); // And there are no other chunks parsed.
+    }
+
+    @Test
+    void mustRejectChunkExtensionsWithEscapedLineBreakInQuotedStrings() throws Exception {
+        // See full explanation: https://w4ke.info/2025/10/29/funky-chunks-2.html
+        String responseStr = "HTTP/1.1 200 OK\r\n" +
+                "Transfer-Encoding: chunked\r\n" +
+                "\r\n" +
+                "1;a=\" \\\n;\t\"\r\n" +
+                "Y\r\n" +
+                "0\r\n" +
+                "\r\n";
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseDecoder());
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(responseStr, CharsetUtil.US_ASCII)));
+        HttpResponse response = channel.readInbound();
+        assertFalse(response.decoderResult().isFailure()); // We parse the headers just fine.
+        assertTrue(response.headers().names().contains("Transfer-Encoding"));
+        assertTrue(response.headers().contains("Transfer-Encoding", "chunked", false));
+        HttpContent content = channel.readInbound();
+        DecoderResult decoderResult = content.decoderResult();
+        assertTrue(decoderResult.isFailure()); // Chunk extension is not allowed to contain line breaks.
+        assertThat(decoderResult.cause()).isInstanceOf(InvalidChunkExtensionException.class);
+        content.release();
+        assertFalse(channel.finish()); // And there are no other chunks parsed.
+    }
+
+    @Test
+    void mustRejectChunkExtensionsWithEscapedCarraigeReturnInQuotedStrings() throws Exception {
+        // See full explanation: https://w4ke.info/2025/10/29/funky-chunks-2.html
+        String responseStr = "HTTP/1.1 200 OK\r\n" +
+                "Transfer-Encoding: chunked\r\n" +
+                "\r\n" +
+                "1;a=\" \\\r;\t\"\r\n" +
+                "Y\r\n" +
+                "0\r\n" +
+                "\r\n";
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseDecoder());
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(responseStr, CharsetUtil.US_ASCII)));
+        HttpResponse response = channel.readInbound();
+        assertFalse(response.decoderResult().isFailure()); // We parse the headers just fine.
+        assertTrue(response.headers().names().contains("Transfer-Encoding"));
+        assertTrue(response.headers().contains("Transfer-Encoding", "chunked", false));
+        HttpContent content = channel.readInbound();
+        DecoderResult decoderResult = content.decoderResult();
+        assertTrue(decoderResult.isFailure()); // Chunk extension is not allowed to contain carriage returns.
+        assertThat(decoderResult.cause()).isInstanceOf(InvalidChunkExtensionException.class);
+        content.release();
+        assertFalse(channel.finish()); // And there are no other chunks parsed.
+    }
+
+    @Test
+    void lineLengthRestrictionMustNotApplyToChunkContents() throws Exception {
+        char[] chars = new char[10000];
+        Arrays.fill(chars, 'a');
+        String requestContent = new String(chars);
+        String responseStr = "HTTP/1.1 200 OK\r\n" +
+                "Host: localhost\r\n" +
+                "Transfer-Encoding: chunked\r\n\r\n" +
+                Integer.toHexString(chars.length) + "\r\n" +
+                requestContent + "\r\n" +
+                "0\r\n\r\n";
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseDecoder());
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(responseStr, CharsetUtil.US_ASCII)));
+        HttpResponse response = channel.readInbound();
+        assertFalse(response.decoderResult().isFailure()); // We parse the headers just fine.
+        assertTrue(response.headers().names().contains("Transfer-Encoding"));
+        assertTrue(response.headers().contains("Transfer-Encoding", "chunked", false));
+        int contentLength = 0;
+        HttpContent content;
+        do {
+            content = channel.readInbound();
+            DecoderResult decoderResult = content.decoderResult();
+            if (decoderResult.cause() != null) {
+                throw new Exception(decoderResult.cause());
+            }
+            assertFalse(decoderResult.isFailure()); // And we parse the chunk.
+            contentLength += content.content().readableBytes();
+            content.release();
+        } while (!(content instanceof LastHttpContent));
+        assertEquals(chars.length, contentLength);
+        assertFalse(channel.finish()); // And there are no other chunks parsed.
+    }
+
+    @Test
+    void mustRejectChunkSizeWithNonHexadecimalCharacters() throws Exception {
+        String responseStr = "HTTP/1.1 200 OK\r\n" +
+                "Transfer-Encoding: chunked\r\n" +
+                "\r\n" +
+                "test\r\n\r\n" + // chunk extension quote start
+                "\r\n";
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseDecoder());
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(responseStr, CharsetUtil.US_ASCII)));
+        HttpResponse response = channel.readInbound();
+        assertFalse(response.decoderResult().isFailure()); // We parse the headers
+        HttpContent content = channel.readInbound();
+        assertTrue(content.decoderResult().isFailure());
+        assertThat(content.decoderResult().cause()).isInstanceOf(NumberFormatException.class);
         assertFalse(channel.finish());
     }
 

--- a/microbench/src/main/java/io/netty/microbench/http/HttpChunkedRequestResponseBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/http/HttpChunkedRequestResponseBenchmark.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.http;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandler;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.HttpRequestDecoder;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.CompletionHandler;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import static io.netty.handler.codec.http.HttpConstants.CR;
+import static io.netty.handler.codec.http.HttpConstants.LF;
+
+@State(Scope.Thread)
+@Warmup(iterations = 10, time = 1)
+@Measurement(iterations = 10, time = 1)
+public class HttpChunkedRequestResponseBenchmark extends AbstractMicrobenchmark {
+    private static final int CRLF_SHORT = (CR << 8) + LF;
+
+    ByteBuf POST;
+    int readerIndex;
+    int writeIndex;
+    EmbeddedChannel nettyChannel;
+
+    @Setup
+    public void setup() {
+        HttpRequestDecoder httpRequestDecoder = new HttpRequestDecoder(
+                HttpRequestDecoder.DEFAULT_MAX_INITIAL_LINE_LENGTH, HttpRequestDecoder.DEFAULT_MAX_HEADER_SIZE,
+                HttpRequestDecoder.DEFAULT_MAX_CHUNK_SIZE, false);
+        ChannelInboundHandler inboundHandlerAdapter = new ChannelInboundHandler() {
+            @Override
+            public void channelRead(ChannelHandlerContext ctx, Object o) {
+                // this is saving a slow type check on LastHttpContent vs HttpRequest
+                try {
+                    if (o == LastHttpContent.EMPTY_LAST_CONTENT) {
+                        writeResponse(ctx);
+                    }
+                } finally {
+                    ReferenceCountUtil.release(o);
+                }
+            }
+
+            @Override
+            public void channelReadComplete(ChannelHandlerContext ctx) {
+                ctx.flush();
+            }
+
+            private void writeResponse(ChannelHandlerContext ctx) {
+                ByteBuf buffer = ctx.alloc().buffer();
+                // Build the response object.
+                ByteBufUtil.writeAscii(buffer, "HTTP/1.1 200 OK\r\n");
+                ByteBufUtil.writeAscii(buffer, "Content-Length: 0\r\n\r\n");
+                ctx.write(buffer, CompletionHandler.ignore());
+            }
+        };
+        nettyChannel = new EmbeddedChannel(httpRequestDecoder, inboundHandlerAdapter);
+
+        ByteBuf buffer = Unpooled.buffer();
+        ByteBufUtil.writeAscii(buffer, "POST / HTTP/1.1\r\n");
+        ByteBufUtil.writeAscii(buffer, "Content-Type: text/plain\r\n");
+        ByteBufUtil.writeAscii(buffer, "Transfer-Encoding: chunked\r\n\r\n");
+        ByteBufUtil.writeAscii(buffer, Integer.toHexString(43) + "\r\n");
+        buffer.writeZero(43);
+        buffer.writeShort(CRLF_SHORT);
+        ByteBufUtil.writeAscii(buffer, Integer.toHexString(18) +
+                ";extension=kjhkasdhfiushdksjfnskdjfbskdjfbskjdfb\r\n");
+        buffer.writeZero(18);
+        buffer.writeShort(CRLF_SHORT);
+        ByteBufUtil.writeAscii(buffer, Integer.toHexString(29) +
+                ";a=12938746238;b=\"lkjkjhskdfhsdkjh\\\"kjshdflkjhdskjhifuwehwi\";c=lkjdshfkjshdiufh\r\n");
+        buffer.writeZero(29);
+        buffer.writeShort(CRLF_SHORT);
+        ByteBufUtil.writeAscii(buffer, Integer.toHexString(9) +
+                ";A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A\r\n");
+        buffer.writeZero(9);
+        buffer.writeShort(CRLF_SHORT);
+        ByteBufUtil.writeAscii(buffer, "0\r\n\r\n"); // Last empty chunk
+        POST = Unpooled.unreleasableBuffer(buffer);
+        readerIndex = POST.readerIndex();
+        writeIndex = POST.writerIndex();
+    }
+
+    @Benchmark
+    public Object netty() throws Exception {
+        POST.setIndex(readerIndex, writeIndex);
+        ByteBuf byteBuf = POST.retainedDuplicate();
+        nettyChannel.writeInbound(byteBuf);
+        return nettyChannel.outboundMessages().poll();
+    }
+}

--- a/microbench/src/main/java/io/netty/microbench/http/HttpRequestResponseBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/http/HttpRequestResponseBenchmark.java
@@ -69,7 +69,7 @@ public class HttpRequestResponseBenchmark extends AbstractMicrobenchmark {
 
     static class Alloc implements ByteBufAllocator {
 
-        private final ByteBuf buf = Unpooled.buffer();
+        private final ByteBuf buf = Unpooled.buffer(512);
         private final int capacity = buf.capacity();
 
         @Override
@@ -83,7 +83,8 @@ public class HttpRequestResponseBenchmark extends AbstractMicrobenchmark {
             if (initialCapacity <= capacity) {
                 return buffer();
             } else {
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException(
+                        "initialCapacity " + initialCapacity + " is greater than capacity " + capacity);
             }
         }
 
@@ -92,7 +93,8 @@ public class HttpRequestResponseBenchmark extends AbstractMicrobenchmark {
             if (initialCapacity <= capacity) {
                 return buffer();
             } else {
-                throw new IllegalArgumentException();
+                throw new IllegalArgumentException(
+                        "initialCapacity " + initialCapacity + " is greater than capacity " + capacity);
             }
         }
 


### PR DESCRIPTION
* Stricter HTTP/1.1 chunk extension parsing

Motivation:
Chunk extensions can include quoted string values, which themselves can include linebreaks and escapes for quotes. We need to parse these properly to ensure we find the correct start of the chunk data.

Modification:
- Implement full RFC 9112 HTTP/1.1 compliant parsing of chunk start lines.
- Add test cases from the Funky Chunks research: https://w4ke.info/2025/10/29/funky-chunks-2.html
- This inclues chunk extensions with quoted strings that have linebreaks in them, and quoted strings that use escape codes.
 - Remove a test case that asserted support for control characters in the middle of chunk start lines, including after a naked chunk length field. Such control characters are not permitted by the standard.

 Result:
 Prevents HTTP message smuggling through carefully crafted chunk extensions.

* Revert the ByteProcessor changes

* Add a benchmark for HTTP/1.1 chunk decoding

* Fix chunk initial line decoding

The initial line was not correctly truncated at its line break and ended up including some of the chunk contents.

* Failing to parse chunk size must throw NumberFormatException

* Line breaks are completely disallowed within chunk extensions

Change the chunk parsing back to its original code, because we know that line breaks are not supposed to occur within chunk extensions at all. This means doing the SWAR search should be suitable.

Modify the byte processor and add it as a validation step of the parsed chunk start line.

Update the tests to match.

* Fix checkstyle

(cherry picked from commit 3b76df185678353733aa21702d6be16130d188a0)