### PR TITLE
 fix FFM address semantics in directBufferAddress

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -802,7 +802,9 @@ final class PlatformDependent0 {
         }
         if (hasMemorySegmentAddressOfBuffer()) {
             try {
-                return (long) MEMORY_SEGMENT_ADDRESS_OF_BUFFER.invokeExact((Buffer) buffer);
+                // MemorySegment.ofBuffer(buffer).address() includes the current position offset.
+                // Netty/JNI GetDirectBufferAddress expects the base (index 0) address, so subtract position.
+                return (long) MEMORY_SEGMENT_ADDRESS_OF_BUFFER.invokeExact((Buffer) buffer) - buffer.position();
             } catch (Throwable e) {
                 LinkageError error = new LinkageError("Failed to call MemorySegment.ofBuffer(arg1).address()");
                 error.initCause(e);

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/Buffer.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/Buffer.java
@@ -62,7 +62,7 @@ public final class Buffer {
      */
     public static long memoryAddress(ByteBuffer buffer) {
         assert buffer.isDirect();
-        if (PlatformDependent.hasUnsafe()) {
+        if (PlatformDependent.hasDirectByteBufferAddress(buffer)) {
             return PlatformDependent.directBufferAddress(buffer);
         }
         return memoryAddress0(buffer);


### PR DESCRIPTION
Motivation:

- Unnecessary JNI fallback
  When `Unsafe` is disabled or unavailable, but the JDK provides a usable FFM (Foreign Function & Memory) API, the existing code still falls back to JNI to obtain the address of a direct `ByteBuffer`.

- Incorrect FFM semantics in `PlatformDependent0#directBufferAddress`  
  The `Unsafe` branch returns the **base address** of the direct buffer (index 0), consistent with JNI `GetDirectBufferAddress`.  
  However, the FFM branch uses `MemorySegment.ofBuffer(buffer).address()`, which effectively returns `baseAddress + position`.  
  This leads to inconsistent semantics between the FFM and Unsafe/JNI implementations.

``` java
        ByteBuffer byteBuffer = ByteBuffer.allocateDirect(1024);

        //ffm api
        System.out.println(PlatformDependent.directBufferAddress(byteBuffer));
        // jni
        System.out.println(Buffer.memoryAddress(byteBuffer));

        byteBuffer = byteBuffer.position(16);
        System.out.println(PlatformDependent.directBufferAddress(byteBuffer));
        System.out.println(Buffer.memoryAddress(byteBuffer));
```

On Java 25 and Netty 4.2.12.Final, this code prints:
```
129502193232224
129502193232224
129502193232240
129502193232224
```

The third line reflects baseAddress + 16, demonstrating that the FFM path is position-dependent, while the JNI path remains position-independent.

Modification:

- Prefer the FFM/JVM path when `Unsafe` is unavailable but FFM is available, avoiding the JNI fallback.  
- Fix the FFM branch to return the same **base-address semantics** as the Unsafe/JNI paths (i.e., position-independent).


Result:

 fix FFM address semantics in directBufferAddress
