### PR TITLE
Fix io_uring op completion TRACE logging

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -282,7 +282,7 @@ public final class IoUringIoHandler implements IoHandler {
 
             if (logger.isTraceEnabled()) {
                 logger.trace("completed(ring {}): {}(id={}, res={})",
-                        ringBuffer.fd(), Native.opToStr(op), data, res);
+                        ringBuffer.fd(), Native.opToStr(op), id, res);
             }
             if (id == EVENTFD_ID) {
                 handleEventFdRead();


### PR DESCRIPTION
Motivation:
Completions accidentally used the `short data` instead of the `int id` of the user-data when TRACE logging. This means we cannot tell from a completion what file descriptor it belongs to.

Modification:
Log the `id` instead.

Result:
We can now tell what file descriptor a completion belongs to when we TRACE log the io_uring transport.