### PR TITLE
Activate noPrintGC by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -625,6 +625,9 @@
     </profile>
     <profile>
       <id>noPrintGC</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <properties>
         <argLine.printGC>-D_</argLine.printGC>
       </properties>


### PR DESCRIPTION
Motivation:
We have `-XX:+PrintGCDetails` enabled by default.
The output is for the most part more noisy than helpful.

Modification:
Make the `noPrintGC` profile active by default.

Result:
Less noisy output when building from a fresh checkout or worktree, and also less output in CI.
