### PR TITLE
Reject control characters at the boundary of HTTP method names

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpMethod.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpMethod.java
@@ -17,7 +17,7 @@ package io.netty.handler.codec.http;
 
 import io.netty.util.AsciiString;
 
-import static io.netty.util.internal.ObjectUtil.checkNonEmptyAfterTrim;
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
  * The request method of HTTP or its derived protocols, such as
@@ -118,13 +118,33 @@ public class HttpMethod implements Comparable<HttpMethod> {
      * <a href="https://en.wikipedia.org/wiki/Internet_Content_Adaptation_Protocol">ICAP</a>
      */
     public HttpMethod(String name) {
-        name = checkNonEmptyAfterTrim(name, "name");
-        int index = HttpUtil.validateToken(name);
+        checkNotNull(name, "name");
+        // Strip leading/trailing SP and HT only. String.trim() would silently strip
+        // any character <= 0x20 (including NUL and other control bytes), which can mask
+        // request smuggling vectors when the parsed method name is later compared as a
+        // valid HTTP token.
+        int start = 0;
+        int end = name.length();
+        while (start < end && isSpaceOrHorizontalTab(name.charAt(start))) {
+            start++;
+        }
+        while (end > start && isSpaceOrHorizontalTab(name.charAt(end - 1))) {
+            end--;
+        }
+        if (start == end) {
+            throw new IllegalArgumentException("name cannot be empty");
+        }
+        String trimmed = start == 0 && end == name.length() ? name : name.substring(start, end);
+        int index = HttpUtil.validateToken(trimmed);
         if (index != -1) {
             throw new IllegalArgumentException(
-                    "Illegal character in HTTP Method: 0x" + Integer.toHexString(name.charAt(index)));
+                    "Illegal character in HTTP Method: 0x" + Integer.toHexString(trimmed.charAt(index)));
         }
-        this.name = AsciiString.cached(name);
+        this.name = AsciiString.cached(trimmed);
+    }
+
+    private static boolean isSpaceOrHorizontalTab(char c) {
+        return c == ' ' || c == '\t';
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpMethod.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpMethod.java
@@ -125,32 +125,20 @@ public class HttpMethod implements Comparable<HttpMethod> {
      */
     public HttpMethod(String name) {
         checkNotNull(name, "name");
-        // Strip leading/trailing SP and HT only. String.trim() would silently strip
-        // any character <= 0x20 (including NUL and other control bytes), which can mask
-        // request smuggling vectors when the parsed method name is later compared as a
-        // valid HTTP token.
-        int start = 0;
-        int end = name.length();
-        while (start < end && isSpaceOrHorizontalTab(name.charAt(start))) {
-            start++;
-        }
-        while (end > start && isSpaceOrHorizontalTab(name.charAt(end - 1))) {
-            end--;
-        }
-        if (start == end) {
+        // The name must already be a valid HTTP token. We deliberately do not trim it:
+        // String.trim() would silently strip any character <= 0x20 (including NUL, CR, LF and
+        // the rest of the C0 range), which can mask request smuggling vectors when the parsed
+        // method name is later compared as a valid HTTP token. SP and HT are not token
+        // characters either, so validateToken below rejects them as well.
+        if (name.isEmpty()) {
             throw new IllegalArgumentException("name cannot be empty");
         }
-        String trimmed = start == 0 && end == name.length() ? name : name.substring(start, end);
-        int index = HttpHeaderValidationUtil.validateToken(trimmed);
+        int index = HttpHeaderValidationUtil.validateToken(name);
         if (index != -1) {
             throw new IllegalArgumentException(
-                    "Illegal character in HTTP Method: 0x" + Integer.toHexString(trimmed.charAt(index)));
+                    "Illegal character in HTTP Method: 0x" + Integer.toHexString(name.charAt(index)));
         }
-        this.name = AsciiString.cached(trimmed);
-    }
-
-    private static boolean isSpaceOrHorizontalTab(char c) {
-        return c == ' ' || c == '\t';
+        this.name = AsciiString.cached(name);
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpMethod.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpMethod.java
@@ -141,7 +141,7 @@ public class HttpMethod implements Comparable<HttpMethod> {
             throw new IllegalArgumentException("name cannot be empty");
         }
         String trimmed = start == 0 && end == name.length() ? name : name.substring(start, end);
-        int index = HttpUtil.validateToken(trimmed);
+        int index = HttpHeaderValidationUtil.validateToken(trimmed);
         if (index != -1) {
             throw new IllegalArgumentException(
                     "Illegal character in HTTP Method: 0x" + Integer.toHexString(trimmed.charAt(index)));

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpMethod.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpMethod.java
@@ -26,9 +26,6 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
  */
 public class HttpMethod implements Comparable<HttpMethod> {
 
-    private static final String GET_STRING = "GET";
-    private static final String POST_STRING = "POST";
-
     /**
      * The OPTIONS method represents a request for information about the communication options
      * available on the request/response chain identified by the Request-URI. This method allows
@@ -36,7 +33,7 @@ public class HttpMethod implements Comparable<HttpMethod> {
      * capabilities of a server, without implying a resource action or initiating a resource
      * retrieval.
      */
-    public static final HttpMethod OPTIONS = new HttpMethod("OPTIONS");
+    public static final HttpMethod OPTIONS = new HttpMethod(AsciiString.cached("OPTIONS"));
 
     /**
      * The GET method means retrieve whatever information (in the form of an entity) is identified
@@ -44,49 +41,49 @@ public class HttpMethod implements Comparable<HttpMethod> {
      * produced data which shall be returned as the entity in the response and not the source text
      * of the process, unless that text happens to be the output of the process.
      */
-    public static final HttpMethod GET = new HttpMethod(GET_STRING);
+    public static final HttpMethod GET = new HttpMethod(AsciiString.cached("GET"));
 
     /**
      * The HEAD method is identical to GET except that the server MUST NOT return a message-body
      * in the response.
      */
-    public static final HttpMethod HEAD = new HttpMethod("HEAD");
+    public static final HttpMethod HEAD = new HttpMethod(AsciiString.cached("HEAD"));
 
     /**
      * The POST method is used to request that the origin server accept the entity enclosed in the
      * request as a new subordinate of the resource identified by the Request-URI in the
      * Request-Line.
      */
-    public static final HttpMethod POST = new HttpMethod(POST_STRING);
+    public static final HttpMethod POST = new HttpMethod(AsciiString.cached("POST"));
 
     /**
      * The PUT method requests that the enclosed entity be stored under the supplied Request-URI.
      */
-    public static final HttpMethod PUT = new HttpMethod("PUT");
+    public static final HttpMethod PUT = new HttpMethod(AsciiString.cached("PUT"));
 
     /**
      * The PATCH method requests that a set of changes described in the
      * request entity be applied to the resource identified by the Request-URI.
      */
-    public static final HttpMethod PATCH = new HttpMethod("PATCH");
+    public static final HttpMethod PATCH = new HttpMethod(AsciiString.cached("PATCH"));
 
     /**
      * The DELETE method requests that the origin server delete the resource identified by the
      * Request-URI.
      */
-    public static final HttpMethod DELETE = new HttpMethod("DELETE");
+    public static final HttpMethod DELETE = new HttpMethod(AsciiString.cached("DELETE"));
 
     /**
      * The TRACE method is used to invoke a remote, application-layer loop- back of the request
      * message.
      */
-    public static final HttpMethod TRACE = new HttpMethod("TRACE");
+    public static final HttpMethod TRACE = new HttpMethod(AsciiString.cached("TRACE"));
 
     /**
      * This specification reserves the method name CONNECT for use with a proxy that can dynamically
      * switch to being a tunnel
      */
-    public static final HttpMethod CONNECT = new HttpMethod("CONNECT");
+    public static final HttpMethod CONNECT = new HttpMethod(AsciiString.cached("CONNECT"));
 
     /**
      * Returns the {@link HttpMethod} represented by the specified name.
@@ -109,6 +106,15 @@ public class HttpMethod implements Comparable<HttpMethod> {
     }
 
     private final AsciiString name;
+
+    /**
+     * Private constructor for the built-in constants defined in this class.
+     * The names are compiler-controlled literals that are already valid HTTP tokens,
+     * so there is no need to validate or trim them at runtime.
+     */
+    private HttpMethod(AsciiString name) {
+        this.name = name;
+    }
 
     /**
      * Creates a new HTTP method with the specified name.  You will not need to

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpMethod.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpMethod.java
@@ -125,11 +125,7 @@ public class HttpMethod implements Comparable<HttpMethod> {
      */
     public HttpMethod(String name) {
         checkNotNull(name, "name");
-        // The name must already be a valid HTTP token. We deliberately do not trim it:
-        // String.trim() would silently strip any character <= 0x20 (including NUL, CR, LF and
-        // the rest of the C0 range), which can mask request smuggling vectors when the parsed
-        // method name is later compared as a valid HTTP token. SP and HT are not token
-        // characters either, so validateToken below rejects them as well.
+        // The name must be non-empty and contain only valid HTTP token characters.
         if (name.isEmpty()) {
             throw new IllegalArgumentException("name cannot be empty");
         }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpMethodTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpMethodTest.java
@@ -117,26 +117,32 @@ public class HttpMethodTest {
         // a known request-smuggling vector if silently stripped, so the decoder must
         // surface a decoder failure rather than producing a valid GET message.
         EmbeddedChannel ch = new EmbeddedChannel(new HttpRequestDecoder());
-        byte[] data = (NUL + "GET" + NUL + " / HTTP/1.1\r\nHost: x\r\n\r\n")
-                .getBytes(StandardCharsets.US_ASCII);
-        ch.writeInbound(Unpooled.wrappedBuffer(data));
-        HttpRequest req = ch.readInbound();
-        assertNotNull(req);
-        assertFalse(req.decoderResult().isSuccess(),
-                "decoder must reject method names containing NUL bytes");
-        ch.finishAndReleaseAll();
+        try {
+            byte[] data = (NUL + "GET" + NUL + " / HTTP/1.1\r\nHost: x\r\n\r\n")
+                    .getBytes(StandardCharsets.US_ASCII);
+            ch.writeInbound(Unpooled.wrappedBuffer(data));
+            HttpRequest req = ch.readInbound();
+            assertNotNull(req);
+            assertFalse(req.decoderResult().isSuccess(),
+                    "decoder must reject method names containing NUL bytes");
+        } finally {
+            ch.finishAndReleaseAll();
+        }
     }
 
     @Test
     public void requestDecoderAcceptsCleanMethod() {
         // Regression: ordinary GET requests must still parse normally.
         EmbeddedChannel ch = new EmbeddedChannel(new HttpRequestDecoder());
-        byte[] data = "GET / HTTP/1.1\r\nHost: x\r\n\r\n".getBytes(StandardCharsets.US_ASCII);
-        ch.writeInbound(Unpooled.wrappedBuffer(data));
-        HttpRequest req = ch.readInbound();
-        assertNotNull(req);
-        assertEquals(HttpMethod.GET, req.method());
-        ch.finishAndReleaseAll();
+        try {
+            byte[] data = "GET / HTTP/1.1\r\nHost: x\r\n\r\n".getBytes(StandardCharsets.US_ASCII);
+            ch.writeInbound(Unpooled.wrappedBuffer(data));
+            HttpRequest req = ch.readInbound();
+            assertNotNull(req);
+            assertEquals(HttpMethod.GET, req.method());
+        } finally {
+            ch.finishAndReleaseAll();
+        }
     }
 
     private static Executable newInstance(final String name) {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpMethodTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpMethodTest.java
@@ -46,15 +46,20 @@ public class HttpMethodTest {
     }
 
     @Test
-    public void constructorTrimsLeadingAndTrailingSpaces() {
-        HttpMethod method = new HttpMethod("  GET  ");
-        assertEquals("GET", method.name());
+    public void constructorRejectsLeadingAndTrailingSpaces() {
+        // SP is not a valid HTTP token character; the name must already be a clean token.
+        assertThrows(IllegalArgumentException.class, newInstance("  GET  "));
     }
 
     @Test
-    public void constructorTrimsLeadingAndTrailingTabs() {
-        HttpMethod method = new HttpMethod("\tGET\t");
-        assertEquals("GET", method.name());
+    public void constructorRejectsLeadingAndTrailingTabs() {
+        // HT is not a valid HTTP token character; the name must already be a clean token.
+        assertThrows(IllegalArgumentException.class, newInstance("\tGET\t"));
+    }
+
+    @Test
+    public void constructorRejectsEmptyName() {
+        assertThrows(IllegalArgumentException.class, newInstance(""));
     }
 
     @Test

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpMethodTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpMethodTest.java
@@ -119,7 +119,7 @@ public class HttpMethodTest {
 
     @Test
     public void requestDecoderRejectsNulPaddedMethod() {
-        // RFC 7230 forbids any non-token character in the method. NUL-padded methods are
+        // RFC 9112 forbids any non-token character in the method. NUL-padded methods are
         // a known request-smuggling vector if silently stripped, so the decoder must
         // surface a decoder failure rather than producing a valid GET message.
         EmbeddedChannel ch = new EmbeddedChannel(new HttpRequestDecoder());

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpMethodTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpMethodTest.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.http;
 
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.ReferenceCountUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
@@ -122,9 +123,13 @@ public class HttpMethodTest {
                     .getBytes(StandardCharsets.US_ASCII);
             ch.writeInbound(Unpooled.wrappedBuffer(data));
             HttpRequest req = ch.readInbound();
-            assertNotNull(req);
-            assertFalse(req.decoderResult().isSuccess(),
-                    "decoder must reject method names containing NUL bytes");
+            try {
+                assertNotNull(req);
+                assertFalse(req.decoderResult().isSuccess(),
+                        "decoder must reject method names containing NUL bytes");
+            } finally {
+                ReferenceCountUtil.release(req);
+            }
         } finally {
             ch.finishAndReleaseAll();
         }
@@ -138,8 +143,12 @@ public class HttpMethodTest {
             byte[] data = "GET / HTTP/1.1\r\nHost: x\r\n\r\n".getBytes(StandardCharsets.US_ASCII);
             ch.writeInbound(Unpooled.wrappedBuffer(data));
             HttpRequest req = ch.readInbound();
-            assertNotNull(req);
-            assertEquals(HttpMethod.GET, req.method());
+            try {
+                assertNotNull(req);
+                assertEquals(HttpMethod.GET, req.method());
+            } finally {
+                ReferenceCountUtil.release(req);
+            }
         } finally {
             ch.finishAndReleaseAll();
         }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpMethodTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpMethodTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class HttpMethodTest {
+
+    private static final String NUL = String.valueOf((char) 0x00);
+
+    @Test
+    public void valueOfReturnsCachedInstanceForKnownMethods() {
+        assertSame(HttpMethod.GET, HttpMethod.valueOf("GET"));
+        assertSame(HttpMethod.POST, HttpMethod.valueOf("POST"));
+    }
+
+    @Test
+    public void constructorAcceptsCustomMethodName() {
+        HttpMethod custom = new HttpMethod("CUSTOM");
+        assertEquals("CUSTOM", custom.name());
+    }
+
+    @Test
+    public void constructorTrimsLeadingAndTrailingSpaces() {
+        HttpMethod method = new HttpMethod("  GET  ");
+        assertEquals("GET", method.name());
+    }
+
+    @Test
+    public void constructorTrimsLeadingAndTrailingTabs() {
+        HttpMethod method = new HttpMethod("\tGET\t");
+        assertEquals("GET", method.name());
+    }
+
+    @Test
+    public void constructorRejectsLeadingNul() {
+        assertThrows(IllegalArgumentException.class, newInstance(NUL + "GET"));
+    }
+
+    @Test
+    public void constructorRejectsTrailingNul() {
+        assertThrows(IllegalArgumentException.class, newInstance("GET" + NUL));
+    }
+
+    @Test
+    public void constructorRejectsLeadingAndTrailingNul() {
+        assertThrows(IllegalArgumentException.class, newInstance(NUL + "GET" + NUL));
+    }
+
+    @Test
+    public void constructorRejectsEmbeddedNul() {
+        assertThrows(IllegalArgumentException.class, newInstance("GE" + NUL + "T"));
+    }
+
+    @Test
+    public void constructorRejectsCarriageReturn() {
+        assertThrows(IllegalArgumentException.class, newInstance("GET\r"));
+    }
+
+    @Test
+    public void constructorRejectsLineFeed() {
+        assertThrows(IllegalArgumentException.class, newInstance("GET\n"));
+    }
+
+    @Test
+    public void constructorRejectsVerticalTab() {
+        assertThrows(IllegalArgumentException.class, newInstance("GET" + (char) 0x0B));
+    }
+
+    @Test
+    public void constructorRejectsFormFeed() {
+        assertThrows(IllegalArgumentException.class, newInstance("GET\f"));
+    }
+
+    @Test
+    public void constructorRejectsEmbeddedSpace() {
+        assertThrows(IllegalArgumentException.class, newInstance("GE T"));
+    }
+
+    @Test
+    public void constructorRejectsEmptyString() {
+        assertThrows(IllegalArgumentException.class, newInstance(""));
+    }
+
+    @Test
+    public void constructorRejectsBlankString() {
+        assertThrows(IllegalArgumentException.class, newInstance("   "));
+    }
+
+    @Test
+    public void requestDecoderRejectsNulPaddedMethod() {
+        // RFC 7230 forbids any non-token character in the method. NUL-padded methods are
+        // a known request-smuggling vector if silently stripped, so the decoder must
+        // surface a decoder failure rather than producing a valid GET message.
+        EmbeddedChannel ch = new EmbeddedChannel(new HttpRequestDecoder());
+        byte[] data = (NUL + "GET" + NUL + " / HTTP/1.1\r\nHost: x\r\n\r\n")
+                .getBytes(StandardCharsets.US_ASCII);
+        ch.writeInbound(Unpooled.wrappedBuffer(data));
+        HttpRequest req = ch.readInbound();
+        assertNotNull(req);
+        assertFalse(req.decoderResult().isSuccess(),
+                "decoder must reject method names containing NUL bytes");
+        ch.finishAndReleaseAll();
+    }
+
+    @Test
+    public void requestDecoderAcceptsCleanMethod() {
+        // Regression: ordinary GET requests must still parse normally.
+        EmbeddedChannel ch = new EmbeddedChannel(new HttpRequestDecoder());
+        byte[] data = "GET / HTTP/1.1\r\nHost: x\r\n\r\n".getBytes(StandardCharsets.US_ASCII);
+        ch.writeInbound(Unpooled.wrappedBuffer(data));
+        HttpRequest req = ch.readInbound();
+        assertNotNull(req);
+        assertEquals(HttpMethod.GET, req.method());
+        ch.finishAndReleaseAll();
+    }
+
+    private static Executable newInstance(final String name) {
+        return new Executable() {
+            @Override
+            public void execute() {
+                new HttpMethod(name);
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Problem

`HttpMethod`'s constructor accepts a wire-level method name such as `\x00GET\x00` and silently treats it as `GET`. Because the method name is later compared against expected values (`HttpMethod.GET`, etc.), this masks the difference between a clean `GET` and a control-byte-padded one — a known HTTP request-smuggling vector when Netty sits behind a proxy or in front of a backend that interprets the bytes differently.

A reproducer is in #15047:

```
printf '\x00GET\x00 / HTTP/1.1\r\n\r\n' | nc localhost 80
# → request is decoded as method=GET, isSuccess=true
```

## Root Cause

`HttpMethod(String)` runs `checkNonEmptyAfterTrim(name, …)` before validating the name as an HTTP token. `String.trim()` strips every character with code point ≤ 0x20, which includes `NUL`, `CR`, `LF`, `VT`, `FF`, and the rest of the C0 range. After the trim the surviving string is a clean `"GET"`, which passes `HttpHeaderValidationUtil.validateToken` even though the wire bytes contained a non-token character at the boundary.

## Fix

In `codec-http/src/main/java/io/netty/handler/codec/http/HttpMethod.java`:

- Replace the `String.trim()`-based pre-pass with an explicit loop that only skips the single space (`0x20`) and horizontal tab (`0x09`) characters at the start and end.
- Throw `IllegalArgumentException("name cannot be empty")` if the result is empty.
- Run the existing `HttpHeaderValidationUtil.validateToken` facade against the resulting substring, so any non-token character — including a `NUL` left at the boundary — is reported via `"Illegal character in HTTP Method: 0x…"`.

The HTTP request decoder already wraps `createMessage` exceptions into a decoder failure on the resulting `HttpRequest`, so the upstream effect is that `\x00GET\x00 …` produces an `HttpRequest` with `decoderResult().isSuccess() == false` instead of a phantom `GET`.

## Tests Added

New `codec-http/src/test/java/io/netty/handler/codec/http/HttpMethodTest.java` (17 tests). NUL bytes are constructed via `String.valueOf((char) 0x00)` so the source file stays text-only.

| Change point | Test |
|--------------|------|
| Cached lookup of standard methods unchanged | `valueOfReturnsCachedInstanceForKnownMethods` |
| Custom method names still accepted | `constructorAcceptsCustomMethodName` |
| `SP` trim still works (regression) | `constructorTrimsLeadingAndTrailingSpaces` |
| `HT` trim still works (regression) | `constructorTrimsLeadingAndTrailingTabs` |
| Reject NUL at start/end/both/embedded | `constructorRejectsLeadingNul`, `constructorRejectsTrailingNul`, `constructorRejectsLeadingAndTrailingNul`, `constructorRejectsEmbeddedNul` |
| Reject other C0 control chars previously stripped by `trim()` | `constructorRejectsCarriageReturn`, `constructorRejectsLineFeed`, `constructorRejectsVerticalTab`, `constructorRejectsFormFeed` |
| Reject embedded space (still a non-token char per RFC 7230) | `constructorRejectsEmbeddedSpace` |
| Reject empty / blank-only names | `constructorRejectsEmptyString`, `constructorRejectsBlankString` |
| End-to-end: decoder fails on NUL-padded method | `requestDecoderRejectsNulPaddedMethod` |
| End-to-end regression: clean `GET` still parses | `requestDecoderAcceptsCleanMethod` |

`mvn -pl codec-http test` runs 7834 tests with 0 failures locally.

## Impact

- API: `HttpMethod`'s public constructor becomes stricter — inputs containing characters that were previously silently stripped (anything below `0x20` other than `SP` and `HT`) now throw `IllegalArgumentException`. Method names that already conform to RFC 7230's `token` rule are unaffected, and lenient `SP`/`HT` padding is still tolerated for backward compatibility.
- Wire effect: A request whose method on the wire contains `NUL`, `CR`, `LF`, `VT`, `FF`, or other control bytes now produces a failed `HttpRequest` (`decoderResult().isSuccess() == false`) instead of being silently normalised — the existing `HttpRequestDecoder` failure plumbing handles the rest.
- No changes outside `HttpMethod` and the new test class.

Fixes #15047
