### PR TITLE
Fix IndexOutOfBoundsException in StompSubframeDecoder on heartbeat

### DIFF
--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeDecoder.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeDecoder.java
@@ -238,6 +238,9 @@ public class StompSubframeDecoder extends ReplayingDecoder<State> {
     private static void skipControlCharacters(ByteBuf buffer) {
         byte b;
         for (;;) {
+            if (!buffer.isReadable()) {
+                return;
+            }
             b = buffer.readByte();
             if (b != StompConstants.CR && b != StompConstants.LF) {
                 buffer.readerIndex(buffer.readerIndex() - 1);

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeDecoderTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeDecoderTest.java
@@ -318,6 +318,118 @@ public class StompSubframeDecoderTest {
     }
 
     @Test
+    public void testHeartbeatOnlyDoesNotThrowException() {
+        // STOMP heartbeat is just a LF byte - should not cause IndexOutOfBoundsException
+        ByteBuf heartbeat = Unpooled.buffer();
+        heartbeat.writeByte('\n');
+        channel.writeInbound(heartbeat);
+
+        // Heartbeat should be consumed silently, no output produced
+        Object result = channel.readInbound();
+        assertNull(result);
+    }
+
+    @Test
+    public void testMultipleHeartbeatsDoNotThrowException() {
+        // Multiple consecutive heartbeats
+        ByteBuf heartbeats = Unpooled.buffer();
+        heartbeats.writeByte('\n');
+        heartbeats.writeByte('\n');
+        heartbeats.writeByte('\n');
+        channel.writeInbound(heartbeats);
+
+        Object result = channel.readInbound();
+        assertNull(result);
+    }
+
+    @Test
+    public void testCarriageReturnLineFeedHeartbeat() {
+        // CR+LF heartbeat
+        ByteBuf heartbeat = Unpooled.buffer();
+        heartbeat.writeByte('\r');
+        heartbeat.writeByte('\n');
+        channel.writeInbound(heartbeat);
+
+        Object result = channel.readInbound();
+        assertNull(result);
+    }
+
+    @Test
+    public void testHeartbeatFollowedByFrame() {
+        // Heartbeat bytes followed by a real STOMP frame should decode correctly
+        ByteBuf incoming = Unpooled.buffer();
+        incoming.writeByte('\n');
+        incoming.writeByte('\n');
+        incoming.writeBytes(StompTestConstants.CONNECT_FRAME.getBytes());
+        channel.writeInbound(incoming);
+
+        StompHeadersSubframe frame = channel.readInbound();
+        assertNotNull(frame);
+        assertEquals(StompCommand.CONNECT, frame.command());
+
+        StompContentSubframe content = channel.readInbound();
+        assertSame(LastStompContentSubframe.EMPTY_LAST_CONTENT, content);
+        content.release();
+
+        assertNull(channel.readInbound());
+    }
+
+    @Test
+    public void testHeartbeatBetweenFrames() {
+        // Heartbeat bytes between two STOMP frames
+        ByteBuf incoming = Unpooled.buffer();
+        incoming.writeBytes(StompTestConstants.CONNECT_FRAME.getBytes());
+        incoming.writeByte('\n');
+        incoming.writeByte('\n');
+        incoming.writeBytes(StompTestConstants.CONNECTED_FRAME.getBytes());
+        channel.writeInbound(incoming);
+
+        StompHeadersSubframe frame1 = channel.readInbound();
+        assertNotNull(frame1);
+        assertEquals(StompCommand.CONNECT, frame1.command());
+
+        StompContentSubframe content1 = channel.readInbound();
+        assertSame(LastStompContentSubframe.EMPTY_LAST_CONTENT, content1);
+        content1.release();
+
+        StompHeadersSubframe frame2 = channel.readInbound();
+        assertNotNull(frame2);
+        assertEquals(StompCommand.CONNECTED, frame2.command());
+
+        StompContentSubframe content2 = channel.readInbound();
+        assertSame(LastStompContentSubframe.EMPTY_LAST_CONTENT, content2);
+        content2.release();
+
+        assertNull(channel.readInbound());
+    }
+
+    @Test
+    public void testHeartbeatSentSeparatelyThenFrame() {
+        // Simulate heartbeat arriving in a separate TCP segment, then a frame later
+        ByteBuf heartbeat = Unpooled.buffer();
+        heartbeat.writeByte('\n');
+        channel.writeInbound(heartbeat);
+
+        // No output from heartbeat
+        assertNull(channel.readInbound());
+
+        // Now send a real frame
+        ByteBuf frame = Unpooled.buffer();
+        frame.writeBytes(StompTestConstants.CONNECT_FRAME.getBytes());
+        channel.writeInbound(frame);
+
+        StompHeadersSubframe headersSubframe = channel.readInbound();
+        assertNotNull(headersSubframe);
+        assertEquals(StompCommand.CONNECT, headersSubframe.command());
+
+        StompContentSubframe content = channel.readInbound();
+        assertSame(LastStompContentSubframe.EMPTY_LAST_CONTENT, content);
+        content.release();
+
+        assertNull(channel.readInbound());
+    }
+
+    @Test
     void testInvalidEscapeHeadersSequence() {
         channel = new EmbeddedChannel(new StompSubframeDecoder(true));
 


### PR DESCRIPTION
## Problem

`StompSubframeDecoder.skipControlCharacters()` reads bytes in an infinite loop without checking if the buffer has readable bytes remaining. When a STOMP heartbeat frame (just a LF byte) arrives, the method consumes the control character and then attempts to read beyond the buffer, causing an IndexOutOfBoundsException.

## Root Cause

The `skipControlCharacters` method has an unconditional `buffer.readByte()` call inside a `for (;;)` loop with no `buffer.isReadable()` guard. When the buffer contains only control characters (heartbeat), all bytes are consumed and the next `readByte()` fails.

## Fix

Add a `buffer.isReadable()` check before each `readByte()` call. When the buffer is exhausted (heartbeat-only data), the method returns gracefully and the decoder waits for more data.

## Tests Added

- `testHeartbeatOnlyDoesNotThrowException` - Single LF heartbeat byte does not cause exception
- `testMultipleHeartbeatsDoNotThrowException` - Multiple consecutive LF bytes handled correctly
- `testCarriageReturnLineFeedHeartbeat` - CR+LF heartbeat handled correctly
- `testHeartbeatFollowedByFrame` - Heartbeat before a real STOMP frame, frame decodes correctly
- `testHeartbeatBetweenFrames` - Heartbeat between two frames, both decode correctly
- `testHeartbeatSentSeparatelyThenFrame` - Heartbeat in separate write, then frame in second write

## Impact

Minimal - only adds a single `isReadable()` guard. No behavioral change for normal STOMP frames.

Fixes #10678