### PR TITLE
Remove test annotations from a method that isn't a test

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/ConscryptJdkSslEngineInteropTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ConscryptJdkSslEngineInteropTest.java
@@ -68,8 +68,6 @@ public class ConscryptJdkSslEngineInteropTest extends SSLEngineTest {
             throws Exception {
     }
 
-    @MethodSource("newTestParams")
-    @ParameterizedTest
     @Override
     protected boolean mySetupMutualAuthServerIsValidServerException(Throwable cause) {
         // TODO(scott): work around for a JDK issue. The exception should be SSLHandshakeException.


### PR DESCRIPTION
Motivation:
JUnit issues a warning that test methods should not return a value. The method is not actually a test.

Modification:
Remove test annotations from a test utility method.

Result:
No more warning from JUnit.