### PR TITLE
Improve flaky NioSocketChannelTest (#16679)

### DIFF
--- a/transport/src/test/java/io/netty/channel/socket/nio/NioSocketChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/nio/NioSocketChannelTest.java
@@ -161,7 +161,7 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
 
     // Test for https://github.com/netty/netty/issues/4805
     @Test
-    @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(30)
     public void testChannelReRegisterReadSameEventLoop() throws Exception {
         testChannelReRegisterRead();
     }
@@ -221,12 +221,12 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
             if (sc != null) {
                 sc.close();
             }
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 
     @Test
-    @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
+    @Timeout(30)
     public void testShutdownOutputAndClose() throws Exception {
         EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
         ServerSocket socket = new ServerSocket();
@@ -256,7 +256,7 @@ public class NioSocketChannelTest extends AbstractNioChannelTest<NioSocketChanne
             } catch (IOException ignore) {
                 // ignore
             }
-            group.shutdownGracefully();
+            group.shutdownGracefully().sync();
         }
     }
 


### PR DESCRIPTION
Motivation:
5.0 port of https://github.com/netty/netty/pull/16679

Modification:
- Increase the test timeouts.
- Add sync() calls so we make sure to wait for the event loop shutdowns to complete, before we close the scope of the LeakPresenceDetector.

Result:
More debuggable test, maybe more stable too.

(cherry picked from commit 82a1f0e8a782da807cf2704b5e76e923202806fd)