### PR TITLE
Make LocalIoHandle public

### DIFF
--- a/transport/src/main/java/io/netty/channel/local/LocalIoHandle.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalIoHandle.java
@@ -20,6 +20,6 @@ import io.netty.channel.IoHandle;
 /**
  * {@link IoHandle} sub-type that is used by the local transport internally.
  */
-interface LocalIoHandle extends IoHandle {
+public interface LocalIoHandle extends IoHandle {
     void closeNow();
 }


### PR DESCRIPTION
Motivation:

LocalIoHandle is not public, unlike all the other sub-interfaces of IoHandle, which makes it difficult to wrap instances

Modification:

Made LocalIoHandle public

Result:

Fixes #16593
