### PR TITLE
IoUring: Allocate the full chunk buffer for the generic FileRegion fallback

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFileRegionTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFileRegionTest.java
@@ -26,23 +26,30 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.DefaultFileRegion;
 import io.netty.channel.FileRegion;
 import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.util.AbstractReferenceCounted;
 import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
 import java.util.Random;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static io.netty.testsuite.transport.TestsuitePermutation.randomBufferType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class SocketFileRegionTest extends AbstractSocketTest {
@@ -65,6 +72,17 @@ public class SocketFileRegionTest extends AbstractSocketTest {
 
     protected boolean supportsCustomFileRegion() {
         return true;
+    }
+
+    /**
+     * Largest per-call output (in bytes) the transport can carry from a custom
+     * {@link FileRegion#transferTo} into the socket without truncation. Defaults to
+     * {@link Long#MAX_VALUE}; transports that copy through an intermediate buffer should
+     * override this to their per-call cap so {@link #testFileRegionEmittingMoreThanCount}
+     * skips when the cap is below the test payload.
+     */
+    protected long maxFileRegionPerCallEmit() {
+        return Long.MAX_VALUE;
     }
 
     @Test
@@ -118,6 +136,18 @@ public class SocketFileRegionTest extends AbstractSocketTest {
         });
     }
 
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    public void testFileRegionEmittingMoreThanCount(TestInfo testInfo) throws Throwable {
+        assumeTrue(supportsCustomFileRegion());
+        run(testInfo, new Runner<ServerBootstrap, Bootstrap>() {
+            @Override
+            public void run(ServerBootstrap serverBootstrap, Bootstrap bootstrap) throws Throwable {
+                testFileRegionEmittingMoreThanCount(serverBootstrap, bootstrap);
+            }
+        });
+    }
+
     public void testFileRegion(ServerBootstrap sb, Bootstrap cb) throws Throwable {
         testFileRegion0(sb, cb, false, true, true);
     }
