### PR TITLE
HttpObjectDecoder skips arbitrary initial control characters when only initial CRLF characters are permitted (#16861)

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpDecoderConfig.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpDecoderConfig.java
@@ -232,13 +232,16 @@ public final class HttpDecoderConfig implements Cloneable {
      * security vulnerabilities, when multiple systems disagree on the meaning of leniently parsed messages.
      * <p>
      * When <em>strict line parsing</em> is enabled ({@code true}), then Netty will enforce that start- and header
-     * field-lines MUST be separated by a CR LF octet pair, and will produce messagas with failed
+     * field-lines MUST be separated by a CR LF octet pair, and will produce messages with failed
      * {@link io.netty.handler.codec.DecoderResult}s.
+     * Additionally, Netty will enforce that only CR LF characters precede the initial line, if any.
      * <p>
      * When <em>strict line parsing</em> is disabled ({@code false}), then Netty will accept lone LF octets as line
-     * seperators for the start- and header field-lines.
+     * separators for the start- and header field-lines.
+     * Additionally, Netty will ignore any ISO control and line separator characters prior to the initial line.
      * <p>
-     * See <a href="https://datatracker.ietf.org/doc/html/rfc9112#name-message-format">RFC 9112 Section 2.1</a>.
+     * See <a href="https://datatracker.ietf.org/doc/html/rfc9112#name-message-format">RFC 9112 Section 2.1</a> and
+     * <a href="https://datatracker.ietf.org/doc/html/rfc9112#section-2.2-6">RFC 9112 Section 2.2</a>.
      * @param strictLineParsing Whether <em>strict line parsing</em> should be enabled ({@code true}),
      * or not ({@code false}).
      * @return This decoder config.

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -224,6 +224,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
      * <em>Internal use only</em>.
      */
     private enum State {
+        SKIP_INITIAL_LINE_CHARS,
         SKIP_CONTROL_CHARS,
         READ_INITIAL,
         READ_HEADER,
@@ -237,7 +238,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
         UPGRADED
     }
 
-    private State currentState = State.SKIP_CONTROL_CHARS;
+    private State currentState = State.SKIP_INITIAL_LINE_CHARS;
 
     /**
      * Creates a new instance with the default
@@ -374,7 +375,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
         }
 
         switch (currentState) {
-        case SKIP_CONTROL_CHARS:
+        case SKIP_INITIAL_LINE_CHARS:
             // Fall-through
         case READ_INITIAL: try {
             ByteBuf line = lineParser.parse(buffer, defaultStrictCRLFCheck);
@@ -618,6 +619,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
                 resetNow();
                 return;
             case SKIP_CONTROL_CHARS: // fall-trough
+            case SKIP_INITIAL_LINE_CHARS: // fall-trough
             case READ_INITIAL:// fall-trough
             case BAD_MESSAGE: // fall-trough
             case UPGRADED: // fall-trough
@@ -717,7 +719,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
         }
 
         resetRequested.lazySet(false);
-        currentState = State.SKIP_CONTROL_CHARS;
+        currentState = State.SKIP_INITIAL_LINE_CHARS;
     }
 
     private HttpMessage invalidMessage(HttpMessage current, ByteBuf in, Exception cause) {
@@ -1338,26 +1340,33 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             if (readableBytes == 0) {
                 return null;
             }
-            if (currentState == State.SKIP_CONTROL_CHARS &&
-                    skipControlChars(buffer, readableBytes, buffer.readerIndex())) {
+            if (currentState == State.SKIP_INITIAL_LINE_CHARS &&
+                    skipLineChars(buffer, readableBytes, buffer.readerIndex(), strictCRLFCheck)) {
                 return null;
             }
             return super.parse(buffer, strictCRLFCheck);
         }
 
-        private boolean skipControlChars(ByteBuf buffer, int readableBytes, int readerIndex) {
-            assert currentState == State.SKIP_CONTROL_CHARS;
+        private boolean skipLineChars(ByteBuf buffer, int readableBytes, int readerIndex, Runnable strictCRLFCheck) {
+            assert currentState == State.SKIP_INITIAL_LINE_CHARS;
             final int maxToSkip = Math.min(maxLength, readableBytes);
-            final int firstNonControlIndex = buffer.forEachByte(readerIndex, maxToSkip, SKIP_CONTROL_CHARS_BYTES);
-            if (firstNonControlIndex == -1) {
+            final int firstNonLineIndex = buffer.forEachByte(readerIndex, maxToSkip,
+                    strictCRLFCheck == null ? SKIP_CONTROL_CHARS_BYTES : ByteProcessor.FIND_NON_CRLF);
+            if (firstNonLineIndex == -1) {
                 buffer.skipBytes(maxToSkip);
                 if (readableBytes > maxLength) {
                     throw newException(maxLength);
                 }
                 return true;
             }
+            if (strictCRLFCheck != null) {
+                final int b = buffer.getByte(firstNonLineIndex) & 0xFF;
+                if (Character.isISOControl(b)) {
+                    strictCRLFCheck.run();
+                }
+            }
             // from now on we don't care about control chars
-            buffer.readerIndex(firstNonControlIndex);
+            buffer.readerIndex(firstNonLineIndex);
             currentState = State.READ_INITIAL;
             return false;
         }
@@ -1378,7 +1387,6 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
     }
 
     private static final ByteProcessor SKIP_CONTROL_CHARS_BYTES = new ByteProcessor() {
-
         @Override
         public boolean process(byte value) {
             return ISO_CONTROL_OR_WHITESPACE[128 + value];

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -490,6 +490,31 @@ public class HttpRequestDecoderTest {
     }
 
     @Test
+    public void testNonCrlfControlBytesPrecedingRequestLineAreRejected() throws Exception {
+        // RFC 9112 §2.2: servers SHOULD ignore "at least one empty line (CRLF)" before the
+        // request-line.  Non-CRLF control bytes are not part of this robustness allowance
+        // and must not be silently swallowed.
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
+
+        ByteBuf buf = Unpooled.buffer();
+        buf.writeByte(0x00);   // NUL  — not an empty CRLF line
+        buf.writeByte(0x01);   // SOH  — not an empty CRLF line
+        buf.writeCharSequence(
+                "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n",
+                CharsetUtil.US_ASCII);
+
+        channel.writeInbound(buf);
+        HttpRequest req = channel.readInbound();
+
+        DecoderResult decoderResult = req.decoderResult();
+        assertTrue(decoderResult.isFailure(),
+                "Non-CRLF control bytes before the request-line must not be silently skipped");
+        assertThat(decoderResult.cause()).isInstanceOf(InvalidLineSeparatorException.class);
+
+        assertFalse(channel.finish());
+    }
+
+    @Test
     public void testTooLargeHeaders() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder(1024, 10, 1024));
         String requestStr = "GET /some/path HTTP/1.1\r\n" +


### PR DESCRIPTION
Motivation:
RFC 9112 permit empty lines (CR LF sequences) prior to the request line,
but we were skipping over any ISO control characters.
This is parsing leniency beyond what the standard mandates and can be a
security liability.

Modification:
Expand the scope of the "strict line parsing" decoder configuration
option to also include enforcing that any octets prior to the initial
line can only be the line separators CR LF.

Result:
Strict line parsing covers more cases.

Co-authored-by: Chris Vest <christianvest_hansen@apple.com>
