### PR TITLE
Update JUnit to 5.14.0 and fix leak scope handling

### DIFF
--- a/common/src/main/java/io/netty/util/LeakPresenceDetector.java
+++ b/common/src/main/java/io/netty/util/LeakPresenceDetector.java
@@ -328,13 +328,6 @@ public class LeakPresenceDetector<T> extends ResourceLeakDetector<T> {
                 check();
             }
         }
-
-        public void retain() {
-            if (closed == 0) {
-                throw new IllegalStateException("Scope already closed");
-            }
-            closed++;
-        }
     }
 
     private static final class LeakCreation extends Throwable {

--- a/common/src/test/java/io/netty/util/internal/JfrEventSafeTest.java
+++ b/common/src/test/java/io/netty/util/internal/JfrEventSafeTest.java
@@ -40,7 +40,7 @@ public class JfrEventSafeTest {
     }
 
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_17) // RecordingStream
+    @EnabledForJreRange(min = JRE.JAVA_17, max = JRE.OTHER) // RecordingStream
     public void simple() throws Throwable {
         try (RecordingStream stream = new RecordingStream()) {
             stream.enable(MyEvent.class.getName());
@@ -57,7 +57,7 @@ public class JfrEventSafeTest {
     }
 
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_17) // RecordingStream
+    @EnabledForJreRange(min = JRE.JAVA_17, max = JRE.OTHER) // RecordingStream
     public void enableDefaults() throws Throwable {
         try (RecordingStream stream = new RecordingStream()) {
             CompletableFuture<String> result = new CompletableFuture<>();

--- a/common/src/test/java/io/netty/util/internal/JfrEventSafeTest.java
+++ b/common/src/test/java/io/netty/util/internal/JfrEventSafeTest.java
@@ -40,7 +40,7 @@ public class JfrEventSafeTest {
     }
 
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_17, max = JRE.OTHER) // RecordingStream
+    @EnabledForJreRange(min = JRE.JAVA_17) // RecordingStream
     public void simple() throws Throwable {
         try (RecordingStream stream = new RecordingStream()) {
             stream.enable(MyEvent.class.getName());
@@ -57,7 +57,7 @@ public class JfrEventSafeTest {
     }
 
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_17, max = JRE.OTHER) // RecordingStream
+    @EnabledForJreRange(min = JRE.JAVA_17) // RecordingStream
     public void enableDefaults() throws Throwable {
         try (RecordingStream stream = new RecordingStream()) {
             CompletableFuture<String> result = new CompletableFuture<>();

--- a/pom.xml
+++ b/pom.xml
@@ -755,7 +755,7 @@
     <logging.logLevel>warn</logging.logLevel>
     <log4j2.version>2.25.3</log4j2.version>
     <enforcer.plugin.version>3.0.0</enforcer.plugin.version>
-    <junit.version>5.12.1</junit.version>
+    <junit.version>6.0.3</junit.version>
     <skipTests>false</skipTests>
     <testJavaHome>${java.home}</testJavaHome>
     <testJvm>${testJavaHome}/bin/java</testJvm>

--- a/pom.xml
+++ b/pom.xml
@@ -755,7 +755,7 @@
     <logging.logLevel>warn</logging.logLevel>
     <log4j2.version>2.25.3</log4j2.version>
     <enforcer.plugin.version>3.0.0</enforcer.plugin.version>
-    <junit.version>6.0.3</junit.version>
+    <junit.version>5.14.0</junit.version>
     <skipTests>false</skipTests>
     <testJavaHome>${java.home}</testJavaHome>
     <testJvm>${testJavaHome}/bin/java</testJvm>

--- a/pom.xml
+++ b/pom.xml
@@ -756,6 +756,7 @@
     <log4j2.version>2.25.3</log4j2.version>
     <enforcer.plugin.version>3.0.0</enforcer.plugin.version>
     <junit.version>5.14.0</junit.version>
+    <junit.platform.version>1.14.0</junit.platform.version>
     <skipTests>false</skipTests>
     <testJavaHome>${java.home}</testJavaHome>
     <testJvm>${testJavaHome}/bin/java</testJvm>

--- a/testsuite-common/pom.xml
+++ b/testsuite-common/pom.xml
@@ -52,5 +52,11 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-testkit</artifactId>
+      <version>${junit.platform.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/testsuite-common/src/main/java/io/netty/util/test/LeakPresenceExtension.java
+++ b/testsuite-common/src/main/java/io/netty/util/test/LeakPresenceExtension.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -55,12 +56,10 @@ public final class LeakPresenceExtension
     @Override
     public void beforeAll(ExtensionContext context) {
         ExtensionContext.Store store = context.getStore(ExtensionContext.Namespace.GLOBAL);
-        LeakPresenceDetector.ResourceScope existingScope = (LeakPresenceDetector.ResourceScope) store.get(SCOPE_KEY);
-        if (existingScope != null) {
-            existingScope.retain();
-            return;
+        if (store.get(SCOPE_KEY) != null) {
+            throw new IllegalStateException("Weird context lifecycle");
         }
-        LeakPresenceDetector.ResourceScope scope = new LeakPresenceDetector.ResourceScope(context.getDisplayName());
+        ScopeWrapper scope = new ScopeWrapper(new LeakPresenceDetector.ResourceScope(context.getDisplayName()));
         store.put(SCOPE_KEY, scope);
 
         WithTransferableScope.SCOPE.set(scope);
@@ -68,10 +67,10 @@ public final class LeakPresenceExtension
 
     @Override
     public void beforeEach(ExtensionContext context) {
-        LeakPresenceDetector.ResourceScope outerScope;
+        ScopeWrapper outerScope;
         ExtensionContext outerContext = context;
         while (true) {
-            outerScope = (LeakPresenceDetector.ResourceScope)
+            outerScope = (ScopeWrapper)
                     outerContext.getStore(ExtensionContext.Namespace.GLOBAL).get(SCOPE_KEY);
             if (outerScope != null) {
                 break;
@@ -80,7 +79,7 @@ public final class LeakPresenceExtension
                     .orElseThrow(() -> new IllegalStateException("No resource scope found"));
         }
 
-        LeakPresenceDetector.ResourceScope previousScope = WithTransferableScope.SCOPE.get();
+        ScopeWrapper previousScope = WithTransferableScope.SCOPE.get();
         WithTransferableScope.SCOPE.set(outerScope);
         if (previousScope != null) {
             context.getStore(ExtensionContext.Namespace.GLOBAL).put(PREVIOUS_SCOPE_KEY, previousScope);
@@ -89,7 +88,7 @@ public final class LeakPresenceExtension
 
     @Override
     public void afterEach(ExtensionContext context) {
-        LeakPresenceDetector.ResourceScope previousScope = (LeakPresenceDetector.ResourceScope)
+        ScopeWrapper previousScope = (ScopeWrapper)
                 context.getStore(ExtensionContext.Namespace.GLOBAL).get(PREVIOUS_SCOPE_KEY);
         if (previousScope != null) {
             WithTransferableScope.SCOPE.set(previousScope);
@@ -98,20 +97,20 @@ public final class LeakPresenceExtension
 
     @Override
     public void afterAll(ExtensionContext context) throws InterruptedException {
-        LeakPresenceDetector.ResourceScope scope =
-                (LeakPresenceDetector.ResourceScope) context.getStore(ExtensionContext.Namespace.GLOBAL).get(SCOPE_KEY);
+        ScopeWrapper scope =
+                (ScopeWrapper) context.getStore(ExtensionContext.Namespace.GLOBAL).get(SCOPE_KEY);
 
         // Wait some time for resources to close. Many tests do loop.shutdownGracefully without waiting, and that's ok.
         long start = System.nanoTime();
-        while (scope.hasOpenResources() && System.nanoTime() - start < TimeUnit.SECONDS.toNanos(5)) {
+        while (scope.scope.hasOpenResources() && System.nanoTime() - start < TimeUnit.SECONDS.toNanos(5)) {
             TimeUnit.MILLISECONDS.sleep(100);
         }
 
-        scope.close();
+        scope.scope.close();
     }
 
     public static final class WithTransferableScope<T> extends LeakPresenceDetector<T> {
-        static final InheritableThreadLocal<ResourceScope> SCOPE = new InheritableThreadLocal<>();
+        static final InheritableThreadLocal<ScopeWrapper> SCOPE = new InheritableThreadLocal<>();
 
         @SuppressWarnings("unused")
         public WithTransferableScope(Class<?> resourceType, int samplingInterval) {
@@ -124,12 +123,19 @@ public final class LeakPresenceExtension
         }
 
         @Override
-        protected ResourceScope currentScope() throws AllocationProhibitedException {
-            ResourceScope scope = SCOPE.get();
-            if (scope == null) {
-                throw new AllocationProhibitedException("Resource created outside test?");
-            }
-            return scope;
+        protected ResourceScope currentScope() {
+            return Objects.requireNonNull(SCOPE.get(), "Resource created outside test?").scope;
+        }
+    }
+
+    /**
+     * Prevent junit from closing the ResourceScope automatically.
+     */
+    private static final class ScopeWrapper {
+        final LeakPresenceDetector.ResourceScope scope;
+
+        ScopeWrapper(LeakPresenceDetector.ResourceScope scope) {
+            this.scope = scope;
         }
     }
 }

--- a/testsuite-common/src/main/java/io/netty/util/test/LeakPresenceExtension.java
+++ b/testsuite-common/src/main/java/io/netty/util/test/LeakPresenceExtension.java
@@ -56,13 +56,22 @@ public final class LeakPresenceExtension
     @Override
     public void beforeAll(ExtensionContext context) {
         ExtensionContext.Store store = context.getStore(ExtensionContext.Namespace.GLOBAL);
-        if (store.get(SCOPE_KEY) != null) {
+        ScopeWrapper existingScope = (ScopeWrapper) store.get(SCOPE_KEY);
+        Class<?> testClass = context.getRequiredTestClass();
+        if (existingScope == null) {
+            ScopeWrapper scope = new ScopeWrapper(
+                    new LeakPresenceDetector.ResourceScope(context.getDisplayName()), testClass);
+            store.put(SCOPE_KEY, scope);
+            WithTransferableScope.SCOPE.set(scope);
+            return;
+        }
+
+        // JUnit creates a distinct ExtensionContext for each @Nested class. Those nested classes must reuse the
+        // shared outer scope, but only when they are enclosed by the class that originally created it.
+        if (!isOwnedBy(testClass, existingScope.owner)) {
             throw new IllegalStateException("Weird context lifecycle");
         }
-        ScopeWrapper scope = new ScopeWrapper(new LeakPresenceDetector.ResourceScope(context.getDisplayName()));
-        store.put(SCOPE_KEY, scope);
-
-        WithTransferableScope.SCOPE.set(scope);
+        WithTransferableScope.SCOPE.set(existingScope);
     }
 
     @Override
@@ -97,8 +106,14 @@ public final class LeakPresenceExtension
 
     @Override
     public void afterAll(ExtensionContext context) throws InterruptedException {
-        ScopeWrapper scope =
-                (ScopeWrapper) context.getStore(ExtensionContext.Namespace.GLOBAL).get(SCOPE_KEY);
+        ExtensionContext.Store store = context.getStore(ExtensionContext.Namespace.GLOBAL);
+        ScopeWrapper scope = (ScopeWrapper) store.get(SCOPE_KEY);
+        if (scope == null) {
+            return;
+        }
+        if (scope.owner != context.getRequiredTestClass()) {
+            return;
+        }
 
         // Wait some time for resources to close. Many tests do loop.shutdownGracefully without waiting, and that's ok.
         long start = System.nanoTime();
@@ -107,6 +122,25 @@ public final class LeakPresenceExtension
         }
 
         scope.scope.close();
+        store.remove(SCOPE_KEY);
+    }
+
+    /**
+     * Accept the class that created the shared scope and any of its @Nested classes.
+     *
+     * JUnit models nested test classes as separate Class objects and separate ExtensionContexts, not as subclasses of
+     * the outer test class. That means a simple assignability check would reject legitimate nested usage and cause the
+     * nested class to fail in beforeAll even though it should reuse the outer scope.
+     */
+    private static boolean isOwnedBy(Class<?> testClass, Class<?> owner) {
+        Class<?> current = testClass;
+        while (current != null) {
+            if (current == owner) {
+                return true;
+            }
+            current = current.getEnclosingClass();
+        }
+        return false;
     }
 
     public static final class WithTransferableScope<T> extends LeakPresenceDetector<T> {
@@ -133,9 +167,17 @@ public final class LeakPresenceExtension
      */
     private static final class ScopeWrapper {
         final LeakPresenceDetector.ResourceScope scope;
+        /**
+         * The test class that originally created the shared scope.
+         *
+         * Nested classes reuse the same scope but must not close it in afterAll; only this owner may do the final
+         * close and remove the scope from the store.
+         */
+        final Class<?> owner;
 
-        ScopeWrapper(LeakPresenceDetector.ResourceScope scope) {
+        ScopeWrapper(LeakPresenceDetector.ResourceScope scope, Class<?> owner) {
             this.scope = scope;
+            this.owner = owner;
         }
     }
 }

--- a/testsuite-common/src/test/java/io/netty/util/test/LeakPresenceExtensionTest.java
+++ b/testsuite-common/src/test/java/io/netty/util/test/LeakPresenceExtensionTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.test;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.testkit.engine.EngineExecutionResults;
+import org.junit.platform.testkit.engine.EngineTestKit;
+
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+
+class LeakPresenceExtensionTest {
+
+    @Test
+    void nestedClassLifecycleIsSupported() {
+        EngineExecutionResults results = EngineTestKit.engine("junit-jupiter")
+                .selectors(selectClass(OuterNestedTest.class))
+                .execute();
+
+        results.containerEvents().failed().assertThatEvents().isEmpty();
+        results.testEvents().failed().assertThatEvents().isEmpty();
+        results.testEvents().succeeded().assertThatEvents().hasSize(2);
+    }
+
+    @Test
+    void inheritedTestClassExecutesParentAndChildTests() {
+        EngineExecutionResults results = EngineTestKit.engine("junit-jupiter")
+                .selectors(selectClass(InheritedChildTest.class))
+                .execute();
+
+        results.containerEvents().failed().assertThatEvents().isEmpty();
+        results.testEvents().failed().assertThatEvents().isEmpty();
+        results.testEvents().succeeded().assertThatEvents().hasSize(2);
+    }
+
+    static class OuterNestedTest {
+        @Test
+        void outerTest() {
+        }
+
+        @Nested
+        class InnerTest {
+            @Test
+            void innerTest() {
+            }
+        }
+    }
+
+    static class InheritedParentTest {
+        @Test
+        void parentTest() {
+        }
+    }
+
+    static class InheritedChildTest extends InheritedParentTest {
+        @Test
+        void childTest() {
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

A newer Java 11 compatible JUnit 5 release is available, and the leak presence extension needs to avoid relying on JUnit-managed resource-scope closing.

Modification:

- Update JUnit from 5.12.1 to 5.14.0.
- Change `LeakPresenceExtension` to wrap the `ResourceScope` so JUnit does not close it automatically.
- Tighten the scope lifecycle handling and keep the explicit close in `afterAll`.
- Update `JfrEventSafeTest` to use an explicit non-default JRE range accepted by the newer JUnit release.

Result:

Use JUnit 5.14.0 on Java 11 and keep leak scope handling and JFR tests working correctly.