@@ -164,6 +194,61 @@ public class SocketFileRegionTest extends AbstractSocketTest {
         assertInstanceOf(IOException.class, cc.writeAndFlush(region).await().cause());
         cc.close().sync();
         sc.close().sync();
+    }
+
+    /**
+     * Regression for the case where a custom {@link FileRegion} emits more bytes through
+     * {@link FileRegion#transferTo} than {@link FileRegion#count()} advertises -- the shape
+     * of an on-the-fly encryption or framing layer whose {@code count()} reports the source
+     * size while {@code transferTo()} writes larger output. Every transport that supports
+     * custom FileRegions must deliver all emitted bytes to the peer; this test pins that
+     * contract.
+     */
+    public void testFileRegionEmittingMoreThanCount(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+        // Small payload sized to exercise the truncation path without bulk data.
+        final int reportedCount = 5;
+        final int actualEmitted = 20;
+        // Below the transport's per-call cap the truncation is unavoidable; skip.
+        assumeTrue(actualEmitted <= maxFileRegionPerCallEmit(),
+                "transport's per-call output cap is smaller than the region's emit; "
+                        + "scenario is not covered");
+
+        byte[] expected = new byte[actualEmitted];
+        for (int i = 0; i < actualEmitted; i++) {
+            expected[i] = (byte) i;
+        }
+        ReceivingHandler sh = new ReceivingHandler(expected);
+        sb.childOption(ChannelOption.AUTO_READ, true);
+        cb.option(ChannelOption.AUTO_READ, true);
+        sb.childHandler(sh);
+        cb.handler(new SimpleChannelInboundHandler<Object>() {
+            @Override
+            protected void channelRead0(ChannelHandlerContext ctx, Object msg) {
+                // drop
+            }
+        });
+
+        Channel sc = sb.bind().sync().channel();
+        Channel cc = cb.connect(sc.localAddress()).sync().channel();
+        try {
+            EmitMoreThanCountFileRegion region =
+                    new EmitMoreThanCountFileRegion(reportedCount, expected);
+            cc.writeAndFlush(region).sync();
+            sh.awaitCompletion();
+            assertNull(sh.exception.get());
+            assertEquals(expected.length, sh.counter,
+                    "expected " + expected.length + " bytes from a region whose transferTo() "
+                            + "emits more than count(); receiver got " + sh.counter);
+            // Pin the fixture's post-write state so a future transport change that calls
+            // transferTo() twice fails here rather than going unnoticed.
+            assertEquals(reportedCount, region.transferred(),
+                    "fixture should advance transferred() to reportedCount after one call");
+            assertEquals(reportedCount, region.count(),
+                    "fixture count() must stay at reportedCount");
+        } finally {
+            cc.close().sync();
+            sc.close().sync();
+        }
     }
 
     private static void testFileRegion0(
@@ -385,6 +470,171 @@ public class SocketFileRegionTest extends AbstractSocketTest {
         @Override
         public FileRegion touch(Object hint) {
             region.touch(hint);
+            return this;
+        }
+    }
+
+    /**
+     * Inbound handler used by {@link #testFileRegionEmittingMoreThanCount}: compares each
+     * inbound chunk against the expected payload and counts down {@code done} once the
+     * full payload has arrived or an error is observed.
+     */
+    protected static final class ReceivingHandler extends SimpleChannelInboundHandler<ByteBuf> {
+        private final byte[] expected;
+        private final CountDownLatch done = new CountDownLatch(1);
+        public final AtomicReference<Throwable> exception = new AtomicReference<Throwable>();
+        // The happens-before edge from CountDownLatch.countDown -> await already makes the
+        // final value visible to the reader; volatile lets a stalled awaitCompletion read
+        // partial progress for diagnostics before the latch releases.
+        public volatile int counter;
+
+        public ReceivingHandler(byte[] expected) {
+            this.expected = expected;
+        }
+
+        @Override
+        protected void channelRead0(ChannelHandlerContext ctx, ByteBuf in) {
+            int readable = in.readableBytes();
+            byte[] actual = new byte[readable];
+            in.readBytes(actual);
+            int offset = counter;
+            if (offset + readable > expected.length) {
+                failed(new AssertionError("Received more than " + expected.length + " bytes"));
+                ctx.close();
+                return;
+            }
+            for (int i = 0; i < actual.length; i++) {
+                if (actual[i] != expected[offset + i]) {
+                    failed(new AssertionError("Byte mismatch at index " + (offset + i)));
+                    ctx.close();
+                    return;
+                }
+            }
+            counter += readable;
+            if (counter == expected.length) {
+                done.countDown();
+            }
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            failed(cause);
+            ctx.close();
+        }
+
+        private void failed(Throwable cause) {
+            if (exception.compareAndSet(null, cause)) {
+                done.countDown();
+            }
+        }
+
+        public void awaitCompletion() throws InterruptedException {
+            if (!done.await(30, TimeUnit.SECONDS)) {
+                fail("Timed out waiting for " + expected.length
+                        + " bytes, received " + counter);
+            }
+        }
+    }
+
+    /**
+     * Single-shot {@link FileRegion} that emits {@code payload.length} bytes through
+     * {@link #transferTo} while reporting only {@code reportedCount} via {@link #count()} --
+     * the shape of an on-the-fly encryption or framing layer.
+     *
+     * <ul>
+     *   <li>{@link #count()} returns {@code reportedCount} for the lifetime of the region.</li>
+     *   <li>The first {@code transferTo} call writes the supplied {@code payload} to the
+     *       target in a single {@code write(ByteBuffer)} call, advances {@code transferred}
+     *       to {@code reportedCount}, and returns {@code payload.length}. A short write
+     *       throws {@link IOException} -- the call site upholds
+     *       {@code maxFileRegionPerCallEmit() >= payload.length} so this should not happen.</li>
+     *   <li>Subsequent calls return 0.</li>
+     * </ul>
+     */
+    private static final class EmitMoreThanCountFileRegion extends AbstractReferenceCounted
+            implements FileRegion {
+        private final long reportedCount;
+        private final byte[] payload;
+        // emitted/transferred are accessed only on the EventLoop, so no synchronization
+        // is needed.
+        private boolean emitted;
+        private long transferred;
+
+        EmitMoreThanCountFileRegion(long reportedCount, byte[] payload) {
+            if (reportedCount < 1 || payload.length <= reportedCount) {
+                throw new IllegalArgumentException(
+                        "reportedCount must be >= 1 and payload.length must be > reportedCount; "
+                                + "got reportedCount=" + reportedCount
+                                + ", payload.length=" + payload.length);
+            }
+            this.reportedCount = reportedCount;
+            this.payload = payload;
+        }
+
+        @Override
+        public long position() {
+            return 0;
+        }
+
+        @Override
+        public long count() {
+            return reportedCount;
+        }
+
+        @Override
+        public long transferred() {
+            return transferred;
+        }
+
+        @Override
+        @Deprecated
+        public long transfered() {
+            return transferred;
+        }
+
+        @Override
+        public long transferTo(WritableByteChannel target, long position) throws IOException {
+            if (emitted) {
+                return 0;
+            }
+            int n = target.write(ByteBuffer.wrap(payload));
+            // The maxFileRegionPerCallEmit() gate at the call site guarantees the target
+            // accepts the full payload; a short write here means a transport regression.
+            if (n < payload.length) {
+                throw new IOException("EmitMoreThanCountFileRegion expected target to accept "
+                        + payload.length + " bytes in one call but only " + n + " were accepted");
+            }
+            // Advance transferred() to count() to model an encryption/framing region whose
+            // source is reported "delivered" once the wider output is emitted.
+            emitted = true;
+            transferred = reportedCount;
+            return n;
+        }
+
+        @Override
+        protected void deallocate() {
+            // No native resources held.
+        }
+
+        @Override
+        public FileRegion retain() {
+            super.retain();
+            return this;
+        }
+
+        @Override
+        public FileRegion retain(int increment) {
+            super.retain(increment);
+            return this;
+        }
+
+        @Override
+        public FileRegion touch() {
+            return this;
+        }
+
+        @Override
+        public FileRegion touch(Object hint) {
             return this;
         }
     }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringStreamChannel.java
@@ -50,6 +50,12 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
      * for the io_uring async send path. Overridable via the {@code io.netty.iouring.fileRegionChunkSize}
      * system property; capped at 16 MiB to guard against pathological configurations that would
      * risk direct-memory OOM.
+     *
+     * <p>Each chunk caps the size of a single {@code transferTo()} call: a custom
+     * {@link FileRegion} whose per-call output exceeds this chunk size will have the excess
+     * silently dropped by the backing {@code WritableByteChannel}. Operators tuning this
+     * down must ensure it stays at or above the largest per-call output their FileRegion
+     * implementations can produce.
      */
     private static final int FILE_REGION_MAX_CHUNK_SIZE = Math.min(16 * 1024 * 1024,
             Math.max(1, SystemPropertyUtil.getInt("io.netty.iouring.fileRegionChunkSize", 64 * 1024)));
@@ -337,13 +343,17 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
             if (buf == null) {
                 long remaining = region.count() - region.transferred();
                 if (remaining > 0) {
-                    int chunkSize = (int) Math.min(remaining, FILE_REGION_MAX_CHUNK_SIZE);
-                    buf = alloc().directBuffer(chunkSize);
+                    // Allocate the full chunk unconditionally: a custom FileRegion may emit
+                    // more bytes through transferTo() than count() advertises -- e.g. an
+                    // on-the-fly encryption or framing layer whose count() reports the source
+                    // size while transferTo() emits larger output -- so a buffer sized to the
+                    // remaining bytes would truncate that output.
                     try {
+                        buf = alloc().directBuffer(FILE_REGION_MAX_CHUNK_SIZE);
                         ByteBufWritableByteChannel ch = new ByteBufWritableByteChannel(buf);
                         while (buf.writableBytes() > 0) {
-                            long t = region.transferTo(ch, region.transferred());
-                            if (t <= 0) {
+                            long transferred = region.transferTo(ch, region.transferred());
+                            if (transferred <= 0) {
                                 break;
                             }
                         }
@@ -354,9 +364,14 @@ abstract class AbstractIoUringStreamChannel extends AbstractIoUringChannel imple
                                             + region.count() + ", transferred=" + region.transferred() + ')'));
                             return 0;
                         }
-                    } catch (Exception e) {
-                        buf.release();
-                        handleWriteError(e);
+                    } catch (Throwable cause) {
+                        // Catch Throwable so an OutOfDirectMemoryError from directBuffer() or
+                        // any Error from transferTo() releases the chunk (when already
+                        // allocated) and surfaces on the write future instead of leaking.
+                        if (buf != null) {
+                            buf.release();
+                        }
+                        handleWriteError(cause);
                         return 0;
                     }
                 } else {

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketFileRegionTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringBufferRingSocketFileRegionTest.java
@@ -46,6 +46,12 @@ public class IoUringBufferRingSocketFileRegionTest extends SocketFileRegionTest 
         return true;
     }
 
