### PR TITLE
Use stream error for maxContentLength exceeded in InboundHttp2ToHttpAdapter

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapter.java
@@ -24,9 +24,11 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpStatusClass;
 import io.netty.handler.codec.http.HttpUtil;
 
+import static io.netty.handler.codec.http2.Http2Error.ENHANCE_YOUR_CALM;
 import static io.netty.handler.codec.http2.Http2Error.INTERNAL_ERROR;
 import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
+import static io.netty.handler.codec.http2.Http2Exception.streamError;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static io.netty.util.internal.ObjectUtil.checkPositive;
@@ -233,7 +235,7 @@ public class InboundHttp2ToHttpAdapter extends Http2EventAdapter {
         ByteBuf content = msg.content();
         final int dataReadableBytes = data.readableBytes();
         if (content.readableBytes() > maxContentLength - dataReadableBytes) {
-            throw connectionError(INTERNAL_ERROR,
+            throw streamError(streamId, ENHANCE_YOUR_CALM,
                     "Content length exceeded max of %d for stream id %d", maxContentLength, streamId);
         }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapter.java
@@ -25,7 +25,6 @@ import io.netty.handler.codec.http.HttpStatusClass;
 import io.netty.handler.codec.http.HttpUtil;
 
 import static io.netty.handler.codec.http2.Http2Error.ENHANCE_YOUR_CALM;
-import static io.netty.handler.codec.http2.Http2Error.INTERNAL_ERROR;
 import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
 import static io.netty.handler.codec.http2.Http2Exception.streamError;

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -295,7 +295,13 @@ public class InboundHttp2ToHttpAdapterTest {
         // Verify that exceeding maxContentLength causes a stream error (RST_STREAM)
         // not a connection error (GOAWAY), so other streams can continue.
         // This is the fix for https://github.com/netty/netty/issues/11994
-        boostrapEnv(0, 1, 1);
+        //
+        // clientLatch=1: RST_STREAM for stream 3 triggers onRstStreamRead on the client,
+        //   which fires exceptionCaught and counts down clientLatch.
+        //   With a connection error (GOAWAY), no RST_STREAM is sent, so clientLatch
+        //   never counts down and awaitResponses() times out — failing the test.
+        // serverLatch=1: stream 5 request should be delivered normally.
+        boostrapEnv(1, 1, 1);
         final byte[] oversizedData = new byte[maxContentLength + 1];
         final ByteBuf oversizedContent = Unpooled.wrappedBuffer(oversizedData);
         final String normalText = "hello";
@@ -327,14 +333,26 @@ public class InboundHttp2ToHttpAdapterTest {
                     clientChannel.flush();
                 }
             });
-            // If maxContentLength caused a CONNECTION error, GOAWAY would close the connection
-            // and stream 5 would never be delivered. With the fix (STREAM error), only stream 3
-            // is reset and stream 5 is delivered successfully.
+
+            // Verify stream 5 is delivered successfully on the server
             awaitRequests();
             ArgumentCaptor<FullHttpMessage> requestCaptor = ArgumentCaptor.forClass(FullHttpMessage.class);
             verify(serverListener).messageReceived(requestCaptor.capture());
             capturedRequests = requestCaptor.getAllValues();
             assertEquals(expectedRequest, capturedRequests.get(0));
+
+            // Verify the client received RST_STREAM (not GOAWAY) for the oversized stream.
+            // The server's onStreamError sends RST_STREAM, which the client's
+            // InboundHttp2ToHttpAdapter.onRstStreamRead translates into an exceptionCaught
+            // event carrying a StreamException — this counts down clientLatch.
+            // With a connection error, the server sends GOAWAY instead — no RST_STREAM is
+            // received, exceptionCaught never fires, and awaitResponses() times out.
+            awaitResponses();
+            assertNotNull(clientException);
+            assertTrue(isStreamError(clientException));
+            Http2Exception.StreamException streamEx = (Http2Exception.StreamException) clientException;
+            assertEquals(3, streamEx.streamId());
+            assertEquals(Http2Error.ENHANCE_YOUR_CALM, streamEx.error());
         } finally {
             expectedRequest.release();
         }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -291,6 +291,56 @@ public class InboundHttp2ToHttpAdapterTest {
     }
 
     @Test
