### PR TITLE
HTTP2: Ensure HTTP2 preface is always send as first message (also on …

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -475,33 +475,19 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
 
     @Override
     public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) throws Exception {
-        ctx.bind(localAddress, promise);
+        // Ensure we send the preface before we notify the bind promise as the user might try to write
+        // directly in the listener attached to the promise and we need to ensure the preface is always the first
+        // thing that is written.
+        ctx.bind(localAddress, ctx.newPromise()).addListener(new PrefaceSendListener(ctx, promise));
     }
 
     @Override
-    public void connect(final ChannelHandlerContext ctx, SocketAddress remoteAddress, SocketAddress localAddress,
-                        final ChannelPromise promise) throws Exception {
+    public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress, SocketAddress localAddress,
+                        ChannelPromise promise) throws Exception {
         // Ensure we send the preface before we notify the connect promise as the user might try to write
         // directly in the listener attached to the promise and we need to ensure the preface is always the first
         // thing that is written.
-        ctx.connect(remoteAddress, localAddress, ctx.newPromise()).addListener(
-                new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture f) {
-                        if (f.isSuccess()) {
-                            try {
-                                byteDecoder.sendPrefaceIfNeeded(ctx);
-                            } catch (Throwable e) {
-                                promise.setFailure(e);
-                                return;
-                            }
-                            promise.setSuccess();
-                        } else {
-                            promise.setFailure(f.cause());
-                        }
-                    }
-                }
-        );
+        ctx.connect(remoteAddress, localAddress, ctx.newPromise()).addListener(new PrefaceSendListener(ctx, promise));
     }
 
     @Override
@@ -1043,6 +1029,33 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
                 ctx.close();
             } else {
                 ctx.close(promise);
+            }
+        }
+    }
+
+    private final class PrefaceSendListener implements ChannelFutureListener {
+        private final ChannelHandlerContext ctx;
+        private final ChannelPromise promise;
+
+        PrefaceSendListener(ChannelHandlerContext ctx, ChannelPromise promise) {
+            this.ctx = ctx;
+            this.promise = promise;
+        }
+
+        @Override
+        public void operationComplete(ChannelFuture f) {
+            if (f.isSuccess()) {
+                try {
+                    if (byteDecoder != null) {
+                        byteDecoder.sendPrefaceIfNeeded(ctx);
+                    }
+                } catch (Throwable e) {
+                    promise.setFailure(e);
+                    return;
+                }
+                promise.setSuccess();
+            } else {
+                promise.setFailure(f.cause());
             }
         }
     }


### PR DESCRIPTION
…the server) (#16667)

Motivation:

caf6f417f1752ad9cf87d6068213993fe1697dab introduced a fix that ensured we always send the preface as the first message on the client but didn't also fix it for the server side.

Modifications:

- Ensure we always send the preface before we give the user a chance to write another frame.

Result:

More complete fix

(cherry picked from commit 29a19f2802d54901bdda4fd68c085431959b071e)