### PR TITLE
Epoll: Cleanup code to always return negative value on failure

### DIFF
--- a/transport-native-epoll/src/main/c/netty_epoll_native.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_native.c
@@ -243,7 +243,7 @@ static jint netty_epoll_native_epollCreate(JNIEnv* env, jclass clazz) {
             int err = errno;
             close(efd);
             netty_unix_errors_throwChannelExceptionErrorNo(env, "fcntl() failed: ", err);
-            return err;
+            return -err;
         }
     }
     return efd;


### PR DESCRIPTION
Motivation:

We usually use a negative value in case of an error but did not in one case. While this does not really matters in practise as weput an exception on the call stack we should be consistent.

Modifications:

Return negative value on fcntl failure

Result:

More consistent code base
