### PR TITLE
Epoll: Use correct inital EpollIoOps

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
@@ -38,7 +38,7 @@ public abstract class AbstractEpollServerChannel extends AbstractEpollChannel im
     }
 
     protected AbstractEpollServerChannel(LinuxSocket fd, boolean active) {
-        super(null, fd, active, EpollIoOps.valueOf(0));
+        super(null, fd, active, EpollIoOps.EPOLLERR);
     }
 
     @Override

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -125,7 +125,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
     }
 
     private EpollDatagramChannel(LinuxSocket fd, boolean active) {
-        super(null, fd, active, EpollIoOps.valueOf(0));
+        super(null, fd, active, EpollIoOps.EPOLLERR);
 
         // Configure IP_MULTICAST_ALL - disable by default to match the behaviour of NIO.
         try {

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDomainDatagramChannel.java
@@ -68,7 +68,7 @@ public final class EpollDomainDatagramChannel extends AbstractEpollChannel imple
     }
 
     private EpollDomainDatagramChannel(LinuxSocket socket, boolean active) {
-        super(null, socket, active, EpollIoOps.valueOf(0));
+        super(null, socket, active, EpollIoOps.EPOLLERR);
         config = new EpollDomainDatagramChannelConfig(this);
     }
 


### PR DESCRIPTION
Motivation:

0ec3d97fab376e243d328ac95fbd288ba0f6e22d introduced a change to correctly handle deletion of FD from the epoll set. Unfortunally it missed to also change the initialOps for some Channels which could lead to problems

Modifications:

Use correct initial ops

Result:

No more issues.
