### PR TITLE
Avoid NPE in JdkSslServerContext when TrustManagerFactory returns nul…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/JdkSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkSslServerContext.java
@@ -353,6 +353,10 @@ public final class JdkSslServerContext extends JdkSslContext {
 
     private static TrustManager[] wrapTrustManagerIfNeeded(
             TrustManager[] trustManagers, ResumptionController resumptionController) {
+
+        if (trustManagers == null) {
+            return null;
+        }
         if (WRAP_TRUST_MANAGER) {
             for (int i = 0; i < trustManagers.length; i++) {
                 TrustManager tm = trustManagers[i];

--- a/handler/src/test/java/io/netty/handler/ssl/JdkSslServerContextTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/JdkSslServerContextTest.java
@@ -15,12 +15,21 @@
  */
 package io.netty.handler.ssl;
 
+import io.netty.handler.ssl.util.SelfSignedCertificate;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
+import javax.net.ssl.ManagerFactoryParameters;
 import javax.net.ssl.SSLException;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.TrustManagerFactorySpi;
 import java.io.File;
+import java.security.KeyStore;
+import java.security.Provider;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class JdkSslServerContextTest extends SslContextTest {
 
@@ -37,5 +46,59 @@ public class JdkSslServerContextTest extends SslContextTest {
                 JdkSslServerContext.checkIfWrappingTrustManagerIsSupported();
             }
         });
+    }
+
+    // A TrustManagerFactory whose getTrustManagers() legitimately returns null
+    // (e.g., asking SSLContext.init to fall back to the JDK default trust store)
+    // previously NPE'd inside wrapTrustManagerIfNeeded. Verify the server context
+    // now builds without throwing.
+    @Test
+    void testTrustManagerFactoryReturningNullDoesNotThrowNpe() throws Exception {
+        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        try {
+            TrustManagerFactory tmf = new TrustManagerFactory(
+                    new NullReturningTrustManagerFactorySpi(),
+                    NullReturningTrustManagerFactorySpi.PROVIDER, "null") {
+            };
+            // TrustManagerFactory must be initialized before SslContextBuilder will accept it;
+            // without this call the builder throws before reaching the code path under test.
+            tmf.init((KeyStore) null);
+
+            SslContext ctx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
+                    .sslProvider(SslProvider.JDK)
+                    .trustManager(tmf)
+                    .build();
+            // Success is "did not throw". Before the fix this call produced
+            // SSLException("failed to initialize the server-side SSL context")
+            // caused by NullPointerException from wrapTrustManagerIfNeeded.
+            assertNotNull(ctx);
+        } finally {
+            ssc.delete();
+        }
+    }
+
+    private static final class NullReturningTrustManagerFactorySpi extends TrustManagerFactorySpi {
+        // The Provider(String, double, String) constructor is deprecated since JDK 9 in
+        // favor of (String, String, String), but the replacement is unavailable on the
+        // JDK 8 source level this module targets, so we suppress the deprecation warning.
+        @SuppressWarnings("deprecation")
+        static final Provider PROVIDER = new Provider("NullReturningProvider", 1.0, "test-only") {
+            private static final long serialVersionUID = 1L;
+        };
+
+        @Override
+        protected void engineInit(KeyStore ks) {
+            // no-op
+        }
+
+        @Override
+        protected void engineInit(ManagerFactoryParameters spec) {
+            // no-op
+        }
+
+        @Override
+        protected TrustManager[] engineGetTrustManagers() {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
…l (#16691)

`JdkSslServerContext.newSSLContext` passes
`trustManagerFactory.getTrustManagers()` through
`wrapTrustManagerIfNeeded` before calling `SSLContext.init`. If a caller supplies a `TrustManagerFactory` whose `getTrustManagers()` legitimately returns `null` (a valid return value that asks `SSLContext.init` to fall back to the JDK default trust store), building the server context fails with:

```
javax.net.ssl.SSLException: failed to initialize the server-side SSL context
Caused by: java.lang.NullPointerException: Cannot read the array length because "trustManagers" is null
    at io.netty.handler.ssl.JdkSslServerContext.wrapTrustManagerIfNeeded(JdkSslServerContext.java:364)
    at io.netty.handler.ssl.JdkSslServerContext.newSSLContext(JdkSslServerContext.java:341)
```

This mirrors the client-side bug reported in #14488 / fixed in PR `JdkSslServerContext` has routed trust managers through `wrapTrustManagerIfNeeded` since the `EnhancingX509ExtendedTrustManager` wrapping was introduced, long before the `ResumptionController` wiring was added — so the NPE has been latent on the server path for multiple releases when a user supplies such a factory.

```java
private static TrustManager[] wrapTrustManagerIfNeeded(
        TrustManager[] trustManagers, ResumptionController resumptionController) {
    if (WRAP_TRUST_MANAGER && PlatformDependent.javaVersion() >= 7) {
        for (int i = 0; i < trustManagers.length; i++) {     // NPE when trustManagers is null
            ...
        }
    }
    return trustManagers;
}
```

`WRAP_TRUST_MANAGER` is `true` on Java 7+ (guarded only by a FIPS feature-check that passes on common JVMs), and `trustManagerFactory` reaches this helper either as the user-supplied factory or — when the user passes `null` — as a default-initialized `TrustManagerFactory`. The user-supplied path is what fails: if the factory's `getTrustManagers()` returns `null`, `trustManagers.length` dereferences `null`.

Short-circuit `wrapTrustManagerIfNeeded` when `trustManagers` is `null`, returning `null` so it flows into `SSLContext.init` exactly as it did before any wrapping was applied. `SSLContext.init(km, null, sr)` is explicitly documented to fall back to the default trust manager.

```java
if (trustManagers == null) {
    return null;
}
```

Scope is limited to this one helper. Public APIs, the `EnhancingX509ExtendedTrustManager` wrapping path, and the `ResumptionController` wrapping path are all unchanged.

| Change point | Test |
|---|---|
| `wrapTrustManagerIfNeeded` null-array guard |
`JdkSslServerContextTest.testTrustManagerFactoryReturningNullDoesNotThrowNpe` — installs a custom `TrustManagerFactorySpi` whose `engineGetTrustManagers()` returns `null`, builds the server `SslContext` via `SslContextBuilder.forServer(cert, key).sslProvider(JDK).trustManager(tmf)`, and asserts it is returned without throwing. Verified to reproduce the
`SSLException`/`NullPointerException` on the pre-fix code (`Cannot read the array length because "trustManagers" is null`) and to pass after the fix. |

All 36 tests in `JdkSslServerContextTest` pass locally (0 failures, 0 errors, 1 pre-existing skip).

- `TrustManagerFactory` implementations that return `null` from `getTrustManagers()` (i.e., "use the JDK defaults") now work with the JDK-backed `SslContextBuilder.forServer()`.
- Purely defensive change inside a private helper. The fix pattern parallels PR #16690 for `JdkSslClientContext.wrapIfNeeded`.

Paired with #16690 (same bug pattern on the client side).