### PR TITLE
Fix parsing HTTP chunks with multiple extensions

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpChunkLineValidatingByteProcessor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpChunkLineValidatingByteProcessor.java
@@ -108,7 +108,7 @@ final class HttpChunkLineValidatingByteProcessor implements ByteProcessor {
                 new Match(CHUNK_EXT_VAL_QUOTED).chars("\""),
                 new Match(CHUNK_EXT_VAL_TOKEN)
                         .range(0x21, 0x7E)
-                        .chars("(),/:<=>?@[\\]{}", false)),
+                        .chars("(),/:<=>?@[\\]{}\"", false)),
         ChunkExtValQuoted(
                 new Match(CHUNK_EXT_VAL_QUOTED_ESCAPE).chars("\\"),
                 new Match(CHUNK_EXT_VAL_QUOTED_END).chars("\""),
@@ -128,7 +128,7 @@ final class HttpChunkLineValidatingByteProcessor implements ByteProcessor {
         ChunkExtValToken(
                 new Match(CHUNK_EXT_VAL_TOKEN)
                         .range(0x21, 0x7E, true)
-                        .chars("(),/:<=>?@[\\]{}", false),
+                        .chars("(),/:<=>?@[\\]{};", false),
                 new Match(CHUNK_EXT_NAME).chars(";")),
         ;
 
@@ -163,8 +163,16 @@ final class HttpChunkLineValidatingByteProcessor implements ByteProcessor {
     }
 
     public void finish() {
-        if (state != State.Size && state != State.ChunkExtName && state != State.ChunkExtValQuotedEnd) {
-            throw new InvalidChunkExtensionException("Invalid chunk extension");
+        switch (state) {
+            case ChunkExtValQuoted:
+            case ChunkExtValQuotedEscape:
+            case ChunkExtValStart:
+                throw new InvalidChunkExtensionException("Invalid chunk extension");
         }
+        // Exhaustiveness check
+        assert state == State.Size ||
+                state == State.ChunkExtName ||
+                state == State.ChunkExtValQuotedEnd ||
+                state == State.ChunkExtValToken;
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -864,6 +864,35 @@ public class HttpRequestDecoderTest {
     }
 
     @Test
+    void mustParseMultipleChunkExtensionsWithTokenValues() throws Exception {
+        // Regression: the old Match-based state machine had ';' (0x3B) missing from the
+        // exclusion set in ChunkExtValToken, so ';' was treated as a token character
+        // instead of starting a new extension.  This caused valid multi-extension lines
+        // like ";name1=val1;name2=val2" to be rejected with InvalidChunkExtensionException.
+        String requestStr = "GET / HTTP/1.1\r\n" +
+                "Host: localhost\r\n" +
+                "Transfer-Encoding: chunked\r\n\r\n" +
+                "1;name1=val1;name2=val2\r\n" +
+                "Y\r\n" +
+                "0\r\n" +
+                "\r\n";
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
+        HttpRequest request = channel.readInbound();
+        assertFalse(request.decoderResult().isFailure());
+        HttpContent content = channel.readInbound();
+        if (content.decoderResult().isFailure()) {
+            content.decoderResult().cause().printStackTrace();
+        }
+        assertFalse(content.decoderResult().isFailure()); // Must accept valid multi-extension token values.
+        content.release();
+        LastHttpContent last = channel.readInbound();
+        assertEquals(0, last.content().readableBytes());
+        last.release();
+        assertFalse(channel.finish());
+    }
+
+    @Test
     void mustRejectChunkExtensionsWithEscapedLineBreakInQuotedStrings() throws Exception {
         // See full explanation: https://w4ke.info/2025/10/29/funky-chunks-2.html
         String requestStr = "GET /one HTTP/1.1\r\n" +

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
@@ -1180,6 +1180,32 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
+    void mustParseMultipleChunkExtensionsWithTokenValues() throws Exception {
+        // Regression: the old Match-based state machine had ';' (0x3B) missing from the
+        // exclusion set in ChunkExtValToken, so ';' was treated as a token character
+        // instead of starting a new extension.  This caused valid multi-extension lines
+        // like ";name1=val1;name2=val2" to be rejected with InvalidChunkExtensionException.
+        String responseStr = "HTTP/1.1 200 OK\r\n" +
+                "Transfer-Encoding: chunked\r\n" +
+                "\r\n" +
+                "1;name1=val1;name2=val2\r\n" +
+                "Y\r\n" +
+                "0\r\n" +
+                "\r\n";
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseDecoder());
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(responseStr, CharsetUtil.US_ASCII)));
+        HttpResponse response = channel.readInbound();
+        assertFalse(response.decoderResult().isFailure());
+        HttpContent content = channel.readInbound();
+        assertFalse(content.decoderResult().isFailure()); // Must accept valid multi-extension token values.
+        content.release();
+        LastHttpContent last = channel.readInbound();
+        assertEquals(0, last.content().readableBytes());
+        last.release();
+        assertFalse(channel.finish());
+    }
+
+    @Test
     void mustRejectChunkExtensionsWithEscapedLineBreakInQuotedStrings() throws Exception {
         // See full explanation: https://w4ke.info/2025/10/29/funky-chunks-2.html
         String responseStr = "HTTP/1.1 200 OK\r\n" +


### PR DESCRIPTION
Motivation:
The chunk extension parsing/validation logic did not correctly account for extensions with multiple key-value pairs.

Modification:
- Adapt parsing logic to accept the repeatability of extension key-value pairs, and that chunk extensions can end on unquoted value tokens.
- Add tests to capture these cases.

Result:
More correct HTTP chunk extension parsing.

The tests are lifted from https://github.com/netty/netty/pull/16542