### PR TITLE
Adaptive: Fix concurrency issue in adaptive allocator (#16767)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -704,13 +704,13 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
             chunkRegistry = group.allocator.chunkRegistry;
         }
 
-        private MpscIntQueue createEmptyFreeList() {
+        private MpscAtomicIntegerArrayQueue createEmptyFreeList() {
             return new MpscAtomicIntegerArrayQueue(chunkSize / segmentSize, SizeClassedChunk.FREE_LIST_EMPTY);
         }
 
-        private MpscIntQueue createFreeList() {
+        private MpscAtomicIntegerArrayQueue createFreeList() {
             final int segmentsCount = chunkSize / segmentSize;
-            final MpscIntQueue freeList = new MpscAtomicIntegerArrayQueue(
+            final MpscAtomicIntegerArrayQueue freeList = new MpscAtomicIntegerArrayQueue(
                     segmentsCount, SizeClassedChunk.FREE_LIST_EMPTY);
             int segmentOffset = 0;
             for (int i = 0; i < segmentsCount; i++) {
@@ -1455,7 +1455,7 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
         private static final int PACK_OFFSET_MASK = 0xFFFF;
         private static final int PACK_SIZE_SHIFT = Integer.SIZE - Integer.numberOfLeadingZeros(PACK_OFFSET_MASK);
 
-        private final MpscIntQueue freeList;
+        private final MpscAtomicIntegerArrayQueue freeList;
         // The bits of each buddy: [1: is claimed][1: has claimed children][30: MIN_BUDDY_SIZE shift to get size]
         private final byte[] buddies;
         private final int freeListCapacity;
@@ -1512,10 +1512,18 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
         @Override
         public void accept(int packed) {
             // Called by allocating thread when draining freeList.
-            int size = MIN_BUDDY_SIZE << (packed >> PACK_SIZE_SHIFT);
-            int offset = (packed & PACK_OFFSET_MASK) * MIN_BUDDY_SIZE;
+            int size = unpackSize(packed);
+            int offset = unpackOffset(packed);
             unreserveMatchingBuddy(1, size, offset, 0);
             allocatedBytes -= size;
+        }
+
+        private static int unpackSize(int packed) {
+            return MIN_BUDDY_SIZE << (packed >> PACK_SIZE_SHIFT);
+        }
+
+        private static int unpackOffset(int packed) {
+            return (packed & PACK_OFFSET_MASK) * MIN_BUDDY_SIZE;
         }
 
         @Override
@@ -1529,10 +1537,17 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
 
         @Override
         public int remainingCapacity() {
+            int capacityInFreeList = 0;
             if (!freeList.isEmpty()) {
-                freeList.drain(freeListCapacity, this);
+                capacityInFreeList = freeList.weakPeekReduce(freeListCapacity, 0,
+                        new MpscAtomicIntegerArrayQueue.IntBinaryOperator() {
+                            @Override
+                            public int applyAsInt(int sum, int entry) {
+                                return sum + unpackSize(entry);
+                            }
+                        });
             }
-            return super.remainingCapacity();
+            return super.remainingCapacity() + capacityInFreeList;
         }
 
         @Override

--- a/common/src/main/java/io/netty/util/concurrent/MpscAtomicIntegerArrayQueue.java
+++ b/common/src/main/java/io/netty/util/concurrent/MpscAtomicIntegerArrayQueue.java
@@ -199,6 +199,37 @@ public final class MpscAtomicIntegerArrayQueue extends AtomicIntegerArray implem
         return actualLimit;
     }
 
+    /**
+     * Peek at all available elements and compute a reduction.
+     * The elements are not removed, and the iteration is weakly consistent.
+     * @param limit The maximum number of elements to process.
+     * @param initial The initial value to the reduction operation.
+     * @param op The reduction operation, taking a prior result and an element, and producing a new result.
+     * @return The last result of the reduction operation.
+     */
+    public int weakPeekReduce(int limit, int initial, IntBinaryOperator op) {
+        ObjectUtil.checkNotNull(op, "op");
+        ObjectUtil.checkPositiveOrZero(limit, "limit");
+        if (limit == 0) {
+            return 0;
+        }
+        int result = initial;
+
+        final int mask = this.mask;
+        final long cIndex = consumerIndex; // Note: could be weakened to plain-load.
+        for (int i = 0; i < limit; i++) {
+            final long index = cIndex + i;
+            final int offset = (int) (index & mask);
+            final int value = get(offset);
+            if (emptyValue == value) {
+                return result;
+            }
+            // Do not remove the element or advance the consumer index.
+            result = op.applyAsInt(result, value);
+        }
+        return result;
+    }
+
     @Override
     public boolean isEmpty() {
         // Load consumer index before producer index, so our check is conservative.
@@ -222,5 +253,9 @@ public final class MpscAtomicIntegerArrayQueue extends AtomicIntegerArray implem
             }
         }
         return size < 0 ? 0 : size > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) size;
+    }
+
+    public interface IntBinaryOperator {
+        int applyAsInt(int a, int b);
     }
 }


### PR DESCRIPTION
Motivation:
We have a few code paths where `Chunk.remainingCapacity()` is called without regard for exclusive access to the given chunk. The `BuddyChunk` implementation unfortunately drained the `freeList` in this call, leading to racy modifications of the `buddies` array, that in turn can manifest as unpredictable bugs.

Modification:
Make the `BuddyChunk.remainingCapacity` non-modifying. Instead of draining the `freeList`, we sum up the capacity held by it and add it to the capacity accounted for in the `Chunk` super class.

This operation needs a `weakPeekReduce` method on the `MpscIntQueue`. This method performs a reduction operation on a given range of entries, but without removing entries or incrementing the consumer index.

A regression test is added, which successfully captured the issue before it was fixed.

Also did a few test cleanups.

Result:
No more corruptions in the buddies array.

This fixes the rare occurrences of assertion errors like the following:

```
java.lang.AssertionError
	at io.netty.buffer.AdaptivePoolingAllocator$Magazine.allocate(AdaptivePoolingAllocator.java:916)
	at io.netty.buffer.AdaptivePoolingAllocator$Magazine.tryAllocate(AdaptivePoolingAllocator.java:854)
	at io.netty.buffer.AdaptivePoolingAllocator$MagazineGroup.allocate(AdaptivePoolingAllocator.java:421)
	at io.netty.buffer.AdaptivePoolingAllocator.allocate(AdaptivePoolingAllocator.java:271)
```

(cherry picked from commit bd866c3d05d3a6166a45aec8bd8efdaec7dd61c7)