### PR TITLE
Use Splittable/ThreadLocalRandom to generate bulk data in tests (#16808)

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/ByteBufDerivationTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufDerivationTest.java
@@ -19,7 +19,7 @@ package io.netty.buffer;
 import org.junit.jupiter.api.Test;
 
 import java.nio.ByteOrder;
-import java.util.Random;
+import java.util.SplittableRandom;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -172,7 +172,7 @@ public class ByteBufDerivationTest {
     public void testMixture() throws Exception {
         ByteBuf buf = Unpooled.buffer(10000);
         ByteBuf derived = buf;
-        Random rnd = new Random();
+        SplittableRandom rnd = new SplittableRandom();
         for (int i = 0; i < buf.capacity(); i ++) {
             ByteBuf newDerived;
             int randomNumber = rnd.nextInt(4);

--- a/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
@@ -28,7 +28,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -114,8 +114,7 @@ public class ByteBufUtilTest {
 
     private static void decodeRandomHexBytes(int len) {
         byte[] b = new byte[len];
-        Random rand = new Random();
-        rand.nextBytes(b);
+        ThreadLocalRandom.current().nextBytes(b);
         String hexDump = ByteBufUtil.hexDump(b);
         for (int i = 0; i <= len; i++) {  // going over sub-strings of various lengths including empty byte[].
             byte[] b2 = Arrays.copyOfRange(b, i, b.length);
@@ -183,9 +182,8 @@ public class ByteBufUtilTest {
     public void equalsBufferSubsections() {
         byte[] b1 = new byte[128];
         byte[] b2 = new byte[256];
-        Random rand = new Random();
-        rand.nextBytes(b1);
-        rand.nextBytes(b2);
+        ThreadLocalRandom.current().nextBytes(b1);
+        ThreadLocalRandom.current().nextBytes(b2);
         final int iB1 = b1.length / 2;
         final int iB2 = iB1 + b1.length;
         final int length = b1.length - iB1;
@@ -193,24 +191,23 @@ public class ByteBufUtilTest {
         assertTrue(ByteBufUtil.equals(Unpooled.wrappedBuffer(b1), iB1, Unpooled.wrappedBuffer(b2), iB2, length));
     }
 
-    private static int random(Random r, int min, int max) {
-        return r.nextInt((max - min) + 1) + min;
+    private static int random(int min, int max) {
+        return ThreadLocalRandom.current().nextInt((max - min) + 1) + min;
     }
 
     @Test
     public void notEqualsBufferSubsections() {
         byte[] b1 = new byte[50];
         byte[] b2 = new byte[256];
-        Random rand = new Random();
-        rand.nextBytes(b1);
-        rand.nextBytes(b2);
+        ThreadLocalRandom.current().nextBytes(b1);
+        ThreadLocalRandom.current().nextBytes(b2);
         final int iB1 = b1.length / 2;
         final int iB2 = iB1 + b1.length;
         final int length = b1.length - iB1;
         System.arraycopy(b1, iB1, b2, iB2, length);
         // Randomly pick an index in the range that will be compared and make the value at that index differ between
         // the 2 arrays.
-        int diffIndex = random(rand, iB1, iB1 + length - 1);
+        int diffIndex = random(iB1, iB1 + length - 1);
         ++b1[diffIndex];
         assertFalse(ByteBufUtil.equals(Unpooled.wrappedBuffer(b1), iB1, Unpooled.wrappedBuffer(b2), iB2, length));
     }
@@ -219,9 +216,8 @@ public class ByteBufUtilTest {
     public void notEqualsBufferOverflow() {
         byte[] b1 = new byte[8];
         byte[] b2 = new byte[16];
-        Random rand = new Random();
-        rand.nextBytes(b1);
-        rand.nextBytes(b2);
+        ThreadLocalRandom.current().nextBytes(b1);
+        ThreadLocalRandom.current().nextBytes(b2);
         final int iB1 = b1.length / 2;
         final int iB2 = iB1 + b1.length;
         final int length = b1.length - iB1;
@@ -234,9 +230,8 @@ public class ByteBufUtilTest {
     public void notEqualsBufferUnderflow() {
         final byte[] b1 = new byte[8];
         final byte[] b2 = new byte[16];
-        Random rand = new Random();
-        rand.nextBytes(b1);
-        rand.nextBytes(b2);
+        ThreadLocalRandom.current().nextBytes(b1);
+        ThreadLocalRandom.current().nextBytes(b2);
         final int iB1 = b1.length / 2;
         final int iB2 = iB1 + b1.length;
         final int length = b1.length - iB1;

--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -28,7 +28,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
-import java.util.Random;
+import java.util.SplittableRandom;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.FutureTask;
@@ -775,7 +775,7 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
         assertEquals(0, allocator.pinnedDirectMemory());
 
         int[] capacities = new int[30];
-        Random rng = new Random();
+        SplittableRandom rng = new SplittableRandom();
         for (int i = 0; i < capacities.length; i++) {
             capacities[i] = initialCapacity / 4 + rng.nextInt(8 * initialCapacity);
         }
@@ -838,7 +838,7 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
         assertEquals(0, allocator.pinnedHeapMemory());
 
         int[] capacities = new int[30];
-        Random rng = new Random();
+        SplittableRandom rng = new SplittableRandom();
         for (int i = 0; i < capacities.length; i++) {
             capacities[i] = initialCapacity / 4 + rng.nextInt(8 * initialCapacity);
         }

--- a/codec-base/src/test/java/io/netty/handler/codec/bytes/ByteArrayDecoderTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/bytes/ByteArrayDecoderTest.java
@@ -20,9 +20,10 @@ import io.netty.util.internal.EmptyArrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
-import static io.netty.buffer.Unpooled.*;
+import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
+import static io.netty.buffer.Unpooled.wrappedBuffer;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
@@ -38,7 +39,7 @@ public class ByteArrayDecoderTest {
     @Test
     public void testDecode() throws Exception {
         byte[] b = new byte[2048];
-        new Random().nextBytes(b);
+        ThreadLocalRandom.current().nextBytes(b);
         ch.writeInbound(wrappedBuffer(b));
         assertArrayEquals(b, ch.readInbound());
     }

--- a/codec-base/src/test/java/io/netty/handler/codec/bytes/ByteArrayEncoderTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/bytes/ByteArrayEncoderTest.java
@@ -22,9 +22,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
-import static io.netty.buffer.Unpooled.*;
+import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
+import static io.netty.buffer.Unpooled.wrappedBuffer;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -46,7 +47,7 @@ public class ByteArrayEncoderTest {
     @Test
     public void testEncode() throws Exception {
         byte[] b = new byte[2048];
-        new Random().nextBytes(b);
+        ThreadLocalRandom.current().nextBytes(b);
         ch.writeOutbound(b);
         ByteBuf encoded = ch.readOutbound();
         assertEquals(wrappedBuffer(b), encoded);

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/AbstractCompressionTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/AbstractCompressionTest.java
@@ -15,24 +15,24 @@
  */
 package io.netty.handler.codec.compression;
 
-import java.util.Random;
+import java.util.SplittableRandom;
 
 public abstract class AbstractCompressionTest {
 
-    protected static final Random rand;
+    protected final SplittableRandom rand = new SplittableRandom();
 
     protected static final byte[] BYTES_SMALL = new byte[256];
     protected static final byte[] BYTES_LARGE = new byte[256 * 1024];
 
     static {
-        rand = new Random();
         fillArrayWithCompressibleData(BYTES_SMALL);
         fillArrayWithCompressibleData(BYTES_LARGE);
     }
 
     private static void fillArrayWithCompressibleData(byte[] array) {
+        SplittableRandom rng = new SplittableRandom();
         for (int i = 0; i < array.length; i++) {
-            array[i] = i % 4 != 0 ? 0 : (byte) rand.nextInt();
+            array[i] = i % 4 != 0 ? 0 : (byte) rng.nextInt();
         }
     }
 }

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/AbstractIntegrationTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/AbstractIntegrationTest.java
@@ -26,12 +26,14 @@ import io.netty.util.ByteProcessor;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.EmptyArrays;
+import io.netty.util.internal.PlatformDependent;
 import io.netty.util.test.DisabledForSlowLeakDetection;
 import org.junit.jupiter.api.Test;
 
 import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.Random;
+import java.util.SplittableRandom;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -106,7 +108,7 @@ public abstract class AbstractIntegrationTest {
     @Test
     public void testLargeRandom() throws Exception {
         final byte[] data = new byte[1024 * 1024];
-        rand.nextBytes(data);
+        PlatformDependent.splittableRandomNextBytes(new SplittableRandom(rand.nextLong()), data);
         testIdentity(data, true);
         testIdentity(data, false);
     }
@@ -114,7 +116,7 @@ public abstract class AbstractIntegrationTest {
     @Test
     public void testPartRandom() throws Exception {
         final byte[] data = new byte[10240];
-        rand.nextBytes(data);
+        PlatformDependent.splittableRandomNextBytes(new SplittableRandom(rand.nextLong()), data);
         for (int i = 0; i < 1024; i++) {
             data[i] = 2;
         }
@@ -124,9 +126,10 @@ public abstract class AbstractIntegrationTest {
 
     @Test
     public void testCompressible() throws Exception {
+        SplittableRandom rng = new SplittableRandom(rand.nextLong());
         final byte[] data = new byte[10240];
         for (int i = 0; i < data.length; i++) {
-            data[i] = i % 4 != 0 ? 0 : (byte) rand.nextInt();
+            data[i] = i % 4 != 0 ? 0 : (byte) rng.nextInt();
         }
         testIdentity(data, true);
         testIdentity(data, false);

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/BrotliDecoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/BrotliDecoderTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Random;
+import java.util.SplittableRandom;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -63,8 +64,9 @@ public class BrotliDecoderTest {
             Unpooled.wrappedBuffer(BYTES_LARGE)).asReadOnly();
 
     private static void fillArrayWithCompressibleData(byte[] array) {
+        SplittableRandom rng = new SplittableRandom(RANDOM.nextLong());
         for (int i = 0; i < array.length; i++) {
-            array[i] = i % 4 != 0 ? 0 : (byte) RANDOM.nextInt();
+            array[i] = i % 4 != 0 ? 0 : (byte) rng.nextInt();
         }
     }
 
@@ -134,12 +136,13 @@ public class BrotliDecoderTest {
 
     private void testDecompressionOfBatchedFlow(final ByteBuf expected, final ByteBuf data) throws Exception {
         final int compressedLength = data.readableBytes();
-        int written = 0, length = RANDOM.nextInt(100);
+        SplittableRandom rng = new SplittableRandom(RANDOM.nextLong());
+        int written = 0, length = rng.nextInt(100);
         while (written + length < compressedLength) {
             ByteBuf compressedBuf = data.retainedSlice(written, length);
             channel.writeInbound(compressedBuf);
             written += length;
-            length = RANDOM.nextInt(100);
+            length = rng.nextInt(100);
         }
         ByteBuf compressedBuf = data.slice(written, compressedLength - written);
         assertTrue(channel.writeInbound(compressedBuf.retain()));

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/ByteBufChecksumTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/ByteBufChecksumTest.java
@@ -21,7 +21,7 @@ import net.jpountz.xxhash.XXHashFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.zip.Adler32;
 import java.util.zip.CRC32;
 import java.util.zip.Checksum;
@@ -35,7 +35,7 @@ public class ByteBufChecksumTest {
 
     @BeforeAll
     public static void setUp() {
-        new Random().nextBytes(BYTE_ARRAY);
+        ThreadLocalRandom.current().nextBytes(BYTE_ARRAY);
     }
 
     @Test

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/Bzip2IntegrationTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/Bzip2IntegrationTest.java
@@ -16,7 +16,10 @@
 package io.netty.handler.codec.compression;
 
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
+
+import java.util.SplittableRandom;
 
 public class Bzip2IntegrationTest extends AbstractIntegrationTest {
 
@@ -33,7 +36,7 @@ public class Bzip2IntegrationTest extends AbstractIntegrationTest {
     @Test
     public void test3Tables() throws Exception {
         byte[] data = new byte[500];
-        rand.nextBytes(data);
+        PlatformDependent.splittableRandomNextBytes(new SplittableRandom(rand.nextLong()), data);
         testIdentity(data, true);
         testIdentity(data, false);
     }
@@ -41,7 +44,7 @@ public class Bzip2IntegrationTest extends AbstractIntegrationTest {
     @Test
     public void test4Tables() throws Exception {
         byte[] data = new byte[1100];
-        rand.nextBytes(data);
+        PlatformDependent.splittableRandomNextBytes(new SplittableRandom(rand.nextLong()), data);
         testIdentity(data, true);
         testIdentity(data, false);
     }
@@ -49,7 +52,7 @@ public class Bzip2IntegrationTest extends AbstractIntegrationTest {
     @Test
     public void test5Tables() throws Exception {
         byte[] data = new byte[2300];
-        rand.nextBytes(data);
+        PlatformDependent.splittableRandomNextBytes(new SplittableRandom(rand.nextLong()), data);
         testIdentity(data, true);
         testIdentity(data, false);
     }

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/FastLzIntegrationTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/FastLzIntegrationTest.java
@@ -20,6 +20,8 @@ import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 
+import java.util.SplittableRandom;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
@@ -70,12 +72,13 @@ public class FastLzIntegrationTest extends AbstractIntegrationTest {
         final CompositeByteBuf decompressed = Unpooled.compositeBuffer();
 
         try {
-            int written = 0, length = rand.nextInt(100);
+            SplittableRandom rng = new SplittableRandom(rand.nextLong());
+            int written = 0, length = rng.nextInt(100);
             while (written + length < data.length) {
                 ByteBuf in = Unpooled.wrappedBuffer(data, written, length);
                 encoder.writeOutbound(in);
                 written += length;
-                length = rand.nextInt(100);
+                length = rng.nextInt(100);
             }
             ByteBuf in = Unpooled.wrappedBuffer(data, written, data.length - written);
             encoder.writeOutbound(in);
@@ -89,12 +92,12 @@ public class FastLzIntegrationTest extends AbstractIntegrationTest {
             final byte[] compressedArray = new byte[compressed.readableBytes()];
             compressed.readBytes(compressedArray);
             written = 0;
-            length = rand.nextInt(100);
+            length = rng.nextInt(100);
             while (written + length < compressedArray.length) {
                 in = Unpooled.wrappedBuffer(compressedArray, written, length);
                 decoder.writeInbound(in);
                 written += length;
-                length = rand.nextInt(100);
+                length = rng.nextInt(100);
             }
             in = Unpooled.wrappedBuffer(compressedArray, written, compressedArray.length - written);
             decoder.writeInbound(in);

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/SnappyIntegrationTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/SnappyIntegrationTest.java
@@ -16,9 +16,10 @@
 package io.netty.handler.codec.compression;
 
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
 
-import java.util.Random;
+import java.util.SplittableRandom;
 
 public class SnappyIntegrationTest extends AbstractIntegrationTest {
 
@@ -103,7 +104,7 @@ public class SnappyIntegrationTest extends AbstractIntegrationTest {
 
     private void testWithSeed(long seed) throws Exception {
         byte[] data = new byte[16 * 1048576];
-        new Random(seed).nextBytes(data);
+        PlatformDependent.splittableRandomNextBytes(new SplittableRandom(seed), data);
         testIdentity(data, true);
     }
 

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/TcpDnsTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/TcpDnsTest.java
@@ -21,7 +21,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.ReferenceCountUtil;
 import org.junit.jupiter.api.Test;
 
-import java.util.Random;
+import java.util.SplittableRandom;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -36,7 +36,7 @@ public class TcpDnsTest {
     public void testQueryDecode() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new TcpDnsQueryDecoder());
 
-        int randomID = new Random().nextInt(60000 - 1000) + 1000;
+        int randomID = new SplittableRandom().nextInt(60000 - 1000) + 1000;
         DnsQuery query = new DefaultDnsQuery(randomID, DnsOpCode.QUERY)
                 .setRecord(DnsSection.QUESTION, new DefaultDnsQuestion(QUERY_DOMAIN, DnsRecordType.A));
         assertTrue(channel.writeInbound(query));
@@ -52,7 +52,7 @@ public class TcpDnsTest {
     public void testDecoderLeak() throws Exception {
         EmbeddedChannel decoder = new EmbeddedChannel(new TcpDnsQueryDecoder());
         EmbeddedChannel encoder = new EmbeddedChannel(new TcpDnsQueryEncoder());
-        int randomID = new Random().nextInt(60000 - 1000) + 1000;
+        int randomID = new SplittableRandom().nextInt(60000 - 1000) + 1000;
         DnsQuery query = new DefaultDnsQuery(randomID, DnsOpCode.QUERY)
                 .setRecord(DnsSection.QUESTION, new DefaultDnsQuestion(QUERY_DOMAIN, DnsRecordType.A));
         assertTrue(encoder.writeOutbound(query));
@@ -74,7 +74,7 @@ public class TcpDnsTest {
     public void testResponseEncode() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel(new TcpDnsResponseEncoder());
 
-        int randomID = new Random().nextInt(60000 - 1000) + 1000;
+        int randomID = new SplittableRandom().nextInt(60000 - 1000) + 1000;
         DnsQuery query = new DefaultDnsQuery(randomID, DnsOpCode.QUERY)
                 .setRecord(DnsSection.QUESTION, new DefaultDnsQuestion(QUERY_DOMAIN, DnsRecordType.A));
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpInvalidMessageTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpInvalidMessageTest.java
@@ -20,9 +20,11 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.util.CharsetUtil;
+import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
 
 import java.util.Random;
+import java.util.SplittableRandom;
 
 import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -108,7 +110,7 @@ public class HttpInvalidMessageTest {
     private void ensureInboundTrafficDiscarded(EmbeddedChannel ch) throws Exception {
         // Generate a lot of random traffic to ensure that it's discarded silently.
         byte[] data = new byte[1048576];
-        rnd.nextBytes(data);
+        PlatformDependent.splittableRandomNextBytes(new SplittableRandom(rnd.nextLong()), data);
 
         ByteBuf buf = Unpooled.wrappedBuffer(data);
         for (int i = 0; i < 4096; i ++) {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
@@ -30,7 +30,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -296,8 +296,7 @@ public class HttpResponseDecoderTest {
         assertEquals(HttpResponseStatus.OK, res.status());
 
         byte[] chunkBytes = new byte[10];
-        Random random = new Random();
-        random.nextBytes(chunkBytes);
+        ThreadLocalRandom.current().nextBytes(chunkBytes);
         final ByteBuf chunk = ch.alloc().buffer().writeBytes(chunkBytes);
         final int chunkSize = chunk.readableBytes();
         ByteBuf partialChunk1 = chunk.retainedSlice(0, 5);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpDataTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpDataTest.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
+import io.netty.util.internal.PlatformDependent;
 import org.assertj.core.api.ThrowableAssert;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -30,7 +31,8 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.util.Random;
+import java.util.SplittableRandom;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -58,8 +60,7 @@ class HttpDataTest {
 
     @BeforeAll
     static void setUp() {
-        Random rndm = new Random();
-        rndm.nextBytes(BYTES);
+        ThreadLocalRandom.current().nextBytes(BYTES);
     }
 
     @ParameterizedHttpDataTest

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerFrameDeflateDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerFrameDeflateDecoderTest.java
@@ -22,12 +22,15 @@ import io.netty.handler.codec.compression.ZlibCodecFactory;
 import io.netty.handler.codec.compression.ZlibWrapper;
 import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.extensions.WebSocketExtension;
+import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
 
 import java.util.Random;
+import java.util.SplittableRandom;
 
-import static io.netty.handler.codec.http.websocketx.extensions.WebSocketExtension.*;
-import static io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionFilter.*;
+import static io.netty.handler.codec.http.websocketx.extensions.WebSocketExtension.RSV1;
+import static io.netty.handler.codec.http.websocketx.extensions.WebSocketExtension.RSV3;
+import static io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionFilter.ALWAYS_SKIP;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -46,7 +49,7 @@ public class PerFrameDeflateDecoderTest {
 
         // initialize
         byte[] payload = new byte[300];
-        random.nextBytes(payload);
+        PlatformDependent.splittableRandomNextBytes(new SplittableRandom(random.nextLong()), payload);
 
         assertTrue(encoderChannel.writeOutbound(Unpooled.wrappedBuffer(payload)));
         ByteBuf compressedPayload = encoderChannel.readOutbound();
@@ -77,7 +80,7 @@ public class PerFrameDeflateDecoderTest {
 
         // initialize
         byte[] payload = new byte[300];
-        random.nextBytes(payload);
+        PlatformDependent.splittableRandomNextBytes(new SplittableRandom(random.nextLong()), payload);
 
         BinaryWebSocketFrame frame = new BinaryWebSocketFrame(true,
                 RSV3, Unpooled.wrappedBuffer(payload));
@@ -129,7 +132,7 @@ public class PerFrameDeflateDecoderTest {
         EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerFrameDeflateDecoder(false, ALWAYS_SKIP, 0));
 
         byte[] payload = new byte[300];
-        random.nextBytes(payload);
+        PlatformDependent.splittableRandomNextBytes(new SplittableRandom(random.nextLong()), payload);
 
         assertTrue(encoderChannel.writeOutbound(Unpooled.wrappedBuffer(payload)));
         ByteBuf compressedPayload = encoderChannel.readOutbound();

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerFrameDeflateEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerFrameDeflateEncoderTest.java
@@ -24,11 +24,13 @@ import io.netty.handler.codec.compression.ZlibWrapper;
 import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.ContinuationWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.extensions.WebSocketExtension;
+import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
 
 import java.util.Random;
+import java.util.SplittableRandom;
 
-import static io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionFilter.*;
+import static io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionFilter.ALWAYS_SKIP;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -47,7 +49,7 @@ public class PerFrameDeflateEncoderTest {
 
         // initialize
         byte[] payload = new byte[300];
-        random.nextBytes(payload);
+        PlatformDependent.splittableRandomNextBytes(new SplittableRandom(random.nextLong()), payload);
         BinaryWebSocketFrame frame = new BinaryWebSocketFrame(true,
                 WebSocketExtension.RSV3, Unpooled.wrappedBuffer(payload));
 
@@ -77,7 +79,7 @@ public class PerFrameDeflateEncoderTest {
 
         // initialize
         byte[] payload = new byte[300];
-        random.nextBytes(payload);
+        PlatformDependent.splittableRandomNextBytes(new SplittableRandom(random.nextLong()), payload);
 
         BinaryWebSocketFrame frame = new BinaryWebSocketFrame(true,
                 WebSocketExtension.RSV3 | WebSocketExtension.RSV1, Unpooled.wrappedBuffer(payload));
@@ -106,11 +108,12 @@ public class PerFrameDeflateEncoderTest {
 
         // initialize
         byte[] payload1 = new byte[100];
-        random.nextBytes(payload1);
+        SplittableRandom rng = new SplittableRandom(random.nextLong());
+        PlatformDependent.splittableRandomNextBytes(rng, payload1);
         byte[] payload2 = new byte[100];
-        random.nextBytes(payload2);
+        PlatformDependent.splittableRandomNextBytes(rng, payload2);
         byte[] payload3 = new byte[100];
-        random.nextBytes(payload3);
+        PlatformDependent.splittableRandomNextBytes(rng, payload3);
 
         BinaryWebSocketFrame frame1 = new BinaryWebSocketFrame(false,
                 WebSocketExtension.RSV3, Unpooled.wrappedBuffer(payload1));
@@ -168,7 +171,7 @@ public class PerFrameDeflateEncoderTest {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(
                 new PerFrameDeflateEncoder(9, 15, false, ALWAYS_SKIP));
         byte[] payload = new byte[300];
-        random.nextBytes(payload);
+        PlatformDependent.splittableRandomNextBytes(new SplittableRandom(random.nextLong()), payload);
         BinaryWebSocketFrame binaryFrame = new BinaryWebSocketFrame(true,
                                                                     0, Unpooled.wrappedBuffer(payload));
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateDecoderTest.java
@@ -28,15 +28,17 @@ import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
 import io.netty.handler.codec.http.websocketx.extensions.WebSocketExtension;
 import io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionFilter;
+import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
 import java.util.Random;
+import java.util.SplittableRandom;
 import java.util.concurrent.CompletionException;
 
-import static io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionFilter.*;
-import static io.netty.handler.codec.http.websocketx.extensions.compression.DeflateDecoder.*;
-import static io.netty.util.CharsetUtil.*;
+import static io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionFilter.ALWAYS_SKIP;
+import static io.netty.handler.codec.http.websocketx.extensions.compression.DeflateDecoder.EMPTY_DEFLATE_BLOCK;
+import static io.netty.util.CharsetUtil.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -57,7 +59,7 @@ public class PerMessageDeflateDecoderTest {
 
         // initialize
         byte[] payload = new byte[300];
-        random.nextBytes(payload);
+        PlatformDependent.splittableRandomNextBytes(new SplittableRandom(random.nextLong()), payload);
 
         assertTrue(encoderChannel.writeOutbound(Unpooled.wrappedBuffer(payload)));
         ByteBuf compressedPayload = encoderChannel.readOutbound();
@@ -88,7 +90,7 @@ public class PerMessageDeflateDecoderTest {
 
         // initialize
         byte[] payload = new byte[300];
-        random.nextBytes(payload);
+        PlatformDependent.splittableRandomNextBytes(new SplittableRandom(random.nextLong()), payload);
 
         BinaryWebSocketFrame frame = new BinaryWebSocketFrame(true,
                 WebSocketExtension.RSV3, Unpooled.wrappedBuffer(payload));
@@ -117,7 +119,7 @@ public class PerMessageDeflateDecoderTest {
 
         // initialize
         byte[] payload = new byte[300];
-        random.nextBytes(payload);
+        PlatformDependent.splittableRandomNextBytes(new SplittableRandom(random.nextLong()), payload);
 
         assertTrue(encoderChannel.writeOutbound(Unpooled.wrappedBuffer(payload)));
         ByteBuf compressedPayload = encoderChannel.readOutbound();
@@ -167,9 +169,10 @@ public class PerMessageDeflateDecoderTest {
 
         // initialize
         byte[] payload1 = new byte[100];
-        random.nextBytes(payload1);
+        SplittableRandom rng = new SplittableRandom(random.nextLong());
+        PlatformDependent.splittableRandomNextBytes(rng, payload1);
         byte[] payload2 = new byte[100];
-        random.nextBytes(payload2);
+        PlatformDependent.splittableRandomNextBytes(rng, payload2);
 
         assertTrue(encoderChannel.writeOutbound(Unpooled.wrappedBuffer(payload1)));
         ByteBuf compressedPayload1 = encoderChannel.readOutbound();
@@ -208,7 +211,7 @@ public class PerMessageDeflateDecoderTest {
         EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerMessageDeflateDecoder(false, ALWAYS_SKIP, 0));
 
         byte[] payload = new byte[300];
-        random.nextBytes(payload);
+        PlatformDependent.splittableRandomNextBytes(new SplittableRandom(random.nextLong()), payload);
 
         assertTrue(encoderChannel.writeOutbound(Unpooled.wrappedBuffer(payload)));
         ByteBuf compressedPayload = encoderChannel.readOutbound();
@@ -242,7 +245,7 @@ public class PerMessageDeflateDecoderTest {
 
         String textPayload = "compressed payload";
         byte[] binaryPayload = new byte[300];
-        random.nextBytes(binaryPayload);
+        PlatformDependent.splittableRandomNextBytes(new SplittableRandom(random.nextLong()), binaryPayload);
 
         assertTrue(encoderChannel.writeOutbound(Unpooled.wrappedBuffer(textPayload.getBytes(UTF_8))));
         assertTrue(encoderChannel.writeOutbound(Unpooled.wrappedBuffer(binaryPayload)));
@@ -287,10 +290,11 @@ public class PerMessageDeflateDecoderTest {
                 new PerMessageDeflateDecoder(false, selectivityDecompressionFilter, 0));
 
         byte[] firstPayload = new byte[200];
-        random.nextBytes(firstPayload);
+        SplittableRandom rng = new SplittableRandom(random.nextLong());
+        PlatformDependent.splittableRandomNextBytes(rng, firstPayload);
 
         byte[] finalPayload = new byte[50];
-        random.nextBytes(finalPayload);
+        PlatformDependent.splittableRandomNextBytes(rng, finalPayload);
 
         assertTrue(encoderChannel.writeOutbound(Unpooled.wrappedBuffer(firstPayload)));
         assertTrue(encoderChannel.writeOutbound(Unpooled.wrappedBuffer(finalPayload)));

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateEncoderTest.java
@@ -28,16 +28,19 @@ import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
 import io.netty.handler.codec.http.websocketx.extensions.WebSocketExtension;
 import io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionFilter;
+import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
 import java.util.Arrays;
 import java.util.Random;
+import java.util.SplittableRandom;
 import java.util.concurrent.CompletionException;
 
-import static io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionFilter.*;
-import static io.netty.handler.codec.http.websocketx.extensions.compression.DeflateDecoder.*;
-import static io.netty.util.CharsetUtil.*;
+import static io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionFilter.ALWAYS_SKIP;
+import static io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionFilter.NEVER_SKIP;
+import static io.netty.handler.codec.http.websocketx.extensions.compression.DeflateDecoder.EMPTY_DEFLATE_BLOCK;
+import static io.netty.util.CharsetUtil.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -58,7 +61,7 @@ public class PerMessageDeflateEncoderTest {
 
         // initialize
         byte[] payload = new byte[300];
-        random.nextBytes(payload);
+        PlatformDependent.splittableRandomNextBytes(new SplittableRandom(random.nextLong()), payload);
         BinaryWebSocketFrame frame = new BinaryWebSocketFrame(true,
                                                               WebSocketExtension.RSV3, Unpooled.wrappedBuffer(payload));
 
@@ -88,7 +91,7 @@ public class PerMessageDeflateEncoderTest {
 
         // initialize
         byte[] payload = new byte[300];
-        random.nextBytes(payload);
+        PlatformDependent.splittableRandomNextBytes(new SplittableRandom(random.nextLong()), payload);
 
         BinaryWebSocketFrame frame = new BinaryWebSocketFrame(true,
                                                               WebSocketExtension.RSV3 | WebSocketExtension.RSV1,
@@ -119,11 +122,12 @@ public class PerMessageDeflateEncoderTest {
 
         // initialize
         byte[] payload1 = new byte[100];
-        random.nextBytes(payload1);
+        SplittableRandom rng = new SplittableRandom(random.nextLong());
+        PlatformDependent.splittableRandomNextBytes(rng, payload1);
         byte[] payload2 = new byte[100];
-        random.nextBytes(payload2);
+        PlatformDependent.splittableRandomNextBytes(rng, payload2);
         byte[] payload3 = new byte[100];
-        random.nextBytes(payload3);
+        PlatformDependent.splittableRandomNextBytes(rng, payload3);
 
         BinaryWebSocketFrame frame1 = new BinaryWebSocketFrame(false,
                                                                WebSocketExtension.RSV3,
@@ -182,7 +186,7 @@ public class PerMessageDeflateEncoderTest {
         EmbeddedChannel encoderChannel = new EmbeddedChannel(new PerMessageDeflateEncoder(9, 15, false,
                                                                                           ALWAYS_SKIP));
         byte[] payload = new byte[300];
-        random.nextBytes(payload);
+        PlatformDependent.splittableRandomNextBytes(new SplittableRandom(random.nextLong()), payload);
 
         WebSocketFrame binaryFrame = new BinaryWebSocketFrame(Unpooled.wrappedBuffer(payload));
 
@@ -212,7 +216,7 @@ public class PerMessageDeflateEncoderTest {
 
         String textPayload = "not compressed payload";
         byte[] binaryPayload = new byte[101];
-        random.nextBytes(binaryPayload);
+        PlatformDependent.splittableRandomNextBytes(new SplittableRandom(random.nextLong()), binaryPayload);
 
         WebSocketFrame textFrame = new TextWebSocketFrame(textPayload);
         BinaryWebSocketFrame binaryFrame = new BinaryWebSocketFrame(Unpooled.wrappedBuffer(binaryPayload));
@@ -256,10 +260,11 @@ public class PerMessageDeflateEncoderTest {
                 new PerMessageDeflateEncoder(9, 15, false, selectivityCompressionFilter));
 
         byte[] firstPayload = new byte[200];
-        random.nextBytes(firstPayload);
+        SplittableRandom rng = new SplittableRandom(random.nextLong());
+        PlatformDependent.splittableRandomNextBytes(rng, firstPayload);
 
         byte[] finalPayload = new byte[90];
-        random.nextBytes(finalPayload);
+        PlatformDependent.splittableRandomNextBytes(rng, finalPayload);
 
         BinaryWebSocketFrame firstPart = new BinaryWebSocketFrame(false, 0, Unpooled.wrappedBuffer(firstPayload));
         final ContinuationWebSocketFrame finalPart = new ContinuationWebSocketFrame(true, 0,

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
@@ -53,12 +53,10 @@ import org.mockito.stubbing.Answer;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.nio.charset.StandardCharsets;
-import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_PRIORITY_WEIGHT;
@@ -67,15 +65,13 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyShort;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
 
 /**
@@ -321,7 +317,7 @@ public class DataCompressionHttp2Test {
     public void deflateEncodingWriteLargeMessage(final int padding) throws Exception {
         final int BUFFER_SIZE = 1 << 12;
         final byte[] bytes = new byte[BUFFER_SIZE];
-        new Random().nextBytes(bytes);
+        ThreadLocalRandom.current().nextBytes(bytes);
         bootstrapEnv(BUFFER_SIZE);
         final ByteBuf data = Unpooled.wrappedBuffer(bytes);
         try {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -49,9 +49,9 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.io.ByteArrayOutputStream;
-import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -1296,7 +1296,7 @@ public class Http2ConnectionRoundtripTest {
      */
     private static ByteBuf randomBytes(int length) {
         final byte[] bytes = new byte[length];
-        new Random().nextBytes(bytes);
+        ThreadLocalRandom.current().nextBytes(bytes);
         return Unpooled.wrappedBuffer(bytes);
     }
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
@@ -23,13 +23,15 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.AsciiString;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.PlatformDependent;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import java.util.Random;
+import java.util.SplittableRandom;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_HEADER_LIST_SIZE;
 import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_HEADER_TABLE_SIZE;
@@ -98,7 +100,7 @@ public final class Http2TestUtil {
      */
     public static byte[] randomBytes(int size) {
         byte[] data = new byte[size];
-        new Random().nextBytes(data);
+        ThreadLocalRandom.current().nextBytes(data);
         return data;
     }
 

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicChannelDatagramTest.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicChannelDatagramTest.java
@@ -25,13 +25,15 @@ import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.net.InetSocketAddress;
-import java.util.Random;
+import java.util.SplittableRandom;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -41,11 +43,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class QuicChannelDatagramTest extends AbstractQuicTest {
 
-    private static final Random random = new Random();
     static final byte[] data = new byte[512];
 
     static {
-        random.nextBytes(data);
+        ThreadLocalRandom.current().nextBytes(data);
     }
 
     @ParameterizedTest

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicChannelEchoTest.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicChannelEchoTest.java
@@ -30,6 +30,7 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.ImmediateExecutor;
+import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -40,6 +41,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
+import java.util.SplittableRandom;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -51,7 +53,7 @@ public class QuicChannelEchoTest extends AbstractQuicTest {
     static final byte[] data = new byte[1048576];
 
     static {
-        random.nextBytes(data);
+        PlatformDependent.splittableRandomNextBytes(new SplittableRandom(random.nextLong()), data);
     }
 
     public static Collection<Object[]> data() {

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -57,6 +57,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Random;
 import java.util.Set;
+import java.util.SplittableRandom;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentMap;
@@ -1363,6 +1364,30 @@ public final class PlatformDependent {
     @Deprecated
     public static Random threadLocalRandom() {
         return ThreadLocalRandom.current();
+    }
+
+    public static void splittableRandomNextBytes(SplittableRandom rng, byte[] data) {
+        if (javaVersion() >= 10) {
+            PlatformDependent0.splittableRandomNextBytes(rng, data);
+        } else {
+            int i = 0;
+            int len = data.length;
+            int longs = len >>> 3;
+            while (longs-- > 0) {
+                long val = rng.nextLong();
+                for (int j = 0; j < Long.BYTES; j++) {
+                    data[i++] = (byte) val;
+                    val = val >>> Byte.SIZE;
+                }
+            }
+            if (i < len) {
+                long val = rng.nextLong();
+                for (; i < len; i++) {
+                    data[i++] = (byte) val;
+                    val = val >>> Byte.SIZE;
+                }
+            }
+        }
     }
 
     private static boolean isWindows0() {

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
+import java.util.SplittableRandom;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static java.lang.invoke.MethodType.methodType;
@@ -568,6 +569,10 @@ final class PlatformDependent0 {
 
     static boolean unalignedAccess() {
         return UNALIGNED;
+    }
+
+    static void splittableRandomNextBytes(SplittableRandom rng, byte[] data) {
+        rng.nextBytes(data);
     }
 
     static void throwException(Throwable cause) {

--- a/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
+++ b/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.util.Random;
+import java.util.SplittableRandom;
 
 import static io.netty.util.AsciiString.contains;
 import static io.netty.util.AsciiString.containsIgnoreCase;
@@ -183,8 +184,9 @@ public class AsciiStringCharacterTest {
         final int upperToLower = (int) 'a' - upperA;
         byte[] lowerCaseBytes = new byte[len];
         StringBuilder upperCaseBuilder = new StringBuilder(len);
+        SplittableRandom rng = new SplittableRandom(r.nextLong());
         for (int i = 0; i < len; ++i) {
-            char upper = (char) (r.nextInt((upperZ - upperA) + 1) + upperA);
+            char upper = (char) (rng.nextInt((upperZ - upperA) + 1) + upperA);
             upperCaseBuilder.append(upper);
             lowerCaseBytes[i] = (byte) (upper + upperToLower);
         }

--- a/common/src/test/java/io/netty/util/AsciiStringMemoryTest.java
+++ b/common/src/test/java/io/netty/util/AsciiStringMemoryTest.java
@@ -15,15 +15,15 @@
  */
 package io.netty.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import io.netty.util.ByteProcessor.IndexOfProcessor;
-
-import java.util.Random;
-import java.util.concurrent.atomic.AtomicReference;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * Test the underlying memory methods for the {@link AsciiString} class.
@@ -36,14 +36,13 @@ public class AsciiStringMemoryTest {
     private int length = 100;
     private AsciiString aAsciiString;
     private AsciiString bAsciiString;
-    private final Random r = new Random();
 
     @BeforeEach
     public void setup() {
         a = new byte[128];
         b = new byte[256];
-        r.nextBytes(a);
-        r.nextBytes(b);
+        ThreadLocalRandom.current().nextBytes(a);
+        ThreadLocalRandom.current().nextBytes(b);
         aOffset = 22;
         bOffset = 53;
         length = 100;

--- a/common/src/test/java/io/netty/util/RecyclerTest.java
+++ b/common/src/test/java/io/netty/util/RecyclerTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
-import java.util.Random;
+import java.util.SplittableRandom;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -447,7 +447,7 @@ public class RecyclerTest {
     @MethodSource("ownerTypeAndUnguarded")
     public void testMaxCapacity(OwnerType ownerType, boolean unguarded) {
         testMaxCapacity(ownerType, unguarded, 300);
-        Random rand = new Random();
+        SplittableRandom rand = new SplittableRandom();
         for (int i = 0; i < 50; i++) {
             testMaxCapacity(ownerType, unguarded, rand.nextInt(1000) + 256); // 256 - 1256
         }

--- a/common/src/test/java/io/netty/util/internal/PlatformDependentTest.java
+++ b/common/src/test/java/io/netty/util/internal/PlatformDependentTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
 import java.util.Random;
+import java.util.SplittableRandom;
 
 import static io.netty.util.internal.PlatformDependent.hashCodeAscii;
 import static io.netty.util.internal.PlatformDependent.hashCodeAsciiSafe;
@@ -116,9 +117,10 @@ public class PlatformDependentTest {
         assertTrue(equalsChecker.equals(bytes1, 2, bytes2, 0, bytes2.length));
         assertTrue(equalsChecker.equals(bytes2, 0, bytes1, 2, bytes2.length));
 
+        SplittableRandom rng = new SplittableRandom(r.nextLong());
         for (int i = 0; i < 1000; ++i) {
             bytes1 = new byte[i];
-            r.nextBytes(bytes1);
+            PlatformDependent.splittableRandomNextBytes(rng, bytes1);
             bytes2 = bytes1.clone();
             assertTrue(equalsChecker.equals(bytes1, 0, bytes2, 0, bytes1.length));
         }
@@ -127,18 +129,15 @@ public class PlatformDependentTest {
         assertTrue(equalsChecker.equals(bytes1, 0, bytes2, 0, -1));
     }
 
-    private static char randomCharInByteRange() {
-        return (char) r.nextInt(255 + 1);
-    }
-
     @Test
     public void testHashCodeAscii() {
+        SplittableRandom rng = new SplittableRandom(r.nextLong());
         for (int i = 0; i < 1000; ++i) {
             // byte[] and char[] need to be initialized such that there values are within valid "ascii" range
             byte[] bytes = new byte[i];
             char[] bytesChar = new char[i];
             for (int j = 0; j < bytesChar.length; ++j) {
-                bytesChar[j] = randomCharInByteRange();
+                bytesChar[j] = (char) rng.nextInt(255 + 1);
                 bytes[j] = (byte) (bytesChar[j] & 0xff);
             }
             String string = new String(bytesChar);

--- a/common/src/test/java/io/netty/util/internal/SWARUtilTest.java
+++ b/common/src/test/java/io/netty/util/internal/SWARUtilTest.java
@@ -17,19 +17,17 @@ package io.netty.util.internal;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.Random;
+import java.util.SplittableRandom;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class SWARUtilTest {
 
-    private final Random random = new Random();
-
     @Test
     void containsUpperCaseLong() {
         // given
         final byte[] asciiTable = getExtendedAsciiTable();
-        shuffleArray(asciiTable, random);
+        shuffleArray(asciiTable);
 
         // when
         for (int idx = 0; idx < asciiTable.length; idx += Long.BYTES) {
@@ -48,7 +46,7 @@ class SWARUtilTest {
     void containsUpperCaseInt() {
         // given
         final byte[] asciiTable = getExtendedAsciiTable();
-        shuffleArray(asciiTable, random);
+        shuffleArray(asciiTable);
 
         // when
         for (int idx = 0; idx < asciiTable.length; idx += Integer.BYTES) {
@@ -67,7 +65,7 @@ class SWARUtilTest {
     void containsLowerCaseLong() {
         // given
         final byte[] asciiTable = getExtendedAsciiTable();
-        shuffleArray(asciiTable, random);
+        shuffleArray(asciiTable);
 
         // when
         for (int idx = 0; idx < asciiTable.length; idx += Long.BYTES) {
@@ -86,7 +84,7 @@ class SWARUtilTest {
     void containsLowerCaseInt() {
         // given
         final byte[] asciiTable = getExtendedAsciiTable();
-        shuffleArray(asciiTable, random);
+        shuffleArray(asciiTable);
 
         // when
         for (int idx = 0; idx < asciiTable.length; idx += Integer.BYTES) {
@@ -105,7 +103,7 @@ class SWARUtilTest {
     void toUpperCaseLong() {
         // given
         final byte[] asciiTable = getExtendedAsciiTable();
-        shuffleArray(asciiTable, random);
+        shuffleArray(asciiTable);
 
         // when
         for (int idx = 0; idx < asciiTable.length; idx += Long.BYTES) {
@@ -125,7 +123,7 @@ class SWARUtilTest {
     void toUpperCaseInt() {
         // given
         final byte[] asciiTable = getExtendedAsciiTable();
-        shuffleArray(asciiTable, random);
+        shuffleArray(asciiTable);
 
         // when
         for (int idx = 0; idx < asciiTable.length; idx += Integer.BYTES) {
@@ -145,7 +143,7 @@ class SWARUtilTest {
     void toLowerCaseLong() {
         // given
         final byte[] asciiTable = getExtendedAsciiTable();
-        shuffleArray(asciiTable, random);
+        shuffleArray(asciiTable);
 
         // when
         for (int idx = 0; idx < asciiTable.length; idx += Long.BYTES) {
@@ -165,7 +163,7 @@ class SWARUtilTest {
     void toLowerCaseInt() {
         // given
         final byte[] asciiTable = getExtendedAsciiTable();
-        shuffleArray(asciiTable, random);
+        shuffleArray(asciiTable);
 
         // when
         for (int idx = 0; idx < asciiTable.length; idx += Integer.BYTES) {
@@ -181,9 +179,10 @@ class SWARUtilTest {
         }
     }
 
-    private static void shuffleArray(byte[] array, Random random) {
+    private static void shuffleArray(byte[] array) {
+        SplittableRandom rng = new SplittableRandom();
         for (int i = array.length - 1; i > 0; i--) {
-            final int index = random.nextInt(i + 1);
+            final int index = rng.nextInt(i + 1);
             final byte tmp = array[index];
             array[index] = array[i];
             array[i] = tmp;

--- a/handler/src/test/java/io/netty/handler/traffic/FileRegionThrottleTest.java
+++ b/handler/src/test/java/io/netty/handler/traffic/FileRegionThrottleTest.java
@@ -46,7 +46,7 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.net.SocketAddress;
 import java.nio.charset.Charset;
-import java.util.Random;
+import java.util.SplittableRandom;
 import java.util.concurrent.CountDownLatch;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -59,7 +59,7 @@ public class FileRegionThrottleTest {
 
     @BeforeAll
     public static void beforeClass() throws IOException {
-        final Random r = new Random();
+        final SplittableRandom r = new SplittableRandom();
         for (int i = 0; i < BYTES.length; i++) {
             BYTES[i] = (byte) r.nextInt(255);
         }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/sctp/SctpEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/sctp/SctpEchoTest.java
@@ -27,12 +27,14 @@ import io.netty.handler.codec.sctp.SctpInboundByteStreamHandler;
 import io.netty.handler.codec.sctp.SctpMessageCompletionHandler;
 import io.netty.handler.codec.sctp.SctpOutboundByteStreamHandler;
 import io.netty.testsuite.util.TestUtils;
+import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import java.io.IOException;
 import java.util.Random;
+import java.util.SplittableRandom;
 import java.util.concurrent.atomic.AtomicReference;
-import org.junit.jupiter.api.TestInfo;
 
 import static io.netty.testsuite.transport.TestsuitePermutation.randomBufferType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -44,7 +46,7 @@ public class SctpEchoTest extends AbstractSctpTest {
     static final byte[] data = new byte[4096]; //could not test ultra jumbo frames
 
     static {
-        random.nextBytes(data);
+        PlatformDependent.splittableRandomNextBytes(new SplittableRandom(random.nextLong()), data);
     }
 
     @Test

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/CompositeBufferGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/CompositeBufferGatheringWriteTest.java
@@ -32,8 +32,8 @@ import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
-import java.util.Random;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -170,11 +170,10 @@ public class CompositeBufferGatheringWriteTest extends AbstractSocketTest {
         Channel serverChannel = null;
         Channel clientChannel = null;
         try {
-            Random r = new Random();
             final int soSndBuf = 1024;
             ByteBufAllocator alloc = ByteBufAllocator.DEFAULT;
             final ByteBuf expectedContent = alloc.buffer(soSndBuf * 2);
-            expectedContent.writeBytes(newRandomBytes(expectedContent.writableBytes(), r));
+            expectedContent.writeBytes(newRandomBytes(expectedContent.writableBytes()));
             final CountDownLatch latch = new CountDownLatch(1);
             final AtomicReference<Object> clientReceived = new AtomicReference<Object>();
             sb.childOption(ChannelOption.SO_SNDBUF, soSndBuf)
@@ -303,9 +302,9 @@ public class CompositeBufferGatheringWriteTest extends AbstractSocketTest {
         return compositeByteBuf;
     }
 
-    private static byte[] newRandomBytes(int size, Random r) {
+    private static byte[] newRandomBytes(int size) {
         byte[] bytes = new byte[size];
-        r.nextBytes(bytes);
+        ThreadLocalRandom.current().nextBytes(bytes);
         return bytes;
     }
 }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketBufReleaseTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketBufReleaseTest.java
@@ -28,8 +28,8 @@ import io.netty.util.concurrent.Promise;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
-import java.util.Random;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -74,7 +74,6 @@ public class SocketBufReleaseTest extends AbstractSocketTest {
 
     private static class BufWriterHandler extends SimpleChannelInboundHandler<Object> {
 
-        private final Random random = new Random();
         private final CountDownLatch latch = new CountDownLatch(1);
         private ByteBuf buf;
         private final Promise<Channel> channelFuture = executor.newPromise();
@@ -87,7 +86,7 @@ public class SocketBufReleaseTest extends AbstractSocketTest {
         @Override
         public void channelActive(final ChannelHandlerContext ctx) throws Exception {
             byte[] data = new byte[1024];
-            random.nextBytes(data);
+            ThreadLocalRandom.current().nextBytes(data);
 
             buf = ctx.alloc().buffer();
             // call retain on it so it can't be put back on the pool

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketEchoTest.java
@@ -25,17 +25,18 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.util.concurrent.DefaultEventExecutorGroup;
 import io.netty.util.concurrent.EventExecutorGroup;
-import java.util.concurrent.TimeUnit;
-
+import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.util.Random;
+import java.util.SplittableRandom;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import org.junit.jupiter.api.TestInfo;
-import org.junit.jupiter.api.Timeout;
 
 import static io.netty.testsuite.transport.TestsuitePermutation.randomBufferType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -48,7 +49,7 @@ public class SocketEchoTest extends AbstractSocketTest {
     private static EventExecutorGroup group;
 
     static {
-        random.nextBytes(data);
+        PlatformDependent.splittableRandomNextBytes(new SplittableRandom(random.nextLong()), data);
     }
 
     @BeforeAll
@@ -112,8 +113,9 @@ public class SocketEchoTest extends AbstractSocketTest {
         Channel sc = sb.bind().get();
         Channel cc = cb.connect(sc.localAddress()).get();
 
+        SplittableRandom rng = new SplittableRandom(random.nextLong());
         for (int i = 0; i < data.length;) {
-            int length = Math.min(random.nextInt(1024 * 64), data.length - i);
+            int length = Math.min(rng.nextInt(1024 * 64), data.length - i);
             ByteBuf buf = randomBufferType(cc.alloc(), data, i, length);
             cc.writeAndFlush(buf);
             i += length;

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFixedLengthEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFixedLengthEchoTest.java
@@ -24,11 +24,13 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.FixedLengthFrameDecoder;
+import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
 import java.io.IOException;
 import java.util.Random;
+import java.util.SplittableRandom;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static io.netty.testsuite.transport.TestsuitePermutation.randomBufferType;
@@ -40,7 +42,7 @@ public class SocketFixedLengthEchoTest extends AbstractSocketTest {
     static final byte[] data = new byte[1048576];
 
     static {
-        random.nextBytes(data);
+        PlatformDependent.splittableRandomNextBytes(new SplittableRandom(random.nextLong()), data);
     }
 
     @Test
@@ -95,8 +97,9 @@ public class SocketFixedLengthEchoTest extends AbstractSocketTest {
 
         Channel sc = sb.bind().get();
         Channel cc = cb.connect(sc.localAddress()).get();
+        SplittableRandom rng = new SplittableRandom(random.nextLong());
         for (int i = 0; i < data.length;) {
-            int length = Math.min(random.nextInt(1024 * 3), data.length - i);
+            int length = Math.min(rng.nextInt(1024 * 3), data.length - i);
             cc.writeAndFlush(randomBufferType(cc.alloc(), data, i, length));
             i += length;
         }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketGatheringWriteTest.java
@@ -28,6 +28,7 @@ import io.netty.testsuite.util.TestUtils;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
@@ -36,6 +37,7 @@ import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.util.Random;
+import java.util.SplittableRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -52,7 +54,7 @@ public class SocketGatheringWriteTest extends AbstractSocketTest {
     static final byte[] data = new byte[1048576];
 
     static {
-        random.nextBytes(data);
+        PlatformDependent.splittableRandomNextBytes(new SplittableRandom(random.nextLong()), data);
     }
 
     @AfterAll
@@ -133,8 +135,9 @@ public class SocketGatheringWriteTest extends AbstractSocketTest {
     }
 
     public void testGatheringWriteBig(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+        SplittableRandom rng = new SplittableRandom(random.nextLong());
         byte[] bigData = new byte[1024 * 1024 * 50];
-        random.nextBytes(bigData);
+        PlatformDependent.splittableRandomNextBytes(rng, bigData);
         testGatheringWrite0(sb, cb, bigData, false, true);
     }
 
@@ -153,8 +156,9 @@ public class SocketGatheringWriteTest extends AbstractSocketTest {
         Channel sc = sb.bind().get();
         Channel cc = cb.connect(sc.localAddress()).get();
 
+        SplittableRandom rng = new SplittableRandom(random.nextLong());
         for (int i = 0; i < data.length;) {
-            int length = Math.min(random.nextInt(1024 * 8), data.length - i);
+            int length = Math.min(rng.nextInt(1024 * 8), data.length - i);
             if (composite && i % 2 == 0) {
                 int firstBufLength = length / 2;
                 CompositeByteBuf comp = compositeBuffer();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
@@ -37,6 +37,7 @@ import io.netty.pkitesting.CertificateBuilder;
 import io.netty.pkitesting.X509Bundle;
 import io.netty.testsuite.util.TestUtils;
 import io.netty.util.concurrent.Future;
+import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.junit.jupiter.api.AfterAll;
@@ -52,6 +53,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Random;
+import java.util.SplittableRandom;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -78,7 +80,7 @@ public class SocketSslEchoTest extends AbstractSocketTest {
     static final byte[] data = new byte[1048576];
 
     static {
-        random.nextBytes(data);
+        PlatformDependent.splittableRandomNextBytes(new SplittableRandom(random.nextLong()), data);
 
         try {
             X509Bundle cert = new CertificateBuilder()
@@ -327,9 +329,10 @@ public class SocketSslEchoTest extends AbstractSocketTest {
 
         boolean needsRenegotiation = renegotiation.type == RenegotiationType.CLIENT_INITIATED;
         Future<Channel> renegoFuture = null;
+        SplittableRandom rng = new SplittableRandom(random.nextLong());
         while (clientSendCounter.get() < data.length) {
             int clientSendCounterVal = clientSendCounter.get();
-            int length = Math.min(random.nextInt(1024 * 64), data.length - clientSendCounterVal);
+            int length = Math.min(rng.nextInt(1024 * 64), data.length - clientSendCounterVal);
             ByteBuf buf = randomBufferType(clientChannel.alloc(), data, clientSendCounterVal, length);
             if (useCompositeByteBuf) {
                 buf = Unpooled.compositeBuffer().addComponent(true, buf);

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/TrafficShapingHandlerTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/TrafficShapingHandlerTest.java
@@ -39,9 +39,9 @@ import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Random;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -60,7 +60,6 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
     static final long stepms = (1000 / bandwidthFactor - 10) / 10 * 10;
     static final long minimalms = Math.max(stepms / 2, 20) / 10 * 10;
     static final long check = 10;
-    private static final Random random = new Random();
     static final byte[] data = new byte[messageSize];
 
     private static final String TRAFFIC = "traffic";
@@ -71,7 +70,7 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
     private static EventExecutorGroup groupForGlobal;
     private static final ScheduledExecutorService executor = Executors.newScheduledThreadPool(10);
     static {
-        random.nextBytes(data);
+        ThreadLocalRandom.current().nextBytes(data);
     }
 
     @BeforeAll

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelConfigTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelConfigTest.java
@@ -73,22 +73,9 @@ public class EpollSocketChannelConfigTest {
         ch.close().syncUninterruptibly();
     }
 
-    private static long randLong(long min, long max) {
-        return min + nextLong(max - min + 1);
-    }
-
-    private static long nextLong(long n) {
-        long bits, val;
-        do {
-           bits = (rand.nextLong() << 1) >>> 1;
-           val = bits % n;
-        } while (bits - val + (n - 1) < 0L);
-        return val;
-     }
-
     @Test
     public void testRandomTcpNotSentLowAt() {
-        final long expected = randLong(0, 0xFFFFFFFFL);
+        final long expected = rand.nextLong() & 0xFFFFFFFFL;
         final long actual;
         try {
             ch.config().setOption(EpollChannelOption.TCP_NOTSENT_LOWAT, expected);

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketChannelConfigTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueSocketChannelConfigTest.java
@@ -20,7 +20,6 @@ import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
-
 import io.netty.channel.MultiThreadIoEventLoopGroup;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -31,7 +30,7 @@ import org.opentest4j.TestAbortedException;
 
 import java.net.InetSocketAddress;
 import java.nio.channels.ClosedChannelException;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static io.netty.channel.kqueue.BsdSocket.BSD_SND_LOW_AT_MAX;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -43,11 +42,9 @@ public class KQueueSocketChannelConfigTest {
 
     private static EventLoopGroup group;
     private static KQueueSocketChannel ch;
-    private static Random rand;
 
     @BeforeAll
     public static void beforeClass() {
-        rand = new Random();
         group = new MultiThreadIoEventLoopGroup(1, KQueueIoHandler.newFactory());
     }
 
@@ -72,7 +69,7 @@ public class KQueueSocketChannelConfigTest {
 
     @Test
     public void testRandomSndLowAt() {
-        final int expected = Math.min(BSD_SND_LOW_AT_MAX, Math.abs(rand.nextInt()));
+        final int expected = Math.min(BSD_SND_LOW_AT_MAX, Math.abs(ThreadLocalRandom.current().nextInt()));
         final int actual;
         try {
             ch.config().setOption(KQueueChannelOption.SO_SNDLOWAT, expected);


### PR DESCRIPTION
Motivation:
When we can guarantee single-threaded access to a random number generator, then the SplittableRandom algorithm is dramatically faster than a single shared Random instance. The old Random class is thread-safe, and pay a high cost for this, which is very noticable when generating kilobytes or megabytes of data.

Modification:
- Go through all uses of the old Random class, and make use of SplittableRandom in ways that ensure single-threaded access.
- Use ThreadLocalRandom in places where seeding isn't used.
- Clean up imports in all test classes touched.

Result:
Faster build, shaving tens of seconds off the execution time of some tests.

(cherry picked from commit 9a469345987dc731ef67d2a61ceff8ccbe4067ad)