### PR TITLE
Epoll: Correctly delete fd from epoll if there is nothing to handle

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
@@ -268,7 +268,7 @@ public class EpollIoHandler implements IoHandler {
                             }
                             Native.epollCtlAdd(epollFd.intValue(), handle.fd().intValue(), epollIoOps.value);
                             state = RegistrationState.Added;
-                            //return epollIoOps.value;
+                            return epollIoOps.value;
                         case Added:
                             if (epollIoOps.value == EpollIoOps.NONE.value) {
                                 // 0 means there is nothing to handle anymore, unregister the fd as otherwise

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
@@ -261,9 +261,21 @@ public class EpollIoHandler implements IoHandler {
                         case Cancelled:
                             return -1;
                         case Pending:
+                            if (epollIoOps.value == EpollIoOps.NONE.value) {
+                                // 0 is a special value that basically means we should remove the registration.
+                                // As we did not add the fd yet we should just return.
+                                return 0;
+                            }
                             Native.epollCtlAdd(epollFd.intValue(), handle.fd().intValue(), epollIoOps.value);
                             state = RegistrationState.Added;
+                            //return epollIoOps.value;
                         case Added:
+                            if (epollIoOps.value == EpollIoOps.NONE.value) {
+                                // 0 means there is nothing to handle anymore, unregister the fd as otherwise
+                                // we might get notified forever because of EPOLLHUP / EPOLLERR.
+                                Native.epollCtlDel(epollFd.intValue(), handle.fd().intValue());
+                                return 0;
+                            }
                             Native.epollCtlMod(epollFd.intValue(), handle.fd().intValue(), epollIoOps.value);
                             return epollIoOps.value;
                         default:

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoOps.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoOps.java
@@ -51,6 +51,12 @@ public final class EpollIoOps implements IoOps {
 
     public static final EpollIoOps EPOLLET = new EpollIoOps(Native.EPOLLET);
 
+    /**
+     * Special {@link EpollIoOps} which basically means we are not interested in any event and so should remove the
+     * fd from underlying epoll fd.
+     */
+    public static final EpollIoOps NONE = new EpollIoOps(0);
+
     static final int EPOLL_ERR_OUT_MASK = EpollIoOps.EPOLLERR.value | EpollIoOps.EPOLLOUT.value;
     static final int EPOLL_ERR_IN_MASK = EpollIoOps.EPOLLERR.value | EpollIoOps.EPOLLIN.value;
     static final int EPOLL_RDHUP_MASK = EpollIoOps.EPOLLRDHUP.value;
@@ -60,7 +66,8 @@ public final class EpollIoOps implements IoOps {
 
     static {
         EpollIoOps all = new EpollIoOps(EPOLLOUT.value | EPOLLIN.value | EPOLLERR.value | EPOLLRDHUP.value);
-        EVENTS = new EpollIoEvent[all.value + 1];
+        EVENTS = new EpollIoEvent[all.value + 2];
+        addToArray(EVENTS, NONE);
         addToArray(EVENTS, EPOLLOUT);
         addToArray(EVENTS, EPOLLIN);
         addToArray(EVENTS, EPOLLERR);


### PR DESCRIPTION
anymore

Motivation:
We did not correctly handle the case when there are no events to handle anymore at the moment and so ended up have a fd registered with epoll using 0 as event mask. This did lead up to a sitation where we could end up getting waken up infinitly until the fd was actually closed.

Modification:

Special handle event mask of 0 by just removing the fd from epoll. The same is also done internally by the JDK when using NIO.

Result:

Fixes https://github.com/netty/netty/issues/16683
