### PR TITLE
Revert to PR build to Ubuntu 22.04 

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -39,7 +39,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -38,7 +38,7 @@ concurrency:
 
 jobs:
   stage-snapshot-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:
@@ -191,7 +191,7 @@ jobs:
           include-hidden-files: true
 
   deploy-staged-snapshots:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # Wait until we have staged everything
     needs: [ stage-snapshot-linux, stage-snapshot-windows-x86_64, stage-snapshot-macos ]
     steps:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -36,7 +36,7 @@ concurrency:
 
 jobs:
   verify-pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 11
@@ -133,7 +133,7 @@ jobs:
 
   build-pr-cross:
     # The host should always be Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -188,7 +188,7 @@ jobs:
             JAVA_HOME=/usr/lib/jvm/java-11-openjdk-${{ matrix.java_arch || matrix.arch }} ./mvnw -V -B -ntp -pl testsuite-native -am clean package -DskipTests=true -Dcheckstyle.skip=true -DskipNativeTestsuite=false -Dtcnative.classifier=
 
   build-pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-release-4.2.yml
+++ b/.github/workflows/ci-release-4.2.yml
@@ -33,7 +33,7 @@ concurrency:
 
 jobs:
   prepare-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -85,7 +85,7 @@ jobs:
           include-hidden-files: true
 
   stage-release-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: prepare-release
     strategy:
       matrix:
@@ -367,7 +367,7 @@ jobs:
         run: ./.github/scripts/release_rollback.ps1 release.properties netty/netty 4.2
 
   deploy-staged-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # Wait until we have staged everything
     needs: [ stage-release-linux, stage-release-macos, stage-release-windows]
     steps:

--- a/.github/workflows/ci-verify-load.yml
+++ b/.github/workflows/ci-verify-load.yml
@@ -36,7 +36,7 @@ concurrency:
 
 jobs:
   install-jars-linux-aarch64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -66,7 +66,7 @@ jobs:
 
   load-native-linux-aarch64:
     # The host should always be Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [ install-jars-linux-aarch64 ]
     steps:
       - uses: actions/checkout@v4

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketFdTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketFdTest.java
@@ -27,7 +27,6 @@ import io.netty.channel.unix.FileDescriptor;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.AbstractSocketTest;
 import io.netty.util.ReferenceCountUtil;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
@@ -54,7 +53,6 @@ public class IoUringDomainSocketFdTest extends AbstractSocketTest {
         return IoUringSocketTestPermutation.INSTANCE.domainSocket();
     }
 
-    @Disabled
     @Test
     @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
     public void testSendRecvFd(TestInfo testInfo) throws Throwable {


### PR DESCRIPTION
Motivation:
The "ubuntu-latest" recently got upgraded to Ubuntu 24.04.4 (from 24.04.3) which introduced the bug described in https://github.com/axboe/liburing/issues/1509 but did not bring the fix.
This breaks our io_uring tests.
The kernel version used in the ubuntu-latest build runners for 24.04.4 is 6.17.0-1008-azure.

Modification:
Revert PR build, normal build, and release builds to instead use ubuntu-22.04 build images, which are based on Ubuntu 22.04.5 and use the kernel 6.8.0-1044-azure.

Result:
The build should pass, but more tests might be disabled because they rely on features not supported on this older kernel version.