### PR TITLE
Gracefully reject invalid per-message-deflate window size on both peers

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshaker.java
@@ -247,7 +247,16 @@ public final class PerMessageDeflateClientExtensionHandshaker implements WebSock
                 }
             } else if (SERVER_MAX_WINDOW.equalsIgnoreCase(parameter.getKey())) {
                 // acknowledged server_window_size_bits
-                serverWindowSize = Integer.parseInt(parameter.getValue());
+                String value = parameter.getValue();
+                if (value != null) {
+                    try {
+                        serverWindowSize = Integer.parseInt(value);
+                    } catch (NumberFormatException e) {
+                        succeed = false;
+                    }
+                } else {
+                    succeed = false;
+                }
                 if (serverWindowSize > MAX_WINDOW_SIZE || serverWindowSize < MIN_WINDOW_SIZE) {
                     succeed = false;
                 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateServerExtensionHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateServerExtensionHandshaker.java
@@ -223,8 +223,11 @@ public final class PerMessageDeflateServerExtensionHandshaker implements WebSock
                 // RFC 7692: client_max_window_bits may have a value or no value
                 String value = parameter.getValue();
                 if (value != null) {
-                    // Let NumberFormatException bubble up if value is invalid
-                    clientWindowSize = Integer.parseInt(value);
+                    try {
+                        clientWindowSize = Integer.parseInt(value);
+                    } catch (NumberFormatException e) {
+                        deflateEnabled = false;
+                    }
                     if (clientWindowSize > MAX_WINDOW_SIZE || clientWindowSize < MIN_WINDOW_SIZE) {
                         deflateEnabled = false;
                     }
@@ -235,7 +238,16 @@ public final class PerMessageDeflateServerExtensionHandshaker implements WebSock
             } else if (SERVER_MAX_WINDOW.equalsIgnoreCase(parameter.getKey())) {
                 // use provided windowSize if it is allowed
                 if (allowServerWindowSize) {
-                    serverWindowSize = Integer.parseInt(parameter.getValue());
+                    String value = parameter.getValue();
+                    if (value != null) {
+                        try {
+                            serverWindowSize = Integer.parseInt(value);
+                        } catch (NumberFormatException e) {
+                            deflateEnabled = false;
+                        }
+                    } else {
+                        deflateEnabled = false;
+                    }
                     if (serverWindowSize > MAX_WINDOW_SIZE || serverWindowSize < MIN_WINDOW_SIZE) {
                         deflateEnabled = false;
                     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshakerTest.java
@@ -285,4 +285,38 @@ public class PerMessageDeflateClientExtensionHandshakerTest {
             }
         });
     }
+
+    // Reproduces https://github.com/netty/netty/issues/13896 on the client handshaker for
+    // server_max_window_bits: a misbehaving server that echoes back server_max_window_bits
+    // with no value previously caused Integer.parseInt(null) to throw
+    // NumberFormatException("Cannot parse null string") out of handshakeExtension.
+    @Test
+    public void testServerMaxWindowWithNullValue() {
+        PerMessageDeflateClientExtensionHandshaker handshaker =
+                new PerMessageDeflateClientExtensionHandshaker(6, true, 15, true, false, 0);
+
+        Map<String, String> parameters = new HashMap<String, String>();
+        parameters.put(SERVER_MAX_WINDOW, null);
+
+        WebSocketClientExtension extension = handshaker.handshakeExtension(
+                new WebSocketExtensionData(PERMESSAGE_DEFLATE_EXTENSION, parameters));
+
+        assertNull(extension);
+    }
+
+    // Reproduces https://github.com/netty/netty/issues/13896 on the client handshaker for
+    // server_max_window_bits with a non-numeric value.
+    @Test
+    public void testServerMaxWindowWithNonNumericValue() {
+        PerMessageDeflateClientExtensionHandshaker handshaker =
+                new PerMessageDeflateClientExtensionHandshaker(6, true, 15, true, false, 0);
+
+        Map<String, String> parameters = new HashMap<String, String>();
+        parameters.put(SERVER_MAX_WINDOW, "abc");
+
+        WebSocketClientExtension extension = handshaker.handshakeExtension(
+                new WebSocketExtensionData(PERMESSAGE_DEFLATE_EXTENSION, parameters));
+
+        assertNull(extension);
+    }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateServerExtensionHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateServerExtensionHandshakerTest.java
@@ -209,4 +209,56 @@ public class PerMessageDeflateServerExtensionHandshakerTest {
         // Handshake should fail when client_max_window_bits is out of range
         assertNull(extension);
     }
+
+    // Reproduces https://github.com/netty/netty/issues/13896
+    // A non-numeric value for client_max_window_bits previously caused a
+    // NumberFormatException to bubble up and crash the request pipeline. The handshaker should
+    // instead reject the extension and let the connection proceed without compression.
+    @Test
+    public void testClientMaxWindowWithNonNumericValue() {
+        PerMessageDeflateServerExtensionHandshaker handshaker =
+                new PerMessageDeflateServerExtensionHandshaker(6, true, 10, true, true, 0);
+
+        Map<String, String> parameters = new HashMap<String, String>();
+        parameters.put(CLIENT_MAX_WINDOW, "not-a-number");
+
+        WebSocketServerExtension extension = handshaker.handshakeExtension(
+                new WebSocketExtensionData(PERMESSAGE_DEFLATE_EXTENSION, parameters));
+
+        assertNull(extension);
+    }
+
+    // Reproduces https://github.com/netty/netty/issues/13896
+    // A null value for server_max_window_bits previously caused NumberFormatException
+    // ("Cannot parse null string") because parseInt was called without a null check.
+    @Test
+    public void testServerMaxWindowWithNullValue() {
+        PerMessageDeflateServerExtensionHandshaker handshaker =
+                new PerMessageDeflateServerExtensionHandshaker(6, true, 10, true, true, 0);
+
+        Map<String, String> parameters = new HashMap<String, String>();
+        parameters.put(SERVER_MAX_WINDOW, null);
+
+        WebSocketServerExtension extension = handshaker.handshakeExtension(
+                new WebSocketExtensionData(PERMESSAGE_DEFLATE_EXTENSION, parameters));
+
+        assertNull(extension);
+    }
+
+    // Reproduces https://github.com/netty/netty/issues/13896
+    // A non-numeric value for server_max_window_bits previously bubbled NumberFormatException
+    // up into the server pipeline.
+    @Test
+    public void testServerMaxWindowWithNonNumericValue() {
+        PerMessageDeflateServerExtensionHandshaker handshaker =
+                new PerMessageDeflateServerExtensionHandshaker(6, true, 10, true, true, 0);
+
+        Map<String, String> parameters = new HashMap<String, String>();
+        parameters.put(SERVER_MAX_WINDOW, "abc");
+
+        WebSocketServerExtension extension = handshaker.handshakeExtension(
+                new WebSocketExtensionData(PERMESSAGE_DEFLATE_EXTENSION, parameters));
+
+        assertNull(extension);
+    }
 }


### PR DESCRIPTION
## Problem

Both `PerMessageDeflateServerExtensionHandshaker` and `PerMessageDeflateClientExtensionHandshaker` parse the peer-supplied `client_max_window_bits` and `server_max_window_bits` WebSocket extension parameters with `Integer.parseInt` but never catch `NumberFormatException`. A peer that sends:

- `server_max_window_bits` with **no value** (`parameter.getValue() == null`), or
- either parameter with a **non-numeric value** (`"abc"`, etc.),

makes `parseInt` throw, and the `NumberFormatException` bubbles out of the WebSocket handshake handler into the pipeline:

```
java.lang.NumberFormatException: Cannot parse null string
    at java.lang.Integer.parseInt(Integer.java:630)
    at java.lang.Integer.parseInt(Integer.java:786)
    at io.netty.handler.codec.http.websocketx.extensions.compression
        .PerMessageDeflateServerExtensionHandshaker.handshakeExtension(...)
```

The rest of the handshaker already treats out-of-range values (e.g. below `MIN_WINDOW_SIZE`) as "extension not negotiated" — just `deflateEnabled = false` / `succeed = false` — so the parse failure is the only malformed input that crashes instead of declining.

## Root Cause

Server handshaker (original):
```java
if (value != null) {
    // Let NumberFormatException bubble up if value is invalid
    clientWindowSize = Integer.parseInt(value);     // throws on non-numeric
    ...
}

if (allowServerWindowSize) {
    serverWindowSize = Integer.parseInt(parameter.getValue());   // throws on null OR non-numeric
    ...
}
```

Client handshaker (original) has the same shape for `server_max_window_bits`:
```java
} else if (SERVER_MAX_WINDOW.equalsIgnoreCase(parameter.getKey())) {
    serverWindowSize = Integer.parseInt(parameter.getValue());   // throws on null OR non-numeric
    ...
}
```

So a malformed value from either peer crashes the opposite side.

## Fix

Catch `NumberFormatException` around each `Integer.parseInt`, and for both `server_max_window_bits` sites guard against a `null` value before calling `parseInt`. Parse failure and null are handled the same way out-of-range already is: set `deflateEnabled = false` / `succeed = false` and fall through. `while (deflateEnabled && ...)` then exits the loop and the handshaker returns `null`.

No `continue` is needed — the trailing range check on a window size that is still at its `MAX_WINDOW_SIZE` initial value is harmless and matches the existing out-of-range fall-through style.

### Scope decision — why the client still throws on `client_max_window_bits`

The `PerMessageDeflateClientExtensionHandshaker.handshakeExtension` path for `client_max_window_bits` is intentionally left throwing `NumberFormatException`, because PR #16424 (merged 2026-03-08) introduced both that behavior and an explicit assertion in `PerMessageDeflateClientExtensionHandshakerTest.testClientMaxWindowWithInvalidValue` that `assertThrows(NumberFormatException.class, ...)`. I took the narrower position here: fix the server side of both parameters (which is what #13896 reports), and extend to the client side of `server_max_window_bits` where no such contract was set. If maintainers prefer fully symmetric "reject, don't throw" on both peers for both parameters, the existing client test can be updated as a follow-up — I'd be happy to do that if you confirm the preference.

## Tests Added

Server handshaker (`PerMessageDeflateServerExtensionHandshakerTest`):

| Change point | Test |
|---|---|
| `parseInt` try/catch for `client_max_window_bits` | `testClientMaxWindowWithNonNumericValue` — client sends `client_max_window_bits=not-a-number`; handshake returns `null`. |
| null-guard + try/catch for `server_max_window_bits` | `testServerMaxWindowWithNullValue` — client sends `server_max_window_bits` with no value; handshake returns `null`. |
| `parseInt` try/catch for `server_max_window_bits` | `testServerMaxWindowWithNonNumericValue` — client sends `server_max_window_bits=abc`; handshake returns `null`. |

Client handshaker (`PerMessageDeflateClientExtensionHandshakerTest`):

| Change point | Test |
|---|---|
| null-guard + try/catch for `server_max_window_bits` | `testServerMaxWindowWithNullValue` — misbehaving server echoes `server_max_window_bits` with no value; handshake returns `null`. |
| `parseInt` try/catch for `server_max_window_bits` | `testServerMaxWindowWithNonNumericValue` — server echoes `server_max_window_bits=abc`; handshake returns `null`. |

Each test was verified to reproduce the exact `NumberFormatException` from the issue when the production changes are temporarily reverted (`Cannot parse null string`, `For input string: "abc"`, `For input string: "not-a-number"`).

All 35 tests across `PerMessageDeflate*Test` pass locally (0 failures / 0 errors / 0 skips), including the pre-existing `testClientMaxWindowWithInvalidValue` on the client handshaker which continues to assert `NumberFormatException` (unchanged).

## Impact

- Malformed `client_max_window_bits` or `server_max_window_bits` values in a WebSocket `Sec-WebSocket-Extensions` header no longer terminate the handshake with an uncaught exception on either peer (except the intentionally preserved client-side `client_max_window_bits` behavior from #16424).
- Purely defensive: no public API change, no behavior change for well-formed parameters.

Fixes #13896
