### PR TITLE
Pin multipart Content-Type / Content-Transfer-Encoding case folding t…

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
@@ -41,6 +41,7 @@ import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -919,7 +920,11 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
         if (encoding != null) {
             String code;
             try {
-                code = encoding.getValue().toLowerCase();
+                // RFC 2045 Content-Transfer-Encoding values are case-insensitive ASCII tokens.
+                // toLowerCase() without a Locale would corrupt them under Turkish (tr_TR) locale,
+                // where 'I' lowercases to 'ı' (U+0131) and "BINARY" becomes "bınary" - never
+                // matching the lowercase ASCII constants compared against below.
+                code = encoding.getValue().toLowerCase(Locale.US);
             } catch (IOException e) {
                 throw new ErrorDataDecoderException(e);
             }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
@@ -48,6 +48,8 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.regex.Pattern;
+import java.util.Locale;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static io.netty.buffer.Unpooled.wrappedBuffer;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
@@ -760,7 +762,12 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
             headers.remove(HttpHeaderNames.CONTENT_TYPE);
             for (String contentType : contentTypes) {
                 // "multipart/form-data; boundary=--89421926422648"
-                String lowercased = contentType.toLowerCase();
+                // toLowerCase() without a Locale would corrupt the comparison under Turkish
+                // (tr_TR) locale, where 'I' -> 'ı' (U+0131): a request that sets
+                // Content-Type: MULTIPART/form-data would lowercase to "multıpart/form-data" and
+                // miss the prefix check, leaving the original header in place alongside the
+                // multipart one this encoder is about to add.
+                String lowercased = contentType.toLowerCase(Locale.US);
                 if (lowercased.startsWith(HttpHeaderValues.MULTIPART_FORM_DATA.toString()) ||
                         lowercased.startsWith(HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())) {
                     // ignore

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostMultipartLocaleDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostMultipartLocaleDecoderTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http.multipart;
+
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.CharsetUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Decoder-side test that flips {@link Locale#setDefault(Locale)} to Turkish to exercise the
+ * {@code Content-Transfer-Encoding} normalization path. Marked {@link Isolated} because the JVM
+ * default Locale is process-global state and codec-http runs tests with
+ * {@code junit.jupiter.execution.parallel.mode.default = concurrent}.
+ */
+@Isolated("Mutates Locale.getDefault() which is JVM-global state.")
+class HttpPostMultipartLocaleDecoderTest {
+
+    @Test
+    void testUppercaseBinaryTransferEncodingUnderTurkishLocale() {
+        // Repro: a part declares an uppercase Content-Transfer-Encoding (RFC 2045 mechanism
+        // tokens are case-insensitive). On a Turkish-locale JVM the decoder used to call
+        // toLowerCase() without a Locale and produced "bınary" (U+0131) which then failed the
+        // compare against the lowercase ASCII constants and threw
+        // "TransferEncoding Unknown: bınary".
+        Locale original = Locale.getDefault();
+        try {
+            Locale.setDefault(new Locale("tr", "TR"));
+            String content = "\n--861fbeab-cd20-470c-9609-d40a0f704466\r\n" +
+                    "content-disposition: form-data; " +
+                    "name=\"file\"; filename=\"myfile.ogg\"\r\n" +
+                    "content-type: audio/ogg; codecs=opus; charset=UTF8\r\n" +
+                    "Content-Transfer-Encoding: BINARY\r\n" +
+                    "\r\n\r\n--861fbeab-cd20-470c-9609-d40a0f704466--\r\n";
+
+            FullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/upload",
+                    Unpooled.copiedBuffer(content, CharsetUtil.US_ASCII));
+            req.headers().set("content-type", "multipart/form-data; boundary=861fbeab-cd20-470c-9609-d40a0f704466");
+            req.headers().set("content-length", content.length());
+
+            HttpPostMultipartRequestDecoder decoder = new HttpPostMultipartRequestDecoder(req);
+            FileUpload httpData = (FileUpload) decoder.getBodyHttpDatas("file").get(0);
+            assertNotNull(httpData);
+            assertEquals("audio/ogg", httpData.getContentType());
+            decoder.destroy();
+        } finally {
+            Locale.setDefault(original);
+        }
+    }
+}

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostMultipartLocaleEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostMultipartLocaleEncoderTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http.multipart;
+
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import java.util.List;
+import java.util.Locale;
+
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
+import static io.netty.handler.codec.http.HttpMethod.POST;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Encoder-side test that flips {@link Locale#setDefault(Locale)} to Turkish to exercise the
+ * {@code Content-Type} de-duplication path inside
+ * {@link HttpPostRequestEncoder#finalizeRequest()}. Marked {@link Isolated} because the JVM
+ * default Locale is process-global state and codec-http runs tests with
+ * {@code junit.jupiter.execution.parallel.mode.default = concurrent}.
+ */
+@Isolated("Mutates Locale.getDefault() which is JVM-global state.")
+class HttpPostMultipartLocaleEncoderTest {
+
+    @Test
+    void testFinalizeRemovesPreexistingMultipartContentTypeUnderTurkishLocale() throws Exception {
+        // Repro: a caller pre-sets `Content-Type: MULTIPART/form-data` (uppercase, RFC-allowed,
+        // case-insensitive). When the JVM default Locale is Turkish, the encoder's
+        // contentType.toLowerCase() used to map 'I' -> 'ı' (U+0131), the resulting
+        // "multıpart/form-data" missed the prefix check, and the original mixed-case header was
+        // left alongside the new multipart Content-Type the encoder is about to set - producing
+        // two Content-Type headers on the request.
+        Locale original = Locale.getDefault();
+        try {
+            Locale.setDefault(new Locale("tr", "TR"));
+            DefaultFullHttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, POST, "http://localhost");
+            request.headers().add(CONTENT_TYPE, "MULTIPART/form-data; boundary=preexisting");
+            HttpPostRequestEncoder encoder = new HttpPostRequestEncoder(request, true);
+            encoder.finalizeRequest();
+            List<String> contentTypes = request.headers().getAll(CONTENT_TYPE);
+            assertEquals(1, contentTypes.size(),
+                    "encoder must drop the pre-existing multipart Content-Type regardless of JVM locale");
+            assertTrue(contentTypes.get(0).startsWith("multipart/form-data"),
+                    "the surviving Content-Type must be the encoder's freshly-built multipart header");
+            request.release();
+        } finally {
+            Locale.setDefault(original);
+        }
+    }
+}


### PR DESCRIPTION
…o Locale.US (#16768)

Two spots in the HTTP multipart codec normalize a header value with `String.toLowerCase()` without an explicit Locale, then compare the result to lowercase ASCII constants. The JVM default Locale governs that call, and on a Turkish (`tr_TR`) JVM the ASCII `'I'` lowercases to `'ı'` (U+0131). A perfectly valid uppercase form silently misses the comparison.

Concretely on a Turkish-locale JVM:

- `HttpPostMultipartRequestDecoder` decoding a part with `Content-Transfer-Encoding: BINARY` (uppercase, RFC 2045 §6.1 says mechanism tokens are case-insensitive) lowercases the value to `"bınary"`, fails the equality check against the `binary` / `7bit` / `8bit` constants, and throws `ErrorDataDecoderException: TransferEncoding Unknown: bınary`.
- `HttpPostRequestEncoder.finalizeRequest()` skipping a pre-existing `Content-Type: MULTIPART/form-data; boundary=...` header (mixed case is allowed by the Content-Type ABNF, RFC 7231 §3.1.1.1) lowercases the value to `"multıpart/..."`, misses the
`startsWith("multipart/form-data")` check, and the original mixed-case header survives alongside the freshly-built multipart Content-Type the encoder is about to add. The outgoing request ends up with **two** `Content-Type` headers.

The values being compared against are lowercase ASCII tokens and have no business consulting the JVM locale.

Pin both `String.toLowerCase()` calls to `Locale.US`:

-
`codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java` — `getFileUpload(String delimiter)` lowercases the `Content-Transfer-Encoding` value before matching it against `BIT7` / `BIT8` / `BINARY` mechanism tokens.
-
`codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java` — `finalizeRequest()` lowercases each existing `Content-Type` before checking if it is the multipart or `application/x-www-form-urlencoded` form (which the encoder is responsible for setting fresh).

| Change Point | Test |
|--------------|------|
| Decoder Content-Transfer-Encoding lowercase under Turkish | `HttpPostMultiPartRequestDecoderTest.testUppercaseBinaryTransferEncodingUnderTurkishLocale` — installs the Turkish locale (restored in `finally`), feeds a multipart body with `Content-Transfer-Encoding: BINARY`, and asserts the file part decodes successfully. Without the fix this throws `TransferEncoding Unknown: bınary`. |
| Encoder Content-Type lowercase under Turkish |
`HttpPostRequestEncoderTest.testFinalizeRemovesPreexistingMultipartContentTypeUnderTurkishLocale` — pre-sets `Content-Type: MULTIPART/form-data; boundary=preexisting`, runs the encoder under the Turkish locale, and asserts only one Content-Type header survives. Without the fix the request ends up with two Content-Type headers. |

Both tests fail deterministically on the unfixed code (one as an assertion failure, the other as a thrown `ErrorDataDecoderException`) and pass after the `Locale.US` change.

Verification:

```
mvn -pl codec-http -am test \
  -Dtest='HttpPostRequestEncoderTest#testFinalizeRemovesPreexistingMultipartContentTypeUnderTurkishLocale,HttpPostMultiPartRequestDecoderTest#testUppercaseBinaryTransferEncodingUnderTurkishLocale' \
  -Dsurefire.failIfNoSpecifiedTests=false
```

- Behavior on en/CJK/most locales: unchanged (the previous default-locale lowercase already produced ASCII).
- Behavior on Turkish (and other locales with non-ASCII case mappings): a multipart upload with uppercase `Content-Transfer-Encoding: BINARY` now decodes instead of throwing; an outgoing multipart request with a pre-existing mixed-case `Content-Type: MULTIPART/...` no longer leaks a duplicate Content-Type header.
- API: no signature change. All callers continue through the existing public API.
- Risk: bounded — `Locale.US` is the standard Netty pattern for protocol-string normalization (see e.g.
`WebSocketClientHandshaker.java:761`).

Sibling fix to #16765, which pinned the same locale gotcha in `HttpVersion`, `RtspMethods`, and `RtspVersions`.