### PR TITLE
SCTP: Limit the number of inflight incomplete SCTP messages and the number of fragments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1597,6 +1597,22 @@
                   <newValue>7</newValue>
                   <justification>SETTINGS_ENABLE_CONNECT_PROTOCOL was added to the standard HTTP/2 settings.</justification>
                 </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.annotation.removed</code>
+                  <old>method void io.netty.channel.ChannelInboundHandlerAdapter::channelInactive(io.netty.channel.ChannelHandlerContext) throws java.lang.Exception @ io.netty.handler.codec.redis.RedisArrayAggregator</old>
+                  <new>method void io.netty.handler.codec.redis.RedisArrayAggregator::channelInactive(io.netty.channel.ChannelHandlerContext) throws java.lang.Exception</new>
+                  <annotation>@io.netty.channel.ChannelHandlerMask.Skip</annotation>
+                  <justification>Change is harmless for compatibility. Needed for a security fix.</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.annotation.removed</code>
+                  <old>method void io.netty.channel.ChannelInboundHandlerAdapter::exceptionCaught(io.netty.channel.ChannelHandlerContext, java.lang.Throwable) throws java.lang.Exception @ io.netty.handler.codec.sctp.SctpMessageCompletionHandler</old>
+                  <new>method void io.netty.handler.codec.sctp.SctpMessageCompletionHandler::exceptionCaught(io.netty.channel.ChannelHandlerContext, java.lang.Throwable) throws java.lang.Exception</new>
+                  <annotation>@io.netty.channel.ChannelHandlerMask.Skip</annotation>
+                  <justification>Change is harmless for compatibility. Needed for a security fix.</justification>
+                </item>
               </differences>
             </revapi.differences>
           </analysisConfiguration>

