### PR TITLE
ChannelInitializer: correct misleading comment on exceptionCaught route

### DIFF
--- a/transport/src/main/java/io/netty/channel/ChannelInitializer.java
+++ b/transport/src/main/java/io/netty/channel/ChannelInitializer.java
@@ -128,8 +128,8 @@ public abstract class ChannelInitializer<C extends Channel> extends ChannelInbou
             try {
                 initChannel((C) ctx.channel());
             } catch (Throwable cause) {
-                // Explicitly call exceptionCaught(...) as we removed the handler before calling initChannel(...).
-                // We do so to prevent multiple calls to initChannel(...).
+                // Explicitly route the failure into the pipeline. Re-entrance is guarded by
+                // the initMap.add(ctx) check above; the finally block below removes the handler.
                 exceptionCaught(ctx, cause);
             } finally {
                 if (!ctx.isRemoved()) {


### PR DESCRIPTION
Motivation:

The catch block in `ChannelInitializer.initChannel(ChannelHandlerContext)` currently attributes the explicit `exceptionCaught(...)` call to two reasons that don't match the current code:

```java
} catch (Throwable cause) {
    // Explicitly call exceptionCaught(...) as we removed the handler before calling initChannel(...).
    // We do so to prevent multiple calls to initChannel(...).
    exceptionCaught(ctx, cause);
} finally {
    if (!ctx.isRemoved()) {
        ctx.pipeline().remove(this);
    }
}
```

- The handler is **not** removed before `initChannel(...)` is called — removal happens in the `finally` block immediately below.
- Re-entrance is guarded by the `initMap.add(ctx)` check at the top of the method, **not** by this catch block.

Both clauses of the comment mislead a reader trying to understand why the catch block exists.

Modification:

Rewrite the two-line comment to name the actual mechanisms:

- the `exceptionCaught(...)` call routes the failure into the pipeline;
- re-entrance is guarded by `initMap.add(ctx)` above;
- handler removal happens in the `finally` block below.

No code change.

Result:

Future readers of `initChannel(ChannelHandlerContext)` can trust the comment instead of having to cross-check it against the surrounding code.

Fixes #16846.

The same wording exists on 4.1, 4.2, and 5.0; targeting 4.1 so auto-port carries it forward.