### PR TITLE
Redis: Correctly release incomplete message on removal when using RedisArrayAggregator

### DIFF
--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisArrayAggregator.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisArrayAggregator.java
@@ -18,6 +18,7 @@ package io.netty.handler.codec.redis;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.CodecException;
 import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.handler.codec.PrematureChannelClosureException;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.UnstableApi;
@@ -118,6 +119,28 @@ public final class RedisArrayAggregator extends MessageToMessageDecoder<RedisMes
         AggregateState(int length) {
             this.length = length;
             this.children = new ArrayList<RedisMessage>(length);
+        }
+    }
+
+    @Override
+    public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+        super.handlerRemoved(ctx);
+        for (AggregateState state : depths) {
+            for (RedisMessage message : state.children) {
+                ReferenceCountUtil.safeRelease(message);
+            }
+        }
+        depths.clear();
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        super.channelInactive(ctx);
+
+        if (!depths.isEmpty()) {
+            ctx.fireExceptionCaught(new PrematureChannelClosureException(
+                    "channel gone inactive with " + depths.size() +
+                            " messages still incomplete"));
         }
     }
 }

--- a/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisArrayAggregatorTest.java
+++ b/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisArrayAggregatorTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.netty.handler.codec.redis;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.CodecException;
+import io.netty.handler.codec.PrematureChannelClosureException;
+import io.netty.util.CharsetUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class RedisArrayAggregatorTest {
+
+    @Test
+    public void testLimitNested() {
+        byte[] arrayHeader = "*1\r\n".getBytes(CharsetUtil.US_ASCII);
+        int maxNestedDepth = 100;
+        EmbeddedChannel channel = new EmbeddedChannel(new RedisDecoder(),
+                new RedisArrayAggregator(maxNestedDepth));
+        for (int i = 0; i < maxNestedDepth; i++) {
+            assertFalse(channel.writeInbound(Unpooled.wrappedBuffer(arrayHeader)));
+        }
+
+        // Next write should trigger an exception.
+        assertThrows(CodecException.class, () -> channel.writeInbound(Unpooled.wrappedBuffer(arrayHeader)));
+        assertFalse(channel.finishAndReleaseAll());
+    }
+
+    @Test
+    void testDoesNotLeakOnClose() {
+        final EmbeddedChannel ch = new EmbeddedChannel(new RedisArrayAggregator());
+        assertFalse(ch.writeInbound(new ArrayHeaderRedisMessage(2)));
+
+        FullBulkStringRedisMessage redisMessage = new FullBulkStringRedisMessage(Unpooled.buffer());
+        assertEquals(1, redisMessage.refCnt());
+        assertFalse(ch.writeInbound(redisMessage));
+        assertEquals(1, redisMessage.refCnt());
+
+        assertThrows(PrematureChannelClosureException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                ch.finish();
+            }
+        });
+        assertEquals(0, redisMessage.refCnt());
+    }
+
+    @Test
+    void testDoesNotLeakOnRemoval() {
+        EmbeddedChannel ch = new EmbeddedChannel(new RedisArrayAggregator());
+        assertFalse(ch.writeInbound(new ArrayHeaderRedisMessage(2)));
+
+        FullBulkStringRedisMessage redisMessage = new FullBulkStringRedisMessage(Unpooled.buffer());
+        assertEquals(1, redisMessage.refCnt());
+        assertFalse(ch.writeInbound(redisMessage));
+        assertEquals(1, redisMessage.refCnt());
+        ch.pipeline().remove(RedisArrayAggregator.class);
+        assertEquals(0, redisMessage.refCnt());
+        assertFalse(ch.finish());
+    }
+}

--- a/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisArrayAggregatorTest.java
+++ b/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisArrayAggregatorTest.java
@@ -17,9 +17,7 @@ package io.netty.handler.codec.redis;
 
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.handler.codec.CodecException;
 import io.netty.handler.codec.PrematureChannelClosureException;
-import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
@@ -28,26 +26,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RedisArrayAggregatorTest {
-
-    @Test
-    public void testLimitNested() {
-        final byte[] arrayHeader = "*1\r\n".getBytes(CharsetUtil.US_ASCII);
-        int maxNestedDepth = 100;
-        final EmbeddedChannel channel = new EmbeddedChannel(new RedisDecoder(),
-                new RedisArrayAggregator(maxNestedDepth));
-        for (int i = 0; i < maxNestedDepth; i++) {
-            assertFalse(channel.writeInbound(Unpooled.wrappedBuffer(arrayHeader)));
-        }
-
-        // Next write should trigger an exception.
-        assertThrows(CodecException.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                channel.writeInbound(Unpooled.wrappedBuffer(arrayHeader));
-            }
-        });
-        assertFalse(channel.finishAndReleaseAll());
-    }
 
     @Test
     void testDoesNotLeakOnClose() {

--- a/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisArrayAggregatorTest.java
+++ b/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisArrayAggregatorTest.java
@@ -31,16 +31,21 @@ public class RedisArrayAggregatorTest {
 
     @Test
     public void testLimitNested() {
-        byte[] arrayHeader = "*1\r\n".getBytes(CharsetUtil.US_ASCII);
+        final byte[] arrayHeader = "*1\r\n".getBytes(CharsetUtil.US_ASCII);
         int maxNestedDepth = 100;
-        EmbeddedChannel channel = new EmbeddedChannel(new RedisDecoder(),
+        final EmbeddedChannel channel = new EmbeddedChannel(new RedisDecoder(),
                 new RedisArrayAggregator(maxNestedDepth));
         for (int i = 0; i < maxNestedDepth; i++) {
             assertFalse(channel.writeInbound(Unpooled.wrappedBuffer(arrayHeader)));
         }
 
         // Next write should trigger an exception.
-        assertThrows(CodecException.class, () -> channel.writeInbound(Unpooled.wrappedBuffer(arrayHeader)));
+        assertThrows(CodecException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                channel.writeInbound(Unpooled.wrappedBuffer(arrayHeader));
+            }
+        });
         assertFalse(channel.finishAndReleaseAll());
     }
 


### PR DESCRIPTION
Motivation:

The RedisArrayAggregator needs to ensure it releases buffered messages when the handler is removed as otherwise it will result in memory leaks.

Modifications:

- fire exception when channel is closed while we still aggregate
- release messages on handler removal
- add unit tests

Result:

Fix memory leak
