### PR TITLE
Resolve all localhost addresses without querying DNS servers (#16749)

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -83,6 +83,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -102,8 +103,8 @@ public class DnsNameResolver extends InetNameResolver {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(DnsNameResolver.class);
     private static final String LOCALHOST = "localhost";
+    private static final String DOT_LOCALHOST = '.' + LOCALHOST;
     private static final String WINDOWS_HOST_NAME;
-    private static final InetAddress LOCALHOST_ADDRESS;
     private static final DnsRecord[] EMPTY_ADDITIONALS = new DnsRecord[0];
     private static final DnsRecordType[] IPV4_ONLY_RESOLVED_RECORD_TYPES =
             {DnsRecordType.A};
@@ -136,18 +137,14 @@ public class DnsNameResolver extends InetNameResolver {
     static {
         if (NetUtil.isIpV4StackPreferred() || !anyInterfaceSupportsIpV6()) {
             DEFAULT_RESOLVE_ADDRESS_TYPES = ResolvedAddressTypes.IPV4_ONLY;
-            LOCALHOST_ADDRESS = NetUtil.LOCALHOST4;
         } else {
             if (NetUtil.isIpV6AddressesPreferred()) {
                 DEFAULT_RESOLVE_ADDRESS_TYPES = ResolvedAddressTypes.IPV6_PREFERRED;
-                LOCALHOST_ADDRESS = NetUtil.LOCALHOST6;
             } else {
                 DEFAULT_RESOLVE_ADDRESS_TYPES = ResolvedAddressTypes.IPV4_PREFERRED;
-                LOCALHOST_ADDRESS = NetUtil.LOCALHOST4;
             }
         }
         logger.debug("Default ResolvedAddressTypes: {}", DEFAULT_RESOLVE_ADDRESS_TYPES);
-        logger.debug("Localhost address: {}", LOCALHOST_ADDRESS);
 
         String hostName;
         try {
@@ -701,7 +698,7 @@ public class DnsNameResolver extends InetNameResolver {
             return null;
         }
         InetAddress address = hostsFileEntriesResolver.address(hostname, resolvedAddressTypes);
-        return address == null && isLocalWindowsHost(hostname) ? LOCALHOST_ADDRESS : address;
+        return address == null && isLocalHostAddress(hostname)? getLocalHostAddress() : address;
     }
 
     private List<InetAddress> resolveHostsFileEntries(String hostname) {
@@ -714,23 +711,54 @@ public class DnsNameResolver extends InetNameResolver {
                     .addresses(hostname, resolvedAddressTypes);
         } else {
             InetAddress address = hostsFileEntriesResolver.address(hostname, resolvedAddressTypes);
-            addresses = address != null ? Collections.singletonList(address) : null;
+            addresses = address != null? Collections.singletonList(address) : null;
         }
-        return addresses == null && isLocalWindowsHost(hostname) ?
-                Collections.singletonList(LOCALHOST_ADDRESS) : addresses;
+        return addresses == null && isLocalHostAddress(hostname)?
+                Collections.singletonList(getLocalHostAddress()) : addresses;
     }
 
     /**
-     * Checks whether the given hostname is the localhost/host (computer) name on Windows OS.
-     * Windows OS removed the localhost/host (computer) name information from the hosts file in the later versions
-     * and such hostname cannot be resolved from hosts file.
-     * See https://github.com/netty/netty/issues/5386
-     * See https://github.com/netty/netty/issues/11142
+     * Checks whether the given hostname refers to the current computer. This is the case for:
+     * <ul>
+     *     <li>localhost.</li>
+     *     <li>any domain within .localhost.</li>
+     *     <li>the hostname of the local computer on Windows</li>
+     * </ul>
+     * <p>
+     * According to RFC 6761 Section 6.3, localhost and subdomains of localhost should be resolved to the loopback
+     * address by name resolution libraries without querying DNS servers. The hostname of the local machine can usually
+     * be resolved from the hosts file, but on Windows, this is no longer possible.
+     *
+     * @param hostname the hostname that's being looked up
+     * @return true if the hostname should point to the loopback adress. False otherwise.
+     * @see <a href="https://github.com/netty/netty/issues/5386">Issue 5386</a>
+     * @see <a href="https://github.com/netty/netty/issues/11142">Issue 11142</a>
+     * @see <a href="https://github.com/netty/netty/issues/16744">Issue 16744</a>
+     * @see <a href="https://www.rfc-editor.org/rfc/rfc6761.html#section-6.3">RFC 6761</a>
      */
-    private static boolean isLocalWindowsHost(String hostname) {
-        return PlatformDependent.isWindows() &&
-                (LOCALHOST.equalsIgnoreCase(hostname) ||
-                        (WINDOWS_HOST_NAME != null && WINDOWS_HOST_NAME.equalsIgnoreCase(hostname)));
+    private static boolean isLocalHostAddress(String hostname) {
+        if (PlatformDependent.isWindows() && WINDOWS_HOST_NAME != null &&
+            WINDOWS_HOST_NAME.equalsIgnoreCase(hostname)) {
+            return true;
+        }
+
+        if (hostname.endsWith(".")) {
+            hostname = hostname.substring(0, hostname.length() - 1);
+        }
+        return hostname.equalsIgnoreCase(LOCALHOST) || hostname.toLowerCase(Locale.US).endsWith(DOT_LOCALHOST);
+    }
+
+    private InetAddress getLocalHostAddress() {
+        switch (resolvedAddressTypes) {
+        case IPV4_ONLY:
+        case IPV4_PREFERRED:
+            return NetUtil.LOCALHOST4;
+        case IPV6_ONLY:
+        case IPV6_PREFERRED:
+            return NetUtil.LOCALHOST6;
+        default:
+            throw new IllegalStateException("Unknown ResolvedAddressTypes " + resolvedAddressTypes);
+        }
     }
 
     /**

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -863,15 +863,15 @@ public class DnsNameResolverTest {
         testResolve0(strategy, ResolvedAddressTypes.IPV6_ONLY, NetUtil.LOCALHOST6, WINDOWS_HOST_NAME);
     }
 
-    private static List<Arguments> testResolveLocalhostWithoutDNSArgs() {
+    private static List<Object[]> testResolveLocalhostWithoutDNSArgs() {
         DnsNameResolverChannelStrategy[] strategies = DnsNameResolverChannelStrategy.values();
         List<String> names = asList("localhost", "localhost.", "test.localhost", "TEsT.LOCalhost", "test.localhost.");
 
-        List<Arguments> output = new ArrayList<Arguments>();
+        List<Object[]> output = new ArrayList<Object[]>();
         for (DnsNameResolverChannelStrategy strategy : strategies) {
             for (String name : names) {
-                output.add(Arguments.of(strategy, ResolvedAddressTypes.IPV4_ONLY, NetUtil.LOCALHOST4, name));
-                output.add(Arguments.of(strategy, ResolvedAddressTypes.IPV6_ONLY, NetUtil.LOCALHOST6, name));
+                output.add(new Object[] { strategy, ResolvedAddressTypes.IPV4_ONLY, NetUtil.LOCALHOST4, name });
+                output.add(new Object[] { strategy, ResolvedAddressTypes.IPV6_ONLY, NetUtil.LOCALHOST6, name });
             }
         }
 

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -867,7 +867,7 @@ public class DnsNameResolverTest {
         DnsNameResolverChannelStrategy[] strategies = DnsNameResolverChannelStrategy.values();
         List<String> names = asList("localhost", "localhost.", "test.localhost", "TEsT.LOCalhost", "test.localhost.");
 
-        List<Arguments> output = new ArrayList<>();
+        List<Arguments> output = new ArrayList<Arguments>();
         for (DnsNameResolverChannelStrategy strategy : strategies) {
             for (String name : names) {
                 output.add(Arguments.of(strategy, ResolvedAddressTypes.IPV4_ONLY, NetUtil.LOCALHOST4, name));

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -112,7 +112,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static io.netty.handler.codec.dns.DnsRecordType.A;
 import static io.netty.handler.codec.dns.DnsRecordType.AAAA;
@@ -859,6 +861,46 @@ public class DnsNameResolverTest {
         assumeThat(WINDOWS_HOSTS_FILE_HOST_NAME_ENTRY_EXISTS).isFalse();
         assumeThat(DEFAULT_RESOLVE_ADDRESS_TYPES).isEqualTo(ResolvedAddressTypes.IPV6_PREFERRED);
         testResolve0(strategy, ResolvedAddressTypes.IPV6_ONLY, NetUtil.LOCALHOST6, WINDOWS_HOST_NAME);
+    }
+
+    private static List<Arguments> testResolveLocalhostWithoutDNSArgs() {
+        DnsNameResolverChannelStrategy[] strategies = DnsNameResolverChannelStrategy.values();
+        List<String> names = asList("localhost", "localhost.", "test.localhost", "TEsT.LOCalhost", "test.localhost.");
+
+        List<Arguments> output = new ArrayList<>();
+        for (DnsNameResolverChannelStrategy strategy : strategies) {
+            for (String name : names) {
+                output.add(Arguments.of(strategy, ResolvedAddressTypes.IPV4_ONLY, NetUtil.LOCALHOST4, name));
+                output.add(Arguments.of(strategy, ResolvedAddressTypes.IPV6_ONLY, NetUtil.LOCALHOST6, name));
+            }
+        }
+
+        return output;
+    }
+
+    @ParameterizedTest
+    @MethodSource("testResolveLocalhostWithoutDNSArgs")
+    public void testResolveLocalhostWithoutDNSOrHostsFile(DnsNameResolverChannelStrategy strategy,
+                                                          ResolvedAddressTypes addressTypes, InetAddress expectedAddr,
+                                                          String name) {
+        DnsNameResolver resolver = newResolver(strategy, addressTypes)
+                .hostsFileEntriesResolver(new HostsFileEntriesResolver() {
+                    @Override
+                    public InetAddress address(String inetHost, ResolvedAddressTypes resolvedAddressTypes) {
+                        // The hosts file should not be required to resolve localhost addresses.
+                        return null;
+                    }
+                })
+                .build();
+        try {
+            InetAddress address = resolver.resolve(name).syncUninterruptibly().getNow();
+            assertEquals(expectedAddr, address);
+
+            // We are resolving the local address, so we shouldn't make any queries.
+            assertNoQueriesMade(resolver);
+        } finally {
+            resolver.close();
+        }
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Motivation:

According to RFC 6761, all domains within .localhost. should be resolved to the loopback address without querying DNS servers. This is useful e.g. when you have multiple web servers behind a local reverse proxy and you want to route the requests based on the hostname. Previously, netty would only resolve hostnames specified in the hosts file (or localhost and the machine hostname on windows) without querying DNS servers.

Modifications:

- localhost and all domains within .localhost. are now directly resolved to the loopback address
- Replaced isLocalWindowsHost with isLocalHostAddress
- Replaced LOCALHOST_ADDRESS constant with getLocalHostAddress method to correctly return the correct loopback address based on resolvedAddressTypes
- Added test that covers all combinations of DnsNameResolverChannelStrategy, ResolvedAddressTypes and various localhost hostnames

Result:

Localhost hostnames are now resolved directly to the loopback address without querying a DNS server. Overriding them in the hosts file is still possible.

Fixes #16744