### PR TITLE
DNS: Only cache CNAME if part of the queried domain

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -641,8 +641,9 @@ abstract class DnsResolveContext<T> {
                 final DnsRecordType type = question.type();
 
                 if (type == DnsRecordType.CNAME) {
-                    onResponseCNAME(question, buildAliasMap(envelope.content(), cnameCache(), parent.executor()),
-                                    queryLifecycleObserver, promise);
+                    onResponseCNAME(question,
+                            buildAliasMap(question.name(), envelope.content(), cnameCache(), parent.executor()),
+                            queryLifecycleObserver, promise);
                     return;
                 }
 
@@ -832,7 +833,7 @@ abstract class DnsResolveContext<T> {
 
         // We often get a bunch of CNAMES as well when we asked for A/AAAA.
         final DnsResponse response = envelope.content();
-        final Map<String, String> cnames = buildAliasMap(response, cnameCache(), parent.executor());
+        final Map<String, String> cnames = buildAliasMap(question.name(), response, cnameCache(), parent.executor());
         final int answerCount = response.count(DnsSection.ANSWER);
 
         boolean found = false;
@@ -991,7 +992,8 @@ abstract class DnsResolveContext<T> {
         }
     }
 
-    private static Map<String, String> buildAliasMap(DnsResponse response, DnsCnameCache cache, EventLoop loop) {
+    private static Map<String, String> buildAliasMap(
+            String queryName, DnsResponse response, DnsCnameCache cache, EventLoop loop) {
         final int answerCount = response.count(DnsSection.ANSWER);
         Map<String, String> cnames = null;
         for (int i = 0; i < answerCount; i ++) {
@@ -1022,7 +1024,13 @@ abstract class DnsResolveContext<T> {
             String nameWithDot = hostnameWithDot(name);
             String mappingWithDot = hostnameWithDot(mapping);
             if (!nameWithDot.equalsIgnoreCase(mappingWithDot)) {
-                cache.cache(nameWithDot, mappingWithDot, r.timeToLive(), loop);
+                String queryNameWithDot = hostnameWithDot(queryName.toLowerCase(Locale.US));
+                // Only cache the CNAME if the owner is in the bailiwick of the original query name.
+                boolean inBailiwick = nameWithDot.equals(queryNameWithDot) ||
+                        nameWithDot.endsWith("." + queryNameWithDot);
+                if (inBailiwick) {
+                    cache.cache(nameWithDot, mappingWithDot, r.timeToLive(), loop);
+                }
                 cnames.put(name, mapping);
             }
         }

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -3043,6 +3043,74 @@ public class DnsNameResolverTest {
         }
     }
 
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testCnameCacheBailiwick(DnsNameResolverChannelStrategy strategy) throws Exception {
+        final Map<String, String> cache = new ConcurrentHashMap<>();
+
+        TestDnsServer dnsServer = new TestDnsServer(question -> {
+            if ("x.netty.io".equals(question.getDomainName())) {
+                Set<ResourceRecord> records = new HashSet<>();
+                // Valid CNAME (in bailiwick of query)
+                records.add(new TestDnsServer.TestResourceRecord(
+                        "x.netty.io", RecordType.CNAME,
+                        Collections.singletonMap(DnsAttribute.DOMAIN_NAME.toLowerCase(), "cname.netty.io")));
+                // Invalid CNAME (out of bailiwick of query)
+                records.add(new TestDnsServer.TestResourceRecord(
+                        "cname.netty.io", RecordType.CNAME,
+                        Collections.singletonMap(DnsAttribute.DOMAIN_NAME.toLowerCase(), "evil.com")));
+                // Provide an A record to satisfy the resolution
+                records.add(new TestDnsServer.TestResourceRecord(
+                        "evil.com", RecordType.A,
+                        Collections.singletonMap(DnsAttribute.IP_ADDRESS.toLowerCase(), "10.0.0.99")));
+                return records;
+            }
+            return Collections.emptySet();
+        });
+        dnsServer.start();
+        DnsNameResolver resolver = null;
+        try {
+            DnsNameResolverBuilder builder = newResolver(strategy)
+                    .recursionDesired(true)
+                    .resolvedAddressTypes(ResolvedAddressTypes.IPV4_ONLY)
+                    .maxQueriesPerResolve(16)
+                    .nameServerProvider(new SingletonDnsServerAddressStreamProvider(dnsServer.localAddress()))
+                    .resolveCache(NoopDnsCache.INSTANCE)
+                    .cnameCache(new DnsCnameCache() {
+                        @Override
+                        public String get(String hostname) {
+                            return cache.get(hostname);
+                        }
+
+                        @Override
+                        public void cache(String hostname, String cname, long originalTtl, EventLoop loop) {
+                            cache.put(hostname, cname);
+                        }
+
+                        @Override
+                        public void clear() {
+                        }
+
+                        @Override
+                        public boolean clear(String hostname) {
+                            return false;
+                        }
+                    });
+            resolver = builder.build();
+            resolver.resolveAll("x.netty.io").syncUninterruptibly();
+
+            // The CNAME for x.netty.io should be cached because it was the queried name
+            assertEquals("cname.netty.io.", cache.get("x.netty.io."));
+            // The CNAME for cname.netty.io should NOT be cached because it is out of bailiwick for x.netty.io
+            assertNull(cache.get("cname.netty.io."));
+        } finally {
+            dnsServer.stop();
+            if (resolver != null) {
+                resolver.close();
+            }
+        }
+    }
+
     @Test
     public void testInstanceWithNullPreferredAddressType() {
         new DnsNameResolver(

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -3052,7 +3052,7 @@ public class DnsNameResolverTest {
             @Override
             public Set<ResourceRecord> getRecords(QuestionRecord question) throws DnsException {
                 if ("x.netty.io".equals(question.getDomainName())) {
-                    Set<ResourceRecord> records = new HashSet<>();
+                    Set<ResourceRecord> records = new HashSet<ResourceRecord>();
                     // Valid CNAME (in bailiwick of query)
                     records.add(new TestDnsServer.TestResourceRecord(
                             "x.netty.io", RecordType.CNAME,

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -3046,26 +3046,29 @@ public class DnsNameResolverTest {
     @ParameterizedTest
     @EnumSource(DnsNameResolverChannelStrategy.class)
     public void testCnameCacheBailiwick(DnsNameResolverChannelStrategy strategy) throws Exception {
-        final Map<String, String> cache = new ConcurrentHashMap<>();
+        final Map<String, String> cache = new ConcurrentHashMap<String, String>();
 
-        TestDnsServer dnsServer = new TestDnsServer(question -> {
-            if ("x.netty.io".equals(question.getDomainName())) {
-                Set<ResourceRecord> records = new HashSet<>();
-                // Valid CNAME (in bailiwick of query)
-                records.add(new TestDnsServer.TestResourceRecord(
-                        "x.netty.io", RecordType.CNAME,
-                        Collections.singletonMap(DnsAttribute.DOMAIN_NAME.toLowerCase(), "cname.netty.io")));
-                // Invalid CNAME (out of bailiwick of query)
-                records.add(new TestDnsServer.TestResourceRecord(
-                        "cname.netty.io", RecordType.CNAME,
-                        Collections.singletonMap(DnsAttribute.DOMAIN_NAME.toLowerCase(), "evil.com")));
-                // Provide an A record to satisfy the resolution
-                records.add(new TestDnsServer.TestResourceRecord(
-                        "evil.com", RecordType.A,
-                        Collections.singletonMap(DnsAttribute.IP_ADDRESS.toLowerCase(), "10.0.0.99")));
-                return records;
+        TestDnsServer dnsServer = new TestDnsServer(new RecordStore() {
+            @Override
+            public Set<ResourceRecord> getRecords(QuestionRecord question) throws DnsException {
+                if ("x.netty.io".equals(question.getDomainName())) {
+                    Set<ResourceRecord> records = new HashSet<>();
+                    // Valid CNAME (in bailiwick of query)
+                    records.add(new TestDnsServer.TestResourceRecord(
+                            "x.netty.io", RecordType.CNAME,
+                            Collections.singletonMap(DnsAttribute.DOMAIN_NAME.toLowerCase(), "cname.netty.io")));
+                    // Invalid CNAME (out of bailiwick of query)
+                    records.add(new TestDnsServer.TestResourceRecord(
+                            "cname.netty.io", RecordType.CNAME,
+                            Collections.singletonMap(DnsAttribute.DOMAIN_NAME.toLowerCase(), "evil.com")));
+                    // Provide an A record to satisfy the resolution
+                    records.add(new TestDnsServer.TestResourceRecord(
+                            "evil.com", RecordType.A,
+                            Collections.singletonMap(DnsAttribute.IP_ADDRESS.toLowerCase(), "10.0.0.99")));
+                    return records;
+                }
+                return Collections.emptySet();
             }
-            return Collections.emptySet();
         });
         dnsServer.start();
         DnsNameResolver resolver = null;

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -3056,15 +3056,18 @@ public class DnsNameResolverTest {
                     // Valid CNAME (in bailiwick of query)
                     records.add(new TestDnsServer.TestResourceRecord(
                             "x.netty.io", RecordType.CNAME,
-                            Collections.singletonMap(DnsAttribute.DOMAIN_NAME.toLowerCase(), "cname.netty.io")));
+                            Collections.<String, Object>singletonMap(
+                                    DnsAttribute.DOMAIN_NAME.toLowerCase(), "cname.netty.io")));
                     // Invalid CNAME (out of bailiwick of query)
                     records.add(new TestDnsServer.TestResourceRecord(
                             "cname.netty.io", RecordType.CNAME,
-                            Collections.singletonMap(DnsAttribute.DOMAIN_NAME.toLowerCase(), "evil.com")));
+                            Collections.<String, Object>singletonMap(
+                                    DnsAttribute.DOMAIN_NAME.toLowerCase(), "evil.com")));
                     // Provide an A record to satisfy the resolution
                     records.add(new TestDnsServer.TestResourceRecord(
                             "evil.com", RecordType.A,
-                            Collections.singletonMap(DnsAttribute.IP_ADDRESS.toLowerCase(), "10.0.0.99")));
+                            Collections.<String, Object>singletonMap(
+                                    DnsAttribute.IP_ADDRESS.toLowerCase(), "10.0.0.99")));
                     return records;
                 }
                 return Collections.emptySet();


### PR DESCRIPTION
Motivation:

We should only cache the CNAME if it is part of the queried domain to ensure the name server is really authoritive for it and not provide us incorrect data.

Modifications:

- Only cache if CNAME is part of the queried domain
- Add unit test

Result:

No more DNS Cache Poisoning (Bailiwick Bypass) possible
