### PR TITLE
HTTP: Re-add constructor to HttpProxyHandler that was removed by mistake

### DIFF
--- a/handler-proxy/src/main/java/io/netty/handler/proxy/HttpProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/handler/proxy/HttpProxyHandler.java
@@ -114,6 +114,14 @@ public final class HttpProxyHandler extends ProxyHandler {
                             String username,
                             String password,
                             HttpHeaders headers,
+                            boolean ignoreDefaultPortsInConnectHostHeader) {
+        this(proxyAddress, username, password, headers, ignoreDefaultPortsInConnectHostHeader, true);
+    }
+
+    public HttpProxyHandler(SocketAddress proxyAddress,
+                            String username,
+                            String password,
+                            HttpHeaders headers,
                             boolean ignoreDefaultPortsInConnectHostHeader,
                             boolean validateInitialHeaders) {
         super(proxyAddress);


### PR DESCRIPTION
Motivation:

d1c3c29fe86ce6d02117272bfcc2173c5443aa5d removed one constructor by mistake

Modifications:

- Re-add constructor

Result:

API compat restored. Fixes https://github.com/netty/netty/issues/16746
