### PR TITLE
SSL: Use sane defaults as limits for the client hello length and timeout

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/AbstractSniHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/AbstractSniHandler.java
@@ -121,6 +121,7 @@ public abstract class AbstractSniHandler<T> extends SslClientHelloHandler<T> {
         return null;
     }
 
+    static final long DEFAULT_HANDSHAKE_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(10);
     protected final long handshakeTimeoutMillis;
     private ScheduledFuture<?> timeoutFuture;
     private String hostname;
@@ -129,7 +130,7 @@ public abstract class AbstractSniHandler<T> extends SslClientHelloHandler<T> {
      * @param handshakeTimeoutMillis    the handshake timeout in milliseconds
      */
     protected AbstractSniHandler(long handshakeTimeoutMillis) {
-        this(0, handshakeTimeoutMillis);
+        this(DEFAULT_MAX_CLIENT_HELLO_LENGTH, handshakeTimeoutMillis);
     }
 
     /**
@@ -142,7 +143,7 @@ public abstract class AbstractSniHandler<T> extends SslClientHelloHandler<T> {
     }
 
     public AbstractSniHandler() {
-        this(0, 0L);
+        this(DEFAULT_MAX_CLIENT_HELLO_LENGTH, DEFAULT_HANDSHAKE_TIMEOUT_MILLIS);
     }
 
     @Override

--- a/handler/src/main/java/io/netty/handler/ssl/SniHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SniHandler.java
@@ -82,7 +82,7 @@ public class SniHandler extends AbstractSniHandler<SslContext> {
      */
     @SuppressWarnings("unchecked")
     public SniHandler(AsyncMapping<? super String, ? extends SslContext> mapping) {
-        this(mapping, 0, 0L);
+        this(mapping, DEFAULT_MAX_CLIENT_HELLO_LENGTH, DEFAULT_HANDSHAKE_TIMEOUT_MILLIS);
     }
 
     /**
@@ -119,7 +119,7 @@ public class SniHandler extends AbstractSniHandler<SslContext> {
      * @param handshakeTimeoutMillis the handshake timeout in milliseconds
      */
     public SniHandler(AsyncMapping<? super String, ? extends SslContext> mapping, long handshakeTimeoutMillis) {
-        this(mapping, 0, handshakeTimeoutMillis);
+        this(mapping, DEFAULT_MAX_CLIENT_HELLO_LENGTH, handshakeTimeoutMillis);
     }
 
     /**

--- a/handler/src/main/java/io/netty/handler/ssl/SslClientHelloHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslClientHelloHandler.java
@@ -44,6 +44,10 @@ public abstract class SslClientHelloHandler<T> extends ByteToMessageDecoder impl
      */
     public static final int MAX_CLIENT_HELLO_LENGTH = 0xFFFFFF;
 
+    // Let's use a default limit of 64kb which should be big enough for almost everything in practice but still
+    // small enough to not allocate to much memory.
+    static final int DEFAULT_MAX_CLIENT_HELLO_LENGTH = 64 * 1024;
+
     private static final InternalLogger logger =
             InternalLoggerFactory.getInstance(SslClientHelloHandler.class);
 
@@ -54,7 +58,7 @@ public abstract class SslClientHelloHandler<T> extends ByteToMessageDecoder impl
     private ByteBuf handshakeBuffer;
 
     public SslClientHelloHandler() {
-        this(MAX_CLIENT_HELLO_LENGTH);
+        this(DEFAULT_MAX_CLIENT_HELLO_LENGTH);
     }
 
     protected SslClientHelloHandler(int maxClientHelloLength) {


### PR DESCRIPTION
Motivation:

There were various issues here... first of in SslClientHelloHandler we used 16MB as default maximum limit for the client hello which could lead to huge memory usage. Second we used no limit at all and no timeout in AbstractSniHandler and its subclasses which is even worse.

Modifications:

- Use 64KB as default limit
- Use 10 seconds as default timeout (same as in SslHandler)

Result:

Saner defaults which helps to guard against high memory usage