--- a/transport-sctp/src/main/java/io/netty/handler/codec/sctp/SctpMessageCompletionHandler.java
+++ b/transport-sctp/src/main/java/io/netty/handler/codec/sctp/SctpMessageCompletionHandler.java
@@ -37,7 +37,7 @@ import static io.netty.util.internal.ObjectUtil.checkPositive;
  * {@link ChannelInboundHandler}.
  */
 public class SctpMessageCompletionHandler extends MessageToMessageDecoder<SctpMessage> {
-    private final IntObjectMap<List<ByteBuf>> incompleteSctpMessages = new IntObjectHashMap<>();
+    private final IntObjectMap<List<ByteBuf>> incompleteSctpMessages = new IntObjectHashMap<List<ByteBuf>>();
     private final int maxIncompleteSctpMessages;
     private final int maxFragments;
 

--- a/transport-sctp/src/main/java/io/netty/handler/codec/sctp/SctpMessageCompletionHandler.java
+++ b/transport-sctp/src/main/java/io/netty/handler/codec/sctp/SctpMessageCompletionHandler.java
@@ -17,15 +17,19 @@
 package io.netty.handler.codec.sctp;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
+import io.netty.buffer.CompositeByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.sctp.SctpMessage;
+import io.netty.handler.codec.CodecException;
 import io.netty.handler.codec.MessageToMessageDecoder;
 import io.netty.util.collection.IntObjectHashMap;
 import io.netty.util.collection.IntObjectMap;
 
+import java.util.ArrayList;
 import java.util.List;
+
+import static io.netty.util.internal.ObjectUtil.checkPositive;
 
 /**
  * {@link MessageToMessageDecoder} which will take care of handle fragmented {@link SctpMessage}s, so
@@ -33,7 +37,25 @@ import java.util.List;
  * {@link ChannelInboundHandler}.
  */
 public class SctpMessageCompletionHandler extends MessageToMessageDecoder<SctpMessage> {
-    private final IntObjectMap<ByteBuf> fragments = new IntObjectHashMap<ByteBuf>();
+    private final IntObjectMap<List<ByteBuf>> incompleteSctpMessages = new IntObjectHashMap<>();
+    private final int maxIncompleteSctpMessages;
+    private final int maxFragments;
+
+    public SctpMessageCompletionHandler() {
+        this(128, 128);
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param maxIncompleteSctpMessages the maximum number of incomplete sctp message inflight.
+     * @param maxFragments              the maximum number of fragments per sctp message.
+     */
+    public SctpMessageCompletionHandler(int maxIncompleteSctpMessages, int maxFragments) {
+        super(SctpMessage.class);
+        this.maxIncompleteSctpMessages = checkPositive(maxIncompleteSctpMessages, "maxIncompleteSctpMessages");
+        this.maxFragments = checkPositive(maxFragments, "maxFragments");
+    }
 
     @Override
     protected void decode(ChannelHandlerContext ctx, SctpMessage msg, List<Object> out) throws Exception {
@@ -43,38 +65,59 @@ public class SctpMessageCompletionHandler extends MessageToMessageDecoder<SctpMe
         final boolean isComplete = msg.isComplete();
         final boolean isUnordered = msg.isUnordered();
 
-        ByteBuf frag = fragments.remove(streamIdentifier);
+        List<ByteBuf> frag = incompleteSctpMessages.get(streamIdentifier);
         if (frag == null) {
-            frag = Unpooled.EMPTY_BUFFER;
-        }
-
-        if (isComplete && !frag.isReadable()) {
-            //data chunk is not fragmented
-            out.add(msg);
-        } else if (!isComplete && frag.isReadable()) {
-            //more message to complete
-            fragments.put(streamIdentifier, Unpooled.wrappedBuffer(frag, byteBuf));
-        } else if (isComplete && frag.isReadable()) {
-            //last message to complete
-            SctpMessage assembledMsg = new SctpMessage(
-                    protocolIdentifier,
-                    streamIdentifier,
-                    isUnordered,
-                    Unpooled.wrappedBuffer(frag, byteBuf));
-            out.add(assembledMsg);
+            // No previous fragments.
+            if (isComplete) {
+                out.add(msg.retain());
+            } else {
+                if (maxIncompleteSctpMessages <= incompleteSctpMessages.size()) {
+                    throw new CodecException(
+                            "Too many incomplete sctp messages in flight: " + maxIncompleteSctpMessages);
+                }
+                //first incomplete message
+                frag = new ArrayList<>();
+                frag.add(byteBuf.retain());
+                incompleteSctpMessages.put(streamIdentifier, frag);
+            }
         } else {
-            //first incomplete message
-            fragments.put(streamIdentifier, byteBuf);
+            if (maxFragments <= frag.size()) {
+                throw new CodecException("Too many fragments for sctp message: " + maxFragments);
+            }
+            frag.add(byteBuf.retain());
+            if (isComplete) {
+                // Is complete so remove it.
+                incompleteSctpMessages.remove(streamIdentifier);
+                CompositeByteBuf composite = ctx.alloc().compositeBuffer();
+
+                for (int i = 0; i < frag.size(); i++) {
+                    composite.addComponent(true, frag.get(i));
+                }
+                // last message to complete
+                SctpMessage assembledMsg = new SctpMessage(
+                        protocolIdentifier,
+                        streamIdentifier,
+                        isUnordered,
+                        composite);
+                out.add(assembledMsg);
+            }
         }
-        byteBuf.retain();
     }
 
     @Override
     public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
-        for (ByteBuf buffer: fragments.values()) {
-            buffer.release();
+        for (List<ByteBuf> buffers: incompleteSctpMessages.values()) {
+            for (ByteBuf buffer: buffers) {
+                buffer.release();
+            }
         }
-        fragments.clear();
+        incompleteSctpMessages.clear();
         super.handlerRemoved(ctx);
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        super.exceptionCaught(ctx, cause);
+        ctx.close();
     }
 }

--- a/transport-sctp/src/main/java/io/netty/handler/codec/sctp/SctpMessageCompletionHandler.java
+++ b/transport-sctp/src/main/java/io/netty/handler/codec/sctp/SctpMessageCompletionHandler.java
@@ -76,7 +76,7 @@ public class SctpMessageCompletionHandler extends MessageToMessageDecoder<SctpMe
                             "Too many incomplete sctp messages in flight: " + maxIncompleteSctpMessages);
                 }
                 //first incomplete message
-                frag = new ArrayList<>();
+                frag = new ArrayList<ByteBuf>();
                 frag.add(byteBuf.retain());
                 incompleteSctpMessages.put(streamIdentifier, frag);
             }

