### PR TITLE
Add generic FileRegion support in io_uring stream channel (#16571)

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
@@ -18,11 +18,13 @@ package io.netty.channel.uring;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
+import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelShutdownType;
 import io.netty.channel.DefaultFileRegion;
 import io.netty.channel.EventLoop;
+import io.netty.channel.FileRegion;
 import io.netty.channel.IoRegistration;
 import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.channel.socket.SocketChannel;
@@ -32,12 +34,15 @@ import io.netty.channel.unix.Errors;
 import io.netty.channel.unix.FileDescriptor;
 import io.netty.channel.unix.IovArray;
 import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.io.IOException;
 import java.net.SocketAddress;
+import java.nio.ByteBuffer;
 import java.nio.channels.NotYetConnectedException;
+import java.nio.channels.WritableByteChannel;
 import java.util.ArrayDeque;
 import java.util.Queue;
 
@@ -51,6 +56,15 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
     // Marker object that is used to mark a batch of buffers that were used with zero-copy write operations.
     private static final Object ZC_BATCH_MARKER = new Object();
 
+    /**
+     * Maximum bytes per chunk when converting a generic {@link FileRegion} to a {@link ByteBuf}
+     * for the io_uring async send path. Overridable via the {@code io.netty.iouring.fileRegionChunkSize}
+     * system property; capped at 16 MiB to guard against pathological configurations that would
+     * risk direct-memory OOM.
+     */
+    private static final int FILE_REGION_MAX_CHUNK_SIZE = Math.min(16 * 1024 * 1024,
+            Math.max(1, SystemPropertyUtil.getInt("io.netty.iouring.fileRegionChunkSize", 64 * 1024)));
+
     private MsgHdrMemory writeMsgHdrMemory;
     private MsgHdrMemory readMsgHdrMemory;
 
@@ -62,6 +76,8 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
     long readId;
 
     private ByteBuf readBuffer;
+    // Chunk buffer for generic FileRegion writes. Non-null while a send is in flight.
+    private ByteBuf fileRegionChunkBuf;
 
     // The configured buffer ring if any
     private IoUringBufferRing bufferRing;
@@ -157,11 +173,14 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
 
     @Override
     protected Object filterOutboundMessage(Object msg) {
-        // Since we cannot use synchronous sendfile,
-        // the channel can only support DefaultFileRegion instead of FileRegion.
         if (IoUring.isSpliceSupported() && msg instanceof DefaultFileRegion) {
             return new IoUringFileRegion((DefaultFileRegion) msg);
         }
+        if (msg instanceof FileRegion) {
+            // Generic FileRegion -- pass through to the write path for chunked conversion.
+            return msg;
+        }
+
         if (socket.protocolFamily() == SocketProtocolFamily.UNIX && msg instanceof FileDescriptor) {
             return msg;
         }
@@ -292,6 +311,8 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
                 return 0;
             }
             ops = fileRegion.splice(fd);
+        } else if (msg instanceof FileRegion) {
+            return scheduleWriteFileRegion(fd, registration, (FileRegion) msg);
         } else {
             ByteBuf buf = (ByteBuf) msg;
             long address = IoUring.memoryAddress(buf) + buf.readerIndex();
@@ -304,6 +325,59 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
         writeId = registration.submit(ops);
         writeOpCode = opCode;
         if (writeId == 0) {
+            return 0;
+        }
+        return 1;
+    }
+
+    // Read a chunk from a generic FileRegion into a direct ByteBuf and submit it as an
+    // io_uring async send. If fileRegionChunkBuf is non-null, re-submits the remaining
+    // bytes from a previous partial/failed send.
+    private int scheduleWriteFileRegion(int fd, IoRegistration registration, FileRegion region) {
+        ByteBuf buf = fileRegionChunkBuf;
+        if (buf == null) {
+            long remaining = region.count() - region.transferred();
+            if (remaining > 0) {
+                int chunkSize = (int) Math.min(remaining, FILE_REGION_MAX_CHUNK_SIZE);
+                buf = alloc().directBuffer(chunkSize);
+                try {
+                    ByteBufWritableByteChannel ch = new ByteBufWritableByteChannel(buf);
+                    while (buf.writableBytes() > 0) {
+                        long t = region.transferTo(ch, region.transferred());
+                        if (t <= 0) {
+                            break;
+                        }
+                    }
+                    if (buf.readableBytes() == 0) {
+                        buf.release();
+                        handleWriteError(new ChannelException(
+                                "FileRegion.transferTo(...) produced 0 bytes (count="
+                                        + region.count() + ", transferred=" + region.transferred() + ')'));
+                        return 0;
+                    }
+                } catch (Exception e) {
+                    buf.release();
+                    handleWriteError(e);
+                    return 0;
+                }
+            } else {
+                // Empty or fully-transferred region. Submit a 0-byte send so the completion
+                // path removes it from the outbound buffer via the normal async flow.
+                buf = alloc().directBuffer(0);
+            }
+            fileRegionChunkBuf = buf;
+        }
+        long address = IoUring.memoryAddress(buf) + buf.readerIndex();
+        int length = buf.readableBytes();
+        IoUringIoOps ops = IoUringIoOps.newSend(fd, (byte) 0, 0, address, length, nextOpsId());
+        byte opCode = ops.opcode();
+        writeId = registration.submit(ops);
+        writeOpCode = opCode;
+        if (writeId == 0) {
+            // Submission only fails when the registration is no longer valid (channel is
+            // being deregistered). unregistered() will release fileRegionChunkBuf and the
+            // outbound buffer will release the FileRegion, so nothing to clean up here --
+            // mirroring the plain ByteBuf path above.
             return 0;
         }
         return 1;
@@ -649,6 +723,11 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
             return handleWriteCompleteFileRegion(channelOutboundBuffer, fileRegion, res, data);
         }
 
