### PR TITLE
Native transports: Correctly create pipe when pipe2 is not supported

### DIFF
--- a/transport-native-unix-common/src/main/c/netty_unix_filedescriptor.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_filedescriptor.c
@@ -244,13 +244,16 @@ static jlong netty_unix_filedescriptor_newPipe(JNIEnv* env, jclass clazz) {
         }
     } else {
          if (pipe(fd) == 0) {
-            if (fcntl(fd[0], F_SETFD, O_NONBLOCK) < 0) {
+            // Read current flags and OR-ing in O_NONBLOCK to preserve old flags as well.
+            int flags0 = fcntl(fd[0], F_GETFL, 0);
+            if (flags0 < 0 || fcntl(fd[0], F_SETFL, flags0 | O_NONBLOCK) < 0) {
                 int err = errno;
                 close(fd[0]);
                 close(fd[1]);
                 return -err;
             }
-            if (fcntl(fd[1], F_SETFD, O_NONBLOCK) < 0) {
+            int flags1 = fcntl(fd[1], F_GETFL, 0);
+            if (flags1 < 0 || fcntl(fd[1], F_SETFL, flags1 | O_NONBLOCK) < 0) {
                 int err = errno;
                 close(fd[0]);
                 close(fd[1]);


### PR DESCRIPTION
Motivation:

We incorrectly used F_SETFD to try to set the fd to non blocking when pipe2 is not supported. This is not correct as we need to use F_SETFL.

Modifications:

- Get current flags and add O_NONBLOCK via F_SETFL

Result:

Pipe is correctly set to non blocking mode even if pipe2 is not supported
