### PR TITLE
Quic: Correctly handle SSL_CTX_new failures

### DIFF
--- a/codec-native-quic/src/main/c/netty_quic_boringssl.c
+++ b/codec-native-quic/src/main/c/netty_quic_boringssl.c
@@ -1057,6 +1057,9 @@ static jlong netty_boringssl_SSLContext_new0(JNIEnv* env, jclass clazz, jboolean
     }
 
     ctx = SSL_CTX_new(TLS_with_buffers_method());
+    if (ctx == NULL) {
+        goto error;
+    }
     // When using BoringSSL we want to use CRYPTO_BUFFER to reduce memory usage and minimize overhead as we do not need
     // X509* at all and just need the raw bytes of the certificates to construct our Java X509Certificate.
     //


### PR DESCRIPTION
Motivation:

We did miss a NULL check which is needed to handle SSL_CTX_new failures.

Modifications:

Add missing NULL check

Result:

Correctly handle SSL_CTX_new failures