--- a/transport-sctp/src/test/java/io/netty/handler/codec/sctp/SctpMessageCompletionHandlerTest.java
+++ b/transport-sctp/src/test/java/io/netty/handler/codec/sctp/SctpMessageCompletionHandlerTest.java
@@ -21,6 +21,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.sctp.SctpMessage;
+import io.netty.handler.codec.CodecException;
 import io.netty.util.SuppressForbidden;
 import org.junit.jupiter.api.Test;
 
@@ -28,6 +29,9 @@ import java.net.SocketAddress;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SctpMessageCompletionHandlerTest {
 
@@ -47,8 +51,61 @@ public class SctpMessageCompletionHandlerTest {
         assertEquals(0, buffer2.refCnt());
     }
 
+    @Test
+    public void testIncompleteMessagesLimited() {
+        EmbeddedChannel channel = new EmbeddedChannel(new SctpMessageCompletionHandler(1, 2));
+        ByteBuf buffer = Unpooled.wrappedBuffer(new byte[] { 1, 2, 3, 4 });
+        ByteBuf buffer2 = Unpooled.wrappedBuffer(new byte[] { 1, 2, 3, 4 });
+        SctpMessage message = new SctpMessage(new TestMessageInfo(false, 1), buffer);
+        assertFalse(channel.writeInbound(message));
+        assertEquals(1, buffer.refCnt());
+        SctpMessage message2 = new SctpMessage(new TestMessageInfo(false, 2), buffer2);
+        assertThrows(CodecException.class, () -> channel.writeInbound(message2));
+
+        assertEquals(1, buffer.refCnt());
+        assertEquals(0, buffer2.refCnt());
+        assertFalse(channel.finish());
+        assertEquals(0, buffer.refCnt());
+        assertEquals(0, buffer2.refCnt());
+    }
+
+    @Test
+    public void testFragmentsLimited() {
+        EmbeddedChannel channel = new EmbeddedChannel(new SctpMessageCompletionHandler(1, 2));
+        ByteBuf buffer = Unpooled.wrappedBuffer(new byte[] { 1, 2, 3, 4 });
+        ByteBuf buffer2 = Unpooled.wrappedBuffer(new byte[] { 1, 2, 3, 4 });
+        ByteBuf buffer3 = Unpooled.wrappedBuffer(new byte[] { 1, 2, 3, 4 });
+
+        assertFalse(channel.writeInbound(new SctpMessage(new TestMessageInfo(false, 1), buffer)));
+        assertEquals(1, buffer.refCnt());
+
+        assertFalse(channel.writeInbound(new SctpMessage(new TestMessageInfo(false, 1), buffer2)));
+        assertEquals(1, buffer2.refCnt());
+
+        assertThrows(CodecException.class, () ->
+                channel.writeInbound(new SctpMessage(new TestMessageInfo(true, 1), buffer3)));
+        assertEquals(0, buffer3.refCnt());
+
+        assertFalse(channel.finish());
+        assertEquals(0, buffer.refCnt());
+        assertEquals(0, buffer2.refCnt());
+    }
+
+    @Test
+    public void testNotFragmented() {
+        EmbeddedChannel channel = new EmbeddedChannel(new SctpMessageCompletionHandler());
+        ByteBuf buffer = Unpooled.wrappedBuffer(new byte[] { 1, 2, 3, 4 });
+        SctpMessage message = new SctpMessage(new TestMessageInfo(true, 1), buffer);
+        assertTrue(channel.writeInbound(message));
+        SctpMessage read = channel.readInbound();
+        assertSame(message, read);
+        assertEquals(1, read.refCnt());
+        read.release();
+        assertFalse(channel.finish());
+    }
+
     @SuppressForbidden(reason = "test-only")
-    private final class TestMessageInfo extends MessageInfo {
+    private static final class TestMessageInfo extends MessageInfo {
 
         private final boolean complete;
         private final int streamNumber;

--- a/transport-sctp/src/test/java/io/netty/handler/codec/sctp/SctpMessageCompletionHandlerTest.java
+++ b/transport-sctp/src/test/java/io/netty/handler/codec/sctp/SctpMessageCompletionHandlerTest.java
@@ -24,6 +24,7 @@ import io.netty.channel.sctp.SctpMessage;
 import io.netty.handler.codec.CodecException;
 import io.netty.util.SuppressForbidden;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.net.SocketAddress;
 
@@ -53,14 +54,19 @@ public class SctpMessageCompletionHandlerTest {
 
     @Test
     public void testIncompleteMessagesLimited() {
-        EmbeddedChannel channel = new EmbeddedChannel(new SctpMessageCompletionHandler(1, 2));
+        final EmbeddedChannel channel = new EmbeddedChannel(new SctpMessageCompletionHandler(1, 2));
         ByteBuf buffer = Unpooled.wrappedBuffer(new byte[] { 1, 2, 3, 4 });
         ByteBuf buffer2 = Unpooled.wrappedBuffer(new byte[] { 1, 2, 3, 4 });
         SctpMessage message = new SctpMessage(new TestMessageInfo(false, 1), buffer);
         assertFalse(channel.writeInbound(message));
         assertEquals(1, buffer.refCnt());
-        SctpMessage message2 = new SctpMessage(new TestMessageInfo(false, 2), buffer2);
-        assertThrows(CodecException.class, () -> channel.writeInbound(message2));
+        final SctpMessage message2 = new SctpMessage(new TestMessageInfo(false, 2), buffer2);
+        assertThrows(CodecException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                channel.writeInbound(message2);
+            }
+        });
 
         assertEquals(1, buffer.refCnt());
         assertEquals(0, buffer2.refCnt());
@@ -71,10 +77,10 @@ public class SctpMessageCompletionHandlerTest {
 
     @Test
     public void testFragmentsLimited() {
-        EmbeddedChannel channel = new EmbeddedChannel(new SctpMessageCompletionHandler(1, 2));
+        final EmbeddedChannel channel = new EmbeddedChannel(new SctpMessageCompletionHandler(1, 2));
         ByteBuf buffer = Unpooled.wrappedBuffer(new byte[] { 1, 2, 3, 4 });
         ByteBuf buffer2 = Unpooled.wrappedBuffer(new byte[] { 1, 2, 3, 4 });
-        ByteBuf buffer3 = Unpooled.wrappedBuffer(new byte[] { 1, 2, 3, 4 });
+        final ByteBuf buffer3 = Unpooled.wrappedBuffer(new byte[] { 1, 2, 3, 4 });
 
         assertFalse(channel.writeInbound(new SctpMessage(new TestMessageInfo(false, 1), buffer)));
         assertEquals(1, buffer.refCnt());
@@ -82,8 +88,12 @@ public class SctpMessageCompletionHandlerTest {
         assertFalse(channel.writeInbound(new SctpMessage(new TestMessageInfo(false, 1), buffer2)));
         assertEquals(1, buffer2.refCnt());
 
-        assertThrows(CodecException.class, () ->
-                channel.writeInbound(new SctpMessage(new TestMessageInfo(true, 1), buffer3)));
+        assertThrows(CodecException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                channel.writeInbound(new SctpMessage(new TestMessageInfo(true, 1), buffer3));
+            }
+        });
         assertEquals(0, buffer3.refCnt());
 
         assertFalse(channel.finish());

--- a/transport-sctp/src/test/java/io/netty/handler/codec/sctp/SctpMessageCompletionHandlerTest.java
+++ b/transport-sctp/src/test/java/io/netty/handler/codec/sctp/SctpMessageCompletionHandlerTest.java
@@ -67,12 +67,10 @@ public class SctpMessageCompletionHandlerTest {
                 channel.writeInbound(message2);
             }
         });
-
-        assertEquals(1, buffer.refCnt());
-        assertEquals(0, buffer2.refCnt());
-        assertFalse(channel.finish());
+        // exceptionCaught closes the channel, triggering handlerRemoved which releases all buffered fragments
         assertEquals(0, buffer.refCnt());
         assertEquals(0, buffer2.refCnt());
+        assertFalse(channel.finish());
     }
 
     @Test


### PR DESCRIPTION
Motivation:

SctpMessageCompletionHandler did not inforce any limits and so could cause unbound memory usage.

Modifications:

- Add new constructor that takes a limit for the maximum incomplete SCTP messages in flight and the number of fragments
- Use sane defaults
- Add unit tests

Result:

No more unbound memory usage
