### PR TITLE
Close connection when both CL and TE are sent and add a option to reject TE+CL requests

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpDecoderConfig.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpDecoderConfig.java
@@ -31,6 +31,8 @@ public final class HttpDecoderConfig implements Cloneable {
     private HttpHeadersFactory headersFactory = DefaultHttpHeadersFactory.headersFactory();
     private HttpHeadersFactory trailersFactory = DefaultHttpHeadersFactory.trailersFactory();
     private boolean allowDuplicateContentLengths = HttpObjectDecoder.DEFAULT_ALLOW_DUPLICATE_CONTENT_LENGTHS;
+    private boolean rejectTransferEncodingWithContentLength =
+            HttpObjectDecoder.DEFAULT_REJECT_TRANSFER_ENCODING_WITH_CONTENT_LENGTH;
     private int maxInitialLineLength = HttpObjectDecoder.DEFAULT_MAX_INITIAL_LINE_LENGTH;
     private int maxHeaderSize = HttpObjectDecoder.DEFAULT_MAX_HEADER_SIZE;
     private int initialBufferSize = HttpObjectDecoder.DEFAULT_INITIAL_BUFFER_SIZE;
@@ -175,6 +177,24 @@ public final class HttpDecoderConfig implements Cloneable {
      */
     public HttpDecoderConfig setAllowDuplicateContentLengths(boolean allowDuplicateContentLengths) {
         this.allowDuplicateContentLengths = allowDuplicateContentLengths;
+        return this;
+    }
+
+    public boolean isRejectTransferEncodingWithContentLength() {
+        return rejectTransferEncodingWithContentLength;
+    }
+
+    /**
+     * Set whether messages that contain both {@code Transfer-Encoding} and {@code Content-Length} headers should be
+     * rejected with a failed {@link io.netty.handler.codec.DecoderResult}.
+     * You usually want to enable this to protect against request smuggling attacks.
+     *
+     * @param rejectTransferEncodingWithContentLength set to {@code true} to reject such messages.
+     * @return This decoder config.
+     */
+    public HttpDecoderConfig setRejectTransferEncodingWithContentLength(
+            boolean rejectTransferEncodingWithContentLength) {
+        this.rejectTransferEncodingWithContentLength = rejectTransferEncodingWithContentLength;
         return this;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -80,6 +80,13 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
  *     See <a href="https://tools.ietf.org/html/rfc7230#section-3.3.2">RFC 7230, Section 3.3.2</a>.</td>
  * </tr>
  * <tr>
+ * <td>{@code rejectTransferEncodingWithContentLength}</td>
+ * <td>{@value #DEFAULT_REJECT_TRANSFER_ENCODING_WITH_CONTENT_LENGTH}</td>
+ * <td>When set to {@code true}, will reject any messages that contain both a Transfer-Encoding and a
+ *     Content-Length header field. Such messages might indicate a request smuggling attempt.
+ *     See <a href="https://www.rfc-editor.org/rfc/rfc9112#section-6.1">RFC 9112, Section 6.1</a>.</td>
+ * </tr>
+ * <tr>
  * <td>{@code allowPartialChunks}</td>
  * <td>{@value #DEFAULT_ALLOW_PARTIAL_CHUNKS}</td>
  * <td>If the length of a chunk exceeds the {@link ByteBuf}s readable bytes and {@code allowPartialChunks}
@@ -152,6 +159,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
     public static final boolean DEFAULT_VALIDATE_HEADERS = true;
     public static final int DEFAULT_INITIAL_BUFFER_SIZE = 128;
     public static final boolean DEFAULT_ALLOW_DUPLICATE_CONTENT_LENGTHS = false;
+    public static final boolean DEFAULT_REJECT_TRANSFER_ENCODING_WITH_CONTENT_LENGTH = false;
     public static final boolean DEFAULT_STRICT_LINE_PARSING =
             SystemPropertyUtil.getBoolean("io.netty.handler.codec.http.defaultStrictLineParsing", true);
 
@@ -180,6 +188,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
     protected final HttpHeadersFactory headersFactory;
     protected final HttpHeadersFactory trailersFactory;
     private final boolean allowDuplicateContentLengths;
+    private final boolean rejectTransferEncodingWithContentLength;
     private final ByteBuf parserScratchBuffer;
     private final Runnable defaultStrictCRLFCheck;
     private final HeaderParser headerParser;
@@ -343,6 +352,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
         trailersFactory = config.getTrailersFactory();
         validateHeaders = isValidating(headersFactory);
         allowDuplicateContentLengths = config.isAllowDuplicateContentLengths();
+        rejectTransferEncodingWithContentLength = config.isRejectTransferEncodingWithContentLength();
         allowPartialChunks = config.isAllowPartialChunks();
     }
 
@@ -848,19 +858,33 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
 
     /**
      * Invoked when a message with both a "Transfer-Encoding: chunked" and a "Content-Length" header field is detected.
-     * The default behavior is to <i>remove</i> the Content-Length field, but this method could be overridden
-     * to change the behavior (to, e.g., throw an exception and produce an invalid message).
+     * The default behavior is to <i>remove</i> the Content-Length field and, when decoding a request (server-side),
+     * set {@code Connection: close} to signal that the connection should be closed after the response is sent.
+     * This method can be overridden to change the behavior (to, e.g., throw an exception and produce an invalid
+     * message).
      * <p>
-     * See: https://tools.ietf.org/html/rfc7230#section-3.3.3
+     * {@link HttpServerCodec} overrides this method to additionally enforce connection closure after the response,
+     * regardless of whether {@link HttpServerKeepAliveHandler} is in the pipeline. When using a standalone
+     * {@link HttpRequestDecoder}, either add {@link HttpServerKeepAliveHandler} to the pipeline or implement
+     * equivalent logic to ensure the connection is closed, as required by
+     * <a href="https://www.rfc-editor.org/rfc/rfc9112#section-6.1">RFC 9112, Section 6.1</a>.
+     * <p>
      * <pre>
      *     If a message is received with both a Transfer-Encoding and a
      *     Content-Length header field, the Transfer-Encoding overrides the
-     *     Content-Length.  Such a message might indicate an attempt to
-     *     perform request smuggling (Section 9.5) or response splitting
-     *     (Section 9.4) and ought to be handled as an error.  A sender MUST
+     *     Content-Length. Such a message might indicate an attempt to
+     *     perform request smuggling (Section 11.2) or response splitting
+     *     (Section 11.1) and ought to be handled as an error. A sender MUST
      *     remove the received Content-Length field prior to forwarding such
      *     a message downstream.
+     *
+     *     ...the server MUST close the connection after responding to such
+     *     a request to avoid the potential attacks.
      * </pre>
+     * When {@link HttpDecoderConfig#setRejectTransferEncodingWithContentLength(boolean)} is set to {@code true},
+     * this method will throw an {@link IllegalArgumentException} and the message will be produced with a failed
+     * {@link DecoderResult}.
+     * <p>
      * Also see:
      * https://github.com/apache/tomcat/blob/b693d7c1981fa7f51e58bc8c8e72e3fe80b7b773/
      * java/org/apache/coyote/http11/Http11Processor.java#L747-L755
@@ -868,8 +892,15 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
      * src/http/ngx_http_request.c#L1946-L1953
      */
     protected void handleTransferEncodingChunkedWithContentLength(HttpMessage message) {
+        if (rejectTransferEncodingWithContentLength) {
+            throw new IllegalArgumentException(
+                    "Both Transfer-Encoding and Content-Length headers found");
+        }
         message.headers().remove(HttpHeaderNames.CONTENT_LENGTH);
         contentLength = Long.MIN_VALUE;
+        if (isDecodingRequest()) {
+            HttpUtil.setKeepAlive(message, false);
+        }
     }
 
     private LastHttpContent readTrailingHeaders(ByteBuf buffer) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerCodec.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerCodec.java
@@ -16,7 +16,9 @@
 package io.netty.handler.codec.http;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
 import io.netty.channel.CombinedChannelDuplexHandler;
 
 import java.util.ArrayDeque;
@@ -69,6 +71,9 @@ public final class HttpServerCodec extends CombinedChannelDuplexHandler<HttpRequ
     private long methodQueue;
     private int methodQueueSize;
     private Queue<Byte> methodOverflowQueue;
+
+    /** When set, the connection will be closed after the next response is written. */
+    private boolean mustCloseAfterResponse;
 
     /**
      * Creates a new instance with the default decoder options
@@ -239,11 +244,26 @@ public final class HttpServerCodec extends CombinedChannelDuplexHandler<HttpRequ
                 }
             }
         }
+
+        @Override
+        protected void handleTransferEncodingChunkedWithContentLength(HttpMessage message) {
+            super.handleTransferEncodingChunkedWithContentLength(message);
+            mustCloseAfterResponse = true;
+        }
     }
 
     private final class HttpServerResponseEncoder extends HttpResponseEncoder {
 
         private byte methodFlag;
+
+        @Override
+        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+            if (mustCloseAfterResponse && msg instanceof LastHttpContent) {
+                mustCloseAfterResponse = false;
+                promise = promise.unvoid().addListener(ChannelFutureListener.CLOSE);
+            }
+            super.write(ctx, msg, promise);
+        }
 
         @Override
         protected void sanitizeHeadersBeforeEncode(HttpResponse msg, boolean isAlwaysEmpty) {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -705,7 +705,6 @@ public class HttpRequestDecoderTest {
     public void testContentLengthHeaderAndChunked() {
         String requestStr = "POST / HTTP/1.1\r\n" +
                 "Host: example.com\r\n" +
-                "Connection: close\r\n" +
                 "Content-Length: 5\r\n" +
                 "Transfer-Encoding: chunked\r\n\r\n" +
                 "0\r\n\r\n";
@@ -713,11 +712,30 @@ public class HttpRequestDecoderTest {
         assertTrue(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
         HttpRequest request = channel.readInbound();
         assertFalse(request.decoderResult().isFailure());
-        assertTrue(request.headers().names().contains("Transfer-Encoding"));
         assertTrue(request.headers().contains("Transfer-Encoding", "chunked", false));
         assertFalse(request.headers().contains("Content-Length"));
+        assertFalse(HttpUtil.isKeepAlive(request));
         LastHttpContent c = channel.readInbound();
         c.release();
+        assertFalse(channel.finish());
+    }
+
+    @Test
+    public void testRejectTransferEncodingWithContentLength() {
+        HttpDecoderConfig config = new HttpDecoderConfig()
+                .setRejectTransferEncodingWithContentLength(true);
+        String requestStr = "POST / HTTP/1.1\r\n" +
+                "Host: example.com\r\n" +
+                "Content-Length: 5\r\n" +
+                "Transfer-Encoding: chunked\r\n\r\n" +
+                "0\r\n\r\n";
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder(config));
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
+        HttpRequest request = channel.readInbound();
+        assertTrue(request.decoderResult().isFailure());
+        assertInstanceOf(IllegalArgumentException.class, request.decoderResult().cause());
+        assertTrue(request.decoderResult().cause().getMessage()
+                .contains("Both Transfer-Encoding and Content-Length"));
         assertFalse(channel.finish());
     }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
@@ -1480,4 +1480,21 @@ public class HttpResponseDecoderTest {
         ReferenceCountUtil.release(response);
         assertFalse(channel.finish());
     }
+
+    @Test
+    public void testContentLengthHeaderAndChunkedResponse() {
+        String responseStr = "HTTP/1.1 200 OK\r\n" +
+                "Content-Length: 5\r\n" +
+                "Transfer-Encoding: chunked\r\n\r\n" +
+                "0\r\n\r\n";
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseDecoder());
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer(responseStr, CharsetUtil.US_ASCII)));
+        HttpResponse response = channel.readInbound();
+        assertFalse(response.decoderResult().isFailure());
+        assertFalse(response.headers().contains("Content-Length"));
+        assertTrue(HttpUtil.isKeepAlive(response));
+        LastHttpContent c = channel.readInbound();
+        c.release();
+        assertFalse(channel.finish());
+    }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerCodecTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerCodecTest.java
@@ -19,8 +19,10 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
+import io.netty.util.ReferenceCountUtil;
 import org.junit.jupiter.api.Test;
 
+import static io.netty.handler.codec.http.HttpUtil.setContentLength;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -172,6 +174,35 @@ public class HttpServerCodecTest {
         assertEquals("HTTP/1.1 200 OK\r\ntransfer-encoding: chunked\r\n\r\n", buf.toString(CharsetUtil.US_ASCII));
         buf.release();
 
+        assertFalse(ch.finishAndReleaseAll());
+    }
+
+    @Test
+    public void testConnectionClosedAfterResponseWhenBothTransferEncodingAndContentLength() {
+        EmbeddedChannel ch = new EmbeddedChannel(new HttpServerCodec());
+
+        String requestStr = "POST / HTTP/1.1\r\n" +
+                "Host: example.com\r\n" +
+                "Content-Length: 5\r\n" +
+                "Transfer-Encoding: chunked\r\n\r\n" +
+                "0\r\n\r\n";
+
+        assertTrue(ch.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
+
+        HttpRequest request = ch.readInbound();
+        assertFalse(request.decoderResult().isFailure());
+        assertFalse(HttpUtil.isKeepAlive(request));
+        LastHttpContent content = ch.readInbound();
+        ReferenceCountUtil.release(content);
+
+        FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        setContentLength(response, 0);
+
+        assertTrue(ch.writeOutbound(response));
+        // Channel should be closed after the response is written
+        assertFalse(ch.isOpen());
+
+        ReferenceCountUtil.release(ch.readOutbound());
         assertFalse(ch.finishAndReleaseAll());
     }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerKeepAliveHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerKeepAliveHandlerTest.java
@@ -15,10 +15,13 @@
  */
 package io.netty.handler.codec.http;
 
+import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.AsciiString;
+import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -210,6 +213,36 @@ public class HttpServerKeepAliveHandlerTest {
         }
         ReferenceCountUtil.release(response);
         assertFalse(channel.finishAndReleaseAll());
+    }
+
+    @Test
+    public void testConnectionClosedWhenBothTransferEncodingAndContentLength() {
+        EmbeddedChannel ch = new EmbeddedChannel(
+                new HttpRequestDecoder(), new HttpServerKeepAliveHandler());
+
+        String requestStr = "POST / HTTP/1.1\r\n" +
+                "Host: example.com\r\n" +
+                "Content-Length: 5\r\n" +
+                "Transfer-Encoding: chunked\r\n\r\n" +
+                "0\r\n\r\n";
+
+        assertTrue(ch.writeInbound(Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
+
+        HttpRequest request = ch.readInbound();
+        assertFalse(HttpUtil.isKeepAlive(request));
+        LastHttpContent content = ch.readInbound();
+        ReferenceCountUtil.release(content);
+
+        FullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        setContentLength(response, 0);
+
+        ch.writeAndFlush(response);
+        HttpResponse writtenResponse = ch.readOutbound();
+
+        assertFalse(isKeepAlive(writtenResponse));
+        assertFalse(ch.isOpen());
+        ReferenceCountUtil.release(writtenResponse);
+        assertFalse(ch.finishAndReleaseAll());
     }
 
     private static void setupMessageLength(HttpResponse response, int setSelfDefinedMessageLength) {


### PR DESCRIPTION
Motivation:

Give option to reject requests which have both CL and TE. Close connections after getting such requests by default.

Result:

Fixes #16721 

If there is no issue then describe the changes introduced by this PR.
