### PR TITLE
Reject non-token characters in HTTP/2 header names

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -54,6 +54,15 @@ public class DefaultHttp2Headers
                 return;
             }
 
+            // RFC 9113 Section 8.2.1: HTTP/2 field names are valid HTTP/1.1 tokens (RFC 7230 Section 3.2.6)
+            // with the additional constraint that they MUST be lowercase. Reject anything outside the token
+            // grammar (non-ASCII, control characters, SP/HTAB, separators) before the lowercase check.
+            int tokenIndex = HttpHeaderValidationUtil.validateToken(name);
+            if (tokenIndex != -1) {
+                PlatformDependent.throwException(connectionError(PROTOCOL_ERROR,
+                        "invalid header name [%s]", name));
+            }
+
             if (name instanceof AsciiString) {
                 final int index;
                 try {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersTest.java
@@ -249,18 +249,6 @@ public class DefaultHttp2HeadersTest {
     }
 
     @Test
-    public void uppercaseHeaderNameStillRejected() {
-        // Regression: pre-existing rejection of upper-case header names must continue to fire.
-        final Http2Headers headers = new DefaultHttp2Headers();
-        assertThrows(Http2Exception.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                headers.add(of("X-Custom"), of("test"));
-            }
-        });
-    }
-
-    @Test
     public void acceptValidLowercaseTokenHeaderName() {
         // Regression: valid RFC 7230 token (lower-case ALPHA, DIGIT, "!#$%&'*+-.^_`|~") must be accepted.
         Http2Headers headers = new DefaultHttp2Headers();

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersTest.java
@@ -162,6 +162,129 @@ public class DefaultHttp2HeadersTest {
     }
 
     @Test
+    public void rejectNonAsciiHeaderNameAsciiString() {
+        // U+1F631 ("😱") encoded as F0 9F 98 B1 — bytes outside the token grammar that previously
+        // slipped past the upper-case-only validator. See issue #11975.
+        final byte[] buf = {(byte) 0xF0, (byte) 0x9F, (byte) 0x98, (byte) 0xB1};
+        final Http2Headers headers = new DefaultHttp2Headers();
+        assertThrows(Http2Exception.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                headers.add(new AsciiString(buf), of("test"));
+            }
+        });
+    }
+
+    @Test
+    public void rejectNonAsciiHeaderNameCharSequence() {
+        final Http2Headers headers = new DefaultHttp2Headers();
+        assertThrows(Http2Exception.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                // Non-ASCII char via the CharSequence path.
+                headers.add("naÿme", "test");
+            }
+        });
+    }
+
+    @Test
+    public void rejectHighBitHeaderNameCharSequence() {
+        final Http2Headers headers = new DefaultHttp2Headers();
+        assertThrows(Http2Exception.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                // U+0100 — above 0xFF, must be rejected by the CharSequence path.
+                headers.add("naĀme", "test");
+            }
+        });
+    }
+
+    @ParameterizedTest(name = "{displayName} [{index}] byte=0x{0}")
+    @MethodSource("nonTokenBytesInHeaderName")
+    void rejectNonTokenCharactersInHeaderName(int illegalByte) {
+        final String name = "n" + (char) illegalByte + "ame";
+        final Http2Headers headers = new DefaultHttp2Headers();
+        assertThrows(Http2Exception.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                headers.add(name, "test");
+            }
+        });
+    }
+
+    static Stream<Arguments> nonTokenBytesInHeaderName() {
+        return Stream.of(
+                // Control characters: every byte in the C0 range that the previous validator silently let through.
+                Arguments.of(0x00), // NUL
+                Arguments.of(0x01), // SOH
+                Arguments.of(0x07), // BEL
+                Arguments.of(0x08), // BS
+                Arguments.of(0x09), // HTAB
+                Arguments.of(0x0A), // LF
+                Arguments.of(0x0B), // VT
+                Arguments.of(0x0C), // FF
+                Arguments.of(0x0D), // CR
+                Arguments.of(0x1F), // US
+                Arguments.of(0x7F), // DEL
+                // Whitespace and RFC 7230 separators that are not valid token characters.
+                Arguments.of(0x20), // SP
+                Arguments.of((int) ','),
+                Arguments.of((int) ';'),
+                Arguments.of((int) ':'),
+                Arguments.of((int) '/'),
+                Arguments.of((int) '='),
+                Arguments.of((int) '?'),
+                Arguments.of((int) '@'),
+                Arguments.of((int) '('),
+                Arguments.of((int) ')'),
+                Arguments.of((int) '['),
+                Arguments.of((int) ']'),
+                Arguments.of((int) '{'),
+                Arguments.of((int) '}'),
+                Arguments.of((int) '<'),
+                Arguments.of((int) '>'),
+                Arguments.of((int) '\\'),
+                Arguments.of((int) '"')
+        );
+    }
+
+    @Test
+    public void uppercaseHeaderNameStillRejected() {
+        // Regression: pre-existing rejection of upper-case header names must continue to fire.
+        final Http2Headers headers = new DefaultHttp2Headers();
+        assertThrows(Http2Exception.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                headers.add(of("X-Custom"), of("test"));
+            }
+        });
+    }
+
+    @Test
+    public void acceptValidLowercaseTokenHeaderName() {
+        // Regression: valid RFC 7230 token (lower-case ALPHA, DIGIT, "!#$%&'*+-.^_`|~") must be accepted.
+        Http2Headers headers = new DefaultHttp2Headers();
+        headers.add(of("x-custom-header"), of("v"));
+        headers.add(of("2name"), of("v"));
+        headers.add(of("a!#$%&'*+-.^_`|~b"), of("v"));
+        assertTrue(headers.contains("x-custom-header"));
+        assertTrue(headers.contains("2name"));
+        assertTrue(headers.contains("a!#$%&'*+-.^_`|~b"));
+    }
+
+    @Test
+    public void acceptPseudoHeaderName() {
+        // Regression: leading-colon pseudo-header names must remain accepted even though ":" is not a token char.
+        Http2Headers headers = new DefaultHttp2Headers();
+        headers.method(of("GET"));
+        headers.path(of("/"));
+        headers.scheme(of("https"));
+        headers.authority(of("example.com"));
+        assertEquals(of("GET"), headers.method());
+        assertEquals(of("/"), headers.path());
+    }
+
+    @Test
     public void testClearResetsPseudoHeaderDivision() {
         DefaultHttp2Headers http2Headers = new DefaultHttp2Headers();
         http2Headers.method("POST");

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -50,6 +50,7 @@ import io.netty.util.concurrent.Future;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -64,6 +65,7 @@ import static io.netty.handler.codec.http2.Http2TestUtil.runInChannel;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -240,22 +242,20 @@ public class InboundHttp2ToHttpAdapterTest {
     @Test
     public void clientRequestSingleHeaderNonAsciiShouldThrow() throws Exception {
         boostrapEnv(1, 1, 1);
+        // Adding a non-ASCII byte sequence as a header name now fails immediately at validation time
+        // (RFC 9113 §8.2.1 requires HTTP/2 field names to be valid HTTP/1.1 tokens).
         final Http2Headers http2Headers = new DefaultHttp2Headers()
                 .method(new AsciiString("GET"))
                 .scheme(new AsciiString("https"))
                 .authority(new AsciiString("example.org"))
-                .path(new AsciiString("/some/path/resource2"))
-                .add(new AsciiString("çã".getBytes(CharsetUtil.UTF_8)),
-                        new AsciiString("Ãã".getBytes(CharsetUtil.UTF_8)));
-        runInChannel(clientChannel, new Http2Runnable() {
+                .path(new AsciiString("/some/path/resource2"));
+        assertThrows(Http2Exception.class, new Executable() {
             @Override
-            public void run() throws Http2Exception {
-                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, true, newPromiseClient());
-                clientChannel.flush();
+            public void execute() {
+                http2Headers.add(new AsciiString("çã".getBytes(CharsetUtil.UTF_8)),
+                        new AsciiString("Ãã".getBytes(CharsetUtil.UTF_8)));
             }
         });
-        awaitResponses();
-        assertTrue(isStreamError(clientException));
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -50,7 +50,6 @@ import io.netty.util.concurrent.Future;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -65,7 +64,6 @@ import static io.netty.handler.codec.http2.Http2TestUtil.runInChannel;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -242,20 +240,25 @@ public class InboundHttp2ToHttpAdapterTest {
     @Test
     public void clientRequestSingleHeaderNonAsciiShouldThrow() throws Exception {
         boostrapEnv(1, 1, 1);
-        // Adding a non-ASCII byte sequence as a header name now fails immediately at validation time
-        // (RFC 9113 §8.2.1 requires HTTP/2 field names to be valid HTTP/1.1 tokens).
-        final Http2Headers http2Headers = new DefaultHttp2Headers()
+        // Disable validation on the client side so the non-ASCII header name reaches the wire; the
+        // server-side validation (RFC 9113 §8.2.1 requires field names to be valid HTTP/1.1 tokens)
+        // then rejects it, which surfaces as a stream error.
+        final Http2Headers http2Headers = new DefaultHttp2Headers(false)
                 .method(new AsciiString("GET"))
                 .scheme(new AsciiString("https"))
                 .authority(new AsciiString("example.org"))
-                .path(new AsciiString("/some/path/resource2"));
-        assertThrows(Http2Exception.class, new Executable() {
-            @Override
-            public void execute() {
-                http2Headers.add(new AsciiString("çã".getBytes(CharsetUtil.UTF_8)),
+                .path(new AsciiString("/some/path/resource2"))
+                .add(new AsciiString("çã".getBytes(CharsetUtil.UTF_8)),
                         new AsciiString("Ãã".getBytes(CharsetUtil.UTF_8)));
+        runInChannel(clientChannel, new Http2Runnable() {
+            @Override
+            public void run() throws Http2Exception {
+                clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, true, newPromiseClient());
+                clientChannel.flush();
             }
         });
+        awaitResponses();
+        assertTrue(isStreamError(clientException));
     }
 
     @Test


### PR DESCRIPTION
## Problem

`DefaultHttp2Headers` accepts header names that contain bytes outside the HTTP token grammar — non-ASCII (e.g. `0xF0`), control characters (NUL/CR/LF/VT/FF/HTAB/...), SP, DEL, and the RFC 7230 separators (`"(),/:;<=>?@[\\]{}\""`). The current `HTTP2_NAME_VALIDATOR` only rejects upper-case ASCII and lets everything else through, so something like `headers.add(new AsciiString(new byte[]{(byte)0xF0}), "v")` succeeds and is then encoded onto the wire.

This was reported in #11975 with maintainer agreement on direction:
- @idelpivnitskiy: confirmed the field-name grammar
- @ejona86: "good and appropriate to restrict keys to the values permitted in HTTP/1, with little risk"

## Root Cause

`DefaultHttp2Headers.HTTP2_NAME_VALIDATOR_PROCESSOR` returns `!isUpperCase(value)` and the non-`AsciiString` fallback only loops on `isUpperCase(charAt(i))`. Both paths therefore enforce the lower-case rule but skip the rest of RFC 9113 §8.2.1, which inherits the RFC 7230 token grammar.

## Fix

In `codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java`:

- After the empty/null and pseudo-header checks, run `HttpHeaderValidationUtil.validateToken(name)` and throw `connectionError(PROTOCOL_ERROR, ...)` when it returns a non-`-1` index.
- Keep the existing upper-case `ByteProcessor` / fallback loop. The token check is additive: pseudo-headers still short-circuit, valid lower-case tokens still pass, upper-case ASCII still gets rejected (now at the upper-case check, not the token check).

Pseudo-headers (`:method`, `:path`, ...) deliberately bypass the token check via the existing `hasPseudoHeaderFormat` early return, since `:` is not a valid token character but is required for pseudo-headers.

## Tests Added

| Change point | Test |
|--------------|------|
| Reject non-ASCII via the `AsciiString` byte path | `rejectNonAsciiHeaderNameAsciiString` (uses the U+1F631 / `0xF0 0x9F 0x98 0xB1` reproducer from #11975) |
| Reject non-ASCII via the `CharSequence` `charAt` path | `rejectNonAsciiHeaderNameCharSequence`, `rejectHighBitHeaderNameCharSequence` (covers char ≤ 0xFF and char > 0xFF) |
| Reject every C0 control byte and every RFC 7230 separator | `rejectNonTokenCharactersInHeaderName` (parameterized — 28 cases: NUL, SOH, BEL, BS, HTAB, LF, VT, FF, CR, US, DEL, SP, and `, ; : / = ? @ ( ) [ ] { } < > \ "`) |
| Regression: upper-case rejection unchanged | `uppercaseHeaderNameStillRejected` |
| Regression: full RFC 7230 lower-case token still accepted | `acceptValidLowercaseTokenHeaderName` (covers `x-custom-header`, `2name`, and a name using every special token char `!#$%&'*+-.^_\`|~`) |
| Regression: pseudo-headers still accepted | `acceptPseudoHeaderName` |
| Existing wire-level test now exercises the validator | `InboundHttp2ToHttpAdapterTest.clientRequestSingleHeaderNonAsciiShouldThrow` updated — the rejection now fires at `headers.add(...)` instead of at the HPACK encoder |

`mvn -pl codec-http2 test -Drevapi.skip=true` runs 1512 tests with 0 failures locally; `codec-http` regression run is also clean (8891 tests, 0 failures).

## Impact

- **API**: `new DefaultHttp2Headers().add(name, value)` now throws `Http2Exception(PROTOCOL_ERROR, ...)` for any name that is not a valid lower-case RFC 7230 token. Code that was relying on the previous lax behaviour (passing non-ASCII or separator bytes) needs to either (a) clean up the name before adding, or (b) construct the headers with `new DefaultHttp2Headers(false)` to opt out of validation, which already exists.
- **Wire effect**: Inbound HPACK-decoded headers with malformed names now produce an `Http2Exception` at validation time and are surfaced via the existing decoder failure path. The previous behaviour silently accepted them and could allow malformed bytes to reach the application as parsed `Http2Headers`.
- **Hot path**: Standard requests are unaffected — `DefaultHttp2Headers` validation only runs when adding non-pseudo headers, and the new `validateToken` call is a single forward scan that returns `-1` on the first invalid byte for clean tokens.

Fixes #11975