### PR TITLE
Fix incorrect bounds in error message of HpackDecoder.setMaxHeaderListSize

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDecoder.java
@@ -335,7 +335,7 @@ final class HpackDecoder {
     void setMaxHeaderListSize(long maxHeaderListSize) throws Http2Exception {
         if (maxHeaderListSize < MIN_HEADER_LIST_SIZE || maxHeaderListSize > MAX_HEADER_LIST_SIZE) {
             throw connectionError(PROTOCOL_ERROR, "Header List Size must be >= %d and <= %d but was %d",
-                    MIN_HEADER_TABLE_SIZE, MAX_HEADER_TABLE_SIZE, maxHeaderListSize);
+                    MIN_HEADER_LIST_SIZE, MAX_HEADER_LIST_SIZE, maxHeaderListSize);
         }
         this.maxHeaderListSize = maxHeaderListSize;
     }


### PR DESCRIPTION

Motivation:
HpackDecoder#setMaxHeaderListSize validates the supplied value against MIN_HEADER_LIST_SIZE and MAX_HEADER_LIST_SIZE, but the error message thrown when the value is out of range incorrectly references MIN_HEADER_TABLE_SIZE and MAX_HEADER_TABLE_SIZE. This is misleading: it reports header table size limits while the method actually validates the header list size, which makes the resulting Http2Exception confusing to diagnose.
Modifications:
In HpackDecoder#setMaxHeaderListSize, update the connectionError call so that the formatted message uses MIN_HEADER_LIST_SIZE and MAX_HEADER_LIST_SIZE instead of the header-table-size constants, matching the actual range check performed on the argument.
Result:
When an invalid maxHeaderListSize is supplied, the thrown Http2Exception now reports the correct lower and upper bounds, making the error self-consistent and easier to debug. No behavioral change in validation logic.