### PR TITLE
Native DNS resolver: Guard against malloc failures

### DIFF
--- a/resolver-dns-native-macos/src/main/c/netty_resolver_dns_macos.c
+++ b/resolver-dns-native-macos/src/main/c/netty_resolver_dns_macos.c
@@ -144,13 +144,23 @@ error:
 
 static JNINativeMethod* createDynamicMethodsTable(const char* packagePrefix) {
     JNINativeMethod* dynamicMethods = malloc(sizeof(JNINativeMethod) * 1);
-
+    if (dynamicMethods == NULL) {
+        return NULL;
+    }
     char* dynamicTypeName = netty_jni_util_prepend(packagePrefix, "io/netty/resolver/dns/macos/DnsResolver;");
+    if (dynamicTypeName == NULL) {
+        free(dynamicMethods);
+        return NULL;
+    }
     JNINativeMethod* dynamicMethod = &dynamicMethods[0];
     dynamicMethod->name = "resolvers";
     dynamicMethod->signature = netty_jni_util_prepend("()[L", dynamicTypeName);
-    dynamicMethod->fnPtr = (void *) netty_resolver_dns_macos_resolvers;
     free(dynamicTypeName);
+    if (dynamicMethod->signature == NULL) {
+        free(dynamicMethods);
+        return NULL;
+    }
+    dynamicMethod->fnPtr = (void *) netty_resolver_dns_macos_resolvers;
     return dynamicMethods;
 }
 


### PR DESCRIPTION
Motivation:

We missed to guard against malloc failures which could lead to UB.

Modifications:

Add guard against malloc failures

Result:

More robust implementation of createDynamicMethodsTable(...) and no UB
