### PR TITLE
Fix SCTP and Redis tests

### DIFF
--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisArrayAggregator.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisArrayAggregator.java
@@ -41,7 +41,6 @@ public final class RedisArrayAggregator extends MessageToMessageDecoder<RedisMes
     private final int maxElements;
 
     /**
-<<<<<<< HEAD
      * Create a new instance that will aggregate an {@link ArrayHeaderRedisMessage}
      * and its subsequent elements into an {@link ArrayRedisMessage}.
      * <p>
@@ -111,6 +110,7 @@ public final class RedisArrayAggregator extends MessageToMessageDecoder<RedisMes
             }
 
             if (depths.size() >= maxNestedArrayDepth) {
+                releaseAndClearDepths();
                 throw new CodecException("max nested array depth exceeded: "  + maxNestedArrayDepth);
             }
             // start aggregating array
@@ -133,6 +133,10 @@ public final class RedisArrayAggregator extends MessageToMessageDecoder<RedisMes
     @Override
     public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
         super.handlerRemoved(ctx);
+        releaseAndClearDepths();
+    }
+
+    private void releaseAndClearDepths() {
         for (AggregateState state : depths) {
             for (RedisMessage message : state.children) {
                 ReferenceCountUtil.safeRelease(message);

--- a/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisArrayAggregatorTest.java
+++ b/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisArrayAggregatorTest.java
@@ -42,6 +42,7 @@ public class RedisArrayAggregatorTest {
         assertThrows(CodecException.class, () -> channel.writeInbound(Unpooled.wrappedBuffer(arrayHeader)));
         assertFalse(channel.finishAndReleaseAll());
     }
+
     @Test
     void testDoesNotLeakOnClose() {
         EmbeddedChannel ch = new EmbeddedChannel(new RedisArrayAggregator());

--- a/transport-sctp/src/test/java/io/netty/handler/codec/sctp/SctpMessageCompletionHandlerTest.java
+++ b/transport-sctp/src/test/java/io/netty/handler/codec/sctp/SctpMessageCompletionHandlerTest.java
@@ -62,11 +62,10 @@ public class SctpMessageCompletionHandlerTest {
         SctpMessage message2 = new SctpMessage(new TestMessageInfo(false, 2), buffer2);
         assertThrows(CodecException.class, () -> channel.writeInbound(message2));
 
-        assertEquals(1, buffer.refCnt());
-        assertEquals(0, buffer2.refCnt());
-        assertFalse(channel.finish());
+        // exceptionCaught closes the channel, triggering handlerRemoved which releases all buffered fragments
         assertEquals(0, buffer.refCnt());
         assertEquals(0, buffer2.refCnt());
+        assertFalse(channel.finish());
     }
 
     @Test


### PR DESCRIPTION
Motivation:
In SCTP, the test fails because the assertion doesn't match the current code. It's possible the code was updated in response to review comments, while the test wasn't updated to match.
In Redis, we had two PRs merged in incompatible ways where one broke the tests of the other.

Modification:
- Correct the assertions to match that the handler now closes the channel in exceptionCaught.
- Make sure that the RedisArrayAggregator releases its messages through both the nested array failure path, as well as on handler removed.

Result:
The transport-sctp and codec-redis module tests now passes.