+    @Override
+    protected long maxFileRegionPerCallEmit() {
+        // Same chunk-size cap as the non-buffer-ring io_uring transport.
+        return IoUringSocketFileRegionTest.CONFIGURED_CHUNK_SIZE;
+    }
+
     //@Disabled("Fix me")
     @Test
     public void testFileRegionCountLargerThenFile(TestInfo testInfo) throws Throwable {

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketFileRegionTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketFileRegionTest.java
@@ -17,7 +17,6 @@ package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
@@ -31,6 +30,7 @@ import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -41,7 +41,6 @@ import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -50,10 +49,10 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class IoUringSocketFileRegionTest extends SocketFileRegionTest {
 
-    // Configured chunk size for the io_uring generic FileRegion fallback. Reads and clamps the
-    // same system property the transport does so the test stays accurate if an operator
-    // overrides it (transport caps at 16 MiB and floors at 1).
-    private static final int CONFIGURED_CHUNK_SIZE = Math.min(16 * 1024 * 1024,
+    // Configured chunk size for the io_uring generic FileRegion fallback. Mirrors the
+    // transport's own clamp (cap 16 MiB, floor 1). Shared with the buffer-ring sibling
+    // test for its maxFileRegionPerCallEmit() override.
+    static final int CONFIGURED_CHUNK_SIZE = Math.min(16 * 1024 * 1024,
             Math.max(1, Integer.getInteger("io.netty.iouring.fileRegionChunkSize", 64 * 1024)));
     // With the default 64 KiB chunk size this demands 8 chunks; with an override larger than
     // the payload chunking simply isn't exercised but the transfer is still validated.
@@ -74,12 +73,20 @@ public class IoUringSocketFileRegionTest extends SocketFileRegionTest {
         return true;
     }
 
+    @Override
+    protected long maxFileRegionPerCallEmit() {
+        // The io_uring fallback copies into a fixed chunk buffer; per-call output above
+        // this size is dropped by the backing WritableByteChannel.
+        return CONFIGURED_CHUNK_SIZE;
+    }
+
     @Test
     public void testFileRegionCountLargerThenFile(TestInfo testInfo) throws Throwable {
         super.testFileRegionCountLargerThenFile(testInfo);
     }
 
     @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     public void testCustomFileRegionChunking(TestInfo testInfo) throws Throwable {
         run(testInfo, new Runner<ServerBootstrap, Bootstrap>() {
             @Override
@@ -90,6 +97,7 @@ public class IoUringSocketFileRegionTest extends SocketFileRegionTest {
     }
 
     @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
     public void testTwoCustomFileRegionsWithChunking(TestInfo testInfo) throws Throwable {
         run(testInfo, new Runner<ServerBootstrap, Bootstrap>() {
             @Override
@@ -207,56 +215,6 @@ public class IoUringSocketFileRegionTest extends SocketFileRegionTest {
         return file;
     }
 
-    private static final class ReceivingHandler extends SimpleChannelInboundHandler<ByteBuf> {
-        private final byte[] expected;
-        final AtomicReference<Throwable> exception = new AtomicReference<Throwable>();
-        volatile int counter;
-
-        ReceivingHandler(byte[] expected) {
-            this.expected = expected;
-        }
-
-        @Override
-        protected void channelRead0(ChannelHandlerContext ctx, ByteBuf in) {
-            int readable = in.readableBytes();
-            byte[] actual = new byte[readable];
-            in.readBytes(actual);
-            int offset = counter;
-            if (offset + readable > expected.length) {
-                exception.compareAndSet(null, new AssertionError(
-                        "Received more than " + expected.length + " bytes"));
-                ctx.close();
-                return;
-            }
-            for (int i = 0; i < actual.length; i++) {
-                if (actual[i] != expected[offset + i]) {
-                    exception.compareAndSet(null, new AssertionError(
-                            "Byte mismatch at index " + (offset + i)));
-                    ctx.close();
-                    return;
-                }
-            }
-            counter += readable;
-        }
-
-        @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-            exception.compareAndSet(null, cause);
-            ctx.close();
-        }
-
-        void awaitCompletion() throws InterruptedException {
-            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
-            while (counter < expected.length && exception.get() == null) {
-                if (System.nanoTime() > deadline) {
-                    throw new AssertionError("Timed out waiting for " + expected.length
-                            + " bytes, received " + counter);
-                }
-                Thread.sleep(50);
-            }
-        }
-    }
-
     /**
      * Wraps a {@link DefaultFileRegion} so it is routed through the io_uring generic
      * (non-splice) chunking path and counts {@link #transferTo} invocations so tests can assert
@@ -336,4 +294,5 @@ public class IoUringSocketFileRegionTest extends SocketFileRegionTest {
             return this;
         }
     }
+
 }


### PR DESCRIPTION
Fixes #16829.

### Motivation:

The generic FileRegion fallback added in #16571 sizes its chunk buffer to `min(region.count() - region.transferred(), FILE_REGION_MAX_CHUNK_SIZE)`. That sizing treats `count()` as the upper bound on what `transferTo()` will emit. `DefaultFileRegion` respects that, but custom FileRegions don't have to: an on-the-fly encryption or framing layer typically reports the plain source size via `count()` while `transferTo()` writes a larger ciphertext or framed payload. When that happens the chunk buffer is too small, the per-call output gets truncated, and once the region advances `transferred()` to `count()` the completion handler removes it from the outbound buffer with bytes still buffered inside. The peer sees a partial frame.

### Modification:

- Always allocate the full `FILE_REGION_MAX_CHUNK_SIZE` in the generic-FileRegion path.
- Widen the surrounding `catch (Exception)` to `catch (Throwable)` so an `OutOfDirectMemoryError` from `directBuffer(...)`, or any `Error` from `transferTo()`, still releases the buffer and fails the write future instead of leaking.
- Pull `testFileRegionEmittingMoreThanCount` and its `EmitMoreThanCountFileRegion` fixture into `SocketFileRegionTest` so the regression runs against every FileRegion-supporting transport.
- Add `SocketFileRegionTest#maxFileRegionPerCallEmit()` for transports that copy through an intermediate buffer to declare their per-call cap. Both io_uring subclasses override it to the configured chunk size, which lets the test skip when an operator has shrunk the chunk below the test payload.
- Note the per-call cap on the `FILE_REGION_MAX_CHUNK_SIZE` Javadoc.

### Result:

Custom FileRegions whose per-call output exceeds `count()` are no longer truncated, provided that output still fits in `FILE_REGION_MAX_CHUNK_SIZE` (default 64 KiB, tunable via `io.netty.iouring.fileRegionChunkSize`). The new regression test exercises the contract on every FileRegion-supporting transport.

Trade-off: every generic-FileRegion send now reserves the full chunk up front, even for tiny regions. The buffer is per in-flight write and released on completion, so the steady-state cost is bounded. Pooled and adaptive allocators recycle it; `UnpooledByteBufAllocator` pays a fresh native alloc/free per send.