### PR TITLE
FlowControlHandler: Suppress duplicate channelReadComplete after draining queue (#15053)

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentDecompressorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentDecompressorTest.java
@@ -15,7 +15,6 @@
  */
 package io.netty.handler.codec.http;
 
-import io.netty.buffer.AdaptiveByteBufAllocator;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
@@ -25,6 +24,8 @@ import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.compression.Brotli;
 import io.netty.handler.codec.compression.Zstd;
+import io.netty.handler.flow.FlowControlHandler;
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.test.DisabledForSlowLeakDetection;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -78,6 +79,50 @@ public class HttpContentDecompressorTest {
         // read was triggered by the HttpContentDecompressor itself as it did not produce any message to the next
         // inbound handler.
         assertEquals(2, readCalled.get());
+        assertFalse(channel.finishAndReleaseAll());
+    }
+
+    // See https://github.com/netty/netty/issues/15053.
+    @Test
+    public void testFlowControlHandlerEmitsOneMessagePerRead() {
+        final AtomicInteger reads = new AtomicInteger();
+        final AtomicInteger readCompletes = new AtomicInteger();
+        EmbeddedChannel channel = new EmbeddedChannel(
+                new FlowControlHandler(),
+                new HttpContentDecompressor(0),
+                new ChannelInboundHandlerAdapter() {
+                    @Override
+                    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                        reads.incrementAndGet();
+                        ReferenceCountUtil.release(msg);
+                    }
+
+                    @Override
+                    public void channelReadComplete(ChannelHandlerContext ctx) {
+                        readCompletes.incrementAndGet();
+                    }
+                });
+
+        channel.config().setAutoRead(false);
+
+        HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        response.headers().set(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
+
+        assertFalse(channel.writeInbound(response));
+        assertFalse(channel.writeInbound(new DefaultHttpContent(Unpooled.EMPTY_BUFFER)));
+        assertFalse(channel.writeInbound(new DefaultHttpContent(Unpooled.EMPTY_BUFFER)));
+
+        assertEquals(1, reads.get());
+        assertEquals(1, readCompletes.get());
+
+        channel.read();
+        assertEquals(2, reads.get());
+        assertEquals(2, readCompletes.get());
+
+        channel.read();
+        assertEquals(3, reads.get());
+        assertEquals(3, readCompletes.get());
+
         assertFalse(channel.finishAndReleaseAll());
     }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentDecompressorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentDecompressorTest.java
@@ -112,6 +112,10 @@ public class HttpContentDecompressorTest {
         assertFalse(channel.writeInbound(new DefaultHttpContent(Unpooled.EMPTY_BUFFER)));
         assertFalse(channel.writeInbound(new DefaultHttpContent(Unpooled.EMPTY_BUFFER)));
 
+        assertEquals(0, reads.get());
+        assertEquals(0, readCompletes.get());
+
+        channel.read();
         assertEquals(1, reads.get());
         assertEquals(1, readCompletes.get());
 

--- a/handler/src/main/java/io/netty/handler/flow/FlowControlHandler.java
+++ b/handler/src/main/java/io/netty/handler/flow/FlowControlHandler.java
@@ -32,7 +32,7 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 
 /**
  * The {@link FlowControlHandler} ensures that only one message per {@code read()} is sent downstream.
- *
+ * <p>
  * Classes such as {@link ByteToMessageDecoder} or {@link MessageToByteEncoder} are free to emit as
  * many events as they like for any given input. A channel's auto reading configuration doesn't usually
  * apply in these scenarios. This is causing problems in downstream {@link ChannelHandler}s that would
@@ -73,7 +73,25 @@ public class FlowControlHandler extends ChannelDuplexHandler {
 
     private ChannelConfig config;
 
-    private boolean shouldConsume;
+    /**
+     * Number of unsatisfied downstream {@code read()} calls. A downstream {@code read()} is considered unsatisfied
+     * if it has not yet been paired with a {@code fireChannelRead} or a cumulative {@code fireChannelReadComplete}.
+     * <p>
+     * A {@code read()} can be satisfied in three ways, whichever comes first:
+     * <ul>
+     *     <li>inside the {@code read()} call itself, by {@code dequeue()}ing a message</li>
+     *     <li>in a {@code channelRead()}</li>
+     *     <li>in a {@code channelReadComplete()}</li>
+     * </ul>
+     * <p>
+     * When one or more {@code read()} calls are unsatisfied, a downstream {@code channelReadComplete} is fired
+     * only when either of the following happens:
+     * <ul>
+     *     <li>{@code unsatisfiedReads} returns to zero after {@code dequeue()}ing, or</li>
+     *     <li>an upstream {@code channelReadComplete} arrives</li>
+     * </ul>
+     */
+    private int unsatisfiedReads;
 
     public FlowControlHandler() {
         this(true);
@@ -123,6 +141,7 @@ public class FlowControlHandler extends ChannelDuplexHandler {
         super.handlerRemoved(ctx);
         if (!isQueueEmpty()) {
             dequeue(ctx, queue.size());
+            ctx.fireChannelReadComplete();
         }
         destroy();
     }
@@ -135,13 +154,11 @@ public class FlowControlHandler extends ChannelDuplexHandler {
 
     @Override
     public void read(ChannelHandlerContext ctx) throws Exception {
-        if (dequeue(ctx, 1) == 0) {
-            // It seems no messages were consumed. We need to read() some
-            // messages from upstream and once one arrives it need to be
-            // relayed to downstream to keep the flow going.
-            shouldConsume = true;
-            ctx.read();
-        } else if (config.isAutoRead()) {
+        unsatisfiedReads++;
+
+        if (dequeue(ctx, 1) > 0) {
+            satisfyRead(ctx);
+        } else {
             ctx.read();
         }
     }
@@ -154,23 +171,35 @@ public class FlowControlHandler extends ChannelDuplexHandler {
 
         queue.offer(msg);
 
+        // Snapshot before dequeue(), which may re-enter read() via fireChannelRead(...).
+        boolean shouldSatisfyRead = unsatisfiedReads > 0;
         // We just received one message. Do we need to relay it regardless
-        // of the auto reading configuration? The answer is yes if this
-        // method was called as a result of a prior read() call.
-        int minConsume = shouldConsume ? 1 : 0;
-        shouldConsume = false;
+        // of the auto-reading configuration? The answer is yes if this
+        // method call originates from a prior read call.
+        int minConsume = shouldSatisfyRead? 1 : 0;
 
-        dequeue(ctx, minConsume);
+        if (dequeue(ctx, minConsume) > 0 && shouldSatisfyRead) {
+            satisfyRead(ctx);
+        }
     }
 
     @Override
     public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
-        if (isQueueEmpty()) {
+        // Upstream closed the read cycle. Collapse every outstanding read() into a single downstream
+        // channelReadComplete; spurious upstream completions with no pending read are dropped.
+        satisfyAllReads(ctx);
+    }
+
+    private void satisfyRead(ChannelHandlerContext ctx) {
+        if (unsatisfiedReads > 0 && --unsatisfiedReads == 0) {
             ctx.fireChannelReadComplete();
-        } else {
-            // Don't relay completion events from upstream as they
-            // make no sense in this context. See dequeue() where
-            // a new set of completion events is being produced.
+        }
+    }
+
+    private void satisfyAllReads(ChannelHandlerContext ctx) {
+        if (unsatisfiedReads > 0) {
+            unsatisfiedReads = 0;
+            ctx.fireChannelReadComplete();
         }
     }
 
@@ -178,7 +207,7 @@ public class FlowControlHandler extends ChannelDuplexHandler {
      * Dequeues one or many (or none) messages depending on the channel's auto
      * reading state and returns the number of messages that were consumed from
      * the internal queue.
-     *
+     * <p>
      * The {@code minConsume} argument is used to force {@code dequeue()} into
      * consuming that number of messages regardless of the channel's auto
      * reading configuration.
@@ -189,8 +218,8 @@ public class FlowControlHandler extends ChannelDuplexHandler {
     private int dequeue(ChannelHandlerContext ctx, int minConsume) {
         int consumed = 0;
 
-        // fireChannelRead(...) may call ctx.read() and so this method may reentrance. Because of this we need to
-        // check if queue was set to null in the meantime and if so break the loop.
+        // fireChannelRead(...) may call ctx.read() and so this method may be re-entered. Because of that
+        // we need to check if queue was set to null in the meantime and, if so, break out of the loop.
         while (queue != null && (consumed < minConsume || config.isAutoRead())) {
             Object msg = queue.poll();
             if (msg == null) {
@@ -201,16 +230,9 @@ public class FlowControlHandler extends ChannelDuplexHandler {
             ctx.fireChannelRead(msg);
         }
 
-        // We're firing a completion event every time one (or more)
-        // messages were consumed and the queue ended up being drained
-        // to an empty state.
         if (queue != null && queue.isEmpty()) {
             queue.recycle();
             queue = null;
-
-            if (consumed > 0) {
-                ctx.fireChannelReadComplete();
-            }
         }
 
         return consumed;

--- a/handler/src/main/java/io/netty/handler/flow/FlowControlHandler.java
+++ b/handler/src/main/java/io/netty/handler/flow/FlowControlHandler.java
@@ -75,7 +75,8 @@ public class FlowControlHandler extends ChannelDuplexHandler {
 
     /**
      * Number of unsatisfied downstream {@code read()} calls. A downstream {@code read()} is considered unsatisfied
-     * if it has not yet been paired with a {@code fireChannelRead} or a cumulative {@code fireChannelReadComplete}.
+     * if auto-read is off and if it has not yet been paired with a {@code fireChannelRead} or
+     * a cumulative {@code fireChannelReadComplete}.
      * <p>
      * A {@code read()} can be satisfied in three ways, whichever comes first:
      * <ul>
@@ -83,11 +84,12 @@ public class FlowControlHandler extends ChannelDuplexHandler {
      *     <li>in a {@code channelRead()}</li>
      *     <li>in a {@code channelReadComplete()}</li>
      * </ul>
+     * A {@code read()} can be satisfied with auto-read on.
      * <p>
      * When one or more {@code read()} calls are unsatisfied, a downstream {@code channelReadComplete} is fired
      * only when either of the following happens:
      * <ul>
-     *     <li>{@code unsatisfiedReads} returns to zero after {@code dequeue()}ing, or</li>
+     *     <li>auto-read is off and {@code unsatisfiedReads} returns to zero after {@code dequeue()}ing, or</li>
      *     <li>an upstream {@code channelReadComplete} arrives</li>
      * </ul>
      */
@@ -140,7 +142,7 @@ public class FlowControlHandler extends ChannelDuplexHandler {
     public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
         super.handlerRemoved(ctx);
         if (!isQueueEmpty()) {
-            dequeue(ctx, queue.size());
+            dequeueAll(ctx);
             ctx.fireChannelReadComplete();
         }
         destroy();
@@ -154,12 +156,22 @@ public class FlowControlHandler extends ChannelDuplexHandler {
 
     @Override
     public void read(ChannelHandlerContext ctx) throws Exception {
-        unsatisfiedReads++;
-
-        if (dequeue(ctx, 1) > 0) {
-            satisfyRead(ctx);
-        } else {
+        if (config.isAutoRead()) {
+            dequeueAll(ctx);
             ctx.read();
+        } else {
+            unsatisfiedReads++;
+
+            if (dequeueOne(ctx)) {
+                if (unsatisfiedReads == 0) {
+                    ctx.fireChannelReadComplete();
+                }
+            } else {
+                // Could not satisfy the read() from the queue.
+                // We need to request data from upstream so we can satisfy the read() in channelRead() or
+                // channelReadComplete() if it is going to be an empty read.
+                ctx.read();
+            }
         }
     }
 
@@ -171,15 +183,14 @@ public class FlowControlHandler extends ChannelDuplexHandler {
 
         queue.offer(msg);
 
-        // Snapshot before dequeue(), which may re-enter read() via fireChannelRead(...).
-        boolean shouldSatisfyRead = unsatisfiedReads > 0;
-        // We just received one message. Do we need to relay it regardless
-        // of the auto-reading configuration? The answer is yes if this
-        // method call originates from a prior read call.
-        int minConsume = shouldSatisfyRead? 1 : 0;
+        if (config.isAutoRead()) {
+            dequeueAll(ctx);
+        } else if (unsatisfiedReads > 0) {
+            dequeueOne(ctx);
 
-        if (dequeue(ctx, minConsume) > 0 && shouldSatisfyRead) {
-            satisfyRead(ctx);
+            if (unsatisfiedReads == 0) {
+                ctx.fireChannelReadComplete();
+            }
         }
     }
 
@@ -187,40 +198,34 @@ public class FlowControlHandler extends ChannelDuplexHandler {
     public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
         // Upstream closed the read cycle. Collapse every outstanding read() into a single downstream
         // channelReadComplete; spurious upstream completions with no pending read are dropped.
-        satisfyAllReads(ctx);
-    }
-
-    private void satisfyRead(ChannelHandlerContext ctx) {
-        if (unsatisfiedReads > 0 && --unsatisfiedReads == 0) {
-            ctx.fireChannelReadComplete();
-        }
-    }
-
-    private void satisfyAllReads(ChannelHandlerContext ctx) {
-        if (unsatisfiedReads > 0) {
+        if (config.isAutoRead() || unsatisfiedReads > 0) {
             unsatisfiedReads = 0;
             ctx.fireChannelReadComplete();
         }
     }
 
+    private boolean dequeueOne(ChannelHandlerContext ctx) {
+        return dequeue(ctx, 1) > 0;
+    }
+
+    private int dequeueAll(ChannelHandlerContext ctx) {
+        return dequeue(ctx, -1);
+    }
+
     /**
-     * Dequeues one or many (or none) messages depending on the channel's auto
-     * reading state and returns the number of messages that were consumed from
-     * the internal queue.
-     * <p>
-     * The {@code minConsume} argument is used to force {@code dequeue()} into
-     * consuming that number of messages regardless of the channel's auto
-     * reading configuration.
+     * Dequeues up to {@code maxConsume} messages, fires them downstream and
+     * updates {@code unsatisfiedReads} accordingly. If {@code maxConsume} is negative,
+     * there is no upper limit on the number of messages to dequeue and fire downstream.
      *
      * @see #read(ChannelHandlerContext)
      * @see #channelRead(ChannelHandlerContext, Object)
      */
-    private int dequeue(ChannelHandlerContext ctx, int minConsume) {
+    private int dequeue(ChannelHandlerContext ctx, int maxConsume) {
         int consumed = 0;
 
         // fireChannelRead(...) may call ctx.read() and so this method may be re-entered. Because of that
         // we need to check if queue was set to null in the meantime and, if so, break out of the loop.
-        while (queue != null && (consumed < minConsume || config.isAutoRead())) {
+        while (queue != null && (consumed < maxConsume || maxConsume < 0)) {
             Object msg = queue.poll();
             if (msg == null) {
                 break;
@@ -234,6 +239,8 @@ public class FlowControlHandler extends ChannelDuplexHandler {
             queue.recycle();
             queue = null;
         }
+
+        unsatisfiedReads = Math.max(unsatisfiedReads - consumed, 0);
 
         return consumed;
     }

--- a/handler/src/test/java/io/netty/handler/flow/FlowControlHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/flow/FlowControlHandlerTest.java
@@ -845,6 +845,124 @@ public class FlowControlHandlerTest {
         assertFalse(channel.finishAndReleaseAll());
     }
 
+    @Test
+    public void testCompleteReadOnUpstreamCompleteWhenAutoReadOn() throws Exception {
+        final AtomicInteger reads = new AtomicInteger();
+        final AtomicInteger readCompletes = new AtomicInteger();
+        final EmbeddedChannel channel = new EmbeddedChannel(
+                false, false,
+                new FlowControlHandler(),
+                new ChannelInboundHandlerAdapter() {
+                    @Override
+                    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                        reads.incrementAndGet();
+                    }
+
+                    @Override
+                    public void channelReadComplete(ChannelHandlerContext ctx) {
+                        readCompletes.incrementAndGet();
+                    }
+                });
+
+        assertTrue(channel.config().isAutoRead());
+        channel.register();
+
+        channel.writeOneInbound("msg1").syncUninterruptibly();
+        channel.writeOneInbound("msg2").syncUninterruptibly();
+        channel.writeOneInbound("msg3").syncUninterruptibly();
+
+        // All three messages must arrive before channelReadComplete signals end-of-batch.
+        assertEquals(3, reads.get());
+        // As auto-read is on, FlowControlHandler should not fire a channelReadComplete on its own but should wait
+        // for upstream to fire it.
+        assertEquals(0, readCompletes.get());
+
+        // Upstream now fires channelReadComplete and FlowControlHandler should pass it through.
+        channel.flushInbound();
+
+        assertEquals(3, reads.get());
+        assertEquals(1, readCompletes.get());
+
+        assertFalse(channel.finishAndReleaseAll());
+    }
+
+    @Test
+    public void testSatisfyPendingReadsAfterDisablingAutoRead() throws Exception {
+        final AtomicInteger reads = new AtomicInteger();
+        final AtomicInteger readCompletes = new AtomicInteger();
+        final EmbeddedChannel channel = new EmbeddedChannel(
+                false, false,
+                new FlowControlHandler(),
+                new ChannelInboundHandlerAdapter() {
+                    @Override
+                    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                        reads.incrementAndGet();
+                    }
+
+                    @Override
+                    public void channelReadComplete(ChannelHandlerContext ctx) {
+                        readCompletes.incrementAndGet();
+                    }
+                });
+
+        channel.config().setAutoRead(false);
+        channel.register();
+
+        // We issue two reads with auto-read off. We expect at least two messages to be delivered, even when we are
+        // going to turn off auto-read in a moment.
+        channel.read();
+        channel.read();
+        channel.config().setAutoRead(true);
+
+        // We got the first message with auto-read on. It immediately satisfies the first read.
+        channel.writeOneInbound("msg1").syncUninterruptibly();
+
+        assertEquals(1, reads.get());
+        assertEquals(0, readCompletes.get());
+
+        channel.config().setAutoRead(false);
+        channel.config().setAutoRead(true);
+        // In the end auto-read is off, and we have one remaining unsatisfied read.
+        channel.config().setAutoRead(false);
+
+        // sanity check: nothing should happen.
+        assertEquals(1, reads.get());
+        assertEquals(0, readCompletes.get());
+
+        // The second message is delivered right away, satisfying the second read, and completing the batch.
+        channel.writeOneInbound("msg2").syncUninterruptibly();
+
+        assertEquals(2, reads.get());
+        assertEquals(1, readCompletes.get());
+
+        // The third message is queued but not delivered as autoRead is off, and we have no unsatisfied reads anymore.
+        channel.writeOneInbound("msg3").syncUninterruptibly();
+
+        assertEquals(2, reads.get());
+        assertEquals(1, readCompletes.get());
+
+        // Upstream fires channelReadComplete.
+        channel.flushInbound();
+
+        // As autoRead is off, FlowControlHandler is the one determining the end of the read cycle, not upstream.
+        // It ignores the channelReadComplete.
+        assertEquals(2, reads.get());
+        assertEquals(1, readCompletes.get());
+
+        channel.config().setAutoRead(true);
+
+        // The third message is dequeued and delivered.
+        assertEquals(3, reads.get());
+        assertEquals(1, readCompletes.get());
+
+        channel.flushInbound();
+
+        assertEquals(3, reads.get());
+        assertEquals(2, readCompletes.get());
+
+        assertFalse(channel.finishAndReleaseAll());
+    }
+
     /**
      * This is a fictional message decoder. It decodes each {@code byte}
      * into three strings.

--- a/handler/src/test/java/io/netty/handler/flow/FlowControlHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/flow/FlowControlHandlerTest.java
@@ -49,6 +49,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Exchanger;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.concurrent.TimeUnit.*;
@@ -661,6 +662,187 @@ public class FlowControlHandlerTest {
             client.close();
             server.close();
         }
+    }
+
+    @Test
+    public void testCompletingReadWithNonEmptyQueue() throws Exception {
+        final AtomicInteger reads = new AtomicInteger();
+        final AtomicInteger readCompletes = new AtomicInteger();
+        final EmbeddedChannel channel = new EmbeddedChannel(
+                false, false,
+                new FlowControlHandler(),
+                new ChannelInboundHandlerAdapter() {
+                    @Override
+                    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                        reads.incrementAndGet();
+                    }
+
+                    @Override
+                    public void channelReadComplete(ChannelHandlerContext ctx) {
+                        readCompletes.incrementAndGet();
+                    }
+                });
+
+        channel.config().setAutoRead(false);
+        channel.register();
+
+        assertFalse(channel.writeInbound("msg1", "msg2"));
+        assertEquals(0, reads.get());
+        assertEquals(0, readCompletes.get());
+
+        channel.read();
+        assertEquals(1, reads.get());
+        assertEquals(1, readCompletes.get());
+
+        channel.read();
+        assertEquals(2, reads.get());
+        assertEquals(2, readCompletes.get());
+
+        assertFalse(channel.finishAndReleaseAll());
+    }
+
+    @Test
+    public void testSuppressingUpstreamReadCompletes() throws Exception {
+        final AtomicInteger reads = new AtomicInteger();
+        final AtomicInteger readCompletes = new AtomicInteger();
+        final EmbeddedChannel channel = new EmbeddedChannel(
+                false, false,
+                new FlowControlHandler(),
+                new ChannelInboundHandlerAdapter() {
+                    @Override
+                    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                        reads.incrementAndGet();
+                    }
+
+                    @Override
+                    public void channelReadComplete(ChannelHandlerContext ctx) {
+                        readCompletes.incrementAndGet();
+                    }
+                });
+
+        channel.config().setAutoRead(false);
+        channel.register();
+
+        assertEquals(0, reads.get());
+        assertEquals(0, readCompletes.get());
+
+        channel.flushInbound();
+        channel.flushInbound();
+        channel.flushInbound();
+
+        assertEquals(0, reads.get());
+        assertEquals(0, readCompletes.get());
+
+        channel.read();
+        channel.writeOneInbound("msg").syncUninterruptibly();
+        assertEquals(1, reads.get());
+        assertEquals(1, readCompletes.get());
+
+        channel.flushInbound();
+        channel.flushInbound();
+        assertEquals(1, reads.get());
+        assertEquals(1, readCompletes.get());
+
+        channel.read();
+        channel.flushInbound();
+
+        assertEquals(1, reads.get());
+        assertEquals(2, readCompletes.get());
+
+        assertFalse(channel.finishAndReleaseAll());
+    }
+
+    @Test
+    public void testEmptyRead() throws Exception {
+        final AtomicInteger reads = new AtomicInteger();
+        final AtomicInteger readCompletes = new AtomicInteger();
+        final EmbeddedChannel channel = new EmbeddedChannel(
+                false, false,
+                new FlowControlHandler(),
+                new ChannelInboundHandlerAdapter() {
+                    @Override
+                    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                        reads.incrementAndGet();
+                    }
+
+                    @Override
+                    public void channelReadComplete(ChannelHandlerContext ctx) {
+                        readCompletes.incrementAndGet();
+                    }
+                });
+
+        channel.config().setAutoRead(false);
+        channel.register();
+
+        // Downstream issues a read() but upstream has no data and only fires channelReadComplete.
+        // FlowControlHandler must forward that channelReadComplete to satisfy the outstanding read.
+        channel.read();
+        channel.flushInbound();
+
+        assertEquals(0, reads.get());
+        assertEquals(1, readCompletes.get());
+
+        assertFalse(channel.finishAndReleaseAll());
+    }
+
+    @Test
+    public void testMultipleReadsOnEmptyQueue() throws Exception {
+        final AtomicInteger reads = new AtomicInteger();
+        final AtomicInteger readCompletes = new AtomicInteger();
+        final EmbeddedChannel channel = new EmbeddedChannel(
+                false, false,
+                new FlowControlHandler(),
+                new ChannelInboundHandlerAdapter() {
+                    @Override
+                    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                        reads.incrementAndGet();
+                    }
+
+                    @Override
+                    public void channelReadComplete(ChannelHandlerContext ctx) {
+                        readCompletes.incrementAndGet();
+                    }
+                });
+        channel.config().setAutoRead(false);
+        channel.register();
+
+        channel.read();
+        channel.read();
+        channel.read();
+
+        channel.writeOneInbound("msg1");
+
+        assertEquals(1, reads.get());
+        assertEquals(0, readCompletes.get());
+
+        channel.flushInbound();
+
+        assertEquals(1, reads.get());
+        assertEquals(1, readCompletes.get());
+
+        channel.read();
+        channel.read();
+        channel.read();
+
+        // empty read
+        channel.flushInbound();
+
+        assertEquals(1, reads.get());
+        assertEquals(2, readCompletes.get());
+
+        // quick check that internal state is not broken
+        channel.writeOneInbound("msg2");
+        channel.flushInbound();
+
+        assertEquals(1, reads.get());
+        assertEquals(2, readCompletes.get());
+
+        channel.read();
+
+        assertEquals(2, reads.get());
+        assertEquals(3, readCompletes.get());
+
+        assertFalse(channel.finishAndReleaseAll());
     }
 
     /**


### PR DESCRIPTION
# Motivation

`FlowControlHandler` has two problems related to read completions:

1. Assume `autoRead == false` and `FlowControlHandler` has already queued two messages from upstream. If a downstream handler calls `read()`, `FlowControlHandler` serves that read with the first queued message. Since the queue is still not empty, `FlowControlHandler` does not fire `channelReadComplete`.

   Because `allowRead == false`, no further messages are delivered downstream until the downstream handler calls `read()` again. A downstream handler that waits for `channelReadComplete` before issuing the next `read()` may therefore stall.

2. Assume `FlowControlHandler` has just emptied its queue and correctly fired `channelRead` followed by `channelReadComplete`. If `FlowControlHandler` then receives one or more `channelReadComplete` events from upstream, it currently relays all of them downstream, resulting in duplicate `channelReadComplete` events. This is unexpected because, from the perspective of downstream handlers, there are no further read operations in progress.

To solve problem 1., we want to ensure that with `autoRead == false`, `FlowControlHandler` fires `channelReadComplete` after `dequeue`ing a message for a downstream `read()`, even if the queue is not empty. This, however, needs to be done carefully as the `read()` can be reentered after `fireChannelRead(...)`.

To solve problem 2., we want to ensure that `FlowControlHandler` does not pass through upstream `channelReadComplete` events by default. The only case where it needs to relay such an event is when there are one or more downstream `read`s for which we did not fire a message yet.

# Modification

`FlowControlHandler` now tracks unsatisfied downstream `read()` calls in `activeReads`. A read is unsatisfied if it has not yet resulted in a downstream `fireChannelRead(...)`.

Based on this state, `read()`, `channelRead(...)`, and `channelReadComplete(...)` were adapted to match the target behavior. `dequeue()` is no longer responsible for firing `channelReadComplete`.

# Testing

- `FlowControlHandlerTest`: added tests covering the new read-completion behavior and related edge cases.
- `HttpContentDecompressorTest`: added a reproducer for #15053.

# Result

`FlowControlHandler` now:

- fires `channelReadComplete` after `dequeue`ing one ore more messages given there are no further unsatisfied `read()` calls, even if the queue is not empty (solving Problem 1);
- refires an upstream `channelReadComplete` only for empty reads, i.e. when upstream completes a read without producing a `channelRead` (solving Problem 2, fixing #15053).