### PR TITLE
Replace chunk extension Match[] state machine with flat transition table

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpChunkLineValidatingByteProcessor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpChunkLineValidatingByteProcessor.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.http;
 
 import io.netty.util.ByteProcessor;
 
+import java.util.Arrays;
 import java.util.BitSet;
 
 /**
@@ -60,10 +61,112 @@ final class HttpChunkLineValidatingByteProcessor implements ByteProcessor {
     private static final int CHUNK_EXT_VAL_QUOTED_ESCAPE = 4;
     private static final int CHUNK_EXT_VAL_QUOTED_END = 5;
     private static final int CHUNK_EXT_VAL_TOKEN = 6;
+    private static final int N_STATES = 7;
+
+    private static final byte[] TRANSITIONS = buildTable();
+
+    private static byte[] buildTable() {
+        byte[] table = new byte[N_STATES * 256];
+        Arrays.fill(table, (byte) -1);
+
+        // SIZE: hex digits and whitespace stay in SIZE, ';' transitions to CHUNK_EXT_NAME
+        for (int i = 0; i < "0123456789abcdefABCDEF \t".length(); i++) {
+            table[SIZE << 8 | "0123456789abcdefABCDEF \t".charAt(i)] = SIZE;
+        }
+        table[SIZE << 8 | ';'] = CHUNK_EXT_NAME;
+
+        // CHUNK_EXT_NAME: token chars + OWS stay, '=' transitions to VAL_START
+        for (int i = 0x21; i <= 0x7E; i++) {
+            table[CHUNK_EXT_NAME << 8 | i] = CHUNK_EXT_NAME;
+        }
+        table[CHUNK_EXT_NAME << 8 | ' '] = CHUNK_EXT_NAME;
+        table[CHUNK_EXT_NAME << 8 | '\t'] = CHUNK_EXT_NAME;
+        // Exclude non-token delimiters from name
+        for (int i = 0; i < "(),/:<=>?@[\\]{}".length(); i++) {
+            table[CHUNK_EXT_NAME << 8 | "(),/:<=>?@[\\]{}".charAt(i)] = -1;
+        }
+        table[CHUNK_EXT_NAME << 8 | '='] = CHUNK_EXT_VAL_START;
+
+        // CHUNK_EXT_VAL_START: OWS stays, '"' goes to QUOTED, token chars go to TOKEN
+        table[CHUNK_EXT_VAL_START << 8 | ' '] = CHUNK_EXT_VAL_START;
+        table[CHUNK_EXT_VAL_START << 8 | '\t'] = CHUNK_EXT_VAL_START;
+        table[CHUNK_EXT_VAL_START << 8 | '"'] = CHUNK_EXT_VAL_QUOTED;
+        for (int i = 0x21; i <= 0x7E; i++) {
+            if (table[CHUNK_EXT_VAL_START << 8 | i] == -1) {
+                table[CHUNK_EXT_VAL_START << 8 | i] = CHUNK_EXT_VAL_TOKEN;
+            }
+        }
+        // Exclude non-token delimiters (including '"' already set above)
+        for (int i = 0; i < "(),/:<=>?@[\\]{}".length(); i++) {
+            table[CHUNK_EXT_VAL_START << 8 | "(),/:<=>?@[\\]{}".charAt(i)] = -1;
+        }
+
+        // CHUNK_EXT_VAL_QUOTED: '\' escapes, '"' ends, qdtext stays
+        table[CHUNK_EXT_VAL_QUOTED << 8 | '\\'] = CHUNK_EXT_VAL_QUOTED_ESCAPE;
+        table[CHUNK_EXT_VAL_QUOTED << 8 | '"'] = CHUNK_EXT_VAL_QUOTED_END;
+        table[CHUNK_EXT_VAL_QUOTED << 8 | '\t'] = CHUNK_EXT_VAL_QUOTED;
+        table[CHUNK_EXT_VAL_QUOTED << 8 | ' '] = CHUNK_EXT_VAL_QUOTED;
+        table[CHUNK_EXT_VAL_QUOTED << 8 | '!'] = CHUNK_EXT_VAL_QUOTED;
+        for (int i = 0x23; i <= 0x5B; i++) {
+            table[CHUNK_EXT_VAL_QUOTED << 8 | i] = CHUNK_EXT_VAL_QUOTED;
+        }
+        for (int i = 0x5D; i <= 0x7E; i++) {
+            table[CHUNK_EXT_VAL_QUOTED << 8 | i] = CHUNK_EXT_VAL_QUOTED;
+        }
+        for (int i = 0x80; i <= 0xFF; i++) {
+            table[CHUNK_EXT_VAL_QUOTED << 8 | i] = CHUNK_EXT_VAL_QUOTED;
+        }
+
+        // CHUNK_EXT_VAL_QUOTED_ESCAPE: any VCHAR/obs-text/SP/HTAB goes back to QUOTED
+        table[CHUNK_EXT_VAL_QUOTED_ESCAPE << 8 | '\t'] = CHUNK_EXT_VAL_QUOTED;
+        table[CHUNK_EXT_VAL_QUOTED_ESCAPE << 8 | ' '] = CHUNK_EXT_VAL_QUOTED;
+        for (int i = 0x21; i <= 0x7E; i++) {
+            table[CHUNK_EXT_VAL_QUOTED_ESCAPE << 8 | i] = CHUNK_EXT_VAL_QUOTED;
+        }
+        for (int i = 0x80; i <= 0xFF; i++) {
+            table[CHUNK_EXT_VAL_QUOTED_ESCAPE << 8 | i] = CHUNK_EXT_VAL_QUOTED;
+        }
+
+        // CHUNK_EXT_VAL_QUOTED_END: OWS stays, ';' transitions to CHUNK_EXT_NAME
+        table[CHUNK_EXT_VAL_QUOTED_END << 8 | '\t'] = CHUNK_EXT_VAL_QUOTED_END;
+        table[CHUNK_EXT_VAL_QUOTED_END << 8 | ' '] = CHUNK_EXT_VAL_QUOTED_END;
+        table[CHUNK_EXT_VAL_QUOTED_END << 8 | ';'] = CHUNK_EXT_NAME;
+
+        // CHUNK_EXT_VAL_TOKEN: token chars stay, ';' transitions to CHUNK_EXT_NAME
+        for (int i = 0x21; i <= 0x7E; i++) {
+            table[CHUNK_EXT_VAL_TOKEN << 8 | i] = CHUNK_EXT_VAL_TOKEN;
+        }
+        // Exclude non-token delimiters (including ';' which is set below)
+        for (int i = 0; i < "(),/:<=>?@[\\]{};".length(); i++) {
+            table[CHUNK_EXT_VAL_TOKEN << 8 | "(),/:<=>?@[\\]{};".charAt(i)] = -1;
+        }
+        table[CHUNK_EXT_VAL_TOKEN << 8 | ';'] = CHUNK_EXT_NAME;
+
+        assert verifyTable(table);
+        return table;
+    }
+
+    /**
+     * Verify the table matches the specification built from Match objects.
+     * Only runs when assertions are enabled.
+     */
+    private static boolean verifyTable(byte[] table) {
+        byte[] expected = compile();
+        for (int i = 0; i < table.length; i++) {
+            if (table[i] != expected[i]) {
+                int state = i >> 8;
+                int byteVal = i & 0xFF;
+                throw new AssertionError(
+                        "Transition mismatch at state " + state + " byte 0x" +
+                        Integer.toHexString(byteVal) + ": got " + table[i] + " expected " + expected[i]);
+            }
+        }
+        return true;
+    }
 
     static final class Match extends BitSet {
         private static final long serialVersionUID = 49522994383099834L;
-        private final int then;
+        final int then;
 
         Match(int then) {
             super(256);
@@ -93,77 +196,96 @@ final class HttpChunkLineValidatingByteProcessor implements ByteProcessor {
         }
     }
 
-    private enum State {
-        Size(
+    /**
+     * Build the transition table from Match objects with explicit disjointness.
+     * Used only for assertion verification.
+     */
+    static byte[] compile() {
+        Match[][] stateMatchers = new Match[N_STATES][];
+
+        stateMatchers[SIZE] = new Match[]{
                 new Match(SIZE).chars("0123456789abcdefABCDEF \t"),
-                new Match(CHUNK_EXT_NAME).chars(";")),
-        ChunkExtName(
+                new Match(CHUNK_EXT_NAME).chars(";")
+        };
+        stateMatchers[CHUNK_EXT_NAME] = new Match[]{
                 new Match(CHUNK_EXT_NAME)
                         .range(0x21, 0x7E)
                         .chars(" \t")
                         .chars("(),/:<=>?@[\\]{}", false),
-                new Match(CHUNK_EXT_VAL_START).chars("=")),
-        ChunkExtValStart(
+                new Match(CHUNK_EXT_VAL_START).chars("=")
+        };
+        stateMatchers[CHUNK_EXT_VAL_START] = new Match[]{
                 new Match(CHUNK_EXT_VAL_START).chars(" \t"),
                 new Match(CHUNK_EXT_VAL_QUOTED).chars("\""),
+                // explicitly exclude '"' (0x22) — disjoint with the matcher above
                 new Match(CHUNK_EXT_VAL_TOKEN)
                         .range(0x21, 0x7E)
-                        .chars("(),/:<=>?@[\\]{}", false)),
-        ChunkExtValQuoted(
+                        .chars("(),/:<=>?@[\\]{}\"", false)
+        };
+        stateMatchers[CHUNK_EXT_VAL_QUOTED] = new Match[]{
                 new Match(CHUNK_EXT_VAL_QUOTED_ESCAPE).chars("\\"),
                 new Match(CHUNK_EXT_VAL_QUOTED_END).chars("\""),
+                // 0x23-0x5B excludes '"' (0x22), 0x5D-0x7E excludes '\' (0x5C) — disjoint by range
                 new Match(CHUNK_EXT_VAL_QUOTED)
                         .chars("\t !")
                         .range(0x23, 0x5B)
                         .range(0x5D, 0x7E)
-                        .range(0x80, 0xFF)),
-        ChunkExtValQuotedEscape(
+                        .range(0x80, 0xFF)
+        };
+        stateMatchers[CHUNK_EXT_VAL_QUOTED_ESCAPE] = new Match[]{
                 new Match(CHUNK_EXT_VAL_QUOTED)
                         .chars("\t ")
                         .range(0x21, 0x7E)
-                        .range(0x80, 0xFF)),
-        ChunkExtValQuotedEnd(
+                        .range(0x80, 0xFF)
+        };
+        stateMatchers[CHUNK_EXT_VAL_QUOTED_END] = new Match[]{
                 new Match(CHUNK_EXT_VAL_QUOTED_END).chars("\t "),
-                new Match(CHUNK_EXT_NAME).chars(";")),
-        ChunkExtValToken(
+                new Match(CHUNK_EXT_NAME).chars(";")
+        };
+        stateMatchers[CHUNK_EXT_VAL_TOKEN] = new Match[]{
+                // explicitly exclude ';' (0x3B) — disjoint with the matcher below
                 new Match(CHUNK_EXT_VAL_TOKEN)
-                        .range(0x21, 0x7E, true)
-                        .chars("(),/:<=>?@[\\]{}", false),
-                new Match(CHUNK_EXT_NAME).chars(";")),
-        ;
+                        .range(0x21, 0x7E)
+                        .chars("(),/:<=>?@[\\]{};", false),
+                new Match(CHUNK_EXT_NAME).chars(";")
+        };
 
-        private final Match[] matches;
-
-        State(Match... matches) {
-            this.matches = matches;
-        }
-
-        State match(byte value) {
-            for (Match match : matches) {
-                if (match.get(value)) {
-                    return STATES_BY_ORDINAL[match.then];
+        byte[] table = new byte[N_STATES * 256];
+        Arrays.fill(table, (byte) -1);
+        for (int state = 0; state < N_STATES; state++) {
+            int base = state << 8;
+            for (Match m : stateMatchers[state]) {
+                for (int i = m.nextSetBit(0); i >= 0; i = m.nextSetBit(i + 1)) {
+                    if (table[base | i] != -1) {
+                        throw new IllegalStateException(
+                                "overlapping matchers at byte 0x" + Integer.toHexString(i) +
+                                " in state " + state);
+                    }
+                    table[base | i] = (byte) m.then;
                 }
             }
-            if (this == Size) {
-                throw new NumberFormatException("Invalid chunk size");
-            } else {
-                throw new InvalidChunkExtensionException("Invalid chunk extension");
-            }
         }
+        return table;
     }
 
-    private static final State[] STATES_BY_ORDINAL = State.values();
-
-    private State state = State.Size;
+    private int state = SIZE;
 
     @Override
     public boolean process(byte value) {
-        state = state.match(value);
+        int next = TRANSITIONS[state << 8 | (value & 0xFF)];
+        if (next < 0) {
+            if (state == SIZE) {
+                throw new NumberFormatException("Invalid chunk size");
+            }
+            throw new InvalidChunkExtensionException("Invalid chunk extension");
+        }
+        state = next;
         return true;
     }
 
     public void finish() {
-        if (state != State.Size && state != State.ChunkExtName && state != State.ChunkExtValQuotedEnd) {
+        if (state != SIZE && state != CHUNK_EXT_NAME
+                && state != CHUNK_EXT_VAL_TOKEN && state != CHUNK_EXT_VAL_QUOTED_END) {
             throw new InvalidChunkExtensionException("Invalid chunk extension");
         }
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -864,6 +864,32 @@ public class HttpRequestDecoderTest {
     }
 
     @Test
+    void mustParseMultipleChunkExtensionsWithTokenValues() throws Exception {
+        // Regression: the old Match-based state machine had ';' (0x3B) missing from the
+        // exclusion set in ChunkExtValToken, so ';' was treated as a token character
+        // instead of starting a new extension.  This caused valid multi-extension lines
+        // like ";name1=val1;name2=val2" to be rejected with InvalidChunkExtensionException.
+        String requestStr = "GET / HTTP/1.1\r\n" +
+                "Host: localhost\r\n" +
+                "Transfer-Encoding: chunked\r\n\r\n" +
+                "1;name1=val1;name2=val2\r\n" +
+                "Y\r\n" +
+                "0\r\n" +
+                "\r\n";
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
+        HttpRequest request = channel.readInbound();
+        assertFalse(request.decoderResult().isFailure());
+        HttpContent content = channel.readInbound();
+        assertFalse(content.decoderResult().isFailure()); // Must accept valid multi-extension token values.
+        content.release();
+        LastHttpContent last = channel.readInbound();
+        assertEquals(0, last.content().readableBytes());
+        last.release();
+        assertFalse(channel.finish());
+    }
+
+    @Test
     void mustRejectChunkExtensionsWithEscapedLineBreakInQuotedStrings() throws Exception {
         // See full explanation: https://w4ke.info/2025/10/29/funky-chunks-2.html
         String requestStr = "GET /one HTTP/1.1\r\n" +

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
@@ -1180,6 +1180,32 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
+    void mustParseMultipleChunkExtensionsWithTokenValues() throws Exception {
+        // Regression: the old Match-based state machine had ';' (0x3B) missing from the
+        // exclusion set in ChunkExtValToken, so ';' was treated as a token character
+        // instead of starting a new extension.  This caused valid multi-extension lines
+        // like ";name1=val1;name2=val2" to be rejected with InvalidChunkExtensionException.
+        String responseStr = "HTTP/1.1 200 OK\r\n" +
+                "Transfer-Encoding: chunked\r\n" +
+                "\r\n" +
+                "1;name1=val1;name2=val2\r\n" +
+                "Y\r\n" +
+                "0\r\n" +
+                "\r\n";
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseDecoder());
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(responseStr, CharsetUtil.US_ASCII)));
+        HttpResponse response = channel.readInbound();
+        assertFalse(response.decoderResult().isFailure());
+        HttpContent content = channel.readInbound();
+        assertFalse(content.decoderResult().isFailure()); // Must accept valid multi-extension token values.
+        content.release();
+        LastHttpContent last = channel.readInbound();
+        assertEquals(0, last.content().readableBytes());
+        last.release();
+        assertFalse(channel.finish());
+    }
+
+    @Test
     void mustRejectChunkExtensionsWithEscapedLineBreakInQuotedStrings() throws Exception {
         // See full explanation: https://w4ke.info/2025/10/29/funky-chunks-2.html
         String responseStr = "HTTP/1.1 200 OK\r\n" +

--- a/microbench/src/main/java/io/netty/handler/codec/http/HttpChunkExtValidationBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http/HttpChunkExtValidationBenchmark.java
@@ -1,0 +1,363 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http;
+
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import io.netty.util.ByteProcessor;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.CompilerControl.Mode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.BitSet;
+import java.util.SplittableRandom;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Isolated benchmark for the {@code process(byte)} loop of chunk extension validation.
+ * Compares the new flat transition table against the old enum + Match[] (BitSet) approach.
+ * <p>
+ * Placed in the same package as {@link HttpChunkLineValidatingByteProcessor} to access it directly.
+ */
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(2)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class HttpChunkExtValidationBenchmark extends AbstractMicrobenchmark {
+
+    private static final int NUM_INPUTS = 64;
+    private static final long SEED = 0xDEADBEEFCAFEBABEL;
+
+    // Token characters: VCHAR minus delimiters "(),/:;<=>?@[\]{}
+    private static final byte[] TOKEN_CHARS;
+    // Hex digits
+    private static final byte[] HEX_CHARS = "0123456789abcdefABCDEF".getBytes();
+    // qdtext characters (subset for generation): printable ASCII minus '"' and '\'
+    private static final byte[] QDTEXT_CHARS;
+
+    static {
+        // Build token char array: 0x21-0x7E minus delimiters
+        String delimiters = "\"(),/:;<=>?@[\\]{}";
+        int count = 0;
+        for (int i = 0x21; i <= 0x7E; i++) {
+            if (delimiters.indexOf(i) < 0) {
+                count++;
+            }
+        }
+        TOKEN_CHARS = new byte[count];
+        int idx = 0;
+        for (int i = 0x21; i <= 0x7E; i++) {
+            if (delimiters.indexOf(i) < 0) {
+                TOKEN_CHARS[idx++] = (byte) i;
+            }
+        }
+
+        // Build qdtext: HTAB, SP, '!', 0x23-0x5B, 0x5D-0x7E
+        count = 2 + 1 + (0x5B - 0x23 + 1) + (0x7E - 0x5D + 1); // HTAB, SP, '!', ranges
+        QDTEXT_CHARS = new byte[count];
+        idx = 0;
+        QDTEXT_CHARS[idx++] = '\t';
+        QDTEXT_CHARS[idx++] = ' ';
+        QDTEXT_CHARS[idx++] = '!';
+        for (int i = 0x23; i <= 0x5B; i++) {
+            QDTEXT_CHARS[idx++] = (byte) i;
+        }
+        for (int i = 0x5D; i <= 0x7E; i++) {
+            QDTEXT_CHARS[idx++] = (byte) i;
+        }
+    }
+
+    @Param({ "64", "256", "1024" })
+    int length;
+
+    private byte[][] inputs;
+    private long next;
+
+    @Setup
+    public void setup() {
+        inputs = new byte[NUM_INPUTS][];
+        SplittableRandom rng = new SplittableRandom(SEED);
+        for (int i = 0; i < NUM_INPUTS; i++) {
+            inputs[i] = generateValidInput(rng, length);
+            // Validate with the new processor
+            HttpChunkLineValidatingByteProcessor p = new HttpChunkLineValidatingByteProcessor();
+            for (byte b : inputs[i]) {
+                p.process(b);
+            }
+            // Also validate with the old processor
+            OldProcessor op = new OldProcessor();
+            for (byte b : inputs[i]) {
+                op.process(b);
+            }
+        }
+        next = 0;
+    }
+
+    /**
+     * Generate a valid chunk line byte sequence covering all states.
+     * <p>
+     * Uses patterns compatible with BOTH old (enum+Match[]) and new (flat table) implementations.
+     * The old code has a bug where ';' inside CHUNK_EXT_VAL_TOKEN is not excluded, so we avoid
+     * chaining extensions after token values. After a token value, we pad with token chars to fill.
+     * Extensions are only chained after quoted values (where ';' correctly starts a new extension).
+     * <p>
+     * Pattern: hex (";" name ["=" (token-to-end | quoted-val)])* pad-with-token
+     */
+    private static byte[] generateValidInput(SplittableRandom rng, int length) {
+        byte[] buf = new byte[length * 2]; // oversize buffer, will trim
+        int pos = 0;
+
+        // Hex prefix: 1-4 hex digits
+        int hexLen = 1 + rng.nextInt(4);
+        for (int i = 0; i < hexLen; i++) {
+            buf[pos++] = HEX_CHARS[rng.nextInt(HEX_CHARS.length)];
+        }
+
+        while (pos < length) {
+            // Start a new extension
+            buf[pos++] = ';';
+            if (pos >= length) {
+                break;
+            }
+
+            // Extension name: 2-8 token chars
+            int nameLen = 2 + rng.nextInt(7);
+            for (int i = 0; i < nameLen && pos < length; i++) {
+                buf[pos++] = TOKEN_CHARS[rng.nextInt(TOKEN_CHARS.length)];
+            }
+
+            // Decide value type: 0=no value (name only), 1=quoted, 2=token (terminal — fills rest)
+            int valueType = rng.nextInt(3);
+
+            if (valueType == 0 || pos >= length) {
+                // Name-only extension, can chain more
+                continue;
+            }
+
+            buf[pos++] = '=';
+            if (pos >= length) {
+                break;
+            }
+
+            if (valueType == 1) {
+                // Quoted string — can chain more extensions after closing quote
+                buf[pos++] = '"';
+                int valLen = 3 + rng.nextInt(12);
+                for (int i = 0; i < valLen && pos < length - 1; i++) {
+                    if (rng.nextInt(10) == 0 && pos < length - 2) {
+                        buf[pos++] = '\\';
+                        buf[pos++] = TOKEN_CHARS[rng.nextInt(TOKEN_CHARS.length)];
+                    } else {
+                        buf[pos++] = QDTEXT_CHARS[rng.nextInt(QDTEXT_CHARS.length)];
+                    }
+                }
+                if (pos < length) {
+                    buf[pos++] = '"';
+                }
+                // Can chain: ';' will correctly transition from QUOTED_END to CHUNK_EXT_NAME
+            } else {
+                // Token value — fill remaining space with token chars (no more ';' after this)
+                while (pos < length) {
+                    buf[pos++] = TOKEN_CHARS[rng.nextInt(TOKEN_CHARS.length)];
+                }
+                break;
+            }
+        }
+
+        // Trim to exact length
+        int finalLen = Math.min(pos, length);
+        byte[] result = new byte[finalLen];
+        System.arraycopy(buf, 0, result, 0, finalLen);
+
+        // Trim back if we ended in an invalid state (e.g. mid-quoted-string)
+        return trimToValidState(result);
+    }
+
+    /**
+     * Trim trailing bytes until the sequence ends in a valid final state.
+     */
+    private static byte[] trimToValidState(byte[] data) {
+        for (int len = data.length; len > 0; len--) {
+            HttpChunkLineValidatingByteProcessor p = new HttpChunkLineValidatingByteProcessor();
+            boolean ok = true;
+            for (int i = 0; i < len; i++) {
+                try {
+                    p.process(data[i]);
+                } catch (Exception e) {
+                    ok = false;
+                    break;
+                }
+            }
+            if (ok) {
+                try {
+                    p.finish();
+                    if (len == data.length) {
+                        return data;
+                    }
+                    byte[] trimmed = new byte[len];
+                    System.arraycopy(data, 0, trimmed, 0, len);
+                    return trimmed;
+                } catch (Exception e) {
+                    // Not a valid final state, trim more
+                }
+            }
+        }
+        return new byte[]{ 'a', 'b', 'c', 'd' };
+    }
+
+    private int nextInput() {
+        return (int) (next++ & (NUM_INPUTS - 1));
+    }
+
+    @Benchmark
+    @CompilerControl(Mode.DONT_INLINE)
+    public HttpChunkLineValidatingByteProcessor flatTable() {
+        byte[] data = inputs[nextInput()];
+        HttpChunkLineValidatingByteProcessor p = new HttpChunkLineValidatingByteProcessor();
+        for (int i = 0, len = data.length; i < len; i++) {
+            p.process(data[i]);
+        }
+        return p;
+    }
+
+    @Benchmark
+    @CompilerControl(Mode.DONT_INLINE)
+    public OldProcessor enumBitSet() {
+        byte[] data = inputs[nextInput()];
+        OldProcessor p = new OldProcessor();
+        for (int i = 0, len = data.length; i < len; i++) {
+            p.process(data[i]);
+        }
+        return p;
+    }
+
+    // ---- Faithful copy of the old enum + Match[] implementation from upstream/4.2 ----
+
+    static final class OldProcessor implements ByteProcessor {
+        private static final int SIZE = 0;
+        private static final int CHUNK_EXT_NAME = 1;
+        private static final int CHUNK_EXT_VAL_START = 2;
+        private static final int CHUNK_EXT_VAL_QUOTED = 3;
+        private static final int CHUNK_EXT_VAL_QUOTED_ESCAPE = 4;
+        private static final int CHUNK_EXT_VAL_QUOTED_END = 5;
+        private static final int CHUNK_EXT_VAL_TOKEN = 6;
+
+        static final class Match extends BitSet {
+            private static final long serialVersionUID = 1L;
+            private final int then;
+
+            Match(int then) {
+                super(256);
+                this.then = then;
+            }
+
+            Match chars(String chars) {
+                return chars(chars, true);
+            }
+
+            Match chars(String chars, boolean value) {
+                for (int i = 0, len = chars.length(); i < len; i++) {
+                    set(chars.charAt(i), value);
+                }
+                return this;
+            }
+
+            Match range(int from, int to) {
+                return range(from, to, true);
+            }
+
+            Match range(int from, int to, boolean value) {
+                for (int i = from; i <= to; i++) {
+                    set(i, value);
+                }
+                return this;
+            }
+        }
+
+        private enum State {
+            Size(
+                    new Match(SIZE).chars("0123456789abcdefABCDEF \t"),
+                    new Match(CHUNK_EXT_NAME).chars(";")),
+            ChunkExtName(
+                    new Match(CHUNK_EXT_NAME)
+                            .range(0x21, 0x7E)
+                            .chars(" \t")
+                            .chars("(),/:<=>?@[\\]{}", false),
+                    new Match(CHUNK_EXT_VAL_START).chars("=")),
+            ChunkExtValStart(
+                    new Match(CHUNK_EXT_VAL_START).chars(" \t"),
+                    new Match(CHUNK_EXT_VAL_QUOTED).chars("\""),
+                    new Match(CHUNK_EXT_VAL_TOKEN)
+                            .range(0x21, 0x7E)
+                            .chars("(),/:<=>?@[\\]{}", false)),
+            ChunkExtValQuoted(
+                    new Match(CHUNK_EXT_VAL_QUOTED_ESCAPE).chars("\\"),
+                    new Match(CHUNK_EXT_VAL_QUOTED_END).chars("\""),
+                    new Match(CHUNK_EXT_VAL_QUOTED)
+                            .chars("\t !")
+                            .range(0x23, 0x5B)
+                            .range(0x5D, 0x7E)
+                            .range(0x80, 0xFF)),
+            ChunkExtValQuotedEscape(
+                    new Match(CHUNK_EXT_VAL_QUOTED)
+                            .chars("\t ")
+                            .range(0x21, 0x7E)
+                            .range(0x80, 0xFF)),
+            ChunkExtValQuotedEnd(
+                    new Match(CHUNK_EXT_VAL_QUOTED_END).chars("\t "),
+                    new Match(CHUNK_EXT_NAME).chars(";")),
+            ChunkExtValToken(
+                    new Match(CHUNK_EXT_VAL_TOKEN)
+                            .range(0x21, 0x7E, true)
+                            .chars("(),/:<=>?@[\\]{}", false),
+                    new Match(CHUNK_EXT_NAME).chars(";")),
+            ;
+
+            private final Match[] matches;
+
+            State(Match... matches) {
+                this.matches = matches;
+            }
+
+            State match(byte value) {
+                for (Match match : matches) {
+                    if (match.get(value)) {
+                        return STATES_BY_ORDINAL[match.then];
+                    }
+                }
+                throw new IllegalStateException("Invalid byte");
+            }
+        }
+
+        private static final State[] STATES_BY_ORDINAL = State.values();
+
+        private State state = State.Size;
+
+        @Override
+        public boolean process(byte value) {
+            state = state.match(value);
+            return true;
+        }
+    }
+}

--- a/microbench/src/main/java/io/netty/microbench/http/HttpChunkLineValidatorStartupBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/http/HttpChunkLineValidatorStartupBenchmark.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.http;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.HttpRequestDecoder;
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import io.netty.util.ReferenceCountUtil;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Measures the startup cost of processing the first chunked HTTP request,
+ * which triggers class loading and static initialization of
+ * {@code HttpChunkLineValidatingByteProcessor} (builds the transition table).
+ * <p>
+ * Uses SingleShotTime with many forks so each measurement is a fresh JVM
+ * with cold class loading.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(value = 30)
+@Warmup(iterations = 0)
+@Measurement(iterations = 1)
+public class HttpChunkLineValidatorStartupBenchmark extends AbstractMicrobenchmark {
+
+    private ByteBuf request;
+    private EmbeddedChannel channel;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        channel = new EmbeddedChannel(new HttpRequestDecoder(
+                HttpRequestDecoder.DEFAULT_MAX_INITIAL_LINE_LENGTH, HttpRequestDecoder.DEFAULT_MAX_HEADER_SIZE,
+                HttpRequestDecoder.DEFAULT_MAX_CHUNK_SIZE, false));
+
+        ByteBuf buffer = Unpooled.buffer();
+        ByteBufUtil.writeAscii(buffer, "POST / HTTP/1.1\r\n");
+        ByteBufUtil.writeAscii(buffer, "Transfer-Encoding: chunked\r\n\r\n");
+        ByteBufUtil.writeAscii(buffer, "a;ext=value\r\n");
+        buffer.writeZero(10);
+        ByteBufUtil.writeAscii(buffer, "\r\n0\r\n\r\n");
+        request = Unpooled.unreleasableBuffer(buffer);
+    }
+
+    @Benchmark
+    public void firstChunkedRequest() {
+        request.resetReaderIndex();
+        channel.writeInbound(request.retainedDuplicate());
+        Object msg;
+        while ((msg = channel.readInbound()) != null) {
+            ReferenceCountUtil.release(msg);
+        }
+    }
+}

--- a/microbench/src/main/java/io/netty/microbench/http/HttpChunkedRequestResponseBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/http/HttpChunkedRequestResponseBenchmark.java
@@ -27,10 +27,13 @@ import io.netty.microbench.util.AbstractMicrobenchmark;
 import io.netty.util.ReferenceCountUtil;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.Random;
 
 import static io.netty.handler.codec.http.HttpConstants.CR;
 import static io.netty.handler.codec.http.HttpConstants.LF;
@@ -40,6 +43,17 @@ import static io.netty.handler.codec.http.HttpConstants.LF;
 @Measurement(iterations = 10, time = 1)
 public class HttpChunkedRequestResponseBenchmark extends AbstractMicrobenchmark {
     private static final int CRLF_SHORT = (CR << 8) + LF;
+    private static final long SEED = 0xDEADBEEFL;
+
+    // Token chars valid in chunk-ext-name and chunk-ext-val (token)
+    private static final String TOKEN_CHARS =
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&'*+-.^_`|~";
+    // Chars valid inside quoted strings (qdtext excluding \ and ")
+    private static final String QDTEXT_CHARS =
+            "abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%&'()*+,-./:;<=>?@[]^_`{|}~\t";
+
+    @Param({ "16" })
+    int chunks;
 
     ByteBuf POST;
     int readerIndex;
@@ -54,7 +68,6 @@ public class HttpChunkedRequestResponseBenchmark extends AbstractMicrobenchmark 
         ChannelInboundHandlerAdapter inboundHandlerAdapter = new ChannelInboundHandlerAdapter() {
             @Override
             public void channelRead(ChannelHandlerContext ctx, Object o) {
-                // this is saving a slow type check on LastHttpContent vs HttpRequest
                 try {
                     if (o == LastHttpContent.EMPTY_LAST_CONTENT) {
                         writeResponse(ctx);
@@ -71,7 +84,6 @@ public class HttpChunkedRequestResponseBenchmark extends AbstractMicrobenchmark 
 
             private void writeResponse(ChannelHandlerContext ctx) {
                 ByteBuf buffer = ctx.alloc().buffer();
-                // Build the response object.
                 ByteBufUtil.writeAscii(buffer, "HTTP/1.1 200 OK\r\n");
                 ByteBufUtil.writeAscii(buffer, "Content-Length: 0\r\n\r\n");
                 ctx.write(buffer, ctx.voidPromise());
@@ -79,29 +91,120 @@ public class HttpChunkedRequestResponseBenchmark extends AbstractMicrobenchmark 
         };
         nettyChannel = new EmbeddedChannel(httpRequestDecoder, inboundHandlerAdapter);
 
+        Random rng = new Random(SEED);
         ByteBuf buffer = Unpooled.buffer();
         ByteBufUtil.writeAscii(buffer, "POST / HTTP/1.1\r\n");
         ByteBufUtil.writeAscii(buffer, "Content-Type: text/plain\r\n");
         ByteBufUtil.writeAscii(buffer, "Transfer-Encoding: chunked\r\n\r\n");
-        ByteBufUtil.writeAscii(buffer, Integer.toHexString(43) + "\r\n");
-        buffer.writeZero(43);
-        buffer.writeShort(CRLF_SHORT);
-        ByteBufUtil.writeAscii(buffer, Integer.toHexString(18) +
-                ";extension=kjhkasdhfiushdksjfnskdjfbskdjfbskjdfb\r\n");
-        buffer.writeZero(18);
-        buffer.writeShort(CRLF_SHORT);
-        ByteBufUtil.writeAscii(buffer, Integer.toHexString(29) +
-                ";a=12938746238;b=\"lkjkjhskdfhsdkjh\\\"kjshdflkjhdskjhifuwehwi\";c=lkjdshfkjshdiufh\r\n");
-        buffer.writeZero(29);
-        buffer.writeShort(CRLF_SHORT);
-        ByteBufUtil.writeAscii(buffer, Integer.toHexString(9) +
-                ";A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A;A\r\n");
-        buffer.writeZero(9);
-        buffer.writeShort(CRLF_SHORT);
-        ByteBufUtil.writeAscii(buffer, "0\r\n\r\n"); // Last empty chunk
+
+        for (int c = 0; c < chunks; c++) {
+            int dataLen = 1 + rng.nextInt(64);
+            StringBuilder chunkLine = new StringBuilder();
+            chunkLine.append(Integer.toHexString(dataLen));
+
+            // Generate a random extension pattern for this chunk
+            int extType = rng.nextInt(5);
+            switch (extType) {
+                case 0:
+                    // No extension
+                    break;
+                case 1:
+                    // Simple name-only extensions: ;A;B;C...
+                    appendNameOnlyExtensions(chunkLine, rng);
+                    break;
+                case 2:
+                    // Token value extension: ;name=tokenvalue
+                    appendTokenValueExtensions(chunkLine, rng);
+                    break;
+                case 3:
+                    // Quoted value extension: ;name="quoted value with \" escapes"
+                    appendQuotedValueExtensions(chunkLine, rng);
+                    break;
+                case 4:
+                    // Mixed: combination of all extension types
+                    appendMixedExtensions(chunkLine, rng);
+                    break;
+                default:
+                    break;
+            }
+
+            ByteBufUtil.writeAscii(buffer, chunkLine.toString() + "\r\n");
+            buffer.writeZero(dataLen);
+            buffer.writeShort(CRLF_SHORT);
+        }
+        ByteBufUtil.writeAscii(buffer, "0\r\n\r\n");
         POST = Unpooled.unreleasableBuffer(buffer);
         readerIndex = POST.readerIndex();
         writeIndex = POST.writerIndex();
+    }
+
+    private static void appendNameOnlyExtensions(StringBuilder sb, Random rng) {
+        int count = 2 + rng.nextInt(30);
+        for (int i = 0; i < count; i++) {
+            sb.append(';');
+            appendRandomToken(sb, rng, 1 + rng.nextInt(8));
+        }
+    }
+
+    private static void appendTokenValueExtensions(StringBuilder sb, Random rng) {
+        int count = 1 + rng.nextInt(5);
+        for (int i = 0; i < count; i++) {
+            sb.append(';');
+            appendRandomToken(sb, rng, 1 + rng.nextInt(12));
+            sb.append('=');
+            appendRandomToken(sb, rng, 1 + rng.nextInt(30));
+        }
+    }
+
+    private static void appendQuotedValueExtensions(StringBuilder sb, Random rng) {
+        int count = 1 + rng.nextInt(4);
+        for (int i = 0; i < count; i++) {
+            sb.append(';');
+            appendRandomToken(sb, rng, 1 + rng.nextInt(10));
+            sb.append("=\"");
+            int qlen = 3 + rng.nextInt(40);
+            for (int j = 0; j < qlen; j++) {
+                if (rng.nextInt(10) == 0) {
+                    // Insert a quoted-pair escape
+                    sb.append('\\');
+                    sb.append(QDTEXT_CHARS.charAt(rng.nextInt(QDTEXT_CHARS.length())));
+                } else {
+                    sb.append(QDTEXT_CHARS.charAt(rng.nextInt(QDTEXT_CHARS.length())));
+                }
+            }
+            sb.append('"');
+        }
+    }
+
+    private static void appendMixedExtensions(StringBuilder sb, Random rng) {
+        int count = 2 + rng.nextInt(6);
+        for (int i = 0; i < count; i++) {
+            sb.append(';');
+            appendRandomToken(sb, rng, 1 + rng.nextInt(8));
+            int valType = rng.nextInt(3);
+            if (valType == 1) {
+                sb.append('=');
+                appendRandomToken(sb, rng, 1 + rng.nextInt(20));
+            } else if (valType == 2) {
+                sb.append("=\"");
+                int qlen = 2 + rng.nextInt(20);
+                for (int j = 0; j < qlen; j++) {
+                    if (rng.nextInt(8) == 0) {
+                        sb.append('\\');
+                        sb.append(QDTEXT_CHARS.charAt(rng.nextInt(QDTEXT_CHARS.length())));
+                    } else {
+                        sb.append(QDTEXT_CHARS.charAt(rng.nextInt(QDTEXT_CHARS.length())));
+                    }
+                }
+                sb.append('"');
+            }
+        }
+    }
+
+    private static void appendRandomToken(StringBuilder sb, Random rng, int len) {
+        for (int i = 0; i < len; i++) {
+            sb.append(TOKEN_CHARS.charAt(rng.nextInt(TOKEN_CHARS.length())));
+        }
     }
 
     @Benchmark


### PR DESCRIPTION
Motivation:
The existing enum State with Match[] (BitSet) arrays uses multiple
pointer-chasing loads per byte. It also has two bugs: ';' was not
excluded from ChunkExtValToken causing valid multi-extension lines
to be rejected, and finish() did not accept CHUNK_EXT_VAL_TOKEN as
a valid final state.

Modification:
Replace with a flat byte[7*256] transition table populated at class
load time. Fix both missing cases. Add regression tests and benchmarks.

Result:
Fixes #16540
