### PR TITLE
Fall back to manual split when java.net.URI rejects HTTP/2 request URI

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
@@ -438,8 +438,40 @@ public final class HttpConversionUtil {
                 out.path(new AsciiString(request.uri()));
                 setHttp2Scheme(inHeaders, out);
             } else {
-                URI requestTargetUri = URI.create(request.uri());
-                out.path(toHttp2Path(requestTargetUri));
+                URI requestTargetUri;
+                AsciiString path;
+                try {
+                    requestTargetUri = URI.create(request.uri());
+                    path = toHttp2Path(requestTargetUri);
+                } catch (IllegalArgumentException e) {
+                    // java.net.URI's parser follows RFC 2396 and rejects characters such
+                    // as '{', '}' or '|' that are accepted under the looser RFC 3986 grammar
+                    // by JDK 21+ and that real-world request URIs commonly carry as
+                    // placeholder substitutions. Split the absolute-form request-target
+                    // around the path component so the :path pseudo-header can still be
+                    // populated and the request is not lost. The base URI is parsed
+                    // separately because authority and scheme extraction still rely on
+                    // java.net.URI; if even that fails we re-throw the original error.
+                    String requestUri = request.uri();
+                    int schemeEnd = requestUri.indexOf("://");
+                    int pathStart = schemeEnd >= 0 ? requestUri.indexOf('/', schemeEnd + 3) : -1;
+                    String baseUri;
+                    String pathWithQueryAndFragment;
+                    if (pathStart >= 0) {
+                        baseUri = requestUri.substring(0, pathStart);
+                        pathWithQueryAndFragment = requestUri.substring(pathStart);
+                    } else {
+                        baseUri = requestUri;
+                        pathWithQueryAndFragment = "/";
+                    }
+                    try {
+                        requestTargetUri = URI.create(baseUri);
+                    } catch (IllegalArgumentException baseFailure) {
+                        throw e;
+                    }
+                    path = new AsciiString(pathWithQueryAndFragment);
+                }
+                out.path(path);
                 // Take from the request-line if HOST header was empty
                 host = isNullOrEmpty(host) ? requestTargetUri.getAuthority() : host;
                 setHttp2Scheme(inHeaders, requestTargetUri, out);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
@@ -231,6 +231,58 @@ public class HttpConversionUtilTest {
     }
 
     @Test
+    public void handlesRequestWhoseQueryHasCharactersRejectedByJavaNetUri() throws Exception {
+        // Reproduces https://github.com/netty/netty/issues/14591 — java.net.URI on JDK
+        // versions whose parser still follows RFC 2396 rejects '{' / '}' characters
+        // that real-world request URIs use as placeholder substitutions. The converter
+        // must fall back to splitting around the path component so the :path
+        // pseudo-header is preserved instead of an IllegalArgumentException bubbling up.
+        HttpRequest msg = new DefaultHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.GET,
+                "https://bh.contextweb.com/bh/rtset?pid=558355&ev=1&us_privacy=${us_privacy}",
+                false);
+        Http2Headers out = HttpConversionUtil.toHttp2Headers(msg, false);
+        assertEquals(new AsciiString("/bh/rtset?pid=558355&ev=1&us_privacy=${us_privacy}"), out.path());
+        assertEquals(new AsciiString("https"), out.scheme());
+        assertEquals(new AsciiString("bh.contextweb.com"), out.authority());
+        assertEquals(HttpMethod.GET.asciiName(), out.method());
+    }
+
+    @Test
+    public void rethrowsOriginalParsingErrorWhenBaseUriCannotBeParsedEither() {
+        // Defensive boundary: when even the scheme + authority portion is unparseable
+        // by java.net.URI, the fallback has nothing useful to recover, so the original
+        // IllegalArgumentException must surface rather than letting the request slip
+        // through with malformed pseudo-headers. Skips request-line validation on the
+        // request itself so the test can construct a URI that the converter would
+        // otherwise never receive.
+        final HttpRequest msg = new DefaultHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.GET,
+                "http://[bad host]/p?q={x}",
+                new DefaultHttpHeaders(false),
+                false);
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() {
+                HttpConversionUtil.toHttp2Headers(msg, false);
+            }
+        });
+    }
+
+    @Test
+    public void handlesRequestWhosePathHasCharactersRejectedByJavaNetUri() throws Exception {
+        // Boundary: brace-style placeholders inside the path component (not just the
+        // query) must also be preserved by the fallback splitter so :path stays
+        // round-trip identical to the request-line.
+        HttpRequest msg = new DefaultHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.GET, "http://example.com/orders/{id}/items", false);
+        Http2Headers out = HttpConversionUtil.toHttp2Headers(msg, false);
+        assertEquals(new AsciiString("/orders/{id}/items"), out.path());
+        assertEquals(new AsciiString("http"), out.scheme());
+        assertEquals(new AsciiString("example.com"), out.authority());
+    }
+
+    @Test
     public void handlesRequestWithDoubleSlashPath() throws Exception {
         boolean validateHeaders = true;
         HttpRequest msg = new DefaultHttpRequest(


### PR DESCRIPTION
## Problem

`HttpConversionUtil.toHttp2Headers` passes the absolute-form request-target through `java.net.URI.create` when converting an HTTP/1.x request to HTTP/2 pseudo-headers. On JDK versions whose URI parser still follows the older RFC 2396 grammar (notably JDK 17, which is still the long-term baseline for many users), characters such as `{`, `}` or `|` cause `IllegalArgumentException` even though they are valid under RFC 3986 and routinely appear in real-world request URIs as placeholder substitutions (e.g. `us_privacy=${us_privacy}` from ad-tech / tracking pipelines).

## Root Cause

`URI.create(request.uri())` is the only path that produces the `:path`, `:scheme` and `:authority` pseudo-headers for absolute-form requests. Any character the parser refuses propagates straight out of the converter and the request is dropped. Maintainers noted on the issue that JDK 21 relaxed the parser, but Netty 4.1/4.2 still target older JDKs, so the regression continues to bite users who cannot upgrade their runtime.

## Fix

When `URI.create` fails on the absolute-form request-target, split the URI manually around the first `/` that follows the authority so `:path` can still carry the user's original path / query / fragment verbatim. The scheme and authority are still derived through `java.net.URI` by re-parsing only the base portion (scheme + authority), which in practice never carries the offending placeholder characters. If even the base portion is unparseable the original `IllegalArgumentException` is rethrown so that genuinely malformed request URIs continue to fail loudly rather than silently producing malformed pseudo-headers.

- `codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java` — wrap the absolute-form URI parsing in try / catch with a manual split fallback.

## Tests Added

| Change Point | Test |
|--------------|------|
| Try / catch wrapping the URI parse + manual split for query placeholders | `handlesRequestWhoseQueryHasCharactersRejectedByJavaNetUri` — exact reproducer from #14591, asserts `:path`, `:scheme`, `:authority`, `:method` round-trip through the converter |
| Manual split also recovers placeholders inside the path component | `handlesRequestWhosePathHasCharactersRejectedByJavaNetUri` — `{id}`-style placeholder before the query is preserved |
| Re-throw of the original parse error when even the base URI is unparseable | `rethrowsOriginalParsingErrorWhenBaseUriCannotBeParsedEither` — boundary check that genuinely malformed authorities still surface `IllegalArgumentException` |

All three new tests fail against the current upstream code and pass with this change. The full `codec-http2` test suite (1405 tests) continues to pass.

## Impact

- Affects only the absolute-form code path of `HttpConversionUtil.toHttp2Headers(HttpMessage, boolean)`. Origin-form and asterisk-form requests are unchanged.
- The success path is bit-for-bit identical to the previous implementation; the new fallback only runs after `URI.create` would have thrown.
- No behaviour change for users on JDK 21+ (where `URI.create` already accepts these characters).
- HTTP/3 contains a similar pattern; it is intentionally out of scope here because the surrounding code differs and warrants its own PR.

Fixes #14591