### PR TITLE
Add epoch-based chunk cache purge with ring buffer for thread-local reuse

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -124,11 +124,11 @@ final class AdaptivePoolingAllocator {
     static final int CHUNK_REUSE_QUEUE = Math.max(2, SystemPropertyUtil.getInt(
             "io.netty.allocator.chunkReuseQueueCapacity", NettyRuntime.availableProcessors() * 2));
 
-    static final long CHUNK_PURGE_POLLS_THREAD_LOCAL = SystemPropertyUtil.getLong(
-            "io.netty.allocator.chunkPurgePollsThreadLocal", 16L);
+    static final long CHUNK_PURGE_POLLS_THREAD_LOCAL = Math.max(1, SystemPropertyUtil.getLong(
+            "io.netty.allocator.chunkPurgePollsThreadLocal", 16L));
 
-    static final long CHUNK_PURGE_POLLS_SHARED = SystemPropertyUtil.getLong(
-            "io.netty.allocator.chunkPurgePollsShared", 128L);
+    static final long CHUNK_PURGE_POLLS_SHARED = Math.max(1, SystemPropertyUtil.getLong(
+            "io.netty.allocator.chunkPurgePollsShared", 128L));
 
     static final int CHUNK_PURGE_THRESHOLD = SystemPropertyUtil.getInt(
             "io.netty.allocator.chunkPurgeThreshold", 3);
@@ -704,9 +704,7 @@ final class AdaptivePoolingAllocator {
                 int readIdx = (head + i) & mask;
                 SizeClassedChunk chunk = chunks[readIdx];
                 if (chunk.purgeEpoch > 0) {
-                    // Unpolled since last purge — still full (no allocations possible,
-                    // scan resets epoch to 0 on pick, so epoch>0 means no scan touched it).
-                    assert chunk.remainingCapacity() == chunk.capacity();
+                    assert chunk.hasFullCapacity();
                     chunk.purgeEpoch++;
                     if (chunk.purgeEpoch > CHUNK_PURGE_THRESHOLD && survivors > CHUNK_REUSE_QUEUE) {
                         chunk.markToDeallocate();
@@ -714,7 +712,7 @@ final class AdaptivePoolingAllocator {
                         survivors--;
                         continue;
                     }
-                } else if (chunk.remainingCapacity() == chunk.capacity()) {
+                } else if (chunk.hasFullCapacity()) {
                     chunk.purgeEpoch = 1;
                 }
                 int writeIdx = (head + kept) & mask;
@@ -958,8 +956,7 @@ final class AdaptivePoolingAllocator {
                     break;
                 }
                 retained++;
-                int remaining = chunk.remainingCapacity();
-                if (remaining == chunk.capacity()) {
+                if (chunk.hasFullCapacity()) {
                     chunk.purgeEpoch++;
                     if (chunk.purgeEpoch > CHUNK_PURGE_THRESHOLD) {
                         if (bufCount == buf.length) {
@@ -972,6 +969,7 @@ final class AdaptivePoolingAllocator {
                 } else {
                     chunk.purgeEpoch = 0;
                 }
+                int remaining = chunk.remainingCapacity();
                 if (remaining > 0) {
                     chunk.lastPurgeGeneration = generation;
                     if (!queue.offer(chunk)) {
@@ -1807,6 +1805,15 @@ final class AdaptivePoolingAllocator {
                 return !localFreeList.isEmpty();
             }
             return !externalFreeList.isEmpty();
+        }
+
+        boolean hasFullCapacity() {
+            int free = externalFreeList.size();
+            IntStack local = localFreeList;
+            if (local != null) {
+                free += local.size();
+            }
+            return free == segments;
         }
 
         @Override

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -631,11 +631,11 @@ final class AdaptivePoolingAllocator {
      * past threshold, but at least {@link #CHUNK_REUSE_QUEUE} chunks are always retained.
      */
     static final class ThreadLocalSizeClassedChunkCache extends SizeClassedChunkCache {
-        private SizeClassedChunk[] chunks;
-        private int head;
-        private int tail;
-        private int count;
-        private int notEmptyCount;
+        SizeClassedChunk[] chunks; // package-private for testing
+        int head;
+        int tail;
+        int count;
+        int notEmptyCount;
         private long purgeBudget;
 
         ThreadLocalSizeClassedChunkCache() {

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -510,6 +510,28 @@ final class AdaptivePoolingAllocator {
     // Cached chunks are detached from magazines: no readInitInto can happen, so segment count
     // can only grow (external releaseSegment returns) and never shrink. Once a chunk reaches
     // full capacity (remainingCapacity == capacity), it stays fully free while in the cache.
+    //
+    // Epoch-based aging invariants (both caches):
+    //
+    // 1. CLASSIFICATION: purge scans all chunks. Full (remainingCapacity == capacity) → epoch++.
+    //    Non-full → epoch = 0. Only full chunks can accumulate epoch.
+    //
+    // 2. EVICTION: full chunks with epoch > CHUNK_PURGE_THRESHOLD are evicted (markToDeallocate).
+    //    Eviction is immediate — all segments are in, no outstanding references.
+    //    Non-full chunks are never evicted (deallocation would be deferred, not immediate).
+    //    At least CHUNK_REUSE_QUEUE chunks are always retained (retention floor).
+    //
+    // 3. SCAN RESET: scanForCapacity resets purgeEpoch = 0 on the chunk it picks. The scan
+    //    knows the chunk is being used. The chunk gets allocated from, becomes non-full, and
+    //    the next purge resets its epoch anyway (non-full → 0). The scan reset covers the case
+    //    where all segments return before the next purge (short-lived buffers).
+    //
+    // 4. CONVERGENCE: idle full chunks that are never picked by scan age undisturbed across
+    //    purge cycles. After CHUNK_PURGE_THRESHOLD + 1 consecutive cycles of being full and
+    //    unpolled, they are evicted. Chunks picked by scan get epoch reset — aging interrupted.
+    //    Thread-local: deterministic, exact (partition orders epoch=0 at head, scan always
+    //    takes head). Shared: approximate, converges over multiple cycles (FIFO queue ordering,
+    //    LRU preference in scan, retained counter in purge).
     abstract static class SizeClassedChunkCache implements ChunkCache {
         static SizeClassedChunkCache create(boolean isThreadLocal) {
             return isThreadLocal ? new ThreadLocalSizeClassedChunkCache() : new SharedSizeClassedChunkCache();
@@ -652,9 +674,9 @@ final class AdaptivePoolingAllocator {
 
         private SizeClassedChunk scanForCapacityFallback() {
             int mask = chunks.length - 1;
+            int emptyCount = count - notEmptyCount;
             int pos = (head + notEmptyCount) & mask;
-            int end = tail;
-            while (pos != end) {
+            for (int i = 0; i < emptyCount; i++) {
                 SizeClassedChunk chunk = chunks[pos];
                 if (chunk.hasRemainingCapacity()) {
                     chunk.purgeEpoch = 0;
@@ -819,8 +841,12 @@ final class AdaptivePoolingAllocator {
      * by this or a later scan, preventing livelock under concurrent access.
      *
      * <p><b>runPurgeScan</b> (every {@link #CHUNK_PURGE_POLLS_SHARED} polls):
-     * drains the queue, ages full chunks (epoch++), resets non-full (epoch=0),
-     * evicts past threshold while retaining at least {@link #CHUNK_REUSE_QUEUE} chunks.
+     * drains the queue, ages full chunks (epoch++), resets non-full (epoch=0).
+     * Non-candidate capacity chunks are re-offered inline. Eviction candidates (full,
+     * epoch past threshold) and no-capacity chunks are deferred to a buffer. After the drain,
+     * the buffer is walked with the known total: candidates are evicted while above
+     * {@link #CHUNK_REUSE_QUEUE}, remainder re-offered. No selection — that is
+     * {@code scanForCapacity}'s job (called after purge via {@code pollChunk}).
      */
     static final class SharedSizeClassedChunkCache extends SizeClassedChunkCache {
         // Must exceed CHUNK_REUSE_QUEUE (the retention floor) to leave room for burst absorption.
@@ -861,22 +887,16 @@ final class AdaptivePoolingAllocator {
             if (first.purgeEpoch == 0 && first.hasRemainingCapacity()) {
                 return first;
             }
-            if (first.hasRemainingCapacity()) {
-                return scanForCapacitySlow(first);
-            }
             long generation = scanGeneration.incrementAndGet();
             first.lastScanGeneration = generation;
+            if (first.hasRemainingCapacity()) {
+                return scanForCapacitySlow(generation, first);
+            }
             if (!queue.offer(first)) {
                 first.markToDeallocate();
                 return null;
             }
             return scanForCapacitySlow(generation, null);
-        }
-
-        private SizeClassedChunk scanForCapacitySlow(SizeClassedChunk fallback) {
-            long generation = scanGeneration.incrementAndGet();
-            fallback.lastScanGeneration = generation;
-            return scanForCapacitySlow(generation, fallback);
         }
 
         private SizeClassedChunk scanForCapacitySlow(long generation, SizeClassedChunk fallback) {
@@ -890,8 +910,8 @@ final class AdaptivePoolingAllocator {
                 }
                 if (chunk.hasRemainingCapacity()) {
                     if (chunk.purgeEpoch == 0) {
-                        if (fallback != null) {
-                            queue.offer(fallback);
+                        if (fallback != null && !queue.offer(fallback)) {
+                            fallback.markToDeallocate();
                         }
                         return chunk;
                     }
@@ -914,8 +934,8 @@ final class AdaptivePoolingAllocator {
 
         private void runPurgeScan() {
             long generation = ++purgeGeneration;
-            int noCapCount = 0;
-            int survivors = queue.size();
+            int bufCount = 0;
+            int retained = 0;
             SizeClassedChunk[] buf = noCapacityBuffer;
             SizeClassedChunk chunk;
             while ((chunk = queue.poll()) != null) {
@@ -925,12 +945,16 @@ final class AdaptivePoolingAllocator {
                     }
                     break;
                 }
+                retained++;
                 int remaining = chunk.remainingCapacity();
                 if (remaining == chunk.capacity()) {
                     chunk.purgeEpoch++;
-                    if (chunk.purgeEpoch > CHUNK_PURGE_THRESHOLD && survivors > CHUNK_REUSE_QUEUE) {
-                        chunk.markToDeallocate();
-                        survivors--;
+                    if (chunk.purgeEpoch > CHUNK_PURGE_THRESHOLD) {
+                        if (bufCount == buf.length) {
+                            buf = Arrays.copyOf(buf, buf.length * 2);
+                            noCapacityBuffer = buf;
+                        }
+                        buf[bufCount++] = chunk;
                         continue;
                     }
                 } else {
@@ -942,19 +966,25 @@ final class AdaptivePoolingAllocator {
                         chunk.markToDeallocate();
                     }
                 } else {
-                    if (noCapCount == buf.length) {
+                    if (bufCount == buf.length) {
                         buf = Arrays.copyOf(buf, buf.length * 2);
                         noCapacityBuffer = buf;
                     }
-                    buf[noCapCount++] = chunk;
+                    buf[bufCount++] = chunk;
                 }
             }
-            for (int i = 0; i < noCapCount; i++) {
-                buf[i].lastPurgeGeneration = generation;
-                if (!queue.offer(buf[i])) {
-                    buf[i].markToDeallocate();
-                }
+            for (int i = 0; i < bufCount; i++) {
+                chunk = buf[i];
                 buf[i] = null;
+                if (chunk.purgeEpoch > CHUNK_PURGE_THRESHOLD && retained > CHUNK_REUSE_QUEUE) {
+                    chunk.markToDeallocate();
+                    retained--;
+                } else {
+                    chunk.lastPurgeGeneration = generation;
+                    if (!queue.offer(chunk)) {
+                        chunk.markToDeallocate();
+                    }
+                }
             }
             purgeBudget.lazySet(CHUNK_PURGE_POLLS_SHARED);
         }

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -624,8 +624,8 @@ final class AdaptivePoolingAllocator {
 
         @Override
         SizeClassedChunk forcePurge() {
-            runPurgeScan();
-            return scanForCapacity();
+            purgeBudget = 1;
+            return pollChunk(0);
         }
 
         @Override
@@ -640,6 +640,7 @@ final class AdaptivePoolingAllocator {
             if (notEmptyCount > 0) {
                 SizeClassedChunk chunk = chunks[head];
                 assert chunk.hasRemainingCapacity();
+                chunk.purgeEpoch = 0;
                 chunks[head] = null;
                 head = (head + 1) & (chunks.length - 1);
                 count--;
@@ -839,15 +840,15 @@ final class AdaptivePoolingAllocator {
 
         @Override
         SizeClassedChunk forcePurge() {
-            purgeBudget.set(CHUNK_PURGE_POLLS_SHARED);
-            return runPurgeScan();
+            purgeBudget.set(1);
+            return pollChunk(0);
         }
 
         @Override
         public SizeClassedChunk pollChunk(int size) {
             long budget = purgeBudget.decrementAndGet();
             if (budget == 0) {
-                return runPurgeScan();
+                runPurgeScan();
             }
             return scanForCapacity();
         }
@@ -911,11 +912,10 @@ final class AdaptivePoolingAllocator {
             return null;
         }
 
-        private SizeClassedChunk runPurgeScan() {
+        private void runPurgeScan() {
             long generation = ++purgeGeneration;
-            SizeClassedChunk selected = null;
             int noCapCount = 0;
-            int retained = 0;
+            int survivors = queue.size();
             SizeClassedChunk[] buf = noCapacityBuffer;
             SizeClassedChunk chunk;
             while ((chunk = queue.poll()) != null) {
@@ -928,23 +928,18 @@ final class AdaptivePoolingAllocator {
                 int remaining = chunk.remainingCapacity();
                 if (remaining == chunk.capacity()) {
                     chunk.purgeEpoch++;
-                    if (chunk.purgeEpoch > CHUNK_PURGE_THRESHOLD && retained >= CHUNK_REUSE_QUEUE) {
+                    if (chunk.purgeEpoch > CHUNK_PURGE_THRESHOLD && survivors > CHUNK_REUSE_QUEUE) {
                         chunk.markToDeallocate();
+                        survivors--;
                         continue;
                     }
                 } else {
                     chunk.purgeEpoch = 0;
                 }
-                retained++;
                 if (remaining > 0) {
-                    if (selected == null) {
-                        selected = chunk;
-                        selected.purgeEpoch = 0;
-                    } else {
-                        chunk.lastPurgeGeneration = generation;
-                        if (!queue.offer(chunk)) {
-                            chunk.markToDeallocate();
-                        }
+                    chunk.lastPurgeGeneration = generation;
+                    if (!queue.offer(chunk)) {
+                        chunk.markToDeallocate();
                     }
                 } else {
                     if (noCapCount == buf.length) {
@@ -962,7 +957,6 @@ final class AdaptivePoolingAllocator {
                 buf[i] = null;
             }
             purgeBudget.lazySet(CHUNK_PURGE_POLLS_SHARED);
-            return selected;
         }
 
         @Override

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -698,8 +698,10 @@ final class AdaptivePoolingAllocator {
             for (int i = 0; i < count; i++) {
                 int readIdx = (head + i) & mask;
                 SizeClassedChunk chunk = chunks[readIdx];
-                int remaining = chunk.remainingCapacity();
-                if (remaining == chunk.capacity()) {
+                if (chunk.purgeEpoch > 0) {
+                    // Unpolled since last purge — still full (no allocations possible,
+                    // scan resets epoch to 0 on pick, so epoch>0 means no scan touched it).
+                    assert chunk.remainingCapacity() == chunk.capacity();
                     chunk.purgeEpoch++;
                     if (chunk.purgeEpoch > CHUNK_PURGE_THRESHOLD && survivors > CHUNK_REUSE_QUEUE) {
                         chunk.markToDeallocate();
@@ -707,8 +709,8 @@ final class AdaptivePoolingAllocator {
                         survivors--;
                         continue;
                     }
-                } else {
-                    chunk.purgeEpoch = 0;
+                } else if (chunk.remainingCapacity() == chunk.capacity()) {
+                    chunk.purgeEpoch = 1;
                 }
                 int writeIdx = (head + kept) & mask;
                 if (writeIdx != readIdx) {

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -894,7 +894,6 @@ final class AdaptivePoolingAllocator {
             }
             if (!queue.offer(first)) {
                 first.markToDeallocate();
-                return null;
             }
             return scanForCapacitySlow(generation, null);
         }

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -957,15 +957,17 @@ final class AdaptivePoolingAllocator {
             return null;
         }
 
-        private void offerOrDeallocate(SizeClassedChunk chunk) {
+        private boolean offerOrDeallocate(SizeClassedChunk chunk) {
             if (!queue.offer(chunk)) {
                 chunk.markToDeallocate();
+                return false;
             }
+            return true;
         }
 
-        private void offerOrDeallocate(SizeClassedChunk chunk, long generation) {
+        private boolean offerOrDeallocate(SizeClassedChunk chunk, long generation) {
             chunk.lastPurgeGeneration = generation;
-            offerOrDeallocate(chunk);
+            return offerOrDeallocate(chunk);
         }
 
         private void runPurgeScan() {
@@ -990,7 +992,9 @@ final class AdaptivePoolingAllocator {
                 }
                 int remaining = chunk.remainingCapacity();
                 if (remaining > 0) {
-                    offerOrDeallocate(chunk, generation);
+                    if (!offerOrDeallocate(chunk, generation)) {
+                        retained--;
+                    }
                 } else {
                     deferred.add(chunk);
                 }
@@ -1001,7 +1005,9 @@ final class AdaptivePoolingAllocator {
                     chunk.markToDeallocate();
                     retained--;
                 } else {
-                    offerOrDeallocate(chunk, generation);
+                    if (!offerOrDeallocate(chunk, generation)) {
+                        retained--;
+                    }
                 }
             }
             deferred.clear();

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -247,7 +247,7 @@ final class AdaptivePoolingAllocator {
             if (!FastThreadLocalThread.currentThreadWillCleanupFastThreadLocals() ||
                     IS_LOW_MEM ||
                     (magazineGroups = threadLocalGroup.get()) == null) {
-                magazineGroups =  sizeClassedMagazineGroups;
+                magazineGroups = sizeClassedMagazineGroups;
             }
             if (index < magazineGroups.length) {
                 allocated = magazineGroups[index].allocate(size, maxCapacity, currentThread, buf);
@@ -296,7 +296,7 @@ final class AdaptivePoolingAllocator {
         chunkRegistry.add(chunk);
         try {
             boolean success = chunk.readInitInto(buf, size, size, maxCapacity);
-            assert success: "Failed to initialize ByteBuf with dedicated chunk";
+            assert success : "Failed to initialize ByteBuf with dedicated chunk";
         } finally {
             // As the chunk is an one-off we need to always call release explicitly as readInitInto(...)
             // will take care of retain once when successful. Once The AdaptiveByteBuf is released it will
@@ -316,7 +316,7 @@ final class AdaptivePoolingAllocator {
      */
     void reallocate(int size, int maxCapacity, AdaptiveByteBuf into) {
         AdaptiveByteBuf result = allocate(size, maxCapacity, Thread.currentThread(), into);
-        assert result == into: "Re-allocation created separate buffer instance";
+        assert result == into : "Re-allocation created separate buffer instance";
     }
 
     long usedMemory() {
@@ -503,6 +503,7 @@ final class AdaptivePoolingAllocator {
 
     interface ChunkCache {
         Chunk pollChunk(int size);
+
         boolean offerChunk(Chunk chunk);
     }
 
@@ -639,13 +640,16 @@ final class AdaptivePoolingAllocator {
             if (notEmptyCount > 0) {
                 SizeClassedChunk chunk = chunks[head];
                 assert chunk.hasRemainingCapacity();
-                chunk.purgeEpoch = 0;
                 chunks[head] = null;
                 head = (head + 1) & (chunks.length - 1);
                 count--;
                 notEmptyCount--;
                 return chunk;
             }
+            return scanForCapacityFallback();
+        }
+
+        private SizeClassedChunk scanForCapacityFallback() {
             int mask = chunks.length - 1;
             int pos = (head + notEmptyCount) & mask;
             int end = tail;
@@ -710,6 +714,7 @@ final class AdaptivePoolingAllocator {
 
         private void partition(int size) {
             int mask = chunks.length - 1;
+            // First pass: hasCapacity to front, noCapacity to back.
             int lo = 0;
             int hi = size - 1;
             while (lo <= hi) {
@@ -725,6 +730,22 @@ final class AdaptivePoolingAllocator {
                 }
             }
             notEmptyCount = lo;
+            // Second pass: within the notEmpty zone [head, head+lo),
+            // sub-partition epoch==0 to front, epoch>0 behind.
+            int elo = 0;
+            int ehi = lo - 1;
+            while (elo <= ehi) {
+                int eloIdx = (head + elo) & mask;
+                if (chunks[eloIdx].purgeEpoch == 0) {
+                    elo++;
+                } else {
+                    int ehiIdx = (head + ehi) & mask;
+                    SizeClassedChunk tmp = chunks[eloIdx];
+                    chunks[eloIdx] = chunks[ehiIdx];
+                    chunks[ehiIdx] = tmp;
+                    ehi--;
+                }
+            }
         }
 
         @Override
@@ -749,11 +770,11 @@ final class AdaptivePoolingAllocator {
             int mask = chunks.length - 1;
             StringBuilder sb = new StringBuilder();
             sb.append("ThreadLocalCache[head=").append(head)
-              .append(", tail=").append(tail)
-              .append(", count=").append(count)
-              .append(", notEmpty=").append(notEmptyCount)
-              .append(", length=").append(chunks.length)
-              .append("]\n  ");
+                    .append(", tail=").append(tail)
+                    .append(", count=").append(count)
+                    .append(", notEmpty=").append(notEmptyCount)
+                    .append(", length=").append(chunks.length)
+                    .append("]\n  ");
             for (int i = 0; i < count; i++) {
                 if (i > 0) {
                     sb.append(", ");
@@ -766,12 +787,40 @@ final class AdaptivePoolingAllocator {
                 String actual = c == null ? "null" :
                         c.hasRemainingCapacity() ? "hasCap" : "noCap";
                 sb.append('[').append(region).append(':').append(actual)
-                  .append(",ep=").append(c == null ? -1 : c.purgeEpoch).append(']');
+                        .append(",ep=").append(c == null ? -1 : c.purgeEpoch).append(']');
             }
             return sb.toString();
         }
     }
 
+    /**
+     * MPMC queue cache for shared (cross-thread) chunk reuse.
+     *
+     * <p><b>scanForCapacity</b> — LRU preference with fallback:
+     * <pre>
+     *   fast path: head chunk has purgeEpoch == 0 and capacity → return O(1)
+     *
+     *   slow path: scan for epoch=0 chunk, hold first idle (epoch &gt; 0) as fallback
+     *     queue: [E&gt;0, E&gt;0, E=0, E&gt;0, ...]
+     *             skip   skip  ↑ return (put fallback back)
+     *
+     *   no epoch=0 found → use fallback, reset its epoch to 0
+     * </pre>
+     *
+     * <p>The LRU preference creates a natural separation: recently-used chunks (epoch=0,
+     * returned via {@link #offerChunk} after magazine use) cycle at the front. Idle chunks
+     * (epoch &gt; 0, aged by purge) are scanned past but never returned — they age undisturbed.
+     * When no recently-used chunks exist, idle ones are reused (fallback) rather than
+     * allocating new chunks.
+     *
+     * <p>All re-offered chunks are stamped with {@code lastScanGeneration} for cycle detection.
+     * The {@code >=} check terminates the scan when encountering any chunk already processed
+     * by this or a later scan, preventing livelock under concurrent access.
+     *
+     * <p><b>runPurgeScan</b> (every {@link #CHUNK_PURGE_POLLS_SHARED} polls):
+     * drains the queue, ages full chunks (epoch++), resets non-full (epoch=0),
+     * evicts past threshold while retaining at least {@link #CHUNK_REUSE_QUEUE} chunks.
+     */
     static final class SharedSizeClassedChunkCache extends SizeClassedChunkCache {
         // Must exceed CHUNK_REUSE_QUEUE (the retention floor) to leave room for burst absorption.
         // TODO replace with an unbounded concurrent collection once available.
@@ -808,8 +857,11 @@ final class AdaptivePoolingAllocator {
             if (first == null) {
                 return null;
             }
-            if (first.hasRemainingCapacity()) {
+            if (first.purgeEpoch == 0 && first.hasRemainingCapacity()) {
                 return first;
+            }
+            if (first.hasRemainingCapacity()) {
+                return scanForCapacitySlow(first);
             }
             long generation = scanGeneration.incrementAndGet();
             first.lastScanGeneration = generation;
@@ -817,20 +869,44 @@ final class AdaptivePoolingAllocator {
                 first.markToDeallocate();
                 return null;
             }
+            return scanForCapacitySlow(generation, null);
+        }
+
+        private SizeClassedChunk scanForCapacitySlow(SizeClassedChunk fallback) {
+            long generation = scanGeneration.incrementAndGet();
+            fallback.lastScanGeneration = generation;
+            return scanForCapacitySlow(generation, fallback);
+        }
+
+        private SizeClassedChunk scanForCapacitySlow(long generation, SizeClassedChunk fallback) {
             SizeClassedChunk chunk;
             while ((chunk = queue.poll()) != null) {
                 if (chunk.lastScanGeneration >= generation) {
                     if (!queue.offer(chunk)) {
                         chunk.markToDeallocate();
                     }
-                    return null;
+                    break;
                 }
                 if (chunk.hasRemainingCapacity()) {
-                    return chunk;
+                    if (chunk.purgeEpoch == 0) {
+                        if (fallback != null) {
+                            queue.offer(fallback);
+                        }
+                        return chunk;
+                    }
+                    if (fallback == null) {
+                        fallback = chunk;
+                        continue;
+                    }
                 }
+                chunk.lastScanGeneration = generation;
                 if (!queue.offer(chunk)) {
                     chunk.markToDeallocate();
                 }
+            }
+            if (fallback != null) {
+                fallback.purgeEpoch = 0;
+                return fallback;
             }
             return null;
         }
@@ -1128,9 +1204,11 @@ final class AdaptivePoolingAllocator {
 
     private static final class Magazine {
         private static final AtomicReferenceFieldUpdater<Magazine, Chunk> NEXT_IN_LINE;
+
         static {
             NEXT_IN_LINE = AtomicReferenceFieldUpdater.newUpdater(Magazine.class, Chunk.class, "nextInLine");
         }
+
         private static final Chunk MAGAZINE_FREED = new Chunk();
 
         private static final class AdaptiveRecycler extends Recycler<AdaptiveByteBuf> {
@@ -1382,7 +1460,7 @@ final class AdaptivePoolingAllocator {
 
         public AdaptiveByteBuf newBuffer() {
             AdaptiveRecycler recycler = this.recycler;
-            AdaptiveByteBuf buf = recycler == null? EVENT_LOOP_LOCAL_BUFFER_POOL.get() : recycler.get();
+            AdaptiveByteBuf buf = recycler == null ? EVENT_LOOP_LOCAL_BUFFER_POOL.get() : recycler.get();
             buf.resetRefCnt();
             buf.discardMarks();
             return buf;
@@ -1449,7 +1527,7 @@ final class AdaptivePoolingAllocator {
             }
         }
 
-        Magazine currentMagazine()  {
+        Magazine currentMagazine() {
             return magazine;
         }
 
@@ -1489,7 +1567,7 @@ final class AdaptivePoolingAllocator {
         }
 
         private void retain() {
-                RefCnt.retain(refCnt);
+            RefCnt.retain(refCnt);
         }
 
         protected boolean release() {
@@ -1620,7 +1698,7 @@ final class AdaptivePoolingAllocator {
         // making late-arriving releaseSegment calls on external threads arithmetically harmless.
         private static final int DEALLOCATED = Integer.MIN_VALUE;
         private static final AtomicIntegerFieldUpdater<SizeClassedChunk> STATE =
-            AtomicIntegerFieldUpdater.newUpdater(SizeClassedChunk.class, "state");
+                AtomicIntegerFieldUpdater.newUpdater(SizeClassedChunk.class, "state");
         private volatile int state;
         private final int segments;
         private final int segmentSize;
@@ -2052,7 +2130,7 @@ final class AdaptivePoolingAllocator {
             allocator.reallocate(newCapacity, maxCapacity(), this);
             oldRoot.getBytes(baseOldRootIndex, this, 0, oldLength);
             chunk.releaseSegment(baseOldRootIndex, oldCapacity);
-            assert oldCapacity < maxFastCapacity && newCapacity <= maxFastCapacity:
+            assert oldCapacity < maxFastCapacity && newCapacity <= maxFastCapacity :
                     "Capacity increase failed";
             this.readerIndex = readerIndex;
             this.writerIndex = writerIndex;
@@ -2489,8 +2567,9 @@ final class AdaptivePoolingAllocator {
     interface ChunkAllocator {
         /**
          * Allocate a buffer for a chunk. This can be any kind of {@link AbstractByteBuf} implementation.
+         *
          * @param initialCapacity The initial capacity of the returned {@link AbstractByteBuf}.
-         * @param maxCapacity The maximum capacity of the returned {@link AbstractByteBuf}.
+         * @param maxCapacity     The maximum capacity of the returned {@link AbstractByteBuf}.
          * @return The buffer that represents the chunk memory.
          */
         AbstractByteBuf allocate(int initialCapacity, int maxCapacity);

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -486,18 +486,16 @@ final class AdaptivePoolingAllocator {
         }
 
         private void freeChunkReuseQueue(Thread ownerThread) {
-            Chunk chunk;
-            while ((chunk = chunkCache.pollChunk(0)) != null) {
-                if (ownerThread != null && chunk instanceof SizeClassedChunk) {
-                    SizeClassedChunk threadLocalChunk = (SizeClassedChunk) chunk;
-                    assert ownerThread == threadLocalChunk.ownerThread;
-                    // no release segment can ever happen from the owner Thread since it's not running anymore
-                    // This is required to let the ownerThread to be GC'ed despite there are AdaptiveByteBuf
-                    // that reference some thread local chunk
-                    threadLocalChunk.ownerThread = null;
+            if (ownerThread != null && chunkCache instanceof ThreadLocalSizeClassedChunkCache) {
+                ThreadLocalSizeClassedChunkCache tlCache = (ThreadLocalSizeClassedChunkCache) chunkCache;
+                int mask = tlCache.chunks.length - 1;
+                for (int i = 0; i < tlCache.count; i++) {
+                    SizeClassedChunk chunk = tlCache.chunks[(tlCache.head + i) & mask];
+                    assert ownerThread == chunk.ownerThread;
+                    chunk.ownerThread = null;
                 }
-                chunk.markToDeallocate();
             }
+            chunkCache.free();
         }
     }
 
@@ -505,6 +503,10 @@ final class AdaptivePoolingAllocator {
         Chunk pollChunk(int size);
 
         boolean offerChunk(Chunk chunk);
+
+        void free();
+
+        boolean isEmpty();
     }
 
     // Cached chunks are detached from magazines: no readInitInto can happen, so segment count
@@ -825,6 +827,25 @@ final class AdaptivePoolingAllocator {
             }
             return sb.toString();
         }
+
+        @Override
+        public void free() {
+            int mask = chunks.length - 1;
+            for (int i = 0; i < count; i++) {
+                int idx = (head + i) & mask;
+                chunks[idx].markToDeallocate();
+                chunks[idx] = null;
+            }
+            head = 0;
+            tail = 0;
+            count = 0;
+            notEmptyCount = 0;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return count == 0;
+        }
     }
 
     /**
@@ -1003,6 +1024,19 @@ final class AdaptivePoolingAllocator {
         public boolean offerChunk(Chunk chunk) {
             return queue.offer((SizeClassedChunk) chunk);
         }
+
+        @Override
+        public void free() {
+            SizeClassedChunk chunk;
+            while ((chunk = queue.poll()) != null) {
+                chunk.markToDeallocate();
+            }
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return queue.isEmpty();
+        }
     }
 
     private static final class ConcurrentSkipListChunkCache implements ChunkCache {
@@ -1090,6 +1124,21 @@ final class AdaptivePoolingAllocator {
                 size = chunks.size();
             }
             return true;
+        }
+
+        @Override
+        public void free() {
+            for (IntEntry<Chunk> entry : chunks) {
+                Chunk chunk = entry.getValue();
+                if (chunk != null && chunks.remove(entry.getKey(), chunk)) {
+                    chunk.markToDeallocate();
+                }
+            }
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return chunks.isEmpty();
         }
     }
 

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -47,9 +47,9 @@ import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.StampedLock;
@@ -77,9 +77,8 @@ import java.util.function.IntConsumer;
  * This allows the allocator to quickly respond to changes in the application workload,
  * without suffering undue overhead from maintaining its statistics.
  * <p>
- * Since magazines are "relatively thread-local", the allocator has a central queue that allow excess chunks from any
- * magazine, to be shared with other magazines.
- * The {@link #createSharedChunkQueue()} method can be overridden to customize this queue.
+ * Since magazines are "relatively thread-local", the allocator has a chunk cache that allows excess chunks from any
+ * magazine to be shared with other magazines.
  */
 @UnstableApi
 final class AdaptivePoolingAllocator {
@@ -122,8 +121,17 @@ final class AdaptivePoolingAllocator {
      * The default size is twice {@link NettyRuntime#availableProcessors()},
      * same as the maximum number of magazines per magazine group.
      */
-    private static final int CHUNK_REUSE_QUEUE = Math.max(2, SystemPropertyUtil.getInt(
+    static final int CHUNK_REUSE_QUEUE = Math.max(2, SystemPropertyUtil.getInt(
             "io.netty.allocator.chunkReuseQueueCapacity", NettyRuntime.availableProcessors() * 2));
+
+    static final long CHUNK_PURGE_POLLS_THREAD_LOCAL = SystemPropertyUtil.getLong(
+            "io.netty.allocator.chunkPurgePollsThreadLocal", 16L);
+
+    static final long CHUNK_PURGE_POLLS_SHARED = SystemPropertyUtil.getLong(
+            "io.netty.allocator.chunkPurgePollsShared", 128L);
+
+    static final int CHUNK_PURGE_THRESHOLD = SystemPropertyUtil.getInt(
+            "io.netty.allocator.chunkPurgeThreshold", 3);
 
     /**
      * The capacity if the magazine local buffer queue. This queue just pools the outer ByteBuf instance and not
@@ -225,30 +233,6 @@ final class AdaptivePoolingAllocator {
                     new SizeClassChunkManagementStrategy(segmentSize), isThreadLocal);
         }
         return groups;
-    }
-
-    /**
-     * Create a thread-safe multi-producer, multi-consumer queue to hold chunks that spill over from the
-     * internal Magazines.
-     * <p>
-     * Each Magazine can only hold two chunks at any one time: the chunk it currently allocates from,
-     * and the next-in-line chunk which will be used for allocation once the current one has been used up.
-     * This queue will be used by magazines to share any excess chunks they allocate, so that they don't need to
-     * allocate new chunks when their current and next-in-line chunks have both been used up.
-     * <p>
-     * The simplest implementation of this method is to return a new {@link ConcurrentLinkedQueue}.
-     * However, the {@code CLQ} is unbounded, and this means there's no limit to how many chunks can be cached in this
-     * queue.
-     * <p>
-     * Each chunk in this queue can be up to {@link #MAX_CHUNK_SIZE} in size, so it is recommended to use a bounded
-     * queue to limit the maximum memory usage.
-     * <p>
-     * The default implementation will create a bounded queue with a capacity of {@link #CHUNK_REUSE_QUEUE}.
-     *
-     * @return A new multi-producer, multi-consumer queue.
-     */
-    private static Queue<SizeClassedChunk> createSharedChunkQueue() {
-        return PlatformDependent.newFixedMpmcQueue(CHUNK_REUSE_QUEUE);
     }
 
     ByteBuf allocate(int size, int maxCapacity) {
@@ -517,34 +501,392 @@ final class AdaptivePoolingAllocator {
         }
     }
 
-    private interface ChunkCache {
+    interface ChunkCache {
         Chunk pollChunk(int size);
         boolean offerChunk(Chunk chunk);
     }
 
-    private static final class ConcurrentQueueChunkCache implements ChunkCache {
-        private final Queue<SizeClassedChunk> queue;
+    // Cached chunks are detached from magazines: no readInitInto can happen, so segment count
+    // can only grow (external releaseSegment returns) and never shrink. Once a chunk reaches
+    // full capacity (remainingCapacity == capacity), it stays fully free while in the cache.
+    abstract static class SizeClassedChunkCache implements ChunkCache {
+        static SizeClassedChunkCache create(boolean isThreadLocal) {
+            return isThreadLocal ? new ThreadLocalSizeClassedChunkCache() : new SharedSizeClassedChunkCache();
+        }
 
-        private ConcurrentQueueChunkCache() {
-            queue = createSharedChunkQueue();
+        @Override
+        public abstract SizeClassedChunk pollChunk(int size);
+
+        // Visible for testing: triggers a purge scan bypassing the budget counter.
+        abstract SizeClassedChunk forcePurge();
+    }
+
+    /**
+     * Ring buffer cache for thread-local chunk reuse (SPSC — only the owner thread accesses it).
+     *
+     * <p>Logical layout after purge:
+     * <pre>
+     *   head                          tail
+     *   v                             v
+     *   [..., notEmpty, notEmpty, ..., empty, empty, ..., null, ...]
+     *        |--- notEmptyCount ---|--- emptyCount --|
+     *        |------------ count ------------------|
+     * </pre>
+     *
+     * <p>Physical layout when the ring wraps:
+     * <pre>
+     *   0         tail          head          length
+     *   v         v             v             v
+     *   [...tail] [  unused  ]  [head................]
+     *             ^             |--- content wraps ---|
+     *             wrap point
+     * </pre>
+     *
+     * <p><b>scanForCapacity</b> — O(1) fast path takes from head while {@code notEmptyCount > 0}:
+     * <pre>
+     *   before: notEmptyCount=2, count=5
+     *   [NE, NE, E, E, E, _, _, _]
+     *    ^head            ^tail
+     *
+     *   after: returns NE, notEmptyCount=1, count=4
+     *   [_,  NE, E, E, E, _, _, _]
+     *        ^head        ^tail
+     * </pre>
+     * Fallback when {@code notEmptyCount == 0}: linear scan of the empty zone for chunks
+     * that gained capacity from external segment returns.
+     *
+     * <p><b>offerChunk</b> — write at tail, grow (double + linearize) if full:
+     * <pre>
+     *   before: count=4
+     *   [_,  NE, E, E, E, _, _, _]
+     *        ^head        ^tail
+     *
+     *   after: count=5
+     *   [_,  NE, E, E, E, X, _, _]
+     *        ^head           ^tail
+     * </pre>
+     *
+     * <p><b>runPurgeScan</b> (every {@link #CHUNK_PURGE_POLLS_THREAD_LOCAL} polls) —
+     * ages idle chunks, evicts past threshold. Never selects — selection is always
+     * {@code scanForCapacity}. Compact (closeGap) only runs when an eviction removed
+     * something. Partition always runs to pick up chunks that gained capacity externally.
+     *
+     * <p>Case 1 — no eviction, an empty chunk gained capacity externally (common):
+     * <pre>
+     *   before (E* gained capacity since last purge):
+     *   [NE, NE, E*, E, _, _, _, _]
+     *    ^head            ^tail
+     *    notEmptyCount=2
+     *
+     *   scan: age idle chunks. None past threshold. No eviction → no compact.
+     *   partition: E* now has capacity → swapped into notEmpty zone.
+     *
+     *   after:
+     *   [NE, NE, E*, E, _, _, _, _]
+     *    ^head            ^tail
+     *    notEmptyCount=3
+     * </pre>
+     *
+     * <p>Case 2 — eviction (uncommon, burst wind-down):
+     * <pre>
+     *   before (ring wraps, IDLE* = idle past threshold):
+     *   [E, NE, _,  IDLE*, NE, E, E, NE]
+     *          ^tail ^head
+     *
+     *   scan: IDLE* evicted (markToDeallocate). Remaining entries compacted → closeGap(kept).
+     *
+     *   after closeGap:
+     *   [NE, _, _,  NE, E, E, NE, E]
+     *       ^tail   ^head
+     *               |--- kept=6 ---|
+     *
+     *   after partition: notEmpty swapped to front, empty to back.
+     *   [NE, _, _,  NE, NE, E, E, E]
+     *       ^tail   ^head
+     *               notEmptyCount=2, count=6
+     * </pre>
+     * Idle chunks ({@code remainingCapacity == capacity}) age via purgeEpoch and are evicted
+     * past threshold, but at least {@link #CHUNK_REUSE_QUEUE} chunks are always retained.
+     */
+    static final class ThreadLocalSizeClassedChunkCache extends SizeClassedChunkCache {
+        private SizeClassedChunk[] chunks;
+        private int head;
+        private int tail;
+        private int count;
+        private int notEmptyCount;
+        private long purgeBudget;
+
+        ThreadLocalSizeClassedChunkCache() {
+            chunks = new SizeClassedChunk[8];
+            purgeBudget = CHUNK_PURGE_POLLS_THREAD_LOCAL;
+        }
+
+        @Override
+        SizeClassedChunk forcePurge() {
+            runPurgeScan();
+            return scanForCapacity();
         }
 
         @Override
         public SizeClassedChunk pollChunk(int size) {
-            // we really don't care about size here since the sized class chunk q
-            // just care about segments of fixed size!
-            Queue<SizeClassedChunk> queue = this.queue;
-            for (int i = 0; i < CHUNK_REUSE_QUEUE; i++) {
-                SizeClassedChunk chunk = queue.poll();
-                if (chunk == null) {
+            if (--purgeBudget == 0) {
+                runPurgeScan();
+            }
+            return scanForCapacity();
+        }
+
+        private SizeClassedChunk scanForCapacity() {
+            if (notEmptyCount > 0) {
+                SizeClassedChunk chunk = chunks[head];
+                assert chunk.hasRemainingCapacity();
+                chunk.purgeEpoch = 0;
+                chunks[head] = null;
+                head = (head + 1) & (chunks.length - 1);
+                count--;
+                notEmptyCount--;
+                return chunk;
+            }
+            int mask = chunks.length - 1;
+            int pos = (head + notEmptyCount) & mask;
+            int end = tail;
+            while (pos != end) {
+                SizeClassedChunk chunk = chunks[pos];
+                if (chunk.hasRemainingCapacity()) {
+                    chunk.purgeEpoch = 0;
+                    int lastIdx = (tail - 1) & mask;
+                    chunks[pos] = chunks[lastIdx];
+                    chunks[lastIdx] = null;
+                    tail = lastIdx;
+                    count--;
+                    return chunk;
+                }
+                pos = (pos + 1) & mask;
+            }
+            return null;
+        }
+
+        private void runPurgeScan() {
+            int mask = chunks.length - 1;
+            int kept = 0;
+            int survivors = count;
+            boolean evicted = false;
+            for (int i = 0; i < count; i++) {
+                int readIdx = (head + i) & mask;
+                SizeClassedChunk chunk = chunks[readIdx];
+                int remaining = chunk.remainingCapacity();
+                if (remaining == chunk.capacity()) {
+                    chunk.purgeEpoch++;
+                    if (chunk.purgeEpoch > CHUNK_PURGE_THRESHOLD && survivors > CHUNK_REUSE_QUEUE) {
+                        chunk.markToDeallocate();
+                        survivors--;
+                        evicted = true;
+                        continue;
+                    }
+                } else {
+                    chunk.purgeEpoch = 0;
+                }
+                if (evicted) {
+                    chunks[(head + kept) & mask] = chunk;
+                }
+                kept++;
+            }
+            if (evicted) {
+                closeGap(kept);
+            }
+            partition(evicted ? kept : count);
+            purgeBudget = CHUNK_PURGE_POLLS_THREAD_LOCAL;
+        }
+
+        private void closeGap(int kept) {
+            int mask = chunks.length - 1;
+            int gapStart = (head + kept) & mask;
+            Arrays.fill(chunks, gapStart, gapStart <= tail ? tail : chunks.length, null);
+            if (gapStart > tail) {
+                Arrays.fill(chunks, 0, tail, null);
+            }
+            tail = (head + kept) & mask;
+            count = kept;
+        }
+
+        private void partition(int size) {
+            int mask = chunks.length - 1;
+            int lo = 0;
+            int hi = size - 1;
+            while (lo <= hi) {
+                int loIdx = (head + lo) & mask;
+                if (chunks[loIdx].hasRemainingCapacity()) {
+                    lo++;
+                } else {
+                    int hiIdx = (head + hi) & mask;
+                    SizeClassedChunk tmp = chunks[loIdx];
+                    chunks[loIdx] = chunks[hiIdx];
+                    chunks[hiIdx] = tmp;
+                    hi--;
+                }
+            }
+            notEmptyCount = lo;
+        }
+
+        @Override
+        public boolean offerChunk(Chunk chunk) {
+            if (count == chunks.length) {
+                SizeClassedChunk[] newChunks = new SizeClassedChunk[chunks.length * 2];
+                for (int i = 0; i < count; i++) {
+                    newChunks[i] = chunks[(head + i) & (chunks.length - 1)];
+                }
+                chunks = newChunks;
+                head = 0;
+                tail = count;
+            }
+            chunks[tail] = (SizeClassedChunk) chunk;
+            tail = (tail + 1) & (chunks.length - 1);
+            count++;
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            int mask = chunks.length - 1;
+            StringBuilder sb = new StringBuilder();
+            sb.append("ThreadLocalCache[head=").append(head)
+              .append(", tail=").append(tail)
+              .append(", count=").append(count)
+              .append(", notEmpty=").append(notEmptyCount)
+              .append(", length=").append(chunks.length)
+              .append("]\n  ");
+            for (int i = 0; i < count; i++) {
+                if (i > 0) {
+                    sb.append(", ");
+                }
+                if (i == notEmptyCount) {
+                    sb.append("| ");
+                }
+                SizeClassedChunk c = chunks[(head + i) & mask];
+                String region = i < notEmptyCount ? "notEmpty" : "empty";
+                String actual = c == null ? "null" :
+                        c.hasRemainingCapacity() ? "hasCap" : "noCap";
+                sb.append('[').append(region).append(':').append(actual)
+                  .append(",ep=").append(c == null ? -1 : c.purgeEpoch).append(']');
+            }
+            return sb.toString();
+        }
+    }
+
+    static final class SharedSizeClassedChunkCache extends SizeClassedChunkCache {
+        // Must exceed CHUNK_REUSE_QUEUE (the retention floor) to leave room for burst absorption.
+        // TODO replace with an unbounded concurrent collection once available.
+        private static final int SHARED_CACHE_CAPACITY = Math.max(128, CHUNK_REUSE_QUEUE * 2);
+        private final Queue<SizeClassedChunk> queue;
+        private final AtomicLong purgeBudget;
+        private SizeClassedChunk[] noCapacityBuffer;
+        private long purgeGeneration;
+        private final AtomicLong scanGeneration = new AtomicLong();
+
+        SharedSizeClassedChunkCache() {
+            queue = PlatformDependent.newFixedMpmcQueue(SHARED_CACHE_CAPACITY);
+            purgeBudget = new AtomicLong(CHUNK_PURGE_POLLS_SHARED);
+            noCapacityBuffer = new SizeClassedChunk[8];
+        }
+
+        @Override
+        SizeClassedChunk forcePurge() {
+            purgeBudget.set(CHUNK_PURGE_POLLS_SHARED);
+            return runPurgeScan();
+        }
+
+        @Override
+        public SizeClassedChunk pollChunk(int size) {
+            long budget = purgeBudget.decrementAndGet();
+            if (budget == 0) {
+                return runPurgeScan();
+            }
+            return scanForCapacity();
+        }
+
+        private SizeClassedChunk scanForCapacity() {
+            SizeClassedChunk first = queue.poll();
+            if (first == null) {
+                return null;
+            }
+            if (first.hasRemainingCapacity()) {
+                return first;
+            }
+            long generation = scanGeneration.incrementAndGet();
+            first.lastScanGeneration = generation;
+            if (!queue.offer(first)) {
+                first.markToDeallocate();
+                return null;
+            }
+            SizeClassedChunk chunk;
+            while ((chunk = queue.poll()) != null) {
+                if (chunk.lastScanGeneration >= generation) {
+                    if (!queue.offer(chunk)) {
+                        chunk.markToDeallocate();
+                    }
                     return null;
                 }
                 if (chunk.hasRemainingCapacity()) {
                     return chunk;
                 }
-                queue.offer(chunk);
+                if (!queue.offer(chunk)) {
+                    chunk.markToDeallocate();
+                }
             }
             return null;
+        }
+
+        private SizeClassedChunk runPurgeScan() {
+            long generation = ++purgeGeneration;
+            SizeClassedChunk selected = null;
+            int noCapCount = 0;
+            int retained = 0;
+            SizeClassedChunk[] buf = noCapacityBuffer;
+            SizeClassedChunk chunk;
+            while ((chunk = queue.poll()) != null) {
+                if (chunk.lastPurgeGeneration == generation) {
+                    if (!queue.offer(chunk)) {
+                        chunk.markToDeallocate();
+                    }
+                    break;
+                }
+                int remaining = chunk.remainingCapacity();
+                if (remaining == chunk.capacity()) {
+                    chunk.purgeEpoch++;
+                    if (chunk.purgeEpoch > CHUNK_PURGE_THRESHOLD && retained >= CHUNK_REUSE_QUEUE) {
+                        chunk.markToDeallocate();
+                        continue;
+                    }
+                } else {
+                    chunk.purgeEpoch = 0;
+                }
+                retained++;
+                if (remaining > 0) {
+                    if (selected == null) {
+                        selected = chunk;
+                        selected.purgeEpoch = 0;
+                    } else {
+                        chunk.lastPurgeGeneration = generation;
+                        if (!queue.offer(chunk)) {
+                            chunk.markToDeallocate();
+                        }
+                    }
+                } else {
+                    if (noCapCount == buf.length) {
+                        buf = Arrays.copyOf(buf, buf.length * 2);
+                        noCapacityBuffer = buf;
+                    }
+                    buf[noCapCount++] = chunk;
+                }
+            }
+            for (int i = 0; i < noCapCount; i++) {
+                buf[i].lastPurgeGeneration = generation;
+                if (!queue.offer(buf[i])) {
+                    buf[i].markToDeallocate();
+                }
+                buf[i] = null;
+            }
+            purgeBudget.lazySet(CHUNK_PURGE_POLLS_SHARED);
+            return selected;
         }
 
         @Override
@@ -679,7 +1021,7 @@ final class AdaptivePoolingAllocator {
 
         @Override
         public ChunkCache createChunkCache(boolean isThreadLocal) {
-            return new ConcurrentQueueChunkCache();
+            return SizeClassedChunkCache.create(isThreadLocal);
         }
     }
 
@@ -1067,7 +1409,7 @@ final class AdaptivePoolingAllocator {
         }
     }
 
-    private static class Chunk implements ChunkInfo {
+    static class Chunk implements ChunkInfo {
         protected final AbstractByteBuf delegate;
         protected Magazine magazine;
         private final AdaptivePoolingAllocator allocator;
@@ -1271,7 +1613,7 @@ final class AdaptivePoolingAllocator {
      * StoreLoad barrier via its {@code offer()}), then reads {@code state} — this guarantees
      * visibility of any preceding {@link #markToDeallocate()} write.
      */
-    private static final class SizeClassedChunk extends Chunk {
+    static class SizeClassedChunk extends Chunk {
         private static final int FREE_LIST_EMPTY = -1;
         private static final int AVAILABLE = -1;
         // Integer.MIN_VALUE so that `DEALLOCATED + externalFreeList.size()` can never equal `segments`,
@@ -1285,6 +1627,9 @@ final class AdaptivePoolingAllocator {
         private final MpscIntQueue externalFreeList;
         private final IntStack localFreeList;
         private Thread ownerThread;
+        int purgeEpoch;
+        long lastPurgeGeneration;
+        long lastScanGeneration;
 
         SizeClassedChunk(AbstractByteBuf delegate, Magazine magazine,
                          SizeClassChunkController controller) {

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -44,6 +44,7 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.ScatteringByteChannel;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Queue;
@@ -130,8 +131,8 @@ final class AdaptivePoolingAllocator {
     static final long CHUNK_PURGE_POLLS_SHARED = Math.max(1, SystemPropertyUtil.getLong(
             "io.netty.allocator.chunkPurgePollsShared", 128L));
 
-    static final int CHUNK_PURGE_THRESHOLD = SystemPropertyUtil.getInt(
-            "io.netty.allocator.chunkPurgeThreshold", 3);
+    static final int CHUNK_PURGE_THRESHOLD = Math.max(1, SystemPropertyUtil.getInt(
+            "io.netty.allocator.chunkPurgeThreshold", 3));
 
     /**
      * The capacity if the magazine local buffer queue. This queue just pools the outer ByteBuf instance and not
@@ -511,25 +512,25 @@ final class AdaptivePoolingAllocator {
 
     // Cached chunks are detached from magazines: no readInitInto can happen, so segment count
     // can only grow (external releaseSegment returns) and never shrink. Once a chunk reaches
-    // full capacity (remainingCapacity == capacity), it stays fully free while in the cache.
+    // full capacity (hasFullCapacity), it stays idle while in the cache.
     //
     // Epoch-based aging invariants (both caches):
     //
-    // 1. CLASSIFICATION: purge scans all chunks. Full (remainingCapacity == capacity) → epoch++.
-    //    Non-full → epoch = 0. Only full chunks can accumulate epoch.
+    // 1. CLASSIFICATION: purge scans all chunks. Idle (hasFullCapacity) → epoch++.
+    //    Non-idle → epoch = 0. Only idle chunks can accumulate epoch.
     //
-    // 2. EVICTION: full chunks with epoch > CHUNK_PURGE_THRESHOLD are evicted (markToDeallocate).
+    // 2. EVICTION: idle chunks with epoch > CHUNK_PURGE_THRESHOLD are evicted (markToDeallocate).
     //    Eviction is immediate — all segments are in, no outstanding references.
-    //    Non-full chunks are never evicted (deallocation would be deferred, not immediate).
+    //    Non-idle chunks are never evicted (deallocation would be deferred, not immediate).
     //    At least CHUNK_REUSE_QUEUE chunks are always retained (retention floor).
     //
     // 3. SCAN RESET: scanForCapacity resets purgeEpoch = 0 on the chunk it picks. The scan
-    //    knows the chunk is being used. The chunk gets allocated from, becomes non-full, and
-    //    the next purge resets its epoch anyway (non-full → 0). The scan reset covers the case
+    //    knows the chunk is being used. The chunk gets allocated from, becomes non-idle, and
+    //    the next purge resets its epoch anyway (non-idle → 0). The scan reset covers the case
     //    where all segments return before the next purge (short-lived buffers).
     //
-    // 4. CONVERGENCE: idle full chunks that are never picked by scan age undisturbed across
-    //    purge cycles. After CHUNK_PURGE_THRESHOLD + 1 consecutive cycles of being full and
+    // 4. CONVERGENCE: idle chunks that are never picked by scan age undisturbed across
+    //    purge cycles. After CHUNK_PURGE_THRESHOLD + 1 consecutive cycles of being idle and
     //    unpolled, they are evicted. Chunks picked by scan get epoch reset — aging interrupted.
     //    Thread-local: partition orders [epoch=0 | 0<epoch<T | epoch>=T | noCap]. Scan takes
     //    from head (epoch=0 first). Chunks with epoch>=threshold are placed at the back of
@@ -886,14 +887,13 @@ final class AdaptivePoolingAllocator {
         private static final int SHARED_CACHE_CAPACITY = Math.max(128, CHUNK_REUSE_QUEUE * 2);
         private final Queue<SizeClassedChunk> queue;
         private final AtomicLong purgeBudget;
-        private SizeClassedChunk[] noCapacityBuffer;
+        private final ArrayList<SizeClassedChunk> deferredBuffer = new ArrayList<>();
         private long purgeGeneration;
         private final AtomicLong scanGeneration = new AtomicLong();
 
         SharedSizeClassedChunkCache() {
             queue = PlatformDependent.newFixedMpmcQueue(SHARED_CACHE_CAPACITY);
             purgeBudget = new AtomicLong(CHUNK_PURGE_POLLS_SHARED);
-            noCapacityBuffer = new SizeClassedChunk[8];
         }
 
         @Override
@@ -924,9 +924,7 @@ final class AdaptivePoolingAllocator {
             if (first.hasRemainingCapacity()) {
                 return scanForCapacitySlow(generation, first);
             }
-            if (!queue.offer(first)) {
-                first.markToDeallocate();
-            }
+            offerOrDeallocate(first);
             return scanForCapacitySlow(generation, null);
         }
 
@@ -934,15 +932,13 @@ final class AdaptivePoolingAllocator {
             SizeClassedChunk chunk;
             while ((chunk = queue.poll()) != null) {
                 if (chunk.lastScanGeneration >= generation) {
-                    if (!queue.offer(chunk)) {
-                        chunk.markToDeallocate();
-                    }
+                    offerOrDeallocate(chunk);
                     break;
                 }
                 if (chunk.hasRemainingCapacity()) {
                     if (chunk.purgeEpoch == 0) {
-                        if (fallback != null && !queue.offer(fallback)) {
-                            fallback.markToDeallocate();
+                        if (fallback != null) {
+                            offerOrDeallocate(fallback);
                         }
                         return chunk;
                     }
@@ -952,9 +948,7 @@ final class AdaptivePoolingAllocator {
                     }
                 }
                 chunk.lastScanGeneration = generation;
-                if (!queue.offer(chunk)) {
-                    chunk.markToDeallocate();
-                }
+                offerOrDeallocate(chunk);
             }
             if (fallback != null) {
                 fallback.purgeEpoch = 0;
@@ -963,28 +957,32 @@ final class AdaptivePoolingAllocator {
             return null;
         }
 
+        private void offerOrDeallocate(SizeClassedChunk chunk) {
+            if (!queue.offer(chunk)) {
+                chunk.markToDeallocate();
+            }
+        }
+
+        private void offerOrDeallocate(SizeClassedChunk chunk, long generation) {
+            chunk.lastPurgeGeneration = generation;
+            offerOrDeallocate(chunk);
+        }
+
         private void runPurgeScan() {
             long generation = ++purgeGeneration;
-            int bufCount = 0;
             int retained = 0;
-            SizeClassedChunk[] buf = noCapacityBuffer;
+            ArrayList<SizeClassedChunk> deferred = deferredBuffer;
             SizeClassedChunk chunk;
             while ((chunk = queue.poll()) != null) {
                 if (chunk.lastPurgeGeneration == generation) {
-                    if (!queue.offer(chunk)) {
-                        chunk.markToDeallocate();
-                    }
+                    offerOrDeallocate(chunk, generation);
                     break;
                 }
                 retained++;
                 if (chunk.hasFullCapacity()) {
                     chunk.purgeEpoch++;
                     if (chunk.purgeEpoch > CHUNK_PURGE_THRESHOLD) {
-                        if (bufCount == buf.length) {
-                            buf = Arrays.copyOf(buf, buf.length * 2);
-                            noCapacityBuffer = buf;
-                        }
-                        buf[bufCount++] = chunk;
+                        deferred.add(chunk);
                         continue;
                     }
                 } else {
@@ -992,31 +990,21 @@ final class AdaptivePoolingAllocator {
                 }
                 int remaining = chunk.remainingCapacity();
                 if (remaining > 0) {
-                    chunk.lastPurgeGeneration = generation;
-                    if (!queue.offer(chunk)) {
-                        chunk.markToDeallocate();
-                    }
+                    offerOrDeallocate(chunk, generation);
                 } else {
-                    if (bufCount == buf.length) {
-                        buf = Arrays.copyOf(buf, buf.length * 2);
-                        noCapacityBuffer = buf;
-                    }
-                    buf[bufCount++] = chunk;
+                    deferred.add(chunk);
                 }
             }
-            for (int i = 0; i < bufCount; i++) {
-                chunk = buf[i];
-                buf[i] = null;
+            for (int i = 0, size = deferred.size(); i < size; i++) {
+                chunk = deferred.get(i);
                 if (chunk.purgeEpoch > CHUNK_PURGE_THRESHOLD && retained > CHUNK_REUSE_QUEUE) {
                     chunk.markToDeallocate();
                     retained--;
                 } else {
-                    chunk.lastPurgeGeneration = generation;
-                    if (!queue.offer(chunk)) {
-                        chunk.markToDeallocate();
-                    }
+                    offerOrDeallocate(chunk, generation);
                 }
             }
+            deferred.clear();
             purgeBudget.lazySet(CHUNK_PURGE_POLLS_SHARED);
         }
 

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -529,8 +529,10 @@ final class AdaptivePoolingAllocator {
     // 4. CONVERGENCE: idle full chunks that are never picked by scan age undisturbed across
     //    purge cycles. After CHUNK_PURGE_THRESHOLD + 1 consecutive cycles of being full and
     //    unpolled, they are evicted. Chunks picked by scan get epoch reset — aging interrupted.
-    //    Thread-local: deterministic, exact (partition orders epoch=0 at head, scan always
-    //    takes head). Shared: approximate, converges over multiple cycles (FIFO queue ordering,
+    //    Thread-local: partition orders [epoch=0 | 0<epoch<T | epoch>=T | noCap]. Scan takes
+    //    from head (epoch=0 first). Chunks with epoch>=threshold are placed at the back of
+    //    the hasCap zone so scan doesn't reach them — they age to threshold+1 and get evicted.
+    //    Shared: approximate, converges over multiple cycles (FIFO queue ordering,
     //    LRU preference in scan, retained counter in purge).
     abstract static class SizeClassedChunkCache implements ChunkCache {
         static SizeClassedChunkCache create(boolean isThreadLocal) {
@@ -591,9 +593,12 @@ final class AdaptivePoolingAllocator {
      *
      * <p><b>runPurgeScan</b> (every {@link #CHUNK_PURGE_POLLS_THREAD_LOCAL} polls) —
      * two passes. Pass 1: age idle chunks (full → epoch++, non-full → epoch=0), evict
-     * past threshold, compact survivors (nulls stale slots inline). Pass 2: three-way
-     * Dutch-flag partition into [epoch=0 hasCap | epoch&gt;0 hasCap | noCap]. Never selects —
-     * selection is always {@code scanForCapacity}.
+     * past threshold, compact survivors (nulls stale slots inline). Pass 2: partition
+     * hasCap to front / noCap to back, then three-way Dutch-flag within hasCap into
+     * [epoch=0 | 0&lt;epoch&lt;threshold | epoch&gt;=threshold]. Chunks with epoch&gt;=threshold
+     * are placed at the back of hasCap so scan doesn't reach them — they age to
+     * threshold+1 and get evicted. Never selects — selection is always
+     * {@code scanForCapacity}.
      *
      * <p>Case 1 — no eviction, an empty chunk gained capacity externally (common):
      * <pre>
@@ -622,7 +627,7 @@ final class AdaptivePoolingAllocator {
      *     ^tail    ^head
      *              |--- kept=6 ---|
      *
-     *   pass 2 (partition): three-way into [epoch=0 hasCap | epoch&gt;0 hasCap | noCap].
+     *   pass 2 (partition): [epoch=0 hasCap | 0&lt;epoch&lt;T hasCap | epoch&gt;=T hasCap | noCap].
      *   [_, _, _,  NE, NE, E, E, E]
      *     ^tail    ^head
      *              notEmptyCount=2, count=6
@@ -727,40 +732,56 @@ final class AdaptivePoolingAllocator {
 
         private void partition(int size) {
             int mask = chunks.length - 1;
-            // Three-way Dutch-flag partition (Dijkstra):
-            //   [epoch=0 hasCap | epoch>0 hasCap | noCap]
-            //
-            // Epoch=0 chunks (recently used) go to the head so scanForCapacity picks them
-            // first. This prevents scan from picking epoch>0 chunks (idle, aging toward
-            // eviction) and resetting their epoch — which would restart their aging clock
-            // and slow convergence. The working set cycles at the front; excess ages
-            // undisturbed at the back.
+            // Pass 1: hasCapacity to front, noCapacity to back.
             int lo = 0;
-            int mid = 0;
             int hi = size - 1;
-            while (mid <= hi) {
-                int midIdx = (head + mid) & mask;
-                SizeClassedChunk chunk = chunks[midIdx];
-                if (chunk.hasRemainingCapacity()) {
-                    if (chunk.purgeEpoch == 0) {
-                        if (lo != mid) {
-                            int loIdx = (head + lo) & mask;
-                            chunks[midIdx] = chunks[loIdx];
-                            chunks[loIdx] = chunk;
-                        }
-                        lo++;
-                        mid++;
-                    } else {
-                        mid++;
-                    }
+            while (lo <= hi) {
+                int loIdx = (head + lo) & mask;
+                if (chunks[loIdx].hasRemainingCapacity()) {
+                    lo++;
                 } else {
                     int hiIdx = (head + hi) & mask;
-                    chunks[midIdx] = chunks[hiIdx];
-                    chunks[hiIdx] = chunk;
+                    SizeClassedChunk tmp = chunks[loIdx];
+                    chunks[loIdx] = chunks[hiIdx];
+                    chunks[hiIdx] = tmp;
                     hi--;
                 }
             }
-            notEmptyCount = mid;
+            notEmptyCount = lo;
+            // Pass 2: three-way Dutch-flag within notEmpty:
+            //   [epoch=0 | 0<epoch<threshold | epoch>=threshold]
+            //
+            // Epoch=0 (recently used) at head — scan picks these first.
+            // Epoch>=threshold (about to be evicted) at back — scan doesn't reach them,
+            // so they age one more cycle to threshold+1 and get evicted.
+            //
+            // This ordering guarantees convergence regardless of count/polls ratio.
+            // Without it (e.g., a simple epoch=0/epoch>0 split with mid++), when
+            // count/polls == threshold the groups rotate perfectly and max epoch never
+            // exceeds threshold — eviction stalls at threshold * polls chunks.
+            int elo = 0;
+            int emid = 0;
+            int ehi = lo - 1;
+            while (emid <= ehi) {
+                int emidIdx = (head + emid) & mask;
+                SizeClassedChunk c = chunks[emidIdx];
+                if (c.purgeEpoch == 0) {
+                    if (elo != emid) {
+                        int eloIdx = (head + elo) & mask;
+                        chunks[emidIdx] = chunks[eloIdx];
+                        chunks[eloIdx] = c;
+                    }
+                    elo++;
+                    emid++;
+                } else if (c.purgeEpoch < CHUNK_PURGE_THRESHOLD) {
+                    emid++;
+                } else {
+                    int ehiIdx = (head + ehi) & mask;
+                    chunks[emidIdx] = chunks[ehiIdx];
+                    chunks[ehiIdx] = c;
+                    ehi--;
+                }
+            }
         }
 
         @Override

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -590,9 +590,10 @@ final class AdaptivePoolingAllocator {
      * </pre>
      *
      * <p><b>runPurgeScan</b> (every {@link #CHUNK_PURGE_POLLS_THREAD_LOCAL} polls) —
-     * ages idle chunks, evicts past threshold. Never selects — selection is always
-     * {@code scanForCapacity}. Compact (closeGap) only runs when an eviction removed
-     * something. Partition always runs to pick up chunks that gained capacity externally.
+     * two passes. Pass 1: age idle chunks (full → epoch++, non-full → epoch=0), evict
+     * past threshold, compact survivors (nulls stale slots inline). Pass 2: three-way
+     * Dutch-flag partition into [epoch=0 hasCap | epoch&gt;0 hasCap | noCap]. Never selects —
+     * selection is always {@code scanForCapacity}.
      *
      * <p>Case 1 — no eviction, an empty chunk gained capacity externally (common):
      * <pre>
@@ -601,8 +602,8 @@ final class AdaptivePoolingAllocator {
      *    ^head            ^tail
      *    notEmptyCount=2
      *
-     *   scan: age idle chunks. None past threshold. No eviction → no compact.
-     *   partition: E* now has capacity → swapped into notEmpty zone.
+     *   pass 1: age idle chunks. None past threshold. No compaction needed.
+     *   pass 2 (partition): E* now has capacity → placed in notEmpty zone.
      *
      *   after:
      *   [NE, NE, E*, E, _, _, _, _]
@@ -616,17 +617,15 @@ final class AdaptivePoolingAllocator {
      *   [E, NE, _,  IDLE*, NE, E, E, NE]
      *          ^tail ^head
      *
-     *   scan: IDLE* evicted (markToDeallocate). Remaining entries compacted → closeGap(kept).
+     *   pass 1: IDLE* evicted (markToDeallocate), survivors compacted, stale slots nulled.
+     *   [_, _, _,  NE, E, E, NE, E]
+     *     ^tail    ^head
+     *              |--- kept=6 ---|
      *
-     *   after closeGap:
-     *   [NE, _, _,  NE, E, E, NE, E]
-     *       ^tail   ^head
-     *               |--- kept=6 ---|
-     *
-     *   after partition: notEmpty swapped to front, empty to back.
-     *   [NE, _, _,  NE, NE, E, E, E]
-     *       ^tail   ^head
-     *               notEmptyCount=2, count=6
+     *   pass 2 (partition): three-way into [epoch=0 hasCap | epoch&gt;0 hasCap | noCap].
+     *   [_, _, _,  NE, NE, E, E, E]
+     *     ^tail    ^head
+     *              notEmptyCount=2, count=6
      * </pre>
      * Idle chunks ({@code remainingCapacity == capacity}) age via purgeEpoch and are evicted
      * past threshold, but at least {@link #CHUNK_REUSE_QUEUE} chunks are always retained.
@@ -696,7 +695,6 @@ final class AdaptivePoolingAllocator {
             int mask = chunks.length - 1;
             int kept = 0;
             int survivors = count;
-            boolean evicted = false;
             for (int i = 0; i < count; i++) {
                 int readIdx = (head + i) & mask;
                 SizeClassedChunk chunk = chunks[readIdx];
@@ -705,70 +703,62 @@ final class AdaptivePoolingAllocator {
                     chunk.purgeEpoch++;
                     if (chunk.purgeEpoch > CHUNK_PURGE_THRESHOLD && survivors > CHUNK_REUSE_QUEUE) {
                         chunk.markToDeallocate();
+                        chunks[readIdx] = null;
                         survivors--;
-                        evicted = true;
                         continue;
                     }
                 } else {
                     chunk.purgeEpoch = 0;
                 }
-                if (evicted) {
-                    chunks[(head + kept) & mask] = chunk;
+                int writeIdx = (head + kept) & mask;
+                if (writeIdx != readIdx) {
+                    chunks[writeIdx] = chunk;
+                    chunks[readIdx] = null;
                 }
                 kept++;
             }
-            if (evicted) {
-                closeGap(kept);
-            }
-            partition(evicted ? kept : count);
-            purgeBudget = CHUNK_PURGE_POLLS_THREAD_LOCAL;
-        }
-
-        private void closeGap(int kept) {
-            int mask = chunks.length - 1;
-            int gapStart = (head + kept) & mask;
-            Arrays.fill(chunks, gapStart, gapStart <= tail ? tail : chunks.length, null);
-            if (gapStart > tail) {
-                Arrays.fill(chunks, 0, tail, null);
-            }
             tail = (head + kept) & mask;
             count = kept;
+            partition(kept);
+            purgeBudget = CHUNK_PURGE_POLLS_THREAD_LOCAL;
         }
 
         private void partition(int size) {
             int mask = chunks.length - 1;
-            // First pass: hasCapacity to front, noCapacity to back.
+            // Three-way Dutch-flag partition (Dijkstra):
+            //   [epoch=0 hasCap | epoch>0 hasCap | noCap]
+            //
+            // Epoch=0 chunks (recently used) go to the head so scanForCapacity picks them
+            // first. This prevents scan from picking epoch>0 chunks (idle, aging toward
+            // eviction) and resetting their epoch — which would restart their aging clock
+            // and slow convergence. The working set cycles at the front; excess ages
+            // undisturbed at the back.
             int lo = 0;
+            int mid = 0;
             int hi = size - 1;
-            while (lo <= hi) {
-                int loIdx = (head + lo) & mask;
-                if (chunks[loIdx].hasRemainingCapacity()) {
-                    lo++;
+            while (mid <= hi) {
+                int midIdx = (head + mid) & mask;
+                SizeClassedChunk chunk = chunks[midIdx];
+                if (chunk.hasRemainingCapacity()) {
+                    if (chunk.purgeEpoch == 0) {
+                        if (lo != mid) {
+                            int loIdx = (head + lo) & mask;
+                            chunks[midIdx] = chunks[loIdx];
+                            chunks[loIdx] = chunk;
+                        }
+                        lo++;
+                        mid++;
+                    } else {
+                        mid++;
+                    }
                 } else {
                     int hiIdx = (head + hi) & mask;
-                    SizeClassedChunk tmp = chunks[loIdx];
-                    chunks[loIdx] = chunks[hiIdx];
-                    chunks[hiIdx] = tmp;
+                    chunks[midIdx] = chunks[hiIdx];
+                    chunks[hiIdx] = chunk;
                     hi--;
                 }
             }
-            notEmptyCount = lo;
-            // Second pass: within the notEmpty zone [head, head+lo),
-            // sub-partition epoch==0 to front, epoch>0 behind.
-            int elo = 0;
-            int ehi = lo - 1;
-            while (elo <= ehi) {
-                int eloIdx = (head + elo) & mask;
-                if (chunks[eloIdx].purgeEpoch == 0) {
-                    elo++;
-                } else {
-                    int ehiIdx = (head + ehi) & mask;
-                    SizeClassedChunk tmp = chunks[eloIdx];
-                    chunks[eloIdx] = chunks[ehiIdx];
-                    chunks[ehiIdx] = tmp;
-                    ehi--;
-                }
-            }
+            notEmptyCount = mid;
         }
 
         @Override

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
@@ -291,7 +291,7 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
         int buffersPerChunk = (int) (chunkSize / 256);
         probe.release();
 
-        int totalChunks = AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE + 3;
+        int totalChunks = (int) Math.max(purgePolls, AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE) * 2 + 10;
         int totalBuffers = totalChunks * buffersPerChunk;
         java.util.List<ByteBuf> bufs = new java.util.ArrayList<>(totalBuffers);
         for (int i = 0; i < totalBuffers; i++) {

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
@@ -291,7 +291,7 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
         int buffersPerChunk = (int) (chunkSize / 256);
         probe.release();
 
-        int totalChunks = (int) Math.max(purgePolls, AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE) * 2 + 10;
+        int totalChunks = (int) Math.max(purgePolls, AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE) * 4 + 10;
         int totalBuffers = totalChunks * buffersPerChunk;
         java.util.List<ByteBuf> bufs = new java.util.ArrayList<>(totalBuffers);
         for (int i = 0; i < totalBuffers; i++) {
@@ -305,7 +305,15 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
         long memoryAfterRelease = allocator.usedHeapMemory();
 
         int threshold = AdaptivePoolingAllocator.CHUNK_PURGE_THRESHOLD;
-        int pollsNeeded = (int) ((threshold + 2) * purgePolls);
+        // Account for pollChunk calls burned during setup (one per chunk created)
+        // and partition shuffle: with N notEmpty and P polls, each chunk is polled
+        // P/N of the time. Epochs advance at rate 1-P/N per cycle. Need enough cycles
+        // for the slowest chunk to reach threshold.
+        int setupPolls = totalChunks;
+        int notEmpty = totalChunks - AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE;
+        double advanceRate = 1.0 - (double) purgePolls / notEmpty;
+        int cyclesNeeded = advanceRate > 0 ? (int) Math.ceil((threshold + 1) / advanceRate) + 2 : threshold + 2;
+        int pollsNeeded = setupPolls + (int) (cyclesNeeded * purgePolls);
         for (int poll = 0; poll < pollsNeeded; poll++) {
             for (int i = 0; i < buffersPerChunk; i++) {
                 bufs.add(allocator.heapBuffer(256));

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
@@ -268,6 +268,60 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
         }
     }
 
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void purgeScanShouldEvictIdleChunks(boolean threadLocal) throws Exception {
+        // Thread-local magazines require FastThreadLocalThread
+        // (allocate() checks currentThreadWillCleanupFastThreadLocals)
+        AdaptiveByteBufAllocator allocator = new AdaptiveByteBufAllocator(false, threadLocal);
+        long purgePolls = threadLocal ?
+                AdaptivePoolingAllocator.CHUNK_PURGE_POLLS_THREAD_LOCAL :
+                AdaptivePoolingAllocator.CHUNK_PURGE_POLLS_SHARED;
+        Runnable test = () -> assertPurgeScanEvictsIdleChunks(allocator, purgePolls);
+        if (threadLocal) {
+            io.netty.util.concurrent.FastThreadLocalThread.runWithFastThreadLocal(test);
+        } else {
+            test.run();
+        }
+    }
+
+    private static void assertPurgeScanEvictsIdleChunks(AdaptiveByteBufAllocator allocator, long purgePolls) {
+        ByteBuf probe = allocator.heapBuffer(256);
+        long chunkSize = allocator.usedHeapMemory();
+        int buffersPerChunk = (int) (chunkSize / 256);
+        probe.release();
+
+        int totalChunks = AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE + 3;
+        int totalBuffers = totalChunks * buffersPerChunk;
+        java.util.List<ByteBuf> bufs = new java.util.ArrayList<>(totalBuffers);
+        for (int i = 0; i < totalBuffers; i++) {
+            bufs.add(allocator.heapBuffer(256));
+        }
+
+        for (ByteBuf buf : bufs) {
+            buf.release();
+        }
+        bufs.clear();
+        long memoryAfterRelease = allocator.usedHeapMemory();
+
+        int threshold = AdaptivePoolingAllocator.CHUNK_PURGE_THRESHOLD;
+        int pollsNeeded = (int) ((threshold + 2) * purgePolls);
+        for (int poll = 0; poll < pollsNeeded; poll++) {
+            for (int i = 0; i < buffersPerChunk; i++) {
+                bufs.add(allocator.heapBuffer(256));
+            }
+            for (ByteBuf buf : bufs) {
+                buf.release();
+            }
+            bufs.clear();
+        }
+
+        long memoryAfterPurge = allocator.usedHeapMemory();
+        assertTrue(memoryAfterPurge < memoryAfterRelease,
+                "Memory should decrease after purge scans evict idle chunks. " +
+                "Before purge: " + memoryAfterRelease + ", after purge: " + memoryAfterPurge);
+    }
+
     private static void shuffle(SplittableRandom rng, Object array) {
         int len = Array.getLength(array);
         for (int i = 0; i < len; i++) {

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
@@ -16,6 +16,7 @@
 package io.netty.buffer;
 
 import io.netty.util.NettyRuntime;
+import io.netty.util.concurrent.FastThreadLocalThread;
 import io.netty.util.test.DisabledForSlowLeakDetection;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.RepetitionInfo;
@@ -25,8 +26,10 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.lang.reflect.Array;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Deque;
+import java.util.List;
 import java.util.SplittableRandom;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadLocalRandom;
@@ -279,7 +282,7 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
                 AdaptivePoolingAllocator.CHUNK_PURGE_POLLS_SHARED;
         Runnable test = () -> assertPurgeScanEvictsIdleChunks(allocator, purgePolls);
         if (threadLocal) {
-            io.netty.util.concurrent.FastThreadLocalThread.runWithFastThreadLocal(test);
+            FastThreadLocalThread.runWithFastThreadLocal(test);
         } else {
             test.run();
         }
@@ -293,7 +296,7 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
 
         int totalChunks = (int) Math.max(purgePolls, AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE) * 4 + 10;
         int totalBuffers = totalChunks * buffersPerChunk;
-        java.util.List<ByteBuf> bufs = new java.util.ArrayList<>(totalBuffers);
+        List<ByteBuf> bufs = new ArrayList<>(totalBuffers);
         for (int i = 0; i < totalBuffers; i++) {
             bufs.add(allocator.heapBuffer(256));
         }

--- a/buffer/src/test/java/io/netty/buffer/SizeClassedChunkCacheTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SizeClassedChunkCacheTest.java
@@ -39,6 +39,7 @@ public class SizeClassedChunkCacheTest {
         when(chunk.remainingCapacity()).thenReturn(512);
         when(chunk.capacity()).thenReturn(4096);
         when(chunk.hasRemainingCapacity()).thenReturn(true);
+        when(chunk.hasFullCapacity()).thenReturn(false);
         return chunk;
     }
 
@@ -47,15 +48,17 @@ public class SizeClassedChunkCacheTest {
         when(chunk.remainingCapacity()).thenReturn(0);
         when(chunk.capacity()).thenReturn(4096);
         when(chunk.hasRemainingCapacity()).thenReturn(false);
+        when(chunk.hasFullCapacity()).thenReturn(false);
         return chunk;
     }
 
     private static SizeClassedChunk fullChunk() {
-        // remaining == capacity → purge ages it. Has capacity (all segments available).
+        // All segments available → purge ages it.
         SizeClassedChunk chunk = mock(SizeClassedChunk.class);
         when(chunk.remainingCapacity()).thenReturn(4096);
         when(chunk.capacity()).thenReturn(4096);
         when(chunk.hasRemainingCapacity()).thenReturn(true);
+        when(chunk.hasFullCapacity()).thenReturn(true);
         return chunk;
     }
 

--- a/buffer/src/test/java/io/netty/buffer/SizeClassedChunkCacheTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SizeClassedChunkCacheTest.java
@@ -97,7 +97,7 @@ public class SizeClassedChunkCacheTest {
     // --- purge: epoch aging and eviction (both caches) ---
 
     @Test
-    void fullChunkAgesEachPurgeAndIsEvictedPastThreshold_threadLocal() {
+    void fullChunkAgesEachPurgeAndIsEvictedPastThresholdThreadLocal() {
         SizeClassedChunkCache cache = SizeClassedChunkCache.create(true);
 
         for (int i = 0; i < AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE; i++) {
@@ -121,7 +121,7 @@ public class SizeClassedChunkCacheTest {
     }
 
     @Test
-    void fullChunkAgesAndIsEventuallyEvicted_shared() {
+    void fullChunkAgesAndIsEventuallyEvictedShared() {
         SizeClassedChunkCache cache = SizeClassedChunkCache.create(false);
 
         for (int i = 0; i < AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE; i++) {
@@ -319,7 +319,7 @@ public class SizeClassedChunkCacheTest {
     // --- bursty traffic: idle chunks are eventually evicted ---
 
     @Test
-    void cacheSettlesAtRetentionFloorAfterBurst_threadLocal() {
+    void cacheSettlesAtRetentionFloorAfterBurstThreadLocal() {
         SizeClassedChunkCache cache = SizeClassedChunkCache.create(true);
 
         int floor = AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE;
@@ -349,7 +349,7 @@ public class SizeClassedChunkCacheTest {
     }
 
     @Test
-    void cacheSettlesAfterBurst_shared() {
+    void cacheSettlesAfterBurstShared() {
         SizeClassedChunkCache cache = SizeClassedChunkCache.create(false);
 
         int excess = 10;
@@ -383,7 +383,7 @@ public class SizeClassedChunkCacheTest {
     // idle chunks age undisturbed behind the working set.
 
     @Test
-    void excessFullChunksAgeWhileWorkingSetIsPreferred_threadLocal() {
+    void excessFullChunksAgeWhileWorkingSetIsPreferredThreadLocal() {
         SizeClassedChunkCache cache = SizeClassedChunkCache.create(true);
 
         for (int i = 0; i < AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE; i++) {
@@ -411,7 +411,7 @@ public class SizeClassedChunkCacheTest {
     }
 
     @Test
-    void excessFullChunksEventuallyEvicted_shared() {
+    void excessFullChunksEventuallyEvictedShared() {
         SizeClassedChunkCache cache = SizeClassedChunkCache.create(false);
 
         for (int i = 0; i < AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE; i++) {
@@ -514,7 +514,7 @@ public class SizeClassedChunkCacheTest {
     // --- free: draining all chunks (thread-local) ---
 
     @Test
-    void pollChunkCannotDrainNoCapChunks_threadLocal() {
+    void pollChunkCannotDrainNoCapChunksThreadLocal() {
         AdaptivePoolingAllocator.ThreadLocalSizeClassedChunkCache cache =
                 new AdaptivePoolingAllocator.ThreadLocalSizeClassedChunkCache();
 
@@ -538,7 +538,7 @@ public class SizeClassedChunkCacheTest {
     }
 
     @Test
-    void freeDrainsAllChunksIncludingNoCap_threadLocal() {
+    void freeDrainsAllChunksIncludingNoCapThreadLocal() {
         AdaptivePoolingAllocator.ThreadLocalSizeClassedChunkCache cache =
                 new AdaptivePoolingAllocator.ThreadLocalSizeClassedChunkCache();
 
@@ -562,7 +562,7 @@ public class SizeClassedChunkCacheTest {
     }
 
     @Test
-    void freeDrainsAllChunks_shared() {
+    void freeDrainsAllChunksShared() {
         SizeClassedChunkCache cache = SizeClassedChunkCache.create(false);
 
         SizeClassedChunk cap = chunkWithCapacity();

--- a/buffer/src/test/java/io/netty/buffer/SizeClassedChunkCacheTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SizeClassedChunkCacheTest.java
@@ -1,0 +1,334 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import io.netty.buffer.AdaptivePoolingAllocator.SizeClassedChunk;
+import io.netty.buffer.AdaptivePoolingAllocator.SizeClassedChunkCache;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class SizeClassedChunkCacheTest {
+
+    private static SizeClassedChunk chunkWithCapacity() {
+        SizeClassedChunk chunk = mock(SizeClassedChunk.class);
+        when(chunk.remainingCapacity()).thenReturn(512);
+        when(chunk.capacity()).thenReturn(4096);
+        when(chunk.hasRemainingCapacity()).thenReturn(true);
+        return chunk;
+    }
+
+    private static SizeClassedChunk chunkWithoutCapacity() {
+        SizeClassedChunk chunk = mock(SizeClassedChunk.class);
+        when(chunk.remainingCapacity()).thenReturn(0);
+        when(chunk.capacity()).thenReturn(4096);
+        when(chunk.hasRemainingCapacity()).thenReturn(false);
+        return chunk;
+    }
+
+    private static SizeClassedChunk idleChunk() {
+        // remaining == capacity → purge ages it. remaining == 0 → never selected.
+        SizeClassedChunk chunk = mock(SizeClassedChunk.class);
+        when(chunk.remainingCapacity()).thenReturn(0);
+        when(chunk.capacity()).thenReturn(0);
+        when(chunk.hasRemainingCapacity()).thenReturn(false);
+        return chunk;
+    }
+
+    // --- purge: selection (both caches) ---
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void purgeSelectsFirstChunkWithCapacity(boolean threadLocal) {
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(threadLocal);
+
+        SizeClassedChunk noCap = chunkWithoutCapacity();
+        SizeClassedChunk cap = chunkWithCapacity();
+        cache.offerChunk(noCap);
+        cache.offerChunk(cap);
+
+        assertSame(cap, cache.forcePurge());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void purgeReturnsNullWhenCacheIsEmpty(boolean threadLocal) {
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(threadLocal);
+        assertNull(cache.forcePurge());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void purgeReturnsNullWhenNoChunkHasCapacity(boolean threadLocal) {
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(threadLocal);
+        cache.offerChunk(chunkWithoutCapacity());
+        cache.offerChunk(chunkWithoutCapacity());
+
+        assertNull(cache.forcePurge());
+    }
+
+    // --- purge: epoch aging and eviction (both caches) ---
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void idleChunkAgesEachPurgeAndIsEvictedPastThreshold(boolean threadLocal) {
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(threadLocal);
+
+        // Pad above retention floor so eviction is allowed
+        for (int i = 0; i < AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE; i++) {
+            cache.offerChunk(chunkWithoutCapacity());
+        }
+        SizeClassedChunk idle = idleChunk();
+        cache.offerChunk(idle);
+
+        for (int i = 0; i < AdaptivePoolingAllocator.CHUNK_PURGE_THRESHOLD; i++) {
+            cache.forcePurge();
+            assertEquals(i + 1, idle.purgeEpoch);
+            verify(idle, never()).markToDeallocate();
+        }
+
+        cache.forcePurge();
+        verify(idle).markToDeallocate();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void purgeResetsEpochForNonIdleChunks(boolean threadLocal) {
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(threadLocal);
+
+        SizeClassedChunk chunk = chunkWithCapacity();
+        chunk.purgeEpoch = 5;
+        cache.offerChunk(chunk);
+
+        cache.forcePurge();
+        assertEquals(0, chunk.purgeEpoch);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void selectedChunkHasEpochReset(boolean threadLocal) {
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(threadLocal);
+
+        SizeClassedChunk chunk = chunkWithCapacity();
+        chunk.purgeEpoch = 2;
+        cache.offerChunk(chunk);
+
+        SizeClassedChunk selected = cache.forcePurge();
+        assertSame(chunk, selected);
+        assertEquals(0, selected.purgeEpoch);
+    }
+
+    // --- scanForCapacity: fallback (both caches) ---
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void scanForCapacityFallbackFindsChunkThatGainedCapacity(boolean threadLocal) {
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(threadLocal);
+
+        SizeClassedChunk chunk = chunkWithoutCapacity();
+        cache.offerChunk(chunk);
+
+        // Purge: no capacity, nothing selected
+        assertNull(cache.forcePurge());
+
+        // External segment return gives the chunk capacity
+        when(chunk.hasRemainingCapacity()).thenReturn(true);
+
+        assertSame(chunk, cache.pollChunk(256));
+    }
+
+    // --- thread-local only: capacity-first ordering ---
+
+    @Test
+    void purgeMovesCapacityChunksBeforeNoCapacityChunks() {
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(true);
+
+        cache.offerChunk(chunkWithoutCapacity());
+        cache.offerChunk(chunkWithCapacity());
+        cache.offerChunk(chunkWithoutCapacity());
+        cache.offerChunk(chunkWithCapacity());
+        cache.offerChunk(chunkWithCapacity());
+
+        // Purge selects one capacity chunk, partitions the rest: [cap, cap | noCap, noCap]
+        SizeClassedChunk selected = cache.forcePurge();
+        assertNotNull(selected);
+        assertTrue(selected.hasRemainingCapacity());
+
+        // Both remaining capacity chunks come out before any no-capacity chunk
+        assertTrue(cache.pollChunk(256).hasRemainingCapacity());
+        assertTrue(cache.pollChunk(256).hasRemainingCapacity());
+        assertNull(cache.pollChunk(256));
+    }
+
+    @Test
+    void scanForCapacityUsesO1FastPathAfterPurge() {
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(true);
+
+        cache.offerChunk(chunkWithCapacity());
+        cache.offerChunk(chunkWithCapacity());
+        cache.offerChunk(chunkWithoutCapacity());
+
+        // Purge partitions: [cap | noCap], selects one cap
+        assertNotNull(cache.forcePurge());
+
+        // Next poll hits the O(1) fast path — capacity chunk is at head
+        SizeClassedChunk fast = cache.pollChunk(256);
+        assertNotNull(fast);
+        assertTrue(fast.hasRemainingCapacity());
+    }
+
+    // --- thread-local only: ring buffer mechanics ---
+
+    @Test
+    void offerGrowsRingWhenFull() {
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(true);
+
+        // Initial ring size is 8 — offer 9 to trigger growth
+        for (int i = 0; i < 9; i++) {
+            cache.offerChunk(chunkWithCapacity());
+        }
+
+        // Purge selects one, 8 remain — all should be retrievable
+        assertNotNull(cache.forcePurge());
+        for (int i = 0; i < 8; i++) {
+            assertNotNull(cache.pollChunk(256));
+        }
+        assertNull(cache.pollChunk(256));
+    }
+
+    @Test
+    void purgeHandlesWrappedRingCorrectly() {
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(true);
+
+        // Fill with 4, purge (linearizes to head=0), consume 3 to advance head
+        for (int i = 0; i < 4; i++) {
+            cache.offerChunk(chunkWithCapacity());
+        }
+        cache.forcePurge();
+        cache.pollChunk(256);
+        cache.pollChunk(256);
+        cache.pollChunk(256);
+
+        // Offer more — tail wraps around past the array end
+        cache.offerChunk(chunkWithoutCapacity());
+        cache.offerChunk(chunkWithCapacity());
+        cache.offerChunk(chunkWithoutCapacity());
+        cache.offerChunk(chunkWithCapacity());
+
+        // Purge with wrapped ring should still partition correctly
+        SizeClassedChunk selected = cache.forcePurge();
+        assertNotNull(selected);
+        assertTrue(selected.hasRemainingCapacity());
+
+        // Remaining capacity chunk at head
+        SizeClassedChunk next = cache.pollChunk(256);
+        if (next != null) {
+            assertTrue(next.hasRemainingCapacity());
+        }
+    }
+
+    // --- bursty traffic: idle chunks are eventually evicted ---
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void cacheSettlesAtRetentionFloorAfterBurst(boolean threadLocal) {
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(threadLocal);
+
+        int floor = AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE;
+        int excess = 10;
+        int total = floor + excess;
+
+        // All chunks are idle — after purge, only the floor should survive
+        SizeClassedChunk[] allChunks = new SizeClassedChunk[total];
+        for (int i = 0; i < total; i++) {
+            allChunks[i] = idleChunk();
+            cache.offerChunk(allChunks[i]);
+        }
+
+        // Run enough purge cycles to evict all excess
+        int purgesNeeded = AdaptivePoolingAllocator.CHUNK_PURGE_THRESHOLD + 1;
+        for (int i = 0; i < purgesNeeded; i++) {
+            cache.forcePurge();
+        }
+
+        // Exactly `excess` chunks evicted, exactly `floor` retained
+        int evicted = 0;
+        int retained = 0;
+        for (SizeClassedChunk chunk : allChunks) {
+            try {
+                verify(chunk, atLeastOnce()).markToDeallocate();
+                evicted++;
+            } catch (AssertionError e) {
+                retained++;
+            }
+        }
+        assertEquals(excess, evicted, "excess chunks should be evicted");
+        assertEquals(floor, retained, "retention floor chunks should survive");
+    }
+
+    // --- stale epoch: chunk polled with accumulated epoch, reused, re-offered (thread-local only) ---
+    // Thread-local scanForCapacity resets purgeEpoch on poll (ring partitioning isolates idle chunks).
+    // Shared cache does not reset — FIFO rotation would reset all chunks, preventing aging.
+
+    @Test
+    void polledChunkWithStaleEpochShouldNotBeEvictedPrematurely() {
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(true);
+
+        // Pad above retention floor
+        for (int i = 0; i < AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE; i++) {
+            cache.offerChunk(chunkWithoutCapacity());
+        }
+
+        // A fully-free chunk that will age
+        SizeClassedChunk chunk = mock(SizeClassedChunk.class);
+        when(chunk.remainingCapacity()).thenReturn(4096);
+        when(chunk.capacity()).thenReturn(4096);
+        when(chunk.hasRemainingCapacity()).thenReturn(true);
+        cache.offerChunk(chunk);
+
+        // Age it to just below threshold via purge cycles
+        // Each purge: chunk is fully free (remaining==capacity) → epoch++
+        // It also has capacity, so scanForCapacity (called after purge) will poll it.
+        // We re-offer it each time to keep it in the cache.
+        for (int i = 0; i < AdaptivePoolingAllocator.CHUNK_PURGE_THRESHOLD - 1; i++) {
+            cache.forcePurge();
+            cache.offerChunk(chunk);
+        }
+
+        // Chunk has been polled and re-offered each cycle.
+        SizeClassedChunk polled = cache.forcePurge();
+        assertNotNull(polled);
+        assertEquals(0, polled.purgeEpoch);
+
+        // Re-offer as fully free (simulating: used briefly, all segments returned)
+        cache.offerChunk(polled);
+
+        // One more purge — should NOT evict (epoch was reset on each poll)
+        cache.forcePurge();
+        verify(chunk, never()).markToDeallocate();
+    }
+}

--- a/buffer/src/test/java/io/netty/buffer/SizeClassedChunkCacheTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SizeClassedChunkCacheTest.java
@@ -510,4 +510,71 @@ public class SizeClassedChunkCacheTest {
         assertTrue(finished, "Concurrent scans should terminate within 30 seconds, not livelock");
         assertNull(error.get());
     }
+
+    // --- free: draining all chunks (thread-local) ---
+
+    @Test
+    void pollChunkCannotDrainNoCapChunks_threadLocal() {
+        AdaptivePoolingAllocator.ThreadLocalSizeClassedChunkCache cache =
+                new AdaptivePoolingAllocator.ThreadLocalSizeClassedChunkCache();
+
+        cache.offerChunk(chunkWithCapacity());
+        cache.offerChunk(chunkWithoutCapacity());
+        cache.offerChunk(chunkWithCapacity());
+        cache.offerChunk(chunkWithoutCapacity());
+
+        int drained = 0;
+        while (cache.pollChunk(0) != null) {
+            drained++;
+            if (drained > 100) {
+                break;
+            }
+        }
+
+        // pollChunk uses scanForCapacity which skips noCap chunks — they're stuck.
+        // This is why free() is needed instead of a pollChunk drain loop.
+        assertEquals(2, cache.count);
+        verify(cache.chunks[cache.head], never()).markToDeallocate();
+    }
+
+    @Test
+    void freeDrainsAllChunksIncludingNoCap_threadLocal() {
+        AdaptivePoolingAllocator.ThreadLocalSizeClassedChunkCache cache =
+                new AdaptivePoolingAllocator.ThreadLocalSizeClassedChunkCache();
+
+        SizeClassedChunk cap1 = chunkWithCapacity();
+        SizeClassedChunk cap2 = chunkWithCapacity();
+        SizeClassedChunk noCap1 = chunkWithoutCapacity();
+        SizeClassedChunk noCap2 = chunkWithoutCapacity();
+
+        cache.offerChunk(cap1);
+        cache.offerChunk(noCap1);
+        cache.offerChunk(cap2);
+        cache.offerChunk(noCap2);
+
+        cache.free();
+
+        assertTrue(cache.isEmpty());
+        verify(cap1, atLeastOnce()).markToDeallocate();
+        verify(cap2, atLeastOnce()).markToDeallocate();
+        verify(noCap1, atLeastOnce()).markToDeallocate();
+        verify(noCap2, atLeastOnce()).markToDeallocate();
+    }
+
+    @Test
+    void freeDrainsAllChunks_shared() {
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(false);
+
+        SizeClassedChunk cap = chunkWithCapacity();
+        SizeClassedChunk noCap = chunkWithoutCapacity();
+
+        cache.offerChunk(cap);
+        cache.offerChunk(noCap);
+
+        cache.free();
+
+        assertTrue(cache.isEmpty());
+        verify(cap, atLeastOnce()).markToDeallocate();
+        verify(noCap, atLeastOnce()).markToDeallocate();
+    }
 }

--- a/buffer/src/test/java/io/netty/buffer/SizeClassedChunkCacheTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SizeClassedChunkCacheTest.java
@@ -50,12 +50,12 @@ public class SizeClassedChunkCacheTest {
         return chunk;
     }
 
-    private static SizeClassedChunk idleChunk() {
-        // remaining == capacity → purge ages it. remaining == 0 → never selected.
+    private static SizeClassedChunk fullChunk() {
+        // remaining == capacity → purge ages it. Has capacity (all segments available).
         SizeClassedChunk chunk = mock(SizeClassedChunk.class);
-        when(chunk.remainingCapacity()).thenReturn(0);
-        when(chunk.capacity()).thenReturn(0);
-        when(chunk.hasRemainingCapacity()).thenReturn(false);
+        when(chunk.remainingCapacity()).thenReturn(4096);
+        when(chunk.capacity()).thenReturn(4096);
+        when(chunk.hasRemainingCapacity()).thenReturn(true);
         return chunk;
     }
 
@@ -95,23 +95,31 @@ public class SizeClassedChunkCacheTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    void idleChunkAgesEachPurgeAndIsEvictedPastThreshold(boolean threadLocal) {
+    void fullChunkAgesEachPurgeAndIsEvictedPastThreshold(boolean threadLocal) {
         SizeClassedChunkCache cache = SizeClassedChunkCache.create(threadLocal);
 
         // Pad above retention floor so eviction is allowed
         for (int i = 0; i < AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE; i++) {
             cache.offerChunk(chunkWithoutCapacity());
         }
-        SizeClassedChunk idle = idleChunk();
+
+        // Working-set chunk absorbs scan picks — non-full, epoch=0 at head after partition
+        SizeClassedChunk workingSet = chunkWithCapacity();
+        cache.offerChunk(workingSet);
+
+        SizeClassedChunk idle = fullChunk();
         cache.offerChunk(idle);
 
         for (int i = 0; i < AdaptivePoolingAllocator.CHUNK_PURGE_THRESHOLD; i++) {
-            cache.forcePurge();
+            SizeClassedChunk polled = cache.forcePurge();
+            assertSame(workingSet, polled);
+            cache.offerChunk(workingSet);
             assertEquals(i + 1, idle.purgeEpoch);
             verify(idle, never()).markToDeallocate();
         }
 
-        cache.forcePurge();
+        SizeClassedChunk polled = cache.forcePurge();
+        assertSame(workingSet, polled);
         verify(idle).markToDeallocate();
     }
 
@@ -260,44 +268,44 @@ public class SizeClassedChunkCacheTest {
 
         int floor = AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE;
         int excess = 10;
-        int total = floor + excess;
 
-        // All chunks are idle — after purge, only the floor should survive
-        SizeClassedChunk[] allChunks = new SizeClassedChunk[total];
-        for (int i = 0; i < total; i++) {
-            allChunks[i] = idleChunk();
-            cache.offerChunk(allChunks[i]);
+        // Working-set chunk absorbs scan picks
+        SizeClassedChunk workingSet = chunkWithCapacity();
+        cache.offerChunk(workingSet);
+
+        // Retention floor padding
+        for (int i = 0; i < floor - 1; i++) {
+            cache.offerChunk(chunkWithoutCapacity());
         }
 
-        // Run enough purge cycles to evict all excess
+        // Excess full chunks — should age and be evicted
+        SizeClassedChunk[] excessChunks = new SizeClassedChunk[excess];
+        for (int i = 0; i < excess; i++) {
+            excessChunks[i] = fullChunk();
+            cache.offerChunk(excessChunks[i]);
+        }
+
         int purgesNeeded = AdaptivePoolingAllocator.CHUNK_PURGE_THRESHOLD + 1;
         for (int i = 0; i < purgesNeeded; i++) {
-            cache.forcePurge();
+            SizeClassedChunk polled = cache.forcePurge();
+            assertSame(workingSet, polled);
+            cache.offerChunk(workingSet);
         }
 
-        // Exactly `excess` chunks evicted, exactly `floor` retained
-        int evicted = 0;
-        int retained = 0;
-        for (SizeClassedChunk chunk : allChunks) {
-            try {
-                verify(chunk, atLeastOnce()).markToDeallocate();
-                evicted++;
-            } catch (AssertionError e) {
-                retained++;
-            }
+        for (SizeClassedChunk chunk : excessChunks) {
+            verify(chunk, atLeastOnce()).markToDeallocate();
         }
-        assertEquals(excess, evicted, "excess chunks should be evicted");
-        assertEquals(floor, retained, "retention floor chunks should survive");
+        verify(workingSet, never()).markToDeallocate();
     }
 
-    // --- epoch aging: polled chunks carry their epoch (no reset on poll) ---
-    // Thread-local: partition sub-ordering puts epoch=0 at head, epoch>0 behind.
-    //   Epoch reset on poll would defeat aging when polls > chunks (e.g., 2-core: 16 polls, 7 chunks).
-    // Shared: LRU preference in scanForCapacity achieves the same without epoch reset.
+    // --- epoch aging with working set ---
+    // Scan resets epoch on pick (the chunk is being used). Partition sub-ordering puts
+    // epoch=0 (recently used) at head, epoch>0 (idle) behind. Scan prefers head, so
+    // idle chunks age undisturbed behind the working set.
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    void excessChunksAgeAndEvictDespiteBeingPolled(boolean threadLocal) {
+    void excessFullChunksAgeWhileWorkingSetIsPreferred(boolean threadLocal) {
         SizeClassedChunkCache cache = SizeClassedChunkCache.create(threadLocal);
 
         // Pad to retention floor
@@ -305,23 +313,63 @@ public class SizeClassedChunkCacheTest {
             cache.offerChunk(chunkWithoutCapacity());
         }
 
-        // Add excess idle chunks above the floor
+        // Working-set chunk: non-full (remaining != capacity), has capacity.
+        // Purge resets its epoch to 0. Partition puts it at head. Scan picks it.
+        SizeClassedChunk workingSet = chunkWithCapacity();
+        cache.offerChunk(workingSet);
+
+        // Excess full chunks: remaining == capacity, has capacity.
+        // Purge ages them. Partition puts them behind working-set (epoch>0).
+        // Scan doesn't reach them — working-set absorbs the pick.
         int excess = 3;
         SizeClassedChunk[] idleChunks = new SizeClassedChunk[excess];
         for (int i = 0; i < excess; i++) {
-            idleChunks[i] = idleChunk();
+            idleChunks[i] = fullChunk();
             cache.offerChunk(idleChunks[i]);
         }
 
-        // Run enough purge cycles for excess to age past threshold and be evicted
         for (int i = 0; i < AdaptivePoolingAllocator.CHUNK_PURGE_THRESHOLD + 1; i++) {
-            cache.forcePurge();
+            SizeClassedChunk polled = cache.forcePurge();
+            assertSame(workingSet, polled, "cycle " + i + ": scan should prefer working-set chunk");
+            cache.offerChunk(workingSet);
         }
 
-        // All excess should be evicted — cache settles at the retention floor
         for (SizeClassedChunk idle : idleChunks) {
             verify(idle, atLeastOnce()).markToDeallocate();
         }
+        verify(workingSet, never()).markToDeallocate();
+    }
+
+    // --- full-but-active chunk must not be prematurely evicted ---
+    // A chunk that is polled every purge cycle but whose buffers are short-lived
+    // (all segments return before next purge) looks "full" (remaining == capacity)
+    // at purge time. Purge must not treat it as idle.
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void activeChunkWithShortLivedBuffersShouldNotBeEvicted(boolean threadLocal) {
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(threadLocal);
+
+        // Pad above retention floor so eviction is allowed
+        for (int i = 0; i < AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE; i++) {
+            cache.offerChunk(chunkWithoutCapacity());
+        }
+
+        // Full chunk: remaining==capacity>0, has capacity.
+        // Simulates short-lived buffers: chunk polled, used, all segments return before next purge.
+        SizeClassedChunk active = fullChunk();
+        cache.offerChunk(active);
+
+        int cycles = AdaptivePoolingAllocator.CHUNK_PURGE_THRESHOLD + 2;
+        for (int cycle = 0; cycle < cycles; cycle++) {
+            SizeClassedChunk polled = cache.forcePurge();
+            assertSame(active, polled, "cycle " + cycle + ": chunk should be polled, not evicted");
+            assertEquals(0, polled.purgeEpoch,
+                    "cycle " + cycle + ": actively-used chunk epoch should be reset");
+            cache.offerChunk(active);
+        }
+
+        verify(active, never()).markToDeallocate();
     }
 
     // --- shared cache: concurrent scanForCapacity must not livelock ---

--- a/buffer/src/test/java/io/netty/buffer/SizeClassedChunkCacheTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SizeClassedChunkCacheTest.java
@@ -290,45 +290,77 @@ public class SizeClassedChunkCacheTest {
         assertEquals(floor, retained, "retention floor chunks should survive");
     }
 
-    // --- stale epoch: chunk polled with accumulated epoch, reused, re-offered (thread-local only) ---
-    // Thread-local scanForCapacity resets purgeEpoch on poll (ring partitioning isolates idle chunks).
-    // Shared cache does not reset — FIFO rotation would reset all chunks, preventing aging.
+    // --- epoch aging: polled chunks carry their epoch (no reset on poll) ---
+    // Thread-local: partition sub-ordering puts epoch=0 at head, epoch>0 behind.
+    //   Epoch reset on poll would defeat aging when polls > chunks (e.g., 2-core: 16 polls, 7 chunks).
+    // Shared: LRU preference in scanForCapacity achieves the same without epoch reset.
 
-    @Test
-    void polledChunkWithStaleEpochShouldNotBeEvictedPrematurely() {
-        SizeClassedChunkCache cache = SizeClassedChunkCache.create(true);
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void excessChunksAgeAndEvictDespiteBeingPolled(boolean threadLocal) {
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(threadLocal);
 
-        // Pad above retention floor
+        // Pad to retention floor
         for (int i = 0; i < AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE; i++) {
             cache.offerChunk(chunkWithoutCapacity());
         }
 
-        // A fully-free chunk that will age
-        SizeClassedChunk chunk = mock(SizeClassedChunk.class);
-        when(chunk.remainingCapacity()).thenReturn(4096);
-        when(chunk.capacity()).thenReturn(4096);
-        when(chunk.hasRemainingCapacity()).thenReturn(true);
-        cache.offerChunk(chunk);
-
-        // Age it to just below threshold via purge cycles
-        // Each purge: chunk is fully free (remaining==capacity) → epoch++
-        // It also has capacity, so scanForCapacity (called after purge) will poll it.
-        // We re-offer it each time to keep it in the cache.
-        for (int i = 0; i < AdaptivePoolingAllocator.CHUNK_PURGE_THRESHOLD - 1; i++) {
-            cache.forcePurge();
-            cache.offerChunk(chunk);
+        // Add excess idle chunks above the floor
+        int excess = 3;
+        SizeClassedChunk[] idleChunks = new SizeClassedChunk[excess];
+        for (int i = 0; i < excess; i++) {
+            idleChunks[i] = idleChunk();
+            cache.offerChunk(idleChunks[i]);
         }
 
-        // Chunk has been polled and re-offered each cycle.
-        SizeClassedChunk polled = cache.forcePurge();
-        assertNotNull(polled);
-        assertEquals(0, polled.purgeEpoch);
+        // Run enough purge cycles for excess to age past threshold and be evicted
+        for (int i = 0; i < AdaptivePoolingAllocator.CHUNK_PURGE_THRESHOLD + 1; i++) {
+            cache.forcePurge();
+        }
 
-        // Re-offer as fully free (simulating: used briefly, all segments returned)
-        cache.offerChunk(polled);
+        // All excess should be evicted — cache settles at the retention floor
+        for (SizeClassedChunk idle : idleChunks) {
+            verify(idle, atLeastOnce()).markToDeallocate();
+        }
+    }
 
-        // One more purge — should NOT evict (epoch was reset on each poll)
-        cache.forcePurge();
-        verify(chunk, never()).markToDeallocate();
+    // --- shared cache: concurrent scanForCapacity must not livelock ---
+
+    @Test
+    void concurrentScansTerminateWhenNoCapacity() throws Exception {
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(false);
+
+        // Fill with no-capacity chunks — no scan can find anything
+        for (int i = 0; i < 10; i++) {
+            cache.offerChunk(chunkWithoutCapacity());
+        }
+
+        int threadCount = 4;
+        java.util.concurrent.CountDownLatch startLatch = new java.util.concurrent.CountDownLatch(1);
+        java.util.concurrent.CountDownLatch doneLatch = new java.util.concurrent.CountDownLatch(threadCount);
+        java.util.concurrent.atomic.AtomicReference<Throwable> error =
+                new java.util.concurrent.atomic.AtomicReference<>();
+
+        for (int t = 0; t < threadCount; t++) {
+            new Thread(() -> {
+                try {
+                    startLatch.await();
+                    for (int i = 0; i < 1000; i++) {
+                        assertNull(cache.pollChunk(256));
+                    }
+                } catch (Throwable e) {
+                    error.compareAndSet(null, e);
+                } finally {
+                    doneLatch.countDown();
+                }
+            }).start();
+        }
+
+        startLatch.countDown();
+        // With the == sentinel check, threads could livelock here.
+        // With >= ordering, all scans terminate promptly.
+        boolean finished = doneLatch.await(5, java.util.concurrent.TimeUnit.SECONDS);
+        assertTrue(finished, "Concurrent scans should terminate within 5 seconds, not livelock");
+        assertNull(error.get());
     }
 }

--- a/buffer/src/test/java/io/netty/buffer/SizeClassedChunkCacheTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SizeClassedChunkCacheTest.java
@@ -503,8 +503,8 @@ public class SizeClassedChunkCacheTest {
         startLatch.countDown();
         // With the == sentinel check, threads could livelock here.
         // With >= ordering, all scans terminate promptly.
-        boolean finished = doneLatch.await(5, java.util.concurrent.TimeUnit.SECONDS);
-        assertTrue(finished, "Concurrent scans should terminate within 5 seconds, not livelock");
+        boolean finished = doneLatch.await(30, java.util.concurrent.TimeUnit.SECONDS);
+        assertTrue(finished, "Concurrent scans should terminate within 30 seconds, not livelock");
         assertNull(error.get());
     }
 }

--- a/buffer/src/test/java/io/netty/buffer/SizeClassedChunkCacheTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SizeClassedChunkCacheTest.java
@@ -273,6 +273,46 @@ public class SizeClassedChunkCacheTest {
         }
     }
 
+    @Test
+    void wrappedRingCompactionLeavesNoStaleReferences() {
+        AdaptivePoolingAllocator.ThreadLocalSizeClassedChunkCache cache =
+                (AdaptivePoolingAllocator.ThreadLocalSizeClassedChunkCache)
+                        SizeClassedChunkCache.create(true);
+
+        // Fill 6 slots of the initial ring (size=8), purge, drain to advance head
+        for (int i = 0; i < 6; i++) {
+            cache.offerChunk(chunkWithCapacity());
+        }
+        cache.forcePurge();
+        while (cache.pollChunk(256) != null) {
+            // drain
+        }
+        assertTrue(cache.head > 0, "head should have advanced past 0");
+
+        // Offer 4 chunks — wraps past the array boundary
+        cache.offerChunk(chunkWithCapacity());
+        cache.offerChunk(chunkWithCapacity());
+        cache.offerChunk(fullChunk());
+        cache.offerChunk(fullChunk());
+        assertTrue(cache.tail < cache.head,
+                "ring should wrap: tail=" + cache.tail + " < head=" + cache.head);
+
+        // Purge partitions on the wrapped ring
+        SizeClassedChunk polled = cache.forcePurge();
+        assertNotNull(polled);
+
+        // Verify the backing array: exactly count non-null entries, no stale refs
+        int nonNull = 0;
+        for (int i = 0; i < cache.chunks.length; i++) {
+            if (cache.chunks[i] != null) {
+                nonNull++;
+            }
+        }
+        assertEquals(cache.count, nonNull,
+                "backing array should have exactly count=" + cache.count
+                        + " non-null entries, but found " + nonNull);
+    }
+
     // --- bursty traffic: idle chunks are eventually evicted ---
 
     @Test

--- a/buffer/src/test/java/io/netty/buffer/SizeClassedChunkCacheTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SizeClassedChunkCacheTest.java
@@ -141,11 +141,10 @@ public class SizeClassedChunkCacheTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    void purgeResetsEpochForNonIdleChunks(boolean threadLocal) {
+    void nonFullChunkDoesNotAge(boolean threadLocal) {
         SizeClassedChunkCache cache = SizeClassedChunkCache.create(threadLocal);
 
         SizeClassedChunk chunk = chunkWithCapacity();
-        chunk.purgeEpoch = 5;
         cache.offerChunk(chunk);
 
         cache.forcePurge();
@@ -154,11 +153,10 @@ public class SizeClassedChunkCacheTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    void selectedChunkHasEpochReset(boolean threadLocal) {
+    void selectedFullChunkHasEpochReset(boolean threadLocal) {
         SizeClassedChunkCache cache = SizeClassedChunkCache.create(threadLocal);
 
-        SizeClassedChunk chunk = chunkWithCapacity();
-        chunk.purgeEpoch = 2;
+        SizeClassedChunk chunk = fullChunk();
         cache.offerChunk(chunk);
 
         SizeClassedChunk selected = cache.forcePurge();

--- a/buffer/src/test/java/io/netty/buffer/SizeClassedChunkCacheTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SizeClassedChunkCacheTest.java
@@ -93,20 +93,15 @@ public class SizeClassedChunkCacheTest {
 
     // --- purge: epoch aging and eviction (both caches) ---
 
-    @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    void fullChunkAgesEachPurgeAndIsEvictedPastThreshold(boolean threadLocal) {
-        SizeClassedChunkCache cache = SizeClassedChunkCache.create(threadLocal);
+    @Test
+    void fullChunkAgesEachPurgeAndIsEvictedPastThreshold_threadLocal() {
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(true);
 
-        // Pad above retention floor so eviction is allowed
         for (int i = 0; i < AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE; i++) {
             cache.offerChunk(chunkWithoutCapacity());
         }
-
-        // Working-set chunk absorbs scan picks — non-full, epoch=0 at head after partition
         SizeClassedChunk workingSet = chunkWithCapacity();
         cache.offerChunk(workingSet);
-
         SizeClassedChunk idle = fullChunk();
         cache.offerChunk(idle);
 
@@ -117,10 +112,31 @@ public class SizeClassedChunkCacheTest {
             assertEquals(i + 1, idle.purgeEpoch);
             verify(idle, never()).markToDeallocate();
         }
-
         SizeClassedChunk polled = cache.forcePurge();
         assertSame(workingSet, polled);
         verify(idle).markToDeallocate();
+    }
+
+    @Test
+    void fullChunkAgesAndIsEventuallyEvicted_shared() {
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(false);
+
+        for (int i = 0; i < AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE; i++) {
+            cache.offerChunk(chunkWithoutCapacity());
+        }
+        SizeClassedChunk workingSet = chunkWithCapacity();
+        cache.offerChunk(workingSet);
+        SizeClassedChunk idle = fullChunk();
+        cache.offerChunk(idle);
+
+        int maxCycles = (AdaptivePoolingAllocator.CHUNK_PURGE_THRESHOLD + 1) * 3;
+        for (int i = 0; i < maxCycles; i++) {
+            SizeClassedChunk polled = cache.forcePurge();
+            if (polled != null) {
+                cache.offerChunk(polled);
+            }
+        }
+        verify(idle, atLeastOnce()).markToDeallocate();
     }
 
     @ParameterizedTest
@@ -261,32 +277,25 @@ public class SizeClassedChunkCacheTest {
 
     // --- bursty traffic: idle chunks are eventually evicted ---
 
-    @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    void cacheSettlesAtRetentionFloorAfterBurst(boolean threadLocal) {
-        SizeClassedChunkCache cache = SizeClassedChunkCache.create(threadLocal);
+    @Test
+    void cacheSettlesAtRetentionFloorAfterBurst_threadLocal() {
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(true);
 
         int floor = AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE;
         int excess = 10;
 
-        // Working-set chunk absorbs scan picks
         SizeClassedChunk workingSet = chunkWithCapacity();
         cache.offerChunk(workingSet);
-
-        // Retention floor padding
         for (int i = 0; i < floor - 1; i++) {
             cache.offerChunk(chunkWithoutCapacity());
         }
-
-        // Excess full chunks — should age and be evicted
         SizeClassedChunk[] excessChunks = new SizeClassedChunk[excess];
         for (int i = 0; i < excess; i++) {
             excessChunks[i] = fullChunk();
             cache.offerChunk(excessChunks[i]);
         }
 
-        int purgesNeeded = AdaptivePoolingAllocator.CHUNK_PURGE_THRESHOLD + 1;
-        for (int i = 0; i < purgesNeeded; i++) {
+        for (int i = 0; i < AdaptivePoolingAllocator.CHUNK_PURGE_THRESHOLD + 1; i++) {
             SizeClassedChunk polled = cache.forcePurge();
             assertSame(workingSet, polled);
             cache.offerChunk(workingSet);
@@ -298,29 +307,49 @@ public class SizeClassedChunkCacheTest {
         verify(workingSet, never()).markToDeallocate();
     }
 
+    @Test
+    void cacheSettlesAfterBurst_shared() {
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(false);
+
+        int excess = 10;
+        SizeClassedChunk workingSet = chunkWithCapacity();
+        cache.offerChunk(workingSet);
+        for (int i = 0; i < AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE - 1; i++) {
+            cache.offerChunk(chunkWithoutCapacity());
+        }
+        SizeClassedChunk[] excessChunks = new SizeClassedChunk[excess];
+        for (int i = 0; i < excess; i++) {
+            excessChunks[i] = fullChunk();
+            cache.offerChunk(excessChunks[i]);
+        }
+
+        int maxCycles = (AdaptivePoolingAllocator.CHUNK_PURGE_THRESHOLD + 1) * 3;
+        for (int i = 0; i < maxCycles; i++) {
+            SizeClassedChunk polled = cache.forcePurge();
+            if (polled != null) {
+                cache.offerChunk(polled);
+            }
+        }
+
+        for (SizeClassedChunk chunk : excessChunks) {
+            verify(chunk, atLeastOnce()).markToDeallocate();
+        }
+    }
+
     // --- epoch aging with working set ---
     // Scan resets epoch on pick (the chunk is being used). Partition sub-ordering puts
     // epoch=0 (recently used) at head, epoch>0 (idle) behind. Scan prefers head, so
     // idle chunks age undisturbed behind the working set.
 
-    @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    void excessFullChunksAgeWhileWorkingSetIsPreferred(boolean threadLocal) {
-        SizeClassedChunkCache cache = SizeClassedChunkCache.create(threadLocal);
+    @Test
+    void excessFullChunksAgeWhileWorkingSetIsPreferred_threadLocal() {
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(true);
 
-        // Pad to retention floor
         for (int i = 0; i < AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE; i++) {
             cache.offerChunk(chunkWithoutCapacity());
         }
-
-        // Working-set chunk: non-full (remaining != capacity), has capacity.
-        // Purge resets its epoch to 0. Partition puts it at head. Scan picks it.
         SizeClassedChunk workingSet = chunkWithCapacity();
         cache.offerChunk(workingSet);
-
-        // Excess full chunks: remaining == capacity, has capacity.
-        // Purge ages them. Partition puts them behind working-set (epoch>0).
-        // Scan doesn't reach them — working-set absorbs the pick.
         int excess = 3;
         SizeClassedChunk[] idleChunks = new SizeClassedChunk[excess];
         for (int i = 0; i < excess; i++) {
@@ -338,6 +367,35 @@ public class SizeClassedChunkCacheTest {
             verify(idle, atLeastOnce()).markToDeallocate();
         }
         verify(workingSet, never()).markToDeallocate();
+    }
+
+    @Test
+    void excessFullChunksEventuallyEvicted_shared() {
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(false);
+
+        for (int i = 0; i < AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE; i++) {
+            cache.offerChunk(chunkWithoutCapacity());
+        }
+        SizeClassedChunk workingSet = chunkWithCapacity();
+        cache.offerChunk(workingSet);
+        int excess = 3;
+        SizeClassedChunk[] idleChunks = new SizeClassedChunk[excess];
+        for (int i = 0; i < excess; i++) {
+            idleChunks[i] = fullChunk();
+            cache.offerChunk(idleChunks[i]);
+        }
+
+        int maxCycles = (AdaptivePoolingAllocator.CHUNK_PURGE_THRESHOLD + 1) * 3;
+        for (int i = 0; i < maxCycles; i++) {
+            SizeClassedChunk polled = cache.forcePurge();
+            if (polled != null) {
+                cache.offerChunk(polled);
+            }
+        }
+
+        for (SizeClassedChunk idle : idleChunks) {
+            verify(idle, atLeastOnce()).markToDeallocate();
+        }
     }
 
     // --- full-but-active chunk must not be prematurely evicted ---


### PR DESCRIPTION
Motivation:

The bounded ConcurrentQueueChunkCache causes chunk malloc/free churn on low-core containers (CHUNK_REUSE_QUEUE=4 on 2 cores). Dead chunks fill the queue, pollChunk cannot find reusable ones, and new chunks are malloc'd while old ones overflow and get deallocated.

Modification:

Replace with unbounded size-classed caches and epoch-based idle chunk eviction. Thread-local cache uses an in-place ring buffer partitioned into [notEmpty | empty] zones for O(1) scanForCapacity. Shared cache uses a fixed MPMC queue sized to max(128, CHUNK_REUSE_QUEUE * 2).

Purge scan runs periodically (every 16/128 polls), ages fully-free chunks via purgeEpoch, and evicts past threshold while retaining at least CHUNK_REUSE_QUEUE chunks to match the baseline warm-cache behavior at idle.

Result:

Eliminates chunk churn on low-core machines. No regression on all-cores production path.