### PR TITLE
Quic: Correctly implement NoQuicTokenHandler to correctly not validate tokens

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/NoQuicTokenHandler.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/NoQuicTokenHandler.java
@@ -20,9 +20,7 @@ import io.netty.buffer.ByteBuf;
 import java.net.InetSocketAddress;
 
 /**
- * {@link QuicTokenHandler} which will disable token generation / validation completely.
- * This will reduce the round-trip for QUIC connection migration, but will also weaking the
- * security during connection establishment.
+ * {@link QuicTokenHandler} which will not use any token and so also fail to validate any given token.
  */
 final class NoQuicTokenHandler implements QuicTokenHandler {
 
@@ -38,7 +36,7 @@ final class NoQuicTokenHandler implements QuicTokenHandler {
 
     @Override
     public int validateToken(ByteBuf token, InetSocketAddress address) {
-        return 0;
+        return -1;
     }
 
     @Override

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/NoQuicTokenHandlerTest.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/NoQuicTokenHandlerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.quic;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class NoQuicTokenHandlerTest {
+
+    @Test
+    public void testMaxTokenLength() {
+        assertEquals(0, NoQuicTokenHandler.INSTANCE.maxTokenLength());
+    }
+
+    @Test
+    public void testDontWriteToken() throws UnknownHostException {
+        ByteBuf out = Unpooled.buffer();
+        ByteBuf dcid = Unpooled.wrappedBuffer(QuicConnectionAddress.random().id());
+        try {
+            boolean written = NoQuicTokenHandler.INSTANCE.writeToken(out, dcid, new InetSocketAddress(
+                    InetAddress.getByAddress(new byte[] { 10, 10, 10, 10 }), 80));
+            assertFalse(written);
+            assertFalse(out.isReadable());
+        } finally {
+            out.release();
+            dcid.release();
+        }
+    }
+
+    @Test
+    public void testValidateToken() throws UnknownHostException {
+        ByteBuf token = Unpooled.wrappedBuffer(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8 });
+        try {
+            int offset = NoQuicTokenHandler.INSTANCE.validateToken(token, new InetSocketAddress(
+                    InetAddress.getByAddress(new byte[]{ 10, 10, 10, 10 }), 80));
+            assertEquals(-1, offset);
+        } finally {
+            token.release();
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

NoQuicTokenHandler is the tokenHandler used when the application does not set one. Its writeToken() returns false (server will not send Retry — acceptable), but validateToken() unconditionally return 0.
In QuicheQuicServerCodec.handlePacket(), a non-negative return from validateToken() is interpreted as 'token is valid, ODCID starts at offset 0', causing the server to call quiche_accept as if the client's
address had been validated by a Retry round-trip. Per RFC 9000 §8.1, a validated address lifts the 3× anti-amplification send limit. Thus any attacker who includes ANY non-empty token bytes in an Initial
packet — with a spoofed victim source IP — causes the Netty server to treat the victim as validated and reflect full-size handshake flights (certificates, etc.) toward it without the 3× cap. The correct
'no token handler' semantics would be to return -1 (invalid) so the normal un-validated path and amplification limit apply.

Modifications:

- Correctly return -1
- Add unit tests

Result:

Don't allow any token
