### PR TITLE
Avoid TCPFastOpen in KQueueCompositeBufferGatheringWriteTest

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/CompositeBufferGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/CompositeBufferGatheringWriteTest.java
@@ -28,7 +28,6 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.internal.ThrowableUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/CompositeBufferGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/CompositeBufferGatheringWriteTest.java
@@ -28,6 +28,7 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.util.ReferenceCountUtil;
+import io.netty.util.internal.ThrowableUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
@@ -60,6 +61,7 @@ public class CompositeBufferGatheringWriteTest extends AbstractSocketTest {
         try {
             final CountDownLatch latch = new CountDownLatch(1);
             final AtomicReference<Object> clientReceived = new AtomicReference<Object>();
+            final AtomicReference<Throwable> unexpectedClientException = new AtomicReference<Throwable>();
             sb.childHandler(new ChannelInitializer<Channel>() {
                 @Override
                 protected void initChannel(Channel ch) throws Exception {
@@ -99,6 +101,9 @@ public class CompositeBufferGatheringWriteTest extends AbstractSocketTest {
                             if (!(cause instanceof IOException)) {
                                 clientReceived.set(cause);
                                 latch.countDown();
+                            } else if (!cause.getMessage().contains("reset")) {
+                                logger.warn("{} client got weird exception",
+                                        CompositeBufferGatheringWriteTest.this.getClass(), cause);
                             }
                         }
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/CompositeBufferGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/CompositeBufferGatheringWriteTest.java
@@ -61,7 +61,6 @@ public class CompositeBufferGatheringWriteTest extends AbstractSocketTest {
         try {
             final CountDownLatch latch = new CountDownLatch(1);
             final AtomicReference<Object> clientReceived = new AtomicReference<Object>();
-            final AtomicReference<Throwable> unexpectedClientException = new AtomicReference<Throwable>();
             sb.childHandler(new ChannelInitializer<Channel>() {
                 @Override
                 protected void initChannel(Channel ch) throws Exception {

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueCompositeBufferGatheringWriteTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueCompositeBufferGatheringWriteTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 public class KQueueCompositeBufferGatheringWriteTest extends CompositeBufferGatheringWriteTest {
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
-        return KQueueSocketTestPermutation.INSTANCE.socket();
+        return KQueueSocketTestPermutation.INSTANCE.socketWithoutFastOpen();
     }
 
     @Override

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTestPermutation.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketTestPermutation.java
@@ -47,9 +47,17 @@ class KQueueSocketTestPermutation extends SocketTestPermutation {
 
     @Override
     public List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> socket() {
-
         List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> list =
                 combo(serverSocket(), clientSocketWithFastOpen());
+
+        list.remove(list.size() - 1); // Exclude NIO x NIO test
+
+        return list;
+    }
+
+    public List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> socketWithoutFastOpen() {
+        List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> list =
+                combo(serverSocket(), clientSocket());
 
         list.remove(list.size() - 1); // Exclude NIO x NIO test
 


### PR DESCRIPTION
Motivation:
We have seen occasional failures from this test in CI, like:

```
Error:  io.netty.channel.kqueue.KQueueCompositeBufferGatheringWriteTest.testSingleCompositeBufferWrite(TestInfo) -- Time elapsed: 0.045 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <20> but was: <0>
	at io.netty.testsuite.transport.socket.CompositeBufferGatheringWriteTest$3$1.channelInactive(CompositeBufferGatheringWriteTest.java:109)
```

In the test, the server writes a composite buffer with 20 bytes as soon as a client connects, and the write future has a listener that closes the channel. I speculate that maybe the close races ahead of the write, when TFO is enabled. Normally, the kernel should still drain the send buffer of closed sockets, but maybe there's an interaction with TFO there.

Modification:
Disable the use of TFO in KQueueCompositeBufferGatheringWriteTest, which matches its epoll counterpart. Log warnings if an unusual IOException gets thrown on the client.

Result:
Maybe more stable test.
