### PR TITLE
Replace usage of strerror with thread-safe alternative

### DIFF
--- a/transport-native-unix-common/src/main/c/netty_unix_errors.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_errors.c
@@ -203,7 +203,9 @@ static jint netty_unix_errors_errorEHOSTUNREACH(JNIEnv* env, jclass clazz) {
 }
 
 static jstring netty_unix_errors_strError(JNIEnv* env, jclass clazz, jint error) {
-    return (*env)->NewStringUTF(env, strerror(error));
+    char strerrbuf[256] = {0};
+    strerror_r_xsi(error, strerrbuf, sizeof(strerrbuf));
+    return (*env)->NewStringUTF(env, strerrbuf);
 }
 // JNI Registered Methods End
 


### PR DESCRIPTION
Motivation:

We used strerror(...) when generating the exception that was thrown via JNI. Unfortunally strerror(...) is not thread-safe as it uses a static buffer internally which could lead to corrupted exception messages.

Modifications:

- strerror() is replaced with strerror_r_xsi() — the thread-safe wrapper already defined in this file

Result:

No more corrupted exception messages thrown by JNI
