### PR TITLE
Improve flaky NioSocketChannelTest (#16679)

### DIFF
--- a/transport/src/test/java/io/netty/channel/socket/nio/NioSocketChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/nio/NioSocketChannelTest.java
@@ -236,6 +236,7 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
                                      } else if (cause != null) {
                                          eventLoopCheck.tryFailure(new AssertionError(cause));
                                      } else {
+                                         eventLoopCheck.trySuccess(null);
                                          group.next().register(channel);
                                      }
                                  }

--- a/transport/src/test/java/io/netty/channel/socket/nio/NioSocketChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/nio/NioSocketChannelTest.java
@@ -35,6 +35,8 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
 import io.netty.util.internal.PlatformDependent;
+import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.ThrowableUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -165,13 +167,13 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
 
     // Test for https://github.com/netty/netty/issues/4805
     @Test
-    @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(30)
     public void testChannelReRegisterReadSameEventLoop() throws Exception {
         testChannelReRegisterRead(true);
     }
 
     @Test
-    @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(30)
     public void testChannelReRegisterReadDifferentEventLoop() throws Exception {
         testChannelReRegisterRead(false);
     }
@@ -179,6 +181,7 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
     private static void testChannelReRegisterRead(final boolean sameEventLoop) throws Exception {
         final EventLoopGroup group = new NioEventLoopGroup(2);
         final CountDownLatch latch = new CountDownLatch(1);
+        Promise<Void> eventLoopCheck = group.next().newPromise();
 
         // Just some random bytes
         byte[] bytes = new byte[1024];
@@ -225,8 +228,16 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
                                  @Override
                                  public void operationComplete(ChannelFuture cf) {
                                      Channel channel = cf.channel();
-                                     assertNotSame(loop, channel.eventLoop());
-                                     group.next().register(channel);
+                                     Throwable cause = cf.cause();
+                                     if (loop == channel.eventLoop()) {
+                                         AssertionError err = new AssertionError("Got same event loop: " + loop);
+                                         ThrowableUtil.addSuppressed(err, cause);
+                                         eventLoopCheck.tryFailure(err);
+                                     } else if (cause != null) {
+                                         eventLoopCheck.tryFailure(new AssertionError(cause));
+                                     } else {
+                                         group.next().register(channel);
+                                     }
                                  }
                              });
                          }
@@ -242,6 +253,7 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
             cc = bootstrap.connect(sc.localAddress()).syncUninterruptibly().channel();
             cc.writeAndFlush(Unpooled.wrappedBuffer(bytes)).syncUninterruptibly();
             latch.await();
+            eventLoopCheck.sync();
         } finally {
             if (cc != null) {
                 cc.close();
@@ -249,13 +261,13 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
             if (sc != null) {
                 sc.close();
             }
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
     @Test
-    @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
-    public void testShutdownOutputAndClose() throws IOException {
+    @Timeout(30)
+    public void testShutdownOutputAndClose() throws Exception {
         NioEventLoopGroup group = new NioEventLoopGroup(1);
         ServerSocket socket = new ServerSocket();
         socket.bind(new InetSocketAddress(0));
@@ -285,7 +297,7 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
             } catch (IOException ignore) {
                 // ignore
             }
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 

--- a/transport/src/test/java/io/netty/channel/socket/nio/NioSocketChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/nio/NioSocketChannelTest.java
@@ -181,7 +181,7 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
     private static void testChannelReRegisterRead(final boolean sameEventLoop) throws Exception {
         final EventLoopGroup group = new NioEventLoopGroup(2);
         final CountDownLatch latch = new CountDownLatch(1);
-        Promise<Void> eventLoopCheck = group.next().newPromise();
+        final Promise<Void> eventLoopCheck = group.next().newPromise();
 
         // Just some random bytes
         byte[] bytes = new byte[1024];


### PR DESCRIPTION
Motivation:
We've seen IllegalReferenceCountException from this test. This is
probably not the root cause, but the root looks like it is lost in the
pipeline.

Modification:
- Increase the test timeouts.
- Add sync() calls so we make sure to wait for the event loop shutdowns
to complete, before we close the scope of the LeakPresenceDetector.
- Change an assertNotSame call in a future listener (which runs on the
event loop) with code that captures the error and funnels it out to the
test code through a future.

Result:
More debuggable test, maybe more stable too.
