### PR TITLE
HTTP: Fix revapi failure introduced by 84530fa81e12dcd1d42310bb20c1385cb44128d8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1399,6 +1399,13 @@
                   <new>class net.jpountz.lz4.LZ4JNIHCFastResetCompressor</new>
                   <justification>Added in at.yawk.lz4:lz4-java:1.11.0.</justification>
                 </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.finalMethodAddedToNonFinalClass</code>
+                  <classQualifiedName>io.netty.handler.codec.http.HttpObjectDecoder</classQualifiedName>
+                  <new>method void io.netty.handler.codec.http.HttpObjectDecoder::clearContentLength()</new>
+                  <justification>Final methods added as utility</justification>
+                </item>
               </differences>
             </revapi.differences>
           </analysisConfiguration>


### PR DESCRIPTION
Motivation:

https://github.com/netty/netty/commit/84530fa81e12dcd1d42310bb20c1385cb44128d8  added a final method but did not add a revapi ignore rule

Modifications:

Add missing revapi config

Result:

revapi validation works again
