### PR TITLE
Avoid re-parsing openssl key material with non-cached provider

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslCachingKeyMaterialProvider.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslCachingKeyMaterialProvider.java
@@ -67,13 +67,17 @@ final class OpenSslCachingKeyMaterialProvider extends OpenSslKeyMaterialProvider
 
     @Override
     void destroy() {
-        // Remove and release all entries.
-        do  {
-            Iterator<OpenSslKeyMaterial> iterator = cache.values().iterator();
-            while (iterator.hasNext()) {
-                iterator.next().release();
-                iterator.remove();
-            }
-        } while (!cache.isEmpty());
+        try {
+            // Remove and release all entries.
+            do  {
+                Iterator<OpenSslKeyMaterial> iterator = cache.values().iterator();
+                while (iterator.hasNext()) {
+                    iterator.next().release();
+                    iterator.remove();
+                }
+            } while (!cache.isEmpty());
+        } finally {
+            super.destroy();
+        }
     }
 }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslKeyMaterialProvider.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslKeyMaterialProvider.java
@@ -18,11 +18,13 @@ package io.netty.handler.ssl;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.internal.tcnative.SSL;
+import io.netty.util.IllegalReferenceCountException;
 
 import javax.net.ssl.SSLException;
 import javax.net.ssl.X509KeyManager;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static io.netty.handler.ssl.ReferenceCountedOpenSslContext.toBIO;
 
