### PR TITLE
Fix IllegalReferenceCountException in AdaptiveByteBuf.deallocate()

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractBufferEvent.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractBufferEvent.java
@@ -41,7 +41,7 @@ abstract class AbstractBufferEvent extends AbstractAllocatorEvent {
         size = buf.capacity();
         maxFastCapacity = buf.maxFastWritableBytes() + buf.writerIndex();
         maxCapacity = buf.maxCapacity();
-        direct = buf.isDirect();
+        direct = buf._isDirect();
         address = buf._memoryAddress();
     }
 }

--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -1497,6 +1497,10 @@ public abstract class AbstractByteBuf extends ByteBuf {
         return isAccessible() && hasMemoryAddress() ? memoryAddress() : 0L;
     }
 
+    boolean _isDirect() {
+        return isDirect();
+    }
+
     ByteBuffer _internalNioBuffer() {
         return internalNioBuffer(0, capacity());
     }

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -2106,7 +2106,7 @@ final class AdaptivePoolingAllocator {
         protected void deallocate() {
             if (PlatformDependent.isJfrEnabled() && FreeBufferEvent.isEventEnabled()) {
                 FreeBufferEvent event = new FreeBufferEvent();
-                if (event.shouldCommit()) {
+                if (event.shouldCommit() && rootParent != null) {
                     event.fill(this, AdaptiveByteBufAllocator.class);
                     event.commit();
                 }

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -1748,6 +1748,12 @@ final class AdaptivePoolingAllocator {
         }
 
         @Override
+        boolean _isDirect() {
+            AbstractByteBuf root = rootParent;
+            return root != null && root.isDirect();
+        }
+
+        @Override
         public ByteBuffer nioBuffer(int index, int length) {
             checkIndex(index, length);
             return rootParent().nioBuffer(idx(index), length);
@@ -2106,7 +2112,7 @@ final class AdaptivePoolingAllocator {
         protected void deallocate() {
             if (PlatformDependent.isJfrEnabled() && FreeBufferEvent.isEventEnabled()) {
                 FreeBufferEvent event = new FreeBufferEvent();
-                if (event.shouldCommit() && rootParent != null) {
+                if (event.shouldCommit()) {
                     event.fill(this, AdaptiveByteBufAllocator.class);
                     event.commit();
                 }


### PR DESCRIPTION


Motivation:

Fix IllegalReferenceCountException in AdaptiveByteBuf.deallocate() when JFR enabled when lot's of buffer is used, we noticed this error: 

```
io.netty.util.IllegalReferenceCountException
    at AdaptiveByteBuf.rootParent(AdaptivePoolingAllocator.java:1653)
    at AdaptiveByteBuf.isDirect(AdaptivePoolingAllocator.java:1725)
    at AbstractBufferEvent.fill(AbstractBufferEvent.java:44)
    at AdaptiveByteBuf.deallocate(AdaptivePoolingAllocator.java:2110)
    at AbstractReferenceCountedByteBuf.handleRelease(AbstractReferenceCountedByteBuf.java:93)
    at AbstractReferenceCountedByteBuf.release(AbstractReferenceCountedByteBuf.java:83)
    at AdaptivePoolingAllocator$MagazineGroup.allocate(AdaptivePoolingAllocator.java:431)
    at AdaptivePoolingAllocator.allocate(AdaptivePoolingAllocator.java:271)
    at AdaptiveByteBufAllocator.newDirectBuffer(AdaptiveByteBufAllocator.java:67)

```
Modification:

    When MagazineGroup.allocate() exhausts all magazine stripes under high
    contention, the bail-out path calls buf.release() on an AdaptiveByteBuf
    that was obtained from newBuffer() but never initialised via init().
    The buffer's rootParent field is therefore null.

    With JFR recording active, deallocate() fires a FreeBufferEvent before
    clearing rootParent. AbstractBufferEvent.fill() calls buf.isDirect()
    which delegates to rootParent().isDirect(), and rootParent() throws
    IllegalReferenceCountException when the field is null.


Result:

JFR events are emitted even under pressure