### PR TITLE
Less logging in AWS-LC build

### DIFF
--- a/docker/Dockerfile.al2023
+++ b/docker/Dockerfile.al2023
@@ -8,7 +8,7 @@ ENV AWS_LC_VERSION $aws_lc_version
 ENV MAVEN_VERSION $maven_version
 
 # install dependencies
-RUN dnf install -y \
+RUN dnf install -yq \
  apr-devel \
  autoconf \
  automake \

--- a/docker/docker-compose.al2023.yaml
+++ b/docker/docker-compose.al2023.yaml
@@ -30,15 +30,15 @@ services:
   install-tcnative:
     <<: *common-tcnative
     command: '/bin/bash -cl "
-      ./mvnw -am -pl openssl-dynamic clean install &&
-      env -u LDFLAGS -u CFLAGS -u CXXFLAGS -u LD_LIBRARY_PATH ./mvnw -am -pl boringssl-static clean install
+      ./mvnw -B -q -am -pl openssl-dynamic clean install &&
+      env -u LDFLAGS -u CFLAGS -u CXXFLAGS -u LD_LIBRARY_PATH ./mvnw -B -q -am -pl boringssl-static clean install
     "'
     working_dir: /netty-tcnative
 
   update-tcnative-version:
     <<: *common
     command: '/bin/bash -cl "
-      ./mvnw versions:update-property -Dproperty=tcnative.version -DnewVersion=$(cd /netty-tcnative && ./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout) -DallowSnapshots=true -DprocessParent=true -DgenerateBackupPoms=false
+      ./mvnw -B -q versions:update-property -Dproperty=tcnative.version -DnewVersion=$(cd /netty-tcnative && ./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout) -DallowSnapshots=true -DprocessParent=true -DgenerateBackupPoms=false
     "'
 
   build:


### PR DESCRIPTION
Motivation:
Most of the log output in the AWS-LC build is just maven downloading stuff. This is too much.

Modification:
Tell maven to run in batch mode and be quiet, when building the AWS-LC version of tcnative.

Result:
Cut down the build log output by ~2 MiB.
