### PR TITLE
MQTT: Fix spurious TooLongFrameException for fragmented messages

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
@@ -97,20 +97,18 @@ public final class MqttDecoder extends ReplayingDecoder<DecoderState> {
 
             case READ_VARIABLE_HEADER:  try {
                 int bytesRemainingBeforeVariableHeader = bytesRemainingInVariablePart;
-                int initialAvailableBytes = buffer.readableBytes();
                 boolean bailOut = false;
                 try {
                     variableHeader = decodeVariableHeader(ctx, buffer, mqttFixedHeader);
                 } catch (Signal signal) {
-                    if (initialAvailableBytes < maxBytesInMessage) {
-                        // Ask for REPLAY if the buffer was less than maxBytesInMessage
+                    if (bytesRemainingBeforeVariableHeader <= maxBytesInMessage) {
+                        // The declared message size fits within the limit; ask for REPLAY so the
+                        // decoder can resume once more data is available.
                         throw signal;
-                    } else {
-                        // We couldn't parse the complete message, and it's already too large.
-                        // Swallow the Signal (we don't need more data) and instead bail out
-                        // and throw the TooLongFrameException below.
-                        bailOut = true;
                     }
+                    // The declared message size already exceeds the limit; don't wait for more
+                    // data, bail out and throw the TooLongFrameException below.
+                    bailOut = true;
                 }
                 if (bailOut || bytesRemainingBeforeVariableHeader > maxBytesInMessage) {
                     buffer.skipBytes(actualReadableBytes());

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
@@ -577,7 +577,7 @@ public class MqttCodecTest {
         ByteBuf encoded = MqttEncoder.doEncode(ctx, message);
         try {
             final int total = encoded.readableBytes();
-            assertTrue(total > 2 && total < DEFAULT_MAX_BYTES_IN_MESSAGE);
+            assertThat(total).isGreaterThan(2).isLessThan(DEFAULT_MAX_BYTES_IN_MESSAGE);
 
             // Split right after the fixed header so the first channelRead leaves the
             // decoder mid-way through the variable header, triggering a REPLAY signal.

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
@@ -567,6 +567,42 @@ public class MqttCodecTest {
     }
 
     @Test
+    public void testFragmentedMessageIsNotReportedAsTooLarge() throws Exception {
+        // Regression test for https://github.com/netty/netty/issues/16776.
+        // When the variable header cannot be decoded yet because more data is needed,
+        // the decoder must ask for REPLAY rather than incorrectly raising a
+        // TooLongFrameException, as long as the declared remaining length is within
+        // maxBytesInMessage.
+        final MqttConnectMessage message = createConnectMessage(MqttVersion.MQTT_3_1_1);
+        ByteBuf encoded = MqttEncoder.doEncode(ctx, message);
+        try {
+            final int total = encoded.readableBytes();
+            assertTrue(total > 2 && total < DEFAULT_MAX_BYTES_IN_MESSAGE);
+
+            // Split right after the fixed header so the first channelRead leaves the
+            // decoder mid-way through the variable header, triggering a REPLAY signal.
+            final int splitPoint = 2;
+            ByteBuf head = encoded.copy(encoded.readerIndex(), splitPoint);
+            ByteBuf tail = encoded.copy(encoded.readerIndex() + splitPoint, total - splitPoint);
+
+            mqttDecoder.channelRead(ctx, head);
+            assertEquals(0, out.size(), "decoder must wait for more data, not emit a frame");
+
+            mqttDecoder.channelRead(ctx, tail);
+            assertEquals(1, out.size());
+
+            final MqttConnectMessage decodedMessage = (MqttConnectMessage) out.get(0);
+            assertFalse(decodedMessage.decoderResult().isFailure(),
+                    "unexpected decoder failure: " + decodedMessage.decoderResult().cause());
+            validateFixedHeaders(message.fixedHeader(), decodedMessage.fixedHeader());
+            validateConnectVariableHeader(message.variableHeader(), decodedMessage.variableHeader());
+            validateConnectPayload(message.payload(), decodedMessage.payload());
+        } finally {
+            encoded.release();
+        }
+    }
+
+    @Test
     public void testConnectMessageForMqtt5() throws Exception {
         MqttProperties props = new MqttProperties();
         props.add(new MqttProperties.IntegerProperty(SESSION_EXPIRY_INTERVAL.value(), 10));


### PR DESCRIPTION
Motivation:

The CVE-2026-44248 fix in 82f47fa53571d04d8add02e3a01762cebd139a00 compares `initialAvailableBytes < maxBytesInMessage` after catching a `REPLAY` `Signal` from `decodeVariableHeader`, treating the comparison as "is there still room in the size budget". Because `MqttDecoder` extends `ReplayingDecoder`, the buffer passed to `decode` is a `ReplayingDecoderByteBuf` whose `readableBytes()` returns `Integer.MAX_VALUE - readerIndex` rather than the actual number of bytes available. The check therefore evaluates to `false` in practice, so any time the variable header cannot be decoded in one pass `bailOut` is set to `true` and a `TooLongFrameException` is thrown even though the declared remaining length is well within `maxBytesInMessage`. This breaks decoding whenever the MQTT message arrives in multiple chunks — Apache Artemis hit this when upgrading from 4.1.132 to 4.1.133 (#16776).

Modification:

Compare against `bytesRemainingBeforeVariableHeader` (the declared remaining length from the fixed header) instead of the buffer's reported size. When the declared message size fits within `maxBytesInMessage`, propagate the `Signal` so the decoder can resume once more data is available. When it exceeds the limit, keep bailing out as before — preserving the CVE-2026-44248 protection.

Added regression test `testFragmentedMessageIsNotReportedAsTooLarge` in `MqttCodecTest` that splits a CONNECT message right after the fixed header and verifies the decoder waits for more data without emitting a frame. Confirmed it fails on the current code (`expected: <0> but was: <1>`) and passes with the fix.

Result:

Fragmented MQTT messages whose declared size is within `maxBytesInMessage` are decoded correctly, while oversized messages still bail out early as intended by the CVE-2026-44248 fix.

Fixes #16776.

---

Note: this fix targets 4.1; the same regression exists on the 4.2 branch via the cherry-pick in 1986c38c9ec4f4130786503dfed2563f59132764, so the `needs-cherry-pick-4.2` label is appropriate. On 5.0 the MQTT decoder no longer uses `ReplayingDecoder`, so that branch is not affected in the same way and is left for maintainer review.