### PR TITLE
IoUring: Pass IORING_ENTER_NO_IOWAIT to report accurate CPU usage

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
@@ -47,10 +47,12 @@ public final class IoUring {
     private static final boolean IORING_SETUP_NO_SQARRAY_SUPPORTED;
     private static final boolean IORING_REGISTER_BUFFER_RING_SUPPORTED;
     private static final boolean IORING_REGISTER_BUFFER_RING_INC_SUPPORTED;
+    private static final boolean IORING_ENTER_NO_IOWAIT_SUPPORTED;
     private static final boolean IORING_ACCEPT_MULTISHOT_ENABLED;
     private static final boolean IORING_RECV_MULTISHOT_ENABLED;
     private static final boolean IORING_RECVSEND_BUNDLE_ENABLED;
     private static final boolean IORING_POLL_ADD_MULTISHOT_ENABLED;
+    private static final boolean IORING_ENTER_NO_IOWAIT_ENABLED;
     static final int NUM_ELEMENTS_IOVEC;
     static final int DEFAULT_RING_SIZE;
     static final int DEFAULT_CQ_SIZE;
@@ -79,6 +81,7 @@ public final class IoUring {
         boolean noSqarraySupported = false;
         boolean registerBufferRingSupported = false;
         boolean registerBufferRingIncSupported = false;
+        boolean enterNoIoWaitSupported = false;
         int numElementsIoVec = 10;
 
         String kernelVersion = "[unknown]";
@@ -106,6 +109,7 @@ public final class IoUring {
                         socketNonEmptySupported = Native.isCqeFSockNonEmptySupported(ioUringProbe);
                         spliceSupported = Native.isSpliceSupported(ioUringProbe);
                         recvsendBundleSupported = (ringBuffer.features() & Native.IORING_FEAT_RECVSEND_BUNDLE) != 0;
+                        enterNoIoWaitSupported = (ringBuffer.features() & Native.IORING_FEAT_NO_IOWAIT) != 0;
                         sendZcSupported = Native.isSendZcSupported(ioUringProbe);
                         sendmsgZcSupported =  Native.isSendmsgZcSupported(ioUringProbe);
                         // IORING_FEAT_RECVSEND_BUNDLE was added in the same release.
@@ -163,6 +167,7 @@ public final class IoUring {
         IORING_SETUP_NO_SQARRAY_SUPPORTED = noSqarraySupported;
         IORING_REGISTER_BUFFER_RING_SUPPORTED = registerBufferRingSupported;
         IORING_REGISTER_BUFFER_RING_INC_SUPPORTED = registerBufferRingIncSupported;
+        IORING_ENTER_NO_IOWAIT_SUPPORTED = enterNoIoWaitSupported;
 
         IORING_ACCEPT_MULTISHOT_ENABLED = IORING_ACCEPT_MULTISHOT_SUPPORTED && SystemPropertyUtil.getBoolean(
                 "io.netty.iouring.acceptMultiShotEnabled", true);
@@ -175,6 +180,8 @@ public final class IoUring {
                 "io.netty.iouring.recvsendBundleEnabled", false);
         IORING_POLL_ADD_MULTISHOT_ENABLED = IORING_POLL_ADD_MULTISHOT_SUPPORTED && SystemPropertyUtil.getBoolean(
                "io.netty.iouring.pollAddMultishotEnabled", true);
+        IORING_ENTER_NO_IOWAIT_ENABLED = IORING_ENTER_NO_IOWAIT_SUPPORTED && SystemPropertyUtil.getBoolean(
+                "io.netty.iouring.enterNoIoWaitEnabled", false);
         NUM_ELEMENTS_IOVEC = numElementsIoVec;
 
         DEFAULT_RING_SIZE =  Math.max(16, SystemPropertyUtil.getInt("io.netty.iouring.ringSize", 128));
@@ -319,6 +326,21 @@ public final class IoUring {
         return IORING_REGISTER_BUFFER_RING_INC_SUPPORTED;
     }
 
+    static boolean isIoringEnterNoIoWaitSupported() {
+        return IORING_ENTER_NO_IOWAIT_SUPPORTED;
+    }
+
+    /**
+     * Returns if {@code IORING_ENTER_NO_IOWAIT} is used or not. When enabled (and supported by the kernel),
+     * idle io_uring_enter(2) waits are not accounted as iowait, which makes server-side CPU metrics more
+     * accurate but also suppresses the cpufreq governor's iowait boost.
+     *
+     * @return {@code true} if enabled, {@code false} otherwise.
+     */
+    public static boolean isIoringEnterNoIoWaitEnabled() {
+        return IORING_ENTER_NO_IOWAIT_ENABLED;
+    }
+
     /**
      * Returns if multi-shot ACCEPT is used or not.
      *
@@ -398,7 +420,8 @@ public final class IoUring {
                 + ", REGISTER_BUFFER_RING_SUPPORTED=" + IORING_REGISTER_BUFFER_RING_SUPPORTED
                 + ", REGISTER_BUFFER_RING_INC_SUPPORTED=" + IORING_REGISTER_BUFFER_RING_INC_SUPPORTED
                 + ", SEND_ZC_SUPPORTED=" + IORING_SEND_ZC_SUPPORTED
-                + ", SENDMSG_ZC_SUPPORTED=" + IORING_SENDMSG_ZC_SUPPORTED;
+                + ", SENDMSG_ZC_SUPPORTED=" + IORING_SENDMSG_ZC_SUPPORTED
+                + ", ENTER_NO_IOWAIT_SUPPORTED=" + IORING_ENTER_NO_IOWAIT_SUPPORTED;
     }
 
     /**

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -253,6 +253,7 @@ final class Native {
     static final int IORING_FEAT_NODROP = 1 << 1;
     static final int IORING_FEAT_SUBMIT_STABLE = 1 << 2;
     static final int IORING_FEAT_RECVSEND_BUNDLE = 1 << 14;
+    static final int IORING_FEAT_NO_IOWAIT = 1 << 17;
 
     static final int IORING_SQ_NEED_WAKEUP = 1 << 0;
     static final int IORING_SQ_CQ_OVERFLOW = 1 << 1;
@@ -316,6 +317,7 @@ final class Native {
 
     static final int IORING_ENTER_GETEVENTS = NativeStaticallyReferencedJniMethods.ioringEnterGetevents();
     static final int IORING_ENTER_REGISTERED_RING = 1 << 4;
+    static final int IORING_ENTER_NO_IOWAIT = 1 << 7;
     static final int IOSQE_ASYNC = NativeStaticallyReferencedJniMethods.iosqeAsync();
     static final int IOSQE_LINK = NativeStaticallyReferencedJniMethods.iosqeLink();
     static final int IOSQE_IO_DRAIN = NativeStaticallyReferencedJniMethods.iosqeDrain();

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/SubmissionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/SubmissionQueue.java
@@ -115,13 +115,18 @@ final class SubmissionQueue {
         // Try to use IORING_REGISTER_RING_FDS.
         // See https://manpages.debian.org/unstable/liburing-dev/io_uring_register.2.en.html#IORING_REGISTER_RING_FDS
         int enterRingFd = Native.ioUringRegisterRingFds(ringFd);
-        final int enterFlags;
+        int enterFlags;
         if (enterRingFd < 0) {
             // Use of IORING_REGISTER_RING_FDS failed, just use the ring fd directly.
             enterRingFd = ringFd;
             enterFlags = 0;
         } else {
             enterFlags = Native.IORING_ENTER_REGISTERED_RING;
+        }
+        // Opt out of iowait accounting while waiting on CQEs for pure networking workloads.
+        // See https://github.com/netty/netty/issues/16655
+        if (IoUring.isIoringEnterNoIoWaitEnabled()) {
+            enterFlags |= Native.IORING_ENTER_NO_IOWAIT;
         }
         this.enterRingFd = enterRingFd;
         this.enterFlags = enterFlags;


### PR DESCRIPTION
### Motivation

When a Netty server uses the io_uring transport, the event loop threads that are idly waiting on CQEs are accounted as being in `iowait` by the kernel. On a server doing no real work, this makes monitoring tools (`iostat`, `top`, `%iowait` metrics) report close to 100% iowait, which:

- Makes it impossible to tell real CPU pressure from an idle io_uring wait on the server.
- Triggers the CPU frequency governor's iowait boost unnecessarily, which wastes power.

This was reported in #16655, where a user with 3 idle connected clients sees:

```
%user %nice %system %iowait %steal %idle
0.00  0.00  0.51    98.97   0.51   0.00
```

### Modifications

Linux 6.15 added `IORING_ENTER_NO_IOWAIT`, advertised via the `IORING_FEAT_NO_IOWAIT` feature bit, which opts out of this accounting (and of the iowait CPU-freq boost) while waiting on CQEs.

- Expose `IORING_ENTER_NO_IOWAIT` (`1 << 7`) and `IORING_FEAT_NO_IOWAIT` (`1 << 17`) as constants in `Native`, following the same hard-coded pattern already used for `IORING_ENTER_REGISTERED_RING` / `IORING_FEAT_RECVSEND_BUNDLE`.
- In `IoUring` static init, check `ringBuffer.features() & IORING_FEAT_NO_IOWAIT` (same mechanism used for `IORING_FEAT_RECVSEND_BUNDLE` right above) to detect support.
- In `SubmissionQueue.tryRegisterRingFd()`, OR `IORING_ENTER_NO_IOWAIT` into `enterFlags` when supported, so every `io_uring_enter(2)` call carries it.
- Report the new capability in `IoUring.featureString()` as `ENTER_NO_IOWAIT_SUPPORTED=...`.

On kernels < 6.15 the feature bit is absent, the flag is not set, and behavior is unchanged.

### Result

- On kernel ≥ 6.15, io_uring event loop threads waiting on completions are no longer counted as iowait. Server CPU/iowait monitoring now reflects reality.
- No behavior change on older kernels.

### Verification

- Built on Linux 7.0.3 (Arch) with OpenJDK 21 via `./mvnw --projects transport-native-io_uring --also-make -DskipTests install` — BUILD SUCCESS.
- `IoUringSocketEchoTest` — 7/7 pass.
- `IoUring.featureString()` prints `ENTER_NO_IOWAIT_SUPPORTED=true` on the 7.x test kernel, confirming the feature bit is detected.

### References

- Kernel commit: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=07754bfd9aee59063f8549f6e4d455eae636ecc7
- `io_uring_enter(2)`: https://man7.org/linux/man-pages/man2/io_uring_enter.2.html
- https://github.com/axboe/liburing/issues/943

Fixes #16655