### PR TITLE
HTTP/2: Treat clients MAX_HEADER_LIST_SIZE as advisory

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
@@ -100,7 +100,9 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder, Ht
         }
 
         Long maxHeaderListSize = settings.maxHeaderListSize();
-        if (maxHeaderListSize != null) {
+        if (maxHeaderListSize != null && !connection.isServer()) {
+            // Servers ignore the MAX_HEADER_LIST_SIZE setting from clients.
+            // It's advisory in spec (RFC 9113 §6.5.2) and best praxis is to ignore it.
             outboundHeaderConfig.maxHeaderListSize(maxHeaderListSize);
         }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -1177,6 +1177,71 @@ public class Http2ConnectionRoundtripTest {
         }
     }
 
+    @Test
+    public void serverShouldNotEnforceClientAdvertisedMaxHeaderListSize() throws Exception {
+        // Verifies that SETTINGS_MAX_HEADER_LIST_SIZE sent by a client is treated as advisory
+        // (per RFC 9113 §6.5.2) and does not prevent the server from encoding response headers.
+        final CountDownLatch clientSettingsAckLatch = new CountDownLatch(2);
+        final CountDownLatch responseLatch = new CountDownLatch(1);
+        final AtomicReference<Throwable> serverWriteError = new AtomicReference<Throwable>();
+
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
+                final ChannelHandlerContext sCtx = serverCtx();
+                final int streamId = (Integer) invocationOnMock.getArgument(1);
+                Http2Headers responseHeaders = new DefaultHttp2Headers().status("200");
+                http2Server.encoder().writeHeaders(sCtx, streamId, responseHeaders, 0, true, sCtx.newPromise())
+                        .addListener(future -> {
+                            serverWriteError.set(future.cause());
+                            responseLatch.countDown();
+                        });
+                http2Server.flush(sCtx);
+                return null;
+            }
+        }).when(serverListener).onHeadersRead(any(ChannelHandlerContext.class), anyInt(), any(Http2Headers.class),
+                anyInt(), anyShort(), anyBoolean(), anyInt(), anyBoolean());
+
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
+                clientSettingsAckLatch.countDown();
+                return null;
+            }
+        }).when(clientListener).onSettingsAckRead(any(ChannelHandlerContext.class));
+
+        bootstrapEnv(0, 1, 2, 0);
+
+        // Client advertises a tiny MAX_HEADER_LIST_SIZE (2 bytes) to the server.
+        runInChannel(clientChannel, new Http2Runnable() {
+            @Override
+            public void run() throws Http2Exception {
+                http2Client.encoder().writeSettings(ctx(),
+                        new Http2Settings().maxHeaderListSize(2),
+                        newPromise());
+                http2Client.flush(ctx());
+            }
+        });
+
+        // Wait for the server to acknowledge both the initial settings and our custom settings.
+        assertTrue(clientSettingsAckLatch.await(DEFAULT_AWAIT_TIMEOUT_SECONDS, SECONDS));
+
+        // Send a request; the server will attempt to respond with headers far exceeding 2 bytes.
+        final short weight = 16;
+        runInChannel(clientChannel, new Http2Runnable() {
+            @Override
+            public void run() throws Http2Exception {
+                http2Client.encoder().writeHeaders(ctx(), 3, dummyHeaders(), 0, weight, false, 0, true,
+                        newPromise());
+                http2Client.flush(ctx());
+            }
+        });
+
+        assertTrue(responseLatch.await(DEFAULT_AWAIT_TIMEOUT_SECONDS, SECONDS));
+        assertNull(serverWriteError.get(),
+                "Server must succeed writing response headers regardless of client's SETTINGS_MAX_HEADER_LIST_SIZE");
+    }
+
     private void bootstrapEnv(int dataCountDown, int settingsAckCount,
             int requestCountDown, int trailersCountDown) throws Exception {
         bootstrapEnv(dataCountDown, settingsAckCount, requestCountDown, trailersCountDown, -1, -1);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -1192,10 +1192,13 @@ public class Http2ConnectionRoundtripTest {
                 final int streamId = (Integer) invocationOnMock.getArgument(1);
                 Http2Headers responseHeaders = new DefaultHttp2Headers().status("200");
                 http2Server.encoder().writeHeaders(sCtx, streamId, responseHeaders, 0, true, sCtx.newPromise())
-                        .addListener(future -> {
-                            serverWriteError.set(future.cause());
-                            responseLatch.countDown();
-                        });
+                        .addListener(new ChannelFutureListener() {
+                    @Override
+                    public void operationComplete(ChannelFuture future) throws Exception {
+                        serverWriteError.set(future.cause());
+                        responseLatch.countDown();
+                    }
+                });
                 http2Server.flush(sCtx);
                 return null;
             }


### PR DESCRIPTION
Motivation:
SETTINGS_MAX_HEADER_LIST_SIZE is advisory per RFC 9113 §6.5.2. When acting as a server, the remote peer is a client whose advertised value reflects what it is prepared to receive. Honoring arbitrarily small values creates a DoS vector: a client setting this to 1 byte would prevent any valid response from being sent.

Modification:
When running as a server, the `DefaultHttp2ConnectionEncoder` now ignore the max header list size setting from clients.

Result:
Clients can no longer cheaply induce errors on an HTTP/2 server by advising unreasonably smaller header size limits.

The behavior of ignoring the max header list size matches other H2 implementations, like nghttp2, nginx, and envoy.
