### PR TITLE
HAProxy: Fix ByteBuf leak when parsing nested SSL TLVs

### DIFF
--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessage.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessage.java
@@ -18,13 +18,13 @@ package io.netty.handler.codec.haproxy;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.haproxy.HAProxyProxiedProtocol.AddressFamily;
 import io.netty.util.AbstractReferenceCounted;
-import io.netty.util.ByteProcessor;
 import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
 import io.netty.util.ResourceLeakDetector;
 import io.netty.util.ResourceLeakDetectorFactory;
 import io.netty.util.ResourceLeakTracker;
 import io.netty.util.internal.ObjectUtil;
+import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 
 import java.util.ArrayList;
@@ -251,13 +251,48 @@ public final class HAProxyMessage extends AbstractReferenceCounted {
         // In most cases there are less than 4 TLVs available
         List<HAProxyTLV> haProxyTLVs = new ArrayList<HAProxyTLV>(4);
 
-        do {
-            haProxyTLVs.add(haProxyTLV);
-            if (haProxyTLV instanceof HAProxySSLTLV) {
-                haProxyTLVs.addAll(((HAProxySSLTLV) haProxyTLV).encapsulatedTLVs());
-            }
-        } while ((haProxyTLV = readNextTLV(header, 0)) != null);
+        try {
+            do {
+                haProxyTLVs.add(haProxyTLV);
+                if (haProxyTLV instanceof HAProxySSLTLV) {
+                    haProxyTLVs.addAll(((HAProxySSLTLV) haProxyTLV).encapsulatedTLVs());
+                }
+            } while ((haProxyTLV = readNextTLV(header, 0)) != null);
+        } catch (Throwable t) {
+            // Release all previously read TLVs before rethrowing as otherwise we would leak.
+            releaseTlvs(haProxyTLVs);
+            PlatformDependent.throwException(t);
+        }
         return haProxyTLVs;
+    }
+
+    private static void releaseDeep(List<HAProxyTLV> children) {
+        for (HAProxyTLV child : children) {
+            child.release();
+            if (child instanceof HAProxySSLTLV) {
+                releaseDeep(((HAProxySSLTLV) child).encapsulatedTLVs());
+            }
+        }
+    }
+
+    private static void releaseTlvs(List<HAProxyTLV> tlvs) {
+        int skip = 0;
+        for (HAProxyTLV tlv : tlvs) {
+            if (skip > 0) {
+                skip--;
+                // This TLV is a flattened depth-1 child. If it encapsulates anything (depth-2+),
+                // those deeper children were NOT flattened, so we must release them recursively.
+                if (tlv instanceof HAProxySSLTLV) {
+                    releaseDeep(((HAProxySSLTLV) tlv).encapsulatedTLVs());
+                }
+            } else if (tlv instanceof HAProxySSLTLV) {
+                // This is a top-level (depth-0) SSL TLV.
+                // Its immediate children (depth-1) were flattened into this list,
+                // so we must skip them in the outer loop to avoid treating them as top-level TLVs.
+                skip = ((HAProxySSLTLV) tlv).encapsulatedTLVs().size();
+            }
+            tlv.release();
+        }
     }
 
     private static HAProxyTLV readNextTLV(final ByteBuf header, int nestingLevel) {
@@ -284,13 +319,19 @@ public final class HAProxyMessage extends AbstractReferenceCounted {
             if (byteBuf.readableBytes() >= 4) {
 
                 final List<HAProxyTLV> encapsulatedTlvs = new ArrayList<HAProxyTLV>(4);
-                do {
-                    final HAProxyTLV haProxyTLV = readNextTLV(byteBuf, nestingLevel + 1);
-                    if (haProxyTLV == null) {
-                        break;
-                    }
-                    encapsulatedTlvs.add(haProxyTLV);
-                } while (byteBuf.readableBytes() >= 4);
+                try {
+                    do {
+                        final HAProxyTLV haProxyTLV = readNextTLV(byteBuf, nestingLevel + 1);
+                        if (haProxyTLV == null) {
+                            break;
+                        }
+                        encapsulatedTlvs.add(haProxyTLV);
+                    } while (byteBuf.readableBytes() >= 4);
+                }  catch (Throwable t) {
+                    // Release all previously read TLVs before rethrowing as otherwise we would leak.
+                    releaseTlvs(encapsulatedTlvs);
+                    PlatformDependent.throwException(t);
+                }
 
                 return new HAProxySSLTLV(verify, client, encapsulatedTlvs, rawContent);
             }
@@ -599,9 +640,7 @@ public final class HAProxyMessage extends AbstractReferenceCounted {
     @Override
     protected void deallocate() {
         try {
-            for (HAProxyTLV tlv : tlvs) {
-                tlv.release();
-            }
+            releaseTlvs(tlvs);
         } finally {
             final ResourceLeakTracker<HAProxyMessage> leak = this.leak;
             if (leak != null) {

--- a/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HAProxyMessageDecoderTest.java
+++ b/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HAProxyMessageDecoderTest.java
@@ -765,6 +765,99 @@ public class HAProxyMessageDecoderTest {
     }
 
     @Test
+    public void testV2WithNestedSslTLVs() {
+        ch = new EmbeddedChannel(new HAProxyMessageDecoder());
+
+        // Outer SSL TLV (type=0x20, content=28):
+        //   client(1)=0x05  verify(4)=0
+        //   Inner SSL TLV (type=0x20, content=13):     <-- depth-1 nested SSL
+        //     client(1)=0x01  verify(4)=0
+        //     PP2_TYPE_SSL_VERSION (type=0x21, len=5): "TLSv1"   <-- depth-2 leaf
+        //   PP2_TYPE_SSL_CN (type=0x22, len=4): "LEAF"           <-- depth-1 leaf
+        final byte[] bytes = {
+                13, 10, 13, 10, 0, 13, 10, 81, 85, 73, 84, 10,   // v2 signature
+                33, 17,                                            // v2|PROXY, TCP4
+                0, 43,                                             // remaining: 12 + 31
+                127, 0, 0, 1, 127, 0, 0, 1, -55, -90, 7, 89,     // addresses + ports
+                32, 0, 28,                                         // outer SSL: type=0x20, len=28
+                5, 0, 0, 0, 0,                                    // outer: client=0x05, verify=0
+                32, 0, 13,                                         // inner SSL: type=0x20, len=13
+                1, 0, 0, 0, 0,                                    // inner: client=0x01, verify=0
+                33, 0, 5, 84, 76, 83, 118, 49,                    // SSL_VERSION: "TLSv1"
+                34, 0, 4, 76, 69, 65, 70                           // SSL_CN: "LEAF"
+        };
+
+        int startChannels = ch.pipeline().names().size();
+        assertTrue(ch.writeInbound(copiedBuffer(bytes)));
+        Object msgObj = ch.readInbound();
+        assertEquals(startChannels - 1, ch.pipeline().names().size());
+        HAProxyMessage msg = (HAProxyMessage) msgObj;
+
+        assertEquals(HAProxyProtocolVersion.V2, msg.protocolVersion());
+        assertEquals(HAProxyCommand.PROXY, msg.command());
+        assertEquals(HAProxyProxiedProtocol.TCP4, msg.proxiedProtocol());
+        assertEquals("127.0.0.1", msg.sourceAddress());
+        assertEquals("127.0.0.1", msg.destinationAddress());
+        assertEquals(51622, msg.sourcePort());
+        assertEquals(1881, msg.destinationPort());
+        final List<HAProxyTLV> tlvs = msg.tlvs();
+
+        // Flattened list: [outerSSL, innerSSL, SSL_CN]
+        // SSL_CN is a direct child of outer, so it is flattened.
+        // innerSSL is also a direct child of outer, so it is flattened.
+        // But "TLSv1" (SSL_VERSION) is a child of innerSSL (depth 2) — NOT flattened.
+        assertEquals(3, tlvs.size());
+        final HAProxyTLV firstTlv = tlvs.get(0);
+        assertEquals(HAProxyTLV.Type.PP2_TYPE_SSL, firstTlv.type());
+        final HAProxySSLTLV sslTlv = (HAProxySSLTLV) firstTlv;
+        assertEquals(0, sslTlv.verify());
+        assertTrue(sslTlv.isPP2ClientSSL());
+        assertTrue(sslTlv.isPP2ClientCertSess());
+        assertFalse(sslTlv.isPP2ClientCertConn());
+
+        final HAProxyTLV secondTlv = tlvs.get(1);
+
+        assertEquals(HAProxyTLV.Type.PP2_TYPE_SSL, secondTlv.type());
+        final HAProxySSLTLV innerSslTlv = (HAProxySSLTLV) secondTlv;
+
+        // The depth-2 leaf: SSL_VERSION "TLSv1" lives inside innerSslTlv
+        assertEquals(1, innerSslTlv.encapsulatedTLVs().size());
+        final HAProxyTLV depth2Leaf = innerSslTlv.encapsulatedTLVs().get(0);
+        assertEquals(HAProxyTLV.Type.PP2_TYPE_SSL_VERSION, depth2Leaf.type());
+        ByteBuf versionBuf = depth2Leaf.content();
+        byte[] versionContent = new byte[versionBuf.readableBytes()];
+        versionBuf.readBytes(versionContent);
+        assertArrayEquals("TLSv1".getBytes(CharsetUtil.US_ASCII), versionContent);
+
+        final HAProxyTLV thirdTLV = tlvs.get(2);
+        assertEquals(HAProxyTLV.Type.PP2_TYPE_SSL_CN, thirdTLV.type());
+        ByteBuf thirdContentBuf = thirdTLV.content();
+        byte[] thirdContent = new byte[thirdContentBuf.readableBytes()];
+        thirdContentBuf.readBytes(thirdContent);
+        assertArrayEquals("LEAF".getBytes(CharsetUtil.US_ASCII), thirdContent);
+
+        assertTrue(sslTlv.encapsulatedTLVs().contains(secondTlv));
+        assertTrue(sslTlv.encapsulatedTLVs().contains(thirdTLV));
+
+        assertTrue(0 < firstTlv.refCnt());
+        assertTrue(0 < secondTlv.refCnt());
+        assertTrue(0 < thirdTLV.refCnt());
+        assertTrue(0 < depth2Leaf.refCnt());
+        assertTrue(msg.release());
+
+        // The depth-2 leaf TLV must be fully released after message.release().
+        // It is a child of the inner SSL TLV (depth 1), but readTlvs() only flattens
+        // one level of encapsulated TLVs.
+        assertEquals(0, depth2Leaf.refCnt(), "Depth-2 leaf TLV leaked");
+        assertEquals(0, firstTlv.refCnt());
+        assertEquals(0, secondTlv.refCnt());
+        assertEquals(0, thirdTLV.refCnt());
+
+        assertNull(ch.readInbound());
+        assertFalse(ch.finish());
+    }
+
+    @Test
     public void testReleaseHAProxyMessage() {
         ch = new EmbeddedChannel(new HAProxyMessageDecoder());
 


### PR DESCRIPTION
Motivation:

When parsing a PROXY protocol v2 header containing nested PP2_TYPE_SSL TLVs
at depth two or greater, the underlying cumulation buffer can remain
retained after the message is deallocated. This happens because deeply nested
TLVs are not flattened into the main tlvs() list, causing them to be missed
during the standard release process.

Modifications:

- Update the release logic in HAProxyMessage to correctly identify and
  recursively release deeply nested TLVs.
- Introduce a releaseTlvs helper method to handle the recursive release
  without altering the existing public API behavior of the tlvs() list.

Result:

The cumulation buffer is properly released when handling deeply nested
SSL TLVs, preventing memory leaks while preserving backwards compatibility.