+    public void exceedMaxContentLengthShouldCauseStreamErrorNotConnectionError() throws Exception {
+        // Verify that exceeding maxContentLength causes a stream error (RST_STREAM)
+        // not a connection error (GOAWAY), so other streams can continue.
+        // This is the fix for https://github.com/netty/netty/issues/11994
+        boostrapEnv(0, 1, 1);
+        final byte[] oversizedData = new byte[maxContentLength + 1];
+        final ByteBuf oversizedContent = Unpooled.wrappedBuffer(oversizedData);
+        final String normalText = "hello";
+        final ByteBuf normalContent = Unpooled.copiedBuffer(normalText.getBytes());
+        final FullHttpRequest expectedRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
+                "/normal/path", normalContent.copy(), true);
+        try {
+            HttpHeaders httpHeaders = expectedRequest.headers();
+            httpHeaders.setInt(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), 5);
+            httpHeaders.setInt(HttpHeaderNames.CONTENT_LENGTH, normalText.length());
+            httpHeaders.setShort(HttpConversionUtil.ExtensionHeaderNames.STREAM_WEIGHT.text(), (short) 16);
+            final Http2Headers oversizedHeaders = new DefaultHttp2Headers().method(new AsciiString("POST")).path(
+                    new AsciiString("/oversized/path"));
+            final Http2Headers normalHeaders = new DefaultHttp2Headers().method(new AsciiString("GET")).path(
+                    new AsciiString("/normal/path"));
+            runInChannel(clientChannel, new Http2Runnable() {
+                @Override
+                public void run() throws Http2Exception {
+                    // Stream 3: send data exceeding maxContentLength - should cause stream error
+                    clientHandler.encoder().writeHeaders(ctxClient(), 3, oversizedHeaders, 0, false,
+                            newPromiseClient());
+                    clientHandler.encoder().writeData(ctxClient(), 3, oversizedContent, 0, true,
+                            newPromiseClient());
+                    // Stream 5: send a normal request - should succeed if connection is still alive
+                    clientHandler.encoder().writeHeaders(ctxClient(), 5, normalHeaders, 0, false,
+                            newPromiseClient());
+                    clientHandler.encoder().writeData(ctxClient(), 5, normalContent, 0, true,
+                            newPromiseClient());
+                    clientChannel.flush();
+                }
+            });
+            // If maxContentLength caused a CONNECTION error, GOAWAY would close the connection
+            // and stream 5 would never be delivered. With the fix (STREAM error), only stream 3
+            // is reset and stream 5 is delivered successfully.
+            awaitRequests();
+            ArgumentCaptor<FullHttpMessage> requestCaptor = ArgumentCaptor.forClass(FullHttpMessage.class);
+            verify(serverListener).messageReceived(requestCaptor.capture());
+            capturedRequests = requestCaptor.getAllValues();
+            assertEquals(expectedRequest, capturedRequests.get(0));
+        } finally {
+            expectedRequest.release();
+        }
+    }
+
+    @Test
     public void clientRequestMultipleDataFrames() throws Exception {
         boostrapEnv(1, 1, 1);
         final String text = "hello world big time data!";


### PR DESCRIPTION
Motivation:

When a message payload exceeds `maxContentLength` in `InboundHttp2ToHttpAdapter`, a connection error (`INTERNAL_ERROR`) is thrown. This sends a GOAWAY frame that closes the entire HTTP/2 connection, affecting all concurrent streams. Load balancers often treat GOAWAY as a 5xx error, even though this is a client-side issue (sending a payload that is too large). Exceeding the content length for a single stream should only affect that stream.

Modification:

Changed the error from `connectionError(INTERNAL_ERROR)` to `streamError(streamId, ENHANCE_YOUR_CALM)` in `onDataRead()`. The `ENHANCE_YOUR_CALM` error code is semantically appropriate for resource limit violations per RFC 7540 Section 7.

Added test `exceedMaxContentLengthShouldCauseStreamErrorNotConnectionError()` that sends oversized data on stream 3 and verifies:
- A `StreamException` (not connection error) is produced
- The error targets stream 3 with `ENHANCE_YOUR_CALM` error code
- The test correctly fails when the fix is reverted

Result:

Fixes #11994.