### PR TITLE
SCTP: Correctly handle SO_BACKLOG

### DIFF
--- a/transport-sctp/src/main/java/io/netty/channel/sctp/DefaultSctpServerChannelConfig.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/DefaultSctpServerChannelConfig.java
@@ -85,7 +85,7 @@ public class DefaultSctpServerChannelConfig extends DefaultChannelConfig impleme
         } else if (option == ChannelOption.SO_SNDBUF) {
             setSendBufferSize((Integer) value);
         } else if (option == ChannelOption.SO_BACKLOG) {
-            setSendBufferSize((Integer) value);
+            setBacklog((Integer) value);
         } else if (option == SctpChannelOption.SCTP_INIT_MAXSTREAMS) {
             setInitMaxStreams((SctpStandardSocketOptions.InitMaxStreams) value);
         } else {


### PR DESCRIPTION
Motivation:

When SO_BACKLOG was used we did call the wrong method and so caused an UnsupportedOperationException

Modifications:

Correctly call setBacklog(...)

Result:

Fixes https://github.com/netty/netty/issues/16713
