### PR TITLE
Fix memoryAddress() for direct ByteBuffers wrapped by Unpooled without Unsafe

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/EmptyByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/EmptyByteBuf.java
@@ -46,7 +46,7 @@ public final class EmptyByteBuf extends ByteBuf {
     static {
         long emptyByteBufferAddress = 0;
         try {
-            if (PlatformDependent.hasUnsafe()) {
+            if (PlatformDependent.hasDirectByteBufferAddress(EMPTY_BYTE_BUFFER)) {
                 emptyByteBufferAddress = PlatformDependent.directBufferAddress(EMPTY_BYTE_BUFFER);
             }
         } catch (Throwable t) {

--- a/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
@@ -230,16 +230,28 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     public boolean hasMemoryAddress() {
         CleanableDirectBuffer cleanable = this.cleanable;
-        return cleanable != null && cleanable.hasMemoryAddress();
+        if (cleanable != null) {
+            return cleanable.hasMemoryAddress();
+        }
+        ByteBuffer buffer = this.buffer;
+        return buffer != null && PlatformDependent.hasDirectByteBufferAddress(buffer);
     }
 
     @Override
     public long memoryAddress() {
         ensureAccessible();
-        if (!hasMemoryAddress()) {
-            throw new UnsupportedOperationException();
+        CleanableDirectBuffer cleanable = this.cleanable;
+        if (cleanable != null) {
+            if (cleanable.hasMemoryAddress()) {
+                return cleanable.memoryAddress();
+            }
+        } else {
+            ByteBuffer buffer = this.buffer;
+            if (PlatformDependent.hasDirectByteBufferAddress(buffer)) {
+                return PlatformDependent.directBufferAddress(buffer);
+            }
         }
-        return cleanable.memoryAddress();
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/buffer/src/test/java/io/netty/buffer/EmptyByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/EmptyByteBufTest.java
@@ -16,11 +16,14 @@
 package io.netty.buffer;
 
 import io.netty.util.CharsetUtil;
+import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
 
+import java.nio.ByteBuffer;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -83,16 +86,26 @@ public class EmptyByteBufTest {
     @Test
     public void testMemoryAddress() {
         EmptyByteBuf empty = new EmptyByteBuf(UnpooledByteBufAllocator.DEFAULT);
-        if (empty.hasMemoryAddress()) {
-            assertNotEquals(0L, empty.memoryAddress());
-        } else {
-            try {
-                empty.memoryAddress();
-                fail();
-            } catch (UnsupportedOperationException ignored) {
-                // Ignore.
-            }
-        }
+        assertEmptyBufferMemoryAddress(empty);
+    }
+
+    @Test
+    public void testAllocatorIoBufferMemoryAddress() {
+        ByteBuf empty = ByteBufAllocator.DEFAULT.ioBuffer(0, 0);
+        assertEmptyBufferMemoryAddress(empty);
+    }
+
+    private static void assertEmptyBufferMemoryAddress(ByteBuf empty) {
+        long memoryAddress = directBufferAddress(empty.nioBuffer());
+        assertTrue(empty.hasMemoryAddress());
+        assertEquals(memoryAddress, empty.memoryAddress());
+    }
+
+    private static long directBufferAddress(ByteBuffer buffer) {
+        assumeTrue(PlatformDependent.hasDirectByteBufferAddress(buffer));
+        long memoryAddress = PlatformDependent.directBufferAddress(buffer);
+        assumeTrue(memoryAddress != 0);
+        return memoryAddress;
     }
 
     @Test

--- a/buffer/src/test/java/io/netty/buffer/UnpooledTest.java
+++ b/buffer/src/test/java/io/netty/buffer/UnpooledTest.java
@@ -16,6 +16,7 @@
 package io.netty.buffer;
 
 import io.netty.util.CharsetUtil;
+import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import org.mockito.Mockito;
@@ -33,6 +34,7 @@ import java.util.Map.Entry;
 
 import static io.netty.buffer.Unpooled.*;
 import static io.netty.util.internal.EmptyArrays.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -279,6 +281,22 @@ public class UnpooledTest {
         assertEqualsAndRelease(wrappedBuffer(new byte[] { 1, 2, 3 }),
                 wrappedBuffer(ByteBuffer.wrap(new byte[] { 1 }),
                 ByteBuffer.wrap(new byte[] { 2 }), ByteBuffer.wrap(new byte[] { 3 })));
+    }
+
+    @Test
+    public void testWrappedDirectBufferMemoryAddress() {
+        ByteBuffer nioBuffer = ByteBuffer.allocateDirect(16);
+        nioBuffer.position(4).limit(12);
+        ByteBuffer expectedBuffer = nioBuffer.slice();
+        assumeTrue(PlatformDependent.hasDirectByteBufferAddress(expectedBuffer));
+
+        ByteBuf buffer = wrappedBuffer(nioBuffer);
+        try {
+            assertTrue(buffer.hasMemoryAddress());
+            assertEquals(PlatformDependent.directBufferAddress(expectedBuffer), buffer.memoryAddress());
+        } finally {
+            buffer.release();
+        }
     }
 
     @Test


### PR DESCRIPTION
Motivation:

Unpooled.wrappedBuffer(ByteBuffer) behaves differently depending on whether Unsafe is available.

When Unsafe is enabled, wrapping a direct ByteBuffer returns a buffer that exposes memoryAddress():

```java
  ByteBuffer byteBuffer = ByteBuffer.allocateDirect(1024);
  ByteBuf byteBuf = Unpooled.wrappedBuffer(byteBuffer);
  System.out.println(byteBuf.memoryAddress());
```

When Unsafe is disabled, the same direct ByteBuffer is wrapped by the non-unsafe path. Even if the platform can still obtain the direct buffer address through FFM, memoryAddress() throws UnsupportedOperationException.

A similar inconsistency exists for the empty buffer returned by:
``` java
  ByteBuf byteBuf = ByteBufAllocator.DEFAULT.ioBuffer(0, 0);
  System.out.println(byteBuf.memoryAddress());
``` 

Modification:

- Use PlatformDependent.hasDirectByteBufferAddress(...) in the unpooled direct wrapper path instead of relying only on Unsafe.
- Use the same address availability check when initializing EmptyByteBuf's cached direct buffer address.

Result:

Fixes #<GitHub issue number>. 

Unpooled wrapped direct buffers expose memoryAddress() consistently when platform address access is available,including when Unsafe is disabled and FFM is used
