### PR TITLE
Remove references to Java versions older than 25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,9 +209,6 @@
         <argLine.java9.extras />
         <argLine.java9>${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
-        <maven.compiler.release>25</maven.compiler.release>
         <!-- pax-exam does not work on latest Java12 EA 22 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
         <revapi.skip>true</revapi.skip>
@@ -226,9 +223,6 @@
         <argLine.java9.extras />
         <argLine.java9>${argLine.java9.extras}</argLine.java9>
         <forbiddenapis.skip>true</forbiddenapis.skip>
-        <maven.compiler.source>25</maven.compiler.source>
-        <maven.compiler.target>25</maven.compiler.target>
-        <maven.compiler.release>25</maven.compiler.release>
         <!-- pax-exam does not work on latest Java12 EA 22 build -->
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
         <revapi.skip>true</revapi.skip>
@@ -405,24 +399,16 @@
         </plugins>
       </build>
     </profile>
-    <profile>
-      <id>jdk8</id>
-      <activation>
-        <jdk>[1.8,)</jdk>
-      </activation>
-      <properties>
-        <!-- Our Javadoc has poor enough quality to fail the build thanks to JDK8 javadoc which got more strict. -->
-        <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
-      </properties>
-    </profile>
   </profiles>
 
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.release />
-    <javadoc.release>9</javadoc.release>
-    <javadoc.source>9</javadoc.source>
+    <maven.compiler.source>25</maven.compiler.source>
+    <maven.compiler.target>25</maven.compiler.target>
+    <maven.compiler.release>25</maven.compiler.release>
+    <javadoc.release>25</javadoc.release>
+    <javadoc.source>25</javadoc.source>
+    <!-- Our Javadoc has poor enough quality to fail the build thanks to JDK8 javadoc which got more strict. -->
+    <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
     <netty.dev.tools.directory>${project.basedir}/../dev-tools/src/main/resources/</netty.dev.tools.directory>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/testsuite-jpms/pom.xml
+++ b/testsuite-jpms/pom.xml
@@ -34,9 +34,6 @@
     <skipDeploy>true</skipDeploy>
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <javaModuleName>io.netty.testsuite_jpms</javaModuleName>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
-    <maven.compiler.release>11</maven.compiler.release>
     <useTestModulePath>true</useTestModulePath>
     <packaging.type>pom</packaging.type>
   </properties>
@@ -423,13 +420,6 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
-    <profile>
-      <id>jdk8-tests</id>
-      <properties>
-        <skipTests>true</skipTests>
-        <skipJpmsTestsuite>true</skipJpmsTestsuite>
-      </properties>
     </profile>
   </profiles>
 </project>

--- a/transport-blockhound-tests/pom.xml
+++ b/transport-blockhound-tests/pom.xml
@@ -161,8 +161,6 @@
   </profiles>
 
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
     <!-- Needed for SelfSignedCertificate -->
     <argLine.java9.extras>--add-exports java.base/sun.security.x509=ALL-UNNAMED</argLine.java9.extras>
     <!-- Do not deploy this module -->

--- a/transport-classes-io_uring/pom.xml
+++ b/transport-classes-io_uring/pom.xml
@@ -28,9 +28,6 @@
 
   <properties>
     <javaModuleName>io.netty.transport.classes.io_uring</javaModuleName>
-    <maven.compiler.source>1.9</maven.compiler.source>
-    <maven.compiler.target>1.9</maven.compiler.target>
-    <maven.compiler.release>9</maven.compiler.release>
   </properties>
 
   <dependencies>
@@ -76,78 +73,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <!--
-          We need to compile everything except the IoUring class with Java9+
-          The reason for this is that we want still be able to use IoUring.ensureAvaibility() on Java8.
-        -->
-        <executions>
-          <execution>
-            <id>default-compile</id>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-            <configuration>
-              <compilerVersion>1.9</compilerVersion>
-              <fork>true</fork>
-              <source>${maven.compiler.source}</source>
-              <target>${maven.compiler.target}</target>
-              <release>${maven.compiler.release}</release>
-              <debug>true</debug>
-              <optimize>true</optimize>
-              <showDeprecation>true</showDeprecation>
-              <showWarnings>true</showWarnings>
-              <compilerArgument>-Xlint:-options</compilerArgument>
-              <meminitial>256m</meminitial>
-              <maxmem>1024m</maxmem>
-              <excludes>
-                <exclude>**/package-info.java</exclude>
-              </excludes>
-            </configuration>
-          </execution>
-          <execution>
-            <id>compile-jdk8</id>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-            <configuration>
-              <compilerVersion>1.8</compilerVersion>
-              <fork>true</fork>
-              <source>1.8</source>
-              <target>1.8</target>
-              <release>8</release>
-              <debug>true</debug>
-              <optimize>true</optimize>
-              <showDeprecation>true</showDeprecation>
-              <showWarnings>true</showWarnings>
-              <compilerArgument>-Xlint:-options</compilerArgument>
-              <meminitial>256m</meminitial>
-              <maxmem>1024m</maxmem>
-              <includes>
-                <include>**/IoUring.java</include>
-              </includes>
-            </configuration>
-          </execution>
-          <execution>
-            <id>compile-tests-jdk8</id>
-            <goals>
-              <goal>testCompile</goal>
-            </goals>
-            <configuration>
-              <compilerVersion>1.8</compilerVersion>
-              <fork>true</fork>
-              <source>1.8</source>
-              <target>1.8</target>
-              <release>8</release>
-              <debug>true</debug>
-              <optimize>true</optimize>
-              <showDeprecation>true</showDeprecation>
-              <showWarnings>true</showWarnings>
-              <compilerArgument>-Xlint:-options</compilerArgument>
-              <meminitial>256m</meminitial>
-              <maxmem>1024m</maxmem>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>io.github.dmlloyd.module-info</groupId>


### PR DESCRIPTION
Motivation:
In Netty 5.0 we baseline on Java 25, so there's no need for our pom files to have references to older versions.

Modification:
Remove references to older Java versions, particularly some modules needed to compile with newer versions than Java 8, that we inherited from Netty 4.2.

Result:
Consistent Java versions used throughout.