### PR TITLE
Avoid logging exceptions that tests ignore

### DIFF
--- a/.devcontainer/centos7/Dockerfile
+++ b/.devcontainer/centos7/Dockerfile
@@ -52,7 +52,7 @@ RUN wget -q https://go.dev/dl/go$GO_VERSION.linux-amd64.tar.gz && tar zxf go$GO_
 RUN curl -s https://cmake.org/files/v$CMAKE_VERSION_BASE/cmake-$CMAKE_VERSION-linux-x86_64.tar.gz --output cmake-$CMAKE_VERSION-linux-x86_64.tar.gz && tar zxf cmake-$CMAKE_VERSION-linux-x86_64.tar.gz && mv cmake-$CMAKE_VERSION-linux-x86_64 /opt/ && echo 'PATH=/opt/cmake-$CMAKE_VERSION-linux-x86_64/bin:$PATH' >> ~/.bashrc
 
 # Downloading and installing SDKMAN!
-RUN curl -s "https://get.sdkman.io?ci=true" | bash
+RUN curl -s "https://beta.sdkman.io?ci=true" | bash
 
 ARG java_version="11.0.26-zulu"
 ENV JAVA_VERSION=$java_version

--- a/.devcontainer/ubi9/Dockerfile
+++ b/.devcontainer/ubi9/Dockerfile
@@ -23,7 +23,7 @@ RUN dnf install -y procps-ng \
  zlib-devel
 
 # Downloading and installing SDKMAN!
-RUN curl -s "https://get.sdkman.io?ci=true" | bash
+RUN curl -s "https://beta.sdkman.io?ci=true" | bash
 
 ARG java_version=25-zulu
 ENV JAVA_VERSION=$java_version

--- a/.devcontainer/ubuntu/Dockerfile
+++ b/.devcontainer/ubuntu/Dockerfile
@@ -19,7 +19,7 @@ RUN apt update && apt install -y \
     golang
 
 USER vscode
-RUN curl -s "https://get.sdkman.io" | bash
+RUN curl -s "https://beta.sdkman.io?ci=true" | bash
 ARG java_version="25-zulu"
 ENV JAVA_VERSION=$java_version
 RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && \

--- a/.github/scripts/check_java_ea_version.sh
+++ b/.github/scripts/check_java_ea_version.sh
@@ -19,7 +19,7 @@ set -e
 # Keep this version in sync with docker-compose.centos-7.26.yaml
 export EXPECTED_VERSION='26.ea.35'
 
-curl -s "https://get.sdkman.io" | bash
+curl -s "https://beta.sdkman.io?ci=true" | bash
 source "$HOME/.sdkman/bin/sdkman-init.sh"
 export JAVA_VERSION=$(sdk list java | grep 26.*-open|head -n 1|cut -f 3 -d '|')
 echo "Java version: '$JAVA_VERSION'" | tee version.txt

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilFuzzTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilFuzzTest.java
@@ -27,6 +27,7 @@ import io.netty.handler.codec.http.HttpScheme;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.AsciiString;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 import java.net.URI;
 
