### PR TITLE
HTTP2: Ensure HTTP2 preface is always send as first message (also on the server)

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -475,7 +475,10 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
 
     @Override
     public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) throws Exception {
-        ctx.bind(localAddress, promise);
+        // Ensure we send the preface before we notify the bind promise as the user might try to write
+        // directly in the listener attached to the promise and we need to ensure the preface is always the first
+        // thing that is written.
+        ctx.bind(localAddress, ctx.newPromise()).addListener(new PrefaceSendListener(ctx, promise));
     }
 
     @Override
@@ -484,19 +487,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         // Ensure we send the preface before we notify the connect promise as the user might try to write
         // directly in the listener attached to the promise and we need to ensure the preface is always the first
         // thing that is written.
-        ctx.connect(remoteAddress, localAddress, ctx.newPromise()).addListener(f -> {
-            if (f.isSuccess()) {
-                try {
-                    byteDecoder.sendPrefaceIfNeeded(ctx);
-                } catch (Throwable e) {
-                    promise.setFailure(e);
-                    return;
-                }
-                promise.setSuccess();
-            } else {
-                promise.setFailure(f.cause());
-            }
-        });
+        ctx.connect(remoteAddress, localAddress, ctx.newPromise()).addListener(new PrefaceSendListener(ctx, promise));
     }
 
     @Override
@@ -1016,6 +1007,33 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
                 ctx.close();
             } else {
                 ctx.close(promise);
+            }
+        }
+    }
+
+    private final class PrefaceSendListener implements ChannelFutureListener {
+        private final ChannelHandlerContext ctx;
+        private final ChannelPromise promise;
+
+        PrefaceSendListener(ChannelHandlerContext ctx, ChannelPromise promise) {
+            this.ctx = ctx;
+            this.promise = promise;
+        }
+
+        @Override
+        public void operationComplete(ChannelFuture f) {
+            if (f.isSuccess()) {
+                try {
+                    if (byteDecoder != null) {
+                        byteDecoder.sendPrefaceIfNeeded(ctx);
+                    }
+                } catch (Throwable e) {
+                    promise.setFailure(e);
+                    return;
+                }
+                promise.setSuccess();
+            } else {
+                promise.setFailure(f.cause());
             }
         }
     }


### PR DESCRIPTION
Motivation:

caf6f417f1752ad9cf87d6068213993fe1697dab introduced a fix that ensured we always send the preface as the first message on the client but didn't also fix it for the server side.

Modifications:

- Ensure we always send the preface before we give the user a chance to write another frame.

Result:

More complete fix
