### PR TITLE
Add maxFrameLength support to ProtobufVarint32FrameDecoder

### DIFF
--- a/codec-protobuf/src/main/java/io/netty/handler/codec/protobuf/ProtobufVarint32FrameDecoder.java
+++ b/codec-protobuf/src/main/java/io/netty/handler/codec/protobuf/ProtobufVarint32FrameDecoder.java
@@ -63,8 +63,7 @@ public class ProtobufVarint32FrameDecoder extends ByteToMessageDecoder {
      *                       {@link TooLongFrameException} will be thrown.
      */
     public ProtobufVarint32FrameDecoder(int maxFrameLength) {
-        checkPositive(maxFrameLength, "maxFrameLength");
-        this.maxFrameLength = maxFrameLength;
+        this.maxFrameLength = checkPositive(maxFrameLength, "maxFrameLength");
     }
 
     @Override

--- a/codec-protobuf/src/main/java/io/netty/handler/codec/protobuf/ProtobufVarint32FrameDecoder.java
+++ b/codec-protobuf/src/main/java/io/netty/handler/codec/protobuf/ProtobufVarint32FrameDecoder.java
@@ -21,8 +21,11 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.CorruptedFrameException;
+import io.netty.handler.codec.TooLongFrameException;
 
 import java.util.List;
+
+import static io.netty.util.internal.ObjectUtil.checkPositive;
 
 /**
  * A decoder that splits the received {@link ByteBuf}s dynamically by the
@@ -42,12 +45,38 @@ import java.util.List;
  */
 public class ProtobufVarint32FrameDecoder extends ByteToMessageDecoder {
 
-    // TODO maxFrameLength + safe skip + fail-fast option
-    //      (just like LengthFieldBasedFrameDecoder)
+    private final int maxFrameLength;
+    private long bytesToDiscard;
+
+    /**
+     * Creates a new instance with no frame length limit.
+     */
+    public ProtobufVarint32FrameDecoder() {
+        this(Integer.MAX_VALUE);
+    }
+
+    /**
+     * Creates a new instance with the specified maximum frame length.
+     *
+     * @param maxFrameLength the maximum length of the frame.
+     *                       If the length exceeds this value,
+     *                       {@link TooLongFrameException} will be thrown.
+     */
+    public ProtobufVarint32FrameDecoder(int maxFrameLength) {
+        checkPositive(maxFrameLength, "maxFrameLength");
+        this.maxFrameLength = maxFrameLength;
+    }
 
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out)
             throws Exception {
+        if (bytesToDiscard > 0) {
+            int localBytesToDiscard = (int) Math.min(bytesToDiscard, in.readableBytes());
+            in.skipBytes(localBytesToDiscard);
+            bytesToDiscard -= localBytesToDiscard;
+            return;
+        }
+
         in.markReaderIndex();
         int preIndex = in.readerIndex();
         int length = readRawVarint32(in);
@@ -56,6 +85,19 @@ public class ProtobufVarint32FrameDecoder extends ByteToMessageDecoder {
         }
         if (length < 0) {
             throw new CorruptedFrameException("negative length: " + length);
+        }
+
+        if (length > maxFrameLength) {
+            long discard = length - in.readableBytes();
+            if (discard <= 0) {
+                in.skipBytes(length);
+            } else {
+                bytesToDiscard = discard;
+                in.skipBytes(in.readableBytes());
+            }
+            throw new TooLongFrameException(
+                    "Frame length exceeds " + maxFrameLength
+                    + ": " + length);
         }
 
         if (in.readableBytes() < length) {

--- a/codec-protobuf/src/test/java/io/netty/handler/codec/protobuf/ProtobufVarint32FrameDecoderTest.java
+++ b/codec-protobuf/src/test/java/io/netty/handler/codec/protobuf/ProtobufVarint32FrameDecoderTest.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.protobuf;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.TooLongFrameException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -25,6 +26,7 @@ import static io.netty.buffer.Unpooled.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ProtobufVarint32FrameDecoderTest {
@@ -75,6 +77,69 @@ public class ProtobufVarint32FrameDecoderTest {
         ByteBuf actual = ch.readInbound();
         assertEquals(expected, actual);
         assertFalse(ch.finish());
+
+        expected.release();
+        actual.release();
+    }
+
+    @Test
+    public void testFrameWithinMaxFrameLength() {
+        EmbeddedChannel channel = new EmbeddedChannel(new ProtobufVarint32FrameDecoder(10));
+        byte[] b = { 4, 1, 1, 1, 1 };
+        assertTrue(channel.writeInbound(wrappedBuffer(b)));
+
+        ByteBuf expected = wrappedBuffer(new byte[] { 1, 1, 1, 1 });
+        ByteBuf actual = channel.readInbound();
+        assertEquals(expected, actual);
+        assertFalse(channel.finish());
+
+        expected.release();
+        actual.release();
+    }
+
+    @Test
+    public void testFrameExceedingMaxFrameLength() {
+        EmbeddedChannel channel = new EmbeddedChannel(new ProtobufVarint32FrameDecoder(3));
+        byte[] b = { 4, 1, 1, 1, 1 };
+        assertThrows(TooLongFrameException.class, () -> channel.writeInbound(wrappedBuffer(b)));
+        assertNull(channel.readInbound());
+        assertFalse(channel.finish());
+    }
+
+    @Test
+    public void testOversizedFramePartialDiscard() {
+        EmbeddedChannel channel = new EmbeddedChannel(new ProtobufVarint32FrameDecoder(3));
+
+        // Frame with length=10, only send length byte + 5 data bytes
+        byte[] partial = { 10, 1, 2, 3, 4, 5 };
+        assertThrows(TooLongFrameException.class, () -> channel.writeInbound(wrappedBuffer(partial)));
+
+        // Send remaining 5 bytes — should be silently discarded
+        byte[] remaining = { 6, 7, 8, 9, 10 };
+        assertFalse(channel.writeInbound(wrappedBuffer(remaining)));
+        assertNull(channel.readInbound());
+        assertFalse(channel.finish());
+    }
+
+    @Test
+    public void testValidFrameAfterOversized() {
+        EmbeddedChannel channel = new EmbeddedChannel(new ProtobufVarint32FrameDecoder(5));
+
+        // Oversized frame: length=10, all data present
+        byte[] oversized = new byte[11];
+        oversized[0] = 10;
+        for (int i = 1; i <= 10; i++) {
+            oversized[i] = (byte) i;
+        }
+        assertThrows(TooLongFrameException.class, () -> channel.writeInbound(wrappedBuffer(oversized)));
+
+        // Valid frame after recovery
+        byte[] valid = { 3, 10, 20, 30 };
+        assertTrue(channel.writeInbound(wrappedBuffer(valid)));
+        ByteBuf expected = wrappedBuffer(new byte[] { 10, 20, 30 });
+        ByteBuf actual = channel.readInbound();
+        assertEquals(expected, actual);
+        assertFalse(channel.finish());
 
         expected.release();
         actual.release();


### PR DESCRIPTION
## Motivation

`ProtobufVarint32FrameDecoder` has no protection against oversized frames. A malicious client can send a large varint length value and cause the server to allocate excessive memory.

## Modification

- Add `maxFrameLength` constructor parameter
- When a frame exceeds `maxFrameLength`, skip the frame bytes and throw `TooLongFrameException`
- Default constructor remains backward-compatible (`maxFrameLength = Integer.MAX_VALUE`)

## Result

Oversized protobuf frames are now rejected with `TooLongFrameException` instead of causing unbounded memory allocation.