@@ -34,6 +35,7 @@ import static io.netty.util.internal.StringUtil.isNullOrEmpty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@EnabledIfEnvironmentVariable(named = "FUZZ_TEST", matches = "1")
 public class HttpConversionUtilFuzzTest {
 
     @FuzzTest(maxDuration = "30s")

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilFuzzTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilFuzzTest.java
@@ -35,7 +35,7 @@ import static io.netty.util.internal.StringUtil.isNullOrEmpty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@EnabledIfEnvironmentVariable(named = "FUZZ_TEST", matches = "1")
+@EnabledIfEnvironmentVariable(named = "JAZZER_FUZZ", matches = "1")
 public class HttpConversionUtilFuzzTest {
 
     @FuzzTest(maxDuration = "30s")

--- a/docker/Dockerfile.al2023
+++ b/docker/Dockerfile.al2023
@@ -37,7 +37,7 @@ RUN dnf install -yq \
  zip
 
 # Downloading and installing SDKMAN!
-RUN curl -s "https://get.sdkman.io" | bash
+RUN curl -s "https://beta.sdkman.io?ci=true" | bash
 
 # Installing Java removing some unnecessary SDKMAN files
 RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && \

--- a/docker/Dockerfile.centos6
+++ b/docker/Dockerfile.centos6
@@ -23,7 +23,7 @@ RUN yum install -y \
 
 
 # Downloading and installing SDKMAN!
-RUN curl -s "https://get.sdkman.io?ci=true" | bash
+RUN curl -s "https://beta.sdkman.io?ci=true" | bash
 
 ARG java_version="8.0.302-zulu"
 ENV JAVA_VERSION=$java_version

--- a/docker/Dockerfile.centos7
+++ b/docker/Dockerfile.centos7
@@ -49,7 +49,7 @@ RUN wget -q https://go.dev/dl/go$GO_VERSION.linux-amd64.tar.gz && tar zxf go$GO_
 RUN curl -s https://cmake.org/files/v$CMAKE_VERSION_BASE/cmake-$CMAKE_VERSION-linux-x86_64.tar.gz --output cmake-$CMAKE_VERSION-linux-x86_64.tar.gz && tar zxf cmake-$CMAKE_VERSION-linux-x86_64.tar.gz && mv cmake-$CMAKE_VERSION-linux-x86_64 /opt/ && echo 'PATH=/opt/cmake-$CMAKE_VERSION-linux-x86_64/bin:$PATH' >> ~/.bashrc
 
 # Downloading and installing SDKMAN!
-RUN curl -s "https://get.sdkman.io?ci=true" | bash
+RUN curl -s "https://beta.sdkman.io?ci=true" | bash
 
 ARG java_version="11.0.26-zulu"
 ENV JAVA_VERSION=$java_version

--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -64,7 +64,7 @@ RUN echo '[target.aarch64-unknown-linux-gnu]' >> /root/.cargo/config
 RUN echo 'linker = "aarch64-none-linux-gnu-gcc"' >> /root/.cargo/config
 
 # Downloading and installing SDKMAN!
-RUN curl -s "https://get.sdkman.io?ci=true" | bash
+RUN curl -s "https://beta.sdkman.io?ci=true" | bash
 
 # Installing Java and Maven, removing some unnecessary SDKMAN files
 RUN bash -c "source $HOME/.sdkman/bin/sdkman-init.sh && \

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslCertificateCompressionTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslCertificateCompressionTest.java
@@ -409,6 +409,9 @@ public class OpenSslCertificateCompressionTest {
                     ctx.fireUserEventTriggered(evt);
                 }
             });
+            pipeline.addLast(new SilenceExceptionHandler()
+                    .messageContains("CERT_DECOMPRESSION_FAILED")
+                    .messageContains("TLSV1_ALERT_DECODE_ERROR"));
         }
     }
 

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslPrivateKeyMethodTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslPrivateKeyMethodTest.java
@@ -367,9 +367,23 @@ public class OpenSslPrivateKeyMethodTest {
                 LocalAddress address = new LocalAddress("test-" + SslProvider.OPENSSL
                         + '-' + SslProvider.JDK + '-' + RFC_CIPHER_NAME + '-' + delegate);
 
-                Channel server = server(address, serverSslHandler);
+                Channel server = server(address, new ChannelInitializer<Channel>() {
+                    @Override
+                    protected void initChannel(Channel ch) {
+                        ch.pipeline().addLast(serverSslHandler);
+                        ch.pipeline().addLast(new SilenceExceptionHandler()
+                                .rootCauseInstanceOf(SignatureException.class));
+                    }
+                });
                 try {
-                    Channel client = client(server, clientSslHandler);
+                    Channel client = client(server, new ChannelInitializer<Channel>() {
+                        @Override
+                        protected void initChannel(Channel ch) {
+                            ch.pipeline().addLast(clientSslHandler);
+                            ch.pipeline().addLast(new SilenceExceptionHandler()
+                                    .rootCauseInstanceOf(SignatureException.class));
+                        }
+                    });
                     try {
                         Throwable clientCause = clientSslHandler.handshakeFuture().await().cause();
                         Throwable serverCause = serverSslHandler.handshakeFuture().await().cause();

--- a/handler/src/test/java/io/netty/handler/ssl/ParameterizedSslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ParameterizedSslHandlerTest.java
@@ -62,6 +62,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.security.KeyStore;
+import java.security.SignatureException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -440,6 +441,8 @@ public class ParameterizedSslHandlerTest {
                                 }
                             });
                             ch.pipeline().addLast(handler);
+                            ch.pipeline().addLast(new SilenceExceptionHandler()
+                                    .rootCauseInstanceOf(SignatureException.class));
                         }
                     }).bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
 

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -1057,6 +1057,8 @@ public abstract class SSLEngineTest {
                         }
                     }
                 });
