### PR TITLE
Fix MQTT decoder size check after variable header replay

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
@@ -124,19 +124,18 @@ public final class MqttDecoder extends ReplayingDecoder<DecoderState> {
 
             case READ_VARIABLE_HEADER:  try {
                 int bytesRemainingBeforeVariableHeader = bytesRemainingInVariablePart;
-                int initialAvailableBytes = buffer.readableBytes();
                 boolean bailOut = false;
                 try {
                     variableHeader = decodeVariableHeader(ctx, buffer, mqttFixedHeader);
                 } catch (Signal signal) {
-                    if (initialAvailableBytes < maxBytesInMessage) {
-                        // Ask for REPLAY if the buffer was less than maxBytesInMessage
-                        throw signal;
-                    } else {
+                    if (bytesRemainingBeforeVariableHeader > maxBytesInMessage) {
                         // We couldn't parse the complete message, and it's already too large.
                         // Swallow the Signal (we don't need more data) and instead bail out
                         // and throw the TooLongFrameException below.
                         bailOut = true;
+                    } else {
+                        // Ask for REPLAY if the current message is within maxBytesInMessage.
+                        throw signal;
                     }
                 }
                 if (bailOut || bytesRemainingBeforeVariableHeader > maxBytesInMessage) {

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
@@ -300,6 +300,20 @@ public class MqttCodecTest {
     }
 
     @Test
+    public void testPublishMessageIncompleteVariableHeaderDoesNotUseCumulationSizeForTooLongCheck() throws Exception {
+        MqttDecoder decoder = new MqttDecoder(16);
+        ByteBuf byteBuf = ALLOCATOR.buffer();
+        byteBuf.writeByte(0x30);
+        byteBuf.writeByte(10);
+        byteBuf.writeShort(32);
+        byteBuf.writeZero(14);
+
+        decoder.channelRead(ctx, byteBuf);
+
+        assertEquals(0, out.size());
+    }
+
+    @Test
     public void testPubAckMessage() throws Exception {
         testMessageWithOnlyFixedHeaderAndMessageIdVariableHeader(MqttMessageType.PUBACK);
     }

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
@@ -302,16 +302,29 @@ public class MqttCodecTest {
 
     @Test
     public void testPublishMessageIncompleteVariableHeaderDoesNotUseCumulationSizeForTooLongCheck() throws Exception {
-        int maxBytesInMessage = 16;
-        int currentPacketRemainingLength = 10;
-        int claimedTopicNameLength = 32;
-        int followingPingReqPackets = 3;
+        // The leading PUBLISH is hand-crafted rather than going through MqttEncoder because the
+        // bug under test only triggers when variable-header decoding asks for REPLAY mid-message,
+        // which in turn requires a deliberately malformed packet (topic-name length prefix larger
+        // than the bytes we actually supply). MqttEncoder only produces well-formed messages.
+        final int maxBytesInMessage = 16;
+        // bytes after the fixed header; < 128 so it fits in a 1-byte Variable Byte Integer.
+        final int currentPacketRemainingLength = 10;
+        // > the bytes we write below, so the decoder must REPLAY mid-variable-header.
+        final int claimedTopicNameLength = 32;
+        final int followingPingReqPackets = 3;
         EmbeddedChannel channel = new EmbeddedChannel(new MqttDecoder(maxBytesInMessage));
         ByteBuf byteBuf = ALLOCATOR.buffer();
+        // Leading PUBLISH packet (incomplete - missing most of the topic name):
+        // Fixed header byte 1: PUBLISH (type 3), DUP=0, QoS=0, RETAIN=0.
         byteBuf.writeByte(0x30);
+        // Fixed header remaining-length, encoded as a Variable Byte Integer (single byte for values < 128).
         byteBuf.writeByte(currentPacketRemainingLength);
+        // Variable header: 2-byte topic-name length prefix.
         byteBuf.writeShort(claimedTopicNameLength);
+        // ... + only 8 of the 32 topic-name bytes the prefix claims (so the decoder will ask for REPLAY).
         byteBuf.writeZero(currentPacketRemainingLength - 2);
+        // Trailing PINGREQ packets - the cumulation bytes that the buggy size check used to look at.
+        // Each PINGREQ is just a 2-byte fixed header: 0xC0 (type 12, flags 0) and remaining-length 0.
         for (int i = 0; i < followingPingReqPackets; i++) {
             byteBuf.writeByte(0xC0);
             byteBuf.writeByte(0);
@@ -327,14 +340,22 @@ public class MqttCodecTest {
 
     @Test
     public void testPublishMessageIncompleteVariableHeaderStillFailsWhenCurrentPacketTooLarge() throws Exception {
-        int maxBytesInMessage = 16;
-        int currentPacketRemainingLength = maxBytesInMessage + 1;
-        int claimedTopicNameLength = 32;
+        // Same hand-crafting rationale as the test above: a malformed (incomplete-topic) PUBLISH
+        // is needed so variable-header decoding asks for REPLAY, which is the code path under test.
+        final int maxBytesInMessage = 16;
+        // Declared packet size already exceeds the limit; the in-flight check must still flag it.
+        final int currentPacketRemainingLength = maxBytesInMessage + 1;
+        // > the bytes we write below, so the decoder still asks for REPLAY mid-variable-header.
+        final int claimedTopicNameLength = 32;
         EmbeddedChannel channel = new EmbeddedChannel(new MqttDecoder(maxBytesInMessage));
         ByteBuf byteBuf = ALLOCATOR.buffer();
+        // Fixed header byte 1: PUBLISH (type 3), all flags 0.
         byteBuf.writeByte(0x30);
+        // Fixed header remaining-length Variable Byte Integer: 17 (still a single byte since < 128).
         byteBuf.writeByte(currentPacketRemainingLength);
+        // Variable header: 2-byte topic-name length prefix claiming 32 bytes.
         byteBuf.writeShort(claimedTopicNameLength);
+        // ... + 14 zero bytes - fewer than the 32 claimed, so the decoder will ask for REPLAY.
         byteBuf.writeZero(maxBytesInMessage - 2);
 
         try {

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
@@ -21,6 +21,7 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.EncoderException;
 import io.netty.handler.codec.TooLongFrameException;
@@ -301,16 +302,27 @@ public class MqttCodecTest {
 
     @Test
     public void testPublishMessageIncompleteVariableHeaderDoesNotUseCumulationSizeForTooLongCheck() throws Exception {
-        MqttDecoder decoder = new MqttDecoder(16);
+        int maxBytesInMessage = 16;
+        int currentPacketRemainingLength = 10;
+        int claimedTopicNameLength = 32;
+        int followingPingReqPackets = 3;
+        EmbeddedChannel channel = new EmbeddedChannel(new MqttDecoder(maxBytesInMessage));
         ByteBuf byteBuf = ALLOCATOR.buffer();
         byteBuf.writeByte(0x30);
-        byteBuf.writeByte(10);
-        byteBuf.writeShort(32);
-        byteBuf.writeZero(14);
+        byteBuf.writeByte(currentPacketRemainingLength);
+        byteBuf.writeShort(claimedTopicNameLength);
+        byteBuf.writeZero(currentPacketRemainingLength - 2);
+        for (int i = 0; i < followingPingReqPackets; i++) {
+            byteBuf.writeByte(0xC0);
+            byteBuf.writeByte(0);
+        }
 
-        decoder.channelRead(ctx, byteBuf);
-
-        assertEquals(0, out.size());
+        try {
+            assertFalse(channel.writeInbound(byteBuf));
+            assertNull(channel.readInbound());
+        } finally {
+            channel.finishAndReleaseAll();
+        }
     }
 
     @Test

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
@@ -326,6 +326,32 @@ public class MqttCodecTest {
     }
 
     @Test
+    public void testPublishMessageIncompleteVariableHeaderStillFailsWhenCurrentPacketTooLarge() throws Exception {
+        int maxBytesInMessage = 16;
+        int currentPacketRemainingLength = maxBytesInMessage + 1;
+        int claimedTopicNameLength = 32;
+        EmbeddedChannel channel = new EmbeddedChannel(new MqttDecoder(maxBytesInMessage));
+        ByteBuf byteBuf = ALLOCATOR.buffer();
+        byteBuf.writeByte(0x30);
+        byteBuf.writeByte(currentPacketRemainingLength);
+        byteBuf.writeShort(claimedTopicNameLength);
+        byteBuf.writeZero(maxBytesInMessage - 2);
+
+        try {
+            assertTrue(channel.writeInbound(byteBuf));
+            MqttMessage decodedMessage = channel.readInbound();
+            try {
+                assertTrue(decodedMessage.decoderResult().isFailure());
+                assertInstanceOf(TooLongFrameException.class, decodedMessage.decoderResult().cause());
+            } finally {
+                ReferenceCountUtil.release(decodedMessage);
+            }
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
     public void testPubAckMessage() throws Exception {
         testMessageWithOnlyFixedHeaderAndMessageIdVariableHeader(MqttMessageType.PUBACK);
     }


### PR DESCRIPTION
## Problem

The MQTT decoder can reject valid packets after the CVE-2026-44248 fix when several MQTT packets are present in the same cumulation buffer. If the current packet's variable header needs a replay, the decoder compares the total readable bytes in the buffer against `maxBytesInMessage`, so later packets can make the current in-limit packet look too large.

## Root Cause

`READ_VARIABLE_HEADER` recorded `buffer.readableBytes()` before decoding the variable header. That value is the cumulation's total readable bytes, not the current MQTT packet's declared remaining length. When `decodeVariableHeader` throws `Signal.REPLAY`, the too-large decision must be based on `bytesRemainingBeforeVariableHeader` for the current packet.

## Fix

- Use `bytesRemainingBeforeVariableHeader` when deciding whether to swallow `Signal.REPLAY` and raise `TooLongFrameException`.
- Continue replaying when the current packet is within `maxBytesInMessage`, even if the cumulation contains additional bytes for following packets.

## Tests Added

| Change Point | Test |
|-------------|------|
| Variable-header replay uses the current packet size instead of total cumulation bytes for the too-long check | `testPublishMessageIncompleteVariableHeaderDoesNotUseCumulationSizeForTooLongCheck()` verifies an incomplete in-limit PUBLISH variable header with extra cumulated PINGREQ packets does not emit an invalid message |
| Oversized current packets still fail during variable-header replay | `testPublishMessageIncompleteVariableHeaderStillFailsWhenCurrentPacketTooLarge()` verifies an incomplete PUBLISH whose own remaining length exceeds `maxBytesInMessage` still emits a `TooLongFrameException` |

## Impact

This restores decoding for valid in-limit MQTT packets batched in the same buffer while preserving the CVE fix: packets whose declared remaining length exceeds `maxBytesInMessage` still fail with `TooLongFrameException` even if variable-header decoding requests replay.

Fixes #16776