### PR TITLE
Add generic FileRegion support in io_uring stream channel

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -45,8 +45,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
     private static final ChannelMetadata METADATA = new ChannelMetadata(false, 16);
 
     /**
-     * Maximum number of bytes to read from a generic {@link FileRegion} per chunk.
-     * This limits memory usage when converting non-{@link DefaultFileRegion} implementations
+     * Maximum bytes per chunk when converting a generic {@link FileRegion}
      * to {@link ByteBuf} for the io_uring async send path.
      */
     private static final int FILE_REGION_MAX_CHUNK_SIZE = 64 * 1024;
@@ -243,8 +242,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
         }
 
         if (msg instanceof FileRegion) {
-            // Generic FileRegion — let it pass through to the write path where it will be
-            // converted to ByteBuf in chunks to limit memory usage.
+            // Generic FileRegion — pass through to the write path for chunked conversion.
             return msg;
         }
 
@@ -255,8 +253,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
 
         private ByteBuf readBuffer;
 
-        // Temporary buffer holding a chunk of data read from a generic FileRegion.
-        // Non-null while an async send for a FileRegion chunk is in flight.
+        // Chunk buffer for generic FileRegion writes. Non-null while a send is in flight.
         private ByteBuf fileRegionChunkBuf;
 
         @Override
@@ -311,8 +308,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                 ops = fileRegion.splice(fd);
             } else if (msg instanceof FileRegion) {
                 // Generic FileRegion: read a chunk into a direct ByteBuf and send it.
-                // If fileRegionChunkBuf is non-null, we are re-sending remaining bytes
-                // from a previous partial send.
+                // Non-null fileRegionChunkBuf means re-sending after a partial send.
                 FileRegion region = (FileRegion) msg;
                 ByteBuf buf = fileRegionChunkBuf;
                 if (buf == null) {
@@ -699,15 +695,13 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                     buf.skipBytes(res);
                     channelOutboundBuffer.progress(res);
                     if (!buf.isReadable()) {
-                        // Chunk fully sent — release it and check if the entire FileRegion is done.
+                        // Chunk fully sent.
                         releaseFileRegionChunkBuf();
                         if (region.transferred() >= region.count()) {
                             channelOutboundBuffer.remove();
                         }
-                        // Return true so the write loop continues with the next chunk or message.
                     } else {
-                        // Partial send — remaining bytes still in the chunk buffer.
-                        // Return false to schedule POLLOUT; next write will re-send the remainder.
+                        // Partial send — schedule POLLOUT to re-send the remainder.
                         return false;
                     }
                 } else {
@@ -781,12 +775,9 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
     }
 
     /**
-     * A {@link WritableByteChannel} that writes into a {@link ByteBuf}.
-     * Used by the generic FileRegion fallback to buffer data from
-     * {@link FileRegion#transferTo(WritableByteChannel, long)} before async send.
-     * Writes are capped to the ByteBuf's writable capacity so that
-     * {@code transferTo} cannot overflow the buffer when the FileRegion
-     * has more data remaining than the chunk size.
+     * A {@link WritableByteChannel} backed by a {@link ByteBuf}.
+     * Writes are capped to {@link ByteBuf#writableBytes()} to prevent overflow
+     * when {@link FileRegion#transferTo} writes more than the chunk size.
      */
     private static final class ByteBufWritableByteChannel implements WritableByteChannel {
         private final ByteBuf buf;

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -263,8 +263,8 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                 }
                 if (region.transferred() < expected) {
                     throw new ChannelException(
-                            "FileRegion transfer incomplete: expected " + expected +
-                            " bytes, got " + region.transferred());
+                            "FileRegion transfer incomplete: expected "
+                            + expected + " bytes, got " + region.transferred());
                 }
                 success = true;
             } catch (IOException e) {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -50,7 +50,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
      * to {@link ByteBuf} for the io_uring async send path.
      */
     private static final int FILE_REGION_MAX_CHUNK_SIZE =
-            SystemPropertyUtil.getInt("io.netty.iouring.fileRegionChunkSize", 64 * 1024);
+            Math.max(1, SystemPropertyUtil.getInt("io.netty.iouring.fileRegionChunkSize", 64 * 1024));
 
     // Store the opCode so we know if we used WRITE or WRITEV.
     byte writeOpCode;

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -17,6 +17,7 @@ package io.netty.channel.uring;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelMetadata;
@@ -25,14 +26,18 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultFileRegion;
 import io.netty.channel.EventLoop;
+import io.netty.channel.FileRegion;
 import io.netty.channel.IoRegistration;
 import io.netty.channel.socket.DuplexChannel;
 import io.netty.channel.unix.IovArray;
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.io.IOException;
 import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.WritableByteChannel;
 
 import static io.netty.channel.unix.Errors.ioResult;
 
@@ -227,10 +232,50 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
 
     @Override
     protected Object filterOutboundMessage(Object msg) {
-        // Since we cannot use synchronous sendfile,
-        // the channel can only support DefaultFileRegion instead of FileRegion.
         if (IoUring.isSpliceSupported() && msg instanceof DefaultFileRegion) {
             return new IoUringFileRegion((DefaultFileRegion) msg);
+        }
+
+        if (msg instanceof FileRegion) {
+            // FileRegion not handled above cannot use splice — convert to a direct ByteBuf
+            // via transferTo so it can be sent through the normal io_uring async send path.
+            // Not zero-copy but functionally correct.
+            //
+            // On error paths, don't release region — the caller (AbstractChannel.write)
+            // releases the original msg. On success, we must release it ourselves because
+            // the caller will only see the returned ByteBuf.
+            FileRegion region = (FileRegion) msg;
+            long remaining = region.count() - region.transferred();
+            if (remaining > Integer.MAX_VALUE) {
+                throw new IllegalArgumentException(
+                        "FileRegion too large to convert to ByteBuf: " + remaining + " bytes");
+            }
+            ByteBuf buf = alloc().directBuffer((int) remaining);
+            boolean success = false;
+            try {
+                ByteBufWritableByteChannel channel = new ByteBufWritableByteChannel(buf);
+                long expected = region.count();
+                while (region.transferred() < expected) {
+                    long transferred = region.transferTo(channel, region.transferred());
+                    if (transferred <= 0) {
+                        break;
+                    }
+                }
+                if (region.transferred() < expected) {
+                    throw new ChannelException(
+                            "FileRegion transfer incomplete: expected " + expected +
+                            " bytes, got " + region.transferred());
+                }
+                success = true;
+            } catch (IOException e) {
+                throw new ChannelException("Failed to convert FileRegion to ByteBuf", e);
+            } finally {
+                if (!success) {
+                    buf.release();
+                }
+            }
+            ReferenceCountUtil.safeRelease(region);
+            return buf;
         }
 
         return super.filterOutboundMessage(msg);
@@ -660,5 +705,34 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
     @Override
     boolean isPollInFirst() {
         return bufferRing == null || !bufferRing.isUsable();
+    }
+
+    /**
+     * A {@link WritableByteChannel} that writes into a {@link ByteBuf}.
+     * Used by the generic FileRegion fallback in filterOutboundMessage.
+     */
+    private static final class ByteBufWritableByteChannel implements WritableByteChannel {
+        private final ByteBuf buf;
+
+        ByteBufWritableByteChannel(ByteBuf buf) {
+            this.buf = buf;
+        }
+
+        @Override
+        public int write(ByteBuffer src) {
+            int remaining = src.remaining();
+            buf.writeBytes(src);
+            return remaining - src.remaining();
+        }
+
+        @Override
+        public boolean isOpen() {
+            return true;
+        }
+
+        @Override
+        public void close() {
+            // NOOP
+        }
     }
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -46,11 +46,13 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
     private static final ChannelMetadata METADATA = new ChannelMetadata(false, 16);
 
     /**
-     * Maximum bytes per chunk when converting a generic {@link FileRegion}
-     * to {@link ByteBuf} for the io_uring async send path.
+     * Maximum bytes per chunk when converting a generic {@link FileRegion} to a {@link ByteBuf}
+     * for the io_uring async send path. Overridable via the {@code io.netty.iouring.fileRegionChunkSize}
+     * system property; capped at 16 MiB to guard against pathological configurations that would
+     * risk direct-memory OOM.
      */
-    private static final int FILE_REGION_MAX_CHUNK_SIZE =
-            Math.max(1, SystemPropertyUtil.getInt("io.netty.iouring.fileRegionChunkSize", 64 * 1024));
+    private static final int FILE_REGION_MAX_CHUNK_SIZE = Math.min(16 * 1024 * 1024,
+            Math.max(1, SystemPropertyUtil.getInt("io.netty.iouring.fileRegionChunkSize", 64 * 1024)));
 
     // Store the opCode so we know if we used WRITE or WRITEV.
     byte writeOpCode;
@@ -244,7 +246,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
         }
 
         if (msg instanceof FileRegion) {
-            // Generic FileRegion — pass through to the write path for chunked conversion.
+            // Generic FileRegion -- pass through to the write path for chunked conversion.
             return msg;
         }
 
@@ -327,11 +329,9 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
             return 1;
         }
 
