### PR TITLE
Quic: Fix shadowing of variable which leads to incorrectly handling errors

### DIFF
--- a/codec-native-quic/src/main/c/netty_quic_boringssl.c
+++ b/codec-native-quic/src/main/c/netty_quic_boringssl.c
@@ -1111,7 +1111,7 @@ static jlong netty_boringssl_SSLContext_new0(JNIEnv* env, jclass clazz, jboolean
 
     if (alpn_protos != NULL) {
         int alpn_length = (*env)->GetArrayLength(env, alpn_protos);
-        alpn_data* alpn = (alpn_data*) OPENSSL_malloc(sizeof(alpn_data));
+        alpn = (alpn_data*) OPENSSL_malloc(sizeof(alpn_data));
         if (alpn != NULL) {
             // Fill the alpn_data struct
             alpn->proto_data = OPENSSL_malloc(alpn_length);


### PR DESCRIPTION
Motivation:

We re-delcared the alpn variable and so shadowed the outer variable which lead to not correctly handle freeing of memory in some error cases.

Modifications:

Remove shadowing

Result:

Correctly be able to free memory on error
