### PR TITLE
Fix component search fast path (#16548)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -1701,7 +1701,7 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
         int cc = componentCount;
         for (int next = lastAccessedIndex + 1; next < cc; next++) {
             Component c = components[next];
-            if (c.endOffset > c.offset) {
+            if (offset < c.endOffset) {
                 lastAccessed = c;
                 lastAccessedIndex = next;
                 return c;

--- a/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
@@ -1855,4 +1855,27 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
         }
     }
 
+    @Test
+    public void testFindComponent() {
+        CompositeByteBuf composite = newCompositeBuffer();
+
+        ByteBuf b1 = newBuffer(10);
+        b1.writeByte('a');
+        composite.addComponent(true, b1);
+
+        ByteBuf b2 = newBuffer(10);
+        b2.writeByte('b');
+        composite.addComponent(true, b2);
+
+        ByteBuf b3 = newBuffer(10);
+        b3.writeByte('c');
+        composite.addComponent(true, b3);
+
+        assertEquals('a', composite.readByte());
+        composite.skipBytes(1);
+        assertEquals('c', composite.readByte());
+
+        composite.release();
+    }
+
 }


### PR DESCRIPTION
Motivation:

In certain scenarios, the findComponentForRead fast path would pick the wrong component for a reader index, leading to out-of-bounds reads for those components.

Modification:

Correct comparison.

Result:

No incorrect read.

---------

Co-authored-by: Chris Vest <christianvest_hansen@apple.com>
Co-authored-by: Norman Maurer <norman_maurer@apple.com>

(cherry picked from commit 59aec4b4dc61d3aeb6393d51a7155ef452fb29ee)