### PR TITLE
Fix `shutdownInput` bug in kqueue for empty recv buffer

### DIFF
--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
@@ -563,7 +563,7 @@ public abstract class AbstractKQueueStreamChannel extends AbstractKQueueChannel 
                 allocHandle.readComplete();
                 pipeline.fireChannelReadComplete();
 
-                if (close) {
+                if (close || allocHandle.isReadEOF()) {
                     shutdownInput(false);
                 }
             } catch (Throwable t) {

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueRecvByteAllocatorHandle.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueRecvByteAllocatorHandle.java
@@ -65,12 +65,16 @@ final class KQueueRecvByteAllocatorHandle extends DelegatingHandle implements Ex
         readEOF = true;
     }
 
+    boolean isReadEOF() {
+        return readEOF;
+    }
+
     void numberBytesPending(long numberBytesPending) {
         this.numberBytesPending = numberBytesPending;
     }
 
     private boolean maybeMoreDataToRead() {
-        /**
+        /*
          * kqueue with EV_CLEAR flag set requires that we read until we consume "data" bytes
          * (see <a href="https://www.freebsd.org/cgi/man.cgi?kqueue">kqueue man</a>). However in order to
          * respect auto read we supporting reading to stop if auto read is off. If auto read is on we force reading to


### PR DESCRIPTION
Motivation:
In kqueue, if we've received and `RDHUB` and an `EVFILTER_READ`, but we've already drained the receive buffer, then there's a possibility that the read call returns `EAGAIN` and we read _zero_ bytes. In that case, `close` won't be set to `true` and we're not going to get more `EVFILTER_READ` events, and thus we won't be calling `shutdownInput`.

Modification:
Call `shutdownInput` if the `allocHandle` has received EOF (i.e. `RDHUB`). This is safe `allocHandle.continueReading()` will always return `true` in this state, and thus we're guaranteed to drain the receive buffer.

Result:
No more rare half-closure related stalls in kqueue, as seen by the flaky `KQueueETSocketHalfClosedTest` test.