-        /**
-         * Read a chunk from a generic {@link FileRegion} into a direct {@link ByteBuf} and
-         * submit it as an io_uring async send. If {@code fileRegionChunkBuf} is non-null,
-         * re-sends the remaining bytes from a previous partial send.
-         */
+        // Read a chunk from a generic FileRegion into a direct ByteBuf and submit it as an
+        // io_uring async send. If fileRegionChunkBuf is non-null, re-submits the remaining
+        // bytes from a previous partial/failed send.
         private int scheduleWriteFileRegion(int fd, IoRegistration registration, FileRegion region) {
             ByteBuf buf = fileRegionChunkBuf;
             if (buf == null) {
@@ -341,18 +341,17 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                     buf = alloc().directBuffer(chunkSize);
                     try {
                         ByteBufWritableByteChannel ch = new ByteBufWritableByteChannel(buf);
-                        int written = 0;
-                        while (written < chunkSize) {
+                        while (buf.writableBytes() > 0) {
                             long t = region.transferTo(ch, region.transferred());
                             if (t <= 0) {
                                 break;
                             }
-                            written += (int) t;
                         }
                         if (buf.readableBytes() == 0) {
                             buf.release();
                             handleWriteError(new ChannelException(
-                                    "FileRegion transferTo produced 0 bytes"));
+                                    "FileRegion.transferTo(...) produced 0 bytes (count="
+                                            + region.count() + ", transferred=" + region.transferred() + ')'));
                             return 0;
                         }
                     } catch (Exception e) {
@@ -361,8 +360,8 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                         return 0;
                     }
                 } else {
-                    // Empty or fully transferred — submit a 0-byte send so the
-                    // completion path removes it from the outbound buffer.
+                    // Empty or fully-transferred region. Submit a 0-byte send so the completion
+                    // path removes it from the outbound buffer via the normal async flow.
                     buf = alloc().directBuffer(0);
                 }
                 fileRegionChunkBuf = buf;
