### PR TITLE
IpSubnetFilter: Correctly handle ipv6 (#16860)

### DIFF
--- a/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
@@ -149,7 +149,7 @@ public final class IpSubnetFilterRule implements IpFilterRule, Comparable<IpSubn
             Ip6SubnetFilterRule ip6SubnetFilterRule = (Ip6SubnetFilterRule) filterRule;
             return ip6SubnetFilterRule.networkAddress
                     .compareTo(Ip6SubnetFilterRule.ipToInt((Inet6Address) inetSocketAddress.getAddress())
-                            .and(ip6SubnetFilterRule.networkAddress));
+                            .and(ip6SubnetFilterRule.subnetMask));
         }
     }
 
@@ -245,7 +245,7 @@ public final class IpSubnetFilterRule implements IpFilterRule, Comparable<IpSubn
             byte[] octets = ipAddress.getAddress();
             assert octets.length == 16;
 
-            return new BigInteger(octets);
+            return new BigInteger(1, octets);
         }
 
         private static BigInteger prefixToSubnetMask(int cidrPrefix) {

--- a/handler/src/test/java/io/netty/handler/ipfilter/IpSubnetFilterTest.java
+++ b/handler/src/test/java/io/netty/handler/ipfilter/IpSubnetFilterTest.java
@@ -29,6 +29,7 @@ import java.net.Inet6Address;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -213,11 +214,28 @@ public class IpSubnetFilterTest {
         assertTrue(ch6.close().isSuccess());
 
         //2001:db8:abcd:0000::/52
-        EmbeddedChannel ch7 = newEmbeddedInetChannel("2001:db8:abcd:1000::",
+        EmbeddedChannel ch7 = newEmbeddedInetChannel("2001:db8:abcd:0000::1",
                 new IpSubnetFilter(ipSubnetFilterRuleList));
         assertFalse(ch7.isActive());
         assertTrue(ch7.close().isSuccess());
     }
+
+    @Test
+    public void testIpv6MaskCorrectlyApplied() {
+        IpSubnetFilterRule rule = new IpSubnetFilterRule("2001:db8:abcd:0000::", 52, IpFilterRuleType.ACCEPT);
+
+        EmbeddedChannel ch = newEmbeddedInetChannel("2001:db8:ffff:0000::",
+                new IpSubnetFilter(false, Collections.singletonList(rule)));
+        assertFalse(ch.isActive());
+        assertTrue(ch.close().isSuccess());
+    }
+
+    @Test
+    public void testIpv6MatchesNoFalsePositiveForAllOnesNetworkBits() {
+        // FFFF:FFFF::1 is NOT in 2001:db8::/32, which will be the case if the comparison is made unsigned.
+        IpSubnetFilterRule rule = new IpSubnetFilterRule("2001:db8::", 32, IpFilterRuleType.ACCEPT);
+        assertFalse(rule.matches(newSockAddress("FFFF:FFFF::1")));
+     }
 
     private static IpSubnetFilterRule buildRejectIP(String ipAddress, int mask) {
         return new IpSubnetFilterRule(ipAddress, mask, IpFilterRuleType.REJECT);


### PR DESCRIPTION
Motivation:

We need to correctly handle subnets for ipv6

Modifications:

- Correctly handle subnets
- Add unit test

Result:

Correctly filter ipv6 addresses