+                p.addLast(new SilenceExceptionHandler()
+                        .messageContains("Received fatal alert: internal_error"));
                 serverConnectedChannel = ch;
             }
         });
@@ -1244,6 +1246,8 @@ public abstract class SSLEngineTest {
                         }
                     }
                 });
+                p.addLast(new SilenceExceptionHandler()
+                        .messageContains("Received fatal alert: internal_error"));
                 serverConnectedChannel = ch;
             }
         });
@@ -1286,6 +1290,8 @@ public abstract class SSLEngineTest {
                         }
                     }
                 });
+                p.addLast(new SilenceExceptionHandler()
+                        .messageContains("TLSV1_ALERT_CERTIFICATE_REQUIRED"));
             }
         });
 
@@ -1604,6 +1610,8 @@ public abstract class SSLEngineTest {
                                 ctx.pipeline().get(SslHandler.class).renegotiate();
                             }
                         });
+                        p.addLast(new SilenceExceptionHandler()
+                                .messageContains("no_renegotiation"));
                     }
                 });
 

--- a/handler/src/test/java/io/netty/handler/ssl/SilenceExceptionHandler.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SilenceExceptionHandler.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Predicate;
+
+public class SilenceExceptionHandler extends ChannelInboundHandlerAdapter {
+    private final List<Predicate<Throwable>> rules;
+
+    public SilenceExceptionHandler() {
+        this.rules = new CopyOnWriteArrayList<>();
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        for (Predicate<Throwable> rule : rules) {
+            if (rule.test(cause)) {
+                return;
+            }
+        }
+        ctx.fireExceptionCaught(cause);
+    }
+
+    public SilenceExceptionHandler rootCauseInstanceOf(Class<? extends Throwable> type) {
+        rules.add(thr -> {
+            Throwable root = thr;
+            while (root.getCause() != null) {
+                root = root.getCause();
+            }
+            return type.isInstance(root);
+        });
+        return this;
+    }
+
+    public SilenceExceptionHandler messageContains(String message) {
+        rules.add(thr -> {
+            return thr.getMessage().contains(message);
+        });
+        return this;
+    }
+}

--- a/handler/src/test/java/io/netty/handler/ssl/SniClientJava8TestUtil.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniClientJava8TestUtil.java
@@ -46,6 +46,7 @@ import javax.net.ssl.SNIMatcher;
 import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManager;
@@ -139,6 +140,8 @@ final class SniClientJava8TestUtil {
                             }
                         }
                     });
+                    ch.pipeline().addLast(new SilenceExceptionHandler()
+                            .rootCauseInstanceOf(SSLHandshakeException.class));
                 }
             }).bind(address).syncUninterruptibly().channel();
 