@@ -374,6 +373,10 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
             writeId = registration.submit(ops);
             writeOpCode = opCode;
             if (writeId == 0) {
+                // Submission only fails when the registration is no longer valid (channel is
+                // being deregistered). unregistered() will release fileRegionChunkBuf and the
+                // outbound buffer will release the FileRegion, so nothing to clean up here --
+                // mirroring the plain ByteBuf path above.
                 return 0;
             }
             return 1;
@@ -697,6 +700,10 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
             return true;
         }
 
+        // Returns true when the completion can be treated as "written all" for this SQE
+        // (the framework may still schedule further writes from the outbound buffer); returns
+        // false to signal the framework that POLLOUT should be armed so the chunk buffer is
+        // resubmitted once the socket becomes writable again.
         private boolean handleWriteCompleteGenericFileRegion(
                 ChannelOutboundBuffer channelOutboundBuffer, FileRegion region, int res) {
             try {
@@ -716,20 +723,16 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                             channelOutboundBuffer.remove();
                         }
                     } else {
-                        // Partial send — schedule POLLOUT to re-send the remainder.
+                        // Partial send -- schedule POLLOUT to re-send the remainder.
                         return false;
                     }
                 } else {
-                    // Don't release the chunk buffer before checking the error —
-                    // for retryable errors (EAGAIN) we need to re-send the same data.
-                    try {
-                        if (ioResult("io_uring write", res) == 0) {
-                            return false;
-                        }
-                    } catch (Throwable cause) {
-                        releaseFileRegionChunkBuf();
-                        handleWriteError(cause);
-                        return true;
+                    // Keep the chunk buffer -- on retryable errors (EAGAIN) ioResult returns 0
+                    // and scheduleWriteFileRegion() will re-submit the same fileRegionChunkBuf
+                    // once POLLOUT fires. On a non-retryable error ioResult throws, and the
+                    // outer catch releases the buffer.
+                    if (ioResult("io_uring write", res) == 0) {
+                        return false;
                     }
                 }
             } catch (Throwable cause) {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -30,7 +30,6 @@ import io.netty.channel.FileRegion;
 import io.netty.channel.IoRegistration;
 import io.netty.channel.socket.DuplexChannel;
 import io.netty.channel.unix.IovArray;
-import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -44,6 +43,13 @@ import static io.netty.channel.unix.Errors.ioResult;
 abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel implements DuplexChannel {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(AbstractIoUringStreamChannel.class);
     private static final ChannelMetadata METADATA = new ChannelMetadata(false, 16);
+
+    /**
+     * Maximum number of bytes to read from a generic {@link FileRegion} per chunk.
+     * This limits memory usage when converting non-{@link DefaultFileRegion} implementations
+     * to {@link ByteBuf} for the io_uring async send path.
+     */
+    private static final int FILE_REGION_MAX_CHUNK_SIZE = 64 * 1024;
 
     // Store the opCode so we know if we used WRITE or WRITEV.
     byte writeOpCode;
@@ -237,45 +243,9 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
         }
 
         if (msg instanceof FileRegion) {
-            // FileRegion not handled above cannot use splice — convert to a direct ByteBuf
-            // via transferTo so it can be sent through the normal io_uring async send path.
-            // Not zero-copy but functionally correct.
-            //
-            // On error paths, don't release region — the caller (AbstractChannel.write)
-            // releases the original msg. On success, we must release it ourselves because
-            // the caller will only see the returned ByteBuf.
-            FileRegion region = (FileRegion) msg;
-            long remaining = region.count() - region.transferred();
-            if (remaining > Integer.MAX_VALUE) {
-                throw new IllegalArgumentException(
-                        "FileRegion too large to convert to ByteBuf: " + remaining + " bytes");
-            }
-            ByteBuf buf = alloc().directBuffer((int) remaining);
-            boolean success = false;
-            try {
-                ByteBufWritableByteChannel channel = new ByteBufWritableByteChannel(buf);
-                long expected = region.count();
-                while (region.transferred() < expected) {
-                    long transferred = region.transferTo(channel, region.transferred());
-                    if (transferred <= 0) {
-                        break;
-                    }
-                }
-                if (region.transferred() < expected) {
-                    throw new ChannelException(
-                            "FileRegion transfer incomplete: expected "
-                            + expected + " bytes, got " + region.transferred());
-                }
-                success = true;
-            } catch (IOException e) {
-                throw new ChannelException("Failed to convert FileRegion to ByteBuf", e);
-            } finally {
-                if (!success) {
-                    buf.release();
-                }
-            }
-            ReferenceCountUtil.safeRelease(region);
-            return buf;
+            // Generic FileRegion — let it pass through to the write path where it will be
+            // converted to ByteBuf in chunks to limit memory usage.
+            return msg;
         }
 
         return super.filterOutboundMessage(msg);
@@ -284,6 +254,10 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
     protected class IoUringStreamUnsafe extends AbstractUringUnsafe {
 
         private ByteBuf readBuffer;
+
+        // Temporary buffer holding a chunk of data read from a generic FileRegion.
+        // Non-null while an async send for a FileRegion chunk is in flight.
+        private ByteBuf fileRegionChunkBuf;
 
         @Override
         protected int scheduleWriteMultiple(ChannelOutboundBuffer in) {
@@ -335,6 +309,48 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                     return 0;
                 }
                 ops = fileRegion.splice(fd);
+            } else if (msg instanceof FileRegion) {
+                // Generic FileRegion: read a chunk into a direct ByteBuf and send it.
+                // If fileRegionChunkBuf is non-null, we are re-sending remaining bytes
+                // from a previous partial send.
+                FileRegion region = (FileRegion) msg;
+                ByteBuf buf = fileRegionChunkBuf;
+                if (buf == null) {
+                    long remaining = region.count() - region.transferred();
+                    if (remaining > 0) {
+                        int chunkSize = (int) Math.min(remaining, FILE_REGION_MAX_CHUNK_SIZE);
+                        buf = alloc().directBuffer(chunkSize);
+                        try {
+                            ByteBufWritableByteChannel ch = new ByteBufWritableByteChannel(buf);
+                            int written = 0;
+                            while (written < chunkSize) {
+                                long t = region.transferTo(ch, region.transferred());
+                                if (t <= 0) {
+                                    break;
+                                }
+                                written += (int) t;
+                            }
+                            if (buf.readableBytes() == 0) {
+                                buf.release();
+                                handleWriteError(new ChannelException(
+                                        "FileRegion transferTo produced 0 bytes"));
+                                return 0;
+                            }
+                        } catch (Exception e) {
+                            buf.release();
+                            handleWriteError(e);
+                            return 0;
+                        }
+                    } else {
+                        // Empty or fully transferred FileRegion — submit a 0-byte send so the
+                        // completion path removes it from the outbound buffer.
+                        buf = alloc().directBuffer(0);
+                    }
+                    fileRegionChunkBuf = buf;
+                }
+                long address = IoUring.memoryAddress(buf) + buf.readerIndex();
+                int length = buf.readableBytes();
+                ops = IoUringIoOps.newSend(fd, (byte) 0, 0, address, length, nextOpsId());
             } else {
                 ByteBuf buf = (ByteBuf) msg;
                 long address = IoUring.memoryAddress(buf) + buf.readerIndex();
@@ -649,6 +665,11 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                 return handleWriteCompleteFileRegion(channelOutboundBuffer, fileRegion, res, data);
             }
 
+            if (current instanceof FileRegion) {
+                return handleWriteCompleteGenericFileRegion(
+                        channelOutboundBuffer, (FileRegion) current, res);
+            }
+
             if (res >= 0) {
                 channelOutboundBuffer.removeBytes(res);
             } else if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
@@ -665,10 +686,62 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
             return true;
         }
 
