### PR TITLE
IoUring: Stop generic FileRegion drain loop when transferred() reaches count()

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFileRegionTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFileRegionTest.java
@@ -26,6 +26,7 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.DefaultFileRegion;
 import io.netty.channel.FileRegion;
 import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.socket.oio.OioSocketChannel;
 import io.netty.util.AbstractReferenceCounted;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
@@ -49,6 +50,7 @@ import static io.netty.testsuite.transport.TestsuitePermutation.randomBufferType
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class SocketFileRegionTest extends AbstractSocketTest {
@@ -215,6 +217,15 @@ public class SocketFileRegionTest extends AbstractSocketTest {
         Channel sc = sb.bind().sync().channel();
         Channel cc = cb.connect(sc.localAddress()).sync().channel();
         try {
+            // OioByteStreamChannel#doWriteFileRegion drains using a locally-tracked
+            // bytes-written counter as the transferTo position (ignoring transferred()), so an
+            // ill-behaved FileRegion that advances transferred() past actual bytes written --
+            // the exact pattern this fixture uses to exercise the overshoot path -- cannot
+            // satisfy OIO's loop without violating the position invariant. The overshoot
+            // detection is meaningless on OIO for the same reason; skip the permutation.
+            assumeFalse(cc instanceof OioSocketChannel,
+                    "OIO transport does not honour transferred() for drain-loop termination");
+
             OvershootDetectingFileRegion region = new OvershootDetectingFileRegion(regionSize);
             // sync() blocks until the write future completes, by which point every
             // transferTo() call the transport is going to make has already been made --

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFileRegionTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFileRegionTest.java
@@ -26,17 +26,22 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.DefaultFileRegion;
 import io.netty.channel.FileRegion;
 import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.util.AbstractReferenceCounted;
 import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static io.netty.testsuite.transport.TestsuitePermutation.randomBufferType;
@@ -118,6 +123,18 @@ public class SocketFileRegionTest extends AbstractSocketTest {
         });
     }
 
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    public void testFileRegionDrainStopsAtCompletion(TestInfo testInfo) throws Throwable {
+        assumeTrue(supportsCustomFileRegion());
+        run(testInfo, new Runner<ServerBootstrap, Bootstrap>() {
+            @Override
+            public void run(ServerBootstrap serverBootstrap, Bootstrap bootstrap) throws Throwable {
+                testFileRegionDrainStopsAtCompletion(serverBootstrap, bootstrap);
+            }
+        });
+    }
+
     public void testFileRegion(ServerBootstrap sb, Bootstrap cb) throws Throwable {
         testFileRegion0(sb, cb, false, true, true);
     }
@@ -164,6 +181,55 @@ public class SocketFileRegionTest extends AbstractSocketTest {
         assertInstanceOf(IOException.class, cc.writeAndFlush(region).await().cause());
         cc.close().sync();
         sc.close().sync();
+    }
+
+    /**
+     * Reproducer for a {@code FileRegion} drain-loop overshoot. Transports must short-circuit
+     * as soon as the region reports {@code transferred() >= count()}; any extra
+     * {@code transferTo} call violates the contract and would corrupt
+     * implementations that lazily emit per-chunk framing.
+     *
+     * <p>A custom {@link FileRegion} whose {@code transferTo} advances {@code transferred}
+     * past the bytes it writes to the target on a single call (legal: an encryption- or
+     * framing-on-write FileRegion that flushes a complete inner chunk in one call behaves
+     * this way) records every {@code transferTo} invocation made past
+     * {@code transferred == count}. The expected behaviour for every transport is that
+     * {@code transferToCallsPastCompletion} stays zero.
+     */
+    public void testFileRegionDrainStopsAtCompletion(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+        // Region size > 1 so any chunked transport (e.g. io_uring's generic FileRegion fallback)
+        // that sizes its chunk buffer from count() retains spare capacity after the first
+        // (and only) source byte is written -- without that spare capacity an inner drain loop
+        // would exit on writableBytes() == 0 and the overshoot path would not be exercised.
+        final int regionSize = 16;
+
+        sb.childHandler(new SimpleChannelInboundHandler<ByteBuf>() {
+            @Override
+            protected void channelRead0(ChannelHandlerContext ctx, ByteBuf msg) {
+                // drain
+            }
+        });
+        cb.handler(new ChannelInboundHandlerAdapter());
+
+        Channel sc = sb.bind().sync().channel();
+        Channel cc = cb.connect(sc.localAddress()).sync().channel();
+        try {
+            OvershootDetectingFileRegion region = new OvershootDetectingFileRegion(regionSize);
+            // sync() blocks until the write future completes, by which point every
+            // transferTo() call the transport is going to make has already been made --
+            // the fixture's call counter is observable here without any timing wait. Ref
+            // ownership is transferred to the pipeline on writeAndFlush(), which releases
+            // it as the write completes (success or failure).
+            cc.writeAndFlush(region).sync();
+            int overshoot = region.transferToCallsPastCompletion.get();
+            assertEquals(0, overshoot,
+                    "transferTo() invoked " + overshoot
+                            + " time(s) after region.transferred() reached region.count()="
+                            + regionSize);
+        } finally {
+            cc.close().sync();
+            sc.close().sync();
+        }
     }
 
     private static void testFileRegion0(
@@ -313,6 +379,114 @@ public class SocketFileRegionTest extends AbstractSocketTest {
             if (exception.compareAndSet(null, cause)) {
                 ctx.close();
             }
+        }
+    }
+
+    /**
+     * Custom {@link FileRegion} that advances {@code transferred()} past the bytes it writes
+     * to the target on a single {@code transferTo} call -- the same pattern an
+     * encryption-on-write or framing FileRegion follows when it reports an inner chunk as
+     * "delivered" once that chunk fully drains. Records every {@code transferTo} invocation
+     * made after the region has been fully transferred so a drain-loop overshoot is visible
+     * synchronously on the writer side.
+     *
+     * <ul>
+     *   <li>{@link #count()} returns the constant configured size.</li>
+     *   <li>The first {@code transferTo} call writes one byte to the target; once that
+     *       byte is accepted it advances {@code transferred} to {@code count} and returns
+     *       the bytes written.</li>
+     *   <li>Every subsequent {@code transferTo} call increments
+     *       {@link #transferToCallsPastCompletion} and writes one phantom byte to mimic
+     *       the protocol-corrupting side effect a real overshoot would produce.</li>
+     * </ul>
+     * The {@code transferred} field is written and read only on the EventLoop (in
+     * {@code transferTo} and the surrounding drain loop), so no synchronization is needed.
+     * The cross-thread observation channel is the {@link AtomicInteger} counter, which the
+     * test reads after {@code writeAndFlush(...).sync()} establishes the happens-before.
+     */
+    private static final class OvershootDetectingFileRegion extends AbstractReferenceCounted
+            implements FileRegion {
+        private final long count;
+        private long transferred;
+        final AtomicInteger transferToCallsPastCompletion = new AtomicInteger();
+
+        OvershootDetectingFileRegion(long count) {
+            if (count < 2) {
+                throw new IllegalArgumentException(
+                        "count must be > 1 so the chunk buffer retains writable capacity "
+                                + "after the first source byte is written");
+            }
+            this.count = count;
+        }
+
+        @Override
+        public long position() {
+            return 0;
+        }
+
+        @Override
+        public long count() {
+            return count;
+        }
+
+        @Override
+        public long transferred() {
+            return transferred;
+        }
+
+        @Override
+        @Deprecated
+        public long transfered() {
+            return transferred;
+        }
+
+        @Override
+        public long transferTo(WritableByteChannel target, long position) throws IOException {
+            // Per FileRegion's contract, the caller passes transferred() as position. Surface
+            // a violation via IOException so the transport's catch (Exception) at the write
+            // site routes it to the write future's cause -- a JUnit AssertionError would
+            // bypass that catch and wedge the EventLoop.
+            if (position != transferred) {
+                throw new IOException("transferTo position " + position + " != transferred() "
+                        + transferred);
+            }
+            if (transferred < count) {
+                int n = target.write(ByteBuffer.wrap(new byte[] { 0x42 }));
+                if (n > 0) {
+                    transferred = count;
+                }
+                return n;
+            }
+            transferToCallsPastCompletion.incrementAndGet();
+            return target.write(ByteBuffer.wrap(new byte[] { (byte) 0xFF }));
+        }
+
+        @Override
+        protected void deallocate() {
+            // No native resources to release. The overshoot counter is observed on the
+            // writer thread immediately after sync() returns; nothing else needs cleanup.
+        }
+
+        @Override
+        public FileRegion retain() {
+            super.retain();
+            return this;
+        }
+
+        @Override
+        public FileRegion retain(int increment) {
+            super.retain(increment);
+            return this;
+        }
+
+        @Override
+        public FileRegion touch() {
+            return this;
+        }
+
+        @Override
+        public FileRegion touch(Object hint) {
+            return this;
         }
     }
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFileRegionTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFileRegionTest.java
@@ -27,6 +27,7 @@ import io.netty.channel.DefaultFileRegion;
 import io.netty.channel.FileRegion;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.util.AbstractReferenceCounted;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -411,12 +412,9 @@ public class SocketFileRegionTest extends AbstractSocketTest {
         final AtomicInteger transferToCallsPastCompletion = new AtomicInteger();
 
         OvershootDetectingFileRegion(long count) {
-            if (count < 2) {
-                throw new IllegalArgumentException(
-                        "count must be > 1 so the chunk buffer retains writable capacity "
-                                + "after the first source byte is written");
-            }
-            this.count = count;
+            // count must be > 1 so the chunk buffer retains writable capacity after the first
+            // source byte is written -- otherwise the drain-loop overshoot path is not exercised.
+            this.count = ObjectUtil.checkInRange(count, 2L, Long.MAX_VALUE, "count");
         }
 
         @Override

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -341,7 +341,11 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                     buf = alloc().directBuffer(chunkSize);
                     try {
                         ByteBufWritableByteChannel ch = new ByteBufWritableByteChannel(buf);
-                        while (buf.writableBytes() > 0) {
+                        // Mirror epoll's writeFileRegion(): stop calling transferTo() once
+                        // the region reports it has been fully transferred. The FileRegion
+                        // contract permits implementations to assume no further invocations
+                        // past transferred() == count().
+                        while (buf.writableBytes() > 0 && region.transferred() < region.count()) {
                             long t = region.transferTo(ch, region.transferred());
                             if (t <= 0) {
                                 break;

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketFileRegionTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketFileRegionTest.java
@@ -21,21 +21,25 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.DefaultFileRegion;
 import io.netty.channel.FileRegion;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketFileRegionTest;
+import io.netty.util.AbstractReferenceCounted;
 import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
@@ -58,6 +62,11 @@ public class IoUringSocketFileRegionTest extends SocketFileRegionTest {
     // With the default 64 KiB chunk size this demands 8 chunks; with an override larger than
     // the payload chunking simply isn't exercised but the transfer is still validated.
     private static final int CHUNKING_REGION_SIZE = 512 * 1024;
+    // Region size used by testFileRegionDrainStopsAtCompletion. Must be > 1 so that the
+    // chunk buffer the transport sizes from count() retains spare capacity after the first
+    // (and only) byte is written -- without that spare capacity the drain loop would exit on
+    // buf.writableBytes() == 0 and the overshoot would not be exercised.
+    private static final int OVERSHOOT_REGION_SIZE = 16;
 
     @BeforeAll
     public static void loadJNI() {
@@ -95,6 +104,17 @@ public class IoUringSocketFileRegionTest extends SocketFileRegionTest {
             @Override
             public void run(ServerBootstrap serverBootstrap, Bootstrap bootstrap) throws Throwable {
                 testTwoCustomFileRegionsWithChunking(serverBootstrap, bootstrap);
+            }
+        });
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    public void testFileRegionDrainStopsAtCompletion(TestInfo testInfo) throws Throwable {
+        run(testInfo, new Runner<ServerBootstrap, Bootstrap>() {
+            @Override
+            public void run(ServerBootstrap serverBootstrap, Bootstrap bootstrap) throws Throwable {
+                testFileRegionDrainStopsAtCompletion(serverBootstrap, bootstrap);
             }
         });
     }
@@ -190,6 +210,69 @@ public class IoUringSocketFileRegionTest extends SocketFileRegionTest {
         assertTrue(firstRegion.transferToCalls.get() >= minFirstCalls,
                 "Expected at least " + minFirstCalls + " transferTo calls for the first (chunked) region, got "
                         + firstRegion.transferToCalls.get());
+    }
+
+    /**
+     * Reproducer for an io_uring generic-FileRegion drain-loop overshoot.
+     * epoll's {@code writeFileRegion} short-circuits as soon as the region reports it is
+     * fully transferred; this test asserts that io_uring does the same. A custom
+     * {@link FileRegion} whose {@code transferTo} advances {@code transferred} past the
+     * bytes it writes to the target on a single call (legal: an encryption- or
+     * framing-on-write FileRegion that flushes a complete inner chunk in one call behaves
+     * this way) records every {@code transferTo} invocation made past
+     * {@code transferred == count}. The fix guarantees that
+     * {@code transferToCallsPastCompletion} remains zero.
+     */
+    private static void testFileRegionDrainStopsAtCompletion(
+            ServerBootstrap sb, Bootstrap cb) throws Throwable {
+        // The bug only reproduces when the chunk buffer has spare capacity AFTER the first
+        // (and only) source byte is written -- if an operator overrode the chunk size to 1
+        // the buffer fills immediately and the overshoot path is never reached, so this
+        // test would silently pass and stop being a regression detector. Skip in that case.
+        // Checked here (before any I/O setup) so a skip costs nothing and leaks nothing.
+        assumeTrue(CONFIGURED_CHUNK_SIZE > 1,
+                "chunk size of 1 leaves no spare capacity to detect drain-loop overshoot");
+
+        sb.childHandler(new SimpleChannelInboundHandler<ByteBuf>() {
+            @Override
+            protected void channelRead0(ChannelHandlerContext ctx, ByteBuf msg) {
+                // drain
+            }
+        });
+        cb.handler(new ChannelInboundHandlerAdapter());
+
+        Channel sc = sb.bind().sync().channel();
+        Channel cc = cb.connect(sc.localAddress()).sync().channel();
+        try {
+            // The bug only manifests when the SENDING (client) side is io_uring -- the
+            // drain loop is in IoUringSocketChannel. Skip permutations whose client uses
+            // NIO/epoll. Done inside the try so the finally still closes the channels on
+            // skip (TestAbortedException unwinds through finally).
+            assumeTrue(cc instanceof IoUringSocketChannel,
+                    "FileRegion drain loop only exercised on io_uring client transport");
+
+            OvershootDetectingFileRegion region =
+                    new OvershootDetectingFileRegion(OVERSHOOT_REGION_SIZE);
+            // sync() blocks until the write future completes, by which point every
+            // transferTo() call the drain loop is going to make has already been made --
+            // the fixture's call counter is observable here without any timing wait. Ref
+            // ownership is transferred to the pipeline on writeAndFlush(), which releases
+            // it as the write completes (success or failure).
+            cc.writeAndFlush(region).sync();
+            int overshoot = region.transferToCallsPastCompletion.get();
+            // The transport sizes the chunk buffer as min(remaining, configured) -- report
+            // both numbers so a failing CI log has the actual buffer capacity at hand.
+            int chunkBufCapacity = Math.min(OVERSHOOT_REGION_SIZE, CONFIGURED_CHUNK_SIZE);
+            assertEquals(0, overshoot,
+                    "transferTo() invoked " + overshoot
+                            + " time(s) after region.transferred() reached region.count()="
+                            + OVERSHOOT_REGION_SIZE
+                            + " (chunkBufCapacity=" + chunkBufCapacity
+                            + ", configuredChunkSize=" + CONFIGURED_CHUNK_SIZE + ')');
+        } finally {
+            cc.close().sync();
+            sc.close().sync();
+        }
     }
 
     private static byte[] randomBytes(int length) {
@@ -333,6 +416,114 @@ public class IoUringSocketFileRegionTest extends SocketFileRegionTest {
         @Override
         public FileRegion touch(Object hint) {
             delegate.touch(hint);
+            return this;
+        }
+    }
+
+    /**
+     * Custom {@link FileRegion} that advances {@code transferred()} past the bytes it writes
+     * to the target on a single {@code transferTo} call -- the same pattern an
+     * encryption-on-write or framing FileRegion follows when it reports an inner chunk as
+     * "delivered" once that chunk fully drains. Records every {@code transferTo} invocation
+     * made after the region has been fully transferred so a drain-loop overshoot is visible
+     * synchronously on the writer side.
+     *
+     * <ul>
+     *   <li>{@link #count()} returns the constant configured size.</li>
+     *   <li>The first {@code transferTo} call writes one byte to the target; once that
+     *       byte is accepted it advances {@code transferred} to {@code count} and returns
+     *       the bytes written.</li>
+     *   <li>Every subsequent {@code transferTo} call increments
+     *       {@link #transferToCallsPastCompletion} and writes one phantom byte to mimic
+     *       the protocol-corrupting side effect a real overshoot would produce.</li>
+     * </ul>
+     * The {@code transferred} field is written and read only on the EventLoop (in
+     * {@code transferTo} and the surrounding drain loop), so no synchronization is needed.
+     * The cross-thread observation channel is the {@link AtomicInteger} counter, which the
+     * test reads after {@code writeAndFlush(...).sync()} establishes the happens-before.
+     */
+    private static final class OvershootDetectingFileRegion extends AbstractReferenceCounted
+            implements FileRegion {
+        private final long count;
+        private long transferred;
+        final AtomicInteger transferToCallsPastCompletion = new AtomicInteger();
+
+        OvershootDetectingFileRegion(long count) {
+            if (count < 2) {
+                throw new IllegalArgumentException(
+                        "count must be > 1 so the chunk buffer retains writable capacity "
+                                + "after the first source byte is written");
+            }
+            this.count = count;
+        }
+
+        @Override
+        public long position() {
+            return 0;
+        }
+
+        @Override
+        public long count() {
+            return count;
+        }
+
+        @Override
+        public long transferred() {
+            return transferred;
+        }
+
+        @Override
+        @Deprecated
+        public long transfered() {
+            return transferred;
+        }
+
+        @Override
+        public long transferTo(WritableByteChannel target, long position) throws IOException {
+            // Per FileRegion's contract, the caller passes transferred() as position. Surface
+            // a violation via IOException so the transport's catch (Exception) at
+            // scheduleWriteFileRegion routes it to handleWriteError and the write future's
+            // cause -- a JUnit AssertionError would bypass that catch and wedge the EventLoop.
+            if (position != transferred) {
+                throw new IOException("transferTo position " + position + " != transferred() "
+                        + transferred);
+            }
+            if (transferred < count) {
+                int n = target.write(ByteBuffer.wrap(new byte[] { 0x42 }));
+                if (n > 0) {
+                    transferred = count;
+                }
+                return n;
+            }
+            transferToCallsPastCompletion.incrementAndGet();
+            return target.write(ByteBuffer.wrap(new byte[] { (byte) 0xFF }));
+        }
+
+        @Override
+        protected void deallocate() {
+            // No native resources to release. The overshoot counter is observed on the
+            // writer thread immediately after sync() returns; nothing else needs cleanup.
+        }
+
+        @Override
+        public FileRegion retain() {
+            super.retain();
+            return this;
+        }
+
+        @Override
+        public FileRegion retain(int increment) {
+            super.retain(increment);
+            return this;
+        }
+
+        @Override
+        public FileRegion touch() {
+            return this;
+        }
+
+        @Override
+        public FileRegion touch(Object hint) {
             return this;
         }
     }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketFileRegionTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketFileRegionTest.java
@@ -21,25 +21,21 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.DefaultFileRegion;
 import io.netty.channel.FileRegion;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketFileRegionTest;
-import io.netty.util.AbstractReferenceCounted;
 import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
-import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
@@ -62,11 +58,6 @@ public class IoUringSocketFileRegionTest extends SocketFileRegionTest {
     // With the default 64 KiB chunk size this demands 8 chunks; with an override larger than
     // the payload chunking simply isn't exercised but the transfer is still validated.
     private static final int CHUNKING_REGION_SIZE = 512 * 1024;
-    // Region size used by testFileRegionDrainStopsAtCompletion. Must be > 1 so that the
-    // chunk buffer the transport sizes from count() retains spare capacity after the first
-    // (and only) byte is written -- without that spare capacity the drain loop would exit on
-    // buf.writableBytes() == 0 and the overshoot would not be exercised.
-    private static final int OVERSHOOT_REGION_SIZE = 16;
 
     @BeforeAll
     public static void loadJNI() {
@@ -104,17 +95,6 @@ public class IoUringSocketFileRegionTest extends SocketFileRegionTest {
             @Override
             public void run(ServerBootstrap serverBootstrap, Bootstrap bootstrap) throws Throwable {
                 testTwoCustomFileRegionsWithChunking(serverBootstrap, bootstrap);
-            }
-        });
-    }
-
-    @Test
-    @Timeout(value = 30, unit = TimeUnit.SECONDS)
-    public void testFileRegionDrainStopsAtCompletion(TestInfo testInfo) throws Throwable {
-        run(testInfo, new Runner<ServerBootstrap, Bootstrap>() {
-            @Override
-            public void run(ServerBootstrap serverBootstrap, Bootstrap bootstrap) throws Throwable {
-                testFileRegionDrainStopsAtCompletion(serverBootstrap, bootstrap);
             }
         });
     }
@@ -210,69 +190,6 @@ public class IoUringSocketFileRegionTest extends SocketFileRegionTest {
         assertTrue(firstRegion.transferToCalls.get() >= minFirstCalls,
                 "Expected at least " + minFirstCalls + " transferTo calls for the first (chunked) region, got "
                         + firstRegion.transferToCalls.get());
-    }
-
-    /**
-     * Reproducer for an io_uring generic-FileRegion drain-loop overshoot.
-     * epoll's {@code writeFileRegion} short-circuits as soon as the region reports it is
-     * fully transferred; this test asserts that io_uring does the same. A custom
-     * {@link FileRegion} whose {@code transferTo} advances {@code transferred} past the
-     * bytes it writes to the target on a single call (legal: an encryption- or
-     * framing-on-write FileRegion that flushes a complete inner chunk in one call behaves
-     * this way) records every {@code transferTo} invocation made past
-     * {@code transferred == count}. The fix guarantees that
-     * {@code transferToCallsPastCompletion} remains zero.
-     */
-    private static void testFileRegionDrainStopsAtCompletion(
-            ServerBootstrap sb, Bootstrap cb) throws Throwable {
-        // The bug only reproduces when the chunk buffer has spare capacity AFTER the first
-        // (and only) source byte is written -- if an operator overrode the chunk size to 1
-        // the buffer fills immediately and the overshoot path is never reached, so this
-        // test would silently pass and stop being a regression detector. Skip in that case.
-        // Checked here (before any I/O setup) so a skip costs nothing and leaks nothing.
-        assumeTrue(CONFIGURED_CHUNK_SIZE > 1,
-                "chunk size of 1 leaves no spare capacity to detect drain-loop overshoot");
-
-        sb.childHandler(new SimpleChannelInboundHandler<ByteBuf>() {
-            @Override
-            protected void channelRead0(ChannelHandlerContext ctx, ByteBuf msg) {
-                // drain
-            }
-        });
-        cb.handler(new ChannelInboundHandlerAdapter());
-
-        Channel sc = sb.bind().sync().channel();
-        Channel cc = cb.connect(sc.localAddress()).sync().channel();
-        try {
-            // The bug only manifests when the SENDING (client) side is io_uring -- the
-            // drain loop is in IoUringSocketChannel. Skip permutations whose client uses
-            // NIO/epoll. Done inside the try so the finally still closes the channels on
-            // skip (TestAbortedException unwinds through finally).
-            assumeTrue(cc instanceof IoUringSocketChannel,
-                    "FileRegion drain loop only exercised on io_uring client transport");
-
-            OvershootDetectingFileRegion region =
-                    new OvershootDetectingFileRegion(OVERSHOOT_REGION_SIZE);
-            // sync() blocks until the write future completes, by which point every
-            // transferTo() call the drain loop is going to make has already been made --
-            // the fixture's call counter is observable here without any timing wait. Ref
-            // ownership is transferred to the pipeline on writeAndFlush(), which releases
-            // it as the write completes (success or failure).
-            cc.writeAndFlush(region).sync();
-            int overshoot = region.transferToCallsPastCompletion.get();
-            // The transport sizes the chunk buffer as min(remaining, configured) -- report
-            // both numbers so a failing CI log has the actual buffer capacity at hand.
-            int chunkBufCapacity = Math.min(OVERSHOOT_REGION_SIZE, CONFIGURED_CHUNK_SIZE);
-            assertEquals(0, overshoot,
-                    "transferTo() invoked " + overshoot
-                            + " time(s) after region.transferred() reached region.count()="
-                            + OVERSHOOT_REGION_SIZE
-                            + " (chunkBufCapacity=" + chunkBufCapacity
-                            + ", configuredChunkSize=" + CONFIGURED_CHUNK_SIZE + ')');
-        } finally {
-            cc.close().sync();
-            sc.close().sync();
-        }
     }
 
     private static byte[] randomBytes(int length) {
@@ -420,111 +337,4 @@ public class IoUringSocketFileRegionTest extends SocketFileRegionTest {
         }
     }
 
-    /**
-     * Custom {@link FileRegion} that advances {@code transferred()} past the bytes it writes
-     * to the target on a single {@code transferTo} call -- the same pattern an
-     * encryption-on-write or framing FileRegion follows when it reports an inner chunk as
-     * "delivered" once that chunk fully drains. Records every {@code transferTo} invocation
-     * made after the region has been fully transferred so a drain-loop overshoot is visible
-     * synchronously on the writer side.
-     *
-     * <ul>
-     *   <li>{@link #count()} returns the constant configured size.</li>
-     *   <li>The first {@code transferTo} call writes one byte to the target; once that
-     *       byte is accepted it advances {@code transferred} to {@code count} and returns
-     *       the bytes written.</li>
-     *   <li>Every subsequent {@code transferTo} call increments
-     *       {@link #transferToCallsPastCompletion} and writes one phantom byte to mimic
-     *       the protocol-corrupting side effect a real overshoot would produce.</li>
-     * </ul>
-     * The {@code transferred} field is written and read only on the EventLoop (in
-     * {@code transferTo} and the surrounding drain loop), so no synchronization is needed.
-     * The cross-thread observation channel is the {@link AtomicInteger} counter, which the
-     * test reads after {@code writeAndFlush(...).sync()} establishes the happens-before.
-     */
-    private static final class OvershootDetectingFileRegion extends AbstractReferenceCounted
-            implements FileRegion {
-        private final long count;
-        private long transferred;
-        final AtomicInteger transferToCallsPastCompletion = new AtomicInteger();
-
-        OvershootDetectingFileRegion(long count) {
-            if (count < 2) {
-                throw new IllegalArgumentException(
-                        "count must be > 1 so the chunk buffer retains writable capacity "
-                                + "after the first source byte is written");
-            }
-            this.count = count;
-        }
-
-        @Override
-        public long position() {
-            return 0;
-        }
-
-        @Override
-        public long count() {
-            return count;
-        }
-
-        @Override
-        public long transferred() {
-            return transferred;
-        }
-
-        @Override
-        @Deprecated
-        public long transfered() {
-            return transferred;
-        }
-
-        @Override
-        public long transferTo(WritableByteChannel target, long position) throws IOException {
-            // Per FileRegion's contract, the caller passes transferred() as position. Surface
-            // a violation via IOException so the transport's catch (Exception) at
-            // scheduleWriteFileRegion routes it to handleWriteError and the write future's
-            // cause -- a JUnit AssertionError would bypass that catch and wedge the EventLoop.
-            if (position != transferred) {
-                throw new IOException("transferTo position " + position + " != transferred() "
-                        + transferred);
-            }
-            if (transferred < count) {
-                int n = target.write(ByteBuffer.wrap(new byte[] { 0x42 }));
-                if (n > 0) {
-                    transferred = count;
-                }
-                return n;
-            }
-            transferToCallsPastCompletion.incrementAndGet();
-            return target.write(ByteBuffer.wrap(new byte[] { (byte) 0xFF }));
-        }
-
-        @Override
-        protected void deallocate() {
-            // No native resources to release. The overshoot counter is observed on the
-            // writer thread immediately after sync() returns; nothing else needs cleanup.
-        }
-
-        @Override
-        public FileRegion retain() {
-            super.retain();
-            return this;
-        }
-
-        @Override
-        public FileRegion retain(int increment) {
-            super.retain(increment);
-            return this;
-        }
-
-        @Override
-        public FileRegion touch() {
-            return this;
-        }
-
-        @Override
-        public FileRegion touch(Object hint) {
-            return this;
-        }
-    }
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketFileRegionTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketFileRegionTest.java
@@ -336,5 +336,4 @@ public class IoUringSocketFileRegionTest extends SocketFileRegionTest {
             return this;
         }
     }
-
 }


### PR DESCRIPTION
Closes #16825.

### Motivation

The generic `FileRegion` fallback added in #16571 drains the region only on `buf.writableBytes() > 0`:

```java
while (buf.writableBytes() > 0) {
    long t = region.transferTo(ch, region.transferred());
    if (t <= 0) {
        break;
    }
}
```

epoll's equivalent at `AbstractEpollStreamChannel#writeFileRegion` guards the call with:

```java
if (region.transferred() >= region.count()) {
    in.remove();
    return 0;
}
```

so epoll never invokes `transferTo()` past `transferred() == count()`. The io_uring fallback can, which violates the `FileRegion` contract for implementations that lazily emit per-chunk framing — the extra call builds an empty next chunk and ships its framing into the buffer, breaking the receiver. See #16825 for the full diagnosis.

### Modification

Bound the inner drain loop with `region.transferred() < region.count()` in addition to `buf.writableBytes() > 0`, mirroring epoll's short-circuit.

Add `IoUringSocketFileRegionTest#testFileRegionDrainStopsAtCompletion` plus an `OvershootDetectingFileRegion` fixture that records every `transferTo()` invocation made past `transferred() == count()`. The fixture writes one byte and advances `transferred` to `count` in one shot, exercising the buggy path (15 overshoots on default chunk size) and the fixed path (0 overshoots) deterministically.

A few test-design notes for review:

- Skips on non-io_uring client permutations — the drain loop is on the sending side.
- Skips when `io.netty.iouring.fileRegionChunkSize` is set to 1, since that leaves no spare capacity for the overshoot to land in.
- Asserts on the writer-side counter synchronously after `writeAndFlush(...).sync()`; no time-based wait.
- Routes contract violations through `IOException` rather than `AssertionError` so they surface on the write future's cause through the transport's `catch (Exception)` instead of wedging the EventLoop.
- `@Timeout(value = 30, unit = SECONDS)` as a safety net for any future regression that wedges `sync()`.

### Result

io_uring's generic `FileRegion` path stops over-calling `transferTo()`. Custom `FileRegion` implementations that lazily emit per-chunk framing work under io_uring with the same semantics they already have under NIO and epoll.
