### PR TITLE
Netty HTTP/3 QPACK Blocked Streams Memory Exhaustion

### DIFF
--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/QpackDecoder.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/QpackDecoder.java
@@ -482,7 +482,7 @@ final class QpackDecoder {
 
     private boolean shouldWaitForDynamicTableUpdates(int requiredInsertCount) throws QpackException {
         if (requiredInsertCount > dynamicTable.insertCount()) {
-            if (blockedStreamsCount == maxBlockedStreams - 1) {
+            if (blockedStreamsCount >= maxBlockedStreams) {
                 throw MAX_BLOCKED_STREAMS_EXCEEDED;
             }
             return true;
@@ -492,8 +492,9 @@ final class QpackDecoder {
 
     private void sendInsertCountIncrementIfRequired(QuicStreamChannel qpackDecoderStream) throws QpackException {
         final int insertCount = dynamicTable.insertCount();
-        final List<Runnable> runnables = this.blockedStreams.get(insertCount);
+        final List<Runnable> runnables = this.blockedStreams.remove(insertCount);
         if (runnables != null) {
+            blockedStreamsCount -= runnables.size();
             boolean failed = false;
             for (Runnable runnable : runnables) {
                 try {

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/QpackDecoderTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/QpackDecoderTest.java
@@ -18,10 +18,12 @@ package io.netty.handler.codec.http3;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Collection;
+import java.util.function.BiConsumer;
 
 import static io.netty.handler.codec.http3.Http3SettingsFrame.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY;
 import static io.netty.handler.codec.http3.QpackDecoderStateSyncStrategy.ackEachInsert;
@@ -30,6 +32,8 @@ import static java.lang.Math.toIntExact;
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class QpackDecoderTest {
@@ -114,7 +118,88 @@ public class QpackDecoderTest {
         verifyField(entry, insertionCount - 1);
     }
 
+    @Test
+    public void zeroMaxBlockedStreamsThrowsOnBlockedStream() throws Exception {
+        setup(128);
+        ByteBuf in = encodeBlockingFrame(1);
+        try {
+            assertThrows(QpackException.class,
+                    () -> decoder.decode(attributes, 0L, in, in.readableBytes(), (n, v) -> { }, () -> { }));
+        } finally {
+            in.release();
+        }
+    }
+
+    @Test
+    public void maxBlockedStreamsLimitEnforced() throws Exception {
+        int maxBlockedStreams = 3;
+        setup(128, maxBlockedStreams);
+        BiConsumer<CharSequence, CharSequence> sink = (n, v) -> { };
+
+        for (long streamId = 0; streamId < maxBlockedStreams; streamId++) {
+            ByteBuf in = encodeBlockingFrame(1);
+            try {
+                assertFalse(decoder.decode(attributes, streamId, in, in.readableBytes(), sink, () -> { }),
+                        "Stream " + streamId + " should be blocked");
+            } finally {
+                in.release();
+            }
+        }
+
+        ByteBuf overflow = encodeBlockingFrame(1);
+        try {
+            assertThrows(QpackException.class,
+                    () -> decoder.decode(attributes, 99L, overflow, overflow.readableBytes(), sink, () -> { }));
+        } finally {
+            overflow.release();
+        }
+    }
+
+    @Test
+    public void blockedStreamsCountReleasedAfterUnblocking() throws Exception {
+        int maxBlockedStreams = 2;
+        setup(128, maxBlockedStreams);
+        BiConsumer<CharSequence, CharSequence> sink = (n, v) -> { };
+
+        for (long streamId = 0; streamId < maxBlockedStreams; streamId++) {
+            ByteBuf in = encodeBlockingFrame(1);
+            try {
+                assertFalse(decoder.decode(attributes, streamId, in, in.readableBytes(), sink, () -> { }),
+                        "Stream " + streamId + " should be blocked");
+            } finally {
+                in.release();
+            }
+        }
+
+        insertLiterals(1);
+
+        for (long streamId = 100; streamId < 100 + maxBlockedStreams; streamId++) {
+            ByteBuf in = encodeBlockingFrame(2);
+            try {
+                assertFalse(decoder.decode(attributes, streamId, in, in.readableBytes(), sink, () -> { }),
+                        "Stream " + streamId + " should be blocked after counter was released");
+            } finally {
+                in.release();
+            }
+        }
+    }
+
+    /**
+     * Encodes a 2-byte QPACK header block prefix (Required Insert Count + Base) that will cause
+     * a stream to block until the dynamic table reaches {@code requiredInsertCount}.
+     */
+    private ByteBuf encodeBlockingFrame(int requiredInsertCount) {
+        ByteBuf buf = Unpooled.buffer(2);
+        QpackUtil.encodePrefixedInteger(buf, (byte) 0b0, 8, requiredInsertCount % (2L * maxEntries) + 1);
+        QpackUtil.encodePrefixedInteger(buf, (byte) 0b0, 7, 0);
+        return buf;
+    }
+
     private void setup(long capacity) throws QpackException {
+        setup(capacity, 0);
+    }
+
+    private void setup(long capacity, int maxBlockedStreams) throws QpackException {
         long maxTableCapacity = MAX_UNSIGNED_INT;
         inserted = 0;
         this.maxEntries = toIntExact(QpackUtil.maxEntries(maxTableCapacity));
@@ -125,7 +210,7 @@ public class QpackDecoderTest {
         attributes = new QpackAttributes(parent, false);
         decoderStream = new EmbeddedQuicStreamChannel();
         attributes.decoderStream(decoderStream);
-        decoder = new QpackDecoder(maxTableCapacity, 0, table, ackEachInsert());
+        decoder = new QpackDecoder(maxTableCapacity, maxBlockedStreams, table, ackEachInsert());
         decoder.setDynamicTableCapacity(capacity);
     }
 


### PR DESCRIPTION
Motivation:

Correct the blocked-streams limit check and ensure entries are
released from the internal map once streams are resumed.

Result:

Ensure  blocked streams are handled correctly