+        private boolean handleWriteCompleteGenericFileRegion(
+                ChannelOutboundBuffer channelOutboundBuffer, FileRegion region, int res) {
+            try {
+                if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
+                    releaseFileRegionChunkBuf();
+                    return true;
+                }
+                if (res >= 0) {
+                    ByteBuf buf = fileRegionChunkBuf;
+                    assert buf != null;
+                    buf.skipBytes(res);
+                    channelOutboundBuffer.progress(res);
+                    if (!buf.isReadable()) {
+                        // Chunk fully sent — release it and check if the entire FileRegion is done.
+                        releaseFileRegionChunkBuf();
+                        if (region.transferred() >= region.count()) {
+                            channelOutboundBuffer.remove();
+                        }
+                        // Return true so the write loop continues with the next chunk or message.
+                    } else {
+                        // Partial send — remaining bytes still in the chunk buffer.
+                        // Return false to schedule POLLOUT; next write will re-send the remainder.
+                        return false;
+                    }
+                } else {
+                    // Don't release the chunk buffer before checking the error —
+                    // for retryable errors (EAGAIN) we need to re-send the same data.
+                    try {
+                        if (ioResult("io_uring write", res) == 0) {
+                            return false;
+                        }
+                    } catch (Throwable cause) {
+                        releaseFileRegionChunkBuf();
+                        handleWriteError(cause);
+                        return true;
+                    }
+                }
+            } catch (Throwable cause) {
+                releaseFileRegionChunkBuf();
+                handleWriteError(cause);
+            }
+            return true;
+        }
+
+        private void releaseFileRegionChunkBuf() {
+            if (fileRegionChunkBuf != null) {
+                fileRegionChunkBuf.release();
+                fileRegionChunkBuf = null;
+            }
+        }
+
         @Override
         public void unregistered() {
             super.unregistered();
             assert readBuffer == null;
+            releaseFileRegionChunkBuf();
         }
     }
 
