### PR TITLE
Make bulk byte moving in ByteBuf faster

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledDirectByteBuf.java
@@ -18,6 +18,7 @@ package io.netty.buffer;
 
 import io.netty.util.Recycler;
 import io.netty.util.internal.ObjectPool.Handle;
+import io.netty.util.internal.PlatformDependent;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -110,14 +111,20 @@ final class PooledDirectByteBuf extends PooledByteBuf<ByteBuffer> {
         checkDstIndex(index, length, dstIndex, dst.capacity());
         if (dst.hasArray()) {
             getBytes(index, dst.array(), dst.arrayOffset() + dstIndex, length);
-        } else if (dst.nioBufferCount() > 0) {
-            for (ByteBuffer bb: dst.nioBuffers(dstIndex, length)) {
-                int bbLen = bb.remaining();
-                getBytes(index, bb);
-                index += bbLen;
-            }
         } else {
-            dst.setBytes(dstIndex, this, index, length);
+            ByteBuf unwrapped = dst instanceof WrappedByteBuf ? dst.unwrap() : dst;
+            if (unwrapped instanceof AbstractByteBuf) {
+                ByteBuffer dstBuf = unwrapped.internalNioBuffer(dstIndex, length);
+                PlatformDependent.absolutePut(dstBuf, dstBuf.position(), memory, idx(index), length);
+            } else if (dst.nioBufferCount() > 0) {
+                for (ByteBuffer bb : dst.nioBuffers(dstIndex, length)) {
+                    int bbLen = bb.remaining();
+                    getBytes(index, bb);
+                    index += bbLen;
+                }
+            } else {
+                dst.setBytes(dstIndex, this, index, length);
+            }
         }
         return this;
     }

--- a/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
@@ -362,14 +362,20 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
         checkDstIndex(index, length, dstIndex, dst.capacity());
         if (dst.hasArray()) {
             getBytes(index, dst.array(), dst.arrayOffset() + dstIndex, length);
-        } else if (dst.nioBufferCount() > 0) {
-            for (ByteBuffer bb: dst.nioBuffers(dstIndex, length)) {
-                int bbLen = bb.remaining();
-                getBytes(index, bb);
-                index += bbLen;
-            }
         } else {
-            dst.setBytes(dstIndex, this, index, length);
+            ByteBuf unwrapped = dst instanceof WrappedByteBuf ? dst.unwrap() : dst;
+            if (unwrapped instanceof AbstractByteBuf) {
+                ByteBuffer dstBuf = unwrapped.internalNioBuffer(dstIndex, length);
+                PlatformDependent.absolutePut(dstBuf, dstBuf.position(), buffer, index, length);
+            } else if (dst.nioBufferCount() > 0) {
+                for (ByteBuffer bb : dst.nioBuffers(dstIndex, length)) {
+                    int bbLen = bb.remaining();
+                    getBytes(index, bb);
+                    index += bbLen;
+                }
+            } else {
+                dst.setBytes(dstIndex, this, index, length);
+            }
         }
         return this;
     }


### PR DESCRIPTION
Motivation:
ByteBuf.getBytes is important for the performance of many bulk byte moving operations.
When the leak detector is enabled, calls like `nioBufferCount`, `nioBuffers`, and `internalNioBuffer` can produce expensive recording calls.

Modification:
- Unwrap the destination buffer if it is wrapped.
- Use `absolutePut` operations on the internal NIO buffer to avoid allocating `ByteBuffer` instances.

Result:
Bulk byte move operations are faster.
So much so that the `DataCompressionHttp2Test.encodingTooBigMessage` test no longer fails on a timeout.
