### PR TITLE
IoUring: Fix recv fd implementation on IoUringDomainSocketChannel and…

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CmsgHdr.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CmsgHdr.java
@@ -58,7 +58,25 @@ final class CmsgHdr {
         cmsghdr.putInt(cmsghdrPosition + cmsgHdrDataOffset, fd);
     }
 
-    static int readScmRights(ByteBuffer cmsghdr, int cmsgHdrDataOffset) {
+    static long readLen(ByteBuffer cmsghdr) {
+        int cmsghdrPosition = cmsghdr.position();
+        if (Native.SIZEOF_SIZE_T == 4) {
+            return cmsghdr.getInt(cmsghdrPosition + Native.CMSG_OFFSETOF_CMSG_LEN);
+        } else {
+            assert Native.SIZEOF_SIZE_T == 8;
+            return cmsghdr.getLong(cmsghdrPosition + Native.CMSG_OFFSETOF_CMSG_LEN);
+        }
+    }
+
+    static int readLevel(ByteBuffer cmsghdr) {
+        return cmsghdr.getInt(cmsghdr.position() + Native.CMSG_OFFSETOF_CMSG_LEVEL);
+    }
+
+    static int readType(ByteBuffer cmsghdr) {
+        return cmsghdr.getInt(cmsghdr.position() + Native.CMSG_OFFSETOF_CMSG_TYPE);
+    }
+
+    static int readIntData(ByteBuffer cmsghdr, int cmsgHdrDataOffset) {
         return cmsghdr.getInt(cmsghdr.position() + cmsgHdrDataOffset);
     }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDomainSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDomainSocketChannel.java
@@ -33,6 +33,8 @@ import io.netty.channel.unix.PeerCredentials;
 import java.io.IOException;
 import java.net.SocketAddress;
 
+import static io.netty.channel.unix.Errors.ioResult;
+
 /**
  * {@link DomainSocketChannel} implementation that uses linux io_uring
  */
@@ -202,17 +204,22 @@ public final class IoUringDomainSocketChannel extends AbstractIoUringStreamChann
                 final IoUringRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
                 final ChannelPipeline pipeline = pipeline();
                 try {
-                    if (res == 0) {
-                        allocHandle.lastBytesRead(0);
-                        return;
-                    } else if (res < 0) {
-                        // Check if we need to throw.
-                        Errors.ioResult("io_uring recvmsg", res);
+                    if (res > 0) {
+                        int fd = readMsgHdrMemory.getScmRightsFd();
+                        allocHandle.lastBytesRead(fd);
+                        allocHandle.incMessagesRead(1);
+                        pipeline.fireChannelRead(new FileDescriptor(fd));
+                    } else {
+                        if (res == 0) {
+                            allocHandle.lastBytesRead(-1);
+                        } else {
+                            allocHandle.lastBytesRead(ioResult("io_uring recvmsg", res));
+                        }
                     }
-                    int fd = readMsgHdrMemory.getScmRightsFd();
-                    allocHandle.lastBytesRead(fd);
-                    allocHandle.incMessagesRead(1);
-                    pipeline.fireChannelRead(new FileDescriptor(fd));
+                    if (allocHandle.lastBytesRead() < 0) {
+                        // There is nothing left to read as we received an EOF.
+                        shutdownInput(true);
+                    }
                 } catch (Throwable throwable) {
                     handleReadException(pipeline, null, throwable, false, allocHandle);
                 } finally {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDomainSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDomainSocketChannel.java
@@ -205,7 +205,12 @@ public final class IoUringDomainSocketChannel extends AbstractIoUringStreamChann
                 final ChannelPipeline pipeline = pipeline();
                 try {
                     if (res > 0) {
-                        int fd = readMsgHdrMemory.getScmRightsFd();
+                        Integer fd = readMsgHdrMemory.getScmRightsFd();
+                        if (fd == null) {
+                            // Ignore if we receive something we don't expect.
+                            scheduleRead(false);
+                            return;
+                        }
                         allocHandle.lastBytesRead(1);
                         allocHandle.incMessagesRead(1);
                         pipeline.fireChannelRead(new FileDescriptor(fd));

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDomainSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDomainSocketChannel.java
@@ -206,7 +206,7 @@ public final class IoUringDomainSocketChannel extends AbstractIoUringStreamChann
                 try {
                     if (res > 0) {
                         int fd = readMsgHdrMemory.getScmRightsFd();
-                        allocHandle.lastBytesRead(fd);
+                        allocHandle.lastBytesRead(1);
                         allocHandle.incMessagesRead(1);
                         pipeline.fireChannelRead(new FileDescriptor(fd));
                     } else {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDomainSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDomainSocketChannel.java
@@ -202,11 +202,17 @@ public final class IoUringDomainSocketChannel extends AbstractIoUringStreamChann
                 final IoUringRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
                 final ChannelPipeline pipeline = pipeline();
                 try {
-                    int nativeCallResult = res >= 0 ? res : Errors.ioResult("io_uring recvmsg", res);
-                    int nativeFd = readMsgHdrMemory.getScmRightsFd();
-                    allocHandle.lastBytesRead(nativeFd);
+                    if (res == 0) {
+                        allocHandle.lastBytesRead(0);
+                        return;
+                    } else if (res < 0) {
+                        // Check if we need to throw.
+                        Errors.ioResult("io_uring recvmsg", res);
+                    }
+                    int fd = readMsgHdrMemory.getScmRightsFd();
+                    allocHandle.lastBytesRead(fd);
                     allocHandle.incMessagesRead(1);
-                    pipeline.fireChannelRead(new FileDescriptor(nativeFd));
+                    pipeline.fireChannelRead(new FileDescriptor(fd));
                 } catch (Throwable throwable) {
                     handleReadException(pipeline, null, throwable, false, allocHandle);
                 } finally {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdr.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdr.java
@@ -125,8 +125,4 @@ final class MsgHdr {
             memory.putLong(memoryPosition + Native.MSGHDR_OFFSETOF_MSG_IOVLEN, iovLength);
         }
     }
-
-    static int getCmsgData(ByteBuffer memory, ByteBuffer msgControl, int cmsgHdrDataOffset) {
-        return CmsgHdr.readScmRights(msgControl, cmsgHdrDataOffset);
-    }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdr.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdr.java
@@ -112,6 +112,12 @@ final class MsgHdr {
                            ByteBuffer iovMemory, int iovLength) {
         int memoryPosition = memory.position();
         long msgControlAddr = Buffer.memoryAddress(msgControl);
+        assert msgControl.position() == 0;
+        for (int i = 0; i < Native.MSG_CONTROL_LEN_FOR_FD; i++) {
+            // Memset memory.
+            msgControl.put(i, (byte) 0);
+        }
+
         if (Native.SIZEOF_SIZE_T == 4) {
             memory.putInt(memoryPosition + Native.MSGHDR_OFFSETOF_MSG_CONTROL, (int) msgControlAddr);
             memory.putInt(memoryPosition + Native.MSGHDR_OFFSETOF_MSG_CONTROLLEN, Native.MSG_CONTROL_LEN_FOR_FD);

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemory.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemory.java
@@ -132,9 +132,9 @@ final class MsgHdrMemory {
         long len = CmsgHdr.readLen(cmsgMemory);
         int level = CmsgHdr.readLevel(cmsgMemory);
         int type = CmsgHdr.readType(cmsgMemory);
-        assert len == Native.CMSG_LEN_FOR_FD;
-        assert level == Native.SOL_SOCKET;
-        assert type == Native.SCM_RIGHTS;
+        assert len == Native.CMSG_LEN_FOR_FD : "len " + len + " is not " + Native.CMSG_LEN_FOR_FD;
+        assert level == Native.SOL_SOCKET : "level " + level + " is not " + Native.SOL_SOCKET;
+        assert type == Native.SCM_RIGHTS : "type " + type + " is not " + Native.SCM_RIGHTS;
         return CmsgHdr.readIntData(cmsgMemory, cmsgDataOffset);
     }
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemory.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemory.java
@@ -128,13 +128,16 @@ final class MsgHdrMemory {
         MsgHdr.prepSendFd(msgHdrMemory, fd, cmsgMemory, cmsgDataOffset, iovMemory, 1);
     }
 
-    int getScmRightsFd() {
+    Integer getScmRightsFd() {
         long len = CmsgHdr.readLen(cmsgMemory);
         int level = CmsgHdr.readLevel(cmsgMemory);
         int type = CmsgHdr.readType(cmsgMemory);
-        assert len == Native.CMSG_LEN_FOR_FD : "len " + len + " is not " + Native.CMSG_LEN_FOR_FD;
-        assert level == Native.SOL_SOCKET : "level " + level + " is not " + Native.SOL_SOCKET;
-        assert type == Native.SCM_RIGHTS : "type " + type + " is not " + Native.SCM_RIGHTS;
+        if (len != Native.CMSG_LEN_FOR_FD || level != Native.SOL_SOCKET || type != Native.SCM_RIGHTS) {
+            return null;
+        }
+        //assert len == Native.CMSG_LEN_FOR_FD : "len " + len + " is not " + Native.CMSG_LEN_FOR_FD;
+        //assert level == Native.SOL_SOCKET : "level " + level + " is not " + Native.SOL_SOCKET;
+        //assert type == Native.SCM_RIGHTS : "type " + type + " is not " + Native.SCM_RIGHTS;
         return CmsgHdr.readIntData(cmsgMemory, cmsgDataOffset);
     }
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemory.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemory.java
@@ -85,7 +85,7 @@ final class MsgHdrMemory {
         msgHdrMemoryCleanable = Buffer.allocateDirectBufferWithNativeOrder(Native.SIZEOF_MSGHDR);
         socketAddrMemoryCleanable = null;
         iovMemoryCleanable = Buffer.allocateDirectBufferWithNativeOrder(Native.SIZEOF_IOVEC);
-        cmsgMemoryCleanable = Buffer.allocateDirectBufferWithNativeOrder(Native.CMSG_SPACE_FOR_FD);
+        cmsgMemoryCleanable = Buffer.allocateDirectBufferWithNativeOrder(Native.MSG_CONTROL_LEN_FOR_FD);
 
         msgHdrMemory = msgHdrMemoryCleanable.buffer();
         socketAddrMemory = null;

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemory.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemory.java
@@ -37,11 +37,11 @@ final class MsgHdrMemory {
     private final CleanableDirectBuffer msgHdrMemoryCleanable;
     private final CleanableDirectBuffer socketAddrMemoryCleanable;
     private final CleanableDirectBuffer iovMemoryCleanable;
-    private final CleanableDirectBuffer cmsgDataMemoryCleanable;
+    private final CleanableDirectBuffer cmsgMemoryCleanable;
     private final ByteBuffer msgHdrMemory;
     private final ByteBuffer socketAddrMemory;
     private final ByteBuffer iovMemory;
-    private final ByteBuffer cmsgDataMemory;
+    private final ByteBuffer cmsgMemory;
 
     private final long msgHdrMemoryAddress;
     private final short idx;
@@ -52,7 +52,7 @@ final class MsgHdrMemory {
         this.msgHdrMemoryCleanable = null;
         this.socketAddrMemoryCleanable = null;
         this.iovMemoryCleanable = null;
-        this.cmsgDataMemoryCleanable = null;
+        this.cmsgMemoryCleanable = null;
         int offset = idx * MSG_HDR_SIZE;
         // ByteBuffer.slice(int, int) / duplicate() are specified to produce BIG_ENDIAN byte buffers.
         // Set native order explicitly so native structs written via putInt/putLong use the expected endianness.
@@ -68,15 +68,15 @@ final class MsgHdrMemory {
                 msgHdrMemoryArray, offset, Native.SIZEOF_IOVEC
         ).order(ByteOrder.nativeOrder());
         offset += Native.SIZEOF_IOVEC;
-        this.cmsgDataMemory = PlatformDependent.offsetSlice(
+        this.cmsgMemory = PlatformDependent.offsetSlice(
                 msgHdrMemoryArray, offset, Native.CMSG_SPACE
         ).order(ByteOrder.nativeOrder());
 
         msgHdrMemoryAddress = Buffer.memoryAddress(msgHdrMemory);
 
-        long cmsgDataMemoryAddr = Buffer.memoryAddress(cmsgDataMemory);
-        long cmsgDataAddr = Native.cmsghdrData(cmsgDataMemoryAddr);
-        cmsgDataOffset = (int) (cmsgDataAddr - cmsgDataMemoryAddr);
+        long cmsgMemoryAddr = Buffer.memoryAddress(cmsgMemory);
+        long cmsgDataAddr = Native.cmsghdrData(cmsgMemoryAddr);
+        cmsgDataOffset = (int) (cmsgDataAddr - cmsgMemoryAddr);
     }
 
     MsgHdrMemory() {
@@ -85,21 +85,21 @@ final class MsgHdrMemory {
         msgHdrMemoryCleanable = Buffer.allocateDirectBufferWithNativeOrder(Native.SIZEOF_MSGHDR);
         socketAddrMemoryCleanable = null;
         iovMemoryCleanable = Buffer.allocateDirectBufferWithNativeOrder(Native.SIZEOF_IOVEC);
-        cmsgDataMemoryCleanable = Buffer.allocateDirectBufferWithNativeOrder(Native.CMSG_SPACE_FOR_FD);
+        cmsgMemoryCleanable = Buffer.allocateDirectBufferWithNativeOrder(Native.CMSG_SPACE_FOR_FD);
 
         msgHdrMemory = msgHdrMemoryCleanable.buffer();
         socketAddrMemory = null;
         iovMemory = iovMemoryCleanable.buffer();
-        cmsgDataMemory = cmsgDataMemoryCleanable.buffer();
+        cmsgMemory = cmsgMemoryCleanable.buffer();
 
         msgHdrMemoryAddress = Buffer.memoryAddress(msgHdrMemory);
         // These two parameters must be set to valid values and cannot be 0,
         // otherwise the fd we get in io_uring_recvmsg is 0
         Iov.set(iovMemory, GLOBAL_IOV_BASE_ADDRESS, GLOBAL_IOV_LEN);
 
-        long cmsgDataMemoryAddr = Buffer.memoryAddress(cmsgDataMemory);
-        long cmsgDataAddr = Native.cmsghdrData(cmsgDataMemoryAddr);
-        cmsgDataOffset = (int) (cmsgDataAddr - cmsgDataMemoryAddr);
+        long cmsgMemoryAddr = Buffer.memoryAddress(cmsgMemory);
+        long cmsgDataAddr = Native.cmsghdrData(cmsgMemoryAddr);
+        cmsgDataOffset = (int) (cmsgDataAddr - cmsgMemoryAddr);
     }
 
     void set(LinuxSocket socket, InetSocketAddress address, long bufferAddress , int length, short segmentSize) {
@@ -116,7 +116,7 @@ final class MsgHdrMemory {
             addressLength = SockaddrIn.set(socket.isIpv6(), socketAddrMemory, address);
         }
         Iov.set(iovMemory, bufferAddress, length);
-        MsgHdr.set(msgHdrMemory, socketAddrMemory, addressLength, iovMemory, 1, cmsgDataMemory,
+        MsgHdr.set(msgHdrMemory, socketAddrMemory, addressLength, iovMemory, 1, cmsgMemory,
                 cmsgDataOffset, segmentSize);
     }
 
@@ -125,15 +125,21 @@ final class MsgHdrMemory {
     }
 
     void setScmRightsFd(int fd) {
-        MsgHdr.prepSendFd(msgHdrMemory, fd, cmsgDataMemory, cmsgDataOffset, iovMemory, 1);
+        MsgHdr.prepSendFd(msgHdrMemory, fd, cmsgMemory, cmsgDataOffset, iovMemory, 1);
     }
 
     int getScmRightsFd() {
-        return MsgHdr.getCmsgData(msgHdrMemory, cmsgDataMemory, cmsgDataOffset);
+        long len = CmsgHdr.readLen(cmsgMemory);
+        int level = CmsgHdr.readLevel(cmsgMemory);
+        int type = CmsgHdr.readType(cmsgMemory);
+        assert len == Native.CMSG_LEN_FOR_FD;
+        assert level == Native.SOL_SOCKET;
+        assert type == Native.SCM_RIGHTS;
+        return CmsgHdr.readIntData(cmsgMemory, cmsgDataOffset);
     }
 
     void prepRecvReadFd() {
-        MsgHdr.prepReadFd(msgHdrMemory, cmsgDataMemory, cmsgDataOffset, iovMemory, 1);
+        MsgHdr.prepReadFd(msgHdrMemory, cmsgMemory, cmsgDataOffset, iovMemory, 1);
     }
 
     boolean hasPort(IoUringDatagramChannel channel) {
@@ -184,8 +190,8 @@ final class MsgHdrMemory {
         if (iovMemoryCleanable != null) {
             iovMemoryCleanable.clean();
         }
-        if (cmsgDataMemoryCleanable != null) {
-            cmsgDataMemoryCleanable.clean();
+        if (cmsgMemoryCleanable != null) {
+            cmsgMemoryCleanable.clean();
         }
     }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemory.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemory.java
@@ -125,11 +125,13 @@ final class MsgHdrMemory {
     }
 
     void setScmRightsFd(int fd) {
-        MsgHdr.prepSendFd(msgHdrMemory, fd, cmsgMemory, cmsgDataOffset, iovMemory, 1);
+        Native.prepSendFd(msgHdrMemoryAddress, Buffer.memoryAddress(cmsgMemory),
+                Native.MSG_CONTROL_LEN_FOR_FD, Buffer.memoryAddress(iovMemory), 1, fd);
+        //MsgHdr.prepSendFd(msgHdrMemory, fd, cmsgMemory, cmsgDataOffset, iovMemory, 1);
     }
 
     Integer getScmRightsFd() {
-        long len = CmsgHdr.readLen(cmsgMemory);
+        /*long len = CmsgHdr.readLen(cmsgMemory);
         int level = CmsgHdr.readLevel(cmsgMemory);
         int type = CmsgHdr.readType(cmsgMemory);
         if (len != Native.CMSG_LEN_FOR_FD || level != Native.SOL_SOCKET || type != Native.SCM_RIGHTS) {
@@ -139,6 +141,8 @@ final class MsgHdrMemory {
         //assert level == Native.SOL_SOCKET : "level " + level + " is not " + Native.SOL_SOCKET;
         //assert type == Native.SCM_RIGHTS : "type " + type + " is not " + Native.SCM_RIGHTS;
         return CmsgHdr.readIntData(cmsgMemory, cmsgDataOffset);
+         */
+        return Native.recvFd(msgHdrMemoryAddress);
     }
 
     void prepRecvReadFd() {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemory.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemory.java
@@ -85,7 +85,7 @@ final class MsgHdrMemory {
         msgHdrMemoryCleanable = Buffer.allocateDirectBufferWithNativeOrder(Native.SIZEOF_MSGHDR);
         socketAddrMemoryCleanable = null;
         iovMemoryCleanable = Buffer.allocateDirectBufferWithNativeOrder(Native.SIZEOF_IOVEC);
-        cmsgMemoryCleanable = Buffer.allocateDirectBufferWithNativeOrder(Native.MSG_CONTROL_LEN_FOR_FD);
+        cmsgMemoryCleanable = Buffer.allocateDirectBufferWithNativeOrder(Native.CMSG_SPACE_FOR_FD);
 
         msgHdrMemory = msgHdrMemoryCleanable.buffer();
         socketAddrMemory = null;

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -645,6 +645,7 @@ final class Native {
 
     private static native int registerUnix();
 
+    static native long cmsghdrFirstHdr(long hdrAddr);
     static native long cmsghdrData(long hdrAddr);
 
     static native String kernelVersion();

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -623,6 +623,9 @@ final class Native {
 
     static native void eventFdWrite(int fd, long value);
 
+    static native void prepSendFd(long msghdrAddress, long msgControlAddress, int controlLen,
+                                  long iovAddress, int iovLen, int fd);
+    static native int recvFd(long msghdrAddress);
     static int getFd(DefaultFileRegion fileChannel) {
         return getFd0(fileChannel);
     }

--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -774,6 +774,36 @@ static jint netty_io_uring_ScmRights(JNIEnv* env, jclass clazz) {
     return SCM_RIGHTS;
 }
 
+static void netty_io_uring_prep_send_fd(JNIEnv* env, jclass clazz, jlong msghdrAddress,
+     jlong msgControlAddress, jint controlLen, jlong iovAddress, jint iovLen, jint fd) {
+     struct cmsghdr *cmsg;
+
+     struct msghdr* msg = (struct msghdr*) msghdrAddress;
+     msg->msg_control = (void *) msgControlAddress;
+     msg->msg_controllen = controlLen;
+     msg->msg_iov = (struct iovec *) iovAddress;
+     msg->msg_iovlen = iovLen;
+
+     cmsg = CMSG_FIRSTHDR(msg);
+     cmsg->cmsg_level = SOL_SOCKET;
+     cmsg->cmsg_type = SCM_RIGHTS;
+     cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+     *((int *)CMSG_DATA(cmsg)) = fd;
+}
+
+static jint netty_io_uring_recv_fd(JNIEnv* env, jclass clazz, jlong msghdrAddress) {
+     struct msghdr* msg = (struct msghdr*) msghdrAddress;
+     struct cmsghdr* cmsg = CMSG_FIRSTHDR(msg);
+     if (!cmsg) {
+         return -errno;
+     }
+     if ((cmsg->cmsg_len == CMSG_LEN(sizeof(int))) && (cmsg->cmsg_level == SOL_SOCKET) && (cmsg->cmsg_type == SCM_RIGHTS)) {
+         int socketFd = *((int *) CMSG_DATA(cmsg));
+         return socketFd;
+     }
+     return -1;
+}
+
 // JNI Method Registration Table Begin
 static const JNINativeMethod statically_referenced_fixed_method_table[] = {
   { "sockNonblock", "()I", (void *) netty_io_uring_sockNonblock },
@@ -860,6 +890,8 @@ static const JNINativeMethod method_table[] = {
     {"eventFdWrite", "(IJ)V", (void *) netty_io_uring_eventFdWrite },
     {"registerUnix", "()I", (void *) netty_io_uring_registerUnix },
     {"cmsghdrData", "(J)J", (void *) netty_io_uring_cmsghdrData},
+    {"prepSendFd", "(JJIJII)V", (void *) netty_io_uring_prep_send_fd},
+    {"recvFd", "(J)I", (void *) netty_io_uring_recv_fd},
     {"kernelVersion", "()Ljava/lang/String;", (void *) netty_io_uring_kernel_version },
     {"getFd0", "(Ljava/lang/Object;)I", (void *) netty_io_uring_getFd0 },
     {"ioUringRegisterBufRing", "(IISI)J", (void *) netty_io_uring_register_buf_ring },

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketFdTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketFdTest.java
@@ -37,9 +37,9 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class IoUringDomainSocketFdTest extends AbstractSocketTest {
@@ -140,7 +140,7 @@ public class IoUringDomainSocketFdTest extends AbstractSocketTest {
 
         FileDescriptor fd = recvFdFuture.get();
         assertTrue(fd.isOpen());
-        assertNotEquals(0, fd.intValue());
+        assertThat(fd.intValue()).isGreaterThanOrEqualTo(0);
         fd.close();
         assertFalse(fd.isOpen());
 

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketFdTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketFdTest.java
@@ -17,7 +17,6 @@ package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -25,11 +24,6 @@ import io.netty.channel.unix.DomainSocketReadMode;
 import io.netty.channel.unix.FileDescriptor;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.AbstractSocketTest;
-<<<<<<< fix_fd
-=======
-import io.netty.util.ReferenceCountUtil;
-import org.junit.jupiter.api.Disabled;
->>>>>>> 4.2
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
@@ -54,7 +48,6 @@ public class IoUringDomainSocketFdTest extends AbstractSocketTest {
         return IoUringSocketTestPermutation.INSTANCE.domainSocket();
     }
 
-    @Disabled
     @Test
     @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
     public void testSendRecvFd(TestInfo testInfo) throws Throwable {

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketFdTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketFdTest.java
@@ -18,7 +18,6 @@ package io.netty.channel.uring;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.CompositeByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -26,19 +25,16 @@ import io.netty.channel.unix.DomainSocketReadMode;
 import io.netty.channel.unix.FileDescriptor;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.AbstractSocketTest;
-import io.netty.util.ReferenceCountUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
 
 import java.net.SocketAddress;
-import java.nio.charset.Charset;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -66,9 +62,7 @@ public class IoUringDomainSocketFdTest extends AbstractSocketTest {
 
     public void testSendRecvFd(ServerBootstrap sb, Bootstrap cb) throws Throwable {
 
-        String expected = "Hello World";
         CompletableFuture<FileDescriptor> recvFdFuture = new CompletableFuture<>();
-        CompletableFuture<ByteBuf> recvByteBufFuture = new CompletableFuture<>();
 
         sb.childHandler(new ChannelInboundHandlerAdapter() {
             @Override
@@ -80,15 +74,6 @@ public class IoUringDomainSocketFdTest extends AbstractSocketTest {
                     if (!future.isSuccess()) {
                         Throwable cause = future.cause();
                         recvFdFuture.completeExceptionally(cause);
-                    } else {
-                        ByteBuf sendBuffer = ctx.alloc().directBuffer(expected.length());
-                        sendBuffer.writeBytes(expected.getBytes());
-                        ctx.writeAndFlush(sendBuffer).addListener(f -> {
-                            if (!f.isSuccess()) {
-                                Throwable cause = f.cause();
-                                recvByteBufFuture.completeExceptionally(cause);
-                            }
-                        });
                     }
                 });
             }
@@ -96,41 +81,18 @@ public class IoUringDomainSocketFdTest extends AbstractSocketTest {
 
         cb.handler(new ChannelInboundHandlerAdapter() {
 
-            private CompositeByteBuf byteBufs;
-
             @Override
             public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
                 if (msg instanceof FileDescriptor) {
                     FileDescriptor fd = (FileDescriptor) msg;
                     recvFdFuture.complete(fd);
-                    ctx.channel().config()
-                            .setOption(IoUringChannelOption.DOMAIN_SOCKET_READ_MODE, DomainSocketReadMode.BYTES);
-                } else {
-                    byteBufs.addComponent(true, (ByteBuf) msg);
                 }
             }
 
             @Override
             public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-                DomainSocketReadMode readMode = ctx.channel().config()
-                        .getOption(IoUringChannelOption.DOMAIN_SOCKET_READ_MODE);
-                if (readMode == DomainSocketReadMode.FILE_DESCRIPTORS) {
-                    recvFdFuture.completeExceptionally(cause);
-                } else {
-                    recvByteBufFuture.completeExceptionally(cause);
-                }
+                recvFdFuture.completeExceptionally(cause);
                 ctx.close();
-            }
-
-            @Override
-            public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
-                if (byteBufs != null) {
-                    recvByteBufFuture.complete(byteBufs);
-                    byteBufs = null;
-                } else {
-                    // after receiving the file descriptor, we need to start receiving the data again.
-                    byteBufs = ctx.alloc().compositeBuffer();
-                }
             }
         });
         cb.option(IoUringChannelOption.DOMAIN_SOCKET_READ_MODE,
@@ -143,14 +105,7 @@ public class IoUringDomainSocketFdTest extends AbstractSocketTest {
         assertThat(fd.intValue()).isGreaterThanOrEqualTo(0);
         fd.close();
         assertFalse(fd.isOpen());
-
-        ByteBuf recvBuffer = recvByteBufFuture.get();
-       try {
-           assertEquals(expected, recvBuffer.toString(Charset.defaultCharset()));
-           cc.close().sync();
-           sc.close().sync();
-       } finally {
-           ReferenceCountUtil.release(recvBuffer);
-       }
+        cc.close().sync();
+        sc.close().sync();
     }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/MsgHdrMemoryTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/MsgHdrMemoryTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MsgHdrMemoryTest {
+
+    @Test
+    void testFd() {
+        MsgHdrMemory mem = new MsgHdrMemory();
+        mem.setScmRightsFd(1);
+        assertEquals(1, mem.getScmRightsFd());
+    }
+}


### PR DESCRIPTION
… also fix test

Motivation:

Our implementation of recv fd in IoUringDomainSocketChannel was not really correct and so not handled errors etc correct. Beside this our test was also not correct as in theory a fd with value 0 is valid.

Modifications:

- Correctly handle recv of fds
- Fix test

Result:

Fix test falures on CI