@@ -709,7 +782,11 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
 
     /**
      * A {@link WritableByteChannel} that writes into a {@link ByteBuf}.
-     * Used by the generic FileRegion fallback in filterOutboundMessage.
+     * Used by the generic FileRegion fallback to buffer data from
+     * {@link FileRegion#transferTo(WritableByteChannel, long)} before async send.
+     * Writes are capped to the ByteBuf's writable capacity so that
+     * {@code transferTo} cannot overflow the buffer when the FileRegion
+     * has more data remaining than the chunk size.
      */
     private static final class ByteBufWritableByteChannel implements WritableByteChannel {
         private final ByteBuf buf;
@@ -720,9 +797,19 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
 
         @Override
         public int write(ByteBuffer src) {
-            int remaining = src.remaining();
+            int toWrite = Math.min(src.remaining(), buf.writableBytes());
+            if (toWrite == 0) {
+                return 0;
+            }
+            if (toWrite < src.remaining()) {
+                int oldLimit = src.limit();
+                src.limit(src.position() + toWrite);
+                buf.writeBytes(src);
+                src.limit(oldLimit);
+                return toWrite;
+            }
             buf.writeBytes(src);
-            return remaining - src.remaining();
+            return toWrite;
         }
 
         @Override

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -30,6 +30,7 @@ import io.netty.channel.FileRegion;
 import io.netty.channel.IoRegistration;
 import io.netty.channel.socket.DuplexChannel;
 import io.netty.channel.unix.IovArray;
+import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -48,7 +49,8 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
      * Maximum bytes per chunk when converting a generic {@link FileRegion}
      * to {@link ByteBuf} for the io_uring async send path.
      */
-    private static final int FILE_REGION_MAX_CHUNK_SIZE = 64 * 1024;
+    private static final int FILE_REGION_MAX_CHUNK_SIZE =
+            SystemPropertyUtil.getInt("io.netty.iouring.fileRegionChunkSize", 64 * 1024);
 
     // Store the opCode so we know if we used WRITE or WRITEV.
     byte writeOpCode;
@@ -307,46 +309,7 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                 }
                 ops = fileRegion.splice(fd);
             } else if (msg instanceof FileRegion) {
-                // Generic FileRegion: read a chunk into a direct ByteBuf and send it.
-                // Non-null fileRegionChunkBuf means re-sending after a partial send.
-                FileRegion region = (FileRegion) msg;
-                ByteBuf buf = fileRegionChunkBuf;
-                if (buf == null) {
-                    long remaining = region.count() - region.transferred();
-                    if (remaining > 0) {
-                        int chunkSize = (int) Math.min(remaining, FILE_REGION_MAX_CHUNK_SIZE);
-                        buf = alloc().directBuffer(chunkSize);
-                        try {
-                            ByteBufWritableByteChannel ch = new ByteBufWritableByteChannel(buf);
-                            int written = 0;
-                            while (written < chunkSize) {
-                                long t = region.transferTo(ch, region.transferred());
-                                if (t <= 0) {
-                                    break;
-                                }
-                                written += (int) t;
-                            }
-                            if (buf.readableBytes() == 0) {
-                                buf.release();
-                                handleWriteError(new ChannelException(
-                                        "FileRegion transferTo produced 0 bytes"));
-                                return 0;
-                            }
-                        } catch (Exception e) {
-                            buf.release();
-                            handleWriteError(e);
-                            return 0;
-                        }
-                    } else {
-                        // Empty or fully transferred FileRegion — submit a 0-byte send so the
-                        // completion path removes it from the outbound buffer.
-                        buf = alloc().directBuffer(0);
-                    }
-                    fileRegionChunkBuf = buf;
-                }
-                long address = IoUring.memoryAddress(buf) + buf.readerIndex();
-                int length = buf.readableBytes();
-                ops = IoUringIoOps.newSend(fd, (byte) 0, 0, address, length, nextOpsId());
+                return scheduleWriteFileRegion(fd, registration, (FileRegion) msg);
             } else {
                 ByteBuf buf = (ByteBuf) msg;
                 long address = IoUring.memoryAddress(buf) + buf.readerIndex();
@@ -355,6 +318,58 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
 
                 ops = IoUringIoOps.newSend(fd, (byte) 0, 0, address, length, opsid);
             }
