### PR TITLE
Make test scope explicit for reflections, gson, and mockito-core in module poms

### DIFF
--- a/buffer/pom.xml
+++ b/buffer/pom.xml
@@ -41,6 +41,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/codec-dns/pom.xml
+++ b/codec-dns/pom.xml
@@ -64,10 +64,12 @@
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/codec-haproxy/pom.xml
+++ b/codec-haproxy/pom.xml
@@ -53,10 +53,12 @@
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/codec-http/pom.xml
+++ b/codec-http/pom.xml
@@ -116,10 +116,12 @@
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/codec-http/pom.xml
+++ b/codec-http/pom.xml
@@ -66,6 +66,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/codec-http2/pom.xml
+++ b/codec-http2/pom.xml
@@ -136,10 +136,12 @@
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/codec-http2/pom.xml
+++ b/codec-http2/pom.xml
@@ -73,6 +73,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>

--- a/codec-memcache/pom.xml
+++ b/codec-memcache/pom.xml
@@ -58,10 +58,12 @@
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/codec-mqtt/pom.xml
+++ b/codec-mqtt/pom.xml
@@ -62,10 +62,12 @@
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/codec-mqtt/pom.xml
+++ b/codec-mqtt/pom.xml
@@ -56,6 +56,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <!-- Automatic native-image reflection metadata generation for handlers dependencies -->

--- a/codec-redis/pom.xml
+++ b/codec-redis/pom.xml
@@ -58,10 +58,12 @@
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/codec-smtp/pom.xml
+++ b/codec-smtp/pom.xml
@@ -58,10 +58,12 @@
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/codec-socks/pom.xml
+++ b/codec-socks/pom.xml
@@ -58,10 +58,12 @@
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/codec-stomp/pom.xml
+++ b/codec-stomp/pom.xml
@@ -58,10 +58,12 @@
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/codec-xml/pom.xml
+++ b/codec-xml/pom.xml
@@ -57,10 +57,12 @@
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/codec/pom.xml
+++ b/codec/pom.xml
@@ -127,6 +127,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <!-- Test dependencies for jboss marshalling encoder/decoder -->

--- a/codec/pom.xml
+++ b/codec/pom.xml
@@ -152,10 +152,12 @@
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -97,6 +97,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
     <!-- Add dependency on dev-tools as otherwise the build will fail if not installed first manually -->
     <!-- See https://github.com/netty/netty/issues/7842 -->

--- a/handler-proxy/pom.xml
+++ b/handler-proxy/pom.xml
@@ -87,10 +87,12 @@
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/handler-proxy/pom.xml
+++ b/handler-proxy/pom.xml
@@ -75,6 +75,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
     <!-- For SelfSignedCertificate usage on JDK20+ -->
     <dependency>

--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -105,6 +105,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -119,10 +119,12 @@
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/resolver-dns/pom.xml
+++ b/resolver-dns/pom.xml
@@ -78,10 +78,12 @@
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/resolver/pom.xml
+++ b/resolver/pom.xml
@@ -41,6 +41,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/transport-sctp/pom.xml
+++ b/transport-sctp/pom.xml
@@ -58,10 +58,12 @@
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -56,10 +56,12 @@
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -51,6 +51,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## Summary

- `org.reflections:reflections`, `com.google.code.gson:gson`, and `org.mockito:mockito-core` are only consumed from `src/test/java`, but they were declared in many child module poms without an explicit `<scope>`.
- The parent `dependencyManagement` already pins all three to `<scope>test</scope>`, so Maven and Gradle consumers see the correct scope, but the unscoped child declarations hid intent and triggered confusion from downstream tools (#16736).
- This PR adds `<scope>test</scope>` to every child declaration of those three artifacts to remove the ambiguity, matching the convention already used by the surrounding test deps (`junit-jupiter-*`, `assertj-core`, `logback-classic`, etc.).

## Files changed

- **reflections + gson** (17 modules): `codec`, `codec-dns`, `codec-haproxy`, `codec-http`, `codec-http2`, `codec-memcache`, `codec-mqtt`, `codec-redis`, `codec-smtp`, `codec-socks`, `codec-stomp`, `codec-xml`, `handler`, `handler-proxy`, `resolver-dns`, `transport`, `transport-sctp`.
- **mockito-core** (10 modules): `common`, `buffer`, `resolver`, `transport`, `codec`, `codec-http`, `codec-http2`, `codec-mqtt`, `handler`, `handler-proxy`.

## Test plan

- [x] `xmllint --noout` passes on every modified `pom.xml`
- [x] `mvn -pl <module> help:effective-pom` shows `<scope>test</scope>` for the three artifacts on `transport`, `codec-http2`, `codec-mqtt`, `resolver-dns`, `codec-stomp`, `transport-sctp`, `handler`
- [x] No imports of these libraries exist under any `src/main/java` — they are strictly test-only (`ChannelHandlerMetadataUtil`, the per-module `NativeImageHandlerMetadataTest`, `HpackTestCase`, and mockito usage in handler/codec test suites)
- [x] No code changes; effective scope is identical to before for Maven / Gradle consumers
- [ ] CI green

Fixes #16736

🤖 Generated with [Claude Code](https://claude.com/claude-code)