### PR TITLE
HTTP3: Enforce default max section size limit of 8kb

### DIFF
--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3CodecUtils.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3CodecUtils.java
@@ -58,6 +58,12 @@ final class Http3CodecUtils {
     static final int HTTP3_QPACK_ENCODER_STREAM_TYPE = 0x02;
     static final int HTTP3_QPACK_DECODER_STREAM_TYPE = 0x03;
 
+    /**
+     * Default is unlimited in the RFC but we want to enforce some "security" default limit.
+     * See <a href="https://datatracker.ietf.org/doc/html/rfc9114#section-4.2.2">RFC9114 Section 4.2.2</a>.
+     */
+    static final long DEFAULT_MAX_FIELD_SECTION_SIZE = 8192;
+
     private Http3CodecUtils() { }
 
     static long checkIsReservedFrameType(long type) {

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ConnectionHandler.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ConnectionHandler.java
@@ -72,16 +72,12 @@ public abstract class Http3ConnectionHandler implements ChannelInboundHandler {
             this.nonStandardSettingsValidator = (id, value) -> false;
         }
         if (localSettings == null) {
-            localSettings = new DefaultHttp3SettingsFrame();
+            localSettings = new DefaultHttp3SettingsFrame(Http3Settings.defaultSettings());
         } else {
             localSettings = DefaultHttp3SettingsFrame.copyOf(localSettings);
         }
-        Long maxFieldSectionSize = localSettings.get(Http3SettingsFrame.HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE);
-        if (maxFieldSectionSize == null) {
-             // Default value in rfc is unlimited
-             // but Quic can have max 2^62-1 max value as TWO bits reserved for Variable-Length Integer Encoding
-            maxFieldSectionSize = (1L << 62) - 1;
-        }
+        Long maxFieldSectionSize = localSettings.getOrDefault(Http3SettingsFrame.HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE,
+                Http3CodecUtils.DEFAULT_MAX_FIELD_SECTION_SIZE);
         this.maxTableCapacity = localSettings.getOrDefault(HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY, 0);
         int maxBlockedStreams = toIntExact(localSettings.getOrDefault(HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS, 0));
         qpackDecoder = new QpackDecoder(maxTableCapacity, maxBlockedStreams);

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3Settings.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3Settings.java
@@ -239,7 +239,7 @@ public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
      *   <li>{@code QPACK_MAX_TABLE_CAPACITY} = 0</li>
      *   <li>{@code QPACK_BLOCKED_STREAMS} = 0</li>
      *   <li>{@code ENABLE_CONNECT_PROTOCOL} = false</li>
-     *   <li>{@code MAX_FIELD_SECTION_SIZE} = unlimited</li>
+     *   <li>{@code MAX_FIELD_SECTION_SIZE} = 8192</li>
      *   <li>{@code H3_DATAGRAM} = false </>
      * </ul>
      *
@@ -249,7 +249,7 @@ public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
         return new Http3Settings()
                 .qpackMaxTableCapacity(0)
                 .qpackBlockedStreams(0)
-                .maxFieldSectionSize(16 * 1024 * 1024)
+                .maxFieldSectionSize(Http3CodecUtils.DEFAULT_MAX_FIELD_SECTION_SIZE)
                 .enableConnectProtocol(false)
                 .enableH3Datagram(false);
     }

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3SettingsTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3SettingsTest.java
@@ -48,7 +48,7 @@ public class Http3SettingsTest {
         assertEquals(0L, settings.qpackMaxTableCapacity());
         assertEquals(0L, settings.qpackBlockedStreams());
         assertEquals(Boolean.FALSE, settings.connectProtocolEnabled());
-        assertEquals(16 * 1024 * 1024, settings.maxFieldSectionSize());
+        assertEquals(Http3CodecUtils.DEFAULT_MAX_FIELD_SECTION_SIZE, settings.maxFieldSectionSize());
         assertEquals(Boolean.FALSE, settings.h3DatagramEnabled());
     }
 


### PR DESCRIPTION
Motivation:

While the RFC does not limit section size by default we should do so to reduce the risk of high memory usage. The user can adjust this if a higher limit should be used.

Modifications:

- Use default limit of 8k

Result:

Limit maximum size of the field section to 8kb by default
