### PR TITLE
Marshalling: Explicit document security requirements

### DIFF
--- a/codec-marshalling/src/main/java/io/netty/handler/codec/marshalling/DefaultUnmarshallerProvider.java
+++ b/codec-marshalling/src/main/java/io/netty/handler/codec/marshalling/DefaultUnmarshallerProvider.java
@@ -25,6 +25,10 @@ import org.jboss.marshalling.Unmarshaller;
  * Default implementation of {@link UnmarshallerProvider} which will just create a new {@link Unmarshaller}
  * on every call to {@link #getUnmarshaller(ChannelHandlerContext)}
  *
+ * <strong>Security:</strong> serialization can be a security liability,
+ * and should not be used without defining a list of classes that are
+ * allowed to be deserialized. This explicitly needs to be done via {@link MarshallingConfiguration},
+ * missing to do so is a security risk.
  */
 public class DefaultUnmarshallerProvider implements UnmarshallerProvider {
 


### PR DESCRIPTION
Motivation:

When unmarshal pojos it is important to configure things strictly enough to not fall into security problems. Let's add some docs related to this so the end-user is aware of it.

Modifications:

Add javadoc that mention the requirement of strict configuration

Result:

Highlight to users the security concerns
