### PR TITLE
IoUring: Disable test while we debug to unblock other builds

### DIFF
--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketFdTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketFdTest.java
@@ -27,6 +27,7 @@ import io.netty.channel.unix.FileDescriptor;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.AbstractSocketTest;
 import io.netty.util.ReferenceCountUtil;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
@@ -53,6 +54,7 @@ public class IoUringDomainSocketFdTest extends AbstractSocketTest {
         return IoUringSocketTestPermutation.INSTANCE.domainSocket();
     }
 
+    @Disabled
     @Test
     @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
     public void testSendRecvFd(TestInfo testInfo) throws Throwable {


### PR DESCRIPTION
Motivation:

This test started to fail all the time on our CI and so affects any CI build. Let's disable it while we investigate to unblock other PRs.

Modification:

Disable test temporary

Result:

CI pass again for other PRs