### PR TITLE
Exclude internal events from IoHandler.run() return value in epoll, io_uring and kqueue

### DIFF
--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/EpollIoHandler.java
@@ -485,18 +485,18 @@ public class EpollIoHandler implements IoHandler {
                 default:
             }
             if (strategy > 0) {
-                handled = strategy;
+                int packed;
                 if (context.shouldReportActiveIoTime()) {
                     long activeIoStartTimeNanos = System.nanoTime();
-                    if (processReady(events, strategy)) {
-                        prevDeadlineNanos = NONE;
-                    }
+                    packed = processReady(events, strategy);
                     long activeIoEndTimeNanos = System.nanoTime();
                     context.reportActiveIoTime(activeIoEndTimeNanos - activeIoStartTimeNanos);
                 } else {
-                    if (processReady(events, strategy)) {
-                        prevDeadlineNanos = NONE;
-                    }
+                    packed = processReady(events, strategy);
+                }
+                handled = packed >>> 1;
+                if ((packed & 1) != 0) {
+                    prevDeadlineNanos = NONE;
                 }
             } else if (context.shouldReportActiveIoTime()) {
                 context.reportActiveIoTime(0);
@@ -529,16 +529,18 @@ public class EpollIoHandler implements IoHandler {
         }
     }
 
-    // Returns true if a timerFd event was encountered
-    private boolean processReady(EpollEventArray events, int ready) {
-        boolean timerFired = false;
+    // Returns packed int: each real I/O event adds 2, timer fired adds 1.
+    // Unpack: real events = result >>> 1, timer fired = (result & 1) != 0.
+    private int processReady(EpollEventArray events, int ready) {
+        int result = 0;
         for (int i = 0; i < ready; i ++) {
             final int fd = events.fd(i);
             if (fd == eventFd.intValue()) {
                 pendingWakeup = false;
             } else if (fd == timerFd.intValue()) {
-                timerFired = true;
+                result |= 1;
             } else {
+                result += 2;
                 final long ev = events.events(i);
 
                 DefaultEpollIoRegistration registration = registrations.get(fd);
@@ -557,7 +559,7 @@ public class EpollIoHandler implements IoHandler {
                 }
             }
         }
-        return timerFired;
+        return result;
     }
 
     /**

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionCallback.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionCallback.java
@@ -27,8 +27,8 @@ interface CompletionCallback {
      * @param extraCqeData  the extra data for the CQE. This will only be non-null of the ring was setup with
      *                      {@code IORING_SETUP_CQE32} or {@code IORING_SETUP_CQE_MIXED} and {@code IORING_CQE_F_32} is
      *                      set in {@code flags}.
-     * @return              {@code true} if we more data (in a loop) can be handled be this callback, {@code false}
-     *                      otherwise.
+     * @return              {@code true} if this completion represents a real I/O event that should be counted,
+     *                      {@code false} for internal completions (e.g. eventfd, ring fd).
      */
-    void handle(int res, int flags, long udata, ByteBuffer extraCqeData);
+    boolean handle(int res, int flags, long udata, ByteBuffer extraCqeData);
 }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionQueue.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/CompletionQueue.java
