### PR TITLE
Reject multipart parts missing required Content-Disposition 'name'

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
@@ -140,6 +140,9 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
 
     private int discardThreshold = HttpPostRequestDecoder.DEFAULT_DISCARD_THRESHOLD;
 
+    private static final String MISSING_NAME_ATTRIBUTE_MESSAGE =
+            "Content-Disposition is missing required 'name' parameter";
+
     /**
      *
      * @param request
@@ -568,6 +571,9 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
             }
             Attribute nameAttribute = currentFieldAttributes.get(HttpHeaderValues.NAME);
             if (currentAttribute == null) {
+                if (nameAttribute == null) {
+                    throw new ErrorDataDecoderException(MISSING_NAME_ATTRIBUTE_MESSAGE);
+                }
                 Attribute lengthAttribute = currentFieldAttributes
                         .get(HttpHeaderNames.CONTENT_LENGTH);
                 long size;
@@ -948,6 +954,9 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
         if (currentFileUpload == null) {
             Attribute filenameAttribute = currentFieldAttributes.get(HttpHeaderValues.FILENAME);
             Attribute nameAttribute = currentFieldAttributes.get(HttpHeaderValues.NAME);
+            if (nameAttribute == null) {
+                throw new ErrorDataDecoderException(MISSING_NAME_ATTRIBUTE_MESSAGE);
+            }
             Attribute contentTypeAttribute = currentFieldAttributes.get(HttpHeaderNames.CONTENT_TYPE);
             Attribute lengthAttribute = currentFieldAttributes.get(HttpHeaderNames.CONTENT_LENGTH);
             long size;

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostMultiPartRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostMultiPartRequestDecoderTest.java
@@ -510,4 +510,91 @@ public class HttpPostMultiPartRequestDecoderTest {
         commonTestFileDelimiterLFLastChunk(factory, false);
     }
 
+    // Reproduces https://github.com/netty/netty/issues/16176
+    // A multipart field whose Content-Disposition has no "name" parameter must be rejected
+    // with ErrorDataDecoderException, not surface as a NullPointerException.
+    @Test
+    public void testFieldWithoutNameAttributeThrowsErrorDataDecoderException() {
+        String boundary = "861fbeab-cd20-470c-9609-d40a0f704466";
+        String content = "--" + boundary + "\n" +
+                "Content-Disposition: form-data\n" +
+                "\n" +
+                "value\n" +
+                "--" + boundary + "--\n";
+
+        FullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/upload",
+                Unpooled.copiedBuffer(content, CharsetUtil.US_ASCII));
+        req.headers().set(HttpHeaderNames.CONTENT_TYPE, "multipart/form-data; boundary=" + boundary);
+        req.headers().set(HttpHeaderNames.CONTENT_LENGTH, content.length());
+
+        try {
+            new HttpPostMultipartRequestDecoder(req);
+            fail("Was expecting an ErrorDataDecoderException");
+        } catch (HttpPostRequestDecoder.ErrorDataDecoderException expected) {
+            assertTrue(expected.getMessage().contains("'name' parameter"),
+                    "Expected message to mention missing 'name' parameter, was: " + expected.getMessage());
+        } finally {
+            assertTrue(req.release());
+        }
+    }
+
+    // Reproduces https://github.com/netty/netty/issues/16176
+    // A multipart file upload whose Content-Disposition has a filename but no "name" parameter
+    // must be rejected with ErrorDataDecoderException, not surface as a NullPointerException.
+    @Test
+    public void testFileUploadWithoutNameAttributeThrowsErrorDataDecoderException() {
+        String boundary = "861fbeab-cd20-470c-9609-d40a0f704466";
+        String content = "--" + boundary + "\n" +
+                "Content-Disposition: form-data; filename=\"upload.txt\"\n" +
+                "Content-Type: text/plain\n" +
+                "\n" +
+                "file-body\n" +
+                "--" + boundary + "--\n";
+
+        FullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/upload",
+                Unpooled.copiedBuffer(content, CharsetUtil.US_ASCII));
+        req.headers().set(HttpHeaderNames.CONTENT_TYPE, "multipart/form-data; boundary=" + boundary);
+        req.headers().set(HttpHeaderNames.CONTENT_LENGTH, content.length());
+
+        try {
+            new HttpPostMultipartRequestDecoder(req);
+            fail("Was expecting an ErrorDataDecoderException");
+        } catch (HttpPostRequestDecoder.ErrorDataDecoderException expected) {
+            assertTrue(expected.getMessage().contains("'name' parameter"),
+                    "Expected message to mention missing 'name' parameter, was: " + expected.getMessage());
+        } finally {
+            assertTrue(req.release());
+        }
+    }
+
+    // Regression: a well-formed multipart field with a name parameter still decodes successfully
+    // after adding the explicit null check.
+    @Test
+    public void testFieldWithNameAttributeStillDecodes() {
+        String boundary = "861fbeab-cd20-470c-9609-d40a0f704466";
+        String content = "--" + boundary + "\n" +
+                "Content-Disposition: form-data; name=\"field1\"\n" +
+                "\n" +
+                "value1\n" +
+                "--" + boundary + "--\n";
+
+        FullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/upload",
+                Unpooled.copiedBuffer(content, CharsetUtil.US_ASCII));
+        req.headers().set(HttpHeaderNames.CONTENT_TYPE, "multipart/form-data; boundary=" + boundary);
+        req.headers().set(HttpHeaderNames.CONTENT_LENGTH, content.length());
+
+        HttpPostMultipartRequestDecoder decoder = new HttpPostMultipartRequestDecoder(req);
+        try {
+            InterfaceHttpData data = decoder.getBodyHttpData("field1");
+            assertNotNull(data);
+            assertTrue(data instanceof Attribute);
+            assertEquals("value1", ((Attribute) data).getValue());
+        } catch (IOException e) {
+            fail("Unexpected exception: " + e.getMessage());
+        } finally {
+            decoder.destroy();
+            assertTrue(req.release());
+        }
+    }
+
 }


### PR DESCRIPTION
## Problem

When a client sends a `multipart/form-data` request whose `Content-Disposition` header is missing the required `name=` parameter (e.g., the attack-style payloads referenced in the issue), `HttpPostMultipartRequestDecoder` surfaces an opaque `NullPointerException`:

```
java.lang.NullPointerException: Cannot invoke
  "io.netty.handler.codec.http.multipart.Attribute.getValue()"
  because "nameAttribute" is null
    at HttpPostMultipartRequestDecoder.decodeMultipart(...)
```

Operators get no hint about which part of the request was malformed, and the decoder relies on a `catch (NullPointerException)` as its validation mechanism instead of surfacing a proper `ErrorDataDecoderException`.

## Root Cause

`currentFieldAttributes.get(HttpHeaderValues.NAME)` returns `null` when the inbound `Content-Disposition` has no `name=` parameter. Both `decodeMultipart` (FIELD branch) and `getFileUpload` dereference the resulting `Attribute` via `nameAttribute.getValue()` without first checking for `null`. The surrounding `try { ... } catch (NullPointerException e) { throw new ErrorDataDecoderException(e); }` is the only guard, which produces the confusing message above and uses NPE-as-control-flow.

## Fix

- Add an explicit `nameAttribute == null` check in `decodeMultipart`'s FIELD branch before the `cleanString(nameAttribute.getValue())` dereference, throwing `ErrorDataDecoderException("Content-Disposition is missing required 'name' parameter")`.
- Apply the same guard in `getFileUpload`, where the same dereference existed for the file-upload path.
- Keep the existing `catch (NullPointerException | IllegalArgumentException | IOException)` around `factory.createAttribute(...)` so any unrelated failures inside the factory are still converted cleanly.
- No formatting or whitespace changes to existing code.

## Tests Added

| Change point | Test |
|---|---|
| Null check in `decodeMultipart` FIELD branch | `testFieldWithoutNameAttributeThrowsErrorDataDecoderException` — sends a multipart field with `Content-Disposition: form-data` (no `name=`) and asserts `ErrorDataDecoderException` whose message mentions `'name' parameter`. |
| Null check in `getFileUpload` | `testFileUploadWithoutNameAttributeThrowsErrorDataDecoderException` — sends a multipart file upload with `Content-Disposition: form-data; filename="upload.txt"` (no `name=`) and asserts the same. |
| Regression | `testFieldWithNameAttributeStillDecodes` — a well-formed multipart field with `name="field1"` still decodes to `Attribute("field1")` with the original value. |

All 77 tests in the `multipart` test classes pass (74 previously + 3 new), including the 17 tests in `HttpPostMultiPartRequestDecoderTest`.

## Impact

- Malformed multipart requests lacking `name=` are now rejected with a clear `ErrorDataDecoderException` whose message identifies the missing parameter.
- The exception type is unchanged (`ErrorDataDecoderException extends DecoderException extends RuntimeException`), so callers that already catch `ErrorDataDecoderException` or `DecoderException` observe the same behavior with a better message. No public API surface is changed.
- Scope is limited to `HttpPostMultipartRequestDecoder`; `HttpPostStandardRequestDecoder` and other codec paths are untouched.

Fixes #16176