### PR TITLE
Fix DiscardClient hang under -Dssl by using a client SSL context

### DIFF
--- a/example/src/main/java/io/netty/example/discard/DiscardClient.java
+++ b/example/src/main/java/io/netty/example/discard/DiscardClient.java
@@ -23,21 +23,29 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
-import io.netty.example.util.ServerUtil;
 import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 
 /**
  * Keeps sending random data to the specified address.
  */
 public final class DiscardClient {
 
+    static final boolean SSL = System.getProperty("ssl") != null;
     static final String HOST = System.getProperty("host", "127.0.0.1");
     static final int PORT = Integer.parseInt(System.getProperty("port", "8009"));
     static final int SIZE = Integer.parseInt(System.getProperty("size", "256"));
 
     public static void main(String[] args) throws Exception {
         // Configure SSL.
-        final SslContext sslCtx = ServerUtil.buildSslContext();
+        final SslContext sslCtx;
+        if (SSL) {
+            sslCtx = SslContextBuilder.forClient()
+                .trustManager(InsecureTrustManagerFactory.INSTANCE).build();
+        } else {
+            sslCtx = null;
+        }
 
         EventLoopGroup group = new NioEventLoopGroup();
         try {


### PR DESCRIPTION
## Problem

`./run-example -Dssl discard-client` against `./run-example -Dssl discard-server` does not complete the TLS handshake — it hangs until the handshake times out.

## Root Cause

`DiscardClient.main` builds its `SslContext` via `ServerUtil.buildSslContext()`:

```java
// example/src/main/java/io/netty/example/util/ServerUtil.java
public static SslContext buildSslContext() throws ... {
    if (!SSL) return null;
    SelfSignedCertificate ssc = new SelfSignedCertificate();
    return SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey()).build();
}
```

`SslContextBuilder.forServer(...)` produces a context whose `isClient()` is `false`, so its `SSLEngine` is created with `setUseClientMode(false)` (see `JdkSslContext`). When the example's "client" attaches that engine to its `SslHandler`, both ends of the connection are configured as TLS servers: each side waits for an inbound `ClientHello` from the other, and neither sends one. The handshake deadlocks until the configured handshake timeout fires.

## Fix

In `DiscardClient`, build a client `SslContext` with `InsecureTrustManagerFactory` when `-Dssl` is set, and leave `sslCtx` as `null` otherwise. This is the same pattern already used by `ObjectEchoClient`, `HttpUploadClient`, `SecureChatClient`, `Http2Client`, `MemcacheClient`, and other client examples in the same module.

The server side (`DiscardServer`) is unchanged and continues to use `ServerUtil.buildSslContext()` correctly.

## Tests Added

The `example` module has no unit-test infrastructure (`example/src/` contains only `main`); examples are runnable demos rather than testable units. The fix is verified by inspection against the matching `if (SSL) { SslContextBuilder.forClient()... }` pattern in the other client examples cited above.

## Impact

- `./run-example -Dssl discard-client` against `./run-example -Dssl discard-server` now completes the TLS handshake instead of timing out.
- Plaintext mode (no `-Dssl`) is unchanged: `sslCtx` is `null` exactly as before.
- Only `DiscardClient.java` is touched. `DiscardServer.java`, `DiscardClientHandler.java`, and `DiscardServerHandler.java` are unchanged.

Other example clients (`EchoClient`, `FactorialClient`, `WorldClockClient`, `TelnetClient`) call the same `ServerUtil.buildSslContext()` and exhibit the same hang under `-Dssl`. Those are kept out of this PR to keep the scope tied to the reported issue and can be addressed in a follow-up.

Fixes #14499