### PR TITLE
Avoid NPE in JdkSslClientContext when TrustManagerFactory returns null

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/JdkSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkSslClientContext.java
@@ -318,10 +318,11 @@ public final class JdkSslClientContext extends JdkSslContext {
     }
 
     private static TrustManager[] wrapIfNeeded(TrustManager[] tms, ResumptionController resumptionController) {
-        if (resumptionController != null) {
-            for (int i = 0; i < tms.length; i++) {
-                tms[i] = resumptionController.wrapIfNeeded(tms[i]);
-            }
+        if (tms == null || resumptionController == null) {
+            return tms;
+        }
+        for (int i = 0; i < tms.length; i++) {
+            tms[i] = resumptionController.wrapIfNeeded(tms[i]);
         }
         return tms;
     }

--- a/handler/src/test/java/io/netty/handler/ssl/JdkSslClientContextTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/JdkSslClientContextTest.java
@@ -16,14 +16,73 @@
 package io.netty.handler.ssl;
 
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import org.junit.jupiter.api.Test;
 
+import javax.net.ssl.ManagerFactoryParameters;
 import javax.net.ssl.SSLException;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.TrustManagerFactorySpi;
 import java.io.File;
+import java.security.KeyStore;
+import java.security.Provider;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class JdkSslClientContextTest extends SslContextTest {
     @Override
     protected SslContext newSslContext(File crtFile, File keyFile, String pass) throws SSLException {
         return new JdkSslClientContext(crtFile, InsecureTrustManagerFactory.INSTANCE, crtFile, keyFile, pass,
                 null, null, IdentityCipherSuiteFilter.INSTANCE, ApplicationProtocolConfig.DISABLED, 0, 0);
+    }
+
+    // Reproduces https://github.com/netty/netty/issues/14488
+    // Before the fix, wrapIfNeeded did tms.length without a null check, so a
+    // TrustManagerFactory whose getTrustManagers() returns null surfaced as an
+    // opaque NullPointerException wrapped in SSLException. After the fix the
+    // context is built successfully, matching pre-4.1.114 behavior that relied
+    // on SSLContext.init accepting a null TrustManager[] to use platform defaults.
+    @Test
+    public void testTrustManagerFactoryReturningNullDoesNotThrowNpe() throws Exception {
+        TrustManagerFactory tmf = new TrustManagerFactory(
+                new NullReturningTrustManagerFactorySpi(), NullReturningTrustManagerFactorySpi.PROVIDER, "null") {
+        };
+        // TrustManagerFactory must be initialized before SslContextBuilder will accept it;
+        // without this call the builder throws before reaching the code path under test.
+        tmf.init((KeyStore) null);
+
+        SslContext ctx = SslContextBuilder.forClient()
+                .sslProvider(SslProvider.JDK)
+                .trustManager(tmf)
+                .build();
+        // Success is "did not throw". Before the fix this call produced
+        // SSLException("failed to initialize the client-side SSL context")
+        // caused by NullPointerException from wrapIfNeeded.
+        assertNotNull(ctx);
+    }
+
+    private static final class NullReturningTrustManagerFactorySpi extends TrustManagerFactorySpi {
+        // The Provider(String, double, String) constructor is deprecated since JDK 9 in
+        // favor of (String, String, String), but the replacement is unavailable on the
+        // JDK 8 source level this module targets, so we suppress the deprecation warning.
+        @SuppressWarnings("deprecation")
+        static final Provider PROVIDER = new Provider("NullReturningProvider", 1.0, "test-only") {
+            private static final long serialVersionUID = 1L;
+        };
+
+        @Override
+        protected void engineInit(KeyStore ks) {
+            // no-op
+        }
+
+        @Override
+        protected void engineInit(ManagerFactoryParameters spec) {
+            // no-op
+        }
+
+        @Override
+        protected TrustManager[] engineGetTrustManagers() {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
## Problem

Since 4.1.114, building a JDK-backed client `SslContext` throws an opaque `SSLException` caused by `NullPointerException` whenever the configured `TrustManagerFactory` returns `null` from `getTrustManagers()`:

```
javax.net.ssl.SSLException: failed to initialize the client-side SSL context
Caused by: java.lang.NullPointerException
    at io.netty.handler.ssl.JdkSslClientContext.wrapIfNeeded(JdkSslClientContext.java:322)
    at io.netty.handler.ssl.JdkSslClientContext.newSSLContext(JdkSslClientContext.java:301)
```

Returning `null` is valid per the `TrustManagerFactory` contract — `SSLContext.init(..., null, ...)` falls back to the JDK's default trust store, and that was the working behavior in 4.1.113 and earlier.

## Root Cause

4.1.114 added `ResumptionController` wiring. `newSSLContext` now routes the trust managers through a helper:

```java
ctx.init(keyManagerFactory == null ? null : keyManagerFactory.getKeyManagers(),
         trustManagerFactory == null ? null :
                 wrapIfNeeded(trustManagerFactory.getTrustManagers(), resumptionController),
         secureRandom);
```

and `wrapIfNeeded` unconditionally dereferences `tms.length`:

```java
private static TrustManager[] wrapIfNeeded(TrustManager[] tms, ResumptionController resumptionController) {
    if (resumptionController != null) {
        for (int i = 0; i < tms.length; i++) {     // NPE when tms is null
            tms[i] = resumptionController.wrapIfNeeded(tms[i]);
        }
    }
    return tms;
}
```

There is no guard for `tms == null`, so any `TrustManagerFactory` whose `getTrustManagers()` legitimately returns `null` regresses with an NPE. Before 4.1.114, `null` flowed straight to `SSLContext.init`, which handled it natively.

## Fix

Short-circuit `wrapIfNeeded` when either `tms` or the `ResumptionController` is `null` and return the input unchanged. `null` then reaches `SSLContext.init` exactly as it did pre-4.1.114.

```java
private static TrustManager[] wrapIfNeeded(TrustManager[] tms, ResumptionController resumptionController) {
    if (tms == null || resumptionController == null) {
        return tms;
    }
    for (int i = 0; i < tms.length; i++) {
        tms[i] = resumptionController.wrapIfNeeded(tms[i]);
    }
    return tms;
}
```

Scope is intentionally limited to `JdkSslClientContext.wrapIfNeeded`, matching the reporter's observation. No other callers or formatting are touched.

## Tests Added

| Change point | Test |
|---|---|
| `wrapIfNeeded` null-array guard | `JdkSslClientContextTest.testTrustManagerFactoryReturningNullDoesNotThrowNpe` — installs a custom `TrustManagerFactorySpi` whose `engineGetTrustManagers()` returns `null`, builds the client `SslContext` via `SslContextBuilder.forClient().sslProvider(JDK).trustManager(tmf)`, and asserts it is returned without throwing. Verified to reproduce the `SSLException`/`NullPointerException` on the pre-fix code and to pass after the fix. |

All 55 tests in `SslContextBuilderTest`, `SslContextTest`, and `JdkSslClientContextTest` pass locally (0 failures, 0 errors, 1 pre-existing skip).

## Impact

- Restores pre-4.1.114 behavior: `TrustManagerFactory` implementations that return `null` from `getTrustManagers()` (i.e., "use the JDK defaults") work again with the JDK-backed `SslContextBuilder.forClient()`.
- Purely defensive change inside a private helper — public APIs, semantics when a non-null `TrustManager[]` is supplied, and the `ResumptionController` wrapping path are all unchanged.

Fixes #14488