@@ -30,13 +32,16 @@ import static io.netty.handler.ssl.ReferenceCountedOpenSslContext.toBIO;
  * Provides {@link OpenSslKeyMaterial} for a given alias.
  */
 class OpenSslKeyMaterialProvider {
+    private static final MaterialCache SENTINEL_DESTROYED = new MaterialCache(null, null, null);
 
     private final X509KeyManager keyManager;
     private final String password;
+    private final AtomicReference<MaterialCache> cache;
 
     OpenSslKeyMaterialProvider(X509KeyManager keyManager, String password) {
         this.keyManager = keyManager;
         this.password = password;
+        cache = new AtomicReference<>();
     }
 
     static void validateKeyMaterialSupported(X509Certificate[] keyCertChain, PrivateKey key, String keyPassword,
@@ -117,6 +122,36 @@ class OpenSslKeyMaterialProvider {
         }
 
         PrivateKey key = keyManager.getPrivateKey(alias);
+        MaterialCache materialCache = cache.get();
+        if (materialCache != null && materialCache != SENTINEL_DESTROYED && materialCache.retain()) {
+            if (materialCache.sameInstances(key, certificates)) {
+                return materialCache.material(); // We already called `retain()`
+            } else {
+                // No match on this cache. Release and build a new one from scratch.
+                materialCache.release();
+            }
+        }
+
+        OpenSslKeyMaterial keyMaterial = createKeyMaterial(allocator, certificates, key);
+        materialCache = new MaterialCache(key, certificates, keyMaterial);
+
+        // Retain the new material to put in the cache, then replace and release the old material.
+        materialCache.retain();
+        MaterialCache oldMaterial = cache.getAndSet(materialCache);
+        if (oldMaterial != null) {
+            if (oldMaterial == SENTINEL_DESTROYED) {
+                destroyCache(); // Call `destroyCache()` instead of `destroy()` to avoid duplicating other effects.
+            } else {
+                oldMaterial.release();
+            }
+        }
+
+        return keyMaterial;
+    }
+
+    private OpenSslKeyMaterial createKeyMaterial(
+            ByteBufAllocator allocator, X509Certificate[] certificates, PrivateKey key)
+            throws Exception {
         PemEncoded encoded = PemX509Certificate.toPEM(allocator, true, certificates);
         long chainBio = 0;
         long pkeyBio = 0;
@@ -157,6 +192,61 @@ class OpenSslKeyMaterialProvider {
      * Will be invoked once the provider should be destroyed.
      */
     void destroy() {
-        // NOOP.
+        destroyCache();
+    }
+
+    private void destroyCache() {
+        MaterialCache oldMaterial;
+        while ((oldMaterial = cache.getAndSet(SENTINEL_DESTROYED)) != SENTINEL_DESTROYED) {
+            if (oldMaterial != null) {
+                oldMaterial.release();
+            }
+        }
+    }
+
+    private static final class MaterialCache {
+        private final PrivateKey key;
+        private final X509Certificate[] certs;
+        private final OpenSslKeyMaterial material;
+
+        private MaterialCache(PrivateKey key, X509Certificate[] certs, OpenSslKeyMaterial material) {
+            this.key = key;
+            this.certs = certs;
+            this.material = material;
+        }
+
+        OpenSslKeyMaterial material() {
+            return material;
+        }
+
+        boolean sameInstances(PrivateKey key, X509Certificate[] certs) {
+            X509Certificate[] existingCerts = this.certs;
+            int length = existingCerts.length;
+            if (this.key != key || length != certs.length) {
+                return false;
+            }
+            for (int i = 0; i < length; i++) {
+                if (certs[i] != existingCerts[i]) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        boolean retain() {
+            if (material.refCnt() != 0) {
+                try {
+                    material.retain();
+                    return true;
+                } catch (IllegalReferenceCountException ignore) {
+                    // Fall through to the `return false` below.
+                }
+            }
+            return false;
+        }
+
+        void release() {
+            material.release();
+        }
     }
 }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslX509KeyManagerFactory.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslX509KeyManagerFactory.java
@@ -225,10 +225,14 @@ public final class OpenSslX509KeyManagerFactory extends KeyManagerFactory {
 
                 @Override
                 void destroy() {
-                    for (Object material: materialMap.values()) {
-                        ReferenceCountUtil.release(material);
+                    try {
+                        for (Object material: materialMap.values()) {
+                            ReferenceCountUtil.release(material);
+                        }
+                        materialMap.clear();
+                    } finally {
+                        super.destroy();
                     }
-                    materialMap.clear();
                 }
             }
         }

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslCachingKeyMaterialProviderTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslCachingKeyMaterialProviderTest.java
@@ -40,11 +40,6 @@ public class OpenSslCachingKeyMaterialProviderTest extends OpenSslKeyMaterialPro
                 factory.getKeyManagers()), password, Integer.MAX_VALUE);
     }
 
-    @Override
-    protected void assertRelease(OpenSslKeyMaterial material) {
-        assertFalse(material.release());
-    }
-
     @Test
     public void testMaterialCached() throws Exception {
         OpenSslKeyMaterialProvider provider = newMaterialProvider(newKeyManagerFactory(), PASSWORD);
@@ -53,14 +48,14 @@ public class OpenSslCachingKeyMaterialProviderTest extends OpenSslKeyMaterialPro
         assertNotNull(material);
         assertNotEquals(0, material.certificateChainAddress());
         assertNotEquals(0, material.privateKeyAddress());
-        assertEquals(2, material.refCnt());
+        assertEquals(3, material.refCnt());
 
         OpenSslKeyMaterial material2 = provider.chooseKeyMaterial(UnpooledByteBufAllocator.DEFAULT, EXISTING_ALIAS);
         assertNotNull(material2);
         assertEquals(material.certificateChainAddress(), material2.certificateChainAddress());
         assertEquals(material.privateKeyAddress(), material2.privateKeyAddress());
-        assertEquals(3, material.refCnt());
-        assertEquals(3, material2.refCnt());
+        assertEquals(4, material.refCnt());
+        assertEquals(4, material2.refCnt());
 
         assertFalse(material.release());
         assertFalse(material2.release());

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslCertificateCompressionTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslCertificateCompressionTest.java
@@ -31,6 +31,7 @@ import io.netty.channel.local.LocalServerChannel;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.internal.tcnative.CertificateCompressionAlgo;
+import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.ReferenceCountUtil;
 import org.junit.jupiter.api.Assertions;
@@ -335,9 +336,10 @@ public class OpenSslCertificateCompressionTest {
             clientChannel.close().syncUninterruptibly();
             serverChannel.close().syncUninterruptibly();
         } finally  {
-            group.shutdownGracefully();
+            Future<?> future = group.shutdownGracefully(0, 10, TimeUnit.SECONDS);
             ReferenceCountUtil.release(clientSslContext);
             ReferenceCountUtil.release(serverSslContext);
+            future.sync();
         }
     }
 

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslKeyMaterialProviderTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslKeyMaterialProviderTest.java
@@ -33,6 +33,7 @@ import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -72,7 +73,7 @@ public class OpenSslKeyMaterialProviderTest {
     }
 
     protected void assertRelease(OpenSslKeyMaterial material) {
-        assertTrue(material.release());
+        assertFalse(material.release());
     }
 
     @Test
@@ -89,6 +90,8 @@ public class OpenSslKeyMaterialProviderTest {
         assertRelease(material);
 
         provider.destroy();
+
+        assertEquals(0, material.refCnt());
     }
 
     /**
@@ -173,13 +176,14 @@ public class OpenSslKeyMaterialProviderTest {
             OpenSslKeyMaterial material = provider.chooseKeyMaterial(ByteBufAllocator.DEFAULT, keyAlias);
             assertNotNull(material);
             assertEquals(2, sslPrivateKey.refCnt());
-            assertEquals(1, material.refCnt());
-            assertTrue(material.release());
-            assertEquals(1, sslPrivateKey.refCnt());
+            assertEquals(2, material.refCnt());
+            assertFalse(material.release());
+            assertEquals(2, sslPrivateKey.refCnt());
             // Can get material multiple times from the same key
             material = provider.chooseKeyMaterial(ByteBufAllocator.DEFAULT, keyAlias);
             assertNotNull(material);
             assertEquals(2, sslPrivateKey.refCnt());
+            provider.destroy(); // Destroy single-entry cache.
             assertTrue(material.release());
             assertTrue(sslPrivateKey.release());
             assertEquals(0, sslPrivateKey.refCnt());


### PR DESCRIPTION
Motivation:
The non-caching `OpenSslKeyMaterialProvider` must check with the `KeyManager` on every handshake, if the certificate and keys have changed. However, if they haven't then it is a waste of cycles to allocate, serialize, and parse the key material on every handshake.

Modification:
Add a single-entry cache of the key material and do an identity on the key and certificates after the `KeyManager` look-up. If there's a match, we can reuse the key material we created earlier. Many systems, particularly internal web services, only have a single key and certificate pair, so the single-entry cache will be very effective there.

Result:
Speeds up TLS handshakes when a server is configured with a `KeyManagerFactory` or `KeyManager`, and the key/cert pair isn't changing on every handshake.