### PR TITLE
Fix ResumptionController wrapping

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -771,7 +771,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
                 if (resumptionController != null) {
                     tm = (X509TrustManager) resumptionController.wrapIfNeeded(tm);
                 }
-                tm = OpenSslX509TrustManagerWrapper.wrapIfNeeded((X509TrustManager) m);
+                tm = OpenSslX509TrustManagerWrapper.wrapIfNeeded(tm);
                 if (useExtendedTrustManager(tm)) {
                     // Wrap the TrustManager to provide a better exception message for users to debug hostname
                     // validation failures.


### PR DESCRIPTION
Motivation:
ReferenceCountedOpenSslContext did not propagate the wrapped trust manager from the resumption controller. With poorly implemented ResumableX509ExtendedTrustManager instances, this can waste a few resources by re-validating initial handshakes as if they are _also_ a resumed session.

Modification:
Change the ReferenceCountedOpenSslContext to ensure that the result of ResumptionController.wrapIfNeeded is passed through to later wrapping steps, if any.

Result:
No more unnecessary double-validation for resumable trust managers.
