### PR TITLE
Redis: Limit the maximum number of nested arrays

### DIFF
--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisArrayAggregator.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisArrayAggregator.java
@@ -36,6 +36,7 @@ import java.util.List;
 public final class RedisArrayAggregator extends MessageToMessageDecoder<RedisMessage> {
 
     private static final int DEFAULT_MAX_ARRAY_LENGTH = RedisConstants.REDIS_MAX_ARRAY_LENGTH;
+    private final int maxNestedArrayDepth;
     private final Deque<AggregateState> depths = new ArrayDeque<AggregateState>(4);
     private final int maxElements;
 
@@ -46,11 +47,12 @@ public final class RedisArrayAggregator extends MessageToMessageDecoder<RedisMes
      * This constructor specifies a maximum number of elements of 1.000.000,
      * but this default can be increased with the {@value RedisConstants#PROP_REDIS_MAX_ARRAY_LENGTH} system property.
      *
-     * @deprecated Use {@link #RedisArrayAggregator(int)} instead to define a max size of the array to aggregate.
+     * @deprecated Use {@link #RedisArrayAggregator(int, int)} instead to define a max size of the array to aggregate.
      */
     @Deprecated
     public RedisArrayAggregator() {
-        this(DEFAULT_MAX_ARRAY_LENGTH);
+        // Let's impose some limit at least by default.
+        this(DEFAULT_MAX_ARRAY_LENGTH, 1024);
     }
 
     /**
@@ -60,10 +62,12 @@ public final class RedisArrayAggregator extends MessageToMessageDecoder<RedisMes
      * A {@link CodecException} will be thrown if the array header specify a length greater than
      * the given number of max elements.
      * @param maxElements The maximum number of elements to aggregate in a single message.
+     * @param maxNestedArrayDepth   the maximum depth of the nested array before an exception will be thrown
      */
-    public RedisArrayAggregator(int maxElements) {
+    public RedisArrayAggregator(int maxElements, int maxNestedArrayDepth) {
         super(RedisMessage.class);
         this.maxElements = ObjectUtil.checkPositive(maxElements, "maxElements");
+        this.maxNestedArrayDepth = ObjectUtil.checkPositive(maxNestedArrayDepth, "maxNestedArrayDepth");
     }
 
     @Override
@@ -105,6 +109,10 @@ public final class RedisArrayAggregator extends MessageToMessageDecoder<RedisMes
                 throw new CodecException("this codec doesn't support longer length than " + maxElements);
             }
 
+            if (depths.size() >= maxNestedArrayDepth) {
+                releaseAndClearDepths();
+                throw new CodecException("max nested array depth exceeded: "  + maxNestedArrayDepth);
+            }
             // start aggregating array
             depths.push(new AggregateState((int) header.length()));
             return null;
@@ -125,6 +133,10 @@ public final class RedisArrayAggregator extends MessageToMessageDecoder<RedisMes
     @Override
     public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
         super.handlerRemoved(ctx);
+        releaseAndClearDepths();
+    }
+
+    private void releaseAndClearDepths() {
         for (AggregateState state : depths) {
             for (RedisMessage message : state.children) {
                 ReferenceCountUtil.safeRelease(message);

--- a/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisArrayAggregatorTest.java
+++ b/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisArrayAggregatorTest.java
@@ -12,12 +12,13 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package io.netty.handler.codec.redis;
 
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.PrematureChannelClosureException;
+import io.netty.handler.codec.CodecException;
+import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
@@ -58,5 +59,25 @@ public class RedisArrayAggregatorTest {
         ch.pipeline().remove(RedisArrayAggregator.class);
         assertEquals(0, redisMessage.refCnt());
         assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testLimitNested() {
+        final byte[] arrayHeader = "*1\r\n".getBytes(CharsetUtil.US_ASCII);
+        int maxNestedDepth = 100;
+        final EmbeddedChannel channel = new EmbeddedChannel(new RedisDecoder(),
+                new RedisArrayAggregator(RedisConstants.REDIS_MAX_ARRAY_LENGTH, maxNestedDepth));
+        for (int i = 0; i < maxNestedDepth; i++) {
+            assertFalse(channel.writeInbound(Unpooled.wrappedBuffer(arrayHeader)));
+        }
+
+        // Next write should trigger an exception.
+        assertThrows(CodecException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                channel.writeInbound(Unpooled.wrappedBuffer(arrayHeader));
+            }
+        });
+        assertFalse(channel.finishAndReleaseAll());
     }
 }

--- a/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisDecoderTest.java
+++ b/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisDecoderTest.java
@@ -58,7 +58,7 @@ public class RedisDecoderTest {
         return new EmbeddedChannel(
                 new RedisDecoder(decodeInlineCommands),
                 new RedisBulkStringAggregator(),
-                new RedisArrayAggregator(100));
+                new RedisArrayAggregator(100, 1024));
     }
 
     @AfterEach

--- a/example/src/main/java/io/netty/example/redis/RedisClient.java
+++ b/example/src/main/java/io/netty/example/redis/RedisClient.java
@@ -52,7 +52,7 @@ public class RedisClient {
                      ChannelPipeline p = ch.pipeline();
                      p.addLast(new RedisDecoder());
                      p.addLast(new RedisBulkStringAggregator());
-                     p.addLast(new RedisArrayAggregator(1000000));
+                     p.addLast(new RedisArrayAggregator(1000000, 1024));
                      p.addLast(new RedisEncoder());
                      p.addLast(new RedisClientHandler());
                  }


### PR DESCRIPTION
Motivation:

We didn'T limit the maximum number of nested array and so we were in risk of OOME

Modifications:

- Add constructor that allows to set a limit and use 1024 by default
- Add unit test

Result:

Limit maximum nested arrays
