### PR TITLE
Avoid unnecessary String allocation in WebSocketServerProtocolHandshakeHandler

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
@@ -58,6 +58,12 @@ public abstract class WebSocketServerHandshaker {
 
     private final String uri;
 
+    private final boolean isSecure;
+
+    private final String host;
+
+    private final String path;
+
     private final String[] subprotocols;
 
     private final WebSocketVersion version;
@@ -109,16 +115,35 @@ public abstract class WebSocketServerHandshaker {
             WebSocketVersion version, String uri, String subprotocols, WebSocketDecoderConfig decoderConfig) {
         this.version = version;
         this.uri = uri;
+        this.isSecure = false;
+        this.host = null;
+        this.path = null;
+        this.subprotocols = parseSubprotocols(subprotocols);
+        this.decoderConfig = ObjectUtil.checkNotNull(decoderConfig, "decoderConfig");
+    }
+
+    // Package-private: defers URI construction to avoid String allocation.
+    WebSocketServerHandshaker(
+            WebSocketVersion version, boolean isSecure, String host, String path,
+            String subprotocols, WebSocketDecoderConfig decoderConfig) {
+        this.version = version;
+        this.uri = null;
+        this.isSecure = isSecure;
+        this.host = host;
+        this.path = path;
+        this.subprotocols = parseSubprotocols(subprotocols);
+        this.decoderConfig = ObjectUtil.checkNotNull(decoderConfig, "decoderConfig");
+    }
+
+    private static String[] parseSubprotocols(String subprotocols) {
         if (subprotocols != null) {
             String[] subprotocolArray = subprotocols.split(",");
             for (int i = 0; i < subprotocolArray.length; i++) {
                 subprotocolArray[i] = subprotocolArray[i].trim();
             }
-            this.subprotocols = subprotocolArray;
-        } else {
-            this.subprotocols = EmptyArrays.EMPTY_STRINGS;
+            return subprotocolArray;
         }
-        this.decoderConfig = ObjectUtil.checkNotNull(decoderConfig, "decoderConfig");
+        return EmptyArrays.EMPTY_STRINGS;
     }
 
     /**
@@ -126,7 +151,10 @@ public abstract class WebSocketServerHandshaker {
      */
     @Deprecated
     public String uri() {
-        return uri;
+        if (uri != null) {
+            return uri;
+        }
+        return (isSecure ? "wss" : "ws") + "://" + host + path;
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker00.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker00.java
@@ -83,6 +83,11 @@ public class WebSocketServerHandshaker00 extends WebSocketServerHandshaker {
         super(WebSocketVersion.V00, webSocketURL, subprotocols, decoderConfig);
     }
 
+    WebSocketServerHandshaker00(boolean isSecure, String host, String path,
+                                String subprotocols, WebSocketDecoderConfig decoderConfig) {
+        super(WebSocketVersion.V00, isSecure, host, path, subprotocols, decoderConfig);
+    }
+
     /**
      * <p>
      * Handle the web socket handshake for the web socket specification <a href=

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker07.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker07.java
@@ -95,6 +95,11 @@ public class WebSocketServerHandshaker07 extends WebSocketServerHandshaker {
         super(WebSocketVersion.V07, webSocketURL, subprotocols, decoderConfig);
     }
 
+    WebSocketServerHandshaker07(boolean isSecure, String host, String path,
+                                String subprotocols, WebSocketDecoderConfig decoderConfig) {
+        super(WebSocketVersion.V07, isSecure, host, path, subprotocols, decoderConfig);
+    }
+
     /**
      * <p>
      * Handle the web socket handshake for the web socket specification <a href=

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker08.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker08.java
@@ -101,6 +101,11 @@ public class WebSocketServerHandshaker08 extends WebSocketServerHandshaker {
         super(WebSocketVersion.V08, webSocketURL, subprotocols, decoderConfig);
     }
 
+    WebSocketServerHandshaker08(boolean isSecure, String host, String path,
+                                String subprotocols, WebSocketDecoderConfig decoderConfig) {
+        super(WebSocketVersion.V08, isSecure, host, path, subprotocols, decoderConfig);
+    }
+
     /**
      * <p>
      * Handle the web socket handshake for the web socket specification <a href=

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13.java
@@ -103,6 +103,11 @@ public class WebSocketServerHandshaker13 extends WebSocketServerHandshaker {
         super(WebSocketVersion.V13, webSocketURL, subprotocols, decoderConfig);
     }
 
+    WebSocketServerHandshaker13(boolean isSecure, String host, String path,
+                                String subprotocols, WebSocketDecoderConfig decoderConfig) {
+        super(WebSocketVersion.V13, isSecure, host, path, subprotocols, decoderConfig);
+    }
+
     /**
      * <p>
      * Handle the web socket handshake for the web socket specification <a href=

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshakerFactory.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshakerFactory.java
@@ -155,6 +155,13 @@ public class WebSocketServerHandshakerFactory {
         return resolveHandshaker0(req, webSocketURL, subprotocols, decoderConfig);
     }
 
+    // Like resolveHandshaker(HttpRequest, String, String, WebSocketDecoderConfig) but defers URI construction.
+    static WebSocketServerHandshaker resolveHandshaker(HttpRequest req, boolean isSecure, String host, String path,
+                                                       String subprotocols, WebSocketDecoderConfig decoderConfig) {
+        ObjectUtil.checkNotNull(decoderConfig, "decoderConfig");
+        return resolveHandshaker0(req, isSecure, host, path, subprotocols, decoderConfig);
+    }
+
     private static WebSocketServerHandshaker resolveHandshaker0(HttpRequest req,
                                                                 String webSocketURL,
                                                                 String subprotocols,
@@ -179,6 +186,35 @@ public class WebSocketServerHandshakerFactory {
         } else {
             // Assume version 00 where version header was not specified
             return new WebSocketServerHandshaker00(webSocketURL, subprotocols, decoderConfig);
+        }
+    }
+
+    private static WebSocketServerHandshaker resolveHandshaker0(HttpRequest req,
+                                                                boolean isSecure,
+                                                                String host,
+                                                                String path,
+                                                                String subprotocols,
+                                                                WebSocketDecoderConfig decoderConfig) {
+        CharSequence version = req.headers().get(HttpHeaderNames.SEC_WEBSOCKET_VERSION);
+        if (version != null) {
+            if (version.equals(WebSocketVersion.V13.toHttpHeaderValue())) {
+                // Version 13 of the wire protocol - RFC 6455 (version 17 of the draft hybi specification).
+                return new WebSocketServerHandshaker13(
+                        isSecure, host, path, subprotocols, decoderConfig);
+            } else if (version.equals(WebSocketVersion.V08.toHttpHeaderValue())) {
+                // Version 8 of the wire protocol - version 10 of the draft hybi specification.
+                return new WebSocketServerHandshaker08(
+                        isSecure, host, path, subprotocols, decoderConfig);
+            } else if (version.equals(WebSocketVersion.V07.toHttpHeaderValue())) {
+                // Version 8 of the wire protocol - version 07 of the draft hybi specification.
+                return new WebSocketServerHandshaker07(
+                        isSecure, host, path, subprotocols, decoderConfig);
+            } else {
+                return null;
+            }
+        } else {
+            // Assume version 00 where version header was not specified
+            return new WebSocketServerHandshaker00(isSecure, host, path, subprotocols, decoderConfig);
         }
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
@@ -18,12 +18,10 @@ package io.netty.handler.codec.http.websocketx;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpRequest;
-import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler.ServerHandshakeStateEvent;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.ReferenceCountUtil;
@@ -67,9 +65,10 @@ class WebSocketServerProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
             }
 
             try {
+                final boolean isSecure = ctx.pipeline().get(SslHandler.class) != null;
+                final String host = req.headers().get(HttpHeaderNames.HOST);
                 final WebSocketServerHandshaker handshaker = WebSocketServerHandshakerFactory.resolveHandshaker(
-                        req,
-                        getWebSocketLocation(ctx.pipeline(), req, serverConfig.websocketPath()),
+                        req, isSecure, host, serverConfig.websocketPath(),
                         serverConfig.subprotocols(), serverConfig.decoderConfig());
                 final ChannelPromise localHandshakePromise = handshakePromise;
                 if (handshaker == null) {
@@ -125,16 +124,6 @@ class WebSocketServerProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
             return nextUri == '/' || nextUri == '?';
         }
         return true;
-    }
-
-    private static String getWebSocketLocation(ChannelPipeline cp, HttpRequest req, String path) {
-        String protocol = "ws";
-        if (cp.get(SslHandler.class) != null) {
-            // SSL in use so use Secure WebSockets
-            protocol = "wss";
-        }
-        String host = req.headers().get(HttpHeaderNames.HOST);
-        return protocol + "://" + host + path;
     }
 
     private void applyHandshakeTimeout() {


### PR DESCRIPTION
Motivation:

`WebSocketServerProtocolHandshakeHandler.getWebSocketLocation()` eagerly allocates a URI string on every WebSocket handshake. However, the URI is only used by `WebSocketServerHandshaker00` (deprecated V00 protocol). V07, V08, and V13 never call `uri()`.

Modification:

- Add package-private constructors to `WebSocketServerHandshaker` and its subclasses that accept URI components (`isSecure`, `host`, `path`) instead of a pre-built URI string
- Build the URI lazily in `uri()` only when actually called
- Extract duplicated subprotocol parsing into `parseSubprotocols()`
- Remove `getWebSocketLocation()` from `WebSocketServerProtocolHandshakeHandler`
- Add a package-private `resolveHandshaker` overload in `WebSocketServerHandshakerFactory`

All existing public constructors and methods remain unchanged.

Result:

No more String allocation on every WebSocket handshake for V07/V08/V13.

Fixes #16488