### PR TITLE
HTTP2: Ensure HTTP2 preface is always send as first message (#16636)

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -222,6 +222,16 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         public boolean prefaceSent() {
             return true;
         }
+
+        /**
+         * Send the preface if needed.
+         *
+         * @param ctx           the {@link ChannelHandlerContext} to use.
+         * @throws Exception    thrown on error.
+         */
+        public void sendPrefaceIfNeeded(ChannelHandlerContext ctx) throws Exception {
+            // Noop by default.
+        }
     }
 
     private final class PrefaceDecoder extends BaseDecoder {
@@ -232,7 +242,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
             clientPrefaceString = clientPrefaceString(encoder.connection());
             // This handler was just added to the context. In case it was handled after
             // the connection became active, send the connection preface now.
-            sendPreface(ctx);
+            sendPrefaceIfNeeded(ctx);
         }
 
         @Override
@@ -260,7 +270,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         @Override
         public void channelActive(ChannelHandlerContext ctx) throws Exception {
             // The channel just became active - send the connection preface to the remote endpoint.
-            sendPreface(ctx);
+            sendPrefaceIfNeeded(ctx);
         }
 
         @Override
@@ -361,7 +371,8 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         /**
          * Sends the HTTP/2 connection preface upon establishment of the connection, if not already sent.
          */
