### PR TITLE
MQTT: Allow MQTT 5 CONNECT with password only

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttEncoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttEncoder.java
@@ -147,8 +147,9 @@ public final class MqttEncoder extends MessageToMessageEncoder<MqttMessage> {
                 (byte) variableHeader.version());
         setMqttVersion(ctx, mqttVersion);
 
-        // as MQTT 3.1 & 3.1.1 spec, If the User Name Flag is set to 0, the Password Flag MUST be set to 0
-        if (!variableHeader.hasUserName() && variableHeader.hasPassword()) {
+        // MQTT 3.1 and 3.1.1 require the Password Flag to be 0 when the User Name Flag is 0.
+        if ((mqttVersion == MqttVersion.MQTT_3_1 || mqttVersion == MqttVersion.MQTT_3_1_1) &&
+                !variableHeader.hasUserName() && variableHeader.hasPassword()) {
             throw new EncoderException("Without a username, the password MUST be not set");
         }
 

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
@@ -259,7 +259,19 @@ public class MqttCodecTest {
     }
 
     @Test
-    public void testConnectMessageNoPassword() throws Exception {
+    public void testConnectMessagePasswordOnlyForMqtt31() throws Exception {
+        final MqttConnectMessage message = createConnectMessage(
+                MqttVersion.MQTT_3_1,
+                null,
+                PASSWORD,
+                MqttProperties.NO_PROPERTIES,
+                MqttProperties.NO_PROPERTIES);
+
+        assertThrows(EncoderException.class, () -> MqttEncoder.doEncode(ctx, message));
+    }
+
+    @Test
+    public void testConnectMessagePasswordOnlyForMqtt311() throws Exception {
         final MqttConnectMessage message = createConnectMessage(
                 MqttVersion.MQTT_3_1_1,
                 null,
@@ -268,6 +280,31 @@ public class MqttCodecTest {
                 MqttProperties.NO_PROPERTIES);
 
         assertThrows(EncoderException.class, () -> MqttEncoder.doEncode(ctx, message));
+    }
+
+    @Test
+    public void testConnectMessagePasswordOnlyForMqtt5() throws Exception {
+        final MqttConnectMessage message = createConnectMessage(
+                MqttVersion.MQTT_5,
+                null,
+                PASSWORD,
+                MqttProperties.NO_PROPERTIES,
+                MqttProperties.NO_PROPERTIES);
+
+        assertFalse(message.variableHeader().hasUserName());
+        assertTrue(message.variableHeader().hasPassword());
+
+        ByteBuf byteBuf = MqttEncoder.doEncode(ctx, message);
+
+        mqttDecoder.channelRead(ctx, byteBuf);
+
+        assertEquals(1, out.size());
+
+        final MqttConnectMessage decodedMessage = (MqttConnectMessage) out.get(0);
+
+        validateFixedHeaders(message.fixedHeader(), decodedMessage.fixedHeader());
+        validateConnectVariableHeader(message.variableHeader(), decodedMessage.variableHeader());
+        validateConnectPayload(message.payload(), decodedMessage.payload());
     }
 
     @Test


### PR DESCRIPTION
Motivation:

MQTT 5 allows CONNECT messages to include a password without a user
name. MqttEncoder currently rejects this combination.

Modification:

Only reject password-only CONNECT messages for MQTT 3.1 and 3.1.1.
Add tests for MQTT 3.1, 3.1.1, and MQTT 5.

Result:

MQTT 5 password-only CONNECT messages can be encoded.

Fixes #16828.