@@ -116,13 +116,16 @@ final class CompletionQueue {
      * Process the completion events in the {@link CompletionQueue} and return the number of processed
      * events.
      */
-    int process(CompletionCallback callback) {
+    // Returns packed long: total completions in upper 32 bits, real I/O completions in lower 32 bits.
+    // Unpack: total = (int)(result >>> 32), realIo = (int) result.
+    long process(CompletionCallback callback) {
         if (closed) {
             return 0;
         }
         int tail = (int) INT_HANDLE.getVolatile(ktail, 0);
         try {
-            int i = 0;
+            int total = 0;
+            int realIo = 0;
             while (ringHead != tail) {
                 int cqeIdx = cqeIdx(ringHead, ringMask);
                 int cqePosition = cqeIdx * cqeLength;
@@ -144,9 +147,10 @@ final class CompletionQueue {
                 }
                 // Check if we should just skip it.
                 if ((flags & Native.IORING_CQE_F_SKIP) == 0) {
-                    i++;
-
-                    callback.handle(res, flags, udata, extraCqeData);
+                    total++;
+                    if (callback.handle(res, flags, udata, extraCqeData)) {
+                        realIo++;
+                    }
                 }
 
                 if (ringHead == tail) {
@@ -156,7 +160,7 @@ final class CompletionQueue {
                     tail = (int) INT_HANDLE.getVolatile(ktail, 0);
                 }
             }
-            return i;
+            return ((long) total << 32) | (realIo & 0xFFFFFFFFL);
         } finally {
             // Ensure that the kernel only sees the new value of the head index after the CQEs have been read.
             INT_HANDLE.setRelease(khead, 0, ringHead);

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -178,17 +178,16 @@ public final class IoUringIoHandler implements IoHandler {
             submitAndClearNow(submissionQueue);
         }
 
-        int processed;
+        int ioCompletions;
         if (context.shouldReportActiveIoTime()) {
-            // Timer starts after the blocking wait, around the processing of completions.
             long activeIoStartTimeNanos = System.nanoTime();
-            processed = processCompletionsAndHandleOverflow(submissionQueue, completionQueue, this::handle);
+            ioCompletions = processCompletionsAndHandleOverflow(submissionQueue, completionQueue, this::handle);
             long activeIoEndTimeNanos = System.nanoTime();
             context.reportActiveIoTime(activeIoEndTimeNanos - activeIoStartTimeNanos);
         } else {
-            processed = processCompletionsAndHandleOverflow(submissionQueue, completionQueue, this::handle);
+            ioCompletions = processCompletionsAndHandleOverflow(submissionQueue, completionQueue, this::handle);
         }
-        return processed;
+        return ioCompletions;
     }
 
     private boolean needSubmit(int sqFlags) {
@@ -199,25 +198,24 @@ public final class IoUringIoHandler implements IoHandler {
 
     private int processCompletionsAndHandleOverflow(SubmissionQueue submissionQueue, CompletionQueue completionQueue,
                                          CompletionCallback callback) {
-        int processed = 0;
-        // Bound the maximum number of times this will loop before we return and so execute some non IO stuff.
-        // 128 here is just some sort of bound and another number might be ok as well.
+        int ioCompletions = 0;
         for (int i = 0; i < 128; i++) {
-            int p = completionQueue.process(callback);
+            long packed = completionQueue.process(callback);
+            int total = (int) (packed >>> 32);
+            ioCompletions += (int) packed;
             int sqFlags = submissionQueue.flags();
             if ((sqFlags & Native.IORING_SQ_CQ_OVERFLOW) != 0) {
                 logger.warn("CompletionQueue overflow detected, consider increasing size: {} ",
                         completionQueue.ringEntries);
             }
-            if (p == 0) {
+            if (total == 0) {
                 if (!needSubmit(sqFlags)) {
                     break;
                 }
                 submitAndClearNow0(submissionQueue);
             }
-            processed += p;
         }
-        return processed;
+        return ioCompletions;
     }
 
     private int submitAndClearNow(SubmissionQueue submissionQueue) {
@@ -277,24 +275,26 @@ public final class IoUringIoHandler implements IoHandler {
         }
     }
 
-    private void handle(int res, int flags, long udata, ByteBuffer extraCqeData) {
+    private boolean handle(int res, int flags, long udata, ByteBuffer extraCqeData) {
         try {
             if (udata == EVENTFD_TOKEN) {
                 handleEventFdRead();
-                return;
+                return false;
             }
             if (udata == RINGFD_TOKEN) {
-                return;
+                return false;
             }
             if (udata >= 0) {
                 handleFastPath(res, flags, udata, extraCqeData);
-                return;
+                return true;
             }
             handleSlowPath(res, flags, udata, extraCqeData);
+            return true;
         } catch (Error e) {
             throw e;
         } catch (Throwable throwable) {
             handleLoopException(throwable);
+            return true;
         }
     }
 
@@ -482,11 +482,11 @@ public final class IoUringIoHandler implements IoHandler {
                 boolean eventFdDrained;
 
                 @Override
-                public void handle(int res, int flags, long udata, ByteBuffer extraCqeData) {
+                public boolean handle(int res, int flags, long udata, ByteBuffer extraCqeData) {
                     if (udata == EVENTFD_TOKEN) {
                         eventFdDrained = true;
                     }
-                    IoUringIoHandler.this.handle(res, flags, udata, extraCqeData);
+                    return IoUringIoHandler.this.handle(res, flags, udata, extraCqeData);
                 }
             }
             final DrainFdEventCallback handler = new DrainFdEventCallback();

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoHandler.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/KQueueIoHandler.java
@@ -189,7 +189,8 @@ public final class KQueueIoHandler implements IoHandler {
         return numEvents;
     }
 
-    private void processReady(int ready) {
+    private int processReady(int ready) {
+        int ioCount = 0;
         for (int i = 0; i < ready; ++i) {
             final short filter = eventList.filter(i);
             final short flags = eventList.flags(i);
@@ -202,6 +203,7 @@ public final class KQueueIoHandler implements IoHandler {
                 continue;
             }
 
+            ioCount++;
             long id = eventList.udata(i);
             DefaultKqueueIoRegistration registration = registrations.get(id);
             if (registration == null) {
@@ -213,6 +215,7 @@ public final class KQueueIoHandler implements IoHandler {
             }
             registration.handle(ident, filter, flags, eventList.fflags(i), eventList.data(i), id);
         }
+        return ioCount;
     }
 
     @Override
@@ -269,15 +272,13 @@ public final class KQueueIoHandler implements IoHandler {
             }
 
             if (strategy > 0) {
-                handled = strategy;
                 if (context.shouldReportActiveIoTime()) {
-                    // The Timer starts after the blocking kqueueWait() call returns with events.
                     long activeIoStartTimeNanos = System.nanoTime();
-                    processReady(strategy);
+                    handled = processReady(strategy);
                     long activeIoEndTimeNanos = System.nanoTime();
                     context.reportActiveIoTime(activeIoEndTimeNanos - activeIoStartTimeNanos);
                 } else {
-                    processReady(strategy);
+                    handled = processReady(strategy);
                 }
             } else if (context.shouldReportActiveIoTime()) {
                 context.reportActiveIoTime(0);

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -616,6 +616,13 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
+      <artifactId>netty-transport</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-unix-common</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollIoHandlerWakeupEventCountTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollIoHandlerWakeupEventCountTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.epoll;
+
+import io.netty.channel.AbstractIoHandlerEventCountTest;
+import io.netty.channel.IoHandlerFactory;
+import org.junit.jupiter.api.BeforeAll;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * On modern kernels with {@code epoll_pwait2} support, timeouts are handled directly by the syscall
+ * without producing a timerfd event. To force the timerfd path and fully exercise the timer filtering,
+ * run with {@code -Dio.netty.channel.epoll.epollWaitThreshold=0} (JVM-global, must be set before
+ * {@code EpollIoHandler} class init).
+ */
+public class EpollIoHandlerWakeupEventCountTest extends AbstractIoHandlerEventCountTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(Epoll.isAvailable());
+    }
+
+    @Override
+    protected IoHandlerFactory newIoHandlerFactory() {
+        return EpollIoHandler.newFactory();
+    }
+}

--- a/transport-native-io_uring/pom.xml
+++ b/transport-native-io_uring/pom.xml
@@ -335,6 +335,13 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
+      <artifactId>netty-transport</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-unix-common</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringIoHandlerWakeupEventCountTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringIoHandlerWakeupEventCountTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.channel.AbstractIoHandlerEventCountTest;
+import io.netty.channel.IoHandlerFactory;
+import org.junit.jupiter.api.BeforeAll;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IoUringIoHandlerWakeupEventCountTest extends AbstractIoHandlerEventCountTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IoUring.isAvailable());
+    }
+
+    @Override
+    protected IoHandlerFactory newIoHandlerFactory() {
+        return IoUringIoHandler.newFactory();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/SubmissionQueueTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/SubmissionQueueTest.java
@@ -91,6 +91,7 @@ public class SubmissionQueueTest {
         assertFalse(completionQueue.hasCompletions());
         assertEquals(0, completionQueue.process((res, flags, data, cqeExtraData) -> {
             fail("Should not be called");
+            return true;
         }));
 
         // Ensure both return not null and also not segfault.
@@ -149,12 +150,12 @@ public class SubmissionQueueTest {
             assertNotEquals(0, ringBuffer.ioUringSubmissionQueue().flags() & Native.IORING_SQ_CQ_OVERFLOW);
 
             // The completion queue should have only had space for 2 events
-            int processed = completionQueue.process((res, flags, udata, extraCqeData) -> { });
+            int processed = (int) (completionQueue.process((res, flags, udata, extraCqeData) -> true) >>> 32);
             assertEquals(2, processed);
 
             // submit again to ensure we flush the event that did overflow
             submissionQueue.submitAndGetNow();
-            processed = completionQueue.process((res, flags, udata, extraCqeData) -> { });
+            processed = (int) (completionQueue.process((res, flags, udata, extraCqeData) -> true) >>> 32);
             assertEquals(1, processed);
 
             // Everything was processed and so the overflow flag should have been cleared
@@ -226,10 +227,10 @@ public class SubmissionQueueTest {
 
             assertEquals(2, submissionQueue.submitAndGet());
             assertEquals(cqeSize == CqeSize.MIXED ? 3 : 2, completionQueue.count());
-            int processed = completionQueue.process(new CompletionCallback() {
+            long packed = completionQueue.process(new CompletionCallback() {
                 private boolean first = true;
                 @Override
-                public void handle(int res, int flags, long udata, ByteBuffer extraCqeData) {
+                public boolean handle(int res, int flags, long udata, ByteBuffer extraCqeData) {
                     assertEquals(0, res);
                     assertEquals(cqeSize == CqeSize.MIXED && first ? Native.IORING_CQE_F_32 : 0, flags);
                     assertEquals(1, udata);
@@ -241,9 +242,10 @@ public class SubmissionQueueTest {
                         assertNull(extraCqeData);
                     }
                     first = false;
+                    return true;
                 }
             });
-            assertEquals(2, processed);
+            assertEquals(2, (int) (packed >>> 32));
             assertFalse(completionQueue.hasCompletions());
         } finally {
             ringBuffer.close();
@@ -277,7 +279,7 @@ public class SubmissionQueueTest {
                 }
 
                 assertEquals(added, submissionQueue.submitAndGet());
-                int processed = completionQueue.process((res, flags, udata, extraCqeData) -> {
+                long packed = completionQueue.process((res, flags, udata, extraCqeData) -> {
                     assertEquals(0, res);
                     // If there is a filler we should not be notified.
                     assertEquals(0, flags & Native.IORING_CQE_F_SKIP);
@@ -290,8 +292,9 @@ public class SubmissionQueueTest {
                         assertEquals(0, flags);
                         assertNull(extraCqeData);
                     }
+                    return true;
                 });
-                assertEquals(7, processed);
+                assertEquals(7, (int) (packed >>> 32));
                 assertFalse(completionQueue.hasCompletions());
             }
         } finally {

--- a/transport-native-kqueue/pom.xml
+++ b/transport-native-kqueue/pom.xml
@@ -728,6 +728,13 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
+      <artifactId>netty-transport</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-unix-common</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueIoHandlerWakeupEventCountTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueIoHandlerWakeupEventCountTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.kqueue;
+
+import io.netty.channel.AbstractIoHandlerEventCountTest;
+import io.netty.channel.IoHandlerFactory;
+import org.junit.jupiter.api.BeforeAll;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class KQueueIoHandlerWakeupEventCountTest extends AbstractIoHandlerEventCountTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(KQueue.isAvailable());
+    }
+
+    @Override
+    protected IoHandlerFactory newIoHandlerFactory() {
+        return KQueueIoHandler.newFactory();
+    }
+}

--- a/transport/src/main/java/io/netty/channel/IoHandler.java
+++ b/transport/src/main/java/io/netty/channel/IoHandler.java
@@ -45,6 +45,7 @@ public interface IoHandler {
      *
      * @param  context  the {@link IoHandlerContext}.
      * @return          the number of {@link IoHandle} for which I/O was handled.
+     *                  Internal events such as wakeups and timer expirations must not be included in this count.
      */
     int run(IoHandlerContext context);
 

--- a/transport/src/test/java/io/netty/channel/AbstractIoHandlerEventCountTest.java
+++ b/transport/src/test/java/io/netty/channel/AbstractIoHandlerEventCountTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that {@link IoHandler#run(IoHandlerContext)} returns only the count of real I/O events,
+ * excluding internal events such as wakeups and timer expirations.
+ * <p>
+ * Subclasses provide the {@link IoHandlerFactory} for each transport. The contract tested here
+ * must hold regardless of the transport implementation.
+ */
+public abstract class AbstractIoHandlerEventCountTest {
+
+    protected abstract IoHandlerFactory newIoHandlerFactory();
+
+    @Test
+    @Timeout(5)
+    public void testTimerExpirationDoesNotCountAsIoEvent() throws Exception {
+        ManualIoEventLoop loop = new ManualIoEventLoop(Thread.currentThread(), newIoHandlerFactory());
+        try {
+            int result = loop.run(TimeUnit.MILLISECONDS.toNanos(100), -1);
+            assertEquals(0, result, "timer expiration should not be counted as an I/O event");
+        } finally {
+            loop.shutdown();
+            while (!loop.isTerminated()) {
+                loop.runNow();
+            }
+        }
+    }
+
+    @Test
+    @Timeout(5)
+    public void testWakeupDoesNotCountAsIoEvent() throws Exception {
+        ManualIoEventLoop loop = new ManualIoEventLoop(Thread.currentThread(), newIoHandlerFactory());
+        try {
+            CountDownLatch aboutToBlock = new CountDownLatch(1);
+            Thread waker = new Thread(() -> {
+                try {
+                    aboutToBlock.await();
+                    Thread.sleep(300);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                loop.wakeup();
+            });
+            waker.start();
+
+            aboutToBlock.countDown();
+            int result = loop.run(0, -1);
+            assertEquals(0, result, "wakeup should not be counted as an I/O event");
+
+            waker.join();
+        } finally {
+            loop.shutdown();
+            while (!loop.isTerminated()) {
+                loop.runNow();
+            }
+        }
+    }
+
+    @Test
+    @Timeout(5)
+    public void testScheduledTaskDoesNotInflateIoCount() throws Exception {
+        ManualIoEventLoop loop = new ManualIoEventLoop(Thread.currentThread(), newIoHandlerFactory());
+        try {
+            AtomicBoolean taskRan = new AtomicBoolean();
+            loop.schedule(() -> taskRan.set(true), 100, TimeUnit.MILLISECONDS);
+
+            // Block until the scheduled task fires and is picked up by runAllTasks.
+            // The handler may return slightly before the task deadline due to timer precision,
+            // so we loop until the task actually executes.
+            int result = 0;
+            while (!taskRan.get()) {
+                result += loop.run(0);
+            }
+            assertEquals(1, result,
+                    "only the scheduled task should be counted, not internal timer events");
+        } finally {
+            loop.shutdown();
+            while (!loop.isTerminated()) {
+                loop.runNow();
+            }
+        }
+    }
+}

--- a/transport/src/test/java/io/netty/channel/nio/NioIoHandlerEventCountTest.java
+++ b/transport/src/test/java/io/netty/channel/nio/NioIoHandlerEventCountTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.nio;
+
+import io.netty.channel.AbstractIoHandlerEventCountTest;
+import io.netty.channel.IoHandlerFactory;
+
+public class NioIoHandlerEventCountTest extends AbstractIoHandlerEventCountTest {
+
+    @Override
+    protected IoHandlerFactory newIoHandlerFactory() {
+        return NioIoHandler.newFactory();
+    }
+}


### PR DESCRIPTION
Motivation:

IoHandler.run() contract returns the number of IoHandle instances for
which I/O was handled. NIO correctly returns 0 for wakeup-only events,
but epoll counted all epoll_wait events (including eventfd and timerfd),
io_uring counted all completions (including eventfd and ring fd), and
kqueue counted EVFILT_USER wakeup events.

Modifications:

Epoll: pack real I/O count and timer flag into processReady() return
value. Each real I/O event adds 2, timer fired ORs 1. Caller unpacks
via shift and mask.

io_uring: change CompletionCallback.handle() to return boolean
indicating whether the completion is real I/O. CompletionQueue.process()
returns a packed long with total completions in upper 32 bits and real
I/O count in lower 32 bits. processCompletionsAndHandleOverflow()
unpacks and returns only the real I/O count.

KQueue: processReady() returns the count of real I/O events, excluding
EVFILT_USER and EV_ERROR.

Add AbstractIoHandlerEventCountTest with shared tests for all
transports (NIO, epoll, io_uring, kqueue) verifying: timer returns 0,
wakeup returns 0, and scheduled tasks are not inflated by internal
events.

Update IoHandler.run() Javadoc to explicitly state that internal events
must not be included in the return value.

Result:

All transports now consistently return 0 from run() when only internal
events occurred, matching the IoHandler contract.