### PR TITLE
DNS: Ensure query id is not predictible

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverChannelStrategy.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverChannelStrategy.java
@@ -22,6 +22,11 @@ public enum DnsNameResolverChannelStrategy {
     /**
      * Use the same underlying {@link io.netty.channel.Channel} for all queries produced by a single
      {@link DnsNameResolver} instance.
+     * <p>
+     * As the same {@link io.netty.channel.Channel} is used for all queries we will also use the same source port
+     * for all of these. To minimize the risk of spoofing integrators should ideally use multiple resolvers randomly,
+     * so that there is source port randomization following the recommendations of
+     * <a href="https://www.rfc-editor.org/rfc/rfc5452#section-9.2">RFC5452 Section 9.2</a>.
      */
     ChannelPerResolver,
     /**

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryIdSpace.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryIdSpace.java
@@ -16,9 +16,8 @@
 package io.netty.resolver.dns;
 
 import io.netty.util.internal.MathUtil;
-import io.netty.util.internal.PlatformDependent;
 
-import java.util.Random;
+import java.security.SecureRandom;
 
 /**
  * Special data-structure that will allow to retrieve the next query id to use, while still guarantee some sort
@@ -34,15 +33,16 @@ final class DnsQueryIdSpace {
     // If there are other buckets left that have at least 500 usable ids we will drop an unused bucket.
     private static final int BUCKET_DROP_THRESHOLD = 500;
     private final DnsQueryIdRange[] idBuckets = new DnsQueryIdRange[BUCKETS];
+    private final SecureRandom random = new SecureRandom();
 
     DnsQueryIdSpace() {
         assert idBuckets.length == MathUtil.findNextPositivePowerOfTwo(idBuckets.length);
         // We start with 1 bucket.
-        idBuckets[0] = newBucket(0);
+        idBuckets[0] = newBucket(0, random);
     }
 
-    private static DnsQueryIdRange newBucket(int idBucketsIdx) {
-        return new DnsQueryIdRange(BUCKET_SIZE, idBucketsIdx * BUCKET_SIZE);
+    private static DnsQueryIdRange newBucket(int idBucketsIdx, SecureRandom random) {
+        return new DnsQueryIdRange(BUCKET_SIZE, idBucketsIdx * BUCKET_SIZE, random);
     }
 
     /**
@@ -61,7 +61,7 @@ final class DnsQueryIdSpace {
                 }
             } else if (freeIdx == -1 ||
                     // Let's make it somehow random which free slot is used.
-                    PlatformDependent.threadLocalRandom().nextBoolean()) {
+                    random.nextBoolean()) {
                 // We have a slot that we can use to create a new bucket if we need to.
                 freeIdx = bucketIdx;
             }
@@ -72,7 +72,7 @@ final class DnsQueryIdSpace {
         }
 
         // We still have some slots free to store a new bucket. Let's do this now and use it to generate the next id.
-        DnsQueryIdRange bucket = newBucket(freeIdx);
+        DnsQueryIdRange bucket = newBucket(freeIdx, random);
         idBuckets[freeIdx] = bucket;
         int id = bucket.nextId();
         assert id >= 0;
@@ -141,11 +141,13 @@ final class DnsQueryIdSpace {
         // Holds all possible ids which are stored as unsigned shorts
         private final short[] ids;
         private final int startId;
+        private final SecureRandom random;
         private int count;
 
-        DnsQueryIdRange(int bucketSize, int startId) {
+        DnsQueryIdRange(int bucketSize, int startId, SecureRandom random) {
             this.ids = new short[bucketSize];
             this.startId = startId;
+            this.random = random;
             for (int v = startId; v < bucketSize + startId; v++) {
                 pushId(v);
             }
@@ -178,7 +180,6 @@ final class DnsQueryIdSpace {
             }
             assert id <= startId + ids.length && id >= startId;
             // pick a slot for our index, and whatever was in that slot before will get moved to the tail.
-            Random random = PlatformDependent.threadLocalRandom();
             int insertionPosition = random.nextInt(count + 1);
             short moveId = ids[insertionPosition];
             short insertId = (short) id;


### PR DESCRIPTION
Motivation:

Netty's DNS resolver uses a predictable PRNG for generating DNS transaction IDs and defaults to a static UDP source port. This combination reduces the entropy of DNS queries, enabling DNS Cache Poisoning (Kaminsky attack).

Modifications:

- Replace usage of ThreadLocalRandom with SecureRandom

Result:

query id is not predictible anymore
