### PR TITLE
Pass maxAllocation to Brotli and Zstd decoders

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentDecompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentDecompressor.java
@@ -117,7 +117,7 @@ public class HttpContentDecompressor extends HttpContentDecoder {
                     .channelId(channel.id())
                     .hasDisconnect(channel.metadata().hasDisconnect())
                     .config(channel.config())
-                    .handlers(new BrotliDecoder())
+                    .handlers(new BrotliDecoder(maxAllocation))
                     .build();
         }
 
@@ -135,7 +135,7 @@ public class HttpContentDecompressor extends HttpContentDecoder {
                     .channelId(channel.id())
                     .hasDisconnect(channel.metadata().hasDisconnect())
                     .config(channel.config())
-                    .handlers(new ZstdDecoder())
+                    .handlers(new ZstdDecoder(maxAllocation))
                     .build();
         }
 


### PR DESCRIPTION
Motivation:
Brotli and Zstd should using the same maxAllocation limits as gzip and zlib, if these limits are defined. This leads to unification of usage and as a prtoection against zip bombs even on memory-strained environments, as well as allowing larger archives on explicitly configured envirironments.

Modifications:
Field maxAllocation of class HttpContentDecompressor is now passed to constructors of BrotliDecoder and ZstdDecoder classes.

Result:
If user configures max allocation for decryption, then the same allocation will be used for decryption of zstd and Brotli loads
