### PR TITLE
Stabilize more AbstractByteBufTests

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
@@ -2731,6 +2731,7 @@ public abstract class AbstractByteBufTest {
     }
 
     @Test
+    @Timeout(30)
     public void testDuplicateReadGatheringByteChannelMultipleThreads() throws Exception {
         final byte[] bytes = new byte[8];
         random.nextBytes(bytes);
@@ -2745,6 +2746,7 @@ public abstract class AbstractByteBufTest {
     }
 
     @Test
+    @Timeout(30)
     public void testSliceReadGatheringByteChannelMultipleThreads() throws Exception {
         final byte[] bytes = new byte[8];
         random.nextBytes(bytes);
@@ -2795,11 +2797,12 @@ public abstract class AbstractByteBufTest {
                 }
             }).start();
         }
-        latch.await(10, TimeUnit.SECONDS);
+        latch.await();
         barrier.await(5, TimeUnit.SECONDS);
     }
 
     @Test
+    @Timeout(30)
     public void testDuplicateReadOutputStreamMultipleThreads() throws Exception {
         final byte[] bytes = new byte[8];
         random.nextBytes(bytes);
@@ -2814,6 +2817,7 @@ public abstract class AbstractByteBufTest {
     }
 
     @Test
+    @Timeout(30)
     public void testSliceReadOutputStreamMultipleThreads() throws Exception {
         final byte[] bytes = new byte[8];
         random.nextBytes(bytes);
@@ -2863,7 +2867,7 @@ public abstract class AbstractByteBufTest {
                 }
             }).start();
         }
-        latch.await(10, TimeUnit.SECONDS);
+        latch.await();
         barrier.await(5, TimeUnit.SECONDS);
     }
 

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
@@ -491,6 +491,7 @@ public class ReadOnlyDirectByteBufferBufTest {
     }
 
     @Test
+    @Timeout(30)
     public void testDuplicateReadGatheringByteChannelMultipleThreads() throws Exception {
         final byte[] bytes = new byte[8];
         ThreadLocalRandom.current().nextBytes(bytes);
@@ -506,6 +507,7 @@ public class ReadOnlyDirectByteBufferBufTest {
     }
 
     @Test
+    @Timeout(30)
     public void testSliceReadGatheringByteChannelMultipleThreads() throws Exception {
         final byte[] bytes = new byte[8];
         ThreadLocalRandom.current().nextBytes(bytes);
@@ -521,6 +523,7 @@ public class ReadOnlyDirectByteBufferBufTest {
     }
 
     @Test
+    @Timeout(30)
     public void testDuplicateReadOutputStreamMultipleThreads() throws Exception {
         final byte[] bytes = new byte[8];
         ThreadLocalRandom.current().nextBytes(bytes);
@@ -536,6 +539,7 @@ public class ReadOnlyDirectByteBufferBufTest {
     }
 
     @Test
+    @Timeout(30)
     public void testSliceReadOutputStreamMultipleThreads() throws Exception {
         final byte[] bytes = new byte[8];
         ThreadLocalRandom.current().nextBytes(bytes);


### PR DESCRIPTION
Motivation:
We have a mix of different timeout approaches going on. We should settle on 30+ seconds minimum, because on busy CI runners it can take seconds to start new threads.

Modification:
Make some test barrier awaits unbounded and instead rely on `@Timeout` annotations on the tests. Increase the timeouts to 30 seconds, from 10.

Result:
More stable build.
