### PR TITLE
MQTT: Reject malformed no-payload packets with non-zero Remaining Length

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
@@ -508,7 +508,10 @@ public final class MqttDecoder extends ReplayingDecoder<DecoderState> {
                 return decodePublishPayload(buffer);
 
             default:
-                // unknown payload , no byte consumed
+                // No payload for this message type. If the fixed header's Remaining Length
+                // claimed bytes beyond what the variable header consumed (e.g. a PINGREQ
+                // with non-zero Remaining Length), the frame is malformed - see #16851.
+                validateNoBytesRemain(0);
                 return null;
         }
     }

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
@@ -510,7 +510,8 @@ public final class MqttDecoder extends ReplayingDecoder<DecoderState> {
             default:
                 // No payload for this message type. If the fixed header's Remaining Length
                 // claimed bytes beyond what the variable header consumed (e.g. a PINGREQ
-                // with non-zero Remaining Length), the frame is malformed - see #16851.
+                // with non-zero Remaining Length), the frame is malformed.
+                // See https://github.com/netty/netty/issues/16851
                 validateNoBytesRemain(0);
                 return null;
         }

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
@@ -534,6 +534,41 @@ public class MqttCodecTest {
         testMessageWithOnlyFixedHeader(MqttMessage.DISCONNECT);
     }
 
+    @Test
+    public void testPingReqWithNonZeroRemainingLengthIsRejected() throws Exception {
+        // Regression for https://github.com/netty/netty/issues/16851: PINGREQ is a 2-byte
+        // fixed-header-only packet (0xC0 0x00). The bytes below claim Remaining Length 2,
+        // which makes the trailing 0xD0 0x00 part of the same (malformed) PINGREQ frame
+        // rather than a separate PINGRESP. The decoder must reject this as one invalid
+        // message rather than silently accept two.
+        EmbeddedChannel channel = new EmbeddedChannel(new MqttDecoder());
+        ByteBuf byteBuf = ALLOCATOR.buffer();
+        // Fixed header byte 1: PINGREQ (type 12), all flags 0.
+        byteBuf.writeByte(0xC0);
+        // Remaining Length 2 - invalid per MQTT 3.1.1 / 5.0 spec (PINGREQ has no variable
+        // header or payload, so Remaining Length must be 0).
+        byteBuf.writeByte(0x02);
+        // Two leftover bytes still inside the malformed packet's frame:
+        byteBuf.writeByte(0xD0);
+        byteBuf.writeByte(0x00);
+
+        try {
+            assertTrue(channel.writeInbound(byteBuf));
+            MqttMessage first = channel.readInbound();
+            try {
+                assertTrue(first.decoderResult().isFailure(),
+                        "expected a failed message for the malformed PINGREQ");
+                assertInstanceOf(DecoderException.class, first.decoderResult().cause());
+            } finally {
+                ReferenceCountUtil.release(first);
+            }
+            // No second message: the trailing bytes belong to the malformed frame.
+            assertNull(channel.readInbound());
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
     //All 0..F message type codes are valid in MQTT 5
     @Test
     public void testUnknownMessageType() throws Exception {

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
@@ -542,7 +542,7 @@ public class MqttCodecTest {
         // rather than a separate PINGRESP. The decoder must reject this as one invalid
         // message rather than silently accept two.
         EmbeddedChannel channel = new EmbeddedChannel(new MqttDecoder());
-        ByteBuf byteBuf = ALLOCATOR.buffer();
+        ByteBuf byteBuf = channel.alloc().buffer();
         // Fixed header byte 1: PINGREQ (type 12), all flags 0.
         byteBuf.writeByte(0xC0);
         // Remaining Length 2 - invalid per MQTT 3.1.1 / 5.0 spec (PINGREQ has no variable
@@ -565,7 +565,7 @@ public class MqttCodecTest {
             // No second message: the trailing bytes belong to the malformed frame.
             assertNull(channel.readInbound());
         } finally {
-            channel.finishAndReleaseAll();
+            assertFalse(channel.finishAndReleaseAll());
         }
     }
 


### PR DESCRIPTION
Motivation:

`MqttDecoder.decodePayload`'s `default` branch returns `null` for payload-less message types (`PINGREQ`, `PINGRESP`, `DISCONNECT`, `AUTH`, `CONNACK`, `PUBACK`, `PUBREC`, `PUBREL`, `PUBCOMP`) without checking that `bytesRemainingInVariablePart` is `0`. A fixed header that claims a non-zero Remaining Length for one of these types is silently accepted, and the leftover bytes are interpreted as another packet.

The reporter's exact repro from #16851 is `C0 02 D0 00`: a `PINGREQ` with Remaining Length `2` (invalid per [MQTT 3.1.1](https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html) and [MQTT 5.0](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html), which both require Remaining Length `0` for `PINGREQ`) is currently decoded as a valid `PINGREQ` followed by a valid `PINGRESP`.

Modification:

Call `validateNoBytesRemain(0)` at the start of the `default` branch. The helper — already used by the `SUBSCRIBE` and `UNSUBSCRIBE` payload decoders — subtracts `0` from `bytesRemainingInVariablePart` and throws `DecoderException` when the result is non-zero, surfacing a single invalid message instead of letting leftover bytes leak into the next decode pass.

Added `MqttCodecTest#testPingReqWithNonZeroRemainingLengthIsRejected` that feeds the reporter's exact byte sequence and verifies a single failed message is produced. Confirmed it fails on the unfixed code (`expected: <true> but was: <false>`) and passes with the fix; all 112 `codec-mqtt` tests pass locally.

Result:

Malformed payload-less MQTT frames are flagged as a single invalid message rather than allowed to silently spill into the next packet. The fix applies uniformly to every message type that goes through the `default` branch.

Fixes #16851.