### PR TITLE
Lazily allocate trailing headers in DefaultFullHttpRequest

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpRequest.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpRequest.java
@@ -29,7 +29,14 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
  */
 public class DefaultFullHttpRequest extends DefaultHttpRequest implements FullHttpRequest {
     private final ByteBuf content;
-    private final HttpHeaders trailingHeader;
+
+    /**
+     * Either {@code trailingHeader} or {@code trailersFactory} is non-null. When the message is
+     * constructed via an {@link HttpHeadersFactory}, allocation of the trailing headers is deferred
+     * until {@link #trailingHeaders()} is first called, since most requests do not carry trailers.
+     */
+    private HttpHeaders trailingHeader;
+    private final HttpHeadersFactory trailersFactory;
 
     /**
      * Used to cache the value of the hash code and avoid {@link IllegalReferenceCountException}.
@@ -81,10 +88,15 @@ public class DefaultFullHttpRequest extends DefaultHttpRequest implements FullHt
      * <p>
      * The recommended default header factory is {@link DefaultHttpHeadersFactory#headersFactory()},
      * and the recommended default trailer factory is {@link DefaultHttpHeadersFactory#trailersFactory()}.
+     * <p>
+     * The trailer headers are not created eagerly; they are allocated on the first call to
+     * {@link #trailingHeaders()} using the supplied {@code trailersFactory}.
      */
     public DefaultFullHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri,
             ByteBuf content, HttpHeadersFactory headersFactory, HttpHeadersFactory trailersFactory) {
-        this(httpVersion, method, uri, content, headersFactory.newHeaders(), trailersFactory.newHeaders());
+        super(httpVersion, method, uri, headersFactory.newHeaders(), true);
+        this.content = checkNotNull(content, "content");
+        this.trailersFactory = checkNotNull(trailersFactory, "trailersFactory");
     }
 
     /**
@@ -103,11 +115,17 @@ public class DefaultFullHttpRequest extends DefaultHttpRequest implements FullHt
         super(httpVersion, method, uri, headers, validateRequestLine);
         this.content = checkNotNull(content, "content");
         this.trailingHeader = checkNotNull(trailingHeader, "trailingHeader");
+        this.trailersFactory = null;
     }
 
     @Override
     public HttpHeaders trailingHeaders() {
-        return trailingHeader;
+        HttpHeaders trailers = trailingHeader;
+        if (trailers == null) {
+            trailers = trailersFactory.newHeaders();
+            trailingHeader = trailers;
+        }
+        return trailers;
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpRequest.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpRequest.java
@@ -20,6 +20,8 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.util.IllegalReferenceCountException;
 
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
 import static io.netty.handler.codec.http.DefaultHttpHeadersFactory.headersFactory;
 import static io.netty.handler.codec.http.DefaultHttpHeadersFactory.trailersFactory;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
@@ -28,14 +30,20 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
  * Default implementation of {@link FullHttpRequest}.
  */
 public class DefaultFullHttpRequest extends DefaultHttpRequest implements FullHttpRequest {
+
+    private static final AtomicReferenceFieldUpdater<DefaultFullHttpRequest, HttpHeaders> TRAILING_HEADER_UPDATER =
+            AtomicReferenceFieldUpdater.newUpdater(
+                    DefaultFullHttpRequest.class, HttpHeaders.class, "trailingHeader");
+
     private final ByteBuf content;
 
     /**
      * Either {@code trailingHeader} or {@code trailersFactory} is non-null. When the message is
      * constructed via an {@link HttpHeadersFactory}, allocation of the trailing headers is deferred
      * until {@link #trailingHeaders()} is first called, since most requests do not carry trailers.
+     * Safely published via {@link #TRAILING_HEADER_UPDATER}.
      */
-    private HttpHeaders trailingHeader;
+    private volatile HttpHeaders trailingHeader;
     private final HttpHeadersFactory trailersFactory;
 
     /**
@@ -123,7 +131,11 @@ public class DefaultFullHttpRequest extends DefaultHttpRequest implements FullHt
         HttpHeaders trailers = trailingHeader;
         if (trailers == null) {
             trailers = trailersFactory.newHeaders();
-            trailingHeader = trailers;
+            if (!TRAILING_HEADER_UPDATER.compareAndSet(this, null, trailers)) {
+                // Another thread won the race and already published its instance; use that one
+                // so all callers observe the same trailing headers reference.
+                trailers = trailingHeader;
+            }
         }
         return trailers;
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/DefaultFullHttpRequestTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/DefaultFullHttpRequestTest.java
@@ -18,6 +18,12 @@ package io.netty.handler.codec.http;
 import io.netty.buffer.Unpooled;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -81,4 +87,54 @@ public class DefaultFullHttpRequestTest {
         assertEquals("v", req.trailingHeaders().get("x-trailer"));
     }
 
+    /**
+     * Race-exposing stress test in the style of {@code UniqueIpFilterTest}: two threads start in
+     * lock-step on a {@link CyclicBarrier} and concurrently call
+     * {@link DefaultFullHttpRequest#trailingHeaders()} on a freshly-constructed request. Both
+     * threads MUST observe the same {@link HttpHeaders} instance — otherwise mutations applied
+     * by the loser of the race would be silently dropped by subsequent readers seeing the
+     * winner's instance.
+     */
+    @Test
+    public void trailingHeadersIsRaceFreeOnFirstAccess() throws ExecutionException, InterruptedException {
+        final CyclicBarrier barrier = new CyclicBarrier(2);
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        try {
+            for (int round = 0; round < 10000; round++) {
+                final DefaultFullHttpRequest req = new DefaultFullHttpRequest(
+                        HttpVersion.HTTP_1_1, HttpMethod.GET, "/", Unpooled.EMPTY_BUFFER,
+                        DefaultHttpHeadersFactory.headersFactory(),
+                        DefaultHttpHeadersFactory.trailersFactory());
+
+                Future<HttpHeaders> f1 = trailingHeadersAsync(barrier, executorService, req);
+                Future<HttpHeaders> f2 = trailingHeadersAsync(barrier, executorService, req);
+
+                HttpHeaders h1 = f1.get();
+                HttpHeaders h2 = f2.get();
+
+                assertSame(h1, h2,
+                        "concurrent first-access callers of trailingHeaders() must observe the "
+                        + "same instance (round " + round + ')');
+                assertSame(h1, req.trailingHeaders(),
+                        "subsequent trailingHeaders() must return the same instance the racers saw "
+                        + "(round " + round + ')');
+
+                barrier.reset();
+            }
+        } finally {
+            executorService.shutdown();
+        }
+    }
+
+    private static Future<HttpHeaders> trailingHeadersAsync(final CyclicBarrier barrier,
+                                                            ExecutorService executorService,
+                                                            final DefaultFullHttpRequest req) {
+        return executorService.submit(new Callable<HttpHeaders>() {
+            @Override
+            public HttpHeaders call() throws Exception {
+                barrier.await();
+                return req.trailingHeaders();
+            }
+        });
+    }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/DefaultFullHttpRequestTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/DefaultFullHttpRequestTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http;
+
+import io.netty.buffer.Unpooled;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class DefaultFullHttpRequestTest {
+
+    private static HttpHeadersFactory countingFactory(final HttpHeadersFactory delegate, final AtomicInteger counter) {
+        return new HttpHeadersFactory() {
+            @Override
+            public HttpHeaders newHeaders() {
+                counter.incrementAndGet();
+                return delegate.newHeaders();
+            }
+
+            @Override
+            public HttpHeaders newEmptyHeaders() {
+                counter.incrementAndGet();
+                return delegate.newEmptyHeaders();
+            }
+        };
+    }
+
+    @Test
+    public void trailingHeadersAreLazilyAllocatedWhenConstructedWithFactory() {
+        AtomicInteger trailersAllocations = new AtomicInteger();
+        HttpHeadersFactory countingTrailers =
+                countingFactory(DefaultHttpHeadersFactory.trailersFactory(), trailersAllocations);
+
+        DefaultFullHttpRequest req = new DefaultFullHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.GET, "/", Unpooled.EMPTY_BUFFER,
+                DefaultHttpHeadersFactory.headersFactory(), countingTrailers);
+
+        // Most requests never carry trailers; the factory must not be invoked at construction time.
+        assertEquals(0, trailersAllocations.get(),
+                "trailing headers should not be eagerly allocated when constructed via factory");
+
+        HttpHeaders trailers = req.trailingHeaders();
+        assertNotNull(trailers);
+        assertEquals(1, trailersAllocations.get(),
+                "trailing headers should be allocated on first access");
+
+        HttpHeaders trailersAgain = req.trailingHeaders();
+        assertSame(trailers, trailersAgain, "trailing headers must be cached after first access");
+        assertEquals(1, trailersAllocations.get(),
+                "subsequent trailingHeaders() calls must not allocate again");
+    }
+
+    @Test
+    public void trailingHeadersFromExplicitConstructorAreReturnedAsIs() {
+        HttpHeaders explicitTrailers = DefaultHttpHeadersFactory.trailersFactory().newHeaders();
+        explicitTrailers.add("x-trailer", "v");
+
+        DefaultFullHttpRequest req = new DefaultFullHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.GET, "/", Unpooled.EMPTY_BUFFER,
+                DefaultHttpHeadersFactory.headersFactory().newHeaders(), explicitTrailers);
+
+        assertSame(explicitTrailers, req.trailingHeaders(),
+                "explicit trailing headers must be returned without re-allocation");
+        assertEquals("v", req.trailingHeaders().get("x-trailer"));
+    }
+
+}


### PR DESCRIPTION
Motivation:

DefaultFullHttpRequest eagerly allocates trailing headers in its
constructor, but most requests never carry trailers.

Modification:

When constructed via an HttpHeadersFactory, defer the trailing header
allocation until trailingHeaders() is first called.

Result:

Reduced GC pressure for the common case. Fixes #14476