### PR TITLE
Adaptive: Fix concurrency issue in adaptive allocator

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -1487,10 +1487,18 @@ final class AdaptivePoolingAllocator {
         @Override
         public void accept(int packed) {
             // Called by allocating thread when draining freeList.
-            int size = MIN_BUDDY_SIZE << (packed >> PACK_SIZE_SHIFT);
-            int offset = (packed & PACK_OFFSET_MASK) * MIN_BUDDY_SIZE;
+            int size = unpackSize(packed);
+            int offset = unpackOffset(packed);
             unreserveMatchingBuddy(1, size, offset, 0);
             allocatedBytes -= size;
+        }
+
+        private static int unpackSize(int packed) {
+            return MIN_BUDDY_SIZE << (packed >> PACK_SIZE_SHIFT);
+        }
+
+        private static int unpackOffset(int packed) {
+            return (packed & PACK_OFFSET_MASK) * MIN_BUDDY_SIZE;
         }
 
         @Override
@@ -1504,10 +1512,12 @@ final class AdaptivePoolingAllocator {
 
         @Override
         public int remainingCapacity() {
+            int capacityInFreeList = 0;
             if (!freeList.isEmpty()) {
-                freeList.drain(freeListCapacity, this);
+                capacityInFreeList = freeList.weakPeekReduce(freeListCapacity, 0,
+                        (sum, entry) -> sum + unpackSize(entry));
             }
-            return super.remainingCapacity();
+            return super.remainingCapacity() + capacityInFreeList;
         }
 
         @Override

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorGrowthTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorGrowthTest.java
@@ -18,6 +18,7 @@ package io.netty.buffer;
 import io.netty.util.NettyRuntime;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.test.DisabledForSlowLeakDetection;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.RepetitionInfo;
 import org.junit.jupiter.api.parallel.Isolated;
@@ -36,6 +37,13 @@ public class AdaptiveByteBufAllocatorGrowthTest {
     private static final int THREAD_COUNT = Math.max(4, NettyRuntime.availableProcessors() * 2);
     private static final ExecutorService THREAD_POOL = Executors.newFixedThreadPool(THREAD_COUNT,
             new DefaultThreadFactory("AdaptiveAllocatorGrowthTest", true));
+    private static AdaptiveByteBufAllocator allocator = new AdaptiveByteBufAllocator(false);
+
+    @AfterAll
+    static void cleanUp() {
+        allocator = null;
+        THREAD_POOL.shutdown();
+    }
 
     @DisabledForSlowLeakDetection
     @RepeatedTest(400)
@@ -59,7 +67,6 @@ public class AdaptiveByteBufAllocatorGrowthTest {
             bufSizeGrowth = 1024;
         }
 
-        AdaptiveByteBufAllocator allocator = new AdaptiveByteBufAllocator(false);
         int threadCount = 20;
         CountDownLatch startLatch = new CountDownLatch(1);
         List<Future<Void>> futures = new ArrayList<>();

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorGrowthTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorGrowthTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import io.netty.util.NettyRuntime;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import io.netty.util.test.DisabledForSlowLeakDetection;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.RepetitionInfo;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SplittableRandom;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+@Isolated("Uses a large amount of heap memory, so we don't want it to run concurrently with other allocator tests")
+public class AdaptiveByteBufAllocatorGrowthTest {
+    private static final int THREAD_COUNT = Math.max(4, NettyRuntime.availableProcessors() * 2);
+    private static final ExecutorService THREAD_POOL = Executors.newFixedThreadPool(THREAD_COUNT,
+            new DefaultThreadFactory("AdaptiveAllocatorGrowthTest", true));
+
+    @DisabledForSlowLeakDetection
+    @RepeatedTest(400)
+    void concurrentBufferAllocateAndGrowth(RepetitionInfo info) throws Exception {
+        // This test targets data races where Chunk.remainingCapacity() is called concurrently
+        // with other operations on the chunk. It is important that calling this method does not
+        // modify or corrupt the state of the chunks.
+
+        final int bufSizeBase;
+        final int bufSizeAdditional;
+        final int bufSizeGrowth;
+        if ((info.getCurrentRepetition() & 1) == 0) {
+            // Target large buffers.
+            bufSizeBase = 17000;
+            bufSizeAdditional = 50000;
+            bufSizeGrowth = 80000;
+        } else {
+            // Target small buffers.
+            bufSizeBase = 64;
+            bufSizeAdditional = 512;
+            bufSizeGrowth = 1024;
+        }
+
+        AdaptiveByteBufAllocator allocator = new AdaptiveByteBufAllocator(false);
+        int threadCount = 20;
+        CountDownLatch startLatch = new CountDownLatch(1);
+        List<Future<Void>> futures = new ArrayList<>();
+
+        for (int t = 0; t < threadCount; t++) {
+            futures.add(THREAD_POOL.submit(() -> {
+                startLatch.await();
+                SplittableRandom rng = new SplittableRandom();
+                for (int i = 0; i < 2000; i++) {
+                    // Allocate buffers in various sizes.
+                    // In the BuddyChunk, we'll exercise different buddy tree levels.
+                    int initialSize = bufSizeBase + rng.nextInt(bufSizeAdditional);
+                    ByteBuf buf = allocator.heapBuffer(initialSize);
+                    try {
+                        // Grow the buffer, which will allocate more space, and deallocate the old space.
+                        int growth = rng.nextInt(bufSizeGrowth);
+                        buf.ensureWritable(initialSize + growth);
+                    } finally {
+                        buf.release();
+                    }
+                }
+                return null;
+            }));
+        }
+
+        startLatch.countDown();
+        for (Future<Void> future : futures) {
+            // We're asserting that the tasks did not fail,
+            // and thus that the futures do not propagate any exception.
+            future.get(30, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorGrowthTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorGrowthTest.java
@@ -69,7 +69,7 @@ public class AdaptiveByteBufAllocatorGrowthTest {
 
         int threadCount = 20;
         CountDownLatch startLatch = new CountDownLatch(1);
-        List<Future<Void>> futures = new ArrayList<>();
+        List<Future<Void>> futures = new ArrayList<>(THREAD_COUNT);
 
         for (int t = 0; t < threadCount; t++) {
             futures.add(THREAD_POOL.submit(() -> {

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
@@ -39,7 +39,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<AdaptiveByteBufAllocator> {
-
     @Override
     protected AdaptiveByteBufAllocator newAllocator(boolean preferDirect) {
         return new AdaptiveByteBufAllocator(preferDirect);
@@ -118,7 +117,7 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
     }
 
     @Test
-    void adaptiveChunkMustDeallocateOrReuseWthBufferRelease() {
+    void adaptiveChunkMustDeallocateOrReuseWthBufferRelease() throws Exception {
         AdaptiveByteBufAllocator allocator = newAllocator(false);
         Deque<ByteBuf> bufs = new ArrayDeque<>();
         assertEquals(0, allocator.usedHeapMemory());

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
@@ -298,7 +298,7 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
             bufSizeGrowth = 1024;
         }
 
-        AdaptiveByteBufAllocator allocator = newAllocator(true);
+        AdaptiveByteBufAllocator allocator = newAllocator(false);
         int threadCount = 20;
         CountDownLatch startLatch = new CountDownLatch(1);
         List<Future<Void>> futures = new ArrayList<>();
@@ -311,7 +311,7 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
                     // Allocate buffers in various sizes.
                     // In the BuddyChunk, we'll exercise different buddy tree levels.
                     int initialSize = bufSizeBase + rng.nextInt(bufSizeAdditional);
-                    ByteBuf buf = allocator.directBuffer(initialSize);
+                    ByteBuf buf = allocator.heapBuffer(initialSize);
                     try {
                         // Grow the buffer, which will allocate more space, and deallocate the old space.
                         int growth = rng.nextInt(bufSizeGrowth);

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
@@ -16,21 +16,27 @@
 package io.netty.buffer;
 
 import io.netty.util.NettyRuntime;
+import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.test.DisabledForSlowLeakDetection;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.RepetitionInfo;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.lang.reflect.Array;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Deque;
+import java.util.List;
 import java.util.SplittableRandom;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -39,6 +45,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<AdaptiveByteBufAllocator> {
+    private static final String ADAPTIVE_ALLOCATOR_TEST_THREAD_POOL = "ADAPTIVE_ALLOCATOR_TEST_THREAD_POOL";
+    private static final int THREAD_COUNT = Math.max(4, NettyRuntime.availableProcessors() * 2);
+    private static final ExecutorService THREAD_POOL = Executors.newFixedThreadPool(THREAD_COUNT,
+            new DefaultThreadFactory(ADAPTIVE_ALLOCATOR_TEST_THREAD_POOL, true));
+
     @Override
     protected AdaptiveByteBufAllocator newAllocator(boolean preferDirect) {
         return new AdaptiveByteBufAllocator(preferDirect);
@@ -117,7 +128,7 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
     }
 
     @Test
-    void adaptiveChunkMustDeallocateOrReuseWthBufferRelease() throws Exception {
+    void adaptiveChunkMustDeallocateOrReuseWthBufferRelease() {
         AdaptiveByteBufAllocator allocator = newAllocator(false);
         Deque<ByteBuf> bufs = new ArrayDeque<>();
         assertEquals(0, allocator.usedHeapMemory());
@@ -175,40 +186,36 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
         assertTrue(buffer.release());
     }
 
+    @ResourceLock(ADAPTIVE_ALLOCATOR_TEST_THREAD_POOL)
     @Test
-    public void testAllocateWithoutLock() throws InterruptedException {
+    public void testAllocateWithoutLock() throws Exception {
         final AdaptiveByteBufAllocator alloc = new AdaptiveByteBufAllocator();
         // Make `threadCount` bigger than `AdaptivePoolingAllocator.MAX_STRIPES`, to let thread collision easily happen.
         int threadCount = NettyRuntime.availableProcessors() * 4;
-        final CountDownLatch countDownLatch = new CountDownLatch(threadCount);
-        final AtomicReference<Throwable> throwableAtomicReference = new AtomicReference<Throwable>();
+        final CountDownLatch countDownLatch = new CountDownLatch(THREAD_COUNT);
+        List<Future<Void>> futures = new ArrayList<>();
         for (int i = 0; i < threadCount; i++) {
-            new Thread(new Runnable() {
-                @Override
-                public void run() {
-                    for (int j = 0; j < 1024; j++) {
-                        try {
-                            ByteBuf buffer = null;
-                            try {
-                                buffer = alloc.heapBuffer(128);
-                                buffer.ensureWritable(ThreadLocalRandom.current().nextInt(512, 32769));
-                            } finally {
-                                if (buffer != null) {
-                                    buffer.release();
-                                }
-                            }
-                        } catch (Throwable t) {
-                            throwableAtomicReference.set(t);
+            futures.add(THREAD_POOL.submit(() -> {
+                for (int j = 0; j < 1024; j++) {
+                    ByteBuf buffer = null;
+                    try {
+                        buffer = alloc.heapBuffer(128);
+                        buffer.ensureWritable(ThreadLocalRandom.current().nextInt(512, 32769));
+                    } finally {
+                        if (buffer != null) {
+                            buffer.release();
                         }
                     }
-                    countDownLatch.countDown();
                 }
-            }).start();
+                countDownLatch.countDown();
+                return null;
+            }));
         }
         countDownLatch.await();
-        Throwable throwable = throwableAtomicReference.get();
-        if (throwable != null) {
-            fail("Expected no exception, but got", throwable);
+        for (Future<Void> future : futures) {
+            // We're asserting that no exceptions were thrown from within the tasks,
+            // and thus that the futures do not propergate any exceptions.
+            future.get();
         }
     }
 
@@ -265,6 +272,62 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
             for (ByteBuf buf : bufs) {
                 buf.release();
             }
+        }
+    }
+
+    @ResourceLock(ADAPTIVE_ALLOCATOR_TEST_THREAD_POOL)
+    @DisabledForSlowLeakDetection
+    @RepeatedTest(400)
+    void concurrentBufferAllocateAndGrowth(RepetitionInfo info) throws Exception {
+        // This test targets data races where Chunk.remainingCapacity() is called concurrently
+        // with other operations on the chunk. It is important that calling this method does not
+        // modify or corrupt the state of the chunks.
+
+        final int bufSizeBase;
+        final int bufSizeAdditional;
+        final int bufSizeGrowth;
+        if ((info.getCurrentRepetition() & 1) == 0) {
+            // Target large buffers.
+            bufSizeBase = 17000;
+            bufSizeAdditional = 50000;
+            bufSizeGrowth = 80000;
+        } else {
+            // Target small buffers.
+            bufSizeBase = 64;
+            bufSizeAdditional = 512;
+            bufSizeGrowth = 1024;
+        }
+
+        AdaptiveByteBufAllocator allocator = newAllocator(true);
+        int threadCount = 20;
+        CountDownLatch startLatch = new CountDownLatch(1);
+        List<Future<Void>> futures = new ArrayList<>();
+
+        for (int t = 0; t < threadCount; t++) {
+            futures.add(THREAD_POOL.submit(() -> {
+                startLatch.await();
+                SplittableRandom rng = new SplittableRandom();
+                for (int i = 0; i < 2000; i++) {
+                    // Allocate buffers in various sizes.
+                    // In the BuddyChunk, we'll exercise different buddy tree levels.
+                    int initialSize = bufSizeBase + rng.nextInt(bufSizeAdditional);
+                    ByteBuf buf = allocator.directBuffer(initialSize);
+                    try {
+                        // Grow the buffer, which will allocate more space, and deallocate the old space.
+                        int growth = rng.nextInt(bufSizeGrowth);
+                        buf.ensureWritable(initialSize + growth);
+                    } finally {
+                        buf.release();
+                    }
+                }
+                return null;
+            }));
+        }
+        startLatch.countDown();
+        for (Future<Void> future : futures) {
+            // We're asserting that the tasks did not fail,
+            // and thus that the futures do not propagate any exception.
+            future.get();
         }
     }
 

--- a/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdaptiveByteBufAllocatorTest.java
@@ -16,27 +16,21 @@
 package io.netty.buffer;
 
 import io.netty.util.NettyRuntime;
-import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.test.DisabledForSlowLeakDetection;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.RepetitionInfo;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.lang.reflect.Array;
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Deque;
-import java.util.List;
 import java.util.SplittableRandom;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -45,10 +39,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<AdaptiveByteBufAllocator> {
-    private static final String ADAPTIVE_ALLOCATOR_TEST_THREAD_POOL = "ADAPTIVE_ALLOCATOR_TEST_THREAD_POOL";
-    private static final int THREAD_COUNT = Math.max(4, NettyRuntime.availableProcessors() * 2);
-    private static final ExecutorService THREAD_POOL = Executors.newFixedThreadPool(THREAD_COUNT,
-            new DefaultThreadFactory(ADAPTIVE_ALLOCATOR_TEST_THREAD_POOL, true));
 
     @Override
     protected AdaptiveByteBufAllocator newAllocator(boolean preferDirect) {
@@ -186,36 +176,40 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
         assertTrue(buffer.release());
     }
 
-    @ResourceLock(ADAPTIVE_ALLOCATOR_TEST_THREAD_POOL)
     @Test
-    public void testAllocateWithoutLock() throws Exception {
+    public void testAllocateWithoutLock() throws InterruptedException {
         final AdaptiveByteBufAllocator alloc = new AdaptiveByteBufAllocator();
         // Make `threadCount` bigger than `AdaptivePoolingAllocator.MAX_STRIPES`, to let thread collision easily happen.
         int threadCount = NettyRuntime.availableProcessors() * 4;
-        final CountDownLatch countDownLatch = new CountDownLatch(THREAD_COUNT);
-        List<Future<Void>> futures = new ArrayList<>();
+        final CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+        final AtomicReference<Throwable> throwableAtomicReference = new AtomicReference<Throwable>();
         for (int i = 0; i < threadCount; i++) {
-            futures.add(THREAD_POOL.submit(() -> {
-                for (int j = 0; j < 1024; j++) {
-                    ByteBuf buffer = null;
-                    try {
-                        buffer = alloc.heapBuffer(128);
-                        buffer.ensureWritable(ThreadLocalRandom.current().nextInt(512, 32769));
-                    } finally {
-                        if (buffer != null) {
-                            buffer.release();
+            new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    for (int j = 0; j < 1024; j++) {
+                        try {
+                            ByteBuf buffer = null;
+                            try {
+                                buffer = alloc.heapBuffer(128);
+                                buffer.ensureWritable(ThreadLocalRandom.current().nextInt(512, 32769));
+                            } finally {
+                                if (buffer != null) {
+                                    buffer.release();
+                                }
+                            }
+                        } catch (Throwable t) {
+                            throwableAtomicReference.set(t);
                         }
                     }
+                    countDownLatch.countDown();
                 }
-                countDownLatch.countDown();
-                return null;
-            }));
+            }).start();
         }
         countDownLatch.await();
-        for (Future<Void> future : futures) {
-            // We're asserting that no exceptions were thrown from within the tasks,
-            // and thus that the futures do not propergate any exceptions.
-            future.get();
+        Throwable throwable = throwableAtomicReference.get();
+        if (throwable != null) {
+            fail("Expected no exception, but got", throwable);
         }
     }
 
@@ -272,62 +266,6 @@ public class AdaptiveByteBufAllocatorTest extends AbstractByteBufAllocatorTest<A
             for (ByteBuf buf : bufs) {
                 buf.release();
             }
-        }
-    }
-
-    @ResourceLock(ADAPTIVE_ALLOCATOR_TEST_THREAD_POOL)
-    @DisabledForSlowLeakDetection
-    @RepeatedTest(400)
-    void concurrentBufferAllocateAndGrowth(RepetitionInfo info) throws Exception {
-        // This test targets data races where Chunk.remainingCapacity() is called concurrently
-        // with other operations on the chunk. It is important that calling this method does not
-        // modify or corrupt the state of the chunks.
-
-        final int bufSizeBase;
-        final int bufSizeAdditional;
-        final int bufSizeGrowth;
-        if ((info.getCurrentRepetition() & 1) == 0) {
-            // Target large buffers.
-            bufSizeBase = 17000;
-            bufSizeAdditional = 50000;
-            bufSizeGrowth = 80000;
-        } else {
-            // Target small buffers.
-            bufSizeBase = 64;
-            bufSizeAdditional = 512;
-            bufSizeGrowth = 1024;
-        }
-
-        AdaptiveByteBufAllocator allocator = newAllocator(false);
-        int threadCount = 20;
-        CountDownLatch startLatch = new CountDownLatch(1);
-        List<Future<Void>> futures = new ArrayList<>();
-
-        for (int t = 0; t < threadCount; t++) {
-            futures.add(THREAD_POOL.submit(() -> {
-                startLatch.await();
-                SplittableRandom rng = new SplittableRandom();
-                for (int i = 0; i < 2000; i++) {
-                    // Allocate buffers in various sizes.
-                    // In the BuddyChunk, we'll exercise different buddy tree levels.
-                    int initialSize = bufSizeBase + rng.nextInt(bufSizeAdditional);
-                    ByteBuf buf = allocator.heapBuffer(initialSize);
-                    try {
-                        // Grow the buffer, which will allocate more space, and deallocate the old space.
-                        int growth = rng.nextInt(bufSizeGrowth);
-                        buf.ensureWritable(initialSize + growth);
-                    } finally {
-                        buf.release();
-                    }
-                }
-                return null;
-            }));
-        }
-        startLatch.countDown();
-        for (Future<Void> future : futures) {
-            // We're asserting that the tasks did not fail,
-            // and thus that the futures do not propagate any exception.
-            future.get();
         }
     }
 

--- a/common/src/main/java/io/netty/util/concurrent/MpscIntQueue.java
+++ b/common/src/main/java/io/netty/util/concurrent/MpscIntQueue.java
@@ -83,7 +83,11 @@ public interface MpscIntQueue {
      * @param op The reduction operation, taking a prior result and an element, and producing a new result.
      * @return The last result of the reduction operation.
      */
-    int weakPeekReduce(int limit, int initial, IntBinaryOperator op);
+    default int weakPeekReduce(int limit, int initial, IntBinaryOperator op) {
+        // There's no safe way to implement this method in terms of the other operations.
+        // Take the "weak" definition to the extreme and just return the initial value.
+        return initial;
+    }
 
     /**
      * Query if the queue is empty or not.

--- a/common/src/main/java/io/netty/util/concurrent/MpscIntQueue.java
+++ b/common/src/main/java/io/netty/util/concurrent/MpscIntQueue.java
@@ -21,6 +21,7 @@ import io.netty.util.internal.ObjectUtil;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicIntegerArray;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.function.IntBinaryOperator;
 import java.util.function.IntConsumer;
 import java.util.function.IntSupplier;
 
@@ -73,6 +74,16 @@ public interface MpscIntQueue {
      * @return The actual number of elements added.
      */
     int fill(int limit, IntSupplier supplier);
+
+    /**
+     * Peek at all available elements and compute a reduction.
+     * The elements are not removed, and the iteration is weakly consistent.
+     * @param limit The maximum number of elements to process.
+     * @param initial The initial value to the reduction operation.
+     * @param op The reduction operation, taking a prior result and an element, and producing a new result.
+     * @return The last result of the reduction operation.
+     */
+    int weakPeekReduce(int limit, int initial, IntBinaryOperator op);
 
     /**
      * Query if the queue is empty or not.
@@ -242,6 +253,30 @@ public interface MpscIntQueue {
                 lazySet(offset, supplier.getAsInt());
             }
             return actualLimit;
+        }
+
+        @Override
+        public int weakPeekReduce(int limit, int initial, IntBinaryOperator op) {
+            Objects.requireNonNull(op, "op");
+            ObjectUtil.checkPositiveOrZero(limit, "limit");
+            if (limit == 0) {
+                return 0;
+            }
+            int result = initial;
+
+            final int mask = this.mask;
+            final long cIndex = consumerIndex; // Note: could be weakened to plain-load.
+            for (int i = 0; i < limit; i++) {
+                final long index = cIndex + i;
+                final int offset = (int) (index & mask);
+                final int value = get(offset);
+                if (emptyValue == value) {
+                    return result;
+                }
+                // Do not remove the element or advance the consumer index.
+                result = op.applyAsInt(result, value);
+            }
+            return result;
         }
 
         @Override


### PR DESCRIPTION
Motivation:
We have a few code paths where `Chunk.remainingCapacity()` is called without regard for exclusive access to the given chunk. The `BuddyChunk` implementation unfortunately drained the `freeList` in this call, leading to racy modifications of the `buddies` array, that in turn can manifest as unpredictable bugs.

Modification:
Make the `BuddyChunk.remainingCapacity` non-modifying. Instead of draining the `freeList`, we sum up the capacity held by it and add it to the capacity accounted for in the `Chunk` super class.

This operation needs a `weakPeekReduce` method on the `MpscIntQueue`. This method performs a reduction operation on a given range of entries, but without removing entries or incrementing the consumer index.

A regression test is added, which successfully captured the issue before it was fixed.

Also did a few test cleanups.

Result:
No more corruptions in the buddies array.

This fixes the rare occurrences of assertion errors like the following:

```
java.lang.AssertionError
	at io.netty.buffer.AdaptivePoolingAllocator$Magazine.allocate(AdaptivePoolingAllocator.java:916)
	at io.netty.buffer.AdaptivePoolingAllocator$Magazine.tryAllocate(AdaptivePoolingAllocator.java:854)
	at io.netty.buffer.AdaptivePoolingAllocator$MagazineGroup.allocate(AdaptivePoolingAllocator.java:421)
	at io.netty.buffer.AdaptivePoolingAllocator.allocate(AdaptivePoolingAllocator.java:271)
```
