### PR TITLE
HTTP/2: Parse request-target path like Vert.x

### DIFF
--- a/codec-http2/pom.xml
+++ b/codec-http2/pom.xml
@@ -176,6 +176,30 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.code-intelligence</groupId>
+      <artifactId>jazzer-junit</artifactId>
+      <version>0.30.0</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-params</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.junit.platform</groupId>
+          <artifactId>junit-platform-commons</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.junit.platform</groupId>
+          <artifactId>junit-platform-launcher</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/codec-http2/pom.xml
+++ b/codec-http2/pom.xml
@@ -178,7 +178,6 @@
     <dependency>
       <groupId>com.code-intelligence</groupId>
       <artifactId>jazzer-junit</artifactId>
-      <version>0.30.0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
@@ -632,8 +632,11 @@ public final class HttpConversionUtil {
             if (!isValidScheme(uri, i)) {
                 i = 0;
             } else {
-                i = uri.indexOf('/', i + 3);
-                if (i == -1) {
+                int authorityStart = i + 3;
+                // Netty change: only accept '/' before query/fragment as path start.
+                int queryOrFragmentStart = queryOrFragmentStart(uri, authorityStart);
+                i = uri.indexOf('/', authorityStart);
+                if (i == -1 || (queryOrFragmentStart != -1 && queryOrFragmentStart < i)) {
                     // contains no /
                     return "/";
                 }
@@ -651,7 +654,7 @@ public final class HttpConversionUtil {
     }
 
     /**
-     * Extract the query out of a request-target or returns the empty string if no query was found.
+     * Extract the query out of a request-target or returns {@code null} if no query was found.
      */
     private static String parseQuery(String uri) {
         int i = uri.indexOf('?');
@@ -680,6 +683,13 @@ public final class HttpConversionUtil {
         }
     }
 
+    static int queryOrFragmentStart(String uri, int searchStart) {
+        int queryStart = uri.indexOf('?', searchStart);
+        int fragmentStart = uri.indexOf('#', searchStart);
+        return queryStart == -1 ? fragmentStart :
+                fragmentStart == -1 ? queryStart : Math.min(queryStart, fragmentStart);
+    }
+
     // Netty addition: detect authority for HTTP/2 :scheme/:authority extraction.
     static boolean hasSchemeAndAuthority(String requestTarget) {
         int schemeEnd = requestTarget.indexOf("://");
@@ -701,12 +711,10 @@ public final class HttpConversionUtil {
         int authorityStart = schemeEnd + 3;
         // Netty addition: strip before path/query/fragment; Vert.x parsePath does not validate authority.
         int pathStart = requestTarget.indexOf('/', authorityStart);
-        int queryStart = requestTarget.indexOf('?', authorityStart);
-        int fragmentStart = requestTarget.indexOf('#', authorityStart);
-        // Netty change: strip path/query/fragment before URI validates scheme and authority.
-        int delimiter = pathStart == -1 ? queryStart : queryStart == -1 ? pathStart : Math.min(pathStart, queryStart);
-        delimiter = delimiter == -1 ? fragmentStart :
-                fragmentStart == -1 ? delimiter : Math.min(delimiter, fragmentStart);
+        int delimiter = queryOrFragmentStart(requestTarget, authorityStart);
+        if (pathStart != -1 && (delimiter == -1 || pathStart < delimiter)) {
+            delimiter = pathStart;
+        }
         if (delimiter == -1) {
             return requestTarget;
         }
@@ -733,7 +741,7 @@ public final class HttpConversionUtil {
     }
 
     private static boolean isAlpha(char c) {
-        return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z';
+        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
     }
 
     // package-private for testing only

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
@@ -448,10 +448,13 @@ public final class HttpConversionUtil {
                     // Take from the request-line if HOST header was empty
                     host = isNullOrEmpty(host) ? requestTargetUri.getAuthority() : host;
                     setHttp2Scheme(inHeaders, requestTargetUri, out);
-                } else if (hasScheme(requestTarget)) {
-                    setHttp2Scheme(inHeaders, scheme(requestTarget), -1, out);
                 } else {
-                    setHttp2Scheme(inHeaders, out);
+                    int schemeEnd = schemeEnd(requestTarget);
+                    if (schemeEnd != -1) {
+                        setHttp2Scheme(inHeaders, requestTarget.substring(0, schemeEnd), -1, out);
+                    } else {
+                        setHttp2Scheme(inHeaders, out);
+                    }
                 }
             }
             setHttp2Authority(host, out);
@@ -697,13 +700,9 @@ public final class HttpConversionUtil {
         return isValidScheme(requestTarget, schemeEnd);
     }
 
-    private static boolean hasScheme(String requestTarget) {
+    private static int schemeEnd(String requestTarget) {
         int schemeEnd = requestTarget.indexOf(':');
-        return isValidScheme(requestTarget, schemeEnd);
-    }
-
-    private static String scheme(String requestTarget) {
-        return requestTarget.substring(0, requestTarget.indexOf(':'));
+        return isValidScheme(requestTarget, schemeEnd) ? schemeEnd : -1;
     }
 
     // Netty addition: prepare only scheme://authority for URI validation.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
@@ -61,13 +61,15 @@ import static io.netty.util.ByteProcessor.FIND_COMMA;
 import static io.netty.util.ByteProcessor.FIND_SEMI_COLON;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static io.netty.util.internal.StringUtil.isNullOrEmpty;
-import static io.netty.util.internal.StringUtil.length;
 import static io.netty.util.internal.StringUtil.unescapeCsvFields;
 
 /**
  * Provides utility methods and constants for the HTTP/2 to HTTP conversion
  */
 public final class HttpConversionUtil {
+    // Parsing logic adapted from Vert.x HttpUtils.parsePath/parseQuery:
+    // https://github.com/eclipse-vertx/vert.x/blob/98a8ef6c8b408009ff86eb8277fd0bbb2b866857/
+    // vertx-core/src/main/java/io/vertx/core/http/impl/HttpUtils.java#L279-L319
     /**
      * The set of headers that should not be directly copied when converting headers from HTTP to HTTP/2.
      */
@@ -438,11 +440,18 @@ public final class HttpConversionUtil {
                 out.path(new AsciiString(request.uri()));
                 setHttp2Scheme(inHeaders, out);
             } else {
-                URI requestTargetUri = URI.create(request.uri());
-                out.path(toHttp2Path(requestTargetUri));
-                // Take from the request-line if HOST header was empty
-                host = isNullOrEmpty(host) ? requestTargetUri.getAuthority() : host;
-                setHttp2Scheme(inHeaders, requestTargetUri, out);
+                String requestTarget = request.uri();
+                out.path(toHttp2Path(requestTarget));
+                if (hasSchemeAndAuthority(requestTarget)) {
+                    URI requestTargetUri = URI.create(http2PathlessRequestTarget(requestTarget));
+                    // Take from the request-line if HOST header was empty
+                    host = isNullOrEmpty(host) ? requestTargetUri.getAuthority() : host;
+                    setHttp2Scheme(inHeaders, requestTargetUri, out);
+                } else if (hasScheme(requestTarget)) {
+                    setHttp2Scheme(inHeaders, scheme(requestTarget), -1, out);
+                } else {
+                    setHttp2Scheme(inHeaders, out);
+                }
             }
             setHttp2Authority(host, out);
             out.method(request.method().asciiName());
@@ -592,25 +601,139 @@ public final class HttpConversionUtil {
     }
 
     /**
-     * Generate an HTTP/2 {code :path} from a URI in accordance with
+     * Generate an HTTP/2 {code :path} from a request-target in accordance with
      * <a href="https://tools.ietf.org/html/rfc7230#section-5.3">rfc7230, 5.3</a>.
      */
-    private static AsciiString toHttp2Path(URI uri) {
-        StringBuilder pathBuilder = new StringBuilder(length(uri.getRawPath()) +
-                length(uri.getRawQuery()) + length(uri.getRawFragment()) + 2);
-        if (!isNullOrEmpty(uri.getRawPath())) {
-            pathBuilder.append(uri.getRawPath());
+    private static AsciiString toHttp2Path(String uri) {
+        String path = dropEmptyFragment(parsePath(uri));
+        String query = parseQuery(uri);
+        if (isNullOrEmpty(query)) {
+            return path.isEmpty() ? EMPTY_REQUEST_PATH : new AsciiString(path);
         }
-        if (!isNullOrEmpty(uri.getRawQuery())) {
-            pathBuilder.append('?');
-            pathBuilder.append(uri.getRawQuery());
+        StringBuilder pathBuilder = new StringBuilder(path.length() + query.length() + 1);
+        pathBuilder.append(path);
+        appendQuery(pathBuilder, query);
+        return new AsciiString(pathBuilder.toString());
+    }
+
+    /**
+     * Extract the path out of the request-target. Based on Vert.x' HttpUtils.parsePath logic.
+     */
+    private static String parsePath(String uri) {
+        if (uri.isEmpty()) {
+            return "";
         }
-        if (!isNullOrEmpty(uri.getRawFragment())) {
-            pathBuilder.append('#');
-            pathBuilder.append(uri.getRawFragment());
+        int i;
+        if (uri.charAt(0) == '/') {
+            i = 0;
+        } else {
+            i = uri.indexOf("://");
+            // Netty change: validate the scheme before treating :// as authority syntax.
+            if (!isValidScheme(uri, i)) {
+                i = 0;
+            } else {
+                i = uri.indexOf('/', i + 3);
+                if (i == -1) {
+                    // contains no /
+                    return "/";
+                }
+            }
         }
-        String path = pathBuilder.toString();
-        return path.isEmpty() ? EMPTY_REQUEST_PATH : new AsciiString(path);
+
+        int queryStart = uri.indexOf('?', i);
+        if (queryStart == -1) {
+            queryStart = uri.length();
+            if (i == 0) {
+                return uri;
+            }
+        }
+        return uri.substring(i, queryStart);
+    }
+
+    /**
+     * Extract the query out of a request-target or returns the empty string if no query was found.
+     */
+    private static String parseQuery(String uri) {
+        int i = uri.indexOf('?');
+        if (i == -1) {
+            return null;
+        } else {
+            return uri.substring(i + 1);
+        }
+    }
+
+    private static String dropEmptyFragment(String path) {
+        // Netty change: old URI-based conversion dropped an empty fragment delimiter.
+        return path.endsWith("#") ? path.substring(0, path.length() - 1) : path;
+    }
+
+    private static void appendQuery(StringBuilder pathBuilder, String query) {
+        int fragmentStart = query.indexOf('#');
+        if (fragmentStart == 0) {
+            // Netty change: old URI-based conversion skipped an empty query before a fragment.
+            pathBuilder.append(query);
+        } else if (fragmentStart == query.length() - 1) {
+            // Netty change: old URI-based conversion dropped an empty fragment delimiter after a query.
+            pathBuilder.append('?').append(query, 0, fragmentStart);
+        } else {
+            pathBuilder.append('?').append(query);
+        }
+    }
+
+    // Netty addition: detect authority for HTTP/2 :scheme/:authority extraction.
+    static boolean hasSchemeAndAuthority(String requestTarget) {
+        int schemeEnd = requestTarget.indexOf("://");
+        return isValidScheme(requestTarget, schemeEnd);
+    }
+
+    private static boolean hasScheme(String requestTarget) {
+        int schemeEnd = requestTarget.indexOf(':');
+        return isValidScheme(requestTarget, schemeEnd);
+    }
+
+    private static String scheme(String requestTarget) {
+        return requestTarget.substring(0, requestTarget.indexOf(':'));
+    }
+
+    // Netty addition: prepare only scheme://authority for URI validation.
+    private static String http2PathlessRequestTarget(String requestTarget) {
+        int schemeEnd = requestTarget.indexOf("://");
+        int authorityStart = schemeEnd + 3;
+        // Netty addition: strip before path/query/fragment; Vert.x parsePath does not validate authority.
+        int pathStart = requestTarget.indexOf('/', authorityStart);
+        int queryStart = requestTarget.indexOf('?', authorityStart);
+        int fragmentStart = requestTarget.indexOf('#', authorityStart);
+        // Netty change: strip path/query/fragment before URI validates scheme and authority.
+        int delimiter = pathStart == -1 ? queryStart : queryStart == -1 ? pathStart : Math.min(pathStart, queryStart);
+        delimiter = delimiter == -1 ? fragmentStart :
+                fragmentStart == -1 ? delimiter : Math.min(delimiter, fragmentStart);
+        if (delimiter == -1) {
+            return requestTarget;
+        }
+        return delimiter == authorityStart ? requestTarget.substring(0, delimiter + 1) :
+                requestTarget.substring(0, delimiter);
+    }
+
+    // Netty addition: validate the text before :// as a scheme.
+    static boolean isValidScheme(String uri, int schemeEnd) {
+        if (schemeEnd <= 0) {
+            return false;
+        }
+        char first = uri.charAt(0);
+        if (!isAlpha(first)) {
+            return false;
+        }
+        for (int i = 1; i < schemeEnd; ++i) {
+            char c = uri.charAt(i);
+            if (!isAlpha(c) && (c < '0' || c > '9') && c != '+' && c != '-' && c != '.') {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isAlpha(char c) {
+        return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z';
     }
 
     // package-private for testing only
@@ -635,9 +758,12 @@ public final class HttpConversionUtil {
     }
 
     private static void setHttp2Scheme(HttpHeaders in, URI uri, Http2Headers out) {
-        String value = uri.getScheme();
-        if (!isNullOrEmpty(value)) {
-            out.scheme(new AsciiString(value));
+        setHttp2Scheme(in, uri.getScheme(), uri.getPort(), out);
+    }
+
+    private static void setHttp2Scheme(HttpHeaders in, String scheme, int port, Http2Headers out) {
+        if (!isNullOrEmpty(scheme)) {
+            out.scheme(new AsciiString(scheme));
             return;
         }
 
@@ -648,9 +774,9 @@ public final class HttpConversionUtil {
             return;
         }
 
-        if (uri.getPort() == HTTPS.port()) {
+        if (port == HTTPS.port()) {
             out.scheme(HTTPS.name());
-        } else if (uri.getPort() == HTTP.port()) {
+        } else if (port == HTTP.port()) {
             out.scheme(HTTP.name());
         } else {
             throw new IllegalArgumentException(":scheme must be specified. " +

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
@@ -35,6 +35,7 @@ import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.AsciiString;
 import io.netty.util.internal.InternalThreadLocalMap;
+import io.netty.util.internal.StringUtil;
 
 import java.net.URI;
 import java.util.Iterator;
@@ -621,7 +622,7 @@ public final class HttpConversionUtil {
      */
     private static String parsePath(String uri) {
         if (uri.isEmpty()) {
-            return "";
+            return StringUtil.EMPTY_STRING;
         }
         int i;
         if (uri.charAt(0) == '/') {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilFuzzTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilFuzzTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http2;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.code_intelligence.jazzer.junit.FuzzTest;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpScheme;
+import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.AsciiString;
+
+import java.net.URI;
+
+import static io.netty.util.internal.StringUtil.isNullOrEmpty;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class HttpConversionUtilFuzzTest {
+
+    @FuzzTest(maxDuration = "30s")
+    public void currentConversionMatchesOldUriBasedConversion(final FuzzedDataProvider data) {
+        String requestTarget = data.consumeString(128);
+        HttpRequest msg = new DefaultHttpRequest(
+                HttpVersion.HTTP_1_1,
+                HttpMethod.GET,
+                requestTarget,
+                new DefaultHttpHeaders(false),
+                false);
+        msg.headers().set(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), HttpScheme.HTTP.name());
+
+        Http2Headers oldHeaders;
+        try {
+            oldHeaders = oldToHttp2Headers(msg);
+        } catch (IllegalArgumentException e) {
+            return;
+        }
+
+        Http2Headers newHeaders = HttpConversionUtil.toHttp2Headers(msg, false);
+        if (!oldHeaders.path().equals(newHeaders.path())) {
+            assertTrue(isKnownPathCompatibilityException(requestTarget), requestTarget);
+        }
+        assertEquals(oldHeaders.scheme(), newHeaders.scheme());
+        assertEquals(oldHeaders.authority(), newHeaders.authority());
+        assertEquals(oldHeaders.method(), newHeaders.method());
+    }
+
+    private static boolean isKnownPathCompatibilityException(final String requestTarget) {
+        // The old URI-based oracle only diverges on a few legacy RFC 2396-style forms:
+        // 1) Opaque scheme-specific targets like "x:y" or "x:foo" where URI path becomes "/".
+        // 2) Absolute-path targets with a scheme but no authority like "x:/path", where the old
+        //    URI oracle strips the scheme while the new path logic preserves the raw path.
+        // 3) Absolute-form targets with no path slash, where Vert.x parsePath returns "/" before
+        //    parseQuery is appended.
+        // 4) Malformed fragment-before-query targets like "#?", where Vert.x-shaped parsePath keeps
+        //    '#' in the path but URI treats the following '?' as fragment data.
+        // 5) Empty query/fragment delimiters like "?#", which URI drops while Vert.x-shaped parsing
+        //    keeps the delimiters as raw path/query syntax.
+        return isOpaqueSchemeSpecificPart(requestTarget) || isSchemeOnlyAbsolutePath(requestTarget)
+                || isAbsoluteFormWithoutPathSlash(requestTarget) || hasFragmentBeforeQuery(requestTarget)
+                || hasEmptyQueryAndFragmentDelimiters(requestTarget);
+    }
+
+    private static boolean isOpaqueSchemeSpecificPart(final String requestTarget) {
+        int schemeEnd = requestTarget.indexOf(':');
+        return HttpConversionUtil.isValidScheme(requestTarget, schemeEnd) && schemeEnd + 1 < requestTarget.length()
+                && requestTarget.charAt(schemeEnd + 1) != '/';
+    }
+
+    private static boolean isSchemeOnlyAbsolutePath(final String requestTarget) {
+        int schemeEnd = requestTarget.indexOf(':');
+        return HttpConversionUtil.isValidScheme(requestTarget, schemeEnd) && schemeEnd + 1 < requestTarget.length()
+                && requestTarget.charAt(schemeEnd + 1) == '/'
+                && !HttpConversionUtil.hasSchemeAndAuthority(requestTarget)
+                && (schemeEnd + 2 >= requestTarget.length() || requestTarget.charAt(schemeEnd + 2) != '/');
+    }
+
+    private static boolean isAbsoluteFormWithoutPathSlash(final String requestTarget) {
+        int schemeEnd = requestTarget.indexOf("://");
+        if (!HttpConversionUtil.hasSchemeAndAuthority(requestTarget)) {
+            return false;
+        }
+        int authorityStart = schemeEnd + 3;
+        int pathStart = requestTarget.indexOf('/', authorityStart);
+        int queryStart = requestTarget.indexOf('?', authorityStart);
+        int fragmentStart = requestTarget.indexOf('#', authorityStart);
+        int delimiter = pathStart == -1 ? queryStart : queryStart == -1 ? pathStart : Math.min(pathStart, queryStart);
+        delimiter = delimiter == -1 ? fragmentStart :
+                fragmentStart == -1 ? delimiter : Math.min(delimiter, fragmentStart);
+        return delimiter == -1 || requestTarget.charAt(delimiter) != '/';
+    }
+
+    private static boolean hasFragmentBeforeQuery(final String requestTarget) {
+        int fragmentStart = requestTarget.indexOf('#');
+        int queryStart = requestTarget.indexOf('?');
+        return fragmentStart != -1 && queryStart != -1 && fragmentStart < queryStart;
+    }
+
+    private static boolean hasEmptyQueryAndFragmentDelimiters(final String requestTarget) {
+        return requestTarget.endsWith("?#");
+    }
+
+    private static Http2Headers oldToHttp2Headers(final HttpRequest request) {
+        HttpHeaders inHeaders = request.headers();
+        Http2Headers out = new DefaultHttp2Headers(false, inHeaders.size());
+        String host = inHeaders.getAsString(HttpHeaderNames.HOST);
+        if (HttpUtil.isOriginForm(request.uri()) || HttpUtil.isAsteriskForm(request.uri())) {
+            out.path(new AsciiString(request.uri()));
+            oldSetHttp2Scheme(inHeaders, URI.create(""), out);
+        } else {
+            URI requestTargetUri = URI.create(request.uri());
+            out.path(oldToHttp2Path(requestTargetUri));
+            host = isNullOrEmpty(host) ? requestTargetUri.getAuthority() : host;
+            oldSetHttp2Scheme(inHeaders, requestTargetUri, out);
+        }
+        HttpConversionUtil.setHttp2Authority(host, out);
+        out.method(request.method().asciiName());
+        return out;
+    }
+
+    private static AsciiString oldToHttp2Path(final URI uri) {
+        StringBuilder pathBuilder = new StringBuilder();
+        if (!isNullOrEmpty(uri.getRawPath())) {
+            pathBuilder.append(uri.getRawPath());
+        }
+        if (!isNullOrEmpty(uri.getRawQuery())) {
+            pathBuilder.append('?');
+            pathBuilder.append(uri.getRawQuery());
+        }
+        if (!isNullOrEmpty(uri.getRawFragment())) {
+            pathBuilder.append('#');
+            pathBuilder.append(uri.getRawFragment());
+        }
+        String path = pathBuilder.toString();
+        return path.isEmpty() ? new AsciiString("/") : new AsciiString(path);
+    }
+
+    private static void oldSetHttp2Scheme(final HttpHeaders in, final URI uri, final Http2Headers out) {
+        String value = uri.getScheme();
+        if (!isNullOrEmpty(value)) {
+            out.scheme(new AsciiString(value));
+            return;
+        }
+
+        CharSequence cValue = in.get(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text());
+        if (cValue != null) {
+            out.scheme(AsciiString.of(cValue));
+            return;
+        }
+
+        if (uri.getPort() == HttpScheme.HTTPS.port()) {
+            out.scheme(HttpScheme.HTTPS.name());
+        } else if (uri.getPort() == HttpScheme.HTTP.port()) {
+            out.scheme(HttpScheme.HTTP.name());
+        } else {
+            throw new IllegalArgumentException(
+                    ":scheme must be specified. see https://tools.ietf.org/html/rfc7540#section-8.1.2.3");
+        }
+    }
+}

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilFuzzTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilFuzzTest.java
@@ -43,7 +43,7 @@ public class HttpConversionUtilFuzzTest {
                 HttpVersion.HTTP_1_1,
                 HttpMethod.GET,
                 requestTarget,
-                new DefaultHttpHeaders(false),
+                new DefaultHttpHeaders(),
                 false);
         msg.headers().set(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), HttpScheme.HTTP.name());
 
@@ -100,12 +100,8 @@ public class HttpConversionUtilFuzzTest {
         }
         int authorityStart = schemeEnd + 3;
         int pathStart = requestTarget.indexOf('/', authorityStart);
-        int queryStart = requestTarget.indexOf('?', authorityStart);
-        int fragmentStart = requestTarget.indexOf('#', authorityStart);
-        int delimiter = pathStart == -1 ? queryStart : queryStart == -1 ? pathStart : Math.min(pathStart, queryStart);
-        delimiter = delimiter == -1 ? fragmentStart :
-                fragmentStart == -1 ? delimiter : Math.min(delimiter, fragmentStart);
-        return delimiter == -1 || requestTarget.charAt(delimiter) != '/';
+        int delimiter = HttpConversionUtil.queryOrFragmentStart(requestTarget, authorityStart);
+        return pathStart == -1 || (delimiter != -1 && delimiter < pathStart);
     }
 
     private static boolean hasFragmentBeforeQuery(final String requestTarget) {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
@@ -250,7 +250,7 @@ public class HttpConversionUtilTest {
     @Test
     public void handlesAbsoluteRequestWhoseQueryHasUrlCharactersRejectedByJavaNetUri() {
         HttpRequest msg = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
-                "https://bh.contextweb.com/bh/rtset?pid=558355&ev=1&us_privacy=${us_privacy}", false);
+                "https://bh.contextweb.com/bh/rtset?pid=558355&ev=1&us_privacy=${us_privacy}", true);
 
         Http2Headers out = HttpConversionUtil.toHttp2Headers(msg, false);
 
@@ -263,7 +263,7 @@ public class HttpConversionUtilTest {
     @Test
     public void handlesAbsoluteRequestWhosePathHasUrlCharactersRejectedByJavaNetUri() {
         HttpRequest msg = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
-                "http://example.com/orders/{id}/items|details?expand={details}#section", false);
+                "http://example.com/orders/{id}/items|details?expand={details}#section", true);
 
         Http2Headers out = HttpConversionUtil.toHttp2Headers(msg, false);
 
@@ -344,7 +344,7 @@ public class HttpConversionUtilTest {
         final HttpRequest msg = new DefaultHttpRequest(
                 HttpVersion.HTTP_1_1, HttpMethod.GET,
                 "http://[bad host]/p?q={x}",
-                new DefaultHttpHeaders(false),
+                new DefaultHttpHeaders(),
                 false);
 
         assertThrows(IllegalArgumentException.class, new Executable() {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
@@ -297,6 +297,18 @@ public class HttpConversionUtilTest {
     }
 
     @Test
+    public void handlesAbsoluteRequestWithoutPathWhoseQueryOrFragmentContainsSlash() {
+        HttpRequest querySlash = new DefaultHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.GET, "http://example.com?next=/home", true);
+        HttpRequest fragmentSlash = new DefaultHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.GET, "http://example.com#/home", true);
+
+        assertEquals(new AsciiString("/?next=/home"),
+                HttpConversionUtil.toHttp2Headers(querySlash, true).path());
+        assertEquals(new AsciiString("/"), HttpConversionUtil.toHttp2Headers(fragmentSlash, true).path());
+    }
+
+    @Test
     public void handlesEmptyRequestTargetUsingLegacyEmptyPathFallback() {
         HttpRequest msg = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "", true);
         msg.headers().add(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), "http");

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
@@ -248,6 +248,114 @@ public class HttpConversionUtilTest {
     }
 
     @Test
+    public void handlesAbsoluteRequestWhoseQueryHasUrlCharactersRejectedByJavaNetUri() {
+        HttpRequest msg = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
+                "https://bh.contextweb.com/bh/rtset?pid=558355&ev=1&us_privacy=${us_privacy}", false);
+
+        Http2Headers out = HttpConversionUtil.toHttp2Headers(msg, false);
+
+        assertEquals(new AsciiString("/bh/rtset?pid=558355&ev=1&us_privacy=${us_privacy}"), out.path());
+        assertEquals(new AsciiString("https"), out.scheme());
+        assertEquals(new AsciiString("bh.contextweb.com"), out.authority());
+        assertEquals(HttpMethod.GET.asciiName(), out.method());
+    }
+
+    @Test
+    public void handlesAbsoluteRequestWhosePathHasUrlCharactersRejectedByJavaNetUri() {
+        HttpRequest msg = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
+                "http://example.com/orders/{id}/items|details?expand={details}#section", false);
+
+        Http2Headers out = HttpConversionUtil.toHttp2Headers(msg, false);
+
+        assertEquals(new AsciiString("/orders/{id}/items|details?expand={details}#section"), out.path());
+        assertEquals(new AsciiString("http"), out.scheme());
+        assertEquals(new AsciiString("example.com"), out.authority());
+    }
+
+    @Test
+    public void handlesAbsoluteRequestWithoutPathUsingVertxCompatiblePath() {
+        HttpRequest msg = new DefaultHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.GET, "http://example.com?x=1#frag", true);
+
+        Http2Headers out = HttpConversionUtil.toHttp2Headers(msg, true);
+
+        assertEquals(new AsciiString("/?x=1#frag"), out.path());
+        assertEquals(new AsciiString("http"), out.scheme());
+        assertEquals(new AsciiString("example.com"), out.authority());
+    }
+
+    @Test
+    public void handlesAbsoluteRequestWithAuthorityOnlyUsingVertxCompatiblePath() {
+        HttpRequest msg = new DefaultHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.GET, "http://example.com", true);
+
+        Http2Headers out = HttpConversionUtil.toHttp2Headers(msg, true);
+
+        assertEquals(new AsciiString("/"), out.path());
+        assertEquals(new AsciiString("http"), out.scheme());
+        assertEquals(new AsciiString("example.com"), out.authority());
+    }
+
+    @Test
+    public void handlesEmptyRequestTargetUsingLegacyEmptyPathFallback() {
+        HttpRequest msg = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "", true);
+        msg.headers().add(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), "http");
+
+        Http2Headers out = HttpConversionUtil.toHttp2Headers(msg, true);
+
+        assertEquals(new AsciiString("/"), out.path());
+        assertEquals(new AsciiString("http"), out.scheme());
+        assertNull(out.authority());
+    }
+
+    @Test
+    public void handlesAbsoluteRequestWithMissingAuthorityUsingUriAuthority() {
+        HttpRequest msg = new DefaultHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.GET, "http://?x=1#frag", true);
+
+        Http2Headers out = HttpConversionUtil.toHttp2Headers(msg, true);
+
+        assertEquals(new AsciiString("/?x=1#frag"), out.path());
+        assertEquals(new AsciiString("http"), out.scheme());
+        assertNull(out.authority());
+    }
+
+    @Test
+    public void handlesAbsoluteRequestWithEmptyQueryOrFragmentUsingVertxCompatiblePath() {
+        HttpRequest emptyQuery = new DefaultHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.GET, "http://example.com/path?", true);
+        HttpRequest emptyFragment = new DefaultHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.GET, "http://example.com/path#", true);
+        HttpRequest emptyQueryWithFragment = new DefaultHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.GET, "http://example.com/path?#frag", true);
+        HttpRequest queryWithEmptyFragment = new DefaultHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.GET, "http://example.com/path?x#", true);
+
+        assertEquals(new AsciiString("/path"), HttpConversionUtil.toHttp2Headers(emptyQuery, true).path());
+        assertEquals(new AsciiString("/path"), HttpConversionUtil.toHttp2Headers(emptyFragment, true).path());
+        assertEquals(new AsciiString("/path#frag"),
+                HttpConversionUtil.toHttp2Headers(emptyQueryWithFragment, true).path());
+        assertEquals(new AsciiString("/path?x"),
+                HttpConversionUtil.toHttp2Headers(queryWithEmptyFragment, true).path());
+    }
+
+    @Test
+    public void rejectsAbsoluteRequestWithMalformedAuthority() {
+        final HttpRequest msg = new DefaultHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.GET,
+                "http://[bad host]/p?q={x}",
+                new DefaultHttpHeaders(false),
+                false);
+
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() {
+                HttpConversionUtil.toHttp2Headers(msg, false);
+            }
+        });
+    }
+
+    @Test
     public void addHttp2ToHttpHeadersCombinesCookies() throws Http2Exception {
         Http2Headers inHeaders = new DefaultHttp2Headers();
         inHeaders.add("yes", "no");

--- a/microbench/src/main/java/io/netty/handler/codec/http2/Http2RequestTargetConversionBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http2/Http2RequestTargetConversionBenchmark.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http2;
+
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpScheme;
+import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import io.netty.util.AsciiString;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+import static io.netty.util.internal.StringUtil.isNullOrEmpty;
+
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 200, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 200, timeUnit = TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class Http2RequestTargetConversionBenchmark extends AbstractMicrobenchmark {
+
+    @Param
+    public RequestTargetType requestTargetType;
+
+    private HttpRequest request;
+
+    @Setup
+    public void setup() {
+        request = new DefaultHttpRequest(
+                HttpVersion.HTTP_1_1,
+                HttpMethod.GET,
+                requestTargetType.requestTarget,
+                new DefaultHttpHeaders(),
+                false);
+        request.headers().set(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), HttpScheme.HTTP.name());
+    }
+
+    @Benchmark
+    public void newConversion(Blackhole bh) {
+        bh.consume(HttpConversionUtil.toHttp2Headers(request, false));
+    }
+
+    @Benchmark
+    public void oldUriConversion(Blackhole bh) {
+        bh.consume(oldToHttp2Headers(request));
+    }
+
+    public enum RequestTargetType {
+        ORIGIN("/orders/123/items?expand=details"),
+        ABSOLUTE("http://example.com/orders/123/items?expand=details#section"),
+        ABSOLUTE_NO_PATH("http://example.com?next=/home#section"),
+        ABSOLUTE_NO_AUTHORITY("http://?x=1#frag"),
+        SCHEME_ONLY_ABSOLUTE_PATH("http:/orders/123/items?expand=details");
+
+        final String requestTarget;
+
+        RequestTargetType(String requestTarget) {
+            this.requestTarget = requestTarget;
+        }
+    }
+
+    private static Http2Headers oldToHttp2Headers(final HttpRequest request) {
+        HttpHeaders inHeaders = request.headers();
+        Http2Headers out = new DefaultHttp2Headers(false, inHeaders.size());
+        String host = inHeaders.getAsString(HttpHeaderNames.HOST);
+        if (HttpUtil.isOriginForm(request.uri()) || HttpUtil.isAsteriskForm(request.uri())) {
+            out.path(new AsciiString(request.uri()));
+            oldSetHttp2Scheme(inHeaders, URI.create(""), out);
+        } else {
+            URI requestTargetUri = URI.create(request.uri());
+            out.path(oldToHttp2Path(requestTargetUri));
+            host = isNullOrEmpty(host) ? requestTargetUri.getAuthority() : host;
+            oldSetHttp2Scheme(inHeaders, requestTargetUri, out);
+        }
+        HttpConversionUtil.setHttp2Authority(host, out);
+        out.method(request.method().asciiName());
+        HttpConversionUtil.toHttp2Headers(inHeaders, out);
+        return out;
+    }
+
+    private static AsciiString oldToHttp2Path(final URI uri) {
+        StringBuilder pathBuilder = new StringBuilder();
+        if (!isNullOrEmpty(uri.getRawPath())) {
+            pathBuilder.append(uri.getRawPath());
+        }
+        if (!isNullOrEmpty(uri.getRawQuery())) {
+            pathBuilder.append('?');
+            pathBuilder.append(uri.getRawQuery());
+        }
+        if (!isNullOrEmpty(uri.getRawFragment())) {
+            pathBuilder.append('#');
+            pathBuilder.append(uri.getRawFragment());
+        }
+        String path = pathBuilder.toString();
+        return path.isEmpty() ? new AsciiString("/") : new AsciiString(path);
+    }
+
+    private static void oldSetHttp2Scheme(final HttpHeaders in, final URI uri, final Http2Headers out) {
+        String value = uri.getScheme();
+        if (!isNullOrEmpty(value)) {
+            out.scheme(new AsciiString(value));
+            return;
+        }
+
+        CharSequence cValue = in.get(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text());
+        if (cValue != null) {
+            out.scheme(AsciiString.of(cValue));
+            return;
+        }
+
+        if (uri.getPort() == HttpScheme.HTTPS.port()) {
+            out.scheme(HttpScheme.HTTPS.name());
+        } else if (uri.getPort() == HttpScheme.HTTP.port()) {
+            out.scheme(HttpScheme.HTTP.name());
+        } else {
+            throw new IllegalArgumentException(
+                    ":scheme must be specified. see https://tools.ietf.org/html/rfc7540#section-8.1.2.3");
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -760,6 +760,7 @@
     <enforcer.plugin.version>3.0.0</enforcer.plugin.version>
     <junit.version>5.14.3</junit.version>
     <junit.platform.version>1.14.0</junit.platform.version>
+    <jazzer.version>0.30.0</jazzer.version>
     <skipTests>false</skipTests>
     <testJavaHome>${java.home}</testJavaHome>
     <testJvm>${testJavaHome}/bin/java</testJvm>
@@ -1112,6 +1113,12 @@
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-params</artifactId>
         <version>${junit.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.code-intelligence</groupId>
+        <artifactId>jazzer-junit</artifactId>
+        <version>${jazzer.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Motivation:

`HttpConversionUtil.toHttp2Headers` currently depends on `java.net.URI` for absolute-form request-target parsing. On JDKs that still enforce older URI syntax, path or query characters that appear in real HTTP request-targets can make HTTP/1.x to HTTP/2 conversion fail before `:path` is produced.

Netty only needs URI parsing for the lower-frequency `scheme://authority` validation/extraction path. The hot path/query extraction can follow the same lightweight parsing shape used by Vert.x while avoiding full URI parsing and avoiding a try/catch fallback.

Modification:

- Split request-target path and query parsing into Vert.x-shaped `parsePath` and `parseQuery` helpers, with comments for Netty-specific differences.
- Keep `URI` parsing for `scheme://authority` validation/extraction only after stripping path/query/fragment data.
- Preserve origin-form and asterisk-form behavior.
- Add regression tests for characters rejected by `java.net.URI`, authority-only and missing-authority absolute-form targets, empty query/fragment handling, and malformed authority validation.
- Add a Jazzer fuzz test that compares the new behavior against the old URI-based conversion using broad `consumeString(128)` request-target input and narrow documented compatibility exceptions.

Result:

HTTP/2 conversion no longer relies on full `java.net.URI` parsing for request-target path/query extraction, while preserving meaningful existing behavior and continuing to validate/extract scheme and authority through URI where appropriate.

Verification performed locally:

- `./mvnw -pl codec-http2 -Drevapi.skip=true -DskipJapicmp -DskipHttp2Testsuite -DskipAutobahn test`
- `JAZZER_FUZZ=1 ./mvnw -pl codec-http2 -Drevapi.skip=true -DskipJapicmp -DskipHttp2Testsuite -DskipAutobahn -Dcheckstyle.skip=true -Dtest=HttpConversionUtilFuzzTest test`
- `./mvnw -pl codec-http2 -Drevapi.skip=true -DskipJapicmp -DskipHttp2Testsuite -DskipAutobahn -Dcheckstyle.skip=true -Dsurefire.failIfNoSpecifiedTests=false -Dtest=HttpConversionUtilTest,HttpConversionUtilFuzzTest test`