### PR TITLE
Kqueue: Fix usage of LOCAL_PEERPID

### DIFF
--- a/transport-native-kqueue/src/main/c/netty_kqueue_bsdsocket.c
+++ b/transport-native-kqueue/src/main/c/netty_kqueue_bsdsocket.c
@@ -279,7 +279,7 @@ static jobject netty_kqueue_bsdsocket_getPeerCredentials(JNIEnv *env, jclass cla
 #ifdef LOCAL_PEERPID
     socklen_t len = sizeof(pid);
     // Getting the LOCAL_PEERPID is expected to return error in some cases (e.g. server socket FDs) - just return 0.
-    if (netty_unix_socket_getOption0(fd, SOCK_STREAM, LOCAL_PEERPID, &pid, len) < 0) {
+    if (netty_unix_socket_getOption0(fd, SOL_LOCAL, LOCAL_PEERPID, &pid, len) < 0) {
         pid = 0;
     }
 #endif


### PR DESCRIPTION
Motivation:

SOCK_STREAM (value 1) was being passed as the socket option level, but LOCAL_PEERPID is a Unix domain socket option that lives under SOL_LOCAL. Using SOCK_STREAM as the level
would cause getsockopt to look in the wrong protocol layer — on most kernels this silently returns EOPNOTSUPP or wrong data rather than a hard error, so it was easy to miss.

Modifications:

- Replace SOCK_STREAM with SOL_LOCAL

Result:

LOCAL_PEERPID works as expected on MacOS / BSD
