### PR TITLE
Fix file descriptor reuse bug in kqueue

### DIFF
--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
@@ -167,8 +167,8 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
     protected void doDeregister() throws Exception {
         IoRegistration registration = this.registration;
         if (registration != null) {
-            // As unregisteredFilters() may have not been called because isOpen() returned false we just set both filters
-            // to false to ensure a consistent state in all cases.
+            // As unregisteredFilters() may have not been called because isOpen() returned false we just set both
+            // filters to false, to ensure a consistent state in all cases.
             // Make sure we unregister our filters from kqueue!
             readFilter(false);
             writeFilter(false);

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
@@ -137,6 +137,10 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
 
     @Override
     protected void doClose() throws Exception {
+        // Clear kqueue registrations *before* we close the file descriptor.
+        // Otherwise, the filter removals might hit a reused file descriptor.
+        doDeregister();
+
         active = false;
         // Even if we allow half closed sockets we should give up on reading. Otherwise we may allow a read attempt on a
         // socket which has not even been connected yet. This has been observed to block during unit tests.
@@ -161,16 +165,17 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
 
     @Override
     protected void doDeregister() throws Exception {
-        // As unregisteredFilters() may have not been called because isOpen() returned false we just set both filters
-        // to false to ensure a consistent state in all cases.
-        // Make sure we unregister our filters from kqueue!
-        readFilter(false);
-        writeFilter(false);
-        clearRdHup0();
-
         IoRegistration registration = this.registration;
         if (registration != null) {
+            // As unregisteredFilters() may have not been called because isOpen() returned false we just set both filters
+            // to false to ensure a consistent state in all cases.
+            // Make sure we unregister our filters from kqueue!
+            readFilter(false);
+            writeFilter(false);
+            clearRdHup0();
+
             registration.cancel();
+            this.registration = null;
         }
     }
 

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
@@ -43,7 +43,6 @@ import java.io.IOException;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
-import java.util.concurrent.Executor;
 
 import static io.netty.channel.internal.ChannelUtils.MAX_BYTES_PER_GATHERING_WRITE_ATTEMPTED_LOW_THRESHOLD;
 import static io.netty.channel.internal.ChannelUtils.WRITE_STATUS_SNDBUF_FULL;
@@ -503,12 +502,6 @@ public abstract class AbstractKQueueStreamChannel extends AbstractKQueueChannel 
     }
 
     class KQueueStreamUnsafe extends AbstractKQueueUnsafe {
-        // Overridden here just to be able to access this method from AbstractKQueueStreamChannel
-        @Override
-        protected Executor prepareToClose() {
-            return super.prepareToClose();
-        }
-
         @Override
         void readReady(final KQueueRecvByteAllocatorHandle allocHandle) {
             final ChannelConfig config = config();

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDomainDatagramChannel.java
@@ -81,10 +81,13 @@ public final class KQueueDomainDatagramChannel extends AbstractKQueueDatagramCha
 
     @Override
     protected void doClose() throws Exception {
-        super.doClose();
-        connected = active = false;
-        local = null;
-        remote = null;
+        try {
+            super.doClose();
+        } finally {
+            connected = active = false;
+            local = null;
+            remote = null;
+        }
     }
 
     @Override

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannel.java
@@ -23,11 +23,9 @@ import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.SocketProtocolFamily;
 import io.netty.channel.unix.IovArray;
-import io.netty.util.concurrent.GlobalEventExecutor;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.util.concurrent.Executor;
 
 public final class KQueueSocketChannel extends AbstractKQueueStreamChannel implements SocketChannel {
     private final KQueueSocketChannelConfig config;
@@ -108,33 +106,5 @@ public final class KQueueSocketChannel extends AbstractKQueueStreamChannel imple
             }
         }
         return super.doConnect0(remoteAddress, localAddress);
-    }
-
-    @Override
-    protected AbstractKQueueUnsafe newUnsafe() {
-        return new KQueueSocketChannelUnsafe();
-    }
-
-    private final class KQueueSocketChannelUnsafe extends KQueueStreamUnsafe {
-        @Override
-        protected Executor prepareToClose() {
-            try {
-                // Check isOpen() first as otherwise it will throw a RuntimeException
-                // when call getSoLinger() as the fd is not valid anymore.
-                if (isOpen() && config().getSoLinger() > 0) {
-                    // We need to cancel this key of the channel so we may not end up in a eventloop spin
-                    // because we try to read or write until the actual close happens which may be later due
-                    // SO_LINGER handling.
-                    // See https://github.com/netty/netty/issues/4449
-                    doDeregister();
-                    return GlobalEventExecutor.INSTANCE;
-                }
-            } catch (Throwable ignore) {
-                // Ignore the error as the underlying channel may be closed in the meantime and so
-                // getSoLinger() may produce an exception. In this case we just return null.
-                // See https://github.com/netty/netty/issues/4449
-            }
-            return null;
-        }
     }
 }


### PR DESCRIPTION
Motivation:
KQueue event registrations are set on file descriptors. When a channel is deregistered, we need to remove the filters to avoid them triggering on future reuses of the same file descriptor. However, this deregistering was done _after_ the file descriptor had been closed, which means we had a race where it could be reused and registered to a channel, and _then_ we cleared the filters.

Modification:
Move the `doDeregister()` to `doClose()` in `AbstractKQueueChannel` and remove the `prepareToClose` machinery that was only used when SO_LINGER had been configured.

Result:
More stable kqueue integration.