### PR TITLE
Move Http2FrameCodecSubClassTest to correct package

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecSubClassTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecSubClassTest.java
@@ -14,19 +14,9 @@
  * under the License.
  */
 
-package io.netty.handler.codec;
+package io.netty.handler.codec.http2;
 
 
-import io.netty.handler.codec.http2.DefaultHttp2Connection;
-import io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder;
-import io.netty.handler.codec.http2.DefaultHttp2ConnectionEncoder;
-import io.netty.handler.codec.http2.DefaultHttp2FrameReader;
-import io.netty.handler.codec.http2.DefaultHttp2FrameWriter;
-import io.netty.handler.codec.http2.Http2Connection;
-import io.netty.handler.codec.http2.Http2ConnectionDecoder;
-import io.netty.handler.codec.http2.Http2ConnectionEncoder;
-import io.netty.handler.codec.http2.Http2FrameCodec;
-import io.netty.handler.codec.http2.Http2Settings;
 import org.junit.jupiter.api.Test;
 
 public class Http2FrameCodecSubClassTest {


### PR DESCRIPTION
Motivation:

Http2FrameCodecSubClassTest was in the incorrect package

Modifications:

Move to http2 package

Result:

Cleanup
