### PR TITLE
HTTP2: DelegatingDecompressorFrameListener must release memory in all cases

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingDecompressorFrameListener.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingDecompressorFrameListener.java
@@ -365,20 +365,22 @@ public class DelegatingDecompressorFrameListener extends Http2FrameListenerDecor
                         buf.release();
                         return;
                     }
+                    try {
+                        // Also take padding into account.
+                        incrementDecompressedBytes(padding);
 
-                    // Also take padding into account.
-                    incrementDecompressedBytes(padding);
+                        incrementDecompressedBytes(buf.readableBytes());
+                        // Immediately return the bytes back to the flow controller. ConsumedBytesConverter will convert
+                        // from the decompressed amount which the user knows about to the compressed amount which flow
+                        // control knows about.
+                        connection.local().flowController().consumeBytes(stream,
+                                listener.onDataRead(targetCtx, stream.id(), buf, padding, false));
+                        padding = 0; // Padding is only communicated once on the first iteration.
 
-                    incrementDecompressedBytes(buf.readableBytes());
-                    // Immediately return the bytes back to the flow controller. ConsumedBytesConverter will convert
-                    // from the decompressed amount which the user knows about to the compressed amount which flow
-                    // control knows about.
-                    connection.local().flowController().consumeBytes(stream,
-                            listener.onDataRead(targetCtx, stream.id(), buf, padding, false));
-                    padding = 0; // Padding is only communicated once on the first iteration.
-                    buf.release();
-
-                    dataDecompressed = true;
+                        dataDecompressed = true;
+                    } finally {
+                        buf.release();
+                    }
                 }
 
                 @Override


### PR DESCRIPTION
Motivation:

We need to ensure we also release the buffer if the flow controller for example throws, missing to do so might result in OOME.

Modifications:

Move buf.release() to finally block

Result:

Always release buffer