### PR TITLE
Fill MsgHdrMemoryArray#hdrs with null entry on release

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemoryArray.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemoryArray.java
@@ -85,8 +85,10 @@ final class MsgHdrMemoryArray {
     void release() {
         assert !released;
         released = true;
-        for (MsgHdrMemory hdr: hdrs) {
+        for (int i = 0; i < hdrs.length; i++) {
+            MsgHdrMemory hdr = hdrs[i];
             hdr.release();
+            hdrs[i] = null;
         }
         msgHdrMemoryArrayMemoryCleanable.clean();
     }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/MsgHdrMemoryArrayTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/MsgHdrMemoryArrayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The Netty Project
+ * Copyright 2026 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/MsgHdrMemoryArrayTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/MsgHdrMemoryArrayTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class MsgHdrMemoryArrayTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IoUring.isAvailable());
+    }
+
+    @Test
+    void releaseNullsHdrEntriesToAllowGarbageCollection() {
+        short capacity = 4;
+        MsgHdrMemoryArray array = new MsgHdrMemoryArray(capacity);
+        for (int i = 0; i < capacity; i++) {
+            assertNotNull(array.hdr(i));
+        }
+        array.release();
+        for (int i = 0; i < capacity; i++) {
+            assertNull(array.hdr(i));
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

See https://github.com/netty/netty/issues/16763

This gives GC a chance to collect entries early.
Calling release on each entry is effectively a no-op.

Modifications:

In MsgHdrMemoryArray#release, fill hdrs array with nulls instead of invoking release on every entry.

Result:

After the instance is release, the GC can collect entries (about 600kb on my machine) early.