### PR TITLE
Update outdated codec-http3 README.md

### DIFF
--- a/codec-http3/README.md
+++ b/codec-http3/README.md
@@ -1,10 +1,8 @@
-![Build project](https://github.com/netty/netty-incubator-codec-http3/workflows/Build%20project/badge.svg)
+# netty-codec-http3
+HTTP/3 codec built on top of Netty's [QUIC codec](https://github.com/netty/netty/tree/main/codec-classes-quic).
 
-# netty-incubator-codec-http3
-Experimental HTTP3 codec on top of our own [QUIC codec](https://github.com/netty/netty-incubator-codec-quic).
+## How to use it
 
-## How Can I use it ?
-
-For some example usage please checkout our
-[server example](https://github.com/netty/netty-incubator-codec-http3/blob/main/src/test/java/io/netty/incubator/codec/http3/example/Http3ServerExample.java) and
-[client example](https://github.com/netty/netty-incubator-codec-http3/blob/main/src/test/java/io/netty/incubator/codec/http3/example/Http3ClientExample.java).
+For example usage, check out the
+[server example](https://github.com/netty/netty/blob/main/codec-http3/src/test/java/io/netty/handler/codec/http3/example/Http3ServerExample.java) and
+[client example](https://github.com/netty/netty/blob/main/codec-http3/src/test/java/io/netty/handler/codec/http3/example/Http3ClientExample.java).


### PR DESCRIPTION
Motivation:

The `codec-http3` module README.md was copied from the old `netty-incubator-codec-http3` repository and never updated after the module was moved into the main Netty repository.

Modification:

- Update the module title from `netty-incubator-codec-http3` to `netty-codec-http3`
- Remove the CI badge that references the old incubator repository
- Fix the QUIC codec link to point to `codec-classes-quic` in the main repository
- Fix example code links to the correct paths in the main repository

Result:

Fixes #16618