### PR TITLE
Remove dead native declarations

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/NativeStaticallyReferencedJniMethods.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/NativeStaticallyReferencedJniMethods.java
@@ -35,10 +35,7 @@ final class NativeStaticallyReferencedJniMethods {
     static native int epollrdhup();
     static native int epollet();
     static native int epollerr();
-    static native long ssizeMax();
     static native int tcpMd5SigMaxKeyLen();
-    static native int iovMax();
-    static native int uioMaxIov();
     static native boolean isSupportingSendmmsg();
     static native boolean isSupportingRecvmmsg();
     static native int tcpFastopenMode();


### PR DESCRIPTION
Motivation:
`ssizeMax`, `iovMax`, `uioMaxIov` are declared native in the epoll `NativeStaticallyReferencedJniMethods` but never added to the epoll RegisterNatives table


Runtime Impact:
None — these three methods are never invoked from the epoll class; they are dead native declarations



Modification:

Remove `ssizeMax`, `iovMax`, and `uioMaxIov` from `NativeStaticallyReferencedJniMethods.java` in the `epoll` package — they are unreachable dead code that causes false positives in bytecode analysis


Result:

Fixes #16757 

If there is no issue then describe the changes introduced by this PR.
