### PR TITLE
IpFilter: Fix ClassCastException caused by IpSubnetFilter if only ipv6 rules are configured but remote peer is using ipv4

### DIFF
--- a/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilter.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilter.java
@@ -21,6 +21,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.internal.ObjectUtil;
 
 import java.net.Inet4Address;
+import java.net.Inet6Address;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.ArrayList;
@@ -175,7 +176,7 @@ public class IpSubnetFilter extends AbstractRemoteAddressFilter<InetSocketAddres
                     return ipFilterRuleTypeIPv4 == IpFilterRuleType.ACCEPT;
                 }
             }
-        } else if (ipv6Rules != null) {
+        } else if (ipv6Rules != null && remoteAddress.getAddress() instanceof Inet6Address) {
             int indexOf = Arrays.binarySearch(ipv6Rules, remoteAddress, IpSubnetFilterRuleComparator.INSTANCE);
             if (indexOf >= 0) {
                 if (ipFilterRuleTypeIPv6 == null) {

--- a/handler/src/test/java/io/netty/handler/ipfilter/IpSubnetFilterTest.java
+++ b/handler/src/test/java/io/netty/handler/ipfilter/IpSubnetFilterTest.java
@@ -24,6 +24,8 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.internal.SocketUtils;
 import org.junit.jupiter.api.Test;
 
+import java.net.Inet4Address;
+import java.net.Inet6Address;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.ArrayList;
@@ -35,6 +37,22 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class IpSubnetFilterTest {
+
+    @Test
+    void noClassCastExceptionIpv4RuleOnly() {
+        IpSubnetFilterRule rule = new IpSubnetFilterRule("10.10.0.0/16", IpFilterRuleType.ACCEPT);
+        IpSubnetFilter filter = new IpSubnetFilter(false, rule);
+        assertFalse(filter.accept(null, new InetSocketAddress(Inet4Address.getLoopbackAddress(), 80)));
+        assertFalse(filter.accept(null, new InetSocketAddress(Inet6Address.getLoopbackAddress(), 80)));
+    }
+
+    @Test
+    void noClassCastExceptionIpv6RuleOnly() {
+        IpSubnetFilterRule rule = new IpSubnetFilterRule("::1/16", IpFilterRuleType.ACCEPT);
+        IpSubnetFilter filter = new IpSubnetFilter(false, rule);
+        assertFalse(filter.accept(null, new InetSocketAddress(Inet4Address.getLoopbackAddress(), 80)));
+        assertFalse(filter.accept(null, new InetSocketAddress(Inet6Address.getLoopbackAddress(), 80)));
+    }
 
     @Test
     public void testIpv4DefaultRoute() {


### PR DESCRIPTION
Motivation:

We did miss an instanceof check which could cause a CCE.

Modifications:

- Add missing instanceof check
- Add unit tests

Result:

No more ClassCastException