-        private void sendPreface(ChannelHandlerContext ctx) throws Exception {
+        @Override
+        public void sendPrefaceIfNeeded(ChannelHandlerContext ctx) throws Exception {
             if (prefaceSent || !ctx.channel().isActive()) {
                 return;
             }
@@ -485,7 +496,26 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
     @Override
     public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress, SocketAddress localAddress,
                         CompletionHandler<Void> handler) {
-        ctx.connect(remoteAddress, localAddress, handler);
+        // Ensure we send the preface before we notify the connect promise as the user might try to write
+        // directly in the listener attached to the promise and we need to ensure the preface is always the first
+        // thing that is written.
+        ctx.connect(remoteAddress, localAddress, new CompletionHandler<>() {
+            @Override
+            public void success(Void result) {
+                try {
+                    byteDecoder.sendPrefaceIfNeeded(ctx);
+                } catch (Throwable e) {
+                    handler.failure(e);
+                    return;
+                }
+                handler.success(result);
+            }
+
+            @Override
+            public void failure(Throwable cause) {
+                handler.failure(cause);
+            }
+        });
     }
 
     @Override

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/H2PrefaceTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/H2PrefaceTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http2;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandler;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.util.NetUtil;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.FutureListener;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class H2PrefaceTest {
+
+    enum OpenMode {
+        Blocked,
+        Listener,
+        SubmitInListener
+    }
+
+    @ParameterizedTest
+    @EnumSource(OpenMode.class)
+    void openStreamAfterBlockingConnect(OpenMode mode) throws Exception {
+        StreamRequestResponseListener streamRequestResponseListener = new StreamRequestResponseListener();
+        EventLoopGroup eventLoopGroup = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
+
+        Channel backend = new ServerBootstrap()
+                .group(eventLoopGroup)
+                .channel(NioServerSocketChannel.class)
+                .childHandler(new ChannelInitializer<SocketChannel>() {
+                    @Override
+                    protected void initChannel(final SocketChannel ch) {
+                        ch.pipeline().addLast(Http2FrameCodecBuilder.forServer().build());
+                        ch.pipeline().addLast(new Http2MultiplexHandler(new ChannelInitializer<Http2StreamChannel>() {
+                            @Override
+                            protected void initChannel(final Http2StreamChannel ch) {
+                                ch.pipeline().addLast(new H2ServerHandler());
+                            }
+                        }));
+                        ch.pipeline().addLast(new ChannelInboundHandler() {
+                            @Override
+                            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                                streamRequestResponseListener.responseHeaders.completeExceptionally(cause);
+                            }
+                        });
+                    }
+                })
+                .bind(NetUtil.LOCALHOST, 0)
+                .get();
+
+        Future<Channel> cf = new Bootstrap()
+                .group(eventLoopGroup)
+                .channel(NioSocketChannel.class)
+                .remoteAddress(backend.localAddress())
+                .handler(new ChannelInitializer<SocketChannel>() {
+                    @Override
+                    protected void initChannel(final SocketChannel ch) {
+                        ch.pipeline().addLast(Http2FrameCodecBuilder.forClient()
+                                .initialSettings(Http2Settings.defaultSettings())
+                                .build());
+                        ch.pipeline().addLast(new Http2MultiplexHandler(new ChannelInboundHandler() { }));
+                        ch.pipeline().addLast(new ChannelInboundHandler() {
+                            @Override
+                            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                                streamRequestResponseListener.responseHeaders.completeExceptionally(cause);
+                            }
+                        });
+                    }
+                }).connect();
+        try {
+            switch (mode) {
+                case Blocked:
+                    new Http2StreamChannelBootstrap(cf.get()).open().addListener(streamRequestResponseListener);
+                    break;
+                case Listener:
+                    cf.addListener(__ ->
+                        new Http2StreamChannelBootstrap(cf.getNow()).open().addListener(streamRequestResponseListener)
+                    );
+                    break;
+                case SubmitInListener:
+                    cf.addListener(f -> f.getNow().executor().submit(() ->
+                            new Http2StreamChannelBootstrap(cf.getNow())
+                                    .open().addListener(streamRequestResponseListener)
+                    ));
+                    break;
+                default:
+                    throw new AssertionError();
+            }
+
+            assertEquals("200", streamRequestResponseListener.responseHeaders.get(
+                    5, TimeUnit.SECONDS).headers().status().toString());
+        } finally {
+            cf.get().close().sync();
+            backend.close().sync();
+            eventLoopGroup.shutdownGracefully().sync();
+        }
+    }
+
+    private static class H2ServerHandler implements ChannelInboundHandler {
+        @Override
+        public void channelRead(final ChannelHandlerContext ctx, final Object msg) {
+            if (msg instanceof Http2HeadersFrame) {
+                final Http2Headers responseHeaders = new DefaultHttp2Headers().status("200");
+                ctx.write(new DefaultHttp2HeadersFrame(responseHeaders, false));
+                ctx.writeAndFlush(
+                        new DefaultHttp2DataFrame(Unpooled.copiedBuffer("hello world", StandardCharsets.UTF_8), true));
+            }
+        }
+    }
+
+    /// Send a request and wait for a response once an Http2StreamChannel is established
+    private static final class StreamRequestResponseListener implements
+            FutureListener<Http2StreamChannel> {
+        private final CompletableFuture<Http2HeadersFrame> responseHeaders = new CompletableFuture<>();
+
+        @Override
+        public void operationComplete(final Future<? extends Http2StreamChannel> future) {
+            final Http2StreamChannel streamChannel = future.getNow();
+            streamChannel.pipeline().addLast(new ChannelInboundHandler() {
+                @Override
+                public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                    if (msg instanceof Http2HeadersFrame) {
+                        responseHeaders.complete((Http2HeadersFrame) msg);
+                    }
+                    ctx.fireChannelRead(msg);
+                }
+
+                @Override
+                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause)  {
+                    responseHeaders.completeExceptionally(cause);
+                }
+            });
+            final Http2Headers headers = new DefaultHttp2Headers()
+                    .method("GET")
+                    .path("/test")
+                    .scheme("http");
+            final Http2HeadersFrame headersFrame = new DefaultHttp2HeadersFrame(headers, true);
+            streamChannel.writeAndFlush(headersFrame).addListener(f -> {
+                if (!f.isSuccess()) {
+                    responseHeaders.completeExceptionally(f.cause());
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

We had a race in which it was possible that we send another frame before
the preface if the write happened in the ChannelListener attached to the
connect promise.

Modifications:

- Ensure we always send the preface before we give the user a chance to
write another frame.
- Add unit test

Result:

Fixes https://github.com/netty/netty/issues/16635
