### PR TITLE
Add all MQTT message subclasses

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/InvalidMqttMessage.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/InvalidMqttMessage.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec.mqtt;
+
+import io.netty.handler.codec.DecoderResult;
+
+public final class InvalidMqttMessage extends MqttMessage {
+
+    public InvalidMqttMessage(MqttFixedHeader mqttFixedHeader,
+            Object variableHeader,
+            Object payload,
+            DecoderResult decoderResult) {
+        super(mqttFixedHeader, variableHeader, payload, decoderResult);
+    }
+}

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttAuthMessage.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttAuthMessage.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec.mqtt;
+
+/**
+ * See <a href="https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901217">MQTTV5.0/auth</a>
+ */
+public final class MqttAuthMessage extends MqttMessage {
+
+    public MqttAuthMessage(MqttFixedHeader mqttFixedHeader, MqttReasonCodeAndPropertiesVariableHeader variableHeader) {
+        super(mqttFixedHeader, variableHeader);
+    }
+
+    @Override
+    public MqttReasonCodeAndPropertiesVariableHeader variableHeader() {
+        return (MqttReasonCodeAndPropertiesVariableHeader) super.variableHeader();
+    }
+}

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDisconnectMessage.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDisconnectMessage.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec.mqtt;
+
+/**
+ * See <a href="https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901205">MQTTV5.0/disconnect</a>
+ */
+public final class MqttDisconnectMessage extends MqttMessage {
+
+    public MqttDisconnectMessage(MqttFixedHeader mqttFixedHeader) {
+        super(mqttFixedHeader);
+    }
+
+    public MqttDisconnectMessage(
+            MqttFixedHeader mqttFixedHeader,
+            MqttReasonCodeAndPropertiesVariableHeader variableHeader) {
+        super(mqttFixedHeader, variableHeader);
+    }
+
+    @Override
+    public MqttReasonCodeAndPropertiesVariableHeader variableHeader() {
+        return (MqttReasonCodeAndPropertiesVariableHeader) super.variableHeader();
+    }
+}

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttMessage.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttMessage.java
@@ -31,14 +31,14 @@ public class MqttMessage {
 
     // Constants for fixed-header only message types with all flags set to 0 (see
     // https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Table_2.2_-)
-    public static final MqttMessage PINGREQ = new MqttMessage(new MqttFixedHeader(MqttMessageType.PINGREQ, false,
-            MqttQoS.AT_MOST_ONCE, false, 0));
+    public static final MqttMessage PINGREQ = new MqttPingReqMessage(
+            new MqttFixedHeader(MqttMessageType.PINGREQ, false, MqttQoS.AT_MOST_ONCE, false, 0));
 
-    public static final MqttMessage PINGRESP = new MqttMessage(new MqttFixedHeader(MqttMessageType.PINGRESP, false,
-            MqttQoS.AT_MOST_ONCE, false, 0));
+    public static final MqttMessage PINGRESP = new MqttPingRespMessage(
+            new MqttFixedHeader(MqttMessageType.PINGRESP, false, MqttQoS.AT_MOST_ONCE, false, 0));
 
-    public static final MqttMessage DISCONNECT = new MqttMessage(new MqttFixedHeader(MqttMessageType.DISCONNECT, false,
-            MqttQoS.AT_MOST_ONCE, false, 0));
+    public static final MqttMessage DISCONNECT = new MqttDisconnectMessage(
+            new MqttFixedHeader(MqttMessageType.DISCONNECT, false, MqttQoS.AT_MOST_ONCE, false, 0));
 
     public MqttMessage(MqttFixedHeader mqttFixedHeader) {
         this(mqttFixedHeader, null, null);

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttMessageFactory.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttMessageFactory.java
@@ -26,7 +26,7 @@ public final class MqttMessageFactory {
 
     public static MqttMessage newMessage(MqttFixedHeader mqttFixedHeader, Object variableHeader, Object payload) {
         switch (mqttFixedHeader.messageType()) {
-            case CONNECT :
+            case CONNECT:
                 return new MqttConnectMessage(
                         mqttFixedHeader,
                         (MqttConnectVariableHeader) variableHeader,
@@ -65,24 +65,28 @@ public final class MqttMessageFactory {
                         (MqttPublishVariableHeader) variableHeader,
                         (ByteBuf) payload);
 
+            //Having MqttPubReplyMessageVariableHeader or MqttMessageIdVariableHeader
             case PUBACK:
-                //Having MqttPubReplyMessageVariableHeader or MqttMessageIdVariableHeader
                 return new MqttPubAckMessage(mqttFixedHeader, (MqttMessageIdVariableHeader) variableHeader);
             case PUBREC:
+                return new MqttPubRecMessage(mqttFixedHeader, (MqttMessageIdVariableHeader) variableHeader);
             case PUBREL:
+                return new MqttPubRelMessage(mqttFixedHeader, (MqttMessageIdVariableHeader) variableHeader);
             case PUBCOMP:
-                //Having MqttPubReplyMessageVariableHeader or MqttMessageIdVariableHeader
-                return new MqttMessage(mqttFixedHeader, variableHeader);
+                return new MqttPubCompMessage(mqttFixedHeader, (MqttMessageIdVariableHeader) variableHeader);
+
+            //Having MqttReasonCodeAndPropertiesVariableHeader
+            case DISCONNECT:
+                return new MqttDisconnectMessage(
+                        mqttFixedHeader,
+                        (MqttReasonCodeAndPropertiesVariableHeader) variableHeader);
+            case AUTH:
+                return new MqttAuthMessage(mqttFixedHeader, (MqttReasonCodeAndPropertiesVariableHeader) variableHeader);
 
             case PINGREQ:
+                return new MqttPingReqMessage(mqttFixedHeader);
             case PINGRESP:
-                return new MqttMessage(mqttFixedHeader);
-
-            case DISCONNECT:
-            case AUTH:
-                //Having MqttReasonCodeAndPropertiesVariableHeader
-                return new MqttMessage(mqttFixedHeader,
-                        variableHeader);
+                return new MqttPingRespMessage(mqttFixedHeader);
 
             default:
                 throw new IllegalArgumentException("unknown message type: " + mqttFixedHeader.messageType());
@@ -90,12 +94,12 @@ public final class MqttMessageFactory {
     }
 
     public static MqttMessage newInvalidMessage(Throwable cause) {
-        return new MqttMessage(null, null, null, DecoderResult.failure(cause));
+        return new InvalidMqttMessage(null, null, null, DecoderResult.failure(cause));
     }
 
     public static MqttMessage newInvalidMessage(MqttFixedHeader mqttFixedHeader, Object variableHeader,
                                                 Throwable cause) {
-        return new MqttMessage(mqttFixedHeader, variableHeader, null, DecoderResult.failure(cause));
+        return new InvalidMqttMessage(mqttFixedHeader, variableHeader, null, DecoderResult.failure(cause));
     }
 
     private MqttMessageFactory() { }

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttPingReqMessage.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttPingReqMessage.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec.mqtt;
+
+/**
+ * See <a href="https://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html#pingreq">MQTTV3.1/pingreq</a>
+ */
+public final class MqttPingReqMessage extends MqttMessage {
+
+    public MqttPingReqMessage(MqttFixedHeader mqttFixedHeader) {
+        super(mqttFixedHeader);
+    }
+}

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttPingRespMessage.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttPingRespMessage.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec.mqtt;
+
+/**
+ * See
+ * <a href="https://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html#pingresp">MQTTV3.1/pingresp</a>
+ */
+public final class MqttPingRespMessage extends MqttMessage {
+
+    public MqttPingRespMessage(MqttFixedHeader mqttFixedHeader) {
+        super(mqttFixedHeader);
+    }
+}

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttPubCompMessage.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttPubCompMessage.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec.mqtt;
+
+/**
+ * See <a href="https://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html#pubcomp">MQTTV3.1/pubcomp</a>
+ */
+public final class MqttPubCompMessage extends MqttMessage {
+
+    public MqttPubCompMessage(MqttFixedHeader mqttFixedHeader, MqttMessageIdVariableHeader variableHeader) {
+        super(mqttFixedHeader, variableHeader);
+    }
+
+    @Override
+    public MqttMessageIdVariableHeader variableHeader() {
+        return (MqttMessageIdVariableHeader) super.variableHeader();
+    }
+}

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttPubRecMessage.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttPubRecMessage.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec.mqtt;
+
+/**
+ * See <a href="https://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html#pubrec">MQTTV3.1/pubrec</a>
+ */
+public final class MqttPubRecMessage extends MqttMessage {
+
+    public MqttPubRecMessage(MqttFixedHeader mqttFixedHeader, MqttMessageIdVariableHeader variableHeader) {
+        super(mqttFixedHeader, variableHeader);
+    }
+
+    @Override
+    public MqttMessageIdVariableHeader variableHeader() {
+        return (MqttMessageIdVariableHeader) super.variableHeader();
+    }
+}

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttPubRelMessage.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttPubRelMessage.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec.mqtt;
+
+/**
+ * See <a href="https://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html#pubrel">MQTTV3.1/pubrel</a>
+ */
+public final class MqttPubRelMessage extends MqttMessage {
+
+    public MqttPubRelMessage(MqttFixedHeader mqttFixedHeader, MqttMessageIdVariableHeader variableHeader) {
+        super(mqttFixedHeader, variableHeader);
+    }
+
+    @Override
+    public MqttMessageIdVariableHeader variableHeader() {
+        return (MqttMessageIdVariableHeader) super.variableHeader();
+    }
+}


### PR DESCRIPTION
Motivation:

When handling MQTT messages, one has to switch on the message type enum and then cast to the correct subclass. This is clunky:

```java
switch (mqttMessage.fixedHeader().messageType()) {
    case CONNECT -> handleMqttConnect((MqttConnectMessage) mqttMessage);
    case SUBSCRIBE -> handleMqttSubscribe((MqttSubscribeMessage) mqttMessage);
    case PUBLISH -> handleMqttPublish((MqttPublishMessage) mqttMessage);
    ...
    default -> throw new IllegalStateException("Unknown message type: " + mqttMessage.fixedHeader().messageType());
}
```


Modification:

Added missing MQTT messages subclasses.


Result:

With this change one can now pattern match all message types:

```java
switch (mqttMessage) {
    case MqttConnectMessage connectMessage -> handleMqttConnect(connectMessage);
    case MqttSubscribeMessage subscribeMessage -> handleMqttSubscribe(subscribeMessage);
    case MqttPublishMessage publishMessage -> handleMqttPublish(publishMessage);
    ...
    default -> throw new IllegalStateException("Unknown message type: " + mqttMessage.getClass());
}
```