@@ -148,7 +151,15 @@ final class SniClientJava8TestUtil {
             SslHandler sslHandler = new SslHandler(
                     sslClientContext.newEngine(ByteBufAllocator.DEFAULT, sniHost, -1));
             Bootstrap cb = new Bootstrap();
-            cc = cb.group(group).channel(LocalChannel.class).handler(sslHandler)
+            cc = cb.group(group).channel(LocalChannel.class)
+                    .handler(new ChannelInitializer<Channel>() {
+                        @Override
+                        protected void initChannel(Channel ch) {
+                            ch.pipeline().addLast(sslHandler);
+                            ch.pipeline().addLast(new SilenceExceptionHandler()
+                                    .rootCauseInstanceOf(SSLHandshakeException.class));
+                        }
+                    })
                     .connect(address).syncUninterruptibly().channel();
 
             promise.syncUninterruptibly();

--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -69,12 +69,14 @@ import org.junit.jupiter.api.function.Executable;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLProtocolException;
 import javax.net.ssl.X509ExtendedTrustManager;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.channels.ClosedChannelException;
 import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Collections;
@@ -627,6 +629,8 @@ public class SslHandlerTest {
                               }
                           }
                       });
+                      ch.pipeline().addLast(new SilenceExceptionHandler()
+                              .rootCauseInstanceOf(NotSslRecordException.class));
                   }
                 });
 
@@ -776,6 +780,8 @@ public class SslHandlerTest {
                         @Override
                         protected void initChannel(Channel ch) {
                             ch.pipeline().addLast(sslServerCtx.newHandler(ch.alloc()));
+                            ch.pipeline().addLast(new SilenceExceptionHandler()
+                                    .rootCauseInstanceOf(SSLHandshakeException.class));
                         }
                     });
             sc = sb.bind(address).syncUninterruptibly().channel();
@@ -794,6 +800,8 @@ public class SslHandlerTest {
                             // This will happen if the channel was closed in the meantime.
                             sslHandlerRef.set(handler);
                             ch.pipeline().addLast(handler);
+                            ch.pipeline().addLast(new SilenceExceptionHandler()
+                                    .rootCauseInstanceOf(SignatureException.class));
                         }
                     });
             cc = b.connect(sc.localAddress()).syncUninterruptibly().channel();
@@ -1528,6 +1536,8 @@ public class SslHandlerTest {
                         @Override
                         protected void initChannel(Channel ch) {
                             ch.pipeline().addLast(clientSslHandler);
+                            ch.pipeline().addLast(new SilenceExceptionHandler()
+                                    .rootCauseInstanceOf(CertificateException.class));
                         }
                     }).connect(sc.localAddress());
             future.syncUninterruptibly();
@@ -1636,6 +1646,8 @@ public class SslHandlerTest {
                         protected void initChannel(Channel ch) throws Exception {
                             ch.pipeline().addLast(serverSslHandler);
                             ch.pipeline().addLast(new SslEventHandler(serverEvent));
+                            ch.pipeline().addLast(new SilenceExceptionHandler()
+                                    .rootCauseInstanceOf(SSLHandshakeException.class));
                         }
                     })
                     .bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
@@ -1648,6 +1660,8 @@ public class SslHandlerTest {
                         protected void initChannel(Channel ch) {
                             ch.pipeline().addLast(clientSslHandler);
                             ch.pipeline().addLast(new SslEventHandler(clientEvent));
+                            ch.pipeline().addLast(new SilenceExceptionHandler()
+                                    .rootCauseInstanceOf(SSLHandshakeException.class));
                         }
                     }).connect(sc.localAddress());
             cc = future.syncUninterruptibly().channel();


### PR DESCRIPTION
Motivation:
Our pipelines by default logs unhandled exceptions. This is generally useful, but we have a number of tests that don't handle every exception and thus cause a large volume of stack trace log output in the build log.
The `HttpConversionUtilFuzzTest` also produces a lot of output from its instrumentation agent.

Modification:
- Add a SilenceExceptionHandler and apply surgically to netty-handler tests that are the largest culprits of excessive exception logging.
- Only enable `HttpConversionUtilFuzzTest` if the `JAZZER_FUZZ=1` environment variable has been defined.

Result:
This saves ~10.000 lines of build log output.