### PR TITLE
Consolidate fake exceptions in HTTP/2 tests into Http2TestUtil

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
@@ -486,7 +486,7 @@ public class DefaultHttp2ConnectionDecoderTest {
             @Override
             public Integer answer(InvocationOnMock in) throws Throwable {
                 localFlow.consumeBytes(stream, 4);
-                throw new RuntimeException("Fake Exception");
+                throw Http2TestUtil.FAKE_EXCEPTION;
             }
         }).when(listener).onDataRead(eq(ctx), eq(STREAM_ID), any(ByteBuf.class), eq(10), eq(true));
         try {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
@@ -352,7 +352,7 @@ public class DefaultHttp2ConnectionEncoderTest {
 
     @Test
     public void writeHeadersUsingVoidPromise() throws Exception {
-        final Throwable cause = new RuntimeException("fake exception");
+        final Throwable cause = Http2TestUtil.FAKE_EXCEPTION;
         when(writer.writeHeaders(eq(ctx), eq(STREAM_ID), any(Http2Headers.class),
                                  anyInt(), anyBoolean(), any(ChannelPromise.class)))
                 .then(new Answer<ChannelFuture>() {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
@@ -709,7 +709,6 @@ public class DefaultHttp2ConnectionTest {
     }
 
     private static final class ListenerExceptionThrower implements Answer<Void> {
-        private static final RuntimeException FAKE_EXCEPTION = new RuntimeException("Fake Exception");
         private final boolean[] array;
         private final int index;
 
@@ -721,7 +720,7 @@ public class DefaultHttp2ConnectionTest {
         @Override
         public Void answer(InvocationOnMock invocation) throws Throwable {
             array[index] = true;
-            throw FAKE_EXCEPTION;
+            throw Http2TestUtil.FAKE_EXCEPTION;
         }
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
@@ -724,11 +724,10 @@ public abstract class DefaultHttp2RemoteFlowControllerTest {
     public void flowControlledWriteAndErrorThrowAnException() throws Exception {
         final Http2RemoteFlowController.FlowControlled flowControlled = mockedFlowControlledThatThrowsOnWrite();
         final Http2Stream stream = stream(STREAM_A);
-        final RuntimeException fakeException = new RuntimeException("error failed");
         doAnswer(new Answer<Void>() {
             @Override
             public Void answer(InvocationOnMock invocationOnMock) {
-                throw fakeException;
+                throw Http2TestUtil.FAKE_EXCEPTION;
             }
         }).when(flowControlled).error(any(ChannelHandlerContext.class), any(Throwable.class));
 
@@ -741,7 +740,7 @@ public abstract class DefaultHttp2RemoteFlowControllerTest {
                 controller.writePendingBytes();
             }
         });
-        assertSame(fakeException, e.getCause());
+        assertSame(Http2TestUtil.FAKE_EXCEPTION, e.getCause());
 
         verify(flowControlled, atLeastOnce()).write(any(ChannelHandlerContext.class), anyInt());
         verify(flowControlled).error(any(ChannelHandlerContext.class), any(Throwable.class));

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -157,7 +157,7 @@ public class Http2ConnectionHandlerTest {
         DefaultChannelConfig config = new DefaultChannelConfig(channel);
         when(channel.config()).thenReturn(config);
 
-        Throwable fakeException = new RuntimeException("Fake exception");
+        Throwable fakeException = Http2TestUtil.FAKE_EXCEPTION;
         when(encoder.connection()).thenReturn(connection);
         when(decoder.connection()).thenReturn(connection);
         when(encoder.frameWriter()).thenReturn(frameWriter);
@@ -726,7 +726,6 @@ public class Http2ConnectionHandlerTest {
         ByteBuf data = dummyData();
         long errorCode = Http2Error.INTERNAL_ERROR.code();
         handler = newHandler();
-        final Throwable cause = new RuntimeException("fake exception");
         doAnswer(new Answer<ChannelFuture>() {
             @Override
             public ChannelFuture answer(InvocationOnMock invocation) throws Throwable {
@@ -737,12 +736,12 @@ public class Http2ConnectionHandlerTest {
                         new SimpleChannelPromiseAggregator(promise, channel, ImmediateEventExecutor.INSTANCE);
                 aggregatedPromise.newPromise();
                 aggregatedPromise.doneAllocatingPromises();
-                return aggregatedPromise.setFailure(cause);
+                return aggregatedPromise.setFailure(Http2TestUtil.FAKE_EXCEPTION);
             }
         }).when(frameWriter).writeGoAway(
                 any(ChannelHandlerContext.class), anyInt(), anyLong(), any(ByteBuf.class), any(ChannelPromise.class));
         handler.goAway(ctx, STREAM_ID, errorCode, data, newVoidPromise(channel));
-        verify(pipeline).fireExceptionCaught(cause);
+        verify(pipeline).fireExceptionCaught(Http2TestUtil.FAKE_EXCEPTION);
     }
 
     @Test
@@ -889,7 +888,6 @@ public class Http2ConnectionHandlerTest {
 
     private void writeRstStreamUsingVoidPromise(int streamId) throws Exception {
         handler = newHandler();
-        final Throwable cause = new RuntimeException("fake exception");
         when(stream.id()).thenReturn(STREAM_ID);
         when(frameWriter.writeRstStream(eq(ctx), eq(streamId), anyLong(), any(ChannelPromise.class)))
                 .then(new Answer<ChannelFuture>() {
@@ -897,12 +895,12 @@ public class Http2ConnectionHandlerTest {
                     public ChannelFuture answer(InvocationOnMock invocationOnMock) throws Throwable {
                         ChannelPromise promise = invocationOnMock.getArgument(3);
                         assertFalse(promise.isVoid());
-                        return promise.setFailure(cause);
+                        return promise.setFailure(Http2TestUtil.FAKE_EXCEPTION);
                     }
                 });
         handler.resetStream(ctx, streamId, STREAM_CLOSED.code(), newVoidPromise(channel));
         verify(frameWriter).writeRstStream(eq(ctx), eq(streamId), anyLong(), any(ChannelPromise.class));
-        verify(pipeline).fireExceptionCaught(cause);
+        verify(pipeline).fireExceptionCaught(Http2TestUtil.FAKE_EXCEPTION);
     }
 
     private static ByteBuf dummyData() {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -605,7 +605,7 @@ public class Http2ConnectionRoundtripTest {
     @Test
     public void listenerExceptionShouldCloseConnection() throws Exception {
         final Http2Headers headers = dummyHeaders();
-        doThrow(new RuntimeException("Fake Exception")).when(serverListener).onHeadersRead(
+        doThrow(Http2TestUtil.FAKE_EXCEPTION).when(serverListener).onHeadersRead(
                 any(ChannelHandlerContext.class), eq(3), eq(headers), eq(0), eq((short) 16),
                 eq(false), eq(0), eq(false));
 
@@ -788,7 +788,7 @@ public class Http2ConnectionRoundtripTest {
         clientChannel.pipeline().addFirst(new ChannelHandlerAdapter() {
             @Override
             public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
-                throw new RuntimeException("Fake Exception");
+                throw Http2TestUtil.FAKE_EXCEPTION;
             }
         });
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
@@ -58,6 +58,19 @@ import static org.mockito.Mockito.when;
  */
 public final class Http2TestUtil {
     /**
+     * A fake exception that can be used in tests to simulate errors. The stack trace is not filled in to avoid
+     * unnecessary overhead.
+     */
+    static final RuntimeException FAKE_EXCEPTION = new RuntimeException("Fake exception") {
+        private static final long serialVersionUID = -8316972447187527869L;
+
+        @Override
+        public Throwable fillInStackTrace() {
+            return this;
+        }
+    };
+
+    /**
      * Interface that allows for running a operation that throws a {@link Http2Exception}.
      */
     interface Http2Runnable {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/UniformStreamByteDistributorTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/UniformStreamByteDistributorTest.java
@@ -128,8 +128,7 @@ public class UniformStreamByteDistributorTest {
         initState(STREAM_C, 3, true);
         initState(STREAM_D, 4, true);
 
-        Exception fakeException = new RuntimeException("Fake exception");
-        doThrow(fakeException).when(writer).write(same(stream(STREAM_C)), eq(3));
+        doThrow(Http2TestUtil.FAKE_EXCEPTION).when(writer).write(same(stream(STREAM_C)), eq(3));
 
         Http2Exception e =  assertThrows(Http2Exception.class, new Executable() {
             @Override
@@ -139,7 +138,7 @@ public class UniformStreamByteDistributorTest {
         });
         assertFalse(Http2Exception.isStreamError(e));
         assertEquals(Http2Error.INTERNAL_ERROR, e.error());
-        assertSame(fakeException, e.getCause());
+        assertSame(Http2TestUtil.FAKE_EXCEPTION, e.getCause());
 
         verifyWrite(atMost(1), STREAM_A, 1);
         verifyWrite(atMost(1), STREAM_B, 2);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/WeightedFairQueueByteDistributorTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/WeightedFairQueueByteDistributorTest.java
@@ -150,8 +150,7 @@ public class WeightedFairQueueByteDistributorTest extends AbstractWeightedFairQu
         initState(STREAM_C, 3, true);
         initState(STREAM_D, 4, true);
 
-        Exception fakeException = new RuntimeException("Fake exception");
-        doThrow(fakeException).when(writer).write(same(stream(STREAM_C)), eq(3));
+        doThrow(Http2TestUtil.FAKE_EXCEPTION).when(writer).write(same(stream(STREAM_C)), eq(3));
 
         Http2Exception e = assertThrows(Http2Exception.class, new Executable() {
             @Override
@@ -161,7 +160,7 @@ public class WeightedFairQueueByteDistributorTest extends AbstractWeightedFairQu
         });
         assertFalse(Http2Exception.isStreamError(e));
         assertEquals(Http2Error.INTERNAL_ERROR, e.error());
-        assertSame(fakeException, e.getCause());
+        assertSame(Http2TestUtil.FAKE_EXCEPTION, e.getCause());
 
         verifyWrite(atMost(1), STREAM_A, 1);
         verifyWrite(atMost(1), STREAM_B, 2);


### PR DESCRIPTION
Motivation:

HTTP/2 tests create ad-hoc fake exceptions to drive error paths.

Modification:

Add `Http2TestUtil.FAKE_EXCEPTION` (stackless singleton) and replace local instances across 8 test classes.

Result:

Fixes #4274