### PR TITLE
Fix file descriptor reuse bug in kqueue (#16650)

### DIFF
--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
@@ -118,6 +118,10 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
 
     @Override
     protected void doClose(Promise<Void> promise) {
+        // Clear kqueue registrations *before* we close the file descriptor.
+        // Otherwise, the filter removals might hit a reused file descriptor.
+        doDeregister(newPromise());
+
         active = false;
         // Even if we allow half closed sockets we should give up on reading. Otherwise we may allow a read attempt on a
         // socket which has not even been connected yet. This has been observed to block during unit tests.
@@ -148,17 +152,17 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
 
     @Override
     protected void doDeregister(Promise<Void> promise) {
-        // As unregisteredFilters() may have not been called because isOpen() returned false we just set both filters
-        // to false to ensure a consistent state in all cases.
-        // Make sure we unregister our filters from kqueue!
-        readFilter(false);
-        writeFilter(false);
-
-        clearRdHup0();
-
         IoRegistration registration = this.registration;
         if (registration != null) {
+            // As unregisteredFilters() may have not been called because isOpen() returned false we just set both
+            // filters to false, to ensure a consistent state in all cases.
+            // Make sure we unregister our filters from kqueue!
+            readFilter(false);
+            writeFilter(false);
+            clearRdHup0();
+
             registration.cancel();
+            this.registration = null;
         }
         promise.setSuccess(null);
     }

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueDatagramChannel.java
@@ -113,8 +113,11 @@ public final class KQueueDatagramChannel extends AbstractKQueueChannel implement
 
     @Override
     protected void doClose(Promise<Void> promise) {
-        super.doClose(promise);
-        connected = false;
+        try {
+            super.doClose(promise);
+        } finally {
+            connected = active = false;
+        }
     }
 
     @Override

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannel.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueSocketChannel.java
@@ -36,7 +36,6 @@ import io.netty.channel.unix.SocketWritableByteChannel;
 import io.netty.channel.unix.UnixChannelUtil;
 import io.netty.util.LeakPresenceDetector;
 import io.netty.util.concurrent.CompletionHandler;
-import io.netty.util.concurrent.GlobalEventExecutor;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.logging.InternalLogger;
@@ -48,7 +47,6 @@ import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.NotYetConnectedException;
 import java.nio.channels.WritableByteChannel;
-import java.util.concurrent.Executor;
 
 import static io.netty.channel.internal.ChannelUtils.MAX_BYTES_PER_GATHERING_WRITE_ATTEMPTED_LOW_THRESHOLD;
 import static io.netty.channel.internal.ChannelUtils.WRITE_STATUS_SNDBUF_FULL;
@@ -623,26 +621,5 @@ public final class KQueueSocketChannel extends AbstractKQueueChannel implements 
             }
         }
         return super.doConnect0(remoteAddress, localAddress);
-    }
-
-    @Override
-    protected Executor prepareToClose() {
-        try {
-            // Check isOpen() first as otherwise it will throw a RuntimeException
-            // when call getSoLinger() as the fd is not valid anymore.
-            if (isOpen() && config.getSoLinger() > 0) {
-                // We need to cancel this key of the channel so we may not end up in a eventloop spin
-                // because we try to read or write until the actual close happens which may be later due
-                // SO_LINGER handling.
-                // See https://github.com/netty/netty/issues/4449
-                doDeregister(newPromise());
-                return GlobalEventExecutor.INSTANCE;
-            }
-        } catch (Throwable ignore) {
-            // Ignore the error as the underlying channel may be closed in the meantime and so
-            // getSoLinger() may produce an exception. In this case we just return null.
-            // See https://github.com/netty/netty/issues/4449
-        }
-        return null;
     }
 }


### PR DESCRIPTION
Motivation:
KQueue event registrations are set on file descriptors. When a channel
is deregistered, we need to remove the filters to avoid them triggering
on future reuses of the same file descriptor. However, this
deregistering was done _after_ the file descriptor had been closed,
which means we had a race where it could be reused and registered to a
channel, and _then_ we cleared the filters.

Modification:
Move the `doDeregister()` to `doClose()` in `AbstractKQueueChannel` and
remove the `prepareToClose` machinery that was only used when SO_LINGER
had been configured.

Result:
More stable kqueue integration.