+        if (current instanceof FileRegion) {
+            return handleWriteCompleteGenericFileRegion(
+                    channelOutboundBuffer, (FileRegion) current, res);
+        }
+
         if (res >= 0) {
             channelOutboundBuffer.removeBytes(res);
         } else if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
@@ -859,9 +938,58 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
         return 1;
     }
 
+    // Returns true when the completion can be treated as "written all" for this SQE
+    // (the framework may still schedule further writes from the outbound buffer); returns
+    // false to signal the framework that POLLOUT should be armed so the chunk buffer is
+    // resubmitted once the socket becomes writable again.
+    private boolean handleWriteCompleteGenericFileRegion(
+            ChannelOutboundBuffer channelOutboundBuffer, FileRegion region, int res) {
+        try {
+            if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
+                releaseFileRegionChunkBuf();
+                return true;
+            }
+            if (res >= 0) {
+                ByteBuf buf = fileRegionChunkBuf;
+                assert buf != null;
+                buf.skipBytes(res);
+                if (!buf.isReadable()) {
+                    // Chunk fully sent.
+                    releaseFileRegionChunkBuf();
+                    if (region.transferred() >= region.count()) {
+                        channelOutboundBuffer.remove();
+                    }
+                } else {
+                    // Partial send -- schedule POLLOUT to re-send the remainder.
+                    return false;
+                }
+            } else {
+                // Keep the chunk buffer -- on retryable errors (EAGAIN) ioResult returns 0
+                // and scheduleWriteFileRegion() will re-submit the same fileRegionChunkBuf
+                // once POLLOUT fires. On a non-retryable error ioResult throws, and the
+                // outer catch releases the buffer.
+                if (ioResult("io_uring write", res) == 0) {
+                    return false;
+                }
+            }
+        } catch (Throwable cause) {
+            releaseFileRegionChunkBuf();
+            handleWriteError(cause);
+        }
+        return true;
+    }
+
+    private void releaseFileRegionChunkBuf() {
+        if (fileRegionChunkBuf != null) {
+            fileRegionChunkBuf.release();
+            fileRegionChunkBuf = null;
+        }
+    }
+
     @Override
     protected void unregistered() {
         super.unregistered();
+        releaseFileRegionChunkBuf();
         if (readMsgHdrMemory != null) {
             readMsgHdrMemory.release();
             readMsgHdrMemory = null;
@@ -879,6 +1007,46 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
             return false;
         }
         return bufferRing == null || !bufferRing.isUsable();
+    }
+
+    /**
+     * A {@link WritableByteChannel} backed by a {@link ByteBuf}.
+     * Writes are capped to {@link ByteBuf#writableBytes()} to prevent overflow
+     * when {@link FileRegion#transferTo} writes more than the chunk size.
+     */
+    private static final class ByteBufWritableByteChannel implements WritableByteChannel {
+        private final ByteBuf buf;
+
+        ByteBufWritableByteChannel(ByteBuf buf) {
+            this.buf = buf;
+        }
+
+        @Override
+        public int write(ByteBuffer src) {
+            int toWrite = Math.min(src.remaining(), buf.writableBytes());
+            if (toWrite == 0) {
+                return 0;
+            }
+            if (toWrite < src.remaining()) {
+                int oldLimit = src.limit();
+                src.limit(src.position() + toWrite);
+                buf.writeBytes(src);
+                src.limit(oldLimit);
+                return toWrite;
+            }
+            buf.writeBytes(src);
+            return toWrite;
+        }
+
+        @Override
+        public boolean isOpen() {
+            return true;
+        }
+
+        @Override
+        public void close() {
+            // NOOP
+        }
     }
 
     @Override

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketFileRegionTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketFileRegionTest.java
@@ -43,7 +43,7 @@ public class IoUringBufferRingSocketFileRegionTest extends SocketFileRegionTest 
 
     @Override
     protected boolean supportsCustomFileRegion() {
-        return false;
+        return true;
     }
 
     //@Disabled("Fix me")

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketFileRegionTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketFileRegionTest.java
@@ -17,17 +17,46 @@ package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.DefaultFileRegion;
+import io.netty.channel.FileRegion;
+import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketFileRegionTest;
+import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.channels.WritableByteChannel;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class IoUringSocketFileRegionTest extends SocketFileRegionTest {
+
+    // Configured chunk size for the io_uring generic FileRegion fallback. Reads and clamps the
+    // same system property the transport does so the test stays accurate if an operator
+    // overrides it (transport caps at 16 MiB and floors at 1).
+    private static final int CONFIGURED_CHUNK_SIZE = Math.min(16 * 1024 * 1024,
+            Math.max(1, Integer.getInteger("io.netty.iouring.fileRegionChunkSize", 64 * 1024)));
+    // With the default 64 KiB chunk size this demands 8 chunks; with an override larger than
+    // the payload chunking simply isn't exercised but the transfer is still validated.
+    private static final int CHUNKING_REGION_SIZE = 512 * 1024;
 
     @BeforeAll
     public static void loadJNI() {
@@ -41,12 +70,273 @@ public class IoUringSocketFileRegionTest extends SocketFileRegionTest {
 
     @Override
     protected boolean supportsCustomFileRegion() {
-        return false;
+        return true;
     }
 
-    //@Disabled("Fix me")
     @Test
     public void testFileRegionCountLargerThenFile(TestInfo testInfo) throws Throwable {
         super.testFileRegionCountLargerThenFile(testInfo);
+    }
+
+    @Test
+    public void testCustomFileRegionChunking(TestInfo testInfo) throws Throwable {
+        run(testInfo, new Runner<ServerBootstrap, Bootstrap>() {
+            @Override
+            public void run(ServerBootstrap serverBootstrap, Bootstrap bootstrap) throws Throwable {
+                testCustomFileRegionChunking(serverBootstrap, bootstrap);
+            }
+        });
+    }
+
+    @Test
+    public void testTwoCustomFileRegionsWithChunking(TestInfo testInfo) throws Throwable {
+        run(testInfo, new Runner<ServerBootstrap, Bootstrap>() {
+            @Override
+            public void run(ServerBootstrap serverBootstrap, Bootstrap bootstrap) throws Throwable {
+                testTwoCustomFileRegionsWithChunking(serverBootstrap, bootstrap);
+            }
+        });
+    }
+
+    private static void testCustomFileRegionChunking(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+        byte[] payload = randomBytes(CHUNKING_REGION_SIZE);
+        File file = writeTempFile(payload);
+
+        ReceivingHandler sh = new ReceivingHandler(payload);
+        sb.childOption(ChannelOption.AUTO_READ, true);
+        cb.option(ChannelOption.AUTO_READ, true);
+        sb.childHandler(sh);
+        cb.handler(new SimpleChannelInboundHandler<Object>() {
+            @Override
+            protected void channelRead0(ChannelHandlerContext ctx, Object msg) {
+                // drop
+            }
+        });
+
+        Channel sc = sb.bind().get();
+        Channel cc = cb.connect(sc.localAddress()).get();
+        boolean ioUringClient = cc instanceof IoUringSocketChannel;
+        CountingFileRegion region = new CountingFileRegion(new DefaultFileRegion(
+                new RandomAccessFile(file, "r").getChannel(), 0, payload.length));
+        try {
+            cc.writeAndFlush(region).sync();
+            sh.awaitCompletion();
+        } finally {
+            cc.close().sync();
+            sc.close().sync();
+        }
+        assertNull(sh.exception.get());
+        assertEquals(payload.length, sh.counter);
+        // Chunking is only exercised when the client uses io_uring -- other transports (e.g. NIO)
+        // hand the FileRegion straight to the socket channel and the kernel's sendfile() transfers
+        // the whole file in a single transferTo call. Skip the chunking assertion for those combos.
+        assumeTrue(ioUringClient, "chunking only applies to io_uring client transport");
+        // Skip the chunking assertion if an operator configured a chunk size larger than the
+        // payload -- chunking is not exercised in that configuration, but the transfer itself is
+        // still validated above.
+        assumeTrue(CONFIGURED_CHUNK_SIZE < CHUNKING_REGION_SIZE, "chunk size >= payload; chunking not exercised");
+        int minExpectedCalls = (payload.length + CONFIGURED_CHUNK_SIZE - 1) / CONFIGURED_CHUNK_SIZE;
+        assertTrue(region.transferToCalls.get() >= minExpectedCalls,
+                "Expected at least " + minExpectedCalls + " transferTo calls to demonstrate chunking, got "
+                        + region.transferToCalls.get());
+    }
+
+    private static void testTwoCustomFileRegionsWithChunking(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+        byte[] firstPayload = randomBytes(CHUNKING_REGION_SIZE);
+        byte[] secondPayload = randomBytes(4 * 1024);
+        byte[] combined = new byte[firstPayload.length + secondPayload.length];
+        System.arraycopy(firstPayload, 0, combined, 0, firstPayload.length);
+        System.arraycopy(secondPayload, 0, combined, firstPayload.length, secondPayload.length);
+
+        File firstFile = writeTempFile(firstPayload);
+        File secondFile = writeTempFile(secondPayload);
+
+        ReceivingHandler sh = new ReceivingHandler(combined);
+        sb.childOption(ChannelOption.AUTO_READ, true);
+        cb.option(ChannelOption.AUTO_READ, true);
+        sb.childHandler(sh);
+        cb.handler(new SimpleChannelInboundHandler<Object>() {
+            @Override
+            protected void channelRead0(ChannelHandlerContext ctx, Object msg) {
+                // drop
+            }
+        });
+
+        Channel sc = sb.bind().get();
+        Channel cc = cb.connect(sc.localAddress()).get();
+        boolean ioUringClient = cc instanceof IoUringSocketChannel;
+        CountingFileRegion firstRegion = new CountingFileRegion(new DefaultFileRegion(
+                new RandomAccessFile(firstFile, "r").getChannel(), 0, firstPayload.length));
+        CountingFileRegion secondRegion = new CountingFileRegion(new DefaultFileRegion(
+                new RandomAccessFile(secondFile, "r").getChannel(), 0, secondPayload.length));
+        try {
+            // Surface any first-write failure immediately instead of waiting on the spin timeout.
+            cc.write(firstRegion).addListener(f -> {
+                if (!f.isSuccess()) {
+                    cc.pipeline().fireExceptionCaught(f.cause());
+                }
+            });
+            cc.writeAndFlush(secondRegion).sync();
+            sh.awaitCompletion();
+        } finally {
+            cc.close().sync();
+            sc.close().sync();
+        }
+        assertNull(sh.exception.get());
+        assertEquals(combined.length, sh.counter);
+        assertTrue(secondRegion.transferToCalls.get() >= 1,
+                "Second region must be transferred too");
+        // Chunking is only exercised when the client uses io_uring -- see testCustomFileRegionChunking.
+        assumeTrue(ioUringClient, "chunking only applies to io_uring client transport");
+        assumeTrue(CONFIGURED_CHUNK_SIZE < CHUNKING_REGION_SIZE, "chunk size >= payload; chunking not exercised");
+        int minFirstCalls = (firstPayload.length + CONFIGURED_CHUNK_SIZE - 1) / CONFIGURED_CHUNK_SIZE;
+        assertTrue(firstRegion.transferToCalls.get() >= minFirstCalls,
+                "Expected at least " + minFirstCalls + " transferTo calls for the first (chunked) region, got "
+                        + firstRegion.transferToCalls.get());
+    }
+
+    private static byte[] randomBytes(int length) {
+        byte[] bytes = new byte[length];
+        ThreadLocalRandom.current().nextBytes(bytes);
+        return bytes;
+    }
+
+    private static File writeTempFile(byte[] data) throws IOException {
+        File file = PlatformDependent.createTempFile("netty-iouring-chunk-", ".tmp", null);
+        file.deleteOnExit();
+        try (FileOutputStream out = new FileOutputStream(file)) {
+            out.write(data);
+        }
+        return file;
+    }
+
+    private static final class ReceivingHandler extends SimpleChannelInboundHandler<ByteBuf> {
+        private final byte[] expected;
+        final AtomicReference<Throwable> exception = new AtomicReference<Throwable>();
+        volatile int counter;
+
+        ReceivingHandler(byte[] expected) {
+            this.expected = expected;
+        }
+
+        @Override
+        protected void channelRead0(ChannelHandlerContext ctx, ByteBuf in) {
+            int readable = in.readableBytes();
+            byte[] actual = new byte[readable];
+            in.readBytes(actual);
+            int offset = counter;
+            if (offset + readable > expected.length) {
+                exception.compareAndSet(null, new AssertionError(
+                        "Received more than " + expected.length + " bytes"));
+                ctx.close();
+                return;
+            }
+            for (int i = 0; i < actual.length; i++) {
+                if (actual[i] != expected[offset + i]) {
+                    exception.compareAndSet(null, new AssertionError(
+                            "Byte mismatch at index " + (offset + i)));
+                    ctx.close();
+                    return;
+                }
+            }
+            counter += readable;
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            exception.compareAndSet(null, cause);
+            ctx.close();
+        }
+
+        void awaitCompletion() throws InterruptedException {
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
+            while (counter < expected.length && exception.get() == null) {
+                if (System.nanoTime() > deadline) {
+                    throw new AssertionError("Timed out waiting for " + expected.length
+                            + " bytes, received " + counter);
+                }
+                Thread.sleep(50);
+            }
+        }
+    }
+
+    /**
+     * Wraps a {@link DefaultFileRegion} so it is routed through the io_uring generic
+     * (non-splice) chunking path and counts {@link #transferTo} invocations so tests can assert
+     * that chunking actually happened.
+     */
+    private static final class CountingFileRegion implements FileRegion {
+        private final FileRegion delegate;
+        final AtomicInteger transferToCalls = new AtomicInteger();
+
+        CountingFileRegion(FileRegion delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public long position() {
+            return delegate.position();
+        }
+
+        @Override
+        @Deprecated
+        public long transfered() {
+            return delegate.transferred();
+        }
+
+        @Override
+        public long transferred() {
+            return delegate.transferred();
+        }
+
+        @Override
+        public long count() {
+            return delegate.count();
+        }
+
+        @Override
+        public long transferTo(WritableByteChannel target, long position) throws IOException {
+            transferToCalls.incrementAndGet();
+            return delegate.transferTo(target, position);
+        }
+
+        @Override
+        public int refCnt() {
+            return delegate.refCnt();
+        }
+
+        @Override
+        public boolean release() {
+            return delegate.release();
+        }
+
+        @Override
+        public boolean release(int decrement) {
+            return delegate.release(decrement);
+        }
+
+        @Override
+        public FileRegion retain() {
+            delegate.retain();
+            return this;
+        }
+
+        @Override
+        public FileRegion retain(int increment) {
+            delegate.retain(increment);
+            return this;
+        }
+
+        @Override
+        public FileRegion touch() {
+            delegate.touch();
+            return this;
+        }
+
+        @Override
+        public FileRegion touch(Object hint) {
+            delegate.touch(hint);
+            return this;
+        }
     }
 }

--- a/transport/src/main/java/io/netty/channel/FileRegion.java
+++ b/transport/src/main/java/io/netty/channel/FileRegion.java
@@ -67,6 +67,12 @@ public interface FileRegion extends ReferenceCounted {
 
     /**
      * Returns the bytes which was transferred already.
+     * <p>
+     * Note: some asynchronous transports (such as the {@code io_uring} transport when falling
+     * back to a chunked send for non-{@link DefaultFileRegion} implementations) advance this
+     * counter when bytes have been queued for submission, which may be before they reach the
+     * peer. If the channel is closed or the write fails after queuing, the reported value may
+     * overstate the number of bytes actually delivered.
      */
     long transferred();
 


### PR DESCRIPTION
`AbstractIoUringStreamChannel` only handles `DefaultFileRegion` (via
splice). Any other `FileRegion` implementation hits
`UnsupportedOperationException` from the parent's
`filterOutboundMessage`.

This is inconsistent with EPOLL and NIO, which accept any `FileRegion`
via a `transferTo` fallback. Frameworks like Apache Spark wrap
`DefaultFileRegion` inside composite `FileRegion` implementations (e.g.,
`MessageWithHeader`) that work on NIO and EPOLL but crash on io_uring.

See https://github.com/netty/netty/issues/16570

For generic `FileRegion` (non-`DefaultFileRegion` or when splice is
unsupported), let it pass through `filterOutboundMessage` into the
outbound buffer, then convert it to a direct `ByteBuf` in **64 KB
chunks** via `FileRegion.transferTo` in the write path
(`scheduleWriteSingle` / `writeComplete0`).

- `DefaultFileRegion` + splice path is unchanged.
- Data is chunked to limit memory usage — each chunk is read via
`transferTo` into a capped `ByteBufWritableByteChannel`, then submitted
as an io_uring async send.
- Partial sends and EAGAIN preserve the chunk buffer for retry;
unrecoverable errors release it and fail the write.
- Empty FileRegions (count = 0) submit a 0-byte send so the completion
path can remove them.

Also enabled `testCustomFileRegion` in `IoUringSocketFileRegionTest` and
`IoUringBufferRingSocketFileRegionTest`.

Any `FileRegion` implementation is now writable on io_uring, consistent
with EPOLL and NIO.

| Transport | `DefaultFileRegion` | Generic `FileRegion` |
|---|---|---|
| NIO | `FileChannel.transferTo` | `region.transferTo` |
| EPOLL | native sendfile | `region.transferTo` fallback |
| io_uring (before) | splice | **UnsupportedOperationException** |
| io_uring (after) | splice (unchanged) | chunked `transferTo` → ByteBuf
→ async send |

---------

Co-authored-by: Norman Maurer <norman_maurer@apple.com>
