### PR TITLE
Merge commit from fork

### DIFF
--- a/handler-proxy/src/main/java/io/netty/handler/proxy/HttpProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/handler/proxy/HttpProxyHandler.java
@@ -70,6 +70,7 @@ public final class HttpProxyHandler extends ProxyHandler {
     private final CharSequence authorization;
     private final HttpHeaders outboundHeaders;
     private final boolean ignoreDefaultPortsInConnectHostHeader;
+    private final boolean validateInitialHeaders;
     private HttpResponseStatus status;
     private HttpHeaders inboundHeaders;
 
@@ -84,12 +85,20 @@ public final class HttpProxyHandler extends ProxyHandler {
     public HttpProxyHandler(SocketAddress proxyAddress,
                             HttpHeaders headers,
                             boolean ignoreDefaultPortsInConnectHostHeader) {
+        this(proxyAddress, headers, ignoreDefaultPortsInConnectHostHeader, true);
+    }
+
+    public HttpProxyHandler(SocketAddress proxyAddress,
+                            HttpHeaders headers,
+                            boolean ignoreDefaultPortsInConnectHostHeader,
+                            boolean validateInitialHeaders) {
         super(proxyAddress);
         username = null;
         password = null;
         authorization = null;
         this.outboundHeaders = headers;
         this.ignoreDefaultPortsInConnectHostHeader = ignoreDefaultPortsInConnectHostHeader;
+        this.validateInitialHeaders = validateInitialHeaders;
     }
 
     public HttpProxyHandler(SocketAddress proxyAddress, String username, String password) {
@@ -98,14 +107,15 @@ public final class HttpProxyHandler extends ProxyHandler {
 
     public HttpProxyHandler(SocketAddress proxyAddress, String username, String password,
                             HttpHeaders headers) {
-        this(proxyAddress, username, password, headers, false);
+        this(proxyAddress, username, password, headers, false, true);
     }
 
     public HttpProxyHandler(SocketAddress proxyAddress,
                             String username,
                             String password,
                             HttpHeaders headers,
-                            boolean ignoreDefaultPortsInConnectHostHeader) {
+                            boolean ignoreDefaultPortsInConnectHostHeader,
+                            boolean validateInitialHeaders) {
         super(proxyAddress);
         this.username = ObjectUtil.checkNotNull(username, "username");
         this.password = ObjectUtil.checkNotNull(password, "password");
@@ -125,6 +135,7 @@ public final class HttpProxyHandler extends ProxyHandler {
 
         this.outboundHeaders = headers;
         this.ignoreDefaultPortsInConnectHostHeader = ignoreDefaultPortsInConnectHostHeader;
+        this.validateInitialHeaders = validateInitialHeaders;
     }
 
     @Override
@@ -173,7 +184,8 @@ public final class HttpProxyHandler extends ProxyHandler {
                 hostString :
                 url;
 
-        HttpHeadersFactory headersFactory = DefaultHttpHeadersFactory.headersFactory().withValidation(false);
+        HttpHeadersFactory headersFactory = DefaultHttpHeadersFactory.headersFactory()
+                .withValidation(validateInitialHeaders);
         FullHttpRequest req = new DefaultFullHttpRequest(
                 HttpVersion.HTTP_1_1, HttpMethod.CONNECT,
                 url,

--- a/handler-proxy/src/test/java/io/netty/handler/proxy/HttpProxyHandlerTest.java
+++ b/handler-proxy/src/test/java/io/netty/handler/proxy/HttpProxyHandlerTest.java
@@ -43,6 +43,8 @@ import io.netty.util.NetUtil;
 
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -51,6 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.*;
 
 public class HttpProxyHandlerTest {
@@ -175,6 +178,29 @@ public class HttpProxyHandlerTest {
                 true);
     }
 
+    @ParameterizedTest
+    @ValueSource(booleans =  { true, false })
+    public void testInvalidHeaders(boolean validation) throws Exception {
+        InetSocketAddress socketAddress = InetSocketAddress.createUnresolved("10.0.0.1", 8080);
+        try {
+            testInitialMessage(
+                    socketAddress,
+                    "10.0.0.1:8080",
+                    "10.0.0.1:8080",
+                    new DefaultHttpHeaders(false)
+                            .add("CUSTOM_HEADER", "CUSTOM_VALUE1\r\nInvalid: true")
+                            .add("CUSTOM_HEADER", "CUSTOM_VALUE2"),
+                    true, validation);
+            if (validation) {
+                fail("Validation should have failed for the provided headers");
+            }
+        } catch (IllegalArgumentException e) {
+            if (!validation) {
+                throw e;
+            }
+        }
+    }
+
     @Test
     public void testExceptionDuringConnect() throws Exception {
         EventLoopGroup group = null;
@@ -239,6 +265,16 @@ public class HttpProxyHandlerTest {
                                            String expectedHostHeader,
                                            HttpHeaders headers,
                                            boolean ignoreDefaultPortsInConnectHostHeader) throws Exception {
+        testInitialMessage(socketAddress, expectedUrl, expectedHostHeader, headers,
+                ignoreDefaultPortsInConnectHostHeader, true);
+    }
+
+    private static void testInitialMessage(InetSocketAddress socketAddress,
+                                           String expectedUrl,
+                                           String expectedHostHeader,
+                                           HttpHeaders headers,
+                                           boolean ignoreDefaultPortsInConnectHostHeader,
+                                           boolean validateInitialHeaders) throws Exception {
         InetSocketAddress proxyAddress = new InetSocketAddress(NetUtil.LOCALHOST, 8080);
 
         ChannelPromise promise = mock(ChannelPromise.class);
@@ -250,7 +286,7 @@ public class HttpProxyHandlerTest {
         HttpProxyHandler handler = new HttpProxyHandler(
                 new InetSocketAddress(NetUtil.LOCALHOST, 8080),
                 headers,
-                ignoreDefaultPortsInConnectHostHeader);
+                ignoreDefaultPortsInConnectHostHeader, validateInitialHeaders);
         handler.connect(ctx, socketAddress, null, promise);
 
         FullHttpRequest request = (FullHttpRequest) handler.newInitialMessage(ctx);


### PR DESCRIPTION
Motivation:

We did not validate the headers of the intial message by default which could in theory let headers to be injected if the HttpProxyHandler was constructed from an unsafe resource

Modifications:

- Validate headers by default but add an extra constructor to also allow to remove validation
- Add unit test

Result:

Validate headers by default of inital message