### PR TITLE
Stabilize read-only toStringMultipleThreads1

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
@@ -581,7 +581,7 @@ public class ReadOnlyDirectByteBufferBufTest {
     }
 
     @Test
-    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(30)
     public void testToStringMultipleThreads1() throws Throwable {
         String expected = "Hello, World!";
         byte[] bytes = expected.getBytes(CharsetUtil.ISO_8859_1);


### PR DESCRIPTION
Motivation:
In https://github.com/netty/netty/pull/16380 we increased the timeout of this test. However, `ReadOnlyDirectByteBufTest` does not inherit from AbstractBtyeBufTest and instead has its own version. We did not increase the timeout of this version.

Modification:
Increase the timeout of the read-only ByteBuf version of the test, to match what we use for all other buffer types.

Result:
More stable build.
