### PR TITLE
Wrapping plain trust manager silently disables hostname verification

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/util/InsecureTrustManagerFactory.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/InsecureTrustManagerFactory.java
@@ -17,6 +17,8 @@
 package io.netty.handler.ssl.util;
 
 import io.netty.util.internal.EmptyArrays;
+import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.SuppressJava6Requirement;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -41,7 +43,8 @@ public final class InsecureTrustManagerFactory extends SimpleTrustManagerFactory
 
     public static final TrustManagerFactory INSTANCE = new InsecureTrustManagerFactory();
 
-    private static final TrustManager tm = new X509TrustManager() {
+    private static final TrustManager tm = wrapIfNeeded(new X509TrustManager() {
+
         @Override
         public void checkClientTrusted(X509Certificate[] chain, String s) {
             if (logger.isDebugEnabled()) {
@@ -60,7 +63,18 @@ public final class InsecureTrustManagerFactory extends SimpleTrustManagerFactory
         public X509Certificate[] getAcceptedIssuers() {
             return EmptyArrays.EMPTY_X509_CERTIFICATES;
         }
-    };
+    });
+
+    @SuppressJava6Requirement(reason = "Usage guarded by java version check")
+    static X509TrustManager wrapIfNeeded(X509TrustManager tm) {
+        if (PlatformDependent.javaVersion() >= 7) {
+            // This needs to be X509ExtendedTrustManager so hostname verification is skipped as well.
+            // Otherwise the JDK will internally wrap it with AbstractTrustManagerWrapper and add hostname verification
+            // by itself.
+            return new X509TrustManagerWrapper(tm);
+        }
+        return tm;
+    }
 
     private InsecureTrustManagerFactory() { }
 

--- a/handler/src/main/java/io/netty/handler/ssl/util/SimpleTrustManagerFactory.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/SimpleTrustManagerFactory.java
@@ -18,15 +18,11 @@ package io.netty.handler.ssl.util;
 
 import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.internal.ObjectUtil;
-import io.netty.util.internal.PlatformDependent;
-import io.netty.util.internal.SuppressJava6Requirement;
 
 import javax.net.ssl.ManagerFactoryParameters;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.TrustManagerFactorySpi;
-import javax.net.ssl.X509ExtendedTrustManager;
-import javax.net.ssl.X509TrustManager;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -135,22 +131,9 @@ public abstract class SimpleTrustManagerFactory extends TrustManagerFactory {
             TrustManager[] trustManagers = this.trustManagers;
             if (trustManagers == null) {
                 trustManagers = parent.engineGetTrustManagers();
-                if (PlatformDependent.javaVersion() >= 7) {
-                    wrapIfNeeded(trustManagers);
-                }
                 this.trustManagers = trustManagers;
             }
             return trustManagers.clone();
-        }
-
-        @SuppressJava6Requirement(reason = "Usage guarded by java version check")
-        private static void wrapIfNeeded(TrustManager[] trustManagers) {
-            for (int i = 0; i < trustManagers.length; i++) {
-                final TrustManager tm = trustManagers[i];
-                if (tm instanceof X509TrustManager && !(tm instanceof X509ExtendedTrustManager)) {
-                    trustManagers[i] = new X509TrustManagerWrapper((X509TrustManager) tm);
-                }
-            }
         }
     }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/util/SimpleTrustManagerFactoryTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/util/SimpleTrustManagerFactoryTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl.util;
+
+import io.netty.util.internal.EmptyArrays;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.ManagerFactoryParameters;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.security.KeyStore;
+import java.security.cert.X509Certificate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class SimpleTrustManagerFactoryTest {
+
+    @Test
+    public void testNotWrap() {
+        final X509TrustManager tm = new X509TrustManager() {
+            @Override
+            public void checkClientTrusted(X509Certificate[] chain, String authType) {
+                // NOOP
+            }
+
+            @Override
+            public void checkServerTrusted(X509Certificate[] chain, String authType) {
+                // NOOP
+            }
+
+            @Override
+            public X509Certificate[] getAcceptedIssuers() {
+                return EmptyArrays.EMPTY_X509_CERTIFICATES;
+            }
+        };
+        SimpleTrustManagerFactory factory = new SimpleTrustManagerFactory() {
+            @Override
+            protected void engineInit(KeyStore keyStore) {
+                // NOOP
+            }
+
+            @Override
+            protected void engineInit(ManagerFactoryParameters managerFactoryParameters) {
+                // NOOP
+            }
+
+            @Override
+            protected TrustManager[] engineGetTrustManagers() {
+                return new TrustManager[] { tm };
+            }
+        };
+
+        TrustManager[] tms = factory.getTrustManagers();
+        assertEquals(1, tms.length);
+        assertSame(tm, tms[0]);
+    }
+}


### PR DESCRIPTION
Motivation:

We need to ensure we don't wrap X509TrustManager into X509ExtendedTrustManager as this will silently disable hostname verification

Modifications:

- Remove wrapping code
- Change InsecureTrustManagerFactory to disable verification

Result:

Correctly leaverage hostname verifications that is provided by the JDK internally.