### PR TITLE
Bump BouncyCastle from 1.83 to 1.84 (#16660)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -424,7 +424,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <netty.build.version>31</netty.build.version>
-    <bouncycastle.version>1.83</bouncycastle.version>
+    <bouncycastle.version>1.84</bouncycastle.version>
     <argLine.common>
       -server
       -dsa -da -ea:io.netty...

--- a/testsuite-jpms/pom.xml
+++ b/testsuite-jpms/pom.xml
@@ -188,12 +188,10 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk18on</artifactId>
-      <version>1.82</version> <!-- TODO reverted version to avoid jlink breakage introduced in 1.83 -->
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk18on</artifactId>
-      <version>1.82</version> <!-- TODO reverted version to avoid jlink breakage introduced in 1.83 -->
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Motivation:
New BouncyCastle version.

Modification:
- Bump the general BouncyCastle version from 1.83 to 1.84.
- Bump the BouncyCastle version used in the JPMS test suite from 1.82 to 1.84.

Result:
We're on the latest BouncyCastle version.

(cherry picked from commit 74ab0a1cc0569febddb0f791807ce653905f9464)