### PR TITLE
Epoll: Use correct inital EpollIoOps (#16728)

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -112,7 +112,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
     }
 
     private EpollDatagramChannel(EventLoop eventLoop, LinuxSocket fd, boolean active) {
-        super(eventLoop, null, fd, active, EpollIoOps.valueOf(0), true);
+        super(eventLoop, null, fd, active, EpollIoOps.EPOLLERR, true);
 
         if (fd.protocolFamily() != SocketProtocolFamily.UNIX) {
             // Configure IP_MULTICAST_ALL - disable by default to match the behaviour of NIO.

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
@@ -82,7 +82,7 @@ public final class EpollServerSocketChannel extends AbstractEpollChannel impleme
 
     private EpollServerSocketChannel(EventLoop eventLoop, EventLoopGroup childEventLoopGroup,
                                          LinuxSocket fd, boolean active) {
-        super(eventLoop, null, fd, active, EpollIoOps.valueOf(0), false);
+        super(eventLoop, null, fd, active, EpollIoOps.EPOLLERR, false);
         this.childEventLoopGroup =
                 validateEventLoopGroup(childEventLoopGroup, "childEventLoopGroup", EpollIoHandle.class);
         config = new EpollServerSocketChannelConfig(this);


### PR DESCRIPTION
Motivation:

0ec3d97fab376e243d328ac95fbd288ba0f6e22d introduced a change to
correctly handle deletion of FD from the epoll set. Unfortunally it
missed to also change the initialOps for some Channels which could lead
to problems

Modifications:

Use correct initial ops

Result:

No more issues.
