### PR TITLE
Replace SizeClassedChunk queue-based reuse with mimalloc-style intrusive lists

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -475,7 +475,6 @@ final class AdaptivePoolingAllocator {
             }
             chunkCache.freeChunks();
         }
-
     }
 
     private interface ChunkCache {

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -77,7 +77,7 @@ import java.util.function.IntConsumer;
  * This allows the allocator to quickly respond to changes in the application workload,
  * without suffering undue overhead from maintaining its statistics.
  * <p>
- * Since magazines are "relatively thread-local", the allocator has a central chunk cache that allow excess chunks
+ * Since magazines are "relatively thread-local", the allocator has a central chunk cache that allows excess chunks
  * from any magazine to be shared with other magazines.
  */
 @UnstableApi
@@ -477,11 +477,11 @@ final class AdaptivePoolingAllocator {
         }
     }
 
-    private interface ChunkCache {
-        Chunk pollChunk(int size);
-        boolean offerChunk(Chunk chunk);
-        void freeChunks();
-        default void notifyReady(Chunk chunk) { }
+    private abstract static class ChunkCache {
+        abstract Chunk pollChunk(int size);
+        abstract boolean offerChunk(Chunk chunk);
+        abstract void freeChunks();
+        void notifyReady(Chunk chunk) { }
     }
 
     /**
@@ -498,7 +498,7 @@ final class AdaptivePoolingAllocator {
      * using a sentinel terminal node. Tracks all chunks for ownerThread/finalize cleanup.
      * Push-once per chunk lifetime, guarded by the {@link SizeClassedChunk#nextFree} link pointer.
      */
-    private static final class ParkingLotChunkCache implements ChunkCache {
+    private static final class ParkingLotChunkCache extends ChunkCache {
         @SuppressWarnings("rawtypes")
         private static final AtomicReferenceFieldUpdater<ParkingLotChunkCache, SizeClassedChunk> READY_HEAD =
                 AtomicReferenceFieldUpdater.newUpdater(
@@ -539,6 +539,9 @@ final class AdaptivePoolingAllocator {
             return true;
         }
 
+        // Push-once: the intrusive nextFree link pointer is the insertion guard.
+        // No concurrent registerToFree on the same chunk — magazine ownership
+        // guarantees single-writer per chunk per lifecycle.
         private void registerToFree(SizeClassedChunk chunk) {
             if (chunk.nextFree != null) {
                 return;
@@ -563,6 +566,11 @@ final class AdaptivePoolingAllocator {
             }
         }
 
+        // Called exactly once from the dying owner thread (FastThreadLocal removal).
+        // No concurrent registerToFree — only the owner thread calls offerChunk.
+        // The first-segment-return vs markToDeallocate race is safe: markToDeallocate
+        // uses CAS (handles both AVAILABLE and AVAILABLE_ARMED), and notification CAS
+        // on the same state variable ensures only one wins.
         private void freeChunksThreadLocal() {
             SizeClassedChunk chunk = cleanupHead;
             while (chunk != SizeClassedChunk.CLEANUP_SENTINEL) {
@@ -588,6 +596,9 @@ final class AdaptivePoolingAllocator {
             return chunk;
         }
 
+        // freeChunksShared is called exactly once, from finalize(). The allocator must be
+        // unreachable for finalize to run, so no concurrent offerChunk/registerToFree calls.
+        // No null guard needed on the getAndSet result.
         private void freeChunksShared() {
             SizeClassedChunk chunk = CLEANUP_HEAD.getAndSet(this, null);
             while (chunk != SizeClassedChunk.CLEANUP_SENTINEL) {
@@ -618,7 +629,7 @@ final class AdaptivePoolingAllocator {
         }
     }
 
-    private static final class ConcurrentSkipListChunkCache implements ChunkCache {
+    private static final class ConcurrentSkipListChunkCache extends ChunkCache {
         private final ConcurrentSkipListIntObjMultimap<Chunk> chunks;
 
         private ConcurrentSkipListChunkCache() {
@@ -1744,6 +1755,7 @@ final class AdaptivePoolingAllocator {
         private AbstractByteBuf rootParent;
         Chunk chunk;
         private int length;
+
         private int maxFastCapacity;
         private ByteBuffer tmpNioBuf;
         private boolean hasArray;

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -77,9 +77,8 @@ import java.util.function.IntConsumer;
  * This allows the allocator to quickly respond to changes in the application workload,
  * without suffering undue overhead from maintaining its statistics.
  * <p>
- * Since magazines are "relatively thread-local", the allocator has a central queue that allow excess chunks from any
- * magazine, to be shared with other magazines.
- * The {@link #createSharedChunkQueue()} method can be overridden to customize this queue.
+ * Since magazines are "relatively thread-local", the allocator has a central chunk cache that allow excess chunks
+ * from any magazine to be shared with other magazines.
  */
 @UnstableApi
 final class AdaptivePoolingAllocator {
@@ -225,30 +224,6 @@ final class AdaptivePoolingAllocator {
                     new SizeClassChunkManagementStrategy(segmentSize), isThreadLocal);
         }
         return groups;
-    }
-
-    /**
-     * Create a thread-safe multi-producer, multi-consumer queue to hold chunks that spill over from the
-     * internal Magazines.
-     * <p>
-     * Each Magazine can only hold two chunks at any one time: the chunk it currently allocates from,
-     * and the next-in-line chunk which will be used for allocation once the current one has been used up.
-     * This queue will be used by magazines to share any excess chunks they allocate, so that they don't need to
-     * allocate new chunks when their current and next-in-line chunks have both been used up.
-     * <p>
-     * The simplest implementation of this method is to return a new {@link ConcurrentLinkedQueue}.
-     * However, the {@code CLQ} is unbounded, and this means there's no limit to how many chunks can be cached in this
-     * queue.
-     * <p>
-     * Each chunk in this queue can be up to {@link #MAX_CHUNK_SIZE} in size, so it is recommended to use a bounded
-     * queue to limit the maximum memory usage.
-     * <p>
-     * The default implementation will create a bounded queue with a capacity of {@link #CHUNK_REUSE_QUEUE}.
-     *
-     * @return A new multi-producer, multi-consumer queue.
-     */
-    private static Queue<SizeClassedChunk> createSharedChunkQueue() {
-        return PlatformDependent.newFixedMpmcQueue(CHUNK_REUSE_QUEUE);
     }
 
     ByteBuf allocate(int size, int maxCapacity) {
@@ -476,7 +451,7 @@ final class AdaptivePoolingAllocator {
 
             if (freed && isAdded) {
                 // Help to free the reuse queue.
-                freeChunkReuseQueue(ownerThread);
+                chunkCache.freeChunks();
             }
             return isAdded;
         }
@@ -498,58 +473,155 @@ final class AdaptivePoolingAllocator {
                     magazineExpandLock.unlockWrite(stamp);
                 }
             }
-            freeChunkReuseQueue(ownerThread);
+            chunkCache.freeChunks();
         }
 
-        private void freeChunkReuseQueue(Thread ownerThread) {
-            Chunk chunk;
-            while ((chunk = chunkCache.pollChunk(0)) != null) {
-                if (ownerThread != null && chunk instanceof SizeClassedChunk) {
-                    SizeClassedChunk threadLocalChunk = (SizeClassedChunk) chunk;
-                    assert ownerThread == threadLocalChunk.ownerThread;
-                    // no release segment can ever happen from the owner Thread since it's not running anymore
-                    // This is required to let the ownerThread to be GC'ed despite there are AdaptiveByteBuf
-                    // that reference some thread local chunk
-                    threadLocalChunk.ownerThread = null;
-                }
-                chunk.markToDeallocate();
-            }
-        }
     }
 
     private interface ChunkCache {
         Chunk pollChunk(int size);
         boolean offerChunk(Chunk chunk);
+        void freeChunks();
+        default void notifyReady(Chunk chunk) { }
     }
 
-    private static final class ConcurrentQueueChunkCache implements ChunkCache {
-        private final Queue<SizeClassedChunk> queue;
+    /**
+     * Notification-driven chunk cache inspired by mimalloc's free-list sharding.
+     * <p>
+     * Exhausted chunks are armed with {@link SizeClassedChunk#armNotification()}. When the first
+     * segment is returned via {@link SizeClassedChunk#releaseSegment}, a CAS disarms the flag
+     * and places the chunk on a ready list for O(1) reuse.
+     * <p>
+     * <b>Ready list:</b> thread-local uses atomic CAS-push + getAndSet drain.
+     * Shared uses a {@link ConcurrentLinkedQueue}.
+     * <p>
+     * <b>Cleanup list:</b> MPSC intrusive linked list (CAS-loop push, single-consumer drain)
+     * using a sentinel terminal node. Tracks all chunks for ownerThread/finalize cleanup.
+     * Push-once per chunk lifetime, guarded by the {@link SizeClassedChunk#nextFree} link pointer.
+     */
+    private static final class ParkingLotChunkCache implements ChunkCache {
+        @SuppressWarnings("rawtypes")
+        private static final AtomicReferenceFieldUpdater<ParkingLotChunkCache, SizeClassedChunk> READY_HEAD =
+                AtomicReferenceFieldUpdater.newUpdater(
+                        ParkingLotChunkCache.class, SizeClassedChunk.class, "readyHead");
+        @SuppressWarnings("rawtypes")
+        private static final AtomicReferenceFieldUpdater<ParkingLotChunkCache, SizeClassedChunk> CLEANUP_HEAD =
+                AtomicReferenceFieldUpdater.newUpdater(
+                        ParkingLotChunkCache.class, SizeClassedChunk.class, "cleanupHead");
 
-        private ConcurrentQueueChunkCache() {
-            queue = createSharedChunkQueue();
+        private volatile SizeClassedChunk readyHead;
+        private SizeClassedChunk localReadyHead;
+        private volatile SizeClassedChunk cleanupHead;
+        private final boolean isThreadLocal;
+        private final Queue<SizeClassedChunk> sharedReadyList;
+
+        ParkingLotChunkCache(boolean isThreadLocal) {
+            this.isThreadLocal = isThreadLocal;
+            this.cleanupHead = SizeClassedChunk.CLEANUP_SENTINEL;
+            sharedReadyList = isThreadLocal ? null : new ConcurrentLinkedQueue<SizeClassedChunk>();
         }
 
         @Override
         public SizeClassedChunk pollChunk(int size) {
-            // we really don't care about size here since the sized class chunk q
-            // just care about segments of fixed size!
-            Queue<SizeClassedChunk> queue = this.queue;
-            for (int i = 0; i < CHUNK_REUSE_QUEUE; i++) {
-                SizeClassedChunk chunk = queue.poll();
-                if (chunk == null) {
-                    return null;
-                }
-                if (chunk.hasRemainingCapacity()) {
-                    return chunk;
-                }
-                queue.offer(chunk);
+            if (isThreadLocal) {
+                return drainReadyThreadLocal();
             }
-            return null;
+            return sharedReadyList.poll();
         }
 
         @Override
         public boolean offerChunk(Chunk chunk) {
-            return queue.offer((SizeClassedChunk) chunk);
+            SizeClassedChunk sized = (SizeClassedChunk) chunk;
+            sized.armNotification();
+            registerToFree(sized);
+            // Volatile write in armNotification + volatile reads in hasRemainingCapacity:
+            // SC ordering guarantees at least one side (us or the returning thread) sees
+            // the other's write — no missed 0→1 transitions on the free list.
+            if (sized.hasRemainingCapacity()) {
+                if (SizeClassedChunk.STATE.compareAndSet(sized, SizeClassedChunk.AVAILABLE_ARMED,
+                        SizeClassedChunk.AVAILABLE)) {
+                    notifyReady(sized);
+                }
+            }
+            return true;
+        }
+
+        private void registerToFree(SizeClassedChunk chunk) {
+            if (chunk.nextFree != null) {
+                return;
+            }
+            SizeClassedChunk head;
+            do {
+                head = cleanupHead;
+                if (head == null) {
+                    chunk.markToDeallocate();
+                    return;
+                }
+                SizeClassedChunk.NEXT_FREE.lazySet(chunk, head);
+            } while (!CLEANUP_HEAD.compareAndSet(this, head, chunk));
+        }
+
+        @Override
+        public void freeChunks() {
+            if (isThreadLocal) {
+                freeChunksThreadLocal();
+            } else {
+                freeChunksShared();
+            }
+        }
+
+        private void freeChunksThreadLocal() {
+            SizeClassedChunk chunk = cleanupHead;
+            while (chunk != SizeClassedChunk.CLEANUP_SENTINEL) {
+                SizeClassedChunk next = chunk.nextFree;
+                chunk.nextFree = null;
+                chunk.ownerThread = null;
+                chunk.markToDeallocate();
+                chunk = next;
+            }
+        }
+
+        private SizeClassedChunk drainReadyThreadLocal() {
+            SizeClassedChunk chunk = localReadyHead;
+            if (chunk == null) {
+                localReadyHead = READY_HEAD.getAndSet(this, null);
+                chunk = localReadyHead;
+            }
+            if (chunk == null) {
+                return null;
+            }
+            localReadyHead = chunk.readyNext;
+            chunk.readyNext = chunk;
+            return chunk;
+        }
+
+        private void freeChunksShared() {
+            SizeClassedChunk chunk = CLEANUP_HEAD.getAndSet(this, null);
+            while (chunk != SizeClassedChunk.CLEANUP_SENTINEL) {
+                SizeClassedChunk next = chunk.nextFree;
+                chunk.nextFree = null;
+                chunk.markToDeallocate();
+                chunk = next;
+            }
+        }
+
+        void notifyReadyLocal(SizeClassedChunk sized) {
+            sized.readyNext = localReadyHead;
+            localReadyHead = sized;
+        }
+
+        @Override
+        public void notifyReady(Chunk chunk) {
+            SizeClassedChunk sized = (SizeClassedChunk) chunk;
+            if (isThreadLocal) {
+                SizeClassedChunk head;
+                do {
+                    head = readyHead;
+                    sized.readyNext = head;
+                } while (!READY_HEAD.compareAndSet(this, head, sized));
+            } else {
+                sharedReadyList.offer(sized);
+            }
         }
     }
 
@@ -639,6 +711,14 @@ final class AdaptivePoolingAllocator {
             }
             return true;
         }
+
+        @Override
+        public void freeChunks() {
+            Chunk chunk;
+            while ((chunk = pollChunk(0)) != null) {
+                chunk.markToDeallocate();
+            }
+        }
     }
 
     private interface ChunkManagementStrategy {
@@ -679,7 +759,7 @@ final class AdaptivePoolingAllocator {
 
         @Override
         public ChunkCache createChunkCache(boolean isThreadLocal) {
-            return new ConcurrentQueueChunkCache();
+            return new ParkingLotChunkCache(isThreadLocal);
         }
     }
 
@@ -912,20 +992,14 @@ final class AdaptivePoolingAllocator {
                     return true;
                 }
             }
+            return allocateSlowPath(size, maxCapacity, buf, startingCapacity);
+        }
 
+        private boolean allocateSlowPath(int size, int maxCapacity, AdaptiveByteBuf buf, int startingCapacity) {
             assert current == null;
-            // The fast-path for allocations did not work.
-            //
-            // Try to fetch the next "Magazine local" Chunk first, if this fails because we don't have a
-            // next-in-line chunk available, we will poll our centralQueue.
-            // If this fails as well we will just allocate a new Chunk.
-            //
-            // In any case we will store the Chunk as the current so it will be used again for the next allocation and
-            // thus be "reserved" by this Magazine for exclusive usage.
-            curr = NEXT_IN_LINE.getAndSet(this, null);
+            Chunk curr = NEXT_IN_LINE.getAndSet(this, null);
             if (curr != null) {
                 if (curr == MAGAZINE_FREED) {
-                    // Allocation raced with a stripe-resize that freed this magazine.
                     restoreMagazineFreed();
                     return false;
                 }
@@ -933,25 +1007,19 @@ final class AdaptivePoolingAllocator {
                 int remainingCapacity = curr.remainingCapacity();
                 if (remainingCapacity > startingCapacity &&
                         curr.readInitInto(buf, size, startingCapacity, maxCapacity)) {
-                    // We have a Chunk that has some space left.
                     current = curr;
                     return true;
                 }
 
                 try {
                     if (remainingCapacity >= size) {
-                        // At this point we know that this will be the last time curr will be used, so directly set it
-                        // to null and release it once we are done.
                         return curr.readInitInto(buf, size, remainingCapacity, maxCapacity);
                     }
                 } finally {
-                    // Release in a finally block so even if readInitInto(...) would throw we would still correctly
-                    // release the current chunk before null it out.
                     curr.releaseFromMagazine();
                 }
             }
 
-            // Now try to poll from the central queue first
             curr = group.pollChunk(size);
             if (curr == null) {
                 curr = chunkController.newChunkAllocation(size, this);
@@ -960,12 +1028,9 @@ final class AdaptivePoolingAllocator {
 
                 int remainingCapacity = curr.remainingCapacity();
                 if (remainingCapacity == 0 || remainingCapacity < size) {
-                    // Check if we either retain the chunk in the nextInLine cache or releasing it.
                     if (remainingCapacity < RETIRE_CAPACITY) {
                         curr.releaseFromMagazine();
                     } else {
-                        // See if it makes sense to transfer the Chunk to the nextInLine cache for later usage.
-                        // This method will release curr if this is not the case
                         transferToNextInLineOrRelease(curr);
                     }
                     curr = chunkController.newChunkAllocation(size, this);
@@ -985,8 +1050,6 @@ final class AdaptivePoolingAllocator {
                 }
             } finally {
                 if (curr != null) {
-                    // Release in a finally block so even if readInitInto(...) would throw we would still correctly
-                    // release the current chunk before null it out.
                     curr.releaseFromMagazine();
                     current = null;
                 }
@@ -1262,6 +1325,8 @@ final class AdaptivePoolingAllocator {
      * State transitions:
      * <ul>
      *   <li>{@link #AVAILABLE} (-1): chunk is in use, no deallocation tracking needed</li>
+     *   <li>{@link #AVAILABLE_ARMED} (-2): chunk released from magazine, armed for notification;
+     *       first segment return CAS-disarms to {@link #AVAILABLE} and triggers ready-list push</li>
      *   <li>0..N: local free list size at the time {@link #markToDeallocate()} was called;
      *       used to track when all segments have been returned</li>
      *   <li>{@link #DEALLOCATED} (Integer.MIN_VALUE): all segments returned, chunk deallocated</li>
@@ -1279,12 +1344,28 @@ final class AdaptivePoolingAllocator {
         private static final int DEALLOCATED = Integer.MIN_VALUE;
         private static final AtomicIntegerFieldUpdater<SizeClassedChunk> STATE =
             AtomicIntegerFieldUpdater.newUpdater(SizeClassedChunk.class, "state");
+        private static final int AVAILABLE_ARMED = -2;
+        @SuppressWarnings("rawtypes")
+        private static final AtomicReferenceFieldUpdater<SizeClassedChunk, SizeClassedChunk> NEXT_FREE =
+            AtomicReferenceFieldUpdater.newUpdater(
+                    SizeClassedChunk.class, SizeClassedChunk.class, "nextFree");
+        static final SizeClassedChunk CLEANUP_SENTINEL = new SizeClassedChunk();
         private volatile int state;
         private final int segments;
         private final int segmentSize;
         private final MpscIntQueue externalFreeList;
         private final IntStack localFreeList;
         private Thread ownerThread;
+        volatile SizeClassedChunk nextFree;
+        SizeClassedChunk readyNext;
+
+        SizeClassedChunk() {
+            super();
+            segmentSize = 0;
+            segments = 0;
+            externalFreeList = null;
+            localFreeList = null;
+        }
 
         SizeClassedChunk(AbstractByteBuf delegate, Magazine magazine,
                          SizeClassChunkController controller) {
@@ -1300,6 +1381,23 @@ final class AdaptivePoolingAllocator {
                 externalFreeList = controller.createEmptyFreeList();
                 localFreeList = controller.createLocalFreeList();
             }
+        }
+
+        @Override
+        void releaseFromMagazine() {
+            if (!magazine.offerToQueue(this)) {
+                markToDeallocate();
+            }
+        }
+
+        @Override
+        void attachToMagazine(Magazine magazine) {
+            this.magazine = magazine;
+        }
+
+        @Override
+        Magazine currentMagazine() {
+            return null;
         }
 
         @Override
@@ -1336,9 +1434,6 @@ final class AdaptivePoolingAllocator {
             return startIndex;
         }
 
-        // this can be used by the ConcurrentQueueChunkCache to find the first buffer to use:
-        // it doesn't update the remaining capacity and it's not consider a single segmentSize
-        // case as not suitable to be reused
         public boolean hasRemainingCapacity() {
             int remaining = super.remainingCapacity();
             if (remaining > 0) {
@@ -1379,6 +1474,10 @@ final class AdaptivePoolingAllocator {
             }
         }
 
+        void armNotification() {
+            STATE.set(this, AVAILABLE_ARMED);
+        }
+
         @Override
         void releaseSegment(int startIndex, int size) {
             IntStack localFreeList = this.localFreeList;
@@ -1386,16 +1485,38 @@ final class AdaptivePoolingAllocator {
                 localFreeList.push(startIndex);
                 int state = this.state;
                 if (state != AVAILABLE) {
-                    updateStateOnLocalReleaseSegment(state, localFreeList);
+                    if (state == AVAILABLE_ARMED) {
+                        if (STATE.compareAndSet(this, AVAILABLE_ARMED, AVAILABLE)) {
+                            ((ParkingLotChunkCache) magazine.group.chunkCache)
+                                    .notifyReadyLocal(this);
+                        } else {
+                            state = this.state;
+                            if (state != AVAILABLE) {
+                                updateStateOnLocalReleaseSegment(state, localFreeList);
+                            }
+                        }
+                    } else {
+                        updateStateOnLocalReleaseSegment(state, localFreeList);
+                    }
                 }
             } else {
-                boolean segmentReturned = externalFreeList.offer(startIndex);
-                assert segmentReturned;
-                // implicit StoreLoad barrier from MPSC offer()
-                int state = this.state;
-                if (state != AVAILABLE) {
-                    deallocateIfNeeded(state);
+                releaseSegmentExternal(startIndex);
+            }
+        }
+
+        private void releaseSegmentExternal(int startIndex) {
+            boolean segmentReturned = externalFreeList.offer(startIndex);
+            assert segmentReturned;
+            int state = this.state;
+            if (state == AVAILABLE_ARMED) {
+                if (STATE.compareAndSet(this, AVAILABLE_ARMED, AVAILABLE)) {
+                    magazine.group.chunkCache.notifyReady(this);
+                    return;
                 }
+                state = this.state;
+            }
+            if (state != AVAILABLE) {
+                deallocateIfNeeded(state);
             }
         }
 
@@ -1418,7 +1539,13 @@ final class AdaptivePoolingAllocator {
         void markToDeallocate() {
             IntStack localFreeList = this.localFreeList;
             int localSize = localFreeList != null ? localFreeList.size() : 0;
-            STATE.set(this, localSize);
+            int currentState;
+            do {
+                currentState = this.state;
+                if (currentState != AVAILABLE && currentState != AVAILABLE_ARMED) {
+                    return;
+                }
+            } while (!STATE.compareAndSet(this, currentState, localSize));
             deallocateIfNeeded(localSize);
         }
     }

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -577,7 +577,7 @@ final class AdaptivePoolingAllocator {
 
         private SizeClassedChunk drainReadyThreadLocal() {
             SizeClassedChunk chunk = localReadyHead;
-            if (chunk == null) {
+            if (chunk == null && readyHead != null) {
                 localReadyHead = READY_HEAD.getAndSet(this, null);
                 chunk = localReadyHead;
             }
@@ -934,7 +934,10 @@ final class AdaptivePoolingAllocator {
         }
 
         private boolean allocateWithoutLock(int size, int maxCapacity, AdaptiveByteBuf buf) {
-            Chunk curr = NEXT_IN_LINE.getAndSet(this, null);
+            Chunk curr = nextInLine;
+            if (curr != null) {
+                curr = NEXT_IN_LINE.getAndSet(this, null);
+            }
             if (curr == MAGAZINE_FREED) {
                 // Allocation raced with a stripe-resize that freed this magazine.
                 restoreMagazineFreed();
@@ -991,7 +994,10 @@ final class AdaptivePoolingAllocator {
 
         private boolean allocateSlowPath(int size, int maxCapacity, AdaptiveByteBuf buf, int startingCapacity) {
             assert current == null;
-            Chunk curr = NEXT_IN_LINE.getAndSet(this, null);
+            Chunk curr = nextInLine;
+            if (curr != null) {
+                curr = NEXT_IN_LINE.getAndSet(this, null);
+            }
             if (curr != null) {
                 if (curr == MAGAZINE_FREED) {
                     restoreMagazineFreed();

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -1491,6 +1491,12 @@ final class AdaptivePoolingAllocator {
         // Catches segments returned between exhaustion and arming.
         // SC ordering (volatile write in armNotification + volatile reads here)
         // guarantees at least one side sees the other's write — no missed 0→1 transitions.
+        //
+        // Thread-local chunks: MUST be called from the owner thread — hasRemainingCapacity()
+        // reads the non-thread-safe localFreeList. Guaranteed because this is only called from
+        // offerChunk, which runs on the magazine's owning thread.
+        // Shared chunks: inherently safe — localFreeList is null, only the thread-safe
+        // externalFreeList is checked.
         boolean disarmIfSegmentsAvailable() {
             return hasRemainingCapacity() &&
                     STATE.compareAndSet(this, AVAILABLE_ARMED, AVAILABLE);

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -534,14 +534,8 @@ final class AdaptivePoolingAllocator {
             SizeClassedChunk sized = (SizeClassedChunk) chunk;
             sized.armNotification();
             registerToFree(sized);
-            // Volatile write in armNotification + volatile reads in hasRemainingCapacity:
-            // SC ordering guarantees at least one side (us or the returning thread) sees
-            // the other's write — no missed 0→1 transitions on the free list.
-            if (sized.hasRemainingCapacity()) {
-                if (SizeClassedChunk.STATE.compareAndSet(sized, SizeClassedChunk.AVAILABLE_ARMED,
-                        SizeClassedChunk.AVAILABLE)) {
-                    notifyReady(sized);
-                }
+            if (sized.disarmIfSegmentsAvailable()) {
+                notifyReady(sized);
             }
             return true;
         }
@@ -1476,6 +1470,14 @@ final class AdaptivePoolingAllocator {
 
         void armNotification() {
             STATE.set(this, AVAILABLE_ARMED);
+        }
+
+        // Catches segments returned between exhaustion and arming.
+        // SC ordering (volatile write in armNotification + volatile reads here)
+        // guarantees at least one side sees the other's write — no missed 0→1 transitions.
+        boolean disarmIfSegmentsAvailable() {
+            return hasRemainingCapacity() &&
+                    STATE.compareAndSet(this, AVAILABLE_ARMED, AVAILABLE);
         }
 
         @Override

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
@@ -25,8 +25,10 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.lang.reflect.Array;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Deque;
+import java.util.List;
 import java.util.SplittableRandom;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadLocalRandom;
@@ -265,6 +267,171 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
             for (ByteBuf buf : bufs) {
                 buf.release();
             }
+        }
+    }
+
+    @Test
+    void chunksShouldBeReusableAfterQueueOverflow() {
+        AdaptiveByteBufAllocator allocator = newAllocator(false);
+
+        ByteBuf probe = allocator.heapBuffer(256);
+        long chunkSize = allocator.usedHeapMemory();
+        int buffersPerChunk = (int) (chunkSize / 256);
+        probe.release();
+
+        // Create enough chunks to overflow the reuse queue.
+        // CHUNK_REUSE_QUEUE = max(2, availableProcessors() * 2).
+        int queueCapacity = Math.max(2, NettyRuntime.availableProcessors() * 2);
+        int totalChunks = queueCapacity + 3;
+        int totalBuffers = totalChunks * buffersPerChunk;
+
+        // Round 1: allocate all buffers (creates totalChunks exhausted chunks)
+        List<ByteBuf> bufs = new ArrayList<>(totalBuffers);
+        for (int i = 0; i < totalBuffers; i++) {
+            bufs.add(allocator.heapBuffer(256));
+        }
+        // Release all — segments return to chunks.
+        // With the current code: overflowed chunks get markToDeallocate'd and deallocate here.
+        for (ByteBuf buf : bufs) {
+            buf.release();
+        }
+        bufs.clear();
+        long baselineAfterRound1 = allocator.usedHeapMemory();
+
+        // Round 2: allocate the same amount
+        for (int i = 0; i < totalBuffers; i++) {
+            bufs.add(allocator.heapBuffer(256));
+        }
+        long round2Memory = allocator.usedHeapMemory();
+        for (ByteBuf buf : bufs) {
+            buf.release();
+        }
+
+        // If all chunks from round 1 were reusable, round 2 should not need more memory.
+        // With the current code, chunks that overflowed the bounded queue were permanently lost,
+        // so round 2 must allocate new chunks to replace them → round2Memory > baseline.
+        assertTrue(round2Memory <= baselineAfterRound1 + chunkSize,
+                "Round 2 should reuse chunks from round 1 without significant new allocation. " +
+                "Baseline after round 1: " + baselineAfterRound1 + ", Round 2 peak: " + round2Memory +
+                ", chunkSize: " + chunkSize);
+    }
+
+    @Test
+    void chunkMemoryShouldStabilizeAcrossAllocationCycles() {
+        AdaptiveByteBufAllocator allocator = newAllocator(false);
+
+        ByteBuf probe = allocator.heapBuffer(256);
+        long chunkSize = allocator.usedHeapMemory();
+        int buffersPerChunk = (int) (chunkSize / 256);
+        probe.release();
+
+        int queueCapacity = Math.max(2, NettyRuntime.availableProcessors() * 2);
+        int buffersPerRound = (queueCapacity + 2) * buffersPerChunk;
+
+        long[] memoryPerRound = new long[6];
+        List<ByteBuf> bufs = new ArrayList<>(buffersPerRound);
+
+        for (int round = 0; round < 6; round++) {
+            for (int i = 0; i < buffersPerRound; i++) {
+                bufs.add(allocator.heapBuffer(256));
+            }
+            memoryPerRound[round] = allocator.usedHeapMemory();
+            for (ByteBuf buf : bufs) {
+                buf.release();
+            }
+            bufs.clear();
+        }
+
+        // Memory at peak should be the same across all rounds if chunks are properly reused.
+        // Allow 1 chunk tolerance for the magazine's current/nextInLine slots.
+        long maxDelta = chunkSize;
+        assertEquals(memoryPerRound[1], memoryPerRound[5], maxDelta,
+                "Memory should stabilize by round 2, not grow. Per-round peaks: " +
+                Arrays.toString(memoryPerRound));
+    }
+
+    @Test
+    void benchmarkPatternChunkReuse() throws Exception {
+        AdaptiveByteBufAllocator allocator = newAllocator(false);
+
+        int[] sizeFreq = {
+            256, 21272,
+            1024, 29289,
+            636, 5443,
+            15, 10344,
+            16639, 9269,
+            4574, 165,
+            8670, 195,
+            2048, 2636,
+            4096, 26,
+        };
+
+        ArrayList<Integer> sizeList = new ArrayList<>();
+        for (int i = 0; i < sizeFreq.length; i += 2) {
+            int size = sizeFreq[i];
+            int freq = Math.min(sizeFreq[i + 1], 2000);
+            for (int j = 0; j < freq; j++) {
+                sizeList.add(size);
+            }
+        }
+        int[] allSizes = new int[sizeList.size()];
+        for (int i = 0; i < allSizes.length; i++) {
+            allSizes[i] = sizeList.get(i);
+        }
+        SplittableRandom rng = new SplittableRandom(42);
+        for (int i = allSizes.length - 1; i > 0; i--) {
+            int j = rng.nextInt(i + 1);
+            int tmp = allSizes[i];
+            allSizes[i] = allSizes[j];
+            allSizes[j] = tmp;
+        }
+
+        // Run on a FastThreadLocalThread with EventExecutor mapped (like the benchmark's HarnessExecutor)
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        io.netty.util.concurrent.EventExecutor dummyExecutor =
+                io.netty.util.concurrent.ImmediateEventExecutor.INSTANCE;
+        Runnable task = () -> {
+            try {
+                int maxLiveBuffers = 8192;
+                ByteBuf[] buffers = new ByteBuf[maxLiveBuffers];
+                SplittableRandom r = new SplittableRandom(99);
+
+                for (int i = 0; i < maxLiveBuffers; i++) {
+                    buffers[i] = allocator.heapBuffer(allSizes[i % allSizes.length]);
+                }
+                long memoryAfterFill = allocator.usedHeapMemory();
+
+                int ops = maxLiveBuffers * 4;
+                long memoryMid = 0;
+                for (int i = 0; i < ops; i++) {
+                    int slot = r.nextInt(maxLiveBuffers);
+                    buffers[slot].release();
+                    buffers[slot] = allocator.heapBuffer(
+                            allSizes[(maxLiveBuffers + i) % allSizes.length]);
+                    if (i == ops / 2) {
+                        memoryMid = allocator.usedHeapMemory();
+                    }
+                }
+                long memoryEnd = allocator.usedHeapMemory();
+
+                for (ByteBuf buf : buffers) {
+                    buf.release();
+                }
+
+                long maxGrowth = memoryAfterFill / 10;
+                assertTrue(memoryEnd - memoryAfterFill <= maxGrowth,
+                        "Memory should stabilize. After fill: " + memoryAfterFill / 1024 +
+                        " KiB, at end: " + memoryEnd / 1024 + " KiB");
+            } catch (Throwable t) {
+                error.set(t);
+            }
+        };
+        Runnable mapped = io.netty.util.internal.ThreadExecutorMap.apply(task, dummyExecutor);
+        Thread ftlt = new io.netty.util.concurrent.FastThreadLocalThread(mapped);
+        ftlt.start();
+        ftlt.join();
+        if (error.get() != null) {
+            fail("Test failed on FastThreadLocalThread", error.get());
         }
     }
 

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
@@ -435,6 +435,61 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
         }
     }
 
+    @Test
+    void chunkDeallocatesWhenNeverOfferedToCache() throws Exception {
+        // A chunk that is never exhausted (never offered to the cache, never registered
+        // in the cleanup list) must still deallocate correctly when the magazine is freed
+        // (thread death) and all its segments are returned by external threads.
+        AdaptiveByteBufAllocator allocator = newAllocator(false);
+        long chunkSize = 128 * 1024; // MIN_CHUNK_SIZE
+
+        // Allocate a few buffers — NOT enough to exhaust the chunk.
+        // The chunk stays as 'current' in the magazine and is never offered to the cache.
+        int buffersPerChunk = (int) (chunkSize / 256);
+        int buffersToAllocate = Math.max(2, buffersPerChunk / 4);
+        List<ByteBuf> bufs = new ArrayList<>();
+
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        io.netty.util.concurrent.EventExecutor executor =
+                io.netty.util.concurrent.ImmediateEventExecutor.INSTANCE;
+        Runnable task = () -> {
+            try {
+                for (int i = 0; i < buffersToAllocate; i++) {
+                    bufs.add(allocator.heapBuffer(256));
+                }
+            } catch (Throwable t) {
+                error.set(t);
+            }
+        };
+        // Thread-local path: FastThreadLocalThread + EventExecutor mapping.
+        // When the thread dies, the magazine is freed and markToDeallocate is
+        // called directly on the chunk (never registered in cleanup list).
+        Runnable mapped = io.netty.util.internal.ThreadExecutorMap.apply(task, executor);
+        Thread ftlt = new io.netty.util.concurrent.FastThreadLocalThread(mapped);
+        ftlt.start();
+        ftlt.join();
+        if (error.get() != null) {
+            fail("Allocation failed", error.get());
+        }
+
+        assertEquals(buffersToAllocate, bufs.size());
+
+        // Memory is still held — chunk is markToDeallocate'd but segments are outstanding.
+        long memoryBeforeRelease = allocator.usedHeapMemory();
+        assertTrue(memoryBeforeRelease >= chunkSize,
+                "Chunk should still be tracked: " + memoryBeforeRelease);
+
+        // Release all buffers from the main thread (external returns).
+        // Each releaseSegment goes through releaseSegmentExternal → deallocateIfNeeded.
+        for (ByteBuf buf : bufs) {
+            buf.release();
+        }
+
+        // After all segments returned, the chunk should be fully deallocated.
+        assertEquals(0, allocator.usedHeapMemory(),
+                "Chunk should be deallocated after all segments returned");
+    }
+
     private static void shuffle(SplittableRandom rng, Object array) {
         int len = Array.getLength(array);
         for (int i = 0; i < len; i++) {

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
@@ -435,61 +435,6 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
         }
     }
 
-    @Test
-    void chunkDeallocatesWhenNeverOfferedToCache() throws Exception {
-        // A chunk that is never exhausted (never offered to the cache, never registered
-        // in the cleanup list) must still deallocate correctly when the magazine is freed
-        // (thread death) and all its segments are returned by external threads.
-        AdaptiveByteBufAllocator allocator = newAllocator(false);
-        long chunkSize = 128 * 1024; // MIN_CHUNK_SIZE
-
-        // Allocate a few buffers — NOT enough to exhaust the chunk.
-        // The chunk stays as 'current' in the magazine and is never offered to the cache.
-        int buffersPerChunk = (int) (chunkSize / 256);
-        int buffersToAllocate = Math.max(2, buffersPerChunk / 4);
-        List<ByteBuf> bufs = new ArrayList<>();
-
-        AtomicReference<Throwable> error = new AtomicReference<>();
-        io.netty.util.concurrent.EventExecutor executor =
-                io.netty.util.concurrent.ImmediateEventExecutor.INSTANCE;
-        Runnable task = () -> {
-            try {
-                for (int i = 0; i < buffersToAllocate; i++) {
-                    bufs.add(allocator.heapBuffer(256));
-                }
-            } catch (Throwable t) {
-                error.set(t);
-            }
-        };
-        // Thread-local path: FastThreadLocalThread + EventExecutor mapping.
-        // When the thread dies, the magazine is freed and markToDeallocate is
-        // called directly on the chunk (never registered in cleanup list).
-        Runnable mapped = io.netty.util.internal.ThreadExecutorMap.apply(task, executor);
-        Thread ftlt = new io.netty.util.concurrent.FastThreadLocalThread(mapped);
-        ftlt.start();
-        ftlt.join();
-        if (error.get() != null) {
-            fail("Allocation failed", error.get());
-        }
-
-        assertEquals(buffersToAllocate, bufs.size());
-
-        // Memory is still held — chunk is markToDeallocate'd but segments are outstanding.
-        long memoryBeforeRelease = allocator.usedHeapMemory();
-        assertTrue(memoryBeforeRelease >= chunkSize,
-                "Chunk should still be tracked: " + memoryBeforeRelease);
-
-        // Release all buffers from the main thread (external returns).
-        // Each releaseSegment goes through releaseSegmentExternal → deallocateIfNeeded.
-        for (ByteBuf buf : bufs) {
-            buf.release();
-        }
-
-        // After all segments returned, the chunk should be fully deallocated.
-        assertEquals(0, allocator.usedHeapMemory(),
-                "Chunk should be deallocated after all segments returned");
-    }
-
     private static void shuffle(SplittableRandom rng, Object array) {
         int len = Array.getLength(array);
         for (int i = 0; i < len; i++) {


### PR DESCRIPTION
Motivation:

The bounded ConcurrentQueueChunkCache causes chunk malloc/free churn on
low-core containers and costs O(n) scanning to find chunks with available
segments.

Modification:

Replace with a notification-driven ParkingLotChunkCache inspired by
mimalloc's free-list sharding.

Result:

Eliminates chunk churn and O(n) scanning.