+            byte opCode = ops.opcode();
+            writeId = registration.submit(ops);
+            writeOpCode = opCode;
+            if (writeId == 0) {
+                return 0;
+            }
+            return 1;
+        }
+
+        /**
+         * Read a chunk from a generic {@link FileRegion} into a direct {@link ByteBuf} and
+         * submit it as an io_uring async send. If {@code fileRegionChunkBuf} is non-null,
+         * re-sends the remaining bytes from a previous partial send.
+         */
+        private int scheduleWriteFileRegion(int fd, IoRegistration registration, FileRegion region) {
+            ByteBuf buf = fileRegionChunkBuf;
+            if (buf == null) {
+                long remaining = region.count() - region.transferred();
+                if (remaining > 0) {
+                    int chunkSize = (int) Math.min(remaining, FILE_REGION_MAX_CHUNK_SIZE);
+                    buf = alloc().directBuffer(chunkSize);
+                    try {
+                        ByteBufWritableByteChannel ch = new ByteBufWritableByteChannel(buf);
+                        int written = 0;
+                        while (written < chunkSize) {
+                            long t = region.transferTo(ch, region.transferred());
+                            if (t <= 0) {
+                                break;
+                            }
+                            written += (int) t;
+                        }
+                        if (buf.readableBytes() == 0) {
+                            buf.release();
+                            handleWriteError(new ChannelException(
+                                    "FileRegion transferTo produced 0 bytes"));
+                            return 0;
+                        }
+                    } catch (Exception e) {
+                        buf.release();
+                        handleWriteError(e);
+                        return 0;
+                    }
+                } else {
+                    // Empty or fully transferred — submit a 0-byte send so the
+                    // completion path removes it from the outbound buffer.
+                    buf = alloc().directBuffer(0);
+                }
+                fileRegionChunkBuf = buf;
+            }
+            long address = IoUring.memoryAddress(buf) + buf.readerIndex();
+            int length = buf.readableBytes();
+            IoUringIoOps ops = IoUringIoOps.newSend(fd, (byte) 0, 0, address, length, nextOpsId());
             byte opCode = ops.opcode();
             writeId = registration.submit(ops);
             writeOpCode = opCode;

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketFileRegionTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketFileRegionTest.java
@@ -43,7 +43,7 @@ public class IoUringBufferRingSocketFileRegionTest extends SocketFileRegionTest 
 
     @Override
     protected boolean supportsCustomFileRegion() {
-        return false;
+        return true;
     }
 
     //@Disabled("Fix me")

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketFileRegionTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketFileRegionTest.java
@@ -116,6 +116,7 @@ public class IoUringSocketFileRegionTest extends SocketFileRegionTest {
 
         Channel sc = sb.bind().sync().channel();
         Channel cc = cb.connect(sc.localAddress()).sync().channel();
+        boolean ioUringClient = cc instanceof IoUringSocketChannel;
         CountingFileRegion region = new CountingFileRegion(new DefaultFileRegion(
                 new RandomAccessFile(file, "r").getChannel(), 0, payload.length));
         try {
@@ -127,6 +128,10 @@ public class IoUringSocketFileRegionTest extends SocketFileRegionTest {
         }
         assertNull(sh.exception.get());
         assertEquals(payload.length, sh.counter);
+        // Chunking is only exercised when the client uses io_uring -- other transports (e.g. NIO)
+        // hand the FileRegion straight to the socket channel and the kernel's sendfile() transfers
+        // the whole file in a single transferTo call. Skip the chunking assertion for those combos.
+        assumeTrue(ioUringClient, "chunking only applies to io_uring client transport");
         // Skip the chunking assertion if an operator configured a chunk size larger than the
         // payload -- chunking is not exercised in that configuration, but the transfer itself is
         // still validated above.
@@ -160,6 +165,7 @@ public class IoUringSocketFileRegionTest extends SocketFileRegionTest {
 
         Channel sc = sb.bind().sync().channel();
         Channel cc = cb.connect(sc.localAddress()).sync().channel();
+        boolean ioUringClient = cc instanceof IoUringSocketChannel;
         CountingFileRegion firstRegion = new CountingFileRegion(new DefaultFileRegion(
                 new RandomAccessFile(firstFile, "r").getChannel(), 0, firstPayload.length));
         CountingFileRegion secondRegion = new CountingFileRegion(new DefaultFileRegion(
@@ -177,6 +183,8 @@ public class IoUringSocketFileRegionTest extends SocketFileRegionTest {
         assertEquals(combined.length, sh.counter);
         assertTrue(secondRegion.transferToCalls.get() >= 1,
                 "Second region must be transferred too");
+        // Chunking is only exercised when the client uses io_uring -- see testCustomFileRegionChunking.
+        assumeTrue(ioUringClient, "chunking only applies to io_uring client transport");
         assumeTrue(CONFIGURED_CHUNK_SIZE < CHUNKING_REGION_SIZE, "chunk size >= payload; chunking not exercised");
         int minFirstCalls = (firstPayload.length + CONFIGURED_CHUNK_SIZE - 1) / CONFIGURED_CHUNK_SIZE;
         assertTrue(firstRegion.transferToCalls.get() >= minFirstCalls,

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketFileRegionTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketFileRegionTest.java
@@ -41,7 +41,7 @@ public class IoUringSocketFileRegionTest extends SocketFileRegionTest {
 
     @Override
     protected boolean supportsCustomFileRegion() {
-        return false;
+        return true;
     }
 
     //@Disabled("Fix me")

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketFileRegionTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketFileRegionTest.java
@@ -17,17 +17,47 @@ package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.DefaultFileRegion;
+import io.netty.channel.FileRegion;
+import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketFileRegionTest;
+import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.channels.WritableByteChannel;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class IoUringSocketFileRegionTest extends SocketFileRegionTest {
+
+    // Configured chunk size for the io_uring generic FileRegion fallback. Reads and clamps the
+    // same system property the transport does so the test stays accurate if an operator
+    // overrides it (transport caps at 16 MiB and floors at 1).
+    private static final int CONFIGURED_CHUNK_SIZE = Math.min(16 * 1024 * 1024,
+            Math.max(1, Integer.getInteger("io.netty.iouring.fileRegionChunkSize", 64 * 1024)));
+    // With the default 64 KiB chunk size this demands 8 chunks; with an override larger than
+    // the payload chunking simply isn't exercised but the transfer is still validated.
+    private static final int CHUNKING_REGION_SIZE = 512 * 1024;
 
     @BeforeAll
     public static void loadJNI() {
@@ -44,9 +74,258 @@ public class IoUringSocketFileRegionTest extends SocketFileRegionTest {
         return true;
     }
 
-    //@Disabled("Fix me")
     @Test
     public void testFileRegionCountLargerThenFile(TestInfo testInfo) throws Throwable {
         super.testFileRegionCountLargerThenFile(testInfo);
+    }
+
+    @Test
+    public void testCustomFileRegionChunking(TestInfo testInfo) throws Throwable {
+        run(testInfo, new Runner<ServerBootstrap, Bootstrap>() {
+            @Override
+            public void run(ServerBootstrap serverBootstrap, Bootstrap bootstrap) throws Throwable {
+                testCustomFileRegionChunking(serverBootstrap, bootstrap);
+            }
+        });
+    }
+
+    @Test
+    public void testTwoCustomFileRegionsWithChunking(TestInfo testInfo) throws Throwable {
+        run(testInfo, new Runner<ServerBootstrap, Bootstrap>() {
+            @Override
+            public void run(ServerBootstrap serverBootstrap, Bootstrap bootstrap) throws Throwable {
+                testTwoCustomFileRegionsWithChunking(serverBootstrap, bootstrap);
+            }
+        });
+    }
+
+    private static void testCustomFileRegionChunking(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+        byte[] payload = randomBytes(CHUNKING_REGION_SIZE);
+        File file = writeTempFile(payload);
+
+        ReceivingHandler sh = new ReceivingHandler(payload);
+        sb.childOption(ChannelOption.AUTO_READ, true);
+        cb.option(ChannelOption.AUTO_READ, true);
+        sb.childHandler(sh);
+        cb.handler(new SimpleChannelInboundHandler<Object>() {
+            @Override
+            protected void channelRead0(ChannelHandlerContext ctx, Object msg) {
+                // drop
+            }
+        });
+
+        Channel sc = sb.bind().sync().channel();
+        Channel cc = cb.connect(sc.localAddress()).sync().channel();
+        CountingFileRegion region = new CountingFileRegion(new DefaultFileRegion(
+                new RandomAccessFile(file, "r").getChannel(), 0, payload.length));
+        try {
+            cc.writeAndFlush(region).sync();
+            sh.awaitCompletion();
+        } finally {
+            cc.close().sync();
+            sc.close().sync();
+        }
+        assertNull(sh.exception.get());
+        assertEquals(payload.length, sh.counter);
+        // Skip the chunking assertion if an operator configured a chunk size larger than the
+        // payload -- chunking is not exercised in that configuration, but the transfer itself is
+        // still validated above.
+        assumeTrue(CONFIGURED_CHUNK_SIZE < CHUNKING_REGION_SIZE, "chunk size >= payload; chunking not exercised");
+        int minExpectedCalls = (payload.length + CONFIGURED_CHUNK_SIZE - 1) / CONFIGURED_CHUNK_SIZE;
+        assertTrue(region.transferToCalls.get() >= minExpectedCalls,
+                "Expected at least " + minExpectedCalls + " transferTo calls to demonstrate chunking, got "
+                        + region.transferToCalls.get());
+    }
+
+    private static void testTwoCustomFileRegionsWithChunking(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+        byte[] firstPayload = randomBytes(CHUNKING_REGION_SIZE);
+        byte[] secondPayload = randomBytes(4 * 1024);
+        byte[] combined = new byte[firstPayload.length + secondPayload.length];
+        System.arraycopy(firstPayload, 0, combined, 0, firstPayload.length);
+        System.arraycopy(secondPayload, 0, combined, firstPayload.length, secondPayload.length);
+
+        File firstFile = writeTempFile(firstPayload);
+        File secondFile = writeTempFile(secondPayload);
+
+        ReceivingHandler sh = new ReceivingHandler(combined);
+        sb.childOption(ChannelOption.AUTO_READ, true);
+        cb.option(ChannelOption.AUTO_READ, true);
+        sb.childHandler(sh);
+        cb.handler(new SimpleChannelInboundHandler<Object>() {
+            @Override
+            protected void channelRead0(ChannelHandlerContext ctx, Object msg) {
+                // drop
+            }
+        });
+
+        Channel sc = sb.bind().sync().channel();
+        Channel cc = cb.connect(sc.localAddress()).sync().channel();
+        CountingFileRegion firstRegion = new CountingFileRegion(new DefaultFileRegion(
+                new RandomAccessFile(firstFile, "r").getChannel(), 0, firstPayload.length));
+        CountingFileRegion secondRegion = new CountingFileRegion(new DefaultFileRegion(
+                new RandomAccessFile(secondFile, "r").getChannel(), 0, secondPayload.length));
+        try {
+            // Surface any first-write failure immediately instead of waiting on the spin timeout.
+            cc.write(firstRegion).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
+            cc.writeAndFlush(secondRegion).sync();
+            sh.awaitCompletion();
+        } finally {
+            cc.close().sync();
+            sc.close().sync();
+        }
+        assertNull(sh.exception.get());
+        assertEquals(combined.length, sh.counter);
+        assertTrue(secondRegion.transferToCalls.get() >= 1,
+                "Second region must be transferred too");
+        assumeTrue(CONFIGURED_CHUNK_SIZE < CHUNKING_REGION_SIZE, "chunk size >= payload; chunking not exercised");
+        int minFirstCalls = (firstPayload.length + CONFIGURED_CHUNK_SIZE - 1) / CONFIGURED_CHUNK_SIZE;
+        assertTrue(firstRegion.transferToCalls.get() >= minFirstCalls,
+                "Expected at least " + minFirstCalls + " transferTo calls for the first (chunked) region, got "
+                        + firstRegion.transferToCalls.get());
+    }
+
+    private static byte[] randomBytes(int length) {
+        byte[] bytes = new byte[length];
+        ThreadLocalRandom.current().nextBytes(bytes);
+        return bytes;
+    }
+
+    private static File writeTempFile(byte[] data) throws IOException {
+        File file = PlatformDependent.createTempFile("netty-iouring-chunk-", ".tmp", null);
+        file.deleteOnExit();
+        try (FileOutputStream out = new FileOutputStream(file)) {
+            out.write(data);
+        }
+        return file;
+    }
+
+    private static final class ReceivingHandler extends SimpleChannelInboundHandler<ByteBuf> {
+        private final byte[] expected;
+        final AtomicReference<Throwable> exception = new AtomicReference<Throwable>();
+        volatile int counter;
+
+        ReceivingHandler(byte[] expected) {
+            this.expected = expected;
+        }
+
+        @Override
+        protected void channelRead0(ChannelHandlerContext ctx, ByteBuf in) {
+            int readable = in.readableBytes();
+            byte[] actual = new byte[readable];
+            in.readBytes(actual);
+            int offset = counter;
+            if (offset + readable > expected.length) {
+                exception.compareAndSet(null, new AssertionError(
+                        "Received more than " + expected.length + " bytes"));
+                ctx.close();
+                return;
+            }
+            for (int i = 0; i < actual.length; i++) {
+                if (actual[i] != expected[offset + i]) {
+                    exception.compareAndSet(null, new AssertionError(
+                            "Byte mismatch at index " + (offset + i)));
+                    ctx.close();
+                    return;
+                }
+            }
+            counter += readable;
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            exception.compareAndSet(null, cause);
+            ctx.close();
+        }
+
+        void awaitCompletion() throws InterruptedException {
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
+            while (counter < expected.length && exception.get() == null) {
+                if (System.nanoTime() > deadline) {
+                    throw new AssertionError("Timed out waiting for " + expected.length
+                            + " bytes, received " + counter);
+                }
+                Thread.sleep(50);
+            }
+        }
+    }
+
+    /**
+     * Wraps a {@link DefaultFileRegion} so it is routed through the io_uring generic
+     * (non-splice) chunking path and counts {@link #transferTo} invocations so tests can assert
+     * that chunking actually happened.
+     */
+    private static final class CountingFileRegion implements FileRegion {
+        private final FileRegion delegate;
+        final AtomicInteger transferToCalls = new AtomicInteger();
+
+        CountingFileRegion(FileRegion delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public long position() {
+            return delegate.position();
+        }
+
+        @Override
+        @Deprecated
+        public long transfered() {
+            return delegate.transferred();
+        }
+
+        @Override
+        public long transferred() {
+            return delegate.transferred();
+        }
+
+        @Override
+        public long count() {
+            return delegate.count();
+        }
+
+        @Override
+        public long transferTo(WritableByteChannel target, long position) throws IOException {
+            transferToCalls.incrementAndGet();
+            return delegate.transferTo(target, position);
+        }
+
+        @Override
+        public int refCnt() {
+            return delegate.refCnt();
+        }
+
+        @Override
+        public boolean release() {
+            return delegate.release();
+        }
+
+        @Override
+        public boolean release(int decrement) {
+            return delegate.release(decrement);
+        }
+
+        @Override
+        public FileRegion retain() {
+            delegate.retain();
+            return this;
+        }
+
+        @Override
+        public FileRegion retain(int increment) {
+            delegate.retain(increment);
+            return this;
+        }
+
+        @Override
+        public FileRegion touch() {
+            delegate.touch();
+            return this;
+        }
+
+        @Override
+        public FileRegion touch(Object hint) {
+            delegate.touch(hint);
+            return this;
+        }
     }
 }

--- a/transport/src/main/java/io/netty/channel/FileRegion.java
+++ b/transport/src/main/java/io/netty/channel/FileRegion.java
@@ -67,6 +67,12 @@ public interface FileRegion extends ReferenceCounted {
 
     /**
      * Returns the bytes which was transferred already.
+     * <p>
+     * Note: some asynchronous transports (such as the {@code io_uring} transport when falling
+     * back to a chunked send for non-{@link DefaultFileRegion} implementations) advance this
+     * counter when bytes have been queued for submission, which may be before they reach the
+     * peer. If the channel is closed or the write fails after queuing, the reported value may
+     * overstate the number of bytes actually delivered.
      */
     long transferred();
 


### PR DESCRIPTION
## Motivation

`AbstractIoUringStreamChannel` only handles `DefaultFileRegion` (via splice). Any other `FileRegion` implementation hits `UnsupportedOperationException` from the parent's `filterOutboundMessage`.

This is inconsistent with EPOLL and NIO, which accept any `FileRegion` via a `transferTo` fallback. Frameworks like Apache Spark wrap `DefaultFileRegion` inside composite `FileRegion` implementations (e.g., `MessageWithHeader`) that work on NIO and EPOLL but crash on io_uring.

See https://github.com/netty/netty/issues/16570

## Modification

For generic `FileRegion` (non-`DefaultFileRegion` or when splice is unsupported), let it pass through `filterOutboundMessage` into the outbound buffer, then convert it to a direct `ByteBuf` in **64 KB chunks** via `FileRegion.transferTo` in the write path (`scheduleWriteSingle` / `writeComplete0`).

- `DefaultFileRegion` + splice path is unchanged.
- Data is chunked to limit memory usage — each chunk is read via `transferTo` into a capped `ByteBufWritableByteChannel`, then submitted as an io_uring async send.
- Partial sends and EAGAIN preserve the chunk buffer for retry; unrecoverable errors release it and fail the write.
- Empty FileRegions (count = 0) submit a 0-byte send so the completion path can remove them.

Also enabled `testCustomFileRegion` in `IoUringSocketFileRegionTest` and `IoUringBufferRingSocketFileRegionTest`.

## Result

Any `FileRegion` implementation is now writable on io_uring, consistent with EPOLL and NIO.

| Transport | `DefaultFileRegion` | Generic `FileRegion` |
|---|---|---|
| NIO | `FileChannel.transferTo` | `region.transferTo` |
| EPOLL | native sendfile | `region.transferTo` fallback |
| io_uring (before) | splice | **UnsupportedOperationException** |
| io_uring (after) | splice (unchanged) | chunked `transferTo` → ByteBuf → async send |
