### PR TITLE
Remove note about needing 256-bit for PQC

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/PkiTestingTlsTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/PkiTestingTlsTest.java
@@ -40,7 +40,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -157,15 +156,10 @@ public class PkiTestingTlsTest {
                 .subject("CN=localhost")
                 .buildSelfSigned();
 
-        // Disable 128-bit ciphers so only 256-bit ciphers remain.
-        String[] ciphers = {"TLS_AES_256_GCM_SHA384",
-                            "TLS_CHACHA20_POLY1305_SHA256"};
-
         String[] groups = new String[]{"X25519MLKEM768"};
         SslContextBuilder serverBuilder = SslContextBuilder.forServer(cert.toKeyManagerFactory())
                 .sslProvider(SslProvider.OPENSSL)
-                .protocols("TLSv1.3")
-                .ciphers(Arrays.asList(ciphers));
+                .protocols("TLSv1.3");
 
         if (!configureViaParameter) {
             serverBuilder.option(OpenSslContextOption.GROUPS, groups.clone());
@@ -176,8 +170,7 @@ public class PkiTestingTlsTest {
                 .trustManager(cert.toTrustManagerFactory())
                 .sslProvider(SslProvider.OPENSSL)
                 .serverName(new SNIHostName("localhost"))
-                .protocols("TLSv1.3")
-                .ciphers(Arrays.asList(ciphers));
+                .protocols("TLSv1.3");
 
         if (!configureViaParameter) {
             clientBuilder.option(OpenSslContextOption.GROUPS, groups.clone());


### PR DESCRIPTION
Motivation:
In the test for hybrid-post-quantum key agreement, we had a comment that 128-bit symmetric ciphers should also be disabled to be quantum safe.

The general consensus among cryptographers is now that this is an unnecessary overreaction, and that 128-bit symmetric ciphers are perfectly fine and safe against cryptographically relevant quantum computers.

The reason is that Grover's algorithm (the main threat to symmetric ciphers) is not parallelizable, hasn't seen any significant optimizations (rather, proofs have been created showing that it is optimal), and is on its own not enough to make any meaningful dent in the security of symmetric ciphers.

See for instance Filipo Valsoda's April 6, 2026 blog post: https://words.filippo.io/crqc-timeline/

Another reason for removing the configuration of ciphers is that BoringSSL actually ignores the configured cipher suite. So when using BoringSSL the ciphers weren't actually disabled anyway.

Modification:
Remove the configuration of ciphers from the `connectWithX25519MLKEM768` test.

Result:
More realistic looking test, based on our most recent knowledge of PQC.