### PR TITLE
IoUring: fix io_uring datagram writes with non-zero readerIndex

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
@@ -612,7 +612,7 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
                 segmentSize = 0;
             }
 
-            long bufferAddress = IoUring.memoryAddress(data);
+            long bufferAddress = IoUring.memoryAddress(data) + data.readerIndex();
             return scheduleSendmsg(remoteAddress, bufferAddress, data.readableBytes(), segmentSize, first);
         }
 

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDatagramConnectedWriteExceptionTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDatagramConnectedWriteExceptionTest.java
@@ -29,8 +29,6 @@ import io.netty.util.NetUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
@@ -52,7 +50,6 @@ public class IoUringDatagramConnectedWriteExceptionTest extends DatagramConnecte
 
     @Test
     @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-    @DisabledOnOs(OS.WINDOWS)
     public void testWriteOffsetBytebuf(TestInfo testInfo) throws Throwable {
         run(testInfo, (Runner<Bootstrap>) this::testWriteOffsetBytebuf);
     }
@@ -91,10 +88,14 @@ public class IoUringDatagramConnectedWriteExceptionTest extends DatagramConnecte
            assertArrayEquals(EXPECTED, actual);
         } finally {
            if (clientChannel != null) {
-               clientChannel.close();
+               clientChannel.close().sync();
+           }
+           if (serverChannel != null) {
+               serverChannel.close().sync();
            }
        }
      }
+
     private static ByteBuf directReaderIndex(ByteBufAllocator alloc) {
         ByteBuf buf = alloc.directBuffer(BAD_PREFIX.length + EXPECTED.length);
         buf.writeBytes(BAD_PREFIX);

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDatagramConnectedWriteExceptionTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDatagramConnectedWriteExceptionTest.java
@@ -16,15 +16,91 @@
 package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.socket.DatagramPacket;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.DatagramConnectedWriteExceptionTest;
+import io.netty.util.NetUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 public class IoUringDatagramConnectedWriteExceptionTest extends DatagramConnectedWriteExceptionTest {
+
+    private static final byte[] BAD_PREFIX = "BAD-PREFIX-".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] EXPECTED = "EXPECTED-direct-reader-index".getBytes(StandardCharsets.UTF_8);
 
     @Override
     protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
         return IoUringSocketTestPermutation.INSTANCE.datagramSocket();
     }
+
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+    @DisabledOnOs(OS.WINDOWS)
+    public void testWriteOffsetBytebuf(TestInfo testInfo) throws Throwable {
+        run(testInfo, (Runner<Bootstrap>) this::testWriteOffsetBytebuf);
+    }
+
+    private void testWriteOffsetBytebuf(Bootstrap clientBootstrap) throws Throwable {
+        CompletableFuture<byte[]> received = new CompletableFuture<>();
+        Bootstrap serverBootstrap = clientBootstrap.clone()
+                .option(ChannelOption.SO_BROADCAST, false)
+                .handler(new SimpleChannelInboundHandler<DatagramPacket>() {
+                    @Override
+                    protected void channelRead0(ChannelHandlerContext ctx, DatagramPacket packet) {
+                        ByteBuf content = packet.content();
+                        byte[] bytes = new byte[content.readableBytes()];
+                        content.getBytes(content.readerIndex(), bytes);
+                        received.complete(bytes);
+                    }
+                });
+
+        Channel serverChannel = serverBootstrap.bind(new InetSocketAddress(NetUtil.LOCALHOST, 0)).sync().channel();
+        InetSocketAddress serverAddress = (InetSocketAddress) serverChannel.localAddress();
+
+        clientBootstrap.option(ChannelOption.AUTO_READ, false)
+                .handler(new SimpleChannelInboundHandler<DatagramPacket>() {
+                    @Override
+                    protected void channelRead0(ChannelHandlerContext ctx, DatagramPacket msg) {
+                        // no-op
+                    }
+                });
+
+        Channel clientChannel = clientBootstrap.connect(serverAddress).sync().channel();
+        try {
+           ByteBuf content = directReaderIndex(serverChannel.alloc());
+           clientChannel.writeAndFlush(new DatagramPacket(content, serverAddress)).sync();
+
+           byte[] actual = received.join();
+           assertArrayEquals(EXPECTED, actual);
+        } finally {
+           if (clientChannel != null) {
+               clientChannel.close();
+           }
+       }
+     }
+    private static ByteBuf directReaderIndex(ByteBufAllocator alloc) {
+        ByteBuf buf = alloc.directBuffer(BAD_PREFIX.length + EXPECTED.length);
+        buf.writeBytes(BAD_PREFIX);
+        buf.writeBytes(EXPECTED);
+        buf.readerIndex(BAD_PREFIX.length);
+        return buf;
+    }
+
 }


### PR DESCRIPTION
Motivation:

`IoUringDatagramChannel` currently builds the send buffer address from the ByteBuf base memory address. When a direct ByteBuf has a non-zero `readerIndex`, UDP writes may send bytes from the beginning of the buffer instead of the readable region.

``` java
// skip eventloopGroup and server/client channel initialization
            byte[] BAD_PREFIX = "BAD-PREFIX-".getBytes(StandardCharsets.UTF_8);
            byte[] EXPECTED = "EXPECTED-direct-reader-index".getBytes(StandardCharsets.UTF_8);
            InetSocketAddress recipient = (InetSocketAddress) server.localAddress();
            ByteBuf content = client.alloc().directBuffer(BAD_PREFIX.length + EXPECTED.length);
            content.writeBytes(BAD_PREFIX);
            content.writeBytes(EXPECTED);
            content.readerIndex(BAD_PREFIX.length);
            client.writeAndFlush(new DatagramPacket(content, recipient)).sync();
            byte[] actual = received.join();
            System.out.println(new String(actual));
```

this code prints `BAD-PREFIX-EXPECTED-direct-r`, but it should print `EXPECTED-direct-reader-index`

Modification:

Add the ByteBuf readerIndex() to the memory address used for io_uringdatagram sendmsg writes

Result:
Datagram writes now use the readable region of direct ByteBufs correctly, including buffers with a non-zero readerIndex.


