### PR TITLE
Deprecate ObjectCleaner and remove usage

### DIFF
--- a/common/src/main/java/io/netty/util/internal/ObjectCleaner.java
+++ b/common/src/main/java/io/netty/util/internal/ObjectCleaner.java
@@ -31,7 +31,10 @@ import static java.lang.Math.max;
 /**
  * Allows a way to register some {@link Runnable} that will executed once there are no references to an {@link Object}
  * anymore.
+ *
+ * @deprecated The object cleaner is deprecated for removal.
  */
+@Deprecated
 public final class ObjectCleaner {
     private static final int REFERENCE_QUEUE_POLL_TIMEOUT_MS =
             max(500, getInt("io.netty.util.internal.ObjectCleaner.refQueuePollTimeout", 10000));

--- a/common/src/test/java/io/netty/util/concurrent/FastThreadLocalTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/FastThreadLocalTest.java
@@ -129,65 +129,6 @@ public class FastThreadLocalTest {
     }
 
     @Test
-    public void testMultipleSetRemove() throws Exception {
-        final FastThreadLocal<String> threadLocal = new FastThreadLocal<String>();
-        final Runnable runnable = new Runnable() {
-            @Override
-            public void run() {
-                threadLocal.set("1");
-                threadLocal.remove();
-                threadLocal.set("2");
-                threadLocal.remove();
-            }
-        };
-
-        final int sizeWhenStart = ObjectCleaner.getLiveSetCount();
-        Thread thread = new Thread(runnable);
-        thread.start();
-        thread.join();
-
-        assertEquals(0, ObjectCleaner.getLiveSetCount() - sizeWhenStart);
-
-        Thread thread2 = new Thread(runnable);
-        thread2.start();
-        thread2.join();
-
-        assertEquals(0, ObjectCleaner.getLiveSetCount() - sizeWhenStart);
-    }
-
-    @Test
-    public void testMultipleSetRemove_multipleThreadLocal() throws Exception {
-        final FastThreadLocal<String> threadLocal = new FastThreadLocal<String>();
-        final FastThreadLocal<String> threadLocal2 = new FastThreadLocal<String>();
-        final Runnable runnable = new Runnable() {
-            @Override
-            public void run() {
-                threadLocal.set("1");
-                threadLocal.remove();
-                threadLocal.set("2");
-                threadLocal.remove();
-                threadLocal2.set("1");
-                threadLocal2.remove();
-                threadLocal2.set("2");
-                threadLocal2.remove();
-            }
-        };
-
-        final int sizeWhenStart = ObjectCleaner.getLiveSetCount();
-        Thread thread = new Thread(runnable);
-        thread.start();
-        thread.join();
-
-        assertEquals(0, ObjectCleaner.getLiveSetCount() - sizeWhenStart);
-
-        Thread thread2 = new Thread(runnable);
-        thread2.start();
-        thread2.join();
-
-        assertEquals(0, ObjectCleaner.getLiveSetCount() - sizeWhenStart);
-    }
-
-    @Test
     public void testWrappedProperties() {
         assertFalse(FastThreadLocalThread.currentThreadWillCleanupFastThreadLocals());
         assertFalse(FastThreadLocalThread.currentThreadHasFastThreadLocal());


### PR DESCRIPTION
Motivation:
FastThreadLocal doesn't use ObjectCleaner anymore, but tests make assertions on it, and occasionally fail.

Modification:
Remove FastThreadLocalTest tests that rely on ObjectCleaner. Deprecate ObjectCleaner.

Result:
No more test failures from those tests, and appropriately signal intent to remove ObjectCleaner.
