### PR TITLE
Redis: Limit decoded length

### DIFF
--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisDecoder.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisDecoder.java
@@ -129,9 +129,13 @@ public final class RedisDecoder extends ByteToMessageDecoder {
                 }
             }
         } catch (RedisCodecException e) {
+            // Let's discard everything
+            in.skipBytes(in.readableBytes());
             resetDecoder();
             throw e;
         } catch (Exception e) {
+            // Let's discard everything
+            in.skipBytes(in.readableBytes());
             resetDecoder();
             throw new RedisCodecException(e);
         }
@@ -169,6 +173,16 @@ public final class RedisDecoder extends ByteToMessageDecoder {
     private boolean decodeLength(ByteBuf in, List<Object> out) throws Exception {
         ByteBuf lineByteBuf = readLine(in);
         if (lineByteBuf == null) {
+            int readableBytes = in.readableBytes();
+            if (readableBytes <= RedisConstants.POSITIVE_LONG_MAX_LENGTH) {
+                // fast-path
+                return false;
+            }
+            boolean isNegative = in.getByte(in.readerIndex()) == '-';
+            int capacity = RedisConstants.POSITIVE_LONG_MAX_LENGTH + (isNegative ? 1 : 0) + 1;
+            if (readableBytes > capacity) {
+                throw new RedisCodecException("too many characters to be a valid RESP Integer: " + readableBytes);
+            }
             return false;
         }
         final long length = parseRedisNumber(lineByteBuf);

--- a/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisDecoderTest.java
+++ b/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisDecoderTest.java
@@ -341,4 +341,67 @@ public class RedisDecoderTest {
         assertNotEquals(FullBulkStringRedisMessage.EMPTY_INSTANCE, FullBulkStringRedisMessage.NULL_INSTANCE);
         assertNotEquals(FullBulkStringRedisMessage.NULL_INSTANCE, FullBulkStringRedisMessage.EMPTY_INSTANCE);
     }
+
+    @Test
+    public void shouldLimitIntegerTo64IntSigned() {
+        ByteBuf buf = Unpooled.buffer();
+        buf.writeByte('$');
+        for (int i = 0; i <= RedisConstants.POSITIVE_LONG_MAX_LENGTH; i++) {
+            buf.writeByte('0');
+        }
+        assertFalse(channel.writeInbound(buf));
+
+        assertThrows(DecoderException.class, new Executable() {
+            @Override
+            public void execute() {
+                channel.writeInbound(byteBufOf("1"));
+            }
+        });
+    }
+
+    @Test
+    public void testPositiveLongWithCr() {
+        EmbeddedChannel channel = new EmbeddedChannel(new RedisDecoder());
+        ByteBuf buf = Unpooled.buffer();
+        buf.writeByte('$');
+        for (int i = 0; i < RedisConstants.POSITIVE_LONG_MAX_LENGTH; i++) {
+            buf.writeByte('0');
+        }
+        buf.writeByte('\r');
+
+        // 19 digits + \r = 20 bytes.
+        // It's a valid incomplete RESP number waiting for \n.
+        assertFalse(channel.writeInbound(buf));
+
+        ByteBuf buf2 = Unpooled.buffer();
+        buf2.writeByte('\n');
+        assertFalse(channel.writeInbound(buf2));
+        assertFalse(channel.finish());
+    }
+
+    @Test
+    public void testGiantPayloadEndingWithCrBypassesLengthCheck() {
+        final EmbeddedChannel channel = new EmbeddedChannel(new RedisDecoder());
+        ByteBuf buf = Unpooled.buffer();
+        buf.writeByte('$');
+        for (int i = 0; i < RedisConstants.POSITIVE_LONG_MAX_LENGTH; i++) {
+            buf.writeByte('1');
+        }
+        assertFalse(channel.writeInbound(buf));
+
+        // We expect that sending 1000 more bytes will exceed the maximum valid length capacity,
+        // regardless of whether the final byte is '\r'. It should throw a DecoderException.
+        assertThrows(DecoderException.class, new Executable() {
+            @Override
+            public void execute() {
+                for (int i = 0; i < 1000; i++) {
+                    ByteBuf chunk = Unpooled.buffer();
+                    chunk.writeByte('a');
+                    chunk.writeByte('\r');
+                    channel.writeInbound(chunk);
+                }
+            }
+        });
+        assertFalse(channel.finish());
+    }
 }


### PR DESCRIPTION
Motivation:

To guard against unbounded memory usage we should enforce a limit when we try to decode the length. This needs to fit into a signed 64 bit integer.

Modifications:

- Enforce limit during decoding
- Add unit test

Result:

Ensure we will limit the number of bytes we buffer