### PR TITLE
Increase timeouts for QuicChannelConnectTest

### DIFF
--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicChannelConnectTest.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicChannelConnectTest.java
@@ -97,7 +97,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
 
     @ParameterizedTest
     @MethodSource("newSslTaskExecutors")
-    @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(10)
     public void testConnectAndQLog(Executor executor) throws Throwable {
         Path path = Files.createTempFile("qlog", ".quic");
         assertTrue(path.toFile().delete());
@@ -115,7 +115,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
 
     @ParameterizedTest
     @MethodSource("newSslTaskExecutors")
-    @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(10)
     public void testConnectAndQLogDir(Executor executor) throws Throwable {
         Path path = Files.createTempDirectory("qlogdir-");
         testQLog(executor, path, p -> {
@@ -383,35 +383,35 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
 
     @ParameterizedTest
     @MethodSource("newSslTaskExecutors")
-    @Timeout(3)
+    @Timeout(10)
     public void testConnectWithNoDroppedPacketsAndRandomConnectionIdGenerator(Executor executor) throws Throwable {
         testConnectWithDroppedPackets(executor, 0, QuicConnectionIdGenerator.randomGenerator());
     }
 
     @ParameterizedTest
     @MethodSource("newSslTaskExecutors")
-    @Timeout(5)
+    @Timeout(10)
     public void testConnectWithDroppedPacketsAndRandomConnectionIdGenerator(Executor executor) throws Throwable {
         testConnectWithDroppedPackets(executor, 2, QuicConnectionIdGenerator.randomGenerator());
     }
 
     @ParameterizedTest
     @MethodSource("newSslTaskExecutors")
-    @Timeout(3)
+    @Timeout(10)
     public void testConnectWithNoDroppedPacketsAndSignConnectionIdGenerator(Executor executor) throws Throwable {
         testConnectWithDroppedPackets(executor, 0, QuicConnectionIdGenerator.signGenerator());
     }
 
     @ParameterizedTest
     @MethodSource("newSslTaskExecutors")
-    @Timeout(5)
+    @Timeout(10)
     public void testConnectWithDroppedPacketsAndSignConnectionIdGenerator(Executor executor) throws Throwable {
         testConnectWithDroppedPackets(executor, 2, QuicConnectionIdGenerator.signGenerator());
     }
 
     @ParameterizedTest
     @MethodSource("newSslTaskExecutors")
-    @Timeout(5)
+    @Timeout(10)
     public void testTimedOut(Executor executor) throws Throwable {
         final AtomicBoolean dropPackets = new AtomicBoolean();
         final BlockingQueue<QuicStreamChannel> acceptedStreams = new LinkedBlockingQueue<>();
@@ -1722,7 +1722,7 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
 
     @ParameterizedTest
     @MethodSource("newSslTaskExecutors")
-    @Timeout(5)
+    @Timeout(10)
     public void testSessionReusedOnClientSide(Executor executor) throws Exception {
         testSessionReuse(executor, false);
     }


### PR DESCRIPTION
Motivation:
Locally, a few of these tests take over 3 seconds to run, but their timeout is only 5 seconds. This causes them to often time out in CI.

Modification:
Increase the timeouts to 10 seconds.

Result:
More stable build.

It's the same in 4.2, so this needs to be cherry-picked.
