### PR TITLE
MQTT: Make the decodeProperties early-REPLAY check actually fire

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
@@ -746,9 +746,14 @@ public final class MqttDecoder extends ReplayingDecoder<DecoderState> {
         final long propertiesLength = decodeVariableByteInteger(buffer);
         int totalPropertiesLength = unpackA(propertiesLength);
         int numberOfBytesConsumed = unpackB(propertiesLength);
-        if (buffer.readableBytes() < totalPropertiesLength) {
-            // Force an early REPLAY to avoid repeatedly parsing the properties.
-            buffer.readSlice(totalPropertiesLength);
+        if (totalPropertiesLength > 0) {
+            // Force an early REPLAY when the buffer does not yet have the full properties block,
+            // so we don't repeatedly parse partial properties as data arrives. A direct
+            // buffer.readableBytes() check is unusable here because ReplayingDecoderByteBuf
+            // returns Integer.MAX_VALUE - readerIndex; touching the last byte via getByte()
+            // routes through ReplayingDecoderByteBuf.checkIndex(), which throws REPLAY if the
+            // buffer's writerIndex hasn't reached that position yet.
+            buffer.getByte(buffer.readerIndex() + totalPropertiesLength - 1);
         }
 
         MqttProperties decodedProperties = new MqttProperties();


### PR DESCRIPTION
Motivation:

The CVE-2026-44248 fix in 82f47fa53571d04d8add02e3a01762cebd139a00 added a guard at the top of `decodeProperties` to trigger an early REPLAY when the cumulation buffer did not yet have the full properties block:

```java
if (buffer.readableBytes() < totalPropertiesLength) {
    buffer.readSlice(totalPropertiesLength);
}
```

Because `MqttDecoder` extends `ReplayingDecoder`, the buffer passed to `decodeProperties` is a `ReplayingDecoderByteBuf` whose `readableBytes()` returns `Integer.MAX_VALUE - readerIndex` rather than the actual number of bytes available (see `ReplayingDecoderByteBuf.readableBytes()`). The `if`-condition is therefore false in practice and the `readSlice()` call never executes, so the early-REPLAY optimization is effectively dead code. When the properties block arrives in chunks the decoder still falls back to partial parsing followed by a mid-loop REPLAY, which defeats the optimization's intent on slow streams.

Modification:

Replace the broken `readableBytes()` check with a `getByte()` probe at `buffer.readerIndex() + totalPropertiesLength - 1`. `ReplayingDecoderByteBuf.checkIndex` throws `Signal.REPLAY` when `index + 1 > writerIndex` — i.e. exactly when the cumulation buffer does not yet hold the full properties block. The call has no side effect on `readerIndex`, so subsequent parsing is unchanged once the data arrives. A `totalPropertiesLength > 0` guard skips the probe when there are no properties.

Result:

The early-REPLAY guard now actually fires when properties data is incomplete, restoring the CVE-2026-44248 fix's intent of avoiding repeated partial-properties parsing on slow streams. No semantic change on the happy path; all 107 existing `codec-mqtt` tests pass locally.

Note: this is complementary to #16787, which addresses the *outer* variable-header REPLAY handling broken by the same CVE patch (same `buffer.readableBytes()` antipattern in a ReplayingDecoder context). Both fixes are independent and can land in either order; together they restore the optimization the CVE-2026-44248 fix originally aimed for.