### PR TITLE
Revapi: Use default "oldVersion"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1261,7 +1261,6 @@
         </dependencies>
         <configuration>
           <versionFormat>.*\.Final</versionFormat>
-          <oldVersion>4.2.0.Final</oldVersion>
           <analysisConfiguration>
             <revapi.filter>
               <elements>


### PR DESCRIPTION
Motivation:
If we fix the old version to be the start of the 4.2 series, then revapi cannot find compatibility breakages in classes that were added after 4.2.0.

Modification:
Let revapi pick the old version using its defaults. This will make it compare to the most recent released version, and thus we detect API breakages between each patch release.

Result:
More fine-grained API breakage detection by revapi.