### PR TITLE
Include user properties and subscription IDs in MqttProperties#isEmpty

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttProperties.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttProperties.java
@@ -401,7 +401,9 @@ public final class MqttProperties {
 
     public boolean isEmpty() {
         IntObjectHashMap<MqttProperty> props = this.props;
-        return props == null || props.isEmpty();
+        return (props == null || props.isEmpty()) &&
+                (userProperties == null || userProperties.isEmpty()) &&
+                (subscriptionIds == null || subscriptionIds.isEmpty());
     }
 
     /**

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
@@ -659,6 +659,25 @@ public class MqttCodecTest {
     }
 
     @Test
+    public void testPubAckMessageWithUserPropertyAndSuccessForMqtt5() throws Exception {
+        when(versionAttrMock.get()).thenReturn(MqttVersion.MQTT_5);
+
+        MqttProperties props = new MqttProperties();
+        props.add(new MqttProperties.UserProperty("traceId", "abc"));
+        final MqttMessage message = createPubAckMessage((byte) 0, props);
+        ByteBuf byteBuf = MqttEncoder.doEncode(ctx, message);
+
+        mqttDecoder.channelRead(ctx, byteBuf);
+
+        assertEquals(1, out.size());
+
+        final MqttMessage decodedMessage = (MqttMessage) out.get(0);
+        validateFixedHeaders(message.fixedHeader(), decodedMessage.fixedHeader());
+        validatePubReplyVariableHeader((MqttPubReplyMessageVariableHeader) message.variableHeader(),
+                (MqttPubReplyMessageVariableHeader) decodedMessage.variableHeader());
+    }
+
+    @Test
     public void testSubAckMessageForMqtt5() throws Exception {
         MqttProperties props = new MqttProperties();
         props.add(new MqttProperties.IntegerProperty(PAYLOAD_FORMAT_INDICATOR, 6));
@@ -797,6 +816,28 @@ public class MqttCodecTest {
         final MqttMessage message = MqttMessageBuilders.disconnect()
                 .reasonCode((byte) 0) // ok
                 .properties(MqttProperties.NO_PROPERTIES)
+                .build();
+        ByteBuf byteBuf = MqttEncoder.doEncode(ctx, message);
+
+        mqttDecoder.channelRead(ctx, byteBuf);
+
+        assertEquals(1, out.size());
+        final MqttMessage decodedMessage = (MqttMessage) out.get(0);
+        validateFixedHeaders(message.fixedHeader(), decodedMessage.fixedHeader());
+        validateReasonCodeAndPropertiesVariableHeader(
+                (MqttReasonCodeAndPropertiesVariableHeader) message.variableHeader(),
+                (MqttReasonCodeAndPropertiesVariableHeader) decodedMessage.variableHeader());
+    }
+
+    @Test
+    public void testDisconnectMessageWithUserPropertyAndSuccessForMqtt5() throws Exception {
+        when(versionAttrMock.get()).thenReturn(MqttVersion.MQTT_5);
+
+        MqttProperties props = new MqttProperties();
+        props.add(new MqttProperties.UserProperty("traceId", "abc"));
+        final MqttMessage message = MqttMessageBuilders.disconnect()
+                .reasonCode((byte) 0)
+                .properties(props)
                 .build();
         ByteBuf byteBuf = MqttEncoder.doEncode(ctx, message);
 

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttPropertiesTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttPropertiesTest.java
@@ -28,6 +28,8 @@ import static io.netty.handler.codec.mqtt.MqttProperties.PAYLOAD_FORMAT_INDICATO
 import static io.netty.handler.codec.mqtt.MqttProperties.SUBSCRIPTION_IDENTIFIER;
 import static io.netty.handler.codec.mqtt.MqttProperties.USER_PROPERTY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MqttPropertiesTest {
 
@@ -106,6 +108,28 @@ public class MqttPropertiesTest {
         expectedProperties.add(expectedUserProperties);
 
         assertEquals(expectedProperties, props.listAll());
+    }
+
+    @Test
+    public void testIsEmptyWithOnlyUserProperties() {
+        MqttProperties props = new MqttProperties();
+
+        assertTrue(props.isEmpty());
+
+        props.add(new MqttProperties.UserProperty("tag", "firstTag"));
+
+        assertFalse(props.isEmpty());
+    }
+
+    @Test
+    public void testIsEmptyWithOnlySubscriptionIdentifiers() {
+        MqttProperties props = new MqttProperties();
+
+        assertTrue(props.isEmpty());
+
+        props.add(new MqttProperties.IntegerProperty(SUBSCRIPTION_IDENTIFIER, 10));
+
+        assertFalse(props.isEmpty());
     }
 
 }


### PR DESCRIPTION
Motivation:

MqttProperties.isEmpty() only checks the regular property map.

Modification:

Update MqttProperties.isEmpty() so it also considers userProperties and subscriptionIds.

Result:

Fixes #16574
