### PR TITLE
QuicheQuicStreamChannel: Handle write after peer sending STOP_SENDING and FIN

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicStreamChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicStreamChannel.java
@@ -864,6 +864,17 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
                         capacity = cap;
                     }
                     if (res < 0) {
+                        if (res == Quiche.QUICHE_ERR_DONE
+                                && cap == Quiche.QUICHE_ERR_INVALID_STREAM_STATE) {
+                            // quiche_conn_stream_send(...) reports QUICHE_ERR_DONE not only when there is no
+                            // capacity to buffer more data (in which case the stream still exists and reports a
+                            // capacity >= 0), but also when the stream was already closed and garbage collected.
+                            // The latter happens when the peer sent a STOP_SENDING frame, and we also received the FIN.
+                            // In that case the stream no longer exists, so quiche_conn_stream_capacity(...) reports
+                            // QUICHE_ERR_INVALID_STREAM_STATE. Report it as QUICHE_ERR_STREAM_STOPPED to fail the
+                            // promise instead of queuing it forever.
+                            return Quiche.QUICHE_ERR_STREAM_STOPPED;
+                        }
                         return res;
                     }
                     if (readable && res == 0) {

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicStreamShutdownTest.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicStreamShutdownTest.java
@@ -21,6 +21,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.socket.ChannelInputShutdownEvent;
 import io.netty.channel.socket.ChannelOutputShutdownException;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -36,6 +37,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 public class QuicStreamShutdownTest extends AbstractQuicTest {
 
@@ -76,6 +78,71 @@ public class QuicStreamShutdownTest extends AbstractQuicTest {
             streamChannel.writeAndFlush(Unpooled.buffer().writeLong(8)).sync();
 
             latch.await();
+        } finally {
+            QuicTestUtils.closeIfNotNull(channel);
+            QuicTestUtils.closeIfNotNull(server);
+
+            shutdown(executor);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("newSslTaskExecutors")
+    public void testWriteAfterStreamClosedFailsPromise(Executor executor) throws Throwable {
+        Channel server = null;
+        Channel channel = null;
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Throwable> writeCauseRef = new AtomicReference<>();
+        AtomicReference<Throwable> errorRef = new AtomicReference<>();
+        try {
+            server = QuicTestUtils.newServer(executor, new ChannelInboundHandlerAdapter(),
+                    new ChannelInboundHandlerAdapter() {
+                        @Override
+                        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                            if (evt instanceof ChannelInputShutdownEvent) {
+                                // At this point the remote already sent STOP_SENDING (shutdownInput) and FIN
+                                // (shutdownOutput). The stream is therefore fully closed and
+                                // quiche_conn_stream_send(...) reports QUICHE_ERR_DONE for this write. The promise
+                                // must be failed instead of being silently queued and hanging forever.
+                                ctx.writeAndFlush(Unpooled.buffer().writeLong(8)).addListener(f -> {
+                                    if (f.isSuccess()) {
+                                        errorRef.compareAndSet(null,
+                                                new AssertionError("Write should have failed but succeeded"));
+                                    } else {
+                                        writeCauseRef.compareAndSet(null, f.cause());
+                                    }
+                                    latch.countDown();
+                                });
+                            }
+                        }
+                    });
+
+            channel = QuicTestUtils.newClient(executor);
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
+                    .handler(new ChannelInboundHandlerAdapter())
+                    .streamHandler(new ChannelInboundHandlerAdapter())
+                    .remoteAddress(server.localAddress())
+                    .connect()
+                    .get();
+
+            QuicStreamChannel streamChannel = quicChannel.createStream(QuicStreamType.BIDIRECTIONAL,
+                    new ChannelInboundHandlerAdapter()).sync().getNow();
+
+            // Creates the stream on the remote peer.
+            streamChannel.writeAndFlush(Unpooled.buffer().writeLong(8)).sync();
+            // Sends a STOP_SENDING frame, to which quiche will respond with a RESET_STREAM frame.
+            streamChannel.shutdownInput().sync();
+            // Sends a STREAM frame with the FIN bit set, which closes the stream on the remote peer.
+            streamChannel.shutdownOutput().sync();
+
+            if (!latch.await(5, TimeUnit.SECONDS)) {
+                fail("Timeout while waiting for the write promise to be failed");
+            }
+            Throwable error = errorRef.get();
+            if (error != null) {
+                fail("Failure during execution", error);
+            }
+            assertInstanceOf(ChannelOutputShutdownException.class, writeCauseRef.get());
         } finally {
             QuicTestUtils.closeIfNotNull(channel);
             QuicTestUtils.closeIfNotNull(server);


### PR DESCRIPTION
Motivation:

QuicheQuicStreamChannel treats QUICHE_ERR_DONE from quiche_conn_stream_send(...)
as backpressure: it queues the buffer and retries when the stream becomes
writable. That goes with quiche's contract of `stream_send`:

```rust
/// Writes data to a stream.
///
/// On success the number of bytes written is returned, or [`Done`] if no
/// data was written (e.g. because the stream has no capacity).
pub fn stream_send(
```
https://github.com/cloudflare/quiche/blob/4f347477006bf7f928335d28f05056013f70b87e/quiche/src/lib.rs#L5481-L5528

But quiche returns the same Done for a stream that has already been closed and
garbage collected. stream_send(...) resolves the stream via get_or_create(...),
which returns Error::Done once the id is in the collected set:

```rust
pub(crate) fn get_or_create(
    &mut self, id: u64, local_params: &crate::TransportParams,
    peer_params: &crate::TransportParams, local: bool, is_server: bool,
) -> Result<&mut Stream<F>> {
    let (stream, is_new_and_writable) = match self.streams.entry(id) {
        hash_map::Entry::Vacant(v) => {
            // Stream has already been closed and garbage collected.
            if self.collected.contains(&id) {
                return Err(Error::Done);
            }
```
https://github.com/cloudflare/quiche/blob/4f347477006bf7f928335d28f05056013f70b87e/quiche/src/stream/mod.rs#L236-L245

For a bidi stream this happens after the peer sends STOP_SENDING (stopping our
send side) and we read the FIN. The FIN completes the stream, and
do_stream_recv(...) collects it:

```rust
fn do_stream_recv(
    &mut self, stream_id: u64, action: RecvAction,
) -> Result<(usize, bool)> {
    ...
    let complete = stream.is_complete();
    ...
    if complete {
        self.streams.collect(stream_id, local);
    }
```
https://github.com/cloudflare/quiche/blob/4f347477006bf7f928335d28f05056013f70b87e/quiche/src/lib.rs#L5387-L5452

collect(...) drops the stream from the map:

```rust
/// Drops completed stream.
///
/// This should only be called when Stream::is_complete() returns true for
/// the given stream.
pub fn collect(&mut self, stream_id: u64, local: bool) {
```
https://github.com/cloudflare/quiche/blob/4f347477006bf7f928335d28f05056013f70b87e/quiche/src/stream/mod.rs#L563-L567

The stream never becomes writable again, so the queued write is never sent and
its promise never completes. The application only sees the failure when the
connection idle timeout tears down the whole connection.

Modification:

In write0(...), when quiche_conn_stream_send(...) returns QUICHE_ERR_DONE,
disambiguate with stream_capacity(...) queried right after. A backpressured
stream is alive and reports capacity as Ok (>= 0); a closed stream is gone from
the map and reports InvalidStreamState:

```rust
/// Returns the stream's send capacity in bytes.
///
/// If the specified stream doesn't exist (including when it has already
/// been completed and closed), the [`InvalidStreamState`] error will be
/// returned.
pub fn stream_capacity(&mut self, stream_id: u64) -> Result<usize> {
    if let Some(stream) = self.streams.get(stream_id) {
        ...
    };
    Err(Error::InvalidStreamState(stream_id))
}
```
https://github.com/cloudflare/quiche/blob/4f347477006bf7f928335d28f05056013f70b87e/quiche/src/lib.rs#L5899-L5937

QUICHE_ERR_DONE plus a QUICHE_ERR_INVALID_STREAM_STATE capacity uniquely
identifies the closed stream. In that case report QUICHE_ERR_STREAM_STOPPED, so
the existing call sites fail the write promise with
ChannelOutputShutdownException instead of queuing it forever.

STREAM_STOPPED is the right code: the only way to reach this branch is the
peer's STOP_SENDING. Seen before the FIN is read, stream_do_send(...) returns
Error::StreamStopped directly:

```rust
fn stream_do_send<B, R, SND>(
    &mut self, stream_id: u64, buf: B, fin: bool, write_fn: SND,
) -> Result<R>
    ...
{
    ...
    if let Err(Error::StreamStopped(e)) = stream.send.cap() {
        ...
        return Err(Error::StreamStopped(e));
    };
```
https://github.com/cloudflare/quiche/blob/4f347477006bf7f928335d28f05056013f70b87e/quiche/src/lib.rs#L5573-L5629

and a write after our own FIN is rejected earlier by the finSent check.

Adds QuicStreamShutdownTest#testWriteAfterStreamClosedFailsPromise, which drives
the write + STOP_SENDING + FIN sequence and asserts the promise fails with
ChannelOutputShutdownException.

Result:

Writes to a stream closed via STOP_SENDING + FIN fail their promise immediately
with ChannelOutputShutdownException instead of hanging until the connection idle
timeout. Fixes #15924.