### PR TITLE
Document Java 9 requirement for io_uring

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ Netty is an asynchronous event-driven network application framework for rapid de
 * [Official Discord server](https://discord.gg/q4aQ2XjaCa)
 * [Modular Netty guide](testsuite-jpms/README.md)
 
+## How to use
+
+### System requirements
+
+Netty 4.2 requires Java 8 or newer. The optional [`io_uring` native transport](./transport-native-io_uring/) requires Java 9 or newer.
+
+### Usage with JDK 9+
+
+You can read the [Modular Netty guide](testsuite-jpms/README.md) to learn more about using Netty with the Java Platform Module System, the guide 
+contains a user section and a developer section for Netty contributors.
+
 ## How to build
 
 For the detailed information about building and developing Netty, please visit [the developer guide](https://netty.io/wiki/developer-guide.html).  This page only gives very basic information.
@@ -21,16 +32,12 @@ For the detailed information about building and developing Netty, please visit [
 You require the following to build Netty:
 
 * Latest stable [OpenJDK 8](https://adoptium.net/)
+  * Note that `io_uring` requires JDK 9
 * Latest stable [Apache Maven](https://maven.apache.org/)
 * If you are on Linux or MacOS, you need [additional development packages](https://netty.io/wiki/native-transports.html) installed on your system, because you'll build the native transport.
 
 Note that this is build-time requirement.  JDK 5 (for 3.x) or 6 (for 4.0+ / 4.1+) is enough to run your Netty-based application.
 
-## Branches to look
+### Branches to look
 
 Development of all versions takes place in each branch whose name is identical to `<majorVersion>.<minorVersion>`.  For example, the development of 3.9 and 4.1 resides in [the branch '3.9'](https://github.com/netty/netty/tree/3.9) and [the branch '4.1'](https://github.com/netty/netty/tree/4.1) respectively.
-
-## Usage with JDK 9+
-
-You can read the [Modular Netty guide](testsuite-jpms/README.md) to learn more about using Netty with the Java Platform Module System, the guide 
-contains a user section and a developer section for Netty contributors.

--- a/transport-classes-io_uring/README.md
+++ b/transport-classes-io_uring/README.md
@@ -1,0 +1,3 @@
+# Netty io_uring
+
+[io_uring](https://kernel.dk/io_uring.pdf) is a high I/O performance scalable interface for fully asynchronous Linux syscalls. While Netty 4.2 generally requires Java 8 or newer, this optional io_uring native transport requires Java 9 or newer.

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/package-info.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/package-info.java
@@ -15,6 +15,7 @@
  */
 /**
  * <a href="https://kernel.dk/io_uring.pdf">io_uring</a> is a high I/O performance scalable interface for fully
- * asynchronous Linux syscalls.
+ * asynchronous Linux syscalls. While Netty 4.2 generally requires Java 8 or newer, this optional io_uring native
+ * transport requires Java 9 or newer.
  */
 package io.netty.channel.uring;

--- a/transport-native-io_uring/README.md
+++ b/transport-native-io_uring/README.md
@@ -7,6 +7,7 @@ The new io_uring interface added to the Linux Kernel 5.1 is a high I/O performan
 - x86-64 / aarch64 / riscv64 processor
 - at least Kernel 5.14, compiled with `CONFIG_IO_URING=y`
 - to run the tests, you have to increase memlock(default 64K)
+- Java 9
 
 
 See [our wiki page](https://netty.io/wiki/native-transports.html).


### PR DESCRIPTION
Motivation:

Most of Netty 4.2 requires Java 8 or newer, but the io_uring native transport requires Java 9 or newer. Documentation of that requirement is sparse, and Java 8 users may be surprised to discover that _most_ native transports work under Java 8, but io_uring is an exception.

Modification:

This change adds notes in a few key locations that Netty 4.2 generally requires Java 8, but io_uring requires Java 9.

Result:

Fixes #16857. 