### PR TITLE
Pin HTTP/RTSP version + method normalization to Locale.US

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpVersion.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpVersion.java
@@ -19,6 +19,8 @@ import io.netty.buffer.ByteBuf;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.ObjectUtil;
 
+import java.util.Locale;
+
 import static io.netty.util.internal.ObjectUtil.checkNonEmptyAfterTrim;
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
@@ -119,7 +121,10 @@ public class HttpVersion implements Comparable<HttpVersion> {
     }
 
     HttpVersion(String text, boolean strict, boolean keepAliveDefault) {
-        text = checkNonEmptyAfterTrim(text, "text").toUpperCase();
+        // toUpperCase() without an explicit Locale uses the JVM default. In Turkish locale
+        // (tr_TR) 'i' uppercases to 'İ' (U+0130), which would corrupt protocol strings such
+        // as "icap/1.0" or any custom HTTP-derived scheme that contains a lowercase 'i'.
+        text = checkNonEmptyAfterTrim(text, "text").toUpperCase(Locale.US);
 
         if (strict) {
             // Only single digit major / minor version is allowed.
@@ -197,7 +202,9 @@ public class HttpVersion implements Comparable<HttpVersion> {
     private HttpVersion(
             String protocolName, int majorVersion, int minorVersion,
             boolean keepAliveDefault, boolean bytes) {
-        protocolName = checkNonEmptyAfterTrim(protocolName, "protocolName").toUpperCase();
+        // See the comment in the (text, strict, keepAliveDefault) constructor for why this needs
+        // an explicit Locale.US: avoids the Turkish-locale 'i' -> 'İ' corruption.
+        protocolName = checkNonEmptyAfterTrim(protocolName, "protocolName").toUpperCase(Locale.US);
 
         for (int i = 0; i < protocolName.length(); i ++) {
             if (Character.isISOControl(protocolName.charAt(i)) ||

--- a/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspMethods.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspMethods.java
@@ -20,6 +20,7 @@ import static io.netty.util.internal.ObjectUtil.checkNonEmptyAfterTrim;
 import io.netty.handler.codec.http.HttpMethod;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -119,7 +120,10 @@ public final class RtspMethods {
      * will be returned.  Otherwise, a new instance will be returned.
      */
     public static HttpMethod valueOf(String name) {
-        name = checkNonEmptyAfterTrim(name, "name").toUpperCase();
+        // RFC 2326 RTSP method names are ASCII tokens. toUpperCase() without an explicit Locale
+        // uses the JVM default, which in Turkish (tr_TR) maps 'i' to 'İ' (U+0130) and breaks the
+        // lookup of methods such as "describe" or "redirect" against the cached uppercase keys.
+        name = checkNonEmptyAfterTrim(name, "name").toUpperCase(Locale.US);
         HttpMethod result = methodMap.get(name);
         if (result != null) {
             return result;

--- a/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspVersions.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspVersions.java
@@ -18,6 +18,8 @@ package io.netty.handler.codec.rtsp;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.internal.ObjectUtil;
 
+import java.util.Locale;
+
 /**
  * The version of RTSP.
  */
@@ -37,7 +39,9 @@ public final class RtspVersions {
     public static HttpVersion valueOf(String text) {
         ObjectUtil.checkNotNull(text, "text");
 
-        text = text.trim().toUpperCase();
+        // toUpperCase() must specify Locale.US so the comparison against "RTSP/1.0" is not
+        // affected by the JVM default locale (e.g. Turkish, where 'i' uppercases to 'İ').
+        text = text.trim().toUpperCase(Locale.US);
         if ("RTSP/1.0".equals(text)) {
             return RTSP_1_0;
         }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpVersionLocaleTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpVersionLocaleTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests that exercise {@link HttpVersion} parsing with the JVM-default Locale flipped to a value
+ * that exposes the Turkish dotted-I problem (U+0130). {@link Locale#setDefault} is process-global
+ * mutable state, so this class is marked {@link Isolated} to keep it from leaking into the rest
+ * of the codec-http suite, which runs in concurrent mode
+ * ({@code junit.jupiter.execution.parallel.mode.default = concurrent}).
+ */
+@Isolated("Mutates Locale.getDefault() which is JVM-global state.")
+class HttpVersionLocaleTest {
+
+    @Test
+    void testLowercaseIotaProtocolNameUnderTurkishLocale() {
+        // Turkish locale maps 'i' -> 'İ' (U+0130) under the JVM-default toUpperCase().
+        // The constructor must use Locale.US so an HTTP-derived protocol name like "icap"
+        // round-trips to the ASCII "ICAP" instead of being corrupted to "İCAP".
+        Locale original = Locale.getDefault();
+        try {
+            Locale.setDefault(new Locale("tr", "TR"));
+            HttpVersion version = HttpVersion.valueOf("icap/1.0");
+            assertEquals("ICAP", version.protocolName());
+            for (int i = 0; i < version.protocolName().length(); i++) {
+                assertTrue(version.protocolName().charAt(i) < 0x80,
+                        "protocolName must remain ASCII regardless of JVM default locale");
+            }
+            assertEquals("ICAP/1.0", version.text());
+        } finally {
+            Locale.setDefault(original);
+        }
+    }
+
+    @Test
+    void testProtocolNameConstructorUnderTurkishLocale() {
+        // Same Locale.US guarantee for the (protocolName, major, minor, ...) constructor.
+        Locale original = Locale.getDefault();
+        try {
+            Locale.setDefault(new Locale("tr", "TR"));
+            HttpVersion version = new HttpVersion("icap", 1, 0, true);
+            assertEquals("ICAP", version.protocolName());
+            assertEquals("ICAP/1.0", version.text());
+        } finally {
+            Locale.setDefault(original);
+        }
+    }
+}

--- a/codec-http/src/test/java/io/netty/handler/codec/rtsp/RtspMethodsTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/rtsp/RtspMethodsTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.rtsp;
+
+import io.netty.handler.codec.http.HttpMethod;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+@Isolated("valueOfNormalizesLowercaseInputUnderTurkishLocale flips the JVM-default Locale, "
+        + "which is process-global state, so the class must not run alongside the rest of the "
+        + "codec-http suite (junit.jupiter.execution.parallel.mode.default = concurrent).")
+class RtspMethodsTest {
+
+    @Test
+    void valueOfReturnsCachedInstanceForUppercaseName() {
+        assertSame(RtspMethods.DESCRIBE, RtspMethods.valueOf("DESCRIBE"));
+        assertSame(RtspMethods.SETUP, RtspMethods.valueOf("SETUP"));
+        assertSame(RtspMethods.GET_PARAMETER, RtspMethods.valueOf("GET_PARAMETER"));
+    }
+
+    @Test
+    void valueOfNormalizesLowercaseInputUnderUsLocale() {
+        assertSame(RtspMethods.DESCRIBE, RtspMethods.valueOf("describe"));
+        assertSame(RtspMethods.PLAY, RtspMethods.valueOf("play"));
+        assertSame(RtspMethods.REDIRECT, RtspMethods.valueOf("redirect"));
+    }
+
+    @Test
+    void valueOfNormalizesLowercaseInputUnderTurkishLocale() {
+        // In Turkish locale (tr_TR), 'i' uppercases to 'İ' (U+0130) under the JVM default.
+        // RtspMethods.valueOf must pin Locale.US so RTSP method names that contain 'i' such as
+        // "describe" or "redirect" continue to resolve to the cached uppercase entries.
+        Locale original = Locale.getDefault();
+        try {
+            Locale.setDefault(new Locale("tr", "TR"));
+            HttpMethod describe = RtspMethods.valueOf("describe");
+            HttpMethod redirect = RtspMethods.valueOf("redirect");
+            assertSame(RtspMethods.DESCRIBE, describe);
+            assertSame(RtspMethods.REDIRECT, redirect);
+            // Sanity-check: with the locale-default toUpperCase the names would have contained
+            // U+0130 instead of plain 'I'. Asserting the resolved names round-trip to ASCII
+            // pins down that the fix is taking effect.
+            assertEquals("DESCRIBE", describe.name());
+            assertEquals("REDIRECT", redirect.name());
+        } finally {
+            Locale.setDefault(original);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`HttpVersion`, `RtspVersions` and `RtspMethods` all uppercase their input via `String.toUpperCase()` without an explicit `Locale`. The JVM default locale governs that call, and in Turkish (`tr_TR`) the ASCII letter `'i'` uppercases to `'İ'` (U+0130), not `'I'`.

Concretely, on a Turkish-locale JVM:

- `RtspMethods.valueOf("describe")` produces `"DESCRİBE"` after the uppercase, fails the cache lookup, falls through to `HttpMethod.valueOf(...)`, and throws `IllegalArgumentException: Illegal character in HTTP Method: 0x130` for what is otherwise a perfectly valid RTSP method. Same for `"redirect"` (`REDİRECT`).
- `HttpVersion.valueOf("icap/1.0")` and the `(protocolName, major, minor, ...)` constructor with `"icap"` end up with `protocolName()` containing U+0130 instead of plain ASCII `'I'`. The version no longer matches its own canonical form.

The protocol grammars are ASCII-only (RFC 7230 §2.6 / RFC 2326 §1.4), so the uppercase has no business consulting the JVM locale.

## Fix

Pin every `String.toUpperCase()` in these three classes to `Locale.US`:

- `codec-http/src/main/java/io/netty/handler/codec/http/HttpVersion.java`
  - `(text, strict, keepAliveDefault)` constructor — line that normalizes the supplied protocol string.
  - `(protocolName, major, minor, keepAliveDefault, bytes)` constructor — line that normalizes the supplied protocol name.
- `codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspMethods.java`
  - `valueOf(String name)` — line that normalizes the supplied RTSP method name before the cache lookup.
- `codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspVersions.java`
  - `valueOf(String text)` — line that normalizes the supplied version string before comparing to the cached `RTSP/1.0`.

`AsciiString.toUpperCase()` / `AsciiString.toLowerCase()` paths in the same module are already ASCII-byte-level and not affected by this issue, so they are left alone.

## Tests

`codec-http/src/test/java/io/netty/handler/codec/http/HttpVersionParsingTest.java`:

| Change Point | Test |
|--------------|------|
| `HttpVersion.valueOf(text)` under Turkish locale | `testLowercaseIotaProtocolNameUnderTurkishLocale` — installs `Locale.setDefault(new Locale("tr","TR"))` (restored in `finally`) and asserts `valueOf("icap/1.0")` returns a version whose `protocolName()` is the ASCII `"ICAP"` and whose `text()` is `"ICAP/1.0"`. |
| `HttpVersion(protocolName, major, minor, ...)` under Turkish locale | `testProtocolNameConstructorUnderTurkishLocale` — same locale setup, asserts `new HttpVersion("icap", 1, 0, true)` ends up with `protocolName()` = `"ICAP"` and `text()` = `"ICAP/1.0"`. |

New `codec-http/src/test/java/io/netty/handler/codec/rtsp/RtspMethodsTest.java`:

| Change Point | Test |
|--------------|------|
| Cached uppercase lookup still works | `valueOfReturnsCachedInstanceForUppercaseName` |
| Lowercase normalization under default locale | `valueOfNormalizesLowercaseInputUnderUsLocale` |
| Lowercase normalization under Turkish locale | `valueOfNormalizesLowercaseInputUnderTurkishLocale` — installs `tr_TR`, calls `valueOf("describe")` and `valueOf("redirect")`, asserts both resolve to the cached `DESCRIBE` / `REDIRECT` instances. |

All three Turkish-locale tests fail deterministically against the unfixed code (one with a clean assertion failure, the `RtspMethods` one with `IllegalArgumentException: Illegal character in HTTP Method: 0x130`) and pass after the `Locale.US` change.

Verification:

```
mvn -pl codec-http -am test -Dtest='HttpVersionParsingTest,RtspMethodsTest' -Dsurefire.failIfNoSpecifiedTests=false
# Tests run: 52, Failures: 0, Errors: 0, Skipped: 0
```

## Impact

- Behavior on en/CJK/most locales: unchanged (the previous default-locale uppercase already produced ASCII).
- Behavior on Turkish (and other locales with non-ASCII case mappings, e.g. Azerbaijani): RTSP method parsing and HTTP-derived version parsing of lowercase or mixed-case inputs now succeed instead of throwing or returning a U+0130-tainted result.
- API: no signature change. All callers continue to use `valueOf(String)` / the existing constructors.
- Risk: bounded — `Locale.US` is the standard Netty pattern for protocol-string normalization (see e.g. `WebSocketClientHandshaker.java:761`).
