### PR TITLE
Skip unnecessary io_uring_enter syscall when submission queue is empty

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/SubmissionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/SubmissionQueue.java
@@ -263,11 +263,19 @@ final class SubmissionQueue {
             return submit(submit, minComplete, Native.IORING_ENTER_GETEVENTS);
         }
         assert submit == 0;
+        if (minComplete == 0 && !cqRingNeedsFlush()) {
+            return 0;
+        }
         int ret = ioUringEnter(0, minComplete, Native.IORING_ENTER_GETEVENTS);
         if (ret < 0) {
             throw new UncheckedIOException(Errors.newIOException("io_uring_enter", ret));
         }
         return ret; // should be 0
+    }
+
+    private boolean cqRingNeedsFlush() {
+        int sqFlags = flags();
+        return (sqFlags & (Native.IORING_SQ_CQ_OVERFLOW | Native.IORING_SQ_TASKRUN)) != 0;
     }
 
     private int submit(int toSubmit, int minComplete, int flags) {


### PR DESCRIPTION
Motivation:

When submitAndGetNow() is called with an empty submission queue, it
unconditionally calls io_uring_enter(0, 0, GETEVENTS). This is
unnecessary when there is no CQ overflow or TASKRUN work pending,
as completions are already visible in the CQ ring via shared memory.

In tight poller loops (e.g. Seastar-style reactors calling run() in a
non-blocking spin), this causes hundreds of millions of wasted syscalls
per second per thread.

Modification:

In submitAndGet0(), when there are no SQEs to submit (submit == 0) and
minComplete is 0, check the SQ flags for IORING_SQ_CQ_OVERFLOW and
IORING_SQ_TASKRUN before entering the kernel. Skip the syscall if
neither flag is set.

This matches the semantics of liburing's cq_ring_needs_flush():
https://github.com/axboe/liburing/blob/liburing-2.9/src/queue.c#L42

Result:

Tight poller loops no longer issue unnecessary io_uring_enter syscalls
when the submission queue is empty and no CQ flush is needed.