### PR TITLE
Pass maxAllocation to Brotli and Zstd decoders (#16844)

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentDecompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentDecompressor.java
@@ -104,7 +104,7 @@ public class HttpContentDecompressor extends HttpContentDecoder {
         }
         if (Brotli.isAvailable() && BR.contentEqualsIgnoreCase(contentEncoding)) {
             return new EmbeddedChannel(ctx.channel().id(), ctx.channel().metadata().hasDisconnect(),
-              ctx.channel().config(), new BrotliDecoder());
+              ctx.channel().config(), new BrotliDecoder(maxAllocation));
         }
 
         if (SNAPPY.contentEqualsIgnoreCase(contentEncoding)) {
@@ -114,7 +114,7 @@ public class HttpContentDecompressor extends HttpContentDecoder {
 
         if (Zstd.isAvailable() && ZSTD.contentEqualsIgnoreCase(contentEncoding)) {
             return new EmbeddedChannel(ctx.channel().id(), ctx.channel().metadata().hasDisconnect(),
-                    ctx.channel().config(), new ZstdDecoder());
+                    ctx.channel().config(), new ZstdDecoder(maxAllocation));
         }
 
         // 'identity' or unsupported


### PR DESCRIPTION
Motivation:
Brotli and Zstd should using the same maxAllocation limits as gzip and zlib, if these limits are defined. This leads to unification of usage and as a prtoection against zip bombs even on memory-strained environments, as well as allowing larger archives on explicitly configured envirironments.

Modifications:
Field maxAllocation of class HttpContentDecompressor is now passed to constructors of BrotliDecoder and ZstdDecoder classes.

Result:
If user configures max allocation for decryption, then the same allocation will be used for decryption of zstd and Brotli loads

(cherry picked from commit 5a52600d96cc6f4d38098e0645be53ecbfc8a811)