### PR TITLE
Implement Adaptive Cumulator

### DIFF
--- a/codec-base/pom.xml
+++ b/codec-base/pom.xml
@@ -48,11 +48,6 @@
       <artifactId>netty-transport</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.jetbrains</groupId>
-      <artifactId>annotations</artifactId>
-      <scope>provided</scope>
-    </dependency>
 
     <dependency>
       <groupId>org.mockito</groupId>

--- a/codec-base/pom.xml
+++ b/codec-base/pom.xml
@@ -48,6 +48,11 @@
       <artifactId>netty-transport</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.mockito</groupId>

--- a/codec-base/src/main/java/io/netty/handler/codec/AdaptiveCumulator.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/AdaptiveCumulator.java
@@ -26,7 +26,7 @@ import io.netty.util.internal.ObjectUtil;
  * "Adaptive" cumulator: cumulate {@link ByteBuf}s by dynamically switching
  * between merge and compose strategies.
  */
-public class AdaptiveCumulator implements Cumulator {
+public final class AdaptiveCumulator implements Cumulator {
     private final int composeMinSize;
 
     /**
@@ -88,17 +88,20 @@ public class AdaptiveCumulator implements Cumulator {
             return in;
         }
         CompositeByteBuf composite = null;
+        boolean cumulationTransferred = false;
         try {
             if (isOwnedCompositeBuf(cumulation)) {
                 composite = (CompositeByteBuf) cumulation;
+                cumulationTransferred = true;
                 // Writer index must equal capacity if we are going to "write"
                 // new components to the end
                 if (composite.writerIndex() != composite.capacity()) {
                     composite.capacity(composite.writerIndex());
                 }
             } else {
-                composite = alloc.compositeBuffer(Integer.MAX_VALUE)
-                        .addFlattenedComponents(true, cumulation);
+                composite = alloc.compositeBuffer(Integer.MAX_VALUE);
+                composite.addFlattenedComponents(true, cumulation);
+                cumulationTransferred = true;
             }
             ByteBuf b = in;
             in = null;
@@ -107,6 +110,14 @@ public class AdaptiveCumulator implements Cumulator {
             CompositeByteBuf result = composite;
             composite = null;
             return result;
+        } catch (Throwable t) {
+            // If an exception was thrown AFTER cumulation was successfully wrapped, 
+            // calling composite.release() in 'finally' will drop its refCount to 0.
+            // We prevent this by calling retain() here on the exception path to keep it alive.
+            if (cumulationTransferred && composite != null && composite != cumulation) {
+                cumulation.retain(); 
+            }
+            throw t;
         } finally {
             if (in != null) {
                 // We must release if the ownership was not transferred as otherwise it may

--- a/codec-base/src/main/java/io/netty/handler/codec/AdaptiveCumulator.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/AdaptiveCumulator.java
@@ -103,7 +103,7 @@ public class AdaptiveCumulator implements Cumulator {
             ByteBuf b = in;
             in = null;
             addInput(alloc, composite, b);
-            
+
             CompositeByteBuf result = composite;
             composite = null;
             return result;
@@ -228,7 +228,7 @@ public class AdaptiveCumulator implements Cumulator {
 
             // Remove the old tail and add the new one.
             composite.removeComponent(tailComponentIndex).setIndex(0, tailStart);
-            
+
             // newTail ownership successfully transferred to the composite buffer.
             // We null out newTail before adding it to avoid a double-release if addFlattenedComponents throws.
             ByteBuf b = newTail;
@@ -238,7 +238,6 @@ public class AdaptiveCumulator implements Cumulator {
             // Restore the reader. We do this before releasing 'in' so that if it fails,
             // the caller's finally block will handle releasing 'in' without a double-free.
             composite.readerIndex(prevReader);
-
         } finally {
             in.release();
             // If new tail's ownership isn't transferred to the composite buf.

--- a/codec-base/src/main/java/io/netty/handler/codec/AdaptiveCumulator.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/AdaptiveCumulator.java
@@ -119,8 +119,7 @@ public class AdaptiveCumulator implements Cumulator {
     return buf instanceof CompositeByteBuf && buf.refCnt() == 1;
   }
 
-  @VisibleForTesting
-  void addInput(ByteBufAllocator alloc, CompositeByteBuf composite, ByteBuf in) {
+  private void addInput(ByteBufAllocator alloc, CompositeByteBuf composite, ByteBuf in) {
     if (shouldCompose(composite, in, composeMinSize)) {
       composite.addFlattenedComponents(true, in);
     } else {
@@ -130,8 +129,7 @@ public class AdaptiveCumulator implements Cumulator {
     }
   }
 
-  @VisibleForTesting
-  static boolean shouldCompose(CompositeByteBuf composite, ByteBuf in, int composeMinSize) {
+  private static boolean shouldCompose(CompositeByteBuf composite, ByteBuf in, int composeMinSize) {
     int componentCount = composite.numComponents();
     if (composite.numComponents() == 0) {
       return true;
@@ -167,8 +165,7 @@ public class AdaptiveCumulator implements Cumulator {
    * This assumption
    * is verified in unit tests for this method.
    */
-  @VisibleForTesting
-  static void mergeWithCompositeTail(
+  private static void mergeWithCompositeTail(
       ByteBufAllocator alloc, CompositeByteBuf composite, ByteBuf in) {
     int inputSize = in.readableBytes();
     int tailComponentIndex = composite.numComponents() - 1;

--- a/codec-base/src/main/java/io/netty/handler/codec/AdaptiveCumulator.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/AdaptiveCumulator.java
@@ -16,234 +16,236 @@
 
 package io.netty.handler.codec;
 
-import org.jetbrains.annotations.VisibleForTesting;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.handler.codec.ByteToMessageDecoder.Cumulator;
+import io.netty.util.internal.ObjectUtil;
 
 /**
  * "Adaptive" cumulator: cumulate {@link ByteBuf}s by dynamically switching
  * between merge and compose strategies.
  */
 public class AdaptiveCumulator implements Cumulator {
-  private final int composeMinSize;
+    private final int composeMinSize;
 
-  /**
-   * @param composeMinSize Determines the minimal size of the buffer that should
-   *                       be composed (added as a new component of the
-   *                       {@link CompositeByteBuf}). If the total size of the
-   *                       last component (tail) and the incoming buffer is
-   *                       below this value, the incoming buffer is appended to
-   *                       the tail, and the new component is not added.
-   */
-  public AdaptiveCumulator(int composeMinSize) {
-    if (composeMinSize < 0) {
-      throw new IllegalArgumentException("composeMinSize must be non-negative");
+    /**
+     * @param composeMinSize Determines the minimal size of the buffer that should
+     *                       be composed (added as a new component of the
+     *                       {@link CompositeByteBuf}). If the total size of the
+     *                       last component (tail) and the incoming buffer is
+     *                       below this value, the incoming buffer is appended to
+     *                       the tail, and the new component is not added.
+     */
+    public AdaptiveCumulator(int composeMinSize) {
+        ObjectUtil.checkPositiveOrZero(composeMinSize, "composeMinSize");
+        this.composeMinSize = composeMinSize;
     }
-    this.composeMinSize = composeMinSize;
-  }
 
-  /**
-   * "Adaptive" cumulator: cumulate {@link ByteBuf}s by dynamically switching
-   * between merge and compose strategies.
-   *
-   * <p>
-   * This cumulator applies a heuristic to make a decision whether to track a
-   * reference to the buffer with bytes received from the network stack in an
-   * array ("zero-copy"), or to merge into the last component (the tail) by
-   * performing a memory copy.
-   *
-   * <p>
-   * It is necessary as a protection from a potential attack on the
-   * {@link io.netty.handler.codec.ByteToMessageDecoder#COMPOSITE_CUMULATOR}.
-   * Consider a pathological case when an attacker sends TCP packages containing a
-   * single byte of data, and forcing the cumulator to track each one in a
-   * separate buffer. The cost is memory overhead for each buffer, and extra
-   * compute to read the cumulation.
-   *
-   * <p>
-   * Implemented heuristic establishes a minimal threshold for the total size of
-   * the tail and incoming buffer, below which they are merged. The sum of the
-   * tail and the incoming buffer is used to avoid a case where attacker
-   * alternates the size of data packets to trick the cumulator into always
-   * selecting compose strategy.
-   *
-   * <p>
-   * Merging strategy attempts to minimize unnecessary memory writes. When
-   * possible, it expands the tail capacity and only copies the incoming buffer
-   * into available memory.
-   * Otherwise, when both tail and the buffer must be copied, the tail is
-   * reallocated (or fully replaced) with a new buffer of exponentially increasing
-   * capacity (bounded to {@link #composeMinSize}) to ensure runtime
-   * {@code O(n^2)} is amortized to {@code O(n)}.
-   */
-  @Override
-  @SuppressWarnings("ReferenceEquality")
-  public final ByteBuf cumulate(ByteBufAllocator alloc, ByteBuf cumulation, ByteBuf in) {
-    if (cumulation == in) {
-      in.release();
-      return cumulation;
-    }
-    if (!cumulation.isReadable()) {
-      cumulation.release();
-      return in;
-    }
-    CompositeByteBuf composite = null;
-    try {
-      if (isOwnedCompositeBuf(cumulation)) {
-        composite = (CompositeByteBuf) cumulation;
-        // Writer index must equal capacity if we are going to "write"
-        // new components to the end
-        if (composite.writerIndex() != composite.capacity()) {
-          composite.capacity(composite.writerIndex());
+    /**
+     * "Adaptive" cumulator: cumulate {@link ByteBuf}s by dynamically switching
+     * between merge and compose strategies.
+     *
+     * <p>
+     * This cumulator applies a heuristic to make a decision whether to track a
+     * reference to the buffer with bytes received from the network stack in an
+     * array ("zero-copy"), or to merge into the last component (the tail) by
+     * performing a memory copy.
+     *
+     * <p>
+     * It is necessary as a protection from a potential attack on the
+     * {@link io.netty.handler.codec.ByteToMessageDecoder#COMPOSITE_CUMULATOR}.
+     * Consider a pathological case when an attacker sends TCP packages containing a
+     * single byte of data, and forcing the cumulator to track each one in a
+     * separate buffer. The cost is memory overhead for each buffer, and extra
+     * compute to read the cumulation.
+     *
+     * <p>
+     * Implemented heuristic establishes a minimal threshold for the total size of
+     * the tail and incoming buffer, below which they are merged. The sum of the
+     * tail and the incoming buffer is used to avoid a case where attacker
+     * alternates the size of data packets to trick the cumulator into always
+     * selecting compose strategy.
+     *
+     * <p>
+     * Merging strategy attempts to minimize unnecessary memory writes. When
+     * possible, it expands the tail capacity and only copies the incoming buffer
+     * into available memory.
+     * Otherwise, when both tail and the buffer must be copied, the tail is
+     * reallocated (or fully replaced) with a new buffer of exponentially increasing
+     * capacity (bounded to {@link #composeMinSize}) to ensure runtime
+     * {@code O(n^2)} is amortized to {@code O(n)}.
+     */
+    @Override
+    @SuppressWarnings("ReferenceEquality")
+    public final ByteBuf cumulate(ByteBufAllocator alloc, ByteBuf cumulation, ByteBuf in) {
+        if (cumulation == in) {
+            in.release();
+            return cumulation;
         }
-      } else {
-        composite = alloc.compositeBuffer(Integer.MAX_VALUE)
-            .addFlattenedComponents(true, cumulation);
-      }
-      addInput(alloc, composite, in);
-      in = null;
-      return composite;
-    } finally {
-      if (in != null) {
-        // We must release if the ownership was not transferred as otherwise it may
-        // produce a leak
-        in.release();
-        // Also release any new buffer allocated if we're not returning it
-        if (composite != null && composite != cumulation) {
-          composite.release();
+        if (!cumulation.isReadable()) {
+            cumulation.release();
+            return in;
         }
-      }
+        CompositeByteBuf composite = null;
+        try {
+            if (isOwnedCompositeBuf(cumulation)) {
+                composite = (CompositeByteBuf) cumulation;
+                // Writer index must equal capacity if we are going to "write"
+                // new components to the end
+                if (composite.writerIndex() != composite.capacity()) {
+                    composite.capacity(composite.writerIndex());
+                }
+            } else {
+                composite = alloc.compositeBuffer(Integer.MAX_VALUE)
+                        .addFlattenedComponents(true, cumulation);
+            }
+            ByteBuf b = in;
+            in = null;
+            addInput(alloc, composite, b);
+            
+            CompositeByteBuf result = composite;
+            composite = null;
+            return result;
+        } finally {
+            if (in != null) {
+                // We must release if the ownership was not transferred as otherwise it may
+                // produce a leak
+                in.release();
+            }
+            // Also release any new buffer allocated if we're not returning it
+            if (composite != null && composite != cumulation) {
+                composite.release();
+            }
+        }
     }
-  }
 
-  private static boolean isOwnedCompositeBuf(ByteBuf buf) {
-    return buf instanceof CompositeByteBuf && buf.refCnt() == 1;
-  }
-
-  private void addInput(ByteBufAllocator alloc, CompositeByteBuf composite, ByteBuf in) {
-    if (shouldCompose(composite, in, composeMinSize)) {
-      composite.addFlattenedComponents(true, in);
-    } else {
-      // The total size of the new data and the last component are below the
-      // threshold. Merge them.
-      mergeWithCompositeTail(alloc, composite, in);
+    private static boolean isOwnedCompositeBuf(ByteBuf buf) {
+        return buf instanceof CompositeByteBuf && buf.refCnt() == 1;
     }
-  }
 
-  private static boolean shouldCompose(CompositeByteBuf composite, ByteBuf in, int composeMinSize) {
-    int componentCount = composite.numComponents();
-    if (componentCount == 0) {
-      return true;
+    private void addInput(ByteBufAllocator alloc, CompositeByteBuf composite, ByteBuf in) {
+        if (shouldCompose(composite, in, composeMinSize)) {
+            composite.addFlattenedComponents(true, in);
+        } else {
+            // The total size of the new data and the last component are below the
+            // threshold. Merge them.
+            mergeWithCompositeTail(alloc, composite, in);
+        }
     }
-    int inputSize = in.readableBytes();
-    int tailStart = composite.toByteIndex(componentCount - 1);
-    int tailSize = composite.writerIndex() - tailStart;
-    return tailSize + inputSize >= composeMinSize;
-  }
 
-  /**
-   * Append the given {@link ByteBuf} {@code in} to {@link CompositeByteBuf}
-   * {@code composite} by expanding or replacing the tail component of the {@link
-   * CompositeByteBuf}.
-   *
-   * <p>
-   * The goal is to prevent {@code O(n^2)} runtime in a pathological case, that
-   * forces copying the tail component into a new buffer, for each incoming
-   * single-byte buffer.
-   * We append the new bytes to the tail, when a write (or a fast write) is
-   * possible.
-   *
-   * <p>
-   * Otherwise, the tail is replaced with a new buffer, with the capacity
-   * increased enough to achieve runtime amortization.
-   *
-   * <p>
-   * We assume that implementations of
-   * {@link ByteBufAllocator#calculateNewCapacity(int, int)},
-   * are similar to
-   * {@link io.netty.buffer.AbstractByteBufAllocator#calculateNewCapacity(int, int)},
-   * which doubles buffer capacity by normalizing it to the closest power of two.
-   * This assumption
-   * is verified in unit tests for this method.
-   */
-  private static void mergeWithCompositeTail(
-      ByteBufAllocator alloc, CompositeByteBuf composite, ByteBuf in) {
-    int inputSize = in.readableBytes();
-    int tailComponentIndex = composite.numComponents() - 1;
-    int tailStart = composite.toByteIndex(tailComponentIndex);
-    int tailSize = composite.writerIndex() - tailStart;
-    int newTailSize = inputSize + tailSize;
-
-    ByteBuf tail = composite.component(tailComponentIndex);
-    ByteBuf newTail = null;
-    // Use componentSlice() to get the correct view of the indices.
-    ByteBuf componentView = composite.componentSlice(tailComponentIndex);
-    try {
-      // Ideal case: The tail is not shared and can be expanded in-place.
-      // In-place expansion should happen only if the component represents the full
-      // capacity of the underlying buffer because if tail.capacity() >
-      // componentView.capacity(), it indicates the component is a partial slice
-      // containing hidden "discarded" bytes. Expanding such a slice in-place would
-      // "resurrect" those discarded bytes leading to silent data corruption.
-      if (tail.refCnt() == 1 && !tail.isReadOnly() && tail.capacity() == componentView.capacity()
-          && newTailSize <= tail.maxCapacity()) {
-        // Take ownership of the tail.
-        newTail = tail.retain();
-
-        // Synchronize indices based on the component's view in the composite buffer.
-        newTail.setIndex(componentView.readerIndex(), componentView.writerIndex());
-
-        /*
-         * The tail is a readable non-composite buffer, so writeBytes() handles
-         * everything for us.
-         *
-         * - ensureWritable() performs a fast resize when possible (f.e. PooledByteBuf
-         * simply updates its boundary to the end of consecutive memory run assigned to
-         * this buffer)
-         * - when the required size doesn't fit into writableBytes(), a new buffer is
-         * allocated, and the capacity is calculated with alloc.calculateNewCapacity()
-         * - note that maxFastWritableBytes() would normally allow a fast expansion of
-         * PooledByteBuf is not called because CompositeByteBuf.component() returns a
-         * duplicate, wrapped buffer.
-         * Unwrapping buffers is unsafe, and potential benefit of fast writes may not be
-         * as pronounced because the capacity is doubled with each reallocation.
-         */
-        newTail.writeBytes(in);
-      } else {
-        // Fallback strategy: Reallocate a new buffer to merge the tail and input.
-        // This ensures absolute index consistency and prevents data corruption
-        // from hidden offsets in sliced or derived buffers.
-        newTail = alloc.buffer(alloc.calculateNewCapacity(newTailSize, Integer.MAX_VALUE));
-        newTail.setBytes(0, composite, tailStart, tailSize)
-            .setBytes(tailSize, in, in.readerIndex(), inputSize)
-            .writerIndex(newTailSize);
-        in.readerIndex(in.writerIndex());
-      }
-
-      // Store readerIndex to avoid out-of-bounds writerIndex during replacement.
-      int prevReader = composite.readerIndex();
-
-      // Remove the old tail and add the new one.
-      composite.removeComponent(tailComponentIndex).setIndex(0, tailStart);
-      composite.addFlattenedComponents(true, newTail);
-
-      // newTail ownership successfully transferred to the composite buffer.
-      newTail = null;
-
-      // Restore the reader. We do this before releasing 'in' so that if it fails,
-      // the caller's finally block will handle releasing 'in' without a double-free.
-      composite.readerIndex(prevReader);
-
-      in.release();
-    } finally {
-      // If new tail's ownership isn't transferred to the composite buf.
-      // Release it to prevent a leak.
-      if (newTail != null) {
-        newTail.release();
-      }
+    private static boolean shouldCompose(CompositeByteBuf composite, ByteBuf in, int composeMinSize) {
+        int componentCount = composite.numComponents();
+        if (componentCount == 0) {
+            return true;
+        }
+        int inputSize = in.readableBytes();
+        int tailStart = composite.toByteIndex(componentCount - 1);
+        long tailSize = composite.writerIndex() - tailStart;
+        return tailSize + inputSize >= composeMinSize;
     }
-  }
+
+    /**
+     * Append the given {@link ByteBuf} {@code in} to {@link CompositeByteBuf}
+     * {@code composite} by expanding or replacing the tail component of the {@link
+     * CompositeByteBuf}.
+     *
+     * <p>
+     * The goal is to prevent {@code O(n^2)} runtime in a pathological case, that
+     * forces copying the tail component into a new buffer, for each incoming
+     * single-byte buffer.
+     * We append the new bytes to the tail, when a write (or a fast write) is
+     * possible.
+     *
+     * <p>
+     * Otherwise, the tail is replaced with a new buffer, with the capacity
+     * increased enough to achieve runtime amortization.
+     *
+     * <p>
+     * We assume that implementations of
+     * {@link ByteBufAllocator#calculateNewCapacity(int, int)},
+     * are similar to
+     * {@link io.netty.buffer.AbstractByteBufAllocator#calculateNewCapacity(int, int)},
+     * which doubles buffer capacity by normalizing it to the closest power of two.
+     * This assumption is verified in unit tests for this method.
+     */
+    private static void mergeWithCompositeTail(
+            ByteBufAllocator alloc, CompositeByteBuf composite, ByteBuf in) {
+        int inputSize = in.readableBytes();
+        int tailComponentIndex = composite.numComponents() - 1;
+        int tailStart = composite.toByteIndex(tailComponentIndex);
+        int tailSize = composite.writerIndex() - tailStart;
+        int newTailSize = inputSize + tailSize;
+
+        ByteBuf tail = composite.component(tailComponentIndex);
+        ByteBuf newTail = null;
+        // Use componentSlice() to get the correct view of the indices.
+        ByteBuf componentView = composite.componentSlice(tailComponentIndex);
+        try {
+            // Ideal case: The tail is not shared and can be expanded in-place.
+            // In-place expansion should happen only if the component represents the full
+            // capacity of the underlying buffer because if tail.capacity() >
+            // componentView.capacity(), it indicates the component is a partial slice
+            // containing hidden "discarded" bytes. Expanding such a slice in-place would
+            // "resurrect" those discarded bytes leading to silent data corruption.
+            if (tail.refCnt() == 1 && !tail.isReadOnly() && tail.capacity() == componentView.capacity()
+                    && newTailSize <= tail.maxCapacity()) {
+                // Take ownership of the tail.
+                newTail = tail.retain();
+
+                // Synchronize indices based on the component's view in the composite buffer.
+                newTail.setIndex(componentView.readerIndex(), componentView.writerIndex());
+
+                /*
+                 * The tail is a readable non-composite buffer, so writeBytes() handles
+                 * everything for us.
+                 *
+                 * - ensureWritable() performs a fast resize when possible (f.e. PooledByteBuf
+                 * simply updates its boundary to the end of consecutive memory run assigned to
+                 * this buffer)
+                 * - when the required size doesn't fit into writableBytes(), a new buffer is
+                 * allocated, and the capacity is calculated with alloc.calculateNewCapacity()
+                 * - note that maxFastWritableBytes() would normally allow a fast expansion of
+                 * PooledByteBuf is not called because CompositeByteBuf.component() returns a
+                 * duplicate, wrapped buffer.
+                 * Unwrapping buffers is unsafe, and potential benefit of fast writes may not be
+                 * as pronounced because the capacity is doubled with each reallocation.
+                 */
+                newTail.writeBytes(in);
+            } else {
+                // Fallback strategy: Reallocate a new buffer to merge the tail and input.
+                // This ensures absolute index consistency and prevents data corruption
+                // from hidden offsets in sliced or derived buffers.
+                newTail = alloc.buffer(alloc.calculateNewCapacity(newTailSize, Integer.MAX_VALUE));
+                newTail.setBytes(0, composite, tailStart, tailSize)
+                        .setBytes(tailSize, in, in.readerIndex(), inputSize)
+                        .writerIndex(newTailSize);
+                in.readerIndex(in.writerIndex());
+            }
+
+            // Store readerIndex to avoid out-of-bounds writerIndex during replacement.
+            int prevReader = composite.readerIndex();
+
+            // Remove the old tail and add the new one.
+            composite.removeComponent(tailComponentIndex).setIndex(0, tailStart);
+            
+            // newTail ownership successfully transferred to the composite buffer.
+            // We null out newTail before adding it to avoid a double-release if addFlattenedComponents throws.
+            ByteBuf b = newTail;
+            newTail = null;
+            composite.addFlattenedComponents(true, b);
+
+            // Restore the reader. We do this before releasing 'in' so that if it fails,
+            // the caller's finally block will handle releasing 'in' without a double-free.
+            composite.readerIndex(prevReader);
+
+        } finally {
+            in.release();
+            // If new tail's ownership isn't transferred to the composite buf.
+            // Release it to prevent a leak.
+            if (newTail != null) {
+                newTail.release();
+            }
+        }
+    }
 }

--- a/codec-base/src/main/java/io/netty/handler/codec/AdaptiveCumulator.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/AdaptiveCumulator.java
@@ -78,7 +78,7 @@ public final class AdaptiveCumulator implements Cumulator {
      */
     @Override
     @SuppressWarnings("ReferenceEquality")
-    public final ByteBuf cumulate(ByteBufAllocator alloc, ByteBuf cumulation, ByteBuf in) {
+    public ByteBuf cumulate(ByteBufAllocator alloc, ByteBuf cumulation, ByteBuf in) {
         if (cumulation == in) {
             in.release();
             return cumulation;
@@ -111,11 +111,11 @@ public final class AdaptiveCumulator implements Cumulator {
             composite = null;
             return result;
         } catch (Throwable t) {
-            // If an exception was thrown AFTER cumulation was successfully wrapped, 
+            // If an exception was thrown AFTER cumulation was successfully wrapped,
             // calling composite.release() in 'finally' will drop its refCount to 0.
             // We prevent this by calling retain() here on the exception path to keep it alive.
             if (cumulationTransferred && composite != null && composite != cumulation) {
-                cumulation.retain(); 
+                cumulation.retain();
             }
             throw t;
         } finally {

--- a/codec-base/src/main/java/io/netty/handler/codec/AdaptiveCumulator.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/AdaptiveCumulator.java
@@ -82,6 +82,10 @@ public class AdaptiveCumulator implements Cumulator {
   @Override
   @SuppressWarnings("ReferenceEquality")
   public final ByteBuf cumulate(ByteBufAllocator alloc, ByteBuf cumulation, ByteBuf in) {
+    if (cumulation == in) {
+      in.release();
+      return cumulation;
+    }
     if (!cumulation.isReadable()) {
       cumulation.release();
       return in;
@@ -131,7 +135,7 @@ public class AdaptiveCumulator implements Cumulator {
 
   private static boolean shouldCompose(CompositeByteBuf composite, ByteBuf in, int composeMinSize) {
     int componentCount = composite.numComponents();
-    if (composite.numComponents() == 0) {
+    if (componentCount == 0) {
       return true;
     }
     int inputSize = in.readableBytes();
@@ -226,14 +230,14 @@ public class AdaptiveCumulator implements Cumulator {
       composite.removeComponent(tailComponentIndex).setIndex(0, tailStart);
       composite.addFlattenedComponents(true, newTail);
 
-      // Ownership successfully transferred to the composite buffer.
+      // newTail ownership successfully transferred to the composite buffer.
       newTail = null;
-      in.release();
-      in = null;
-      // Restore the reader. In case it fails we restore the reader after
-      // releasing/forgetting the input and the new tail so that finally block can
-      // handles them properly.
+
+      // Restore the reader. We do this before releasing 'in' so that if it fails,
+      // the caller's finally block will handle releasing 'in' without a double-free.
       composite.readerIndex(prevReader);
+
+      in.release();
     } finally {
       // If new tail's ownership isn't transferred to the composite buf.
       // Release it to prevent a leak.

--- a/codec-base/src/main/java/io/netty/handler/codec/AdaptiveCumulator.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/AdaptiveCumulator.java
@@ -16,6 +16,8 @@
 
 package io.netty.handler.codec;
 
+import org.jetbrains.annotations.VisibleForTesting;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.CompositeByteBuf;
@@ -85,62 +87,30 @@ public class AdaptiveCumulator implements Cumulator {
       return in;
     }
     CompositeByteBuf composite = null;
-    boolean success = false;
     try {
       if (isOwnedCompositeBuf(cumulation)) {
         composite = (CompositeByteBuf) cumulation;
+        // Writer index must equal capacity if we are going to "write"
+        // new components to the end
         if (composite.writerIndex() != composite.capacity()) {
           composite.capacity(composite.writerIndex());
         }
       } else {
-        composite = alloc.compositeBuffer(Integer.MAX_VALUE);
-        cumulation.retain(); // Ref count = 2
-        int cumulationRefCntBefore = cumulation.refCnt();
-        int componentsBefore = composite.numComponents();
-        try {
-          composite.addFlattenedComponents(true, cumulation);
-        } catch (Throwable t) {
-          if (composite.numComponents() == componentsBefore && cumulation.refCnt() == cumulationRefCntBefore) {
-            cumulation.release();
-          }
-          throw t;
-        }
+        composite = alloc.compositeBuffer(Integer.MAX_VALUE)
+            .addFlattenedComponents(true, cumulation);
       }
-
-      boolean compose = shouldCompose(composite, in, composeMinSize);
-      int inRefCntBefore = in.refCnt();
-      int componentsBefore = composite.numComponents();
-      try {
-        if (compose) {
-          composite.addFlattenedComponents(true, in);
-        } else {
-          mergeWithCompositeTail(alloc, composite, in);
-        }
-        in = null; // Ownership of 'in' transferred successfully.
-      } catch (Throwable t) {
-        if (in.refCnt() == inRefCntBefore && composite.numComponents() == componentsBefore) {
-          // Ownership was not transferred, and it was not released.
-        } else {
-          in = null;
-        }
-        throw t;
-      }
-
-      // If we promoted to a new composite, we must undo the defensive retain.
-      if (cumulation != composite) {
-        cumulation.release();
-      }
-      success = true;
+      addInput(alloc, composite, in);
+      in = null;
       return composite;
     } finally {
       if (in != null) {
+        // We must release if the ownership was not transferred as otherwise it may
+        // produce a leak
         in.release();
-      }
-      // If we created a new composite but failed before returning,
-      // releasing 'composite' will drop 'cumulation' to ref count 1.
-      // This is safe because ByteToMessageDecoder still owns that 1 reference.
-      if (!success && composite != null && composite != cumulation) {
-        composite.release();
+        // Also release any new buffer allocated if we're not returning it
+        if (composite != null && composite != cumulation) {
+          composite.release();
+        }
       }
     }
   }
@@ -149,7 +119,19 @@ public class AdaptiveCumulator implements Cumulator {
     return buf instanceof CompositeByteBuf && buf.refCnt() == 1;
   }
 
-  private static boolean shouldCompose(CompositeByteBuf composite, ByteBuf in, int composeMinSize) {
+  @VisibleForTesting
+  void addInput(ByteBufAllocator alloc, CompositeByteBuf composite, ByteBuf in) {
+    if (shouldCompose(composite, in, composeMinSize)) {
+      composite.addFlattenedComponents(true, in);
+    } else {
+      // The total size of the new data and the last component are below the
+      // threshold. Merge them.
+      mergeWithCompositeTail(alloc, composite, in);
+    }
+  }
+
+  @VisibleForTesting
+  static boolean shouldCompose(CompositeByteBuf composite, ByteBuf in, int composeMinSize) {
     int componentCount = composite.numComponents();
     if (composite.numComponents() == 0) {
       return true;
@@ -185,7 +167,8 @@ public class AdaptiveCumulator implements Cumulator {
    * This assumption
    * is verified in unit tests for this method.
    */
-  private static void mergeWithCompositeTail(
+  @VisibleForTesting
+  static void mergeWithCompositeTail(
       ByteBufAllocator alloc, CompositeByteBuf composite, ByteBuf in) {
     int inputSize = in.readableBytes();
     int tailComponentIndex = composite.numComponents() - 1;

--- a/codec-base/src/main/java/io/netty/handler/codec/AdaptiveCumulator.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/AdaptiveCumulator.java
@@ -20,7 +20,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.handler.codec.ByteToMessageDecoder.Cumulator;
-import org.jetbrains.annotations.VisibleForTesting;
 
 /**
  * "Adaptive" cumulator: cumulate {@link ByteBuf}s by dynamically switching
@@ -86,39 +85,62 @@ public class AdaptiveCumulator implements Cumulator {
       return in;
     }
     CompositeByteBuf composite = null;
+    boolean success = false;
     try {
       if (isOwnedCompositeBuf(cumulation)) {
         composite = (CompositeByteBuf) cumulation;
-        // Writer index must equal capacity if we are going to "write"
-        // new components to the end
         if (composite.writerIndex() != composite.capacity()) {
           composite.capacity(composite.writerIndex());
         }
       } else {
         composite = alloc.compositeBuffer(Integer.MAX_VALUE);
-        cumulation.retain();
+        cumulation.retain(); // Ref count = 2
+        int cumulationRefCntBefore = cumulation.refCnt();
+        int componentsBefore = composite.numComponents();
         try {
           composite.addFlattenedComponents(true, cumulation);
-        } catch (RuntimeException e) {
-          cumulation.release();
-          throw e;
+        } catch (Throwable t) {
+          if (composite.numComponents() == componentsBefore && cumulation.refCnt() == cumulationRefCntBefore) {
+            cumulation.release();
+          }
+          throw t;
         }
       }
-      addInput(alloc, composite, in);
+
+      boolean compose = shouldCompose(composite, in, composeMinSize);
+      int inRefCntBefore = in.refCnt();
+      int componentsBefore = composite.numComponents();
+      try {
+        if (compose) {
+          composite.addFlattenedComponents(true, in);
+        } else {
+          mergeWithCompositeTail(alloc, composite, in);
+        }
+        in = null; // Ownership of 'in' transferred successfully.
+      } catch (Throwable t) {
+        if (in.refCnt() == inRefCntBefore && composite.numComponents() == componentsBefore) {
+          // Ownership was not transferred, and it was not released.
+        } else {
+          in = null;
+        }
+        throw t;
+      }
+
+      // If we promoted to a new composite, we must undo the defensive retain.
       if (cumulation != composite) {
         cumulation.release();
       }
-      in = null;
+      success = true;
       return composite;
     } finally {
       if (in != null) {
-        // We must release if the ownership was not transferred as otherwise it may
-        // produce a leak
         in.release();
-        // Also release any new buffer allocated if we're not returning it
-        if (composite != null && composite != cumulation) {
-          composite.release();
-        }
+      }
+      // If we created a new composite but failed before returning,
+      // releasing 'composite' will drop 'cumulation' to ref count 1.
+      // This is safe because ByteToMessageDecoder still owns that 1 reference.
+      if (!success && composite != null && composite != cumulation) {
+        composite.release();
       }
     }
   }
@@ -127,19 +149,7 @@ public class AdaptiveCumulator implements Cumulator {
     return buf instanceof CompositeByteBuf && buf.refCnt() == 1;
   }
 
-  @VisibleForTesting
-  void addInput(ByteBufAllocator alloc, CompositeByteBuf composite, ByteBuf in) {
-    if (shouldCompose(composite, in, composeMinSize)) {
-      composite.addFlattenedComponents(true, in);
-    } else {
-      // The total size of the new data and the last component are below the
-      // threshold. Merge them.
-      mergeWithCompositeTail(alloc, composite, in);
-    }
-  }
-
-  @VisibleForTesting
-  static boolean shouldCompose(CompositeByteBuf composite, ByteBuf in, int composeMinSize) {
+  private static boolean shouldCompose(CompositeByteBuf composite, ByteBuf in, int composeMinSize) {
     int componentCount = composite.numComponents();
     if (composite.numComponents() == 0) {
       return true;
@@ -175,8 +185,7 @@ public class AdaptiveCumulator implements Cumulator {
    * This assumption
    * is verified in unit tests for this method.
    */
-  @VisibleForTesting
-  static void mergeWithCompositeTail(
+  private static void mergeWithCompositeTail(
       ByteBufAllocator alloc, CompositeByteBuf composite, ByteBuf in) {
     int inputSize = in.readableBytes();
     int tailComponentIndex = composite.numComponents() - 1;

--- a/codec-base/src/main/java/io/netty/handler/codec/AdaptiveCumulator.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/AdaptiveCumulator.java
@@ -20,6 +20,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.handler.codec.ByteToMessageDecoder.Cumulator;
+import org.jetbrains.annotations.VisibleForTesting;
 
 /**
  * "Adaptive" cumulator: cumulate {@link ByteBuf}s by dynamically switching
@@ -86,7 +87,7 @@ public class AdaptiveCumulator implements Cumulator {
     }
     CompositeByteBuf composite = null;
     try {
-      if (cumulation instanceof CompositeByteBuf && cumulation.refCnt() == 1) {
+      if (isOwnedCompositeBuf(cumulation)) {
         composite = (CompositeByteBuf) cumulation;
         // Writer index must equal capacity if we are going to "write"
         // new components to the end
@@ -94,10 +95,19 @@ public class AdaptiveCumulator implements Cumulator {
           composite.capacity(composite.writerIndex());
         }
       } else {
-        composite = alloc.compositeBuffer(Integer.MAX_VALUE)
-            .addFlattenedComponents(true, cumulation);
+        composite = alloc.compositeBuffer(Integer.MAX_VALUE);
+        cumulation.retain();
+        try {
+          composite.addFlattenedComponents(true, cumulation);
+        } catch (RuntimeException e) {
+          cumulation.release();
+          throw e;
+        }
       }
       addInput(alloc, composite, in);
+      if (cumulation != composite) {
+        cumulation.release();
+      }
       in = null;
       return composite;
     } finally {
@@ -113,6 +123,11 @@ public class AdaptiveCumulator implements Cumulator {
     }
   }
 
+  private static boolean isOwnedCompositeBuf(ByteBuf buf) {
+    return buf instanceof CompositeByteBuf && buf.refCnt() == 1;
+  }
+
+  @VisibleForTesting
   void addInput(ByteBufAllocator alloc, CompositeByteBuf composite, ByteBuf in) {
     if (shouldCompose(composite, in, composeMinSize)) {
       composite.addFlattenedComponents(true, in);
@@ -123,6 +138,7 @@ public class AdaptiveCumulator implements Cumulator {
     }
   }
 
+  @VisibleForTesting
   static boolean shouldCompose(CompositeByteBuf composite, ByteBuf in, int composeMinSize) {
     int componentCount = composite.numComponents();
     if (composite.numComponents() == 0) {
@@ -159,6 +175,7 @@ public class AdaptiveCumulator implements Cumulator {
    * This assumption
    * is verified in unit tests for this method.
    */
+  @VisibleForTesting
   static void mergeWithCompositeTail(
       ByteBufAllocator alloc, CompositeByteBuf composite, ByteBuf in) {
     int inputSize = in.readableBytes();

--- a/codec-base/src/main/java/io/netty/handler/codec/AdaptiveCumulator.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/AdaptiveCumulator.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.handler.codec.ByteToMessageDecoder.Cumulator;
+
+/**
+ * "Adaptive" cumulator: cumulate {@link ByteBuf}s by dynamically switching
+ * between merge and compose strategies.
+ */
+public class AdaptiveCumulator implements Cumulator {
+  private final int composeMinSize;
+
+  /**
+   * @param composeMinSize Determines the minimal size of the buffer that should
+   *                       be composed (added as a new component of the
+   *                       {@link CompositeByteBuf}). If the total size of the
+   *                       last component (tail) and the incoming buffer is
+   *                       below this value, the incoming buffer is appended to
+   *                       the tail, and the new component is not added.
+   */
+  public AdaptiveCumulator(int composeMinSize) {
+    if (composeMinSize < 0) {
+      throw new IllegalArgumentException("composeMinSize must be non-negative");
+    }
+    this.composeMinSize = composeMinSize;
+  }
+
+  /**
+   * "Adaptive" cumulator: cumulate {@link ByteBuf}s by dynamically switching
+   * between merge and compose strategies.
+   *
+   * <p>
+   * This cumulator applies a heuristic to make a decision whether to track a
+   * reference to the buffer with bytes received from the network stack in an
+   * array ("zero-copy"), or to merge into the last component (the tail) by
+   * performing a memory copy.
+   *
+   * <p>
+   * It is necessary as a protection from a potential attack on the
+   * {@link io.netty.handler.codec.ByteToMessageDecoder#COMPOSITE_CUMULATOR}.
+   * Consider a pathological case when an attacker sends TCP packages containing a
+   * single byte of data, and forcing the cumulator to track each one in a
+   * separate buffer. The cost is memory overhead for each buffer, and extra
+   * compute to read the cumulation.
+   *
+   * <p>
+   * Implemented heuristic establishes a minimal threshold for the total size of
+   * the tail and incoming buffer, below which they are merged. The sum of the
+   * tail and the incoming buffer is used to avoid a case where attacker
+   * alternates the size of data packets to trick the cumulator into always
+   * selecting compose strategy.
+   *
+   * <p>
+   * Merging strategy attempts to minimize unnecessary memory writes. When
+   * possible, it expands the tail capacity and only copies the incoming buffer
+   * into available memory.
+   * Otherwise, when both tail and the buffer must be copied, the tail is
+   * reallocated (or fully replaced) with a new buffer of exponentially increasing
+   * capacity (bounded to {@link #composeMinSize}) to ensure runtime
+   * {@code O(n^2)} is amortized to {@code O(n)}.
+   */
+  @Override
+  @SuppressWarnings("ReferenceEquality")
+  public final ByteBuf cumulate(ByteBufAllocator alloc, ByteBuf cumulation, ByteBuf in) {
+    if (!cumulation.isReadable()) {
+      cumulation.release();
+      return in;
+    }
+    CompositeByteBuf composite = null;
+    try {
+      if (cumulation instanceof CompositeByteBuf && cumulation.refCnt() == 1) {
+        composite = (CompositeByteBuf) cumulation;
+        // Writer index must equal capacity if we are going to "write"
+        // new components to the end
+        if (composite.writerIndex() != composite.capacity()) {
+          composite.capacity(composite.writerIndex());
+        }
+      } else {
+        composite = alloc.compositeBuffer(Integer.MAX_VALUE)
+            .addFlattenedComponents(true, cumulation);
+      }
+      addInput(alloc, composite, in);
+      in = null;
+      return composite;
+    } finally {
+      if (in != null) {
+        // We must release if the ownership was not transferred as otherwise it may
+        // produce a leak
+        in.release();
+        // Also release any new buffer allocated if we're not returning it
+        if (composite != null && composite != cumulation) {
+          composite.release();
+        }
+      }
+    }
+  }
+
+  void addInput(ByteBufAllocator alloc, CompositeByteBuf composite, ByteBuf in) {
+    if (shouldCompose(composite, in, composeMinSize)) {
+      composite.addFlattenedComponents(true, in);
+    } else {
+      // The total size of the new data and the last component are below the
+      // threshold. Merge them.
+      mergeWithCompositeTail(alloc, composite, in);
+    }
+  }
+
+  static boolean shouldCompose(CompositeByteBuf composite, ByteBuf in, int composeMinSize) {
+    int componentCount = composite.numComponents();
+    if (composite.numComponents() == 0) {
+      return true;
+    }
+    int inputSize = in.readableBytes();
+    int tailStart = composite.toByteIndex(componentCount - 1);
+    int tailSize = composite.writerIndex() - tailStart;
+    return tailSize + inputSize >= composeMinSize;
+  }
+
+  /**
+   * Append the given {@link ByteBuf} {@code in} to {@link CompositeByteBuf}
+   * {@code composite} by expanding or replacing the tail component of the {@link
+   * CompositeByteBuf}.
+   *
+   * <p>
+   * The goal is to prevent {@code O(n^2)} runtime in a pathological case, that
+   * forces copying the tail component into a new buffer, for each incoming
+   * single-byte buffer.
+   * We append the new bytes to the tail, when a write (or a fast write) is
+   * possible.
+   *
+   * <p>
+   * Otherwise, the tail is replaced with a new buffer, with the capacity
+   * increased enough to achieve runtime amortization.
+   *
+   * <p>
+   * We assume that implementations of
+   * {@link ByteBufAllocator#calculateNewCapacity(int, int)},
+   * are similar to
+   * {@link io.netty.buffer.AbstractByteBufAllocator#calculateNewCapacity(int, int)},
+   * which doubles buffer capacity by normalizing it to the closest power of two.
+   * This assumption
+   * is verified in unit tests for this method.
+   */
+  static void mergeWithCompositeTail(
+      ByteBufAllocator alloc, CompositeByteBuf composite, ByteBuf in) {
+    int inputSize = in.readableBytes();
+    int tailComponentIndex = composite.numComponents() - 1;
+    int tailStart = composite.toByteIndex(tailComponentIndex);
+    int tailSize = composite.writerIndex() - tailStart;
+    int newTailSize = inputSize + tailSize;
+
+    ByteBuf tail = composite.component(tailComponentIndex);
+    ByteBuf newTail = null;
+    // Use componentSlice() to get the correct view of the indices.
+    ByteBuf componentView = composite.componentSlice(tailComponentIndex);
+    try {
+      // Ideal case: The tail is not shared and can be expanded in-place.
+      // In-place expansion should happen only if the component represents the full
+      // capacity of the underlying buffer because if tail.capacity() >
+      // componentView.capacity(), it indicates the component is a partial slice
+      // containing hidden "discarded" bytes. Expanding such a slice in-place would
+      // "resurrect" those discarded bytes leading to silent data corruption.
+      if (tail.refCnt() == 1 && !tail.isReadOnly() && tail.capacity() == componentView.capacity()
+          && newTailSize <= tail.maxCapacity()) {
+        // Take ownership of the tail.
+        newTail = tail.retain();
+
+        // Synchronize indices based on the component's view in the composite buffer.
+        newTail.setIndex(componentView.readerIndex(), componentView.writerIndex());
+
+        /*
+         * The tail is a readable non-composite buffer, so writeBytes() handles
+         * everything for us.
+         *
+         * - ensureWritable() performs a fast resize when possible (f.e. PooledByteBuf
+         * simply updates its boundary to the end of consecutive memory run assigned to
+         * this buffer)
+         * - when the required size doesn't fit into writableBytes(), a new buffer is
+         * allocated, and the capacity is calculated with alloc.calculateNewCapacity()
+         * - note that maxFastWritableBytes() would normally allow a fast expansion of
+         * PooledByteBuf is not called because CompositeByteBuf.component() returns a
+         * duplicate, wrapped buffer.
+         * Unwrapping buffers is unsafe, and potential benefit of fast writes may not be
+         * as pronounced because the capacity is doubled with each reallocation.
+         */
+        newTail.writeBytes(in);
+      } else {
+        // Fallback strategy: Reallocate a new buffer to merge the tail and input.
+        // This ensures absolute index consistency and prevents data corruption
+        // from hidden offsets in sliced or derived buffers.
+        newTail = alloc.buffer(alloc.calculateNewCapacity(newTailSize, Integer.MAX_VALUE));
+        newTail.setBytes(0, composite, tailStart, tailSize)
+            .setBytes(tailSize, in, in.readerIndex(), inputSize)
+            .writerIndex(newTailSize);
+        in.readerIndex(in.writerIndex());
+      }
+
+      // Store readerIndex to avoid out-of-bounds writerIndex during replacement.
+      int prevReader = composite.readerIndex();
+
+      // Remove the old tail and add the new one.
+      composite.removeComponent(tailComponentIndex).setIndex(0, tailStart);
+      composite.addFlattenedComponents(true, newTail);
+
+      // Ownership successfully transferred to the composite buffer.
+      newTail = null;
+      in.release();
+      in = null;
+      // Restore the reader. In case it fails we restore the reader after
+      // releasing/forgetting the input and the new tail so that finally block can
+      // handles them properly.
+      composite.readerIndex(prevReader);
+    } finally {
+      // If new tail's ownership isn't transferred to the composite buf.
+      // Release it to prevent a leak.
+      if (newTail != null) {
+        newTail.release();
+      }
+    }
+  }
+}

--- a/codec-base/src/test/java/io/netty/handler/codec/AdaptiveCumulatorTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/AdaptiveCumulatorTest.java
@@ -147,7 +147,7 @@ public class AdaptiveCumulatorTest {
         assertSame(throwingCumulatorError, actualError);
         assertEquals(0, in.refCnt());
         assertEquals(0, newComposite.refCnt());
-        assertEquals(0, contiguous.refCnt());
+        assertEquals(1, contiguous.refCnt());
       }
     }
   }

--- a/codec-base/src/test/java/io/netty/handler/codec/AdaptiveCumulatorTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/AdaptiveCumulatorTest.java
@@ -66,19 +66,7 @@ public class AdaptiveCumulatorTest {
       contiguous = ByteBufUtil.writeAscii(alloc, DATA_INITIAL);
       in = ByteBufUtil.writeAscii(alloc, DATA_INCOMING);
 
-      cumulator = new AdaptiveCumulator(0) {
-        @Override
-        void addInput(ByteBufAllocator alloc, CompositeByteBuf composite, ByteBuf in) {
-          composite.addFlattenedComponents(true, in);
-        }
-      };
-
-      throwingCumulator = new AdaptiveCumulator(0) {
-        @Override
-        void addInput(ByteBufAllocator alloc, CompositeByteBuf composite, ByteBuf in) {
-          throw throwingCumulatorError;
-        }
-      };
+      cumulator = new AdaptiveCumulator(0);
     }
 
     @Test
@@ -120,9 +108,14 @@ public class AdaptiveCumulatorTest {
 
     @Test
     public void cumulate_compositeCumulation_inputReleasedOnError() {
-      CompositeByteBuf composite = alloc.compositeBuffer().addComponent(true, contiguous);
+      CompositeByteBuf composite = new CompositeByteBuf(alloc, false, Integer.MAX_VALUE, contiguous) {
+        @Override
+        public CompositeByteBuf addFlattenedComponents(boolean increaseWriterIndex, ByteBuf buffer) {
+          throw throwingCumulatorError;
+        }
+      };
       try {
-        throwingCumulator.cumulate(alloc, composite, in);
+        cumulator.cumulate(alloc, composite, in);
         fail("Cumulator didn't throw");
       } catch (UnsupportedOperationException actualError) {
         assertSame(throwingCumulatorError, actualError);
@@ -136,12 +129,22 @@ public class AdaptiveCumulatorTest {
 
     @Test
     public void cumulate_contiguousCumulation_inputAndNewCompositeReleasedOnError() {
-      CompositeByteBuf newComposite = alloc.compositeBuffer(Integer.MAX_VALUE);
+      CompositeByteBuf newComposite = new CompositeByteBuf(alloc, false, Integer.MAX_VALUE) {
+        int count = 0;
+
+        @Override
+        public CompositeByteBuf addFlattenedComponents(boolean increaseWriterIndex, ByteBuf buffer) {
+          if (++count == 2) {
+            throw throwingCumulatorError;
+          }
+          return super.addFlattenedComponents(increaseWriterIndex, buffer);
+        }
+      };
       ByteBufAllocator mockAlloc = mock(ByteBufAllocator.class);
       when(mockAlloc.compositeBuffer(anyInt())).thenReturn(newComposite);
 
       try {
-        throwingCumulator.cumulate(mockAlloc, contiguous, in);
+        cumulator.cumulate(mockAlloc, contiguous, in);
         fail("Cumulator didn't throw");
       } catch (UnsupportedOperationException actualError) {
         assertSame(throwingCumulatorError, actualError);
@@ -180,47 +183,37 @@ public class AdaptiveCumulatorTest {
     }
 
     private void tearDown() {
-      if (in != null) {
-        in.release();
-      }
-      if (composite != null) {
+      if (composite != null && composite.refCnt() > 0) {
         composite.release();
       }
     }
 
     @ParameterizedTest(name = "composeMinSize={0}, tailData=\"{1}\", inData=\"{2}\"")
     @MethodSource("shouldComposeParams")
-    public void shouldCompose_emptyComposite(int composeMinSize, String tailData, String inData) {
+    public void shouldCompose(int composeMinSize, String tailData, String inData) {
       setUp(composeMinSize, tailData, inData);
       try {
-        Assumptions.assumeTrue(composite.numComponents() == 0);
-        assertTrue(AdaptiveCumulator.shouldCompose(composite, in, composeMinSize));
-      } finally {
-        tearDown();
-      }
-    }
+        int initialComponents = composite.numComponents();
+        AdaptiveCumulator cumulator = new AdaptiveCumulator(composeMinSize);
+        ByteBuf result = cumulator.cumulate(alloc, composite, in);
 
-    @ParameterizedTest(name = "composeMinSize={0}, tailData=\"{1}\", inData=\"{2}\"")
-    @MethodSource("shouldComposeParams")
-    public void shouldCompose_composeMinSizeReached(int composeMinSize, String tailData, String inData) {
-      setUp(composeMinSize, tailData, inData);
-      try {
-        Assumptions.assumeTrue(composite.numComponents() > 0);
-        Assumptions.assumeTrue(tail.readableBytes() + in.readableBytes() >= composeMinSize);
-        assertTrue(AdaptiveCumulator.shouldCompose(composite, in, composeMinSize));
-      } finally {
-        tearDown();
-      }
-    }
-
-    @ParameterizedTest(name = "composeMinSize={0}, tailData=\"{1}\", inData=\"{2}\"")
-    @MethodSource("shouldComposeParams")
-    public void shouldCompose_composeMinSizeNotReached(int composeMinSize, String tailData, String inData) {
-      setUp(composeMinSize, tailData, inData);
-      try {
-        Assumptions.assumeTrue(composite.numComponents() > 0);
-        Assumptions.assumeTrue(tail.readableBytes() + in.readableBytes() < composeMinSize);
-        assertFalse(AdaptiveCumulator.shouldCompose(composite, in, composeMinSize));
+        if (!composite.isReadable()) {
+          assertSame(in, result);
+          composite = null;
+          in.release();
+        } else if (!in.isReadable()) {
+          assertSame(composite, result);
+          assertEquals(initialComponents, composite.numComponents());
+          assertEquals(tailData + inData, composite.toString(US_ASCII));
+        } else if (tail.readableBytes() + in.readableBytes() >= composeMinSize) {
+          composite = (CompositeByteBuf) result;
+          assertEquals(initialComponents + 1, composite.numComponents());
+          assertEquals(tailData + inData, composite.toString(US_ASCII));
+        } else {
+          composite = (CompositeByteBuf) result;
+          assertEquals(initialComponents, composite.numComponents());
+          assertEquals(tailData + inData, composite.toString(US_ASCII));
+        }
       } finally {
         tearDown();
       }
@@ -270,14 +263,8 @@ public class AdaptiveCumulatorTest {
     }
 
     private void tearDown() {
-      if (composite != null) {
+      if (composite != null && composite.refCnt() > 0) {
         composite.release();
-      }
-      if (in != null && in.refCnt() > 0) {
-        in.release();
-      }
-      if (tail != null && tail.refCnt() > 0) {
-        tail.release();
       }
     }
 
@@ -294,8 +281,19 @@ public class AdaptiveCumulatorTest {
       int originalNumComponents = composite.numComponents();
       int compositeReaderIndexBounded = Math.min(compositeReaderIndex, composite.writerIndex());
       composite.readerIndex(compositeReaderIndexBounded);
+      boolean wasReadable = composite.isReadable();
 
-      AdaptiveCumulator.mergeWithCompositeTail(alloc, composite, in);
+      AdaptiveCumulator cumulator = new AdaptiveCumulator(Integer.MAX_VALUE);
+      ByteBuf result = cumulator.cumulate(alloc, composite, in);
+
+      if (!wasReadable) {
+        assertSame(in, result, "When composite is fully read, cumulate should return in");
+        assertEquals(0, composite.refCnt(), "Old composite should be released");
+        in.release(); // Free the returned buffer manually
+        return;
+      }
+
+      composite = (CompositeByteBuf) result;
 
       assertEquals(originalNumComponents, composite.numComponents(),
           "When tail is expanded, the number of components in the cumulation must not change");
@@ -342,7 +340,19 @@ public class AdaptiveCumulatorTest {
 
       int compositeReaderIndexBounded = Math.min(compositeReaderIndex, composite.writerIndex());
       composite.readerIndex(compositeReaderIndexBounded);
-      AdaptiveCumulator.mergeWithCompositeTail(alloc, composite, in);
+      boolean wasReadable = composite.isReadable();
+
+      AdaptiveCumulator cumulator = new AdaptiveCumulator(Integer.MAX_VALUE);
+      ByteBuf result = cumulator.cumulate(alloc, composite, in);
+
+      if (!wasReadable) {
+        assertSame(in, result, "When composite is fully read, cumulate should return in");
+        assertEquals(0, composite.refCnt(), "Old composite should be released");
+        in.release(); // Free the returned buffer manually
+        return;
+      }
+
+      composite = (CompositeByteBuf) result;
 
       assertEquals(cumulationOriginalComponentsNum, composite.numComponents());
       ByteBuf replacedTail = composite.component(composite.numComponents() - 1);
@@ -474,7 +484,8 @@ public class AdaptiveCumulatorTest {
       };
 
       try {
-        AdaptiveCumulator.mergeWithCompositeTail(alloc, compositeThrows, in);
+        AdaptiveCumulator cumulator = new AdaptiveCumulator(Integer.MAX_VALUE);
+        compositeThrows = (CompositeByteBuf) cumulator.cumulate(alloc, compositeThrows, in);
         fail("Cumulator didn't throw");
       } catch (UnsupportedOperationException actualError) {
         assertSame(expectedError, actualError);
@@ -506,7 +517,8 @@ public class AdaptiveCumulatorTest {
       when(mockAlloc.buffer(anyInt())).thenReturn(newTail);
 
       try {
-        AdaptiveCumulator.mergeWithCompositeTail(mockAlloc, compositeRo, in);
+        AdaptiveCumulator cumulator = new AdaptiveCumulator(Integer.MAX_VALUE);
+        compositeRo = (CompositeByteBuf) cumulator.cumulate(mockAlloc, compositeRo, in);
         fail("Cumulator didn't throw");
       } catch (UnsupportedOperationException actualError) {
         assertSame(expectedError, actualError);

--- a/codec-base/src/test/java/io/netty/handler/codec/AdaptiveCumulatorTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/AdaptiveCumulatorTest.java
@@ -55,7 +55,6 @@ public class AdaptiveCumulatorTest {
 
     private final ByteBufAllocator alloc = new UnpooledByteBufAllocator(false);
     private AdaptiveCumulator cumulator;
-    private AdaptiveCumulator throwingCumulator;
     private final UnsupportedOperationException throwingCumulatorError = new UnsupportedOperationException();
 
     private ByteBuf contiguous;
@@ -65,20 +64,7 @@ public class AdaptiveCumulatorTest {
     public void setUp() {
       contiguous = ByteBufUtil.writeAscii(alloc, DATA_INITIAL);
       in = ByteBufUtil.writeAscii(alloc, DATA_INCOMING);
-
-      cumulator = new AdaptiveCumulator(0) {
-        @Override
-        void addInput(ByteBufAllocator alloc, CompositeByteBuf composite, ByteBuf in) {
-          composite.addFlattenedComponents(true, in);
-        }
-      };
-
-      throwingCumulator = new AdaptiveCumulator(0) {
-        @Override
-        void addInput(ByteBufAllocator alloc, CompositeByteBuf composite, ByteBuf in) {
-          throw throwingCumulatorError;
-        }
-      };
+      cumulator = new AdaptiveCumulator(0);
     }
 
     @Test
@@ -120,9 +106,14 @@ public class AdaptiveCumulatorTest {
 
     @Test
     public void cumulate_compositeCumulation_inputReleasedOnError() {
-      CompositeByteBuf composite = alloc.compositeBuffer().addComponent(true, contiguous);
+      CompositeByteBuf composite = new CompositeByteBuf(alloc, false, Integer.MAX_VALUE, contiguous) {
+        @Override
+        public CompositeByteBuf addFlattenedComponents(boolean increaseWriterIndex, ByteBuf buffer) {
+          throw throwingCumulatorError;
+        }
+      };
       try {
-        throwingCumulator.cumulate(alloc, composite, in);
+        cumulator.cumulate(alloc, composite, in);
         fail("Cumulator didn't throw");
       } catch (UnsupportedOperationException actualError) {
         assertSame(throwingCumulatorError, actualError);
@@ -136,18 +127,83 @@ public class AdaptiveCumulatorTest {
 
     @Test
     public void cumulate_contiguousCumulation_inputAndNewCompositeReleasedOnError() {
-      CompositeByteBuf newComposite = alloc.compositeBuffer(Integer.MAX_VALUE);
+      CompositeByteBuf newComposite = new CompositeByteBuf(alloc, false, Integer.MAX_VALUE) {
+        @Override
+        public CompositeByteBuf addFlattenedComponents(boolean increaseWriterIndex, ByteBuf buffer) {
+          if (buffer == in) {
+            throw throwingCumulatorError;
+          }
+          return super.addFlattenedComponents(increaseWriterIndex, buffer);
+        }
+      };
       ByteBufAllocator mockAlloc = mock(ByteBufAllocator.class);
       when(mockAlloc.compositeBuffer(anyInt())).thenReturn(newComposite);
 
       try {
-        throwingCumulator.cumulate(mockAlloc, contiguous, in);
+        cumulator.cumulate(mockAlloc, contiguous, in);
         fail("Cumulator didn't throw");
       } catch (UnsupportedOperationException actualError) {
         assertSame(throwingCumulatorError, actualError);
         assertEquals(0, in.refCnt());
         assertEquals(0, newComposite.refCnt());
         assertEquals(1, contiguous.refCnt());
+      }
+    }
+
+    @Test
+    public void cumulate_sharedCompositeCumulation_retainedAndReleasedOnError() {
+      final CompositeByteBuf compositeCumulation = alloc.compositeBuffer(Integer.MAX_VALUE);
+      compositeCumulation.addComponent(true, contiguous);
+      compositeCumulation.retain();
+      assertEquals(2, compositeCumulation.refCnt());
+
+      ByteBufAllocator mockAlloc = mock(ByteBufAllocator.class);
+      CompositeByteBuf newComposite = new CompositeByteBuf(alloc, false, Integer.MAX_VALUE) {
+        @Override
+        public CompositeByteBuf addFlattenedComponents(boolean increaseWriterIndex, ByteBuf buffer) {
+          if (buffer == compositeCumulation) {
+            throw throwingCumulatorError;
+          }
+          return super.addFlattenedComponents(increaseWriterIndex, buffer);
+        }
+      };
+      when(mockAlloc.compositeBuffer(anyInt())).thenReturn(newComposite);
+
+      try {
+        cumulator.cumulate(mockAlloc, compositeCumulation, in);
+        fail("Cumulator didn't throw");
+      } catch (UnsupportedOperationException actualError) {
+        assertSame(throwingCumulatorError, actualError);
+        assertEquals(0, in.refCnt());
+        assertEquals(2, compositeCumulation.refCnt());
+      } finally {
+        compositeCumulation.release();
+        compositeCumulation.release();
+      }
+    }
+
+    @Test
+    public void cumulate_contiguousCumulation_inputAddComponent0FailureDoubleRelease() {
+      ByteBufAllocator failAlloc = mock(ByteBufAllocator.class);
+      when(failAlloc.heapBuffer(anyInt())).thenThrow(throwingCumulatorError);
+      when(failAlloc.directBuffer(anyInt())).thenThrow(throwingCumulatorError);
+
+      CompositeByteBuf newComposite = new CompositeByteBuf(alloc, false, 1) {
+        @Override
+        public ByteBufAllocator alloc() {
+          return failAlloc;
+        }
+      };
+
+      ByteBufAllocator mockAlloc = mock(ByteBufAllocator.class);
+      when(mockAlloc.compositeBuffer(anyInt())).thenReturn(newComposite);
+
+      try {
+        cumulator.cumulate(mockAlloc, contiguous, in);
+        fail("Cumulator didn't throw");
+      } catch (UnsupportedOperationException actualError) {
+        assertSame(throwingCumulatorError, actualError);
+        assertEquals(0, in.refCnt());
       }
     }
   }
@@ -194,7 +250,12 @@ public class AdaptiveCumulatorTest {
       setUp(composeMinSize, tailData, inData);
       try {
         Assumptions.assumeTrue(composite.numComponents() == 0);
-        assertTrue(AdaptiveCumulator.shouldCompose(composite, in, composeMinSize));
+        AdaptiveCumulator cumulator = new AdaptiveCumulator(composeMinSize);
+        ByteBuf cumulation = cumulator.cumulate(alloc, composite, in);
+        composite = null;
+        in = null;
+        assertEquals(inData, cumulation.toString(US_ASCII));
+        cumulation.release();
       } finally {
         tearDown();
       }
@@ -206,8 +267,15 @@ public class AdaptiveCumulatorTest {
       setUp(composeMinSize, tailData, inData);
       try {
         Assumptions.assumeTrue(composite.numComponents() > 0);
+        Assumptions.assumeTrue(in.isReadable());
         Assumptions.assumeTrue(tail.readableBytes() + in.readableBytes() >= composeMinSize);
-        assertTrue(AdaptiveCumulator.shouldCompose(composite, in, composeMinSize));
+        AdaptiveCumulator cumulator = new AdaptiveCumulator(composeMinSize);
+        CompositeByteBuf cumulation = (CompositeByteBuf) cumulator.cumulate(alloc, composite, in);
+        composite = null;
+        in = null;
+        assertEquals(2, cumulation.numComponents());
+        assertEquals(tailData + inData, cumulation.toString(US_ASCII));
+        cumulation.release();
       } finally {
         tearDown();
       }
@@ -220,7 +288,13 @@ public class AdaptiveCumulatorTest {
       try {
         Assumptions.assumeTrue(composite.numComponents() > 0);
         Assumptions.assumeTrue(tail.readableBytes() + in.readableBytes() < composeMinSize);
-        assertFalse(AdaptiveCumulator.shouldCompose(composite, in, composeMinSize));
+        AdaptiveCumulator cumulator = new AdaptiveCumulator(composeMinSize);
+        CompositeByteBuf cumulation = (CompositeByteBuf) cumulator.cumulate(alloc, composite, in);
+        composite = null;
+        in = null;
+        assertEquals(1, cumulation.numComponents());
+        assertEquals(tailData + inData, cumulation.toString(US_ASCII));
+        cumulation.release();
       } finally {
         tearDown();
       }
@@ -294,8 +368,10 @@ public class AdaptiveCumulatorTest {
       int originalNumComponents = composite.numComponents();
       int compositeReaderIndexBounded = Math.min(compositeReaderIndex, composite.writerIndex());
       composite.readerIndex(compositeReaderIndexBounded);
+      Assumptions.assumeTrue(composite.isReadable());
 
-      AdaptiveCumulator.mergeWithCompositeTail(alloc, composite, in);
+      AdaptiveCumulator cumulator = new AdaptiveCumulator(Integer.MAX_VALUE);
+      cumulator.cumulate(alloc, composite, in);
 
       assertEquals(originalNumComponents, composite.numComponents(),
           "When tail is expanded, the number of components in the cumulation must not change");
@@ -342,7 +418,9 @@ public class AdaptiveCumulatorTest {
 
       int compositeReaderIndexBounded = Math.min(compositeReaderIndex, composite.writerIndex());
       composite.readerIndex(compositeReaderIndexBounded);
-      AdaptiveCumulator.mergeWithCompositeTail(alloc, composite, in);
+      Assumptions.assumeTrue(composite.isReadable());
+      AdaptiveCumulator cumulator = new AdaptiveCumulator(Integer.MAX_VALUE);
+      cumulator.cumulate(alloc, composite, in);
 
       assertEquals(cumulationOriginalComponentsNum, composite.numComponents());
       ByteBuf replacedTail = composite.component(composite.numComponents() - 1);
@@ -474,7 +552,8 @@ public class AdaptiveCumulatorTest {
       };
 
       try {
-        AdaptiveCumulator.mergeWithCompositeTail(alloc, compositeThrows, in);
+        AdaptiveCumulator cumulator = new AdaptiveCumulator(Integer.MAX_VALUE);
+        cumulator.cumulate(alloc, compositeThrows, in);
         fail("Cumulator didn't throw");
       } catch (UnsupportedOperationException actualError) {
         assertSame(expectedError, actualError);
@@ -506,7 +585,8 @@ public class AdaptiveCumulatorTest {
       when(mockAlloc.buffer(anyInt())).thenReturn(newTail);
 
       try {
-        AdaptiveCumulator.mergeWithCompositeTail(mockAlloc, compositeRo, in);
+        AdaptiveCumulator cumulator = new AdaptiveCumulator(Integer.MAX_VALUE);
+        cumulator.cumulate(mockAlloc, compositeRo, in);
         fail("Cumulator didn't throw");
       } catch (UnsupportedOperationException actualError) {
         assertSame(expectedError, actualError);

--- a/codec-base/src/test/java/io/netty/handler/codec/AdaptiveCumulatorTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/AdaptiveCumulatorTest.java
@@ -176,7 +176,9 @@ public class AdaptiveCumulatorTest {
             List<String> inDatas = Arrays.asList("", DATA_INCOMING);
 
             return composeMinSizes.stream()
-                    .flatMap(cms -> tailDatas.stream().flatMap(td -> inDatas.stream().map(id -> Arguments.of(cms, td, id))));
+                    .flatMap(cms -> tailDatas.stream()
+                            .flatMap(td -> inDatas.stream()
+                                    .map(id -> Arguments.of(cms, td, id))));
         }
 
         private CompositeByteBuf composite;

--- a/codec-base/src/test/java/io/netty/handler/codec/AdaptiveCumulatorTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/AdaptiveCumulatorTest.java
@@ -1,0 +1,588 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assumptions;
+
+import static io.netty.util.CharsetUtil.US_ASCII;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AdaptiveCumulatorTest {
+
+  @Nested
+  public class CumulateTests {
+    private static final String DATA_INITIAL = "0123";
+    private static final String DATA_INCOMING = "456789";
+    private static final String DATA_CUMULATED = "0123456789";
+
+    private final ByteBufAllocator alloc = new UnpooledByteBufAllocator(false);
+    private AdaptiveCumulator cumulator;
+    private AdaptiveCumulator throwingCumulator;
+    private final UnsupportedOperationException throwingCumulatorError = new UnsupportedOperationException();
+
+    private ByteBuf contiguous;
+    private ByteBuf in;
+
+    @BeforeEach
+    public void setUp() {
+      contiguous = ByteBufUtil.writeAscii(alloc, DATA_INITIAL);
+      in = ByteBufUtil.writeAscii(alloc, DATA_INCOMING);
+
+      cumulator = new AdaptiveCumulator(0) {
+        @Override
+        void addInput(ByteBufAllocator alloc, CompositeByteBuf composite, ByteBuf in) {
+          composite.addFlattenedComponents(true, in);
+        }
+      };
+
+      throwingCumulator = new AdaptiveCumulator(0) {
+        @Override
+        void addInput(ByteBufAllocator alloc, CompositeByteBuf composite, ByteBuf in) {
+          throw throwingCumulatorError;
+        }
+      };
+    }
+
+    @Test
+    public void cumulate_notReadableCumulation_replacedWithInputAndReleased() {
+      contiguous.readerIndex(contiguous.writerIndex());
+      assertFalse(contiguous.isReadable());
+      ByteBuf cumulation = cumulator.cumulate(alloc, contiguous, in);
+      assertEquals(DATA_INCOMING, cumulation.toString(US_ASCII));
+      assertEquals(0, contiguous.refCnt());
+      assertEquals(1, in.refCnt());
+      assertEquals(1, cumulation.refCnt());
+      cumulation.release();
+    }
+
+    @Test
+    public void cumulate_contiguousCumulation_newCompositeFromContiguousAndInput() {
+      CompositeByteBuf cumulation = (CompositeByteBuf) cumulator.cumulate(alloc, contiguous, in);
+      assertEquals(DATA_INITIAL, cumulation.component(0).toString(US_ASCII));
+      assertEquals(DATA_INCOMING, cumulation.component(1).toString(US_ASCII));
+      assertEquals(DATA_CUMULATED, cumulation.toString(US_ASCII));
+      assertEquals(1, contiguous.refCnt());
+      assertEquals(1, in.refCnt());
+      assertEquals(1, cumulation.refCnt());
+      cumulation.release();
+    }
+
+    @Test
+    public void cumulate_compositeCumulation_inputAppendedAsANewComponent() {
+      CompositeByteBuf composite = alloc.compositeBuffer().addComponent(true, contiguous);
+      assertSame(composite, cumulator.cumulate(alloc, composite, in));
+      assertEquals(DATA_INITIAL, composite.component(0).toString(US_ASCII));
+      assertEquals(DATA_INCOMING, composite.component(1).toString(US_ASCII));
+      assertEquals(DATA_CUMULATED, composite.toString(US_ASCII));
+      assertEquals(1, contiguous.refCnt());
+      assertEquals(1, in.refCnt());
+      assertEquals(1, composite.refCnt());
+      composite.release();
+    }
+
+    @Test
+    public void cumulate_compositeCumulation_inputReleasedOnError() {
+      CompositeByteBuf composite = alloc.compositeBuffer().addComponent(true, contiguous);
+      try {
+        throwingCumulator.cumulate(alloc, composite, in);
+        fail("Cumulator didn't throw");
+      } catch (UnsupportedOperationException actualError) {
+        assertSame(throwingCumulatorError, actualError);
+        assertEquals(0, in.refCnt());
+        assertEquals(1, composite.refCnt());
+        assertEquals(1, contiguous.refCnt());
+      } finally {
+        composite.release();
+      }
+    }
+
+    @Test
+    public void cumulate_contiguousCumulation_inputAndNewCompositeReleasedOnError() {
+      CompositeByteBuf newComposite = alloc.compositeBuffer(Integer.MAX_VALUE);
+      ByteBufAllocator mockAlloc = mock(ByteBufAllocator.class);
+      when(mockAlloc.compositeBuffer(anyInt())).thenReturn(newComposite);
+
+      try {
+        throwingCumulator.cumulate(mockAlloc, contiguous, in);
+        fail("Cumulator didn't throw");
+      } catch (UnsupportedOperationException actualError) {
+        assertSame(throwingCumulatorError, actualError);
+        assertEquals(0, in.refCnt());
+        assertEquals(0, newComposite.refCnt());
+        assertEquals(0, contiguous.refCnt());
+      }
+    }
+  }
+
+  @Nested
+  @TestInstance(Lifecycle.PER_CLASS)
+  public class ShouldComposeTests {
+    private final String DATA_INITIAL = "0123";
+    private final String DATA_INCOMING = "456789";
+
+    public Stream<Arguments> shouldComposeParams() {
+      List<Integer> composeMinSizes = Arrays.asList(0, 9, 10, 11, Integer.MAX_VALUE);
+      List<String> tailDatas = Arrays.asList("", DATA_INITIAL);
+      List<String> inDatas = Arrays.asList("", DATA_INCOMING);
+
+      return composeMinSizes.stream()
+          .flatMap(cms -> tailDatas.stream().flatMap(td -> inDatas.stream().map(id -> Arguments.of(cms, td, id))));
+    }
+
+    private CompositeByteBuf composite;
+    private ByteBuf tail;
+    private ByteBuf in;
+    private ByteBufAllocator alloc = new UnpooledByteBufAllocator(false);
+
+    private void setUp(int composeMinSize, String tailData, String inData) {
+      in = ByteBufUtil.writeAscii(alloc, inData);
+      tail = ByteBufUtil.writeAscii(alloc, tailData);
+      composite = alloc.compositeBuffer(Integer.MAX_VALUE);
+      composite.addFlattenedComponents(true, tail);
+    }
+
+    private void tearDown() {
+      if (in != null) {
+        in.release();
+      }
+      if (composite != null) {
+        composite.release();
+      }
+    }
+
+    @ParameterizedTest(name = "composeMinSize={0}, tailData=\"{1}\", inData=\"{2}\"")
+    @MethodSource("shouldComposeParams")
+    public void shouldCompose_emptyComposite(int composeMinSize, String tailData, String inData) {
+      setUp(composeMinSize, tailData, inData);
+      try {
+        Assumptions.assumeTrue(composite.numComponents() == 0);
+        assertTrue(AdaptiveCumulator.shouldCompose(composite, in, composeMinSize));
+      } finally {
+        tearDown();
+      }
+    }
+
+    @ParameterizedTest(name = "composeMinSize={0}, tailData=\"{1}\", inData=\"{2}\"")
+    @MethodSource("shouldComposeParams")
+    public void shouldCompose_composeMinSizeReached(int composeMinSize, String tailData, String inData) {
+      setUp(composeMinSize, tailData, inData);
+      try {
+        Assumptions.assumeTrue(composite.numComponents() > 0);
+        Assumptions.assumeTrue(tail.readableBytes() + in.readableBytes() >= composeMinSize);
+        assertTrue(AdaptiveCumulator.shouldCompose(composite, in, composeMinSize));
+      } finally {
+        tearDown();
+      }
+    }
+
+    @ParameterizedTest(name = "composeMinSize={0}, tailData=\"{1}\", inData=\"{2}\"")
+    @MethodSource("shouldComposeParams")
+    public void shouldCompose_composeMinSizeNotReached(int composeMinSize, String tailData, String inData) {
+      setUp(composeMinSize, tailData, inData);
+      try {
+        Assumptions.assumeTrue(composite.numComponents() > 0);
+        Assumptions.assumeTrue(tail.readableBytes() + in.readableBytes() < composeMinSize);
+        assertFalse(AdaptiveCumulator.shouldCompose(composite, in, composeMinSize));
+      } finally {
+        tearDown();
+      }
+    }
+  }
+
+  @Nested
+  @TestInstance(Lifecycle.PER_CLASS)
+  public class MergeWithCompositeTailTests {
+    private final String INCOMING_DATA_READABLE = "+incoming";
+    private final String INCOMING_DATA_DISCARDABLE = "discard";
+
+    private final String TAIL_DATA_DISCARDABLE = "---";
+    private final String TAIL_DATA_READABLE = "tail";
+    private final String TAIL_DATA = TAIL_DATA_DISCARDABLE + TAIL_DATA_READABLE;
+    private final int TAIL_READER_INDEX = TAIL_DATA_DISCARDABLE.length();
+    private final int TAIL_MAX_CAPACITY = 128;
+
+    private final String EXPECTED_TAIL_DATA = "tail+incoming";
+
+    public Stream<Arguments> mergeParams() {
+      List<String> headDatas = Arrays.asList("", "head");
+      List<Integer> readerIndexes = Arrays.asList(0, 2, 6); // 0, head.length()-2, head.length()+2
+
+      return headDatas.stream().flatMap(hd -> readerIndexes.stream().map(ri -> Arguments.of(hd, ri)));
+    }
+
+    private CompositeByteBuf composite;
+    private ByteBuf tail;
+    private ByteBuf in;
+    private final ByteBufAllocator alloc = new io.netty.buffer.PooledByteBufAllocator();
+
+    private void setUp(String compositeHeadData, int compositeReaderIndex) {
+      composite = alloc.compositeBuffer();
+
+      ByteBuf head = alloc.buffer().writeBytes(compositeHeadData.getBytes(US_ASCII));
+      composite.addFlattenedComponents(true, head);
+
+      tail = alloc.buffer(TAIL_DATA.length(), TAIL_MAX_CAPACITY)
+          .writeBytes(TAIL_DATA.getBytes(US_ASCII))
+          .readerIndex(TAIL_READER_INDEX);
+
+      in = alloc.buffer()
+          .writeBytes(INCOMING_DATA_DISCARDABLE.getBytes(US_ASCII))
+          .writeBytes(INCOMING_DATA_READABLE.getBytes(US_ASCII))
+          .readerIndex(INCOMING_DATA_DISCARDABLE.length());
+    }
+
+    private void tearDown() {
+      if (composite != null) {
+        composite.release();
+      }
+      if (in != null && in.refCnt() > 0) {
+        in.release();
+      }
+      if (tail != null && tail.refCnt() > 0) {
+        tail.release();
+      }
+    }
+
+    private String repeat(String s, int count) {
+      StringBuilder sb = new StringBuilder();
+      for (int i = 0; i < count; i++) {
+        sb.append(s);
+      }
+      return sb.toString();
+    }
+
+    private void assertTailExpanded(String expectedTailReadableData, int expectedNewTailCapacity,
+        int compositeReaderIndex, String compositeHeadData) {
+      int originalNumComponents = composite.numComponents();
+      int compositeReaderIndexBounded = Math.min(compositeReaderIndex, composite.writerIndex());
+      composite.readerIndex(compositeReaderIndexBounded);
+
+      AdaptiveCumulator.mergeWithCompositeTail(alloc, composite, in);
+
+      assertEquals(originalNumComponents, composite.numComponents(),
+          "When tail is expanded, the number of components in the cumulation must not change");
+
+      ByteBuf newTail = composite.component(composite.numComponents() - 1);
+
+      assertEquals(expectedTailReadableData, newTail.toString(US_ASCII));
+      assertEquals(expectedNewTailCapacity, newTail.capacity());
+
+      String newTailDataDiscardable = newTail.toString(0, newTail.readerIndex(), US_ASCII);
+      assertEquals("", newTailDataDiscardable,
+          "After tail expansion, its discardable bytes should be discarded");
+
+      assertEquals(0, newTail.readerIndex());
+      assertEquals(expectedTailReadableData.length(), newTail.writerIndex());
+
+      assertExpectedCumulation(newTail, expectedTailReadableData, compositeReaderIndexBounded, compositeHeadData);
+
+      assertFalse(in.isReadable(), "Incoming buffer is fully read");
+      assertEquals(0, in.refCnt(), "Incoming buffer is released");
+    }
+
+    private void assertExpectedCumulation(ByteBuf newTail, String expectedTailReadable,
+        int expectedReaderIndex, String compositeHeadData) {
+      String expectedCumulationData = compositeHeadData.concat(expectedTailReadable)
+          .substring(expectedReaderIndex);
+      assertEquals(expectedCumulationData, composite.toString(US_ASCII));
+
+      int expectedCumulationCapacity = compositeHeadData.length() + expectedTailReadable.length();
+      assertEquals(expectedCumulationCapacity, composite.capacity());
+      assertEquals(expectedReaderIndex, composite.readerIndex());
+      assertEquals(expectedCumulationCapacity, composite.writerIndex());
+
+      assertEquals(1, composite.refCnt());
+      assertEquals(1, newTail.refCnt());
+    }
+
+    private void assertTailReplaced(int compositeReaderIndex, String compositeHeadData) {
+      int cumulationOriginalComponentsNum = composite.numComponents();
+      int taiOriginalRefCount = tail.refCnt();
+      String expectedTailReadable = tail.toString(US_ASCII) + in.toString(US_ASCII);
+      int expectedReallocatedTailCapacity = alloc.calculateNewCapacity(
+          expectedTailReadable.length(), Integer.MAX_VALUE);
+
+      int compositeReaderIndexBounded = Math.min(compositeReaderIndex, composite.writerIndex());
+      composite.readerIndex(compositeReaderIndexBounded);
+      AdaptiveCumulator.mergeWithCompositeTail(alloc, composite, in);
+
+      assertEquals(cumulationOriginalComponentsNum, composite.numComponents());
+      ByteBuf replacedTail = composite.component(composite.numComponents() - 1);
+
+      assertEquals(0, in.readableBytes());
+      assertEquals(expectedTailReadable, replacedTail.toString(US_ASCII));
+
+      assertEquals(0, replacedTail.readerIndex());
+      assertEquals(expectedTailReadable.length(), replacedTail.writerIndex());
+      assertEquals(expectedReallocatedTailCapacity, replacedTail.capacity());
+
+      assertExpectedCumulation(replacedTail, expectedTailReadable,
+          compositeReaderIndexBounded, compositeHeadData);
+
+      assertFalse(in.isReadable(), "Incoming buffer is fully read");
+      assertEquals(0, in.refCnt(), "Incoming buffer is released");
+      assertEquals(taiOriginalRefCount - 1, tail.refCnt(), "Replaced tail released once.");
+    }
+
+    @ParameterizedTest(name = "head=\"{0}\", readerIndex={1}")
+    @MethodSource("mergeParams")
+    public void mergeWithCompositeTail_tailExpandable_write(String compositeHeadData, int compositeReaderIndex) {
+      setUp(compositeHeadData, compositeReaderIndex);
+      try {
+        int fitCapacity = tail.capacity() + INCOMING_DATA_READABLE.length();
+        tail.capacity(fitCapacity);
+        int expectedCapacity = alloc.calculateNewCapacity(fitCapacity, Integer.MAX_VALUE);
+        assertTrue(in.readableBytes() <= tail.writableBytes());
+
+        composite.addFlattenedComponents(true, tail);
+        assertTailExpanded(EXPECTED_TAIL_DATA, expectedCapacity, compositeReaderIndex, compositeHeadData);
+      } finally {
+        tearDown();
+      }
+    }
+
+    @ParameterizedTest(name = "head=\"{0}\", readerIndex={1}")
+    @MethodSource("mergeParams")
+    public void mergeWithCompositeTail_tailExpandable_fastWrite(
+        String compositeHeadData, int compositeReaderIndex) {
+      setUp(compositeHeadData, compositeReaderIndex);
+      try {
+        int tailFastCapacity = alloc.calculateNewCapacity(EXPECTED_TAIL_DATA.length(), Integer.MAX_VALUE);
+
+        composite.addFlattenedComponents(true, tail);
+        assertTailExpanded(EXPECTED_TAIL_DATA, tailFastCapacity, compositeReaderIndex, compositeHeadData);
+      } finally {
+        tearDown();
+      }
+    }
+
+    @ParameterizedTest(name = "head=\"{0}\", readerIndex={1}")
+    @MethodSource("mergeParams")
+    public void mergeWithCompositeTail_tailExpandable_reallocateInMemory(
+        String compositeHeadData, int compositeReaderIndex) {
+      setUp(compositeHeadData, compositeReaderIndex);
+      try {
+        int tailFastCapacity = tail.writerIndex() + tail.maxFastWritableBytes();
+        String inSuffixOverFastBytes = repeat("a", tailFastCapacity + 1);
+        int newTailSize = tail.readableBytes() + inSuffixOverFastBytes.length();
+        composite.addFlattenedComponents(true, tail);
+
+        in.writeCharSequence(inSuffixOverFastBytes, US_ASCII);
+        assertTrue(in.readableBytes() > tail.maxFastWritableBytes());
+        assertTrue(in.readableBytes() <= tail.maxWritableBytes());
+
+        int expectedTailCapacity = alloc.calculateNewCapacity(newTailSize, Integer.MAX_VALUE);
+        assertTailExpanded(EXPECTED_TAIL_DATA.concat(inSuffixOverFastBytes),
+            expectedTailCapacity, compositeReaderIndex, compositeHeadData);
+      } finally {
+        tearDown();
+      }
+    }
+
+    @ParameterizedTest(name = "head=\"{0}\", readerIndex={1}")
+    @MethodSource("mergeParams")
+    public void mergeWithCompositeTail_tailNotExpandable_maxCapacityReached(
+        String compositeHeadData, int compositeReaderIndex) {
+      setUp(compositeHeadData, compositeReaderIndex);
+      try {
+        String tailSuffixFullCapacity = repeat("a", tail.maxWritableBytes());
+        tail.writeCharSequence(tailSuffixFullCapacity, US_ASCII);
+        composite.addFlattenedComponents(true, tail);
+        assertTailReplaced(compositeReaderIndex, compositeHeadData);
+      } finally {
+        tearDown();
+      }
+    }
+
+    @ParameterizedTest(name = "head=\"{0}\", readerIndex={1}")
+    @MethodSource("mergeParams")
+    public void mergeWithCompositeTail_tailNotExpandable_shared(
+        String compositeHeadData, int compositeReaderIndex) {
+      setUp(compositeHeadData, compositeReaderIndex);
+      try {
+        tail.retain();
+        composite.addFlattenedComponents(true, tail);
+        assertTailReplaced(compositeReaderIndex, compositeHeadData);
+        tail.release();
+      } finally {
+        tearDown();
+      }
+    }
+
+    @ParameterizedTest(name = "head=\"{0}\", readerIndex={1}")
+    @MethodSource("mergeParams")
+    public void mergeWithCompositeTail_tailNotExpandable_readOnly(
+        String compositeHeadData, int compositeReaderIndex) {
+      setUp(compositeHeadData, compositeReaderIndex);
+      try {
+        composite.addFlattenedComponents(true, tail.asReadOnly());
+        assertTailReplaced(compositeReaderIndex, compositeHeadData);
+      } finally {
+        tearDown();
+      }
+    }
+
+    @ParameterizedTest(name = "head=\"{0}\", readerIndex={1}")
+    @MethodSource("mergeParams")
+    public void mergeWithCompositeTail_tailExpandable_mergedReleaseOnThrow(
+        String compositeHeadData, int compositeReaderIndex) {
+      setUp(compositeHeadData, compositeReaderIndex);
+      final UnsupportedOperationException expectedError = new UnsupportedOperationException();
+      CompositeByteBuf compositeThrows = new CompositeByteBuf(alloc, false, Integer.MAX_VALUE, tail) {
+        @Override
+        public CompositeByteBuf addFlattenedComponents(boolean increaseWriterIndex, ByteBuf buffer) {
+          throw expectedError;
+        }
+      };
+
+      try {
+        AdaptiveCumulator.mergeWithCompositeTail(alloc, compositeThrows, in);
+        fail("Cumulator didn't throw");
+      } catch (UnsupportedOperationException actualError) {
+        assertSame(expectedError, actualError);
+        assertEquals(0, tail.refCnt());
+        assertEquals(1, compositeThrows.refCnt());
+        assertEquals(0, compositeThrows.numComponents());
+      } finally {
+        compositeThrows.release();
+        tearDown();
+      }
+    }
+
+    @ParameterizedTest(name = "head=\"{0}\", readerIndex={1}")
+    @MethodSource("mergeParams")
+    public void mergeWithCompositeTail_tailNotExpandable_mergedReleaseOnThrow(
+        String compositeHeadData, int compositeReaderIndex) {
+      setUp(compositeHeadData, compositeReaderIndex);
+      final UnsupportedOperationException expectedError = new UnsupportedOperationException();
+      CompositeByteBuf compositeRo = new CompositeByteBuf(alloc, false, Integer.MAX_VALUE, tail.asReadOnly()) {
+        @Override
+        public CompositeByteBuf addFlattenedComponents(boolean increaseWriterIndex, ByteBuf buffer) {
+          throw expectedError;
+        }
+      };
+
+      int newTailSize = tail.readableBytes() + in.readableBytes();
+      ByteBuf newTail = alloc.buffer(alloc.calculateNewCapacity(newTailSize, Integer.MAX_VALUE));
+      ByteBufAllocator mockAlloc = mock(ByteBufAllocator.class);
+      when(mockAlloc.buffer(anyInt())).thenReturn(newTail);
+
+      try {
+        AdaptiveCumulator.mergeWithCompositeTail(mockAlloc, compositeRo, in);
+        fail("Cumulator didn't throw");
+      } catch (UnsupportedOperationException actualError) {
+        assertSame(expectedError, actualError);
+        assertEquals(1, compositeRo.refCnt());
+        assertEquals(0, compositeRo.numComponents());
+      } finally {
+        compositeRo.release();
+        if (newTail.refCnt() > 0) {
+          newTail.release();
+        }
+        tearDown();
+      }
+    }
+  }
+
+  @Nested
+  public class MergeWithCompositeTailMiscTests {
+    private final ByteBufAllocator alloc = new io.netty.buffer.PooledByteBufAllocator();
+
+    @Test
+    public void mergeWithCompositeTail_outOfSyncComposite() {
+      AdaptiveCumulator cumulator = new AdaptiveCumulator(1024);
+
+      ByteBuf buf = alloc.buffer(32).writeBytes("---01234".getBytes(US_ASCII));
+
+      CompositeByteBuf composite1 = alloc.compositeBuffer(8).addFlattenedComponents(true, buf.retain());
+      assertEquals("---", composite1.readCharSequence(3, US_ASCII).toString());
+
+      CompositeByteBuf composite2 = alloc.compositeBuffer(8).addFlattenedComponents(true, composite1);
+      assertEquals("01234", composite2.toString(US_ASCII));
+
+      CompositeByteBuf cumulation = (CompositeByteBuf) cumulator.cumulate(alloc, composite2,
+          ByteBufUtil.writeAscii(alloc, "56789"));
+      assertEquals("0123456789", cumulation.toString(US_ASCII));
+
+      assertEquals(1, cumulation.numComponents());
+      buf.setByte(5, '*').setByte(11, '$');
+      assertEquals("0123456789", cumulation.toString(US_ASCII));
+      cumulation.release();
+      buf.release();
+    }
+
+    @Test
+    public void mergeWithCompositeTail_detectsIndicesInNestedComposite() {
+      // 1. Setup local allocator and a real cumulator that triggers merging.
+      ByteBufAllocator alloc = new UnpooledByteBufAllocator(false);
+      AdaptiveCumulator realCumulator = new AdaptiveCumulator(1024);
+
+      // 2. Create a buffer with some "header" data we intend to skip.
+      ByteBuf buf = alloc.buffer(32).writeBytes("SKIP01234".getBytes(US_ASCII));
+
+      // 3. Wrap it in a composite buffer and read the "SKIP" part.
+      CompositeByteBuf innerComposite = alloc.compositeBuffer()
+          .addFlattenedComponents(true, buf);
+      innerComposite.readCharSequence(4, US_ASCII); // Discard "SKIP"
+
+      // 4. Wrap that into a second composite (simulating cumulate() with refCnt > 1).
+      // The readable content here is "01234".
+      CompositeByteBuf outerComposite = alloc.compositeBuffer()
+          .addFlattenedComponents(true, innerComposite);
+
+      try {
+        // 5. Perform a cumulation that triggers mergeWithCompositeTail.
+        // Use realCumulator to ensure the merge logic is executed.
+        realCumulator.cumulate(alloc, outerComposite,
+            ByteBufUtil.writeAscii(alloc, "56789"));
+
+        // Verify the "SKIP" bytes did not reappear.
+        assertThat(outerComposite.toString(US_ASCII)).isEqualTo("0123456789");
+
+        // Verify the merge occurred (resulting in a single component).
+        assertThat(outerComposite.numComponents()).isEqualTo(1);
+      } finally {
+        // Clean up to prevent leaks.
+        outerComposite.release();
+      }
+    }
+  }
+}

--- a/codec-base/src/test/java/io/netty/handler/codec/AdaptiveCumulatorTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/AdaptiveCumulatorTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Assumptions;
 
 import static io.netty.util.CharsetUtil.US_ASCII;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,566 +46,569 @@ import static org.mockito.Mockito.when;
 
 public class AdaptiveCumulatorTest {
 
-  @Nested
-  public class CumulateTests {
-    private static final String DATA_INITIAL = "0123";
-    private static final String DATA_INCOMING = "456789";
-    private static final String DATA_CUMULATED = "0123456789";
+    @Nested
+    public class CumulateTests {
+        private static final String DATA_INITIAL = "0123";
+        private static final String DATA_INCOMING = "456789";
+        private static final String DATA_CUMULATED = "0123456789";
 
-    private final ByteBufAllocator alloc = new UnpooledByteBufAllocator(false);
-    private AdaptiveCumulator cumulator;
-    private AdaptiveCumulator throwingCumulator;
-    private final UnsupportedOperationException throwingCumulatorError = new UnsupportedOperationException();
+        private final ByteBufAllocator alloc = new UnpooledByteBufAllocator(false);
+        private AdaptiveCumulator cumulator;
+        private final UnsupportedOperationException throwingCumulatorError = new UnsupportedOperationException();
 
-    private ByteBuf contiguous;
-    private ByteBuf in;
+        private ByteBuf contiguous;
+        private ByteBuf in;
 
-    @BeforeEach
-    public void setUp() {
-      contiguous = ByteBufUtil.writeAscii(alloc, DATA_INITIAL);
-      in = ByteBufUtil.writeAscii(alloc, DATA_INCOMING);
+        @BeforeEach
+        public void setUp() {
+            contiguous = ByteBufUtil.writeAscii(alloc, DATA_INITIAL);
+            in = ByteBufUtil.writeAscii(alloc, DATA_INCOMING);
 
-      cumulator = new AdaptiveCumulator(0);
-    }
-
-    @Test
-    public void cumulate_notReadableCumulation_replacedWithInputAndReleased() {
-      contiguous.readerIndex(contiguous.writerIndex());
-      assertFalse(contiguous.isReadable());
-      ByteBuf cumulation = cumulator.cumulate(alloc, contiguous, in);
-      assertEquals(DATA_INCOMING, cumulation.toString(US_ASCII));
-      assertEquals(0, contiguous.refCnt());
-      assertEquals(1, in.refCnt());
-      assertEquals(1, cumulation.refCnt());
-      cumulation.release();
-    }
-
-    @Test
-    public void cumulate_sameBuffer_identityHandled() {
-      in.retain(); // simulate double retention when the same buffer is passed twice
-      ByteBuf result = cumulator.cumulate(alloc, in, in);
-      assertSame(in, result);
-      assertEquals(1, in.refCnt(), "The cumulator should release the doubly-retained buffer once");
-      in.release();
-    }
-
-    @Test
-    public void cumulate_contiguousCumulation_newCompositeFromContiguousAndInput() {
-      CompositeByteBuf cumulation = (CompositeByteBuf) cumulator.cumulate(alloc, contiguous, in);
-      assertEquals(DATA_INITIAL, cumulation.component(0).toString(US_ASCII));
-      assertEquals(DATA_INCOMING, cumulation.component(1).toString(US_ASCII));
-      assertEquals(DATA_CUMULATED, cumulation.toString(US_ASCII));
-      assertEquals(1, contiguous.refCnt());
-      assertEquals(1, in.refCnt());
-      assertEquals(1, cumulation.refCnt());
-      cumulation.release();
-    }
-
-    @Test
-    public void cumulate_compositeCumulation_inputAppendedAsANewComponent() {
-      CompositeByteBuf composite = alloc.compositeBuffer().addComponent(true, contiguous);
-      assertSame(composite, cumulator.cumulate(alloc, composite, in));
-      assertEquals(DATA_INITIAL, composite.component(0).toString(US_ASCII));
-      assertEquals(DATA_INCOMING, composite.component(1).toString(US_ASCII));
-      assertEquals(DATA_CUMULATED, composite.toString(US_ASCII));
-      assertEquals(1, contiguous.refCnt());
-      assertEquals(1, in.refCnt());
-      assertEquals(1, composite.refCnt());
-      composite.release();
-    }
-
-    @Test
-    public void cumulate_compositeCumulation_inputReleasedOnError() {
-      CompositeByteBuf composite = new CompositeByteBuf(alloc, false, Integer.MAX_VALUE, contiguous) {
-        @Override
-        public CompositeByteBuf addFlattenedComponents(boolean increaseWriterIndex, ByteBuf buffer) {
-          throw throwingCumulatorError;
+            cumulator = new AdaptiveCumulator(0);
         }
-      };
-      try {
-        cumulator.cumulate(alloc, composite, in);
-        fail("Cumulator didn't throw");
-      } catch (UnsupportedOperationException actualError) {
-        assertSame(throwingCumulatorError, actualError);
-        assertEquals(0, in.refCnt());
-        assertEquals(1, composite.refCnt());
-        assertEquals(1, contiguous.refCnt());
-      } finally {
-        composite.release();
-      }
-    }
 
-    @Test
-    public void cumulate_contiguousCumulation_inputAndNewCompositeReleasedOnError() {
-      CompositeByteBuf newComposite = new CompositeByteBuf(alloc, false, Integer.MAX_VALUE) {
-        int count = 0;
-
-        @Override
-        public CompositeByteBuf addFlattenedComponents(boolean increaseWriterIndex, ByteBuf buffer) {
-          if (++count == 2) {
-            throw throwingCumulatorError;
-          }
-          return super.addFlattenedComponents(increaseWriterIndex, buffer);
+        @Test
+        public void cumulate_notReadableCumulation_replacedWithInputAndReleased() {
+            contiguous.readerIndex(contiguous.writerIndex());
+            assertFalse(contiguous.isReadable());
+            ByteBuf cumulation = cumulator.cumulate(alloc, contiguous, in);
+            assertEquals(DATA_INCOMING, cumulation.toString(US_ASCII));
+            assertEquals(0, contiguous.refCnt());
+            assertEquals(1, in.refCnt());
+            assertEquals(1, cumulation.refCnt());
+            cumulation.release();
         }
-      };
-      ByteBufAllocator mockAlloc = mock(ByteBufAllocator.class);
-      when(mockAlloc.compositeBuffer(anyInt())).thenReturn(newComposite);
 
-      try {
-        cumulator.cumulate(mockAlloc, contiguous, in);
-        fail("Cumulator didn't throw");
-      } catch (UnsupportedOperationException actualError) {
-        assertSame(throwingCumulatorError, actualError);
-        assertEquals(0, in.refCnt());
-        assertEquals(0, newComposite.refCnt());
-        assertEquals(0, contiguous.refCnt());
-      }
-    }
-  }
-
-  @Nested
-  @TestInstance(Lifecycle.PER_CLASS)
-  public class ShouldComposeTests {
-    private final String DATA_INITIAL = "0123";
-    private final String DATA_INCOMING = "456789";
-
-    public Stream<Arguments> shouldComposeParams() {
-      List<Integer> composeMinSizes = Arrays.asList(0, 9, 10, 11, Integer.MAX_VALUE);
-      List<String> tailDatas = Arrays.asList("", DATA_INITIAL);
-      List<String> inDatas = Arrays.asList("", DATA_INCOMING);
-
-      return composeMinSizes.stream()
-          .flatMap(cms -> tailDatas.stream().flatMap(td -> inDatas.stream().map(id -> Arguments.of(cms, td, id))));
-    }
-
-    private CompositeByteBuf composite;
-    private ByteBuf tail;
-    private ByteBuf in;
-    private ByteBufAllocator alloc = new UnpooledByteBufAllocator(false);
-
-    private void setUp(int composeMinSize, String tailData, String inData) {
-      in = ByteBufUtil.writeAscii(alloc, inData);
-      tail = ByteBufUtil.writeAscii(alloc, tailData);
-      composite = alloc.compositeBuffer(Integer.MAX_VALUE);
-      composite.addFlattenedComponents(true, tail);
-    }
-
-    private void tearDown() {
-      if (composite != null && composite.refCnt() > 0) {
-        composite.release();
-      }
-    }
-
-    @ParameterizedTest(name = "composeMinSize={0}, tailData=\"{1}\", inData=\"{2}\"")
-    @MethodSource("shouldComposeParams")
-    public void shouldCompose(int composeMinSize, String tailData, String inData) {
-      setUp(composeMinSize, tailData, inData);
-      try {
-        int initialComponents = composite.numComponents();
-        AdaptiveCumulator cumulator = new AdaptiveCumulator(composeMinSize);
-        ByteBuf result = cumulator.cumulate(alloc, composite, in);
-
-        if (!composite.isReadable()) {
-          assertSame(in, result);
-          composite = null;
-          in.release();
-        } else if (!in.isReadable()) {
-          assertSame(composite, result);
-          assertEquals(initialComponents, composite.numComponents());
-          assertEquals(tailData + inData, composite.toString(US_ASCII));
-        } else if (tail.readableBytes() + in.readableBytes() >= composeMinSize) {
-          composite = (CompositeByteBuf) result;
-          assertEquals(initialComponents + 1, composite.numComponents());
-          assertEquals(tailData + inData, composite.toString(US_ASCII));
-        } else {
-          composite = (CompositeByteBuf) result;
-          assertEquals(initialComponents, composite.numComponents());
-          assertEquals(tailData + inData, composite.toString(US_ASCII));
+        @Test
+        public void cumulate_sameBuffer_identityHandled() {
+            in.retain(); // simulate double retention when the same buffer is passed twice
+            ByteBuf result = cumulator.cumulate(alloc, in, in);
+            assertSame(in, result);
+            assertEquals(1, in.refCnt(), "The cumulator should release the doubly-retained buffer once");
+            in.release();
         }
-      } finally {
-        tearDown();
-      }
-    }
-  }
 
-  @Nested
-  @TestInstance(Lifecycle.PER_CLASS)
-  public class MergeWithCompositeTailTests {
-    private final String INCOMING_DATA_READABLE = "+incoming";
-    private final String INCOMING_DATA_DISCARDABLE = "discard";
-
-    private final String TAIL_DATA_DISCARDABLE = "---";
-    private final String TAIL_DATA_READABLE = "tail";
-    private final String TAIL_DATA = TAIL_DATA_DISCARDABLE + TAIL_DATA_READABLE;
-    private final int TAIL_READER_INDEX = TAIL_DATA_DISCARDABLE.length();
-    private final int TAIL_MAX_CAPACITY = 128;
-
-    private final String EXPECTED_TAIL_DATA = "tail+incoming";
-
-    public Stream<Arguments> mergeParams() {
-      List<String> headDatas = Arrays.asList("", "head");
-      List<Integer> readerIndexes = Arrays.asList(0, 2, 6); // 0, head.length()-2, head.length()+2
-
-      return headDatas.stream().flatMap(hd -> readerIndexes.stream().map(ri -> Arguments.of(hd, ri)));
-    }
-
-    private CompositeByteBuf composite;
-    private ByteBuf tail;
-    private ByteBuf in;
-    private final ByteBufAllocator alloc = new io.netty.buffer.PooledByteBufAllocator();
-
-    private void setUp(String compositeHeadData, int compositeReaderIndex) {
-      composite = alloc.compositeBuffer();
-
-      ByteBuf head = alloc.buffer().writeBytes(compositeHeadData.getBytes(US_ASCII));
-      composite.addFlattenedComponents(true, head);
-
-      tail = alloc.buffer(TAIL_DATA.length(), TAIL_MAX_CAPACITY)
-          .writeBytes(TAIL_DATA.getBytes(US_ASCII))
-          .readerIndex(TAIL_READER_INDEX);
-
-      in = alloc.buffer()
-          .writeBytes(INCOMING_DATA_DISCARDABLE.getBytes(US_ASCII))
-          .writeBytes(INCOMING_DATA_READABLE.getBytes(US_ASCII))
-          .readerIndex(INCOMING_DATA_DISCARDABLE.length());
-    }
-
-    private void tearDown() {
-      if (composite != null && composite.refCnt() > 0) {
-        composite.release();
-      }
-    }
-
-    private String repeat(String s, int count) {
-      StringBuilder sb = new StringBuilder();
-      for (int i = 0; i < count; i++) {
-        sb.append(s);
-      }
-      return sb.toString();
-    }
-
-    private void assertTailExpanded(String expectedTailReadableData, int expectedNewTailCapacity,
-        int compositeReaderIndex, String compositeHeadData) {
-      int originalNumComponents = composite.numComponents();
-      int compositeReaderIndexBounded = Math.min(compositeReaderIndex, composite.writerIndex());
-      composite.readerIndex(compositeReaderIndexBounded);
-      boolean wasReadable = composite.isReadable();
-
-      AdaptiveCumulator cumulator = new AdaptiveCumulator(Integer.MAX_VALUE);
-      ByteBuf result = cumulator.cumulate(alloc, composite, in);
-
-      if (!wasReadable) {
-        assertSame(in, result, "When composite is fully read, cumulate should return in");
-        assertEquals(0, composite.refCnt(), "Old composite should be released");
-        in.release(); // Free the returned buffer manually
-        return;
-      }
-
-      composite = (CompositeByteBuf) result;
-
-      assertEquals(originalNumComponents, composite.numComponents(),
-          "When tail is expanded, the number of components in the cumulation must not change");
-
-      ByteBuf newTail = composite.component(composite.numComponents() - 1);
-
-      assertEquals(expectedTailReadableData, newTail.toString(US_ASCII));
-      assertEquals(expectedNewTailCapacity, newTail.capacity());
-
-      String newTailDataDiscardable = newTail.toString(0, newTail.readerIndex(), US_ASCII);
-      assertEquals("", newTailDataDiscardable,
-          "After tail expansion, its discardable bytes should be discarded");
-
-      assertEquals(0, newTail.readerIndex());
-      assertEquals(expectedTailReadableData.length(), newTail.writerIndex());
-
-      assertExpectedCumulation(newTail, expectedTailReadableData, compositeReaderIndexBounded, compositeHeadData);
-
-      assertFalse(in.isReadable(), "Incoming buffer is fully read");
-      assertEquals(0, in.refCnt(), "Incoming buffer is released");
-    }
-
-    private void assertExpectedCumulation(ByteBuf newTail, String expectedTailReadable,
-        int expectedReaderIndex, String compositeHeadData) {
-      String expectedCumulationData = compositeHeadData.concat(expectedTailReadable)
-          .substring(expectedReaderIndex);
-      assertEquals(expectedCumulationData, composite.toString(US_ASCII));
-
-      int expectedCumulationCapacity = compositeHeadData.length() + expectedTailReadable.length();
-      assertEquals(expectedCumulationCapacity, composite.capacity());
-      assertEquals(expectedReaderIndex, composite.readerIndex());
-      assertEquals(expectedCumulationCapacity, composite.writerIndex());
-
-      assertEquals(1, composite.refCnt());
-      assertEquals(1, newTail.refCnt());
-    }
-
-    private void assertTailReplaced(int compositeReaderIndex, String compositeHeadData) {
-      int cumulationOriginalComponentsNum = composite.numComponents();
-      int taiOriginalRefCount = tail.refCnt();
-      String expectedTailReadable = tail.toString(US_ASCII) + in.toString(US_ASCII);
-      int expectedReallocatedTailCapacity = alloc.calculateNewCapacity(
-          expectedTailReadable.length(), Integer.MAX_VALUE);
-
-      int compositeReaderIndexBounded = Math.min(compositeReaderIndex, composite.writerIndex());
-      composite.readerIndex(compositeReaderIndexBounded);
-      boolean wasReadable = composite.isReadable();
-
-      AdaptiveCumulator cumulator = new AdaptiveCumulator(Integer.MAX_VALUE);
-      ByteBuf result = cumulator.cumulate(alloc, composite, in);
-
-      if (!wasReadable) {
-        assertSame(in, result, "When composite is fully read, cumulate should return in");
-        assertEquals(0, composite.refCnt(), "Old composite should be released");
-        in.release(); // Free the returned buffer manually
-        return;
-      }
-
-      composite = (CompositeByteBuf) result;
-
-      assertEquals(cumulationOriginalComponentsNum, composite.numComponents());
-      ByteBuf replacedTail = composite.component(composite.numComponents() - 1);
-
-      assertEquals(0, in.readableBytes());
-      assertEquals(expectedTailReadable, replacedTail.toString(US_ASCII));
-
-      assertEquals(0, replacedTail.readerIndex());
-      assertEquals(expectedTailReadable.length(), replacedTail.writerIndex());
-      assertEquals(expectedReallocatedTailCapacity, replacedTail.capacity());
-
-      assertExpectedCumulation(replacedTail, expectedTailReadable,
-          compositeReaderIndexBounded, compositeHeadData);
-
-      assertFalse(in.isReadable(), "Incoming buffer is fully read");
-      assertEquals(0, in.refCnt(), "Incoming buffer is released");
-      assertEquals(taiOriginalRefCount - 1, tail.refCnt(), "Replaced tail released once.");
-    }
-
-    @ParameterizedTest(name = "head=\"{0}\", readerIndex={1}")
-    @MethodSource("mergeParams")
-    public void mergeWithCompositeTail_tailExpandable_write(String compositeHeadData, int compositeReaderIndex) {
-      setUp(compositeHeadData, compositeReaderIndex);
-      try {
-        int fitCapacity = tail.capacity() + INCOMING_DATA_READABLE.length();
-        tail.capacity(fitCapacity);
-        int expectedCapacity = alloc.calculateNewCapacity(fitCapacity, Integer.MAX_VALUE);
-        assertTrue(in.readableBytes() <= tail.writableBytes());
-
-        composite.addFlattenedComponents(true, tail);
-        assertTailExpanded(EXPECTED_TAIL_DATA, expectedCapacity, compositeReaderIndex, compositeHeadData);
-      } finally {
-        tearDown();
-      }
-    }
-
-    @ParameterizedTest(name = "head=\"{0}\", readerIndex={1}")
-    @MethodSource("mergeParams")
-    public void mergeWithCompositeTail_tailExpandable_fastWrite(
-        String compositeHeadData, int compositeReaderIndex) {
-      setUp(compositeHeadData, compositeReaderIndex);
-      try {
-        int tailFastCapacity = alloc.calculateNewCapacity(EXPECTED_TAIL_DATA.length(), Integer.MAX_VALUE);
-
-        composite.addFlattenedComponents(true, tail);
-        assertTailExpanded(EXPECTED_TAIL_DATA, tailFastCapacity, compositeReaderIndex, compositeHeadData);
-      } finally {
-        tearDown();
-      }
-    }
-
-    @ParameterizedTest(name = "head=\"{0}\", readerIndex={1}")
-    @MethodSource("mergeParams")
-    public void mergeWithCompositeTail_tailExpandable_reallocateInMemory(
-        String compositeHeadData, int compositeReaderIndex) {
-      setUp(compositeHeadData, compositeReaderIndex);
-      try {
-        int tailFastCapacity = tail.writerIndex() + tail.maxFastWritableBytes();
-        String inSuffixOverFastBytes = repeat("a", tailFastCapacity + 1);
-        int newTailSize = tail.readableBytes() + inSuffixOverFastBytes.length();
-        composite.addFlattenedComponents(true, tail);
-
-        in.writeCharSequence(inSuffixOverFastBytes, US_ASCII);
-        assertTrue(in.readableBytes() > tail.maxFastWritableBytes());
-        assertTrue(in.readableBytes() <= tail.maxWritableBytes());
-
-        int expectedTailCapacity = alloc.calculateNewCapacity(newTailSize, Integer.MAX_VALUE);
-        assertTailExpanded(EXPECTED_TAIL_DATA.concat(inSuffixOverFastBytes),
-            expectedTailCapacity, compositeReaderIndex, compositeHeadData);
-      } finally {
-        tearDown();
-      }
-    }
-
-    @ParameterizedTest(name = "head=\"{0}\", readerIndex={1}")
-    @MethodSource("mergeParams")
-    public void mergeWithCompositeTail_tailNotExpandable_maxCapacityReached(
-        String compositeHeadData, int compositeReaderIndex) {
-      setUp(compositeHeadData, compositeReaderIndex);
-      try {
-        String tailSuffixFullCapacity = repeat("a", tail.maxWritableBytes());
-        tail.writeCharSequence(tailSuffixFullCapacity, US_ASCII);
-        composite.addFlattenedComponents(true, tail);
-        assertTailReplaced(compositeReaderIndex, compositeHeadData);
-      } finally {
-        tearDown();
-      }
-    }
-
-    @ParameterizedTest(name = "head=\"{0}\", readerIndex={1}")
-    @MethodSource("mergeParams")
-    public void mergeWithCompositeTail_tailNotExpandable_shared(
-        String compositeHeadData, int compositeReaderIndex) {
-      setUp(compositeHeadData, compositeReaderIndex);
-      try {
-        tail.retain();
-        composite.addFlattenedComponents(true, tail);
-        assertTailReplaced(compositeReaderIndex, compositeHeadData);
-        tail.release();
-      } finally {
-        tearDown();
-      }
-    }
-
-    @ParameterizedTest(name = "head=\"{0}\", readerIndex={1}")
-    @MethodSource("mergeParams")
-    public void mergeWithCompositeTail_tailNotExpandable_readOnly(
-        String compositeHeadData, int compositeReaderIndex) {
-      setUp(compositeHeadData, compositeReaderIndex);
-      try {
-        composite.addFlattenedComponents(true, tail.asReadOnly());
-        assertTailReplaced(compositeReaderIndex, compositeHeadData);
-      } finally {
-        tearDown();
-      }
-    }
-
-    @ParameterizedTest(name = "head=\"{0}\", readerIndex={1}")
-    @MethodSource("mergeParams")
-    public void mergeWithCompositeTail_tailExpandable_mergedReleaseOnThrow(
-        String compositeHeadData, int compositeReaderIndex) {
-      setUp(compositeHeadData, compositeReaderIndex);
-      final UnsupportedOperationException expectedError = new UnsupportedOperationException();
-      CompositeByteBuf compositeThrows = new CompositeByteBuf(alloc, false, Integer.MAX_VALUE, tail) {
-        @Override
-        public CompositeByteBuf addFlattenedComponents(boolean increaseWriterIndex, ByteBuf buffer) {
-          throw expectedError;
+        @Test
+        public void cumulate_contiguousCumulation_newCompositeFromContiguousAndInput() {
+            CompositeByteBuf cumulation = (CompositeByteBuf) cumulator.cumulate(alloc, contiguous, in);
+            assertEquals(DATA_INITIAL, cumulation.component(0).toString(US_ASCII));
+            assertEquals(DATA_INCOMING, cumulation.component(1).toString(US_ASCII));
+            assertEquals(DATA_CUMULATED, cumulation.toString(US_ASCII));
+            assertEquals(1, contiguous.refCnt());
+            assertEquals(1, in.refCnt());
+            assertEquals(1, cumulation.refCnt());
+            cumulation.release();
         }
-      };
 
-      try {
-        AdaptiveCumulator cumulator = new AdaptiveCumulator(Integer.MAX_VALUE);
-        compositeThrows = (CompositeByteBuf) cumulator.cumulate(alloc, compositeThrows, in);
-        fail("Cumulator didn't throw");
-      } catch (UnsupportedOperationException actualError) {
-        assertSame(expectedError, actualError);
-        assertEquals(0, tail.refCnt());
-        assertEquals(1, compositeThrows.refCnt());
-        assertEquals(0, compositeThrows.numComponents());
-        assertEquals(0, in.refCnt());
-      } finally {
-        compositeThrows.release();
-        tearDown();
-      }
-    }
-
-    @ParameterizedTest(name = "head=\"{0}\", readerIndex={1}")
-    @MethodSource("mergeParams")
-    public void mergeWithCompositeTail_tailNotExpandable_mergedReleaseOnThrow(
-        String compositeHeadData, int compositeReaderIndex) {
-      setUp(compositeHeadData, compositeReaderIndex);
-      final UnsupportedOperationException expectedError = new UnsupportedOperationException();
-      CompositeByteBuf compositeRo = new CompositeByteBuf(alloc, false, Integer.MAX_VALUE, tail.asReadOnly()) {
-        @Override
-        public CompositeByteBuf addFlattenedComponents(boolean increaseWriterIndex, ByteBuf buffer) {
-          throw expectedError;
+        @Test
+        public void cumulate_compositeCumulation_inputAppendedAsANewComponent() {
+            CompositeByteBuf composite = alloc.compositeBuffer().addComponent(true, contiguous);
+            assertSame(composite, cumulator.cumulate(alloc, composite, in));
+            assertEquals(DATA_INITIAL, composite.component(0).toString(US_ASCII));
+            assertEquals(DATA_INCOMING, composite.component(1).toString(US_ASCII));
+            assertEquals(DATA_CUMULATED, composite.toString(US_ASCII));
+            assertEquals(1, contiguous.refCnt());
+            assertEquals(1, in.refCnt());
+            assertEquals(1, composite.refCnt());
+            composite.release();
         }
-      };
 
-      int newTailSize = tail.readableBytes() + in.readableBytes();
-      ByteBuf newTail = alloc.buffer(alloc.calculateNewCapacity(newTailSize, Integer.MAX_VALUE));
-      ByteBufAllocator mockAlloc = mock(ByteBufAllocator.class);
-      when(mockAlloc.buffer(anyInt())).thenReturn(newTail);
-
-      try {
-        AdaptiveCumulator cumulator = new AdaptiveCumulator(Integer.MAX_VALUE);
-        compositeRo = (CompositeByteBuf) cumulator.cumulate(mockAlloc, compositeRo, in);
-        fail("Cumulator didn't throw");
-      } catch (UnsupportedOperationException actualError) {
-        assertSame(expectedError, actualError);
-        assertEquals(1, compositeRo.refCnt());
-        assertEquals(0, compositeRo.numComponents());
-        assertEquals(0, newTail.refCnt());
-        assertEquals(0, in.refCnt());
-      } finally {
-        compositeRo.release();
-        if (newTail.refCnt() > 0) {
-          newTail.release();
+        @Test
+        public void cumulate_compositeCumulation_inputReleasedOnError() {
+            CompositeByteBuf composite = new CompositeByteBuf(alloc, false, Integer.MAX_VALUE, contiguous) {
+                @Override
+                public CompositeByteBuf addFlattenedComponents(boolean increaseWriterIndex, ByteBuf buffer) {
+                    buffer.release();
+                    throw throwingCumulatorError;
+                }
+            };
+            try {
+                cumulator.cumulate(alloc, composite, in);
+                fail("Cumulator didn't throw");
+            } catch (UnsupportedOperationException actualError) {
+                assertSame(throwingCumulatorError, actualError);
+                assertEquals(0, in.refCnt());
+                assertEquals(1, composite.refCnt());
+                assertEquals(1, contiguous.refCnt());
+            } finally {
+                composite.release();
+            }
         }
-        tearDown();
-      }
-    }
-  }
 
-  @Nested
-  public class MergeWithCompositeTailMiscTests {
-    private final ByteBufAllocator alloc = new io.netty.buffer.PooledByteBufAllocator();
+        @Test
+        public void cumulate_contiguousCumulation_inputAndNewCompositeReleasedOnError() {
+            CompositeByteBuf newComposite = new CompositeByteBuf(alloc, false, Integer.MAX_VALUE) {
+                int count;
 
-    @Test
-    public void mergeWithCompositeTail_outOfSyncComposite() {
-      AdaptiveCumulator cumulator = new AdaptiveCumulator(1024);
+                @Override
+                public CompositeByteBuf addFlattenedComponents(boolean increaseWriterIndex, ByteBuf buffer) {
+                    if (++count == 2) {
+                        buffer.release();
+                        throw throwingCumulatorError;
+                    }
+                    return super.addFlattenedComponents(increaseWriterIndex, buffer);
+                }
+            };
+            ByteBufAllocator mockAlloc = mock(ByteBufAllocator.class);
+            when(mockAlloc.compositeBuffer(anyInt())).thenReturn(newComposite);
 
-      ByteBuf buf = alloc.buffer(32).writeBytes("---01234".getBytes(US_ASCII));
-
-      CompositeByteBuf composite1 = alloc.compositeBuffer(8).addFlattenedComponents(true, buf.retain());
-      assertEquals("---", composite1.readCharSequence(3, US_ASCII).toString());
-
-      CompositeByteBuf composite2 = alloc.compositeBuffer(8).addFlattenedComponents(true, composite1);
-      assertEquals("01234", composite2.toString(US_ASCII));
-
-      CompositeByteBuf cumulation = (CompositeByteBuf) cumulator.cumulate(alloc, composite2,
-          ByteBufUtil.writeAscii(alloc, "56789"));
-      assertEquals("0123456789", cumulation.toString(US_ASCII));
-
-      assertEquals(1, cumulation.numComponents());
-      buf.setByte(5, '*').setByte(11, '$');
-      assertEquals("0123456789", cumulation.toString(US_ASCII));
-      cumulation.release();
-      buf.release();
+            try {
+                cumulator.cumulate(mockAlloc, contiguous, in);
+                fail("Cumulator didn't throw");
+            } catch (UnsupportedOperationException actualError) {
+                assertSame(throwingCumulatorError, actualError);
+                assertEquals(0, in.refCnt());
+                assertEquals(0, newComposite.refCnt());
+                assertEquals(0, contiguous.refCnt());
+            }
+        }
     }
 
-    @Test
-    public void mergeWithCompositeTail_detectsIndicesInNestedComposite() {
-      // 1. Setup local allocator and a real cumulator that triggers merging.
-      ByteBufAllocator alloc = new UnpooledByteBufAllocator(false);
-      AdaptiveCumulator realCumulator = new AdaptiveCumulator(1024);
+    @Nested
+    @TestInstance(Lifecycle.PER_CLASS)
+    public class ShouldComposeTests {
+        private final String DATA_INITIAL = "0123";
+        private final String DATA_INCOMING = "456789";
 
-      // 2. Create a buffer with some "header" data we intend to skip.
-      ByteBuf buf = alloc.buffer(32).writeBytes("SKIP01234".getBytes(US_ASCII));
+        public Stream<Arguments> shouldComposeParams() {
+            List<Integer> composeMinSizes = Arrays.asList(0, 9, 10, 11, Integer.MAX_VALUE);
+            List<String> tailDatas = Arrays.asList("", DATA_INITIAL);
+            List<String> inDatas = Arrays.asList("", DATA_INCOMING);
 
-      // 3. Wrap it in a composite buffer and read the "SKIP" part.
-      CompositeByteBuf innerComposite = alloc.compositeBuffer()
-          .addFlattenedComponents(true, buf);
-      innerComposite.readCharSequence(4, US_ASCII); // Discard "SKIP"
+            return composeMinSizes.stream()
+                    .flatMap(cms -> tailDatas.stream().flatMap(td -> inDatas.stream().map(id -> Arguments.of(cms, td, id))));
+        }
 
-      // 4. Wrap that into a second composite (simulating cumulate() with refCnt > 1).
-      // The readable content here is "01234".
-      CompositeByteBuf outerComposite = alloc.compositeBuffer()
-          .addFlattenedComponents(true, innerComposite);
+        private CompositeByteBuf composite;
+        private ByteBuf tail;
+        private ByteBuf in;
+        private ByteBufAllocator alloc = new UnpooledByteBufAllocator(false);
 
-      try {
-        // 5. Perform a cumulation that triggers mergeWithCompositeTail.
-        // Use realCumulator to ensure the merge logic is executed.
-        realCumulator.cumulate(alloc, outerComposite,
-            ByteBufUtil.writeAscii(alloc, "56789"));
+        private void setUp(int composeMinSize, String tailData, String inData) {
+            in = ByteBufUtil.writeAscii(alloc, inData);
+            tail = ByteBufUtil.writeAscii(alloc, tailData);
+            composite = alloc.compositeBuffer(Integer.MAX_VALUE);
+            composite.addFlattenedComponents(true, tail);
+        }
 
-        // Verify the "SKIP" bytes did not reappear.
-        assertThat(outerComposite.toString(US_ASCII)).isEqualTo("0123456789");
+        private void tearDown() {
+            if (composite != null && composite.refCnt() > 0) {
+                composite.release();
+            }
+        }
 
-        // Verify the merge occurred (resulting in a single component).
-        assertThat(outerComposite.numComponents()).isEqualTo(1);
-      } finally {
-        // Clean up to prevent leaks.
-        outerComposite.release();
-      }
+        @ParameterizedTest(name = "composeMinSize={0}, tailData=\"{1}\", inData=\"{2}\"")
+        @MethodSource("shouldComposeParams")
+        public void shouldCompose(int composeMinSize, String tailData, String inData) {
+            setUp(composeMinSize, tailData, inData);
+            try {
+                int initialComponents = composite.numComponents();
+                AdaptiveCumulator cumulator = new AdaptiveCumulator(composeMinSize);
+                ByteBuf result = cumulator.cumulate(alloc, composite, in);
+
+                if (!composite.isReadable()) {
+                    assertSame(in, result);
+                    composite = null;
+                    in.release();
+                } else if (!in.isReadable()) {
+                    assertSame(composite, result);
+                    assertEquals(initialComponents, composite.numComponents());
+                    assertEquals(tailData + inData, composite.toString(US_ASCII));
+                } else if (tail.readableBytes() + in.readableBytes() >= composeMinSize) {
+                    composite = (CompositeByteBuf) result;
+                    assertEquals(initialComponents + 1, composite.numComponents());
+                    assertEquals(tailData + inData, composite.toString(US_ASCII));
+                } else {
+                    composite = (CompositeByteBuf) result;
+                    assertEquals(initialComponents, composite.numComponents());
+                    assertEquals(tailData + inData, composite.toString(US_ASCII));
+                }
+            } finally {
+                tearDown();
+            }
+        }
     }
-  }
+
+    @Nested
+    @TestInstance(Lifecycle.PER_CLASS)
+    public class MergeWithCompositeTailTests {
+        private final String INCOMING_DATA_READABLE = "+incoming";
+        private final String INCOMING_DATA_DISCARDABLE = "discard";
+
+        private final String TAIL_DATA_DISCARDABLE = "---";
+        private final String TAIL_DATA_READABLE = "tail";
+        private final String TAIL_DATA = TAIL_DATA_DISCARDABLE + TAIL_DATA_READABLE;
+        private final int TAIL_READER_INDEX = TAIL_DATA_DISCARDABLE.length();
+        private final int TAIL_MAX_CAPACITY = 128;
+
+        private final String EXPECTED_TAIL_DATA = "tail+incoming";
+
+        public Stream<Arguments> mergeParams() {
+            List<String> headDatas = Arrays.asList("", "head");
+            List<Integer> readerIndexes = Arrays.asList(0, 2, 6); // 0, head.length()-2, head.length()+2
+
+            return headDatas.stream().flatMap(hd -> readerIndexes.stream().map(ri -> Arguments.of(hd, ri)));
+        }
+
+        private CompositeByteBuf composite;
+        private ByteBuf tail;
+        private ByteBuf in;
+        private final ByteBufAllocator alloc = new io.netty.buffer.PooledByteBufAllocator();
+
+        private void setUp(String compositeHeadData, int compositeReaderIndex) {
+            composite = alloc.compositeBuffer();
+
+            ByteBuf head = alloc.buffer().writeBytes(compositeHeadData.getBytes(US_ASCII));
+            composite.addFlattenedComponents(true, head);
+
+            tail = alloc.buffer(TAIL_DATA.length(), TAIL_MAX_CAPACITY)
+                    .writeBytes(TAIL_DATA.getBytes(US_ASCII))
+                    .readerIndex(TAIL_READER_INDEX);
+
+            in = alloc.buffer()
+                    .writeBytes(INCOMING_DATA_DISCARDABLE.getBytes(US_ASCII))
+                    .writeBytes(INCOMING_DATA_READABLE.getBytes(US_ASCII))
+                    .readerIndex(INCOMING_DATA_DISCARDABLE.length());
+        }
+
+        private void tearDown() {
+            if (composite != null && composite.refCnt() > 0) {
+                composite.release();
+            }
+        }
+
+        private String repeat(String s, int count) {
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < count; i++) {
+                sb.append(s);
+            }
+            return sb.toString();
+        }
+
+        private void assertTailExpanded(String expectedTailReadableData, int expectedNewTailCapacity,
+                int compositeReaderIndex, String compositeHeadData) {
+            int originalNumComponents = composite.numComponents();
+            int compositeReaderIndexBounded = Math.min(compositeReaderIndex, composite.writerIndex());
+            composite.readerIndex(compositeReaderIndexBounded);
+            boolean wasReadable = composite.isReadable();
+
+            AdaptiveCumulator cumulator = new AdaptiveCumulator(Integer.MAX_VALUE);
+            ByteBuf result = cumulator.cumulate(alloc, composite, in);
+
+            if (!wasReadable) {
+                assertSame(in, result, "When composite is fully read, cumulate should return in");
+                assertEquals(0, composite.refCnt(), "Old composite should be released");
+                in.release(); // Free the returned buffer manually
+                return;
+            }
+
+            composite = (CompositeByteBuf) result;
+
+            assertEquals(originalNumComponents, composite.numComponents(),
+                    "When tail is expanded, the number of components in the cumulation must not change");
+
+            ByteBuf newTail = composite.component(composite.numComponents() - 1);
+
+            assertEquals(expectedTailReadableData, newTail.toString(US_ASCII));
+            assertEquals(expectedNewTailCapacity, newTail.capacity());
+
+            String newTailDataDiscardable = newTail.toString(0, newTail.readerIndex(), US_ASCII);
+            assertEquals("", newTailDataDiscardable,
+                    "After tail expansion, its discardable bytes should be discarded");
+
+            assertEquals(0, newTail.readerIndex());
+            assertEquals(expectedTailReadableData.length(), newTail.writerIndex());
+
+            assertExpectedCumulation(newTail, expectedTailReadableData, compositeReaderIndexBounded, compositeHeadData);
+
+            assertFalse(in.isReadable(), "Incoming buffer is fully read");
+            assertEquals(0, in.refCnt(), "Incoming buffer is released");
+        }
+
+        private void assertExpectedCumulation(ByteBuf newTail, String expectedTailReadable,
+                int expectedReaderIndex, String compositeHeadData) {
+            String expectedCumulationData = compositeHeadData.concat(expectedTailReadable)
+                    .substring(expectedReaderIndex);
+            assertEquals(expectedCumulationData, composite.toString(US_ASCII));
+
+            int expectedCumulationCapacity = compositeHeadData.length() + expectedTailReadable.length();
+            assertEquals(expectedCumulationCapacity, composite.capacity());
+            assertEquals(expectedReaderIndex, composite.readerIndex());
+            assertEquals(expectedCumulationCapacity, composite.writerIndex());
+
+            assertEquals(1, composite.refCnt());
+            assertEquals(1, newTail.refCnt());
+        }
+
+        private void assertTailReplaced(int compositeReaderIndex, String compositeHeadData) {
+            int cumulationOriginalComponentsNum = composite.numComponents();
+            int taiOriginalRefCount = tail.refCnt();
+            String expectedTailReadable = tail.toString(US_ASCII) + in.toString(US_ASCII);
+            int expectedReallocatedTailCapacity = alloc.calculateNewCapacity(
+                    expectedTailReadable.length(), Integer.MAX_VALUE);
+
+            int compositeReaderIndexBounded = Math.min(compositeReaderIndex, composite.writerIndex());
+            composite.readerIndex(compositeReaderIndexBounded);
+            boolean wasReadable = composite.isReadable();
+
+            AdaptiveCumulator cumulator = new AdaptiveCumulator(Integer.MAX_VALUE);
+            ByteBuf result = cumulator.cumulate(alloc, composite, in);
+
+            if (!wasReadable) {
+                assertSame(in, result, "When composite is fully read, cumulate should return in");
+                assertEquals(0, composite.refCnt(), "Old composite should be released");
+                in.release(); // Free the returned buffer manually
+                return;
+            }
+
+            composite = (CompositeByteBuf) result;
+
+            assertEquals(cumulationOriginalComponentsNum, composite.numComponents());
+            ByteBuf replacedTail = composite.component(composite.numComponents() - 1);
+
+            assertEquals(0, in.readableBytes());
+            assertEquals(expectedTailReadable, replacedTail.toString(US_ASCII));
+
+            assertEquals(0, replacedTail.readerIndex());
+            assertEquals(expectedTailReadable.length(), replacedTail.writerIndex());
+            assertEquals(expectedReallocatedTailCapacity, replacedTail.capacity());
+
+            assertExpectedCumulation(replacedTail, expectedTailReadable,
+                    compositeReaderIndexBounded, compositeHeadData);
+
+            assertFalse(in.isReadable(), "Incoming buffer is fully read");
+            assertEquals(0, in.refCnt(), "Incoming buffer is released");
+            assertEquals(taiOriginalRefCount - 1, tail.refCnt(), "Replaced tail released once.");
+        }
+
+        @ParameterizedTest(name = "head=\"{0}\", readerIndex={1}")
+        @MethodSource("mergeParams")
+        public void mergeWithCompositeTail_tailExpandable_write(String compositeHeadData, int compositeReaderIndex) {
+            setUp(compositeHeadData, compositeReaderIndex);
+            try {
+                int fitCapacity = tail.capacity() + INCOMING_DATA_READABLE.length();
+                tail.capacity(fitCapacity);
+                int expectedCapacity = alloc.calculateNewCapacity(fitCapacity, Integer.MAX_VALUE);
+                assertTrue(in.readableBytes() <= tail.writableBytes());
+
+                composite.addFlattenedComponents(true, tail);
+                assertTailExpanded(EXPECTED_TAIL_DATA, expectedCapacity, compositeReaderIndex, compositeHeadData);
+            } finally {
+                tearDown();
+            }
+        }
+
+        @ParameterizedTest(name = "head=\"{0}\", readerIndex={1}")
+        @MethodSource("mergeParams")
+        public void mergeWithCompositeTail_tailExpandable_fastWrite(
+                String compositeHeadData, int compositeReaderIndex) {
+            setUp(compositeHeadData, compositeReaderIndex);
+            try {
+                int tailFastCapacity = alloc.calculateNewCapacity(EXPECTED_TAIL_DATA.length(), Integer.MAX_VALUE);
+
+                composite.addFlattenedComponents(true, tail);
+                assertTailExpanded(EXPECTED_TAIL_DATA, tailFastCapacity, compositeReaderIndex, compositeHeadData);
+            } finally {
+                tearDown();
+            }
+        }
+
+        @ParameterizedTest(name = "head=\"{0}\", readerIndex={1}")
+        @MethodSource("mergeParams")
+        public void mergeWithCompositeTail_tailExpandable_reallocateInMemory(
+                String compositeHeadData, int compositeReaderIndex) {
+            setUp(compositeHeadData, compositeReaderIndex);
+            try {
+                int tailFastCapacity = tail.writerIndex() + tail.maxFastWritableBytes();
+                String inSuffixOverFastBytes = repeat("a", tailFastCapacity + 1);
+                int newTailSize = tail.readableBytes() + inSuffixOverFastBytes.length();
+                composite.addFlattenedComponents(true, tail);
+
+                in.writeCharSequence(inSuffixOverFastBytes, US_ASCII);
+                assertTrue(in.readableBytes() > tail.maxFastWritableBytes());
+                assertTrue(in.readableBytes() <= tail.maxWritableBytes());
+
+                int expectedTailCapacity = alloc.calculateNewCapacity(newTailSize, Integer.MAX_VALUE);
+                assertTailExpanded(EXPECTED_TAIL_DATA.concat(inSuffixOverFastBytes),
+                        expectedTailCapacity, compositeReaderIndex, compositeHeadData);
+            } finally {
+                tearDown();
+            }
+        }
+
+        @ParameterizedTest(name = "head=\"{0}\", readerIndex={1}")
+        @MethodSource("mergeParams")
+        public void mergeWithCompositeTail_tailNotExpandable_maxCapacityReached(
+                String compositeHeadData, int compositeReaderIndex) {
+            setUp(compositeHeadData, compositeReaderIndex);
+            try {
+                String tailSuffixFullCapacity = repeat("a", tail.maxWritableBytes());
+                tail.writeCharSequence(tailSuffixFullCapacity, US_ASCII);
+                composite.addFlattenedComponents(true, tail);
+                assertTailReplaced(compositeReaderIndex, compositeHeadData);
+            } finally {
+                tearDown();
+            }
+        }
+
+        @ParameterizedTest(name = "head=\"{0}\", readerIndex={1}")
+        @MethodSource("mergeParams")
+        public void mergeWithCompositeTail_tailNotExpandable_shared(
+                String compositeHeadData, int compositeReaderIndex) {
+            setUp(compositeHeadData, compositeReaderIndex);
+            try {
+                tail.retain();
+                composite.addFlattenedComponents(true, tail);
+                assertTailReplaced(compositeReaderIndex, compositeHeadData);
+                tail.release();
+            } finally {
+                tearDown();
+            }
+        }
+
+        @ParameterizedTest(name = "head=\"{0}\", readerIndex={1}")
+        @MethodSource("mergeParams")
+        public void mergeWithCompositeTail_tailNotExpandable_readOnly(
+                String compositeHeadData, int compositeReaderIndex) {
+            setUp(compositeHeadData, compositeReaderIndex);
+            try {
+                composite.addFlattenedComponents(true, tail.asReadOnly());
+                assertTailReplaced(compositeReaderIndex, compositeHeadData);
+            } finally {
+                tearDown();
+            }
+        }
+
+        @ParameterizedTest(name = "head=\"{0}\", readerIndex={1}")
+        @MethodSource("mergeParams")
+        public void mergeWithCompositeTail_tailExpandable_mergedReleaseOnThrow(
+                String compositeHeadData, int compositeReaderIndex) {
+            setUp(compositeHeadData, compositeReaderIndex);
+            final UnsupportedOperationException expectedError = new UnsupportedOperationException();
+            CompositeByteBuf compositeThrows = new CompositeByteBuf(alloc, false, Integer.MAX_VALUE, tail) {
+                @Override
+                public CompositeByteBuf addFlattenedComponents(boolean increaseWriterIndex, ByteBuf buffer) {
+                    buffer.release();
+                    throw expectedError;
+                }
+            };
+
+            try {
+                AdaptiveCumulator cumulator = new AdaptiveCumulator(Integer.MAX_VALUE);
+                compositeThrows = (CompositeByteBuf) cumulator.cumulate(alloc, compositeThrows, in);
+                fail("Cumulator didn't throw");
+            } catch (UnsupportedOperationException actualError) {
+                assertSame(expectedError, actualError);
+                assertEquals(0, tail.refCnt());
+                assertEquals(1, compositeThrows.refCnt());
+                assertEquals(0, compositeThrows.numComponents());
+                assertEquals(0, in.refCnt());
+            } finally {
+                compositeThrows.release();
+                tearDown();
+            }
+        }
+
+        @ParameterizedTest(name = "head=\"{0}\", readerIndex={1}")
+        @MethodSource("mergeParams")
+        public void mergeWithCompositeTail_tailNotExpandable_mergedReleaseOnThrow(
+                String compositeHeadData, int compositeReaderIndex) {
+            setUp(compositeHeadData, compositeReaderIndex);
+            final UnsupportedOperationException expectedError = new UnsupportedOperationException();
+            CompositeByteBuf compositeRo = new CompositeByteBuf(alloc, false, Integer.MAX_VALUE, tail.asReadOnly()) {
+                @Override
+                public CompositeByteBuf addFlattenedComponents(boolean increaseWriterIndex, ByteBuf buffer) {
+                    buffer.release();
+                    throw expectedError;
+                }
+            };
+
+            int newTailSize = tail.readableBytes() + in.readableBytes();
+            ByteBuf newTail = alloc.buffer(alloc.calculateNewCapacity(newTailSize, Integer.MAX_VALUE));
+            ByteBufAllocator mockAlloc = mock(ByteBufAllocator.class);
+            when(mockAlloc.buffer(anyInt())).thenReturn(newTail);
+
+            try {
+                AdaptiveCumulator cumulator = new AdaptiveCumulator(Integer.MAX_VALUE);
+                compositeRo = (CompositeByteBuf) cumulator.cumulate(mockAlloc, compositeRo, in);
+                fail("Cumulator didn't throw");
+            } catch (UnsupportedOperationException actualError) {
+                assertSame(expectedError, actualError);
+                assertEquals(1, compositeRo.refCnt());
+                assertEquals(0, compositeRo.numComponents());
+                assertEquals(0, newTail.refCnt());
+                assertEquals(0, in.refCnt());
+            } finally {
+                compositeRo.release();
+                if (newTail.refCnt() > 0) {
+                    newTail.release();
+                }
+                tearDown();
+            }
+        }
+    }
+
+    @Nested
+    public class MergeWithCompositeTailMiscTests {
+        private final ByteBufAllocator alloc = new io.netty.buffer.PooledByteBufAllocator();
+
+        @Test
+        public void mergeWithCompositeTail_outOfSyncComposite() {
+            AdaptiveCumulator cumulator = new AdaptiveCumulator(1024);
+
+            ByteBuf buf = alloc.buffer(32).writeBytes("---01234".getBytes(US_ASCII));
+
+            CompositeByteBuf composite1 = alloc.compositeBuffer(8).addFlattenedComponents(true, buf.retain());
+            assertEquals("---", composite1.readCharSequence(3, US_ASCII).toString());
+
+            CompositeByteBuf composite2 = alloc.compositeBuffer(8).addFlattenedComponents(true, composite1);
+            assertEquals("01234", composite2.toString(US_ASCII));
+
+            CompositeByteBuf cumulation = (CompositeByteBuf) cumulator.cumulate(alloc, composite2,
+                    ByteBufUtil.writeAscii(alloc, "56789"));
+            assertEquals("0123456789", cumulation.toString(US_ASCII));
+
+            assertEquals(1, cumulation.numComponents());
+            buf.setByte(5, '*').setByte(11, '$');
+            assertEquals("0123456789", cumulation.toString(US_ASCII));
+            cumulation.release();
+            buf.release();
+        }
+
+        @Test
+        public void mergeWithCompositeTail_detectsIndicesInNestedComposite() {
+            // 1. Setup local allocator and a real cumulator that triggers merging.
+            ByteBufAllocator alloc = new UnpooledByteBufAllocator(false);
+            AdaptiveCumulator realCumulator = new AdaptiveCumulator(1024);
+
+            // 2. Create a buffer with some "header" data we intend to skip.
+            ByteBuf buf = alloc.buffer(32).writeBytes("SKIP01234".getBytes(US_ASCII));
+
+            // 3. Wrap it in a composite buffer and read the "SKIP" part.
+            CompositeByteBuf innerComposite = alloc.compositeBuffer()
+                    .addFlattenedComponents(true, buf);
+            innerComposite.readCharSequence(4, US_ASCII); // Discard "SKIP"
+
+            // 4. Wrap that into a second composite (simulating cumulate() with refCnt > 1).
+            // The readable content here is "01234".
+            CompositeByteBuf outerComposite = alloc.compositeBuffer()
+                    .addFlattenedComponents(true, innerComposite);
+
+            try {
+                // 5. Perform a cumulation that triggers mergeWithCompositeTail.
+                // Use realCumulator to ensure the merge logic is executed.
+                realCumulator.cumulate(alloc, outerComposite,
+                        ByteBufUtil.writeAscii(alloc, "56789"));
+
+                // Verify the "SKIP" bytes did not reappear.
+                assertThat(outerComposite.toString(US_ASCII)).isEqualTo("0123456789");
+
+                // Verify the merge occurred (resulting in a single component).
+                assertThat(outerComposite.numComponents()).isEqualTo(1);
+            } finally {
+                // Clean up to prevent leaks.
+                outerComposite.release();
+            }
+        }
+    }
 }

--- a/codec-base/src/test/java/io/netty/handler/codec/AdaptiveCumulatorTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/AdaptiveCumulatorTest.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.codec;
 
+import io.netty.buffer.AbstractByteBufAllocator;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufUtil;
@@ -35,6 +36,8 @@ import java.util.stream.Stream;
 
 import static io.netty.util.CharsetUtil.US_ASCII;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.in;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -159,7 +162,44 @@ public class AdaptiveCumulatorTest {
                 assertSame(throwingCumulatorError, actualError);
                 assertEquals(0, in.refCnt());
                 assertEquals(0, newComposite.refCnt());
-                assertEquals(0, contiguous.refCnt());
+                assertEquals(1, contiguous.refCnt());
+            }
+        }
+
+        @Test
+        public void mustNotReleaseNonOwnedCumulationIfAddInputFails() {
+            final UnsupportedOperationException expectedError = new UnsupportedOperationException();
+            ByteBufAllocator throwingAlloc = new AbstractByteBufAllocator(false) {
+                @Override
+                protected ByteBuf newHeapBuffer(int initialCapacity, int maxCapacity) {
+                    throw expectedError;
+                }
+
+                @Override
+                protected ByteBuf newDirectBuffer(int initialCapacity, int maxCapacity) {
+                    throw expectedError;
+                }
+
+                @Override
+                public boolean isDirectBufferPooled() {
+                    return false;
+                }
+            };
+
+            AdaptiveCumulator cumulator = new AdaptiveCumulator(1024);
+            ByteBufAllocator bufAlloc = new UnpooledByteBufAllocator(false);
+            ByteBuf cumulation = bufAlloc.buffer(4, 4).writeBytes("0123".getBytes(US_ASCII));
+            ByteBuf in = bufAlloc.buffer().writeBytes("456".getBytes(US_ASCII));
+
+            try {
+                assertThatThrownBy(() -> cumulator.cumulate(throwingAlloc, cumulation, in)).isSameAs(expectedError);
+                assertEquals(0, in.refCnt(), "Incoming buffer must be released on failure");
+                assertEquals(1, cumulation.refCnt(),
+                        "Caller-owned cumulation must NOT be released when the merge fails");
+            } finally {
+                if (cumulation.refCnt() > 0) {
+                    cumulation.release();
+                }
             }
         }
     }

--- a/codec-base/src/test/java/io/netty/handler/codec/AdaptiveCumulatorTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/AdaptiveCumulatorTest.java
@@ -82,6 +82,15 @@ public class AdaptiveCumulatorTest {
     }
 
     @Test
+    public void cumulate_sameBuffer_identityHandled() {
+      in.retain(); // simulate double retention when the same buffer is passed twice
+      ByteBuf result = cumulator.cumulate(alloc, in, in);
+      assertSame(in, result);
+      assertEquals(1, in.refCnt(), "The cumulator should release the doubly-retained buffer once");
+      in.release();
+    }
+
+    @Test
     public void cumulate_contiguousCumulation_newCompositeFromContiguousAndInput() {
       CompositeByteBuf cumulation = (CompositeByteBuf) cumulator.cumulate(alloc, contiguous, in);
       assertEquals(DATA_INITIAL, cumulation.component(0).toString(US_ASCII));
@@ -492,6 +501,7 @@ public class AdaptiveCumulatorTest {
         assertEquals(0, tail.refCnt());
         assertEquals(1, compositeThrows.refCnt());
         assertEquals(0, compositeThrows.numComponents());
+        assertEquals(0, in.refCnt());
       } finally {
         compositeThrows.release();
         tearDown();
@@ -524,6 +534,8 @@ public class AdaptiveCumulatorTest {
         assertSame(expectedError, actualError);
         assertEquals(1, compositeRo.refCnt());
         assertEquals(0, compositeRo.numComponents());
+        assertEquals(0, newTail.refCnt());
+        assertEquals(0, in.refCnt());
       } finally {
         compositeRo.release();
         if (newTail.refCnt() > 0) {

--- a/codec-base/src/test/java/io/netty/handler/codec/AdaptiveCumulatorTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/AdaptiveCumulatorTest.java
@@ -55,6 +55,7 @@ public class AdaptiveCumulatorTest {
 
     private final ByteBufAllocator alloc = new UnpooledByteBufAllocator(false);
     private AdaptiveCumulator cumulator;
+    private AdaptiveCumulator throwingCumulator;
     private final UnsupportedOperationException throwingCumulatorError = new UnsupportedOperationException();
 
     private ByteBuf contiguous;
@@ -64,7 +65,20 @@ public class AdaptiveCumulatorTest {
     public void setUp() {
       contiguous = ByteBufUtil.writeAscii(alloc, DATA_INITIAL);
       in = ByteBufUtil.writeAscii(alloc, DATA_INCOMING);
-      cumulator = new AdaptiveCumulator(0);
+
+      cumulator = new AdaptiveCumulator(0) {
+        @Override
+        void addInput(ByteBufAllocator alloc, CompositeByteBuf composite, ByteBuf in) {
+          composite.addFlattenedComponents(true, in);
+        }
+      };
+
+      throwingCumulator = new AdaptiveCumulator(0) {
+        @Override
+        void addInput(ByteBufAllocator alloc, CompositeByteBuf composite, ByteBuf in) {
+          throw throwingCumulatorError;
+        }
+      };
     }
 
     @Test
@@ -106,14 +120,9 @@ public class AdaptiveCumulatorTest {
 
     @Test
     public void cumulate_compositeCumulation_inputReleasedOnError() {
-      CompositeByteBuf composite = new CompositeByteBuf(alloc, false, Integer.MAX_VALUE, contiguous) {
-        @Override
-        public CompositeByteBuf addFlattenedComponents(boolean increaseWriterIndex, ByteBuf buffer) {
-          throw throwingCumulatorError;
-        }
-      };
+      CompositeByteBuf composite = alloc.compositeBuffer().addComponent(true, contiguous);
       try {
-        cumulator.cumulate(alloc, composite, in);
+        throwingCumulator.cumulate(alloc, composite, in);
         fail("Cumulator didn't throw");
       } catch (UnsupportedOperationException actualError) {
         assertSame(throwingCumulatorError, actualError);
@@ -127,83 +136,18 @@ public class AdaptiveCumulatorTest {
 
     @Test
     public void cumulate_contiguousCumulation_inputAndNewCompositeReleasedOnError() {
-      CompositeByteBuf newComposite = new CompositeByteBuf(alloc, false, Integer.MAX_VALUE) {
-        @Override
-        public CompositeByteBuf addFlattenedComponents(boolean increaseWriterIndex, ByteBuf buffer) {
-          if (buffer == in) {
-            throw throwingCumulatorError;
-          }
-          return super.addFlattenedComponents(increaseWriterIndex, buffer);
-        }
-      };
+      CompositeByteBuf newComposite = alloc.compositeBuffer(Integer.MAX_VALUE);
       ByteBufAllocator mockAlloc = mock(ByteBufAllocator.class);
       when(mockAlloc.compositeBuffer(anyInt())).thenReturn(newComposite);
 
       try {
-        cumulator.cumulate(mockAlloc, contiguous, in);
+        throwingCumulator.cumulate(mockAlloc, contiguous, in);
         fail("Cumulator didn't throw");
       } catch (UnsupportedOperationException actualError) {
         assertSame(throwingCumulatorError, actualError);
         assertEquals(0, in.refCnt());
         assertEquals(0, newComposite.refCnt());
-        assertEquals(1, contiguous.refCnt());
-      }
-    }
-
-    @Test
-    public void cumulate_sharedCompositeCumulation_retainedAndReleasedOnError() {
-      final CompositeByteBuf compositeCumulation = alloc.compositeBuffer(Integer.MAX_VALUE);
-      compositeCumulation.addComponent(true, contiguous);
-      compositeCumulation.retain();
-      assertEquals(2, compositeCumulation.refCnt());
-
-      ByteBufAllocator mockAlloc = mock(ByteBufAllocator.class);
-      CompositeByteBuf newComposite = new CompositeByteBuf(alloc, false, Integer.MAX_VALUE) {
-        @Override
-        public CompositeByteBuf addFlattenedComponents(boolean increaseWriterIndex, ByteBuf buffer) {
-          if (buffer == compositeCumulation) {
-            throw throwingCumulatorError;
-          }
-          return super.addFlattenedComponents(increaseWriterIndex, buffer);
-        }
-      };
-      when(mockAlloc.compositeBuffer(anyInt())).thenReturn(newComposite);
-
-      try {
-        cumulator.cumulate(mockAlloc, compositeCumulation, in);
-        fail("Cumulator didn't throw");
-      } catch (UnsupportedOperationException actualError) {
-        assertSame(throwingCumulatorError, actualError);
-        assertEquals(0, in.refCnt());
-        assertEquals(2, compositeCumulation.refCnt());
-      } finally {
-        compositeCumulation.release();
-        compositeCumulation.release();
-      }
-    }
-
-    @Test
-    public void cumulate_contiguousCumulation_inputAddComponent0FailureDoubleRelease() {
-      ByteBufAllocator failAlloc = mock(ByteBufAllocator.class);
-      when(failAlloc.heapBuffer(anyInt())).thenThrow(throwingCumulatorError);
-      when(failAlloc.directBuffer(anyInt())).thenThrow(throwingCumulatorError);
-
-      CompositeByteBuf newComposite = new CompositeByteBuf(alloc, false, 1) {
-        @Override
-        public ByteBufAllocator alloc() {
-          return failAlloc;
-        }
-      };
-
-      ByteBufAllocator mockAlloc = mock(ByteBufAllocator.class);
-      when(mockAlloc.compositeBuffer(anyInt())).thenReturn(newComposite);
-
-      try {
-        cumulator.cumulate(mockAlloc, contiguous, in);
-        fail("Cumulator didn't throw");
-      } catch (UnsupportedOperationException actualError) {
-        assertSame(throwingCumulatorError, actualError);
-        assertEquals(0, in.refCnt());
+        assertEquals(0, contiguous.refCnt());
       }
     }
   }
@@ -250,12 +194,7 @@ public class AdaptiveCumulatorTest {
       setUp(composeMinSize, tailData, inData);
       try {
         Assumptions.assumeTrue(composite.numComponents() == 0);
-        AdaptiveCumulator cumulator = new AdaptiveCumulator(composeMinSize);
-        ByteBuf cumulation = cumulator.cumulate(alloc, composite, in);
-        composite = null;
-        in = null;
-        assertEquals(inData, cumulation.toString(US_ASCII));
-        cumulation.release();
+        assertTrue(AdaptiveCumulator.shouldCompose(composite, in, composeMinSize));
       } finally {
         tearDown();
       }
@@ -267,15 +206,8 @@ public class AdaptiveCumulatorTest {
       setUp(composeMinSize, tailData, inData);
       try {
         Assumptions.assumeTrue(composite.numComponents() > 0);
-        Assumptions.assumeTrue(in.isReadable());
         Assumptions.assumeTrue(tail.readableBytes() + in.readableBytes() >= composeMinSize);
-        AdaptiveCumulator cumulator = new AdaptiveCumulator(composeMinSize);
-        CompositeByteBuf cumulation = (CompositeByteBuf) cumulator.cumulate(alloc, composite, in);
-        composite = null;
-        in = null;
-        assertEquals(2, cumulation.numComponents());
-        assertEquals(tailData + inData, cumulation.toString(US_ASCII));
-        cumulation.release();
+        assertTrue(AdaptiveCumulator.shouldCompose(composite, in, composeMinSize));
       } finally {
         tearDown();
       }
@@ -288,13 +220,7 @@ public class AdaptiveCumulatorTest {
       try {
         Assumptions.assumeTrue(composite.numComponents() > 0);
         Assumptions.assumeTrue(tail.readableBytes() + in.readableBytes() < composeMinSize);
-        AdaptiveCumulator cumulator = new AdaptiveCumulator(composeMinSize);
-        CompositeByteBuf cumulation = (CompositeByteBuf) cumulator.cumulate(alloc, composite, in);
-        composite = null;
-        in = null;
-        assertEquals(1, cumulation.numComponents());
-        assertEquals(tailData + inData, cumulation.toString(US_ASCII));
-        cumulation.release();
+        assertFalse(AdaptiveCumulator.shouldCompose(composite, in, composeMinSize));
       } finally {
         tearDown();
       }
@@ -368,10 +294,8 @@ public class AdaptiveCumulatorTest {
       int originalNumComponents = composite.numComponents();
       int compositeReaderIndexBounded = Math.min(compositeReaderIndex, composite.writerIndex());
       composite.readerIndex(compositeReaderIndexBounded);
-      Assumptions.assumeTrue(composite.isReadable());
 
-      AdaptiveCumulator cumulator = new AdaptiveCumulator(Integer.MAX_VALUE);
-      cumulator.cumulate(alloc, composite, in);
+      AdaptiveCumulator.mergeWithCompositeTail(alloc, composite, in);
 
       assertEquals(originalNumComponents, composite.numComponents(),
           "When tail is expanded, the number of components in the cumulation must not change");
@@ -418,9 +342,7 @@ public class AdaptiveCumulatorTest {
 
       int compositeReaderIndexBounded = Math.min(compositeReaderIndex, composite.writerIndex());
       composite.readerIndex(compositeReaderIndexBounded);
-      Assumptions.assumeTrue(composite.isReadable());
-      AdaptiveCumulator cumulator = new AdaptiveCumulator(Integer.MAX_VALUE);
-      cumulator.cumulate(alloc, composite, in);
+      AdaptiveCumulator.mergeWithCompositeTail(alloc, composite, in);
 
       assertEquals(cumulationOriginalComponentsNum, composite.numComponents());
       ByteBuf replacedTail = composite.component(composite.numComponents() - 1);
@@ -552,8 +474,7 @@ public class AdaptiveCumulatorTest {
       };
 
       try {
-        AdaptiveCumulator cumulator = new AdaptiveCumulator(Integer.MAX_VALUE);
-        cumulator.cumulate(alloc, compositeThrows, in);
+        AdaptiveCumulator.mergeWithCompositeTail(alloc, compositeThrows, in);
         fail("Cumulator didn't throw");
       } catch (UnsupportedOperationException actualError) {
         assertSame(expectedError, actualError);
@@ -585,8 +506,7 @@ public class AdaptiveCumulatorTest {
       when(mockAlloc.buffer(anyInt())).thenReturn(newTail);
 
       try {
-        AdaptiveCumulator cumulator = new AdaptiveCumulator(Integer.MAX_VALUE);
-        cumulator.cumulate(mockAlloc, compositeRo, in);
+        AdaptiveCumulator.mergeWithCompositeTail(mockAlloc, compositeRo, in);
         fail("Cumulator didn't throw");
       } catch (UnsupportedOperationException actualError) {
         assertSame(expectedError, actualError);


### PR DESCRIPTION
**Motivation:**

This PR introduces the `AdaptiveCumulator`, a specialized Cumulator implementation for `ByteToMessageDecoder` that dynamically switches between merge (memory copy) and compose (zero-copy) strategies based on the size of incoming data.

Standard cumulators in Netty present a trade-off: the `MERGE_CUMULATOR` is safe but can consume up to 10% of CPU time due to excessive copies during high-throughput transfers. Conversely, the `COMPOSITE_CUMULATOR` provides zero-copy benefits but is vulnerable to "Single Byte Attacks," where an attacker sends messages one byte at a time to force the server to allocate excessive object metadata.

The `AdaptiveCumulator` applies a heuristic to achieve the best of both worlds:

- **Merge (Copy):** If the total size of the tail component and the incoming buffer is below a configurable threshold (default 1024 bytes), the data is copied into a new buffer to minimize object overhead.
- **Compose (Zero-Copy):** Once the threshold is reached, the buffer is added as a new component without copying, maximizing throughput.

**Modification:**

- Added `AdaptiveCumulator.java` to the `io.netty.handler.codec` package.
- Added `AdaptiveCumulatorTest.java`, a comprehensive test suite modernized for JUnit 5.

This PR is an attempt to upstream what we were trying to do in gRPC https://github.com/grpc/grpc-java/pull/9558, but the behaviour of `duplicate()` method on slices was changed/corrected in https://github.com/netty/netty/pull/14093 which invalidated previous manual index workarounds and since then it has been a tech debt in grpc-java. This implementation is "PR #14093-aware" and correctly handles the capacity-capping introduced by that change by verifying the state of the tail component before expansion.

This implementation is specifically designed to address historical failure modes associated with `CompositeByteBuf` manipulation:

- **Modernized Index Synchronization with componentSlice()** Previous attempts to implement this logic relied on fragile internal hacks like `internalComponent().duplicate()` to correct stale indices returned by `CompositeByteBuf.component()`. This PR leverages the `componentSlice()` method (introduced in Netty 4.2.4) to obtain a correctly indexed view through a public, supported API.

- **Protection Against "Resurrected" Bytes** To prevent silent data corruption, we have introduced a capacity safety check: `tail.capacity() == componentView.capacity()`. If a mismatch is detected, it indicates the component is a partial slice containing hidden "discarded" bytes. In such cases, the logic correctly falls back to a safe reallocation to "cleanse" the data, preventing discarded bytes from reappearing in the message. This particular problem was caught in the unit test `mergeWithCompositeTail_detectsIndicesInNestedComposite()` while trying to invalidate the use of previous way (`internalComponent.duplicate()`) as in https://github.com/grpc/grpc-java/pull/9558.

- **Prevention of "Russian Doll" Nesting** The implementation strictly uses `addFlattenedComponents` to ensure the `CompositeByteBuf` remains a flat, linear structure. This avoids the recursive deallocation crashes (StackOverflow) that occurred in previous versions when buffers were nested thousands of layers deep.

- **Single-Owner Lifecycle Management** The lifecycle of the input buffer is managed using a single-owner pattern in the top-level cumulate method. Sub-methods like `mergeWithCompositeTail` no longer release the input buffer in their finally blocks, which we were doing otherwise in https://github.com/grpc/grpc-java/pull/9558. This prevents `IllegalReferenceCountException` (double-release) crashes during error scenarios.

**Usage**
Downstream projects can enable the `AdaptiveCumulator` by calling the `setCumulator()` method on any handler that extends `ByteToMessageDecoder`. For example, to use the adaptive strategy with a 1KB threshold:

`setCumulator(new AdaptiveCumulator(1024));`


CC: @ejona86, @sauravzg