### PR TITLE
Skip VarHandle init when unaligned access is supported (#16664)

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -273,7 +273,7 @@ public final class PlatformDependent {
     }
 
     private static boolean initializeVarHandle() {
-        if (PlatformDependent0.isNativeImage()) {
+        if (isUnaligned() || PlatformDependent0.isNativeImage()) {
             return false;
         }
         boolean varHandleAvailable = false;


### PR DESCRIPTION
`initializeVarHandle()`. This made VarHandle code reachable even when
Unsafe is available,
causing Truffle/Polyglot native-image builds to fail with
`MethodHandle.linkToStatic` blocklist violations (#16607).
Restoring the original Unsafe guard fixes #16607, but also kills

Use `isUnaligned()` as the guard instead. On platforms where unaligned
access is known (x86, modern ARM), Unsafe already handles multi-byte
access fine, so VarHandle
   isn't needed and VarHandleFactory stays unreachable.
On platforms where UNALIGNED is unknown (exactly the case #16207
targets), VarHandle still gets initialized and works as before.

Fixes #16607.

Tested with the reporter's project
(https://github.com/adamdickmeiss/vertx-graalvm-native-image-log4j):
- Before: `=== Found 4 compilation blocklist violations ===` BUILD
FAILURE
- After: No violations, BUILD SUCCESS

Co-authored-by: Chris Vest <christianvest_hansen@apple.com>
