### PR TITLE
SingleThreadEventExecutor: document Throwable safety contract on run()

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -540,7 +540,7 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
      * Runs the task-processing loop until {@link #confirmShutdown()} returns {@code true}.
      *
      * <p>Implementations <strong>must not let a {@link Throwable} thrown by a task escape this
-     * method</strong>: any uncaught throwable terminates the executor (logged at {@code WARN}
+     * method</strong>: any uncaught {@link Throwable} terminates the executor (logged at {@code WARN}
      * and surfaced via {@link #terminationFuture()}), at which point every {@code Channel}
      * registered with this executor stops processing I/O and new task submissions are rejected.
      * The supplied helpers - {@link #runAllTasks()}, {@link #runAllTasks(long)}, and

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -537,7 +537,16 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
     }
 
     /**
-     * Run the tasks in the {@link #taskQueue}
+     * Runs the task-processing loop until {@link #confirmShutdown()} returns {@code true}.
+     *
+     * <p>Implementations <strong>must not let a {@link Throwable} thrown by a task escape this
+     * method</strong>: any uncaught throwable terminates the executor (logged at {@code WARN}
+     * and surfaced via {@link #terminationFuture()}), at which point every {@code Channel}
+     * registered with this executor stops processing I/O and new task submissions are rejected.
+     * The supplied helpers - {@link #runAllTasks()}, {@link #runAllTasks(long)}, and
+     * {@link #safeExecute(Runnable)} - catch {@code Throwable} for you; custom loops built on
+     * {@link #pollTask()} or {@link #takeTask()} are responsible for wrapping each task
+     * invocation accordingly.
      */
     protected abstract void run();
 


### PR DESCRIPTION
Motivation:

Subclasses of `SingleThreadEventExecutor` can silently take down the event-loop thread — and with it every `Channel` registered to that loop — if their `run()` implementation lets a `Throwable` escape from a task invocation. The default helpers (`runAllTasks*`, `safeExecute`) catch `Throwable` correctly, but the abstract `run()` contract gives no hint that this is a hard requirement; the existing one-line javadoc just says "Run the tasks in the taskQueue". Subclassers writing bespoke task loops on top of `pollTask`/`takeTask` have no guidance — see #16102 for the full report.

Modification:

Expand the javadoc on `SingleThreadEventExecutor#run()` to spell out:

- `run()` must keep going until `confirmShutdown()` returns `true`;
- an uncaught `Throwable` terminates the event-loop thread and silently breaks every `Channel` registered to it;
- `runAllTasks()`, `runAllTasks(long)`, and `safeExecute(Runnable)` already handle `Throwable`, so prefer them;
- custom loops built on `pollTask()`/`takeTask()` must wrap each task invocation themselves.

No code change.

Result:

Implementers of `SingleThreadEventExecutor` see the safety contract on the method they are required to override, rather than discovering the failure mode in production.

Refs #16102. The optional "Defensive Mechanism" piece (enforce an `UncaughtExceptionHandler` on event-loop threads) from the original issue is intentionally out of scope here — happy to do that as a follow-up if maintainers want it.