### PR TITLE
Update many dependencies (#16707)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -452,7 +452,7 @@
     <conscrypt.artifactId>conscrypt-openjdk-uber</conscrypt.artifactId>
     <conscrypt.version>2.5.2</conscrypt.version>
     <conscrypt.classifier />
-    <corretto.version>2.4.1</corretto.version>
+    <corretto.version>2.5.0</corretto.version>
     <!--
       Don't use os.detected.classifier as it will also add the "likes" as configure above.
       ${os.detected.name}-${os.detected.arch} is the same but without "likes".
@@ -462,9 +462,9 @@
     <jni.classifier>${os.detected.name}-${os.detected.arch}</jni.classifier>
     <logging.config>${project.basedir}/../common/src/test/resources/logback-test.xml</logging.config>
     <logging.logLevel>warn</logging.logLevel>
-    <log4j2.version>2.25.3</log4j2.version>
+    <log4j2.version>2.25.4</log4j2.version>
     <enforcer.plugin.version>3.0.0</enforcer.plugin.version>
-    <junit.version>5.14.0</junit.version>
+    <junit.version>5.14.4</junit.version>
     <junit.platform.version>1.14.0</junit.platform.version>
     <skipTests>false</skipTests>
     <testJavaHome>${java.home}</testJavaHome>
@@ -472,9 +472,9 @@
     <skipOsgiTestsuite>false</skipOsgiTestsuite>
     <skipAutobahnTestsuite>false</skipAutobahnTestsuite>
     <skipHttp2Testsuite>false</skipHttp2Testsuite>
-    <graalvm.version>25.0.2</graalvm.version>
-    <brotli4j.version>1.16.0</brotli4j.version>
-    <aalto.version>1.3.3</aalto.version>
+    <graalvm.version>25.0.3</graalvm.version>
+    <brotli4j.version>1.22.0</brotli4j.version>
+    <aalto.version>1.3.4</aalto.version>
     <rxtx.version>2.1.7</rxtx.version>
     <!-- By default skip native testsuite as it requires a custom environment with graalvm installed -->
     <skipNativeImageTestsuite>true</skipNativeImageTestsuite>
@@ -573,12 +573,12 @@
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
-        <version>3.25.5</version>
+        <version>3.25.9</version>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf.nano</groupId>
         <artifactId>protobuf-javanano</artifactId>
-        <version>3.0.0-alpha-5</version>
+        <version>3.0.0-alpha-7</version>
       </dependency>
 
       <!-- Our own Tomcat Native fork - completely optional for the native lib, used for accelerating SSL with OpenSSL. -->
@@ -645,7 +645,7 @@
       <dependency>
         <groupId>at.yawk.lz4</groupId>
         <artifactId>lz4-java</artifactId>
-        <version>1.10.1</version>
+        <version>1.11.0</version>
       </dependency>
       <dependency>
         <groupId>com.github.jponge</groupId>
@@ -655,7 +655,7 @@
       <dependency>
         <groupId>com.github.luben</groupId>
         <artifactId>zstd-jni</artifactId>
-        <version>1.5.6-5</version>
+        <version>1.5.7-7</version>
         <optional>true</optional>
       </dependency>
       <dependency>
@@ -713,14 +713,14 @@
       <dependency>
         <groupId>org.jctools</groupId>
         <artifactId>jctools-core</artifactId>
-        <version>4.0.5</version>
+        <version>4.0.6</version>
       </dependency>
 
       <!-- Annotations for IDE integration and analysis -->
       <dependency>
         <groupId>org.jetbrains</groupId>
         <artifactId>annotations</artifactId>
-        <version>26.0.2</version>
+        <version>26.1.0</version>
         <scope>provided</scope>
       </dependency>
 
@@ -753,12 +753,12 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>2.0.13</version>
+        <version>2.0.17</version>
       </dependency>
       <dependency>
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
-        <version>1.3.4</version>
+        <version>1.3.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
@@ -836,7 +836,7 @@
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>1.3.14</version>
+        <version>1.5.32</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -866,7 +866,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.20.0</version>
+        <version>2.22.0</version>
         <scope>test</scope>
       </dependency>
 
@@ -874,7 +874,7 @@
       <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
-        <version>2.8.9</version>
+        <version>2.14.0</version>
         <scope>test</scope>
       </dependency>
 
@@ -882,7 +882,7 @@
       <dependency>
         <groupId>org.tukaani</groupId>
         <artifactId>xz</artifactId>
-        <version>1.5</version>
+        <version>1.12</version>
       </dependency>
 
       <!-- Test dependency for resolver-dns -->
@@ -1055,6 +1055,18 @@
                   <classQualifiedName>io.netty.channel.ManualIoEventLoop</classQualifiedName>
                   <justification>Final methods added to an inheritable class are intentional and safe in this context.
                   </justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.externalClassExposedInAPI</code>
+                  <new>class net.jpountz.lz4.LZ4JNIFastResetCompressor</new>
+                  <justification>Added in at.yawk.lz4:lz4-java:1.11.0.</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.externalClassExposedInAPI</code>
+                  <new>class net.jpountz.lz4.LZ4JNIHCFastResetCompressor</new>
+                  <justification>Added in at.yawk.lz4:lz4-java:1.11.0.</justification>
                 </item>
               </differences>
             </revapi.differences>


### PR DESCRIPTION
Motivation:
We should keep up to date on our dependencies, at least as far as we can with Java 8 support.

Modification:
Update our dependencies to the latest supported versions.

Result:
Dependencies are up to date.

(cherry picked from commit 7d954422936a6d1ed6bcfb2956033fe5fa80e0c9)