### PR TITLE
Configurable bound on RedisArrayAggregator

### DIFF
--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisArrayAggregator.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisArrayAggregator.java
@@ -19,6 +19,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.CodecException;
 import io.netty.handler.codec.MessageToMessageDecoder;
 import io.netty.util.ReferenceCountUtil;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.UnstableApi;
 
 import java.util.ArrayDeque;
@@ -33,7 +34,36 @@ import java.util.List;
 @UnstableApi
 public final class RedisArrayAggregator extends MessageToMessageDecoder<RedisMessage> {
 
+    private static final int DEFAULT_MAX_ARRAY_LENGTH = RedisConstants.REDIS_MAX_ARRAY_LENGTH;
     private final Deque<AggregateState> depths = new ArrayDeque<AggregateState>(4);
+    private final int maxElements;
+
+    /**
+     * Create a new instance that will aggregate an {@link ArrayHeaderRedisMessage}
+     * and its subsequent elements into an {@link ArrayRedisMessage}.
+     * <p>
+     * This constructor specifies a maximum number of elements of 1.000.000,
+     * but this default can be increased with the {@value RedisConstants#PROP_REDIS_MAX_ARRAY_LENGTH} system property.
+     *
+     * @deprecated Use {@link #RedisArrayAggregator(int)} instead to define a max size of the array to aggregate.
+     */
+    @Deprecated
+    public RedisArrayAggregator() {
+        this(DEFAULT_MAX_ARRAY_LENGTH);
+    }
+
+    /**
+     * Create a new instance that will aggregate an {@link ArrayHeaderRedisMessage}
+     * and its subsequent elements into an {@link ArrayRedisMessage}.
+     * <p>
+     * A {@link CodecException} will be thrown if the array header specify a length greater than
+     * the given number of max elements.
+     * @param maxElements The maximum number of elements to aggregate in a single message.
+     */
+    public RedisArrayAggregator(int maxElements) {
+        super(RedisMessage.class);
+        this.maxElements = ObjectUtil.checkPositive(maxElements, "maxElements");
+    }
 
     @Override
     protected void decode(ChannelHandlerContext ctx, RedisMessage msg, List<Object> out) throws Exception {
@@ -70,8 +100,8 @@ public final class RedisArrayAggregator extends MessageToMessageDecoder<RedisMes
             return ArrayRedisMessage.EMPTY_INSTANCE;
         } else if (header.length() > 0L) {
             // Currently, this codec doesn't support `long` length for arrays because Java's List.size() is int.
-            if (header.length() > Integer.MAX_VALUE) {
-                throw new CodecException("this codec doesn't support longer length than " + Integer.MAX_VALUE);
+            if (header.length() > maxElements) {
+                throw new CodecException("this codec doesn't support longer length than " + maxElements);
             }
 
             // start aggregating array

--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisConstants.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisConstants.java
@@ -15,6 +15,8 @@
 
 package io.netty.handler.codec.redis;
 
+import io.netty.util.internal.SystemPropertyUtil;
+
 /**
  * Constant values for Redis encoder/decoder.
  */
@@ -43,4 +45,7 @@ final class RedisConstants {
     static final short NULL_SHORT = RedisCodecUtil.makeShort('-', '1');
 
     static final short EOL_SHORT = RedisCodecUtil.makeShort('\r', '\n');
+
+    static final String PROP_REDIS_MAX_ARRAY_LENGTH = "io.netty.handler.codec.redis.maxArrayLength";
+    static final int REDIS_MAX_ARRAY_LENGTH = SystemPropertyUtil.getInt(PROP_REDIS_MAX_ARRAY_LENGTH, 1000000);
 }

--- a/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisDecoderTest.java
+++ b/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisDecoderTest.java
@@ -19,9 +19,11 @@ package io.netty.handler.codec.redis;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.CodecException;
 import io.netty.handler.codec.DecoderException;
 import io.netty.util.IllegalReferenceCountException;
 import io.netty.util.ReferenceCountUtil;
+import org.assertj.core.api.ThrowableAssert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,6 +32,7 @@ import org.junit.jupiter.api.function.Executable;
 import java.util.List;
 
 import static io.netty.handler.codec.redis.RedisCodecTestUtil.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -55,7 +58,7 @@ public class RedisDecoderTest {
         return new EmbeddedChannel(
                 new RedisDecoder(decodeInlineCommands),
                 new RedisBulkStringAggregator(),
-                new RedisArrayAggregator());
+                new RedisArrayAggregator(100));
     }
 
     @AfterEach
@@ -273,6 +276,20 @@ public class RedisDecoderTest {
         assertEquals("Bar", ((ErrorRedisMessage) strArray.children().get(1)).content());
 
         ReferenceCountUtil.release(msg);
+    }
+
+    @Test
+    public void shouldErrorOnTooLargeArray() {
+        // We defined the max aggregate array size to be 100
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            @Override
+            public void call() throws Throwable {
+                channel.writeInbound(byteBufOf("*101\r\n"));
+            }
+        }).isInstanceOf(DecoderException.class)
+                .rootCause()
+                .isInstanceOf(CodecException.class)
+                .hasMessageContaining("100");
     }
 
     @Test

--- a/example/src/main/java/io/netty/example/redis/RedisClient.java
+++ b/example/src/main/java/io/netty/example/redis/RedisClient.java
@@ -52,7 +52,7 @@ public class RedisClient {
                      ChannelPipeline p = ch.pipeline();
                      p.addLast(new RedisDecoder());
                      p.addLast(new RedisBulkStringAggregator());
-                     p.addLast(new RedisArrayAggregator());
+                     p.addLast(new RedisArrayAggregator(1000000));
                      p.addLast(new RedisEncoder());
                      p.addLast(new RedisClientHandler());
                  }


### PR DESCRIPTION
Motivation:
The RedisArrayAggregator was pre-allocating the aggregating ArrayList instance based on just the array header message.

Modification:
Add a RedisArrayAggregator constructor that takes a max number of elements as an argument. Deprecate the other constructor and make it use 1.000.000 as a default, defined by a new system property.

Why 1.000.000? It seemed big enough to not cause too many compatibility problems from this change, yet small enough to somewhat constrain the resource usage from nefarious peers.

Result:
Less exposure to excessive resource usage by adversarial peers.