### PR TITLE
Quic: Ensure writes are done before notify close promise of QuicheQui…

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicChannel.java
@@ -646,11 +646,20 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
                     outErrorCodeBuffer = null;
                 }
             } finally {
-                if (sendResult == SendResult.SOME) {
-                    // As this is the close let us flush it asap.
-                    forceFlushParent();
+                Future<Void> wf = null;
+                final InetSocketAddress sendToAddress = remote;
+                if (sendToAddress == null) {
+                    if (sendResult == SendResult.SOME) {
+                        // As this is the close let us flush it asap.
+                        forceFlushParent();
+                    } else {
+                        flushParent();
+                    }
                 } else {
-                    flushParent();
+                    // We need to ensure all writes were done before we actually notify the close promise as otherwise
+                    // we might not be able to write things to the underlying socket if the socket is closed as soon
+                    // as all QuicChannel.close() ChannelFutures are completed.
+                    wf = parent().writeAndFlush(new DatagramPacket(Unpooled.EMPTY_BUFFER, sendToAddress));
                 }
                 conn.free();
                 if (freeTask != null) {
@@ -660,7 +669,13 @@ final class QuicheQuicChannel extends AbstractChannel implements QuicChannel {
 
                 local = null;
                 remote = null;
-                promise.setSuccess(null);
+                if (wf == null) {
+                    promise.setSuccess(null);
+                } else {
+                    wf.addListener(__ -> {
+                        promise.setSuccess(null);
+                    });
+                }
             }
         }
     }

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicChannelConnectTest.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicChannelConnectTest.java
@@ -68,6 +68,7 @@ import java.security.cert.X509Certificate;
 import java.security.spec.MGF1ParameterSpec;
 import java.security.spec.PSSParameterSpec;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -80,18 +81,19 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class QuicChannelConnectTest extends AbstractQuicTest {
 
@@ -1858,6 +1860,110 @@ public class QuicChannelConnectTest extends AbstractQuicTest {
             if (bytes == numBytes) {
                 latch.countDown();
             }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("newSslTaskExecutors")
+    @Timeout(10)
+    public void testConnectionCloseFrameDeliveredWhenParentClosedImmediately(Executor executor) throws Throwable {
+        int numConnections = 10;
+        int streamsPerConnection = 50;
+
+        CountDownLatch serverStreamsLatch = new CountDownLatch(numConnections * streamsPerConnection);
+        List<QuicChannel> serverConnections = Collections.synchronizedList(new ArrayList<>(numConnections));
+
+        Channel server = QuicTestUtils.newServer(executor, new ChannelInboundHandler() {
+            @Override
+            public boolean isSharable() {
+                return true;
+            }
+
+            @Override
+            public void channelActive(ChannelHandlerContext ctx) {
+                serverConnections.add((QuicChannel) ctx.channel());
+                ctx.fireChannelActive();
+            }
+        }, new ChannelInboundHandler() {
+            @Override
+            public boolean isSharable() {
+                return true;
+            }
+
+            @Override
+            public void channelActive(ChannelHandlerContext ctx) {
+                serverStreamsLatch.countDown();
+                ctx.fireChannelActive();
+            }
+        });
+
+        server.pipeline().addFirst(new ChannelOutboundHandler() {
+            // simulate delay for writing and flushing packets so it would race with closing.
+            @Override
+            public void write(ChannelHandlerContext ctx, Object msg, CompletionHandler<Void> callback) {
+                ctx.executor().execute(() -> ctx.write(msg, callback));
+            }
+
+            @Override
+            public void flush(ChannelHandlerContext ctx) {
+                ctx.executor().execute(ctx::flush);
+            }
+        });
+        InetSocketAddress address = (InetSocketAddress) server.localAddress();
+        Channel channel = QuicTestUtils.newClient(executor);
+
+        CountDownLatch clientConnectionsLatch = new CountDownLatch(numConnections);
+        try {
+            for (int i = 0; i < numConnections; i++) {
+                QuicChannelBootstrap quicChannelBootstrap = QuicTestUtils.newQuicChannelBootstrap(channel);
+                quicChannelBootstrap.handler(new ChannelInboundHandler() {
+                    @Override
+                    public boolean isSharable() {
+                        return true;
+                    }
+
+                    @Override
+                    public void userEventTriggered(ChannelHandlerContext ctx,
+                                                   Object evt) {
+                        if (evt instanceof QuicConnectionCloseEvent) {
+                            clientConnectionsLatch.countDown();
+                        }
+                        ctx.fireUserEventTriggered(evt);
+                    }
+                });
+                QuicChannel quicChannel = quicChannelBootstrap.streamHandler(new ChannelInboundHandler() { })
+                                                              .remoteAddress(address)
+                                                              .connect()
+                                                              .get();
+
+                for (int j = 0; j < streamsPerConnection; j++) {
+                    QuicStreamChannel stream =
+                            quicChannel.createStream(QuicStreamType.BIDIRECTIONAL, new ChannelInboundHandler() { })
+                                       .sync().getNow();
+                    stream.writeAndFlush(Unpooled.directBuffer().writeZero(1)).sync();
+                }
+            }
+
+            assertTrue(serverStreamsLatch.await(5, TimeUnit.SECONDS), "Server did not receive all streams");
+            assertEquals(numConnections, serverConnections.size());
+
+            AtomicInteger closedConnections = new AtomicInteger();
+            server.executor().execute(() -> {
+                for (int i = 0; i < numConnections; i++) {
+                    serverConnections.get(i).close().addListener(v -> {
+                        if (closedConnections.incrementAndGet() == numConnections) {
+                             server.close();
+                        }
+                    });
+                }
+            });
+
+            assertTrue(clientConnectionsLatch.await(5, TimeUnit.SECONDS),
+                       "Not all clients received QuicConnectionCloseEvent");
+        } finally {
+            server.close().sync();
+            channel.close().sync();
+            shutdown(executor);
         }
     }
 


### PR DESCRIPTION
…… (#16758)

…cChannel

Motivation:

We need to ensure the writes are actually done before we notify the close promise as otherwise the user might close the parent socket while things are still infligth and so the remote peer will not receive the close frame.

Modifications:

- Ensure writes are done before we actually notify the close promise
- Add unit test that simulates delay of writes and the raced close

Result:

Fixes https://github.com/netty/netty/issues/16718
