### PR TITLE
Revert to PR build to Ubuntu 22.04  (#16595)

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -39,7 +39,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -38,7 +38,7 @@ concurrency:
 
 jobs:
   stage-snapshot:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:
@@ -82,7 +82,7 @@ jobs:
           include-hidden-files: true
 
   deploy-staged-snapshots:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # Wait until we have staged everything
     needs: stage-snapshot
     steps:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -36,7 +36,7 @@ concurrency:
 
 jobs:
   verify-pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 25
@@ -137,7 +137,7 @@ jobs:
   build-pr-aarch64:
     name: linux-aarch64-verify-native
     # The host should always be Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read  # for actions/checkout to fetch code
       packages: write  # for uraimo/run-on-arch-action to cache docker images
@@ -189,7 +189,7 @@ jobs:
             JAVA_HOME=/usr/lib/jvm/zulu25 ./mvnw -B -ntp -pl testsuite-native -am clean package -Pboringssl -DskipTests=true -Dcheckstyle.skip=true -DskipNativeTestsuite=false -Dtcnative.classifier=
 
   build-pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-release-4.2.yml
+++ b/.github/workflows/ci-release-4.2.yml
@@ -33,7 +33,7 @@ concurrency:
 
 jobs:
   prepare-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -85,7 +85,7 @@ jobs:
           include-hidden-files: true
 
   stage-release-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: prepare-release
     strategy:
       matrix:
@@ -367,7 +367,7 @@ jobs:
         run: ./.github/scripts/release_rollback.ps1 release.properties netty/netty 4.2
 
   deploy-staged-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # Wait until we have staged everything
     needs: [ stage-release-linux, stage-release-macos, stage-release-windows]
     steps:


### PR DESCRIPTION
Motivation:
The "ubuntu-latest" recently got upgraded to Ubuntu 24.04.4 (from 24.04.3) which introduced the bug described in
https://github.com/axboe/liburing/issues/1509 but did not bring the fix. This breaks our io_uring tests.
The kernel version used in the ubuntu-latest build runners for 24.04.4 is 6.17.0-1008-azure.

Modification:
Revert PR build, normal build, and release builds to instead use ubuntu-22.04 build images, which are based on Ubuntu 22.04.5 and use the kernel 6.8.0-1044-azure.

Result:
The build should pass, but more tests might be disabled because they rely on features not supported on this older kernel version.

(cherry picked from commit ef1d588613ba34090d4cb0e7b994bb859801988a)