### PR TITLE
Move test to shared testsuite

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastIPv6MappedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastIPv6MappedTest.java
@@ -32,7 +32,7 @@ public class DatagramUnicastIPv6MappedTest extends DatagramUnicastIPv6Test {
     }
 
     @Override
-    protected InetSocketAddress sendToAddress(InetSocketAddress serverAddress) {
+    protected InetSocketAddress convertAnyAddress(InetSocketAddress serverAddress) {
         InetAddress addr = serverAddress.getAddress();
         if (addr.isAnyLocalAddress()) {
             return new InetSocketAddress(NetUtil.LOCALHOST4, serverAddress.getPort());

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
@@ -244,7 +244,7 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
             throw e;
         }
         SocketAddress sendAddress = address instanceof InetSocketAddress ?
-                sendToAddress((InetSocketAddress) address) : address;
+                convertAnyAddress((InetSocketAddress) address) : address;
         for (int i = 0; i < 100; i++) {
             try {
                 client.send(new java.net.DatagramPacket(EmptyArrays.EMPTY_BYTES, 0, sendAddress));
@@ -285,7 +285,7 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
         Channel cc = cb.option(ChannelOption.DATAGRAM_CHANNEL_ACTIVE_ON_REGISTRATION, true).
                 handler(new ChannelInboundHandlerAdapter()).register().sync().channel();
         try {
-            InetSocketAddress goodHost = sendToAddress((InetSocketAddress) sc.localAddress());
+            InetSocketAddress goodHost = convertAnyAddress((InetSocketAddress) sc.localAddress());
             InetSocketAddress unresolvedHost = new InetSocketAddress("NOT_A_REAL_ADDRESS", goodHost.getPort());
 
             assertFalse(goodHost.isUnresolved());
@@ -341,7 +341,7 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
 
             SocketAddress localAddr = sc.localAddress();
             SocketAddress addr = localAddr instanceof InetSocketAddress ?
-                    sendToAddress((InetSocketAddress) sc.localAddress()) : localAddr;
+                    convertAnyAddress((InetSocketAddress) sc.localAddress()) : localAddr;
             List<ChannelFuture> futures = new ArrayList<ChannelFuture>(count);
             for (int i = 0; i < count; i++) {
                 futures.add(write(cc, buf, addr, wrapType));
@@ -393,7 +393,7 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
 
             SocketAddress localAddr = sc.localAddress();
             SocketAddress addr = localAddr instanceof InetSocketAddress ?
-                    sendToAddress((InetSocketAddress) sc.localAddress()) : localAddr;
+                    convertAnyAddress((InetSocketAddress) sc.localAddress()) : localAddr;
             cc.connect(addr).syncUninterruptibly();
 
             List<ChannelFuture> futures = new ArrayList<ChannelFuture>();
@@ -520,7 +520,10 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
         try {
             sc = sb.bind(newSocketAddress()).sync().channel();
             SocketAddress serverAddress = sc.localAddress();
-
+            if (serverAddress instanceof InetSocketAddress) {
+                // Correctly ha
+                serverAddress = convertAnyAddress((InetSocketAddress) serverAddress);
+            }
             cb.handler(new SimpleChannelInboundHandler<ByteBufHolder>() {
                 @Override
                 protected void channelRead0(ChannelHandlerContext ctx, ByteBufHolder msg) {
@@ -570,7 +573,7 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
         }
     }
 
-    protected InetSocketAddress sendToAddress(InetSocketAddress serverAddress) {
+    protected InetSocketAddress convertAnyAddress(InetSocketAddress serverAddress) {
         InetAddress addr = serverAddress.getAddress();
         if (addr.isAnyLocalAddress()) {
             if (addr instanceof Inet6Address) {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
@@ -500,8 +500,7 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
     }
 
     private void testWriteOffsetBytebuf0(Bootstrap sb, Bootstrap cb, ByteBuf buf, byte[] expected,
-                                         WrapType wrapType)
-            throws Throwable {
+                                         WrapType wrapType) throws Throwable {
         CompletableFuture<byte[]> received = new CompletableFuture<>();
         sb.handler(new SimpleChannelInboundHandler<DatagramPacket>() {
             @Override
@@ -531,6 +530,9 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
             byte[] actual = received.join();
             assertArrayEquals(expected, actual);
         } finally {
+            // release as we used buf.retain() before
+            buf.release();
+
             if (cc != null) {
                 cc.close().sync();
             }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
@@ -17,6 +17,7 @@ package io.netty.testsuite.transport.socket;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
@@ -502,9 +503,9 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
     private void testWriteOffsetBytebuf0(Bootstrap sb, Bootstrap cb, ByteBuf buf, byte[] expected,
                                          WrapType wrapType) throws Throwable {
         CompletableFuture<byte[]> received = new CompletableFuture<>();
-        sb.handler(new SimpleChannelInboundHandler<DatagramPacket>() {
+        sb.handler(new SimpleChannelInboundHandler<ByteBufHolder>() {
             @Override
-            protected void channelRead0(ChannelHandlerContext ctx, DatagramPacket packet) {
+            protected void channelRead0(ChannelHandlerContext ctx, ByteBufHolder packet) {
                 ByteBuf content = packet.content();
                 byte[] bytes = new byte[content.readableBytes()];
                 content.getBytes(content.readerIndex(), bytes);
@@ -515,9 +516,9 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
         Channel sc = sb.bind(newSocketAddress()).sync().channel();
         SocketAddress serverAddress = sc.localAddress();
 
-        cb.handler(new SimpleChannelInboundHandler<DatagramPacket>() {
+        cb.handler(new SimpleChannelInboundHandler<ByteBufHolder>() {
             @Override
-            protected void channelRead0(ChannelHandlerContext ctx, DatagramPacket msg) {
+            protected void channelRead0(ChannelHandlerContext ctx, ByteBufHolder msg) {
                 // no-op
             }
         });

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
@@ -33,6 +33,7 @@ import io.netty.util.NetUtil;
 import io.netty.util.internal.EmptyArrays;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 import org.opentest4j.TestAbortedException;
 
 import java.net.BindException;
@@ -44,14 +45,17 @@ import java.net.SocketAddress;
 import java.net.SocketException;
 import java.nio.channels.NotYetConnectedException;
 import java.nio.channels.UnresolvedAddressException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -61,6 +65,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 public abstract class DatagramUnicastTest extends AbstractDatagramTest {
 
+    private static final byte[] BAD_PREFIX = "BAD-PREFIX-".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] EXPECTED = "EXPECTED-direct-reader-index".getBytes(StandardCharsets.UTF_8);
     private static final byte[] BYTES = {0, 1, 2, 3};
     protected enum WrapType {
         NONE, DUP, SLICE, READ_ONLY
@@ -465,6 +471,70 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
                 return cc.write(buf.retain());
             default:
                 throw new Error("Unexpected wrap type: " + wrapType);
+        }
+    }
+
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+    public void testWriteOffsetBytebuf(TestInfo testInfo) throws Throwable {
+        run(testInfo, new Runner<Bootstrap, Bootstrap>() {
+            @Override
+            public void run(Bootstrap sb, Bootstrap cb) throws Throwable {
+                testWriteOffsetBytebuf(sb, cb);
+            }
+        });
+    }
+
+    private void testWriteOffsetBytebuf(Bootstrap sb, Bootstrap cb) throws Throwable {
+        ByteBuf buf = Unpooled.directBuffer(BAD_PREFIX.length + EXPECTED.length);
+        buf.writeBytes(BAD_PREFIX);
+        buf.writeBytes(EXPECTED);
+        buf.readerIndex(BAD_PREFIX.length);
+        try {
+            for (WrapType type : WrapType.values()) {
+                testWriteOffsetBytebuf0(sb, cb, buf.retain(), EXPECTED, type);
+            }
+        } finally {
+            assertTrue(buf.release());
+        }
+    }
+
+    private void testWriteOffsetBytebuf0(Bootstrap sb, Bootstrap cb, ByteBuf buf, byte[] expected,
+                                         WrapType wrapType)
+            throws Throwable {
+        CompletableFuture<byte[]> received = new CompletableFuture<>();
+        sb.handler(new SimpleChannelInboundHandler<DatagramPacket>() {
+            @Override
+            protected void channelRead0(ChannelHandlerContext ctx, DatagramPacket packet) {
+                ByteBuf content = packet.content();
+                byte[] bytes = new byte[content.readableBytes()];
+                content.getBytes(content.readerIndex(), bytes);
+                received.complete(bytes);
+            }
+        });
+
+        Channel sc = sb.bind(newSocketAddress()).sync().channel();
+        SocketAddress serverAddress = sc.localAddress();
+
+        cb.handler(new SimpleChannelInboundHandler<DatagramPacket>() {
+            @Override
+            protected void channelRead0(ChannelHandlerContext ctx, DatagramPacket msg) {
+                // no-op
+            }
+        });
+
+        Channel cc = cb.connect(serverAddress).sync().channel();
+        try {
+            ChannelFuture wf = write(cc, buf, wrapType);
+            cc.flush();
+            wf.sync();
+            byte[] actual = received.join();
+            assertArrayEquals(expected, actual);
+        } finally {
+            if (cc != null) {
+                cc.close().sync();
+            }
+            sc.close().sync();
         }
     }
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
@@ -57,6 +57,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -495,8 +496,9 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
             for (WrapType type : WrapType.values()) {
                 testWriteOffsetBytebuf0(sb, cb, buf.retain(), EXPECTED, type);
             }
+            assertEquals(1, buf.refCnt());
         } finally {
-            assertTrue(buf.release());
+            buf.release();
         }
     }
 
@@ -513,18 +515,20 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
             }
         });
 
-        Channel sc = sb.bind(newSocketAddress()).sync().channel();
-        SocketAddress serverAddress = sc.localAddress();
-
-        cb.handler(new SimpleChannelInboundHandler<ByteBufHolder>() {
-            @Override
-            protected void channelRead0(ChannelHandlerContext ctx, ByteBufHolder msg) {
-                // no-op
-            }
-        });
-
-        Channel cc = cb.connect(serverAddress).sync().channel();
+        Channel sc = null;
+        Channel cc = null;
         try {
+            sc = sb.bind(newSocketAddress()).sync().channel();
+            SocketAddress serverAddress = sc.localAddress();
+
+            cb.handler(new SimpleChannelInboundHandler<ByteBufHolder>() {
+                @Override
+                protected void channelRead0(ChannelHandlerContext ctx, ByteBufHolder msg) {
+                    // no-op
+                }
+            });
+
+            cc = cb.connect(serverAddress).sync().channel();
             ChannelFuture wf = write(cc, buf, wrapType);
             cc.flush();
             wf.sync();
@@ -537,7 +541,9 @@ public abstract class DatagramUnicastTest extends AbstractDatagramTest {
             if (cc != null) {
                 cc.close().sync();
             }
-            sc.close().sync();
+            if (sc != null) {
+                sc.close().sync();
+            }
         }
     }
 

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramUnicastTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDatagramUnicastTest.java
@@ -161,7 +161,7 @@ public class EpollDatagramUnicastTest extends DatagramUnicastInetTest {
             if (sc instanceof EpollDatagramChannel) {
                 assertEquals(gro, sc.config().getOption(EpollChannelOption.UDP_GRO));
             }
-            InetSocketAddress addr = sendToAddress((InetSocketAddress) sc.localAddress());
+            InetSocketAddress addr = convertAnyAddress((InetSocketAddress) sc.localAddress());
             final ByteBuf buffer;
             if (composite) {
                 CompositeByteBuf compositeBuffer = Unpooled.compositeBuffer();

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDatagramConnectedWriteExceptionTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDatagramConnectedWriteExceptionTest.java
@@ -16,92 +16,15 @@
 package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelOption;
-import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.channel.socket.DatagramPacket;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.DatagramConnectedWriteExceptionTest;
-import io.netty.util.NetUtil;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
-import org.junit.jupiter.api.Timeout;
 
-import java.net.InetSocketAddress;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 public class IoUringDatagramConnectedWriteExceptionTest extends DatagramConnectedWriteExceptionTest {
-
-    private static final byte[] BAD_PREFIX = "BAD-PREFIX-".getBytes(StandardCharsets.UTF_8);
-    private static final byte[] EXPECTED = "EXPECTED-direct-reader-index".getBytes(StandardCharsets.UTF_8);
 
     @Override
     protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
         return IoUringSocketTestPermutation.INSTANCE.datagramSocket();
     }
-
-    @Test
-    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-    public void testWriteOffsetBytebuf(TestInfo testInfo) throws Throwable {
-        run(testInfo, (Runner<Bootstrap>) this::testWriteOffsetBytebuf);
-    }
-
-    private void testWriteOffsetBytebuf(Bootstrap clientBootstrap) throws Throwable {
-        CompletableFuture<byte[]> received = new CompletableFuture<>();
-        Bootstrap serverBootstrap = clientBootstrap.clone()
-                .option(ChannelOption.SO_BROADCAST, false)
-                .handler(new SimpleChannelInboundHandler<DatagramPacket>() {
-                    @Override
-                    protected void channelRead0(ChannelHandlerContext ctx, DatagramPacket packet) {
-                        ByteBuf content = packet.content();
-                        byte[] bytes = new byte[content.readableBytes()];
-                        content.getBytes(content.readerIndex(), bytes);
-                        received.complete(bytes);
-                    }
-                });
-
-        Channel serverChannel = serverBootstrap.bind(new InetSocketAddress(NetUtil.LOCALHOST, 0)).sync().channel();
-        InetSocketAddress serverAddress = (InetSocketAddress) serverChannel.localAddress();
-
-        clientBootstrap.option(ChannelOption.AUTO_READ, false)
-                .handler(new SimpleChannelInboundHandler<DatagramPacket>() {
-                    @Override
-                    protected void channelRead0(ChannelHandlerContext ctx, DatagramPacket msg) {
-                        // no-op
-                    }
-                });
-
-        Channel clientChannel = clientBootstrap.connect(serverAddress).sync().channel();
-        try {
-           ByteBuf content = directReaderIndex(serverChannel.alloc());
-           clientChannel.writeAndFlush(new DatagramPacket(content, serverAddress)).sync();
-
-           byte[] actual = received.join();
-           assertArrayEquals(EXPECTED, actual);
-        } finally {
-           if (clientChannel != null) {
-               clientChannel.close().sync();
-           }
-           if (serverChannel != null) {
-               serverChannel.close().sync();
-           }
-       }
-     }
-
-    private static ByteBuf directReaderIndex(ByteBufAllocator alloc) {
-        ByteBuf buf = alloc.directBuffer(BAD_PREFIX.length + EXPECTED.length);
-        buf.writeBytes(BAD_PREFIX);
-        buf.writeBytes(EXPECTED);
-        buf.readerIndex(BAD_PREFIX.length);
-        return buf;
-    }
-
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDatagramUnicastTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDatagramUnicastTest.java
@@ -84,7 +84,7 @@ public class IoUringDatagramUnicastTest extends DatagramUnicastInetTest {
                 }
             }).option(ChannelOption.RECVBUF_ALLOCATOR, new FixedRecvByteBufAllocator(2048))
                     .bind(newSocketAddress()).sync().channel();
-            InetSocketAddress addr = sendToAddress((InetSocketAddress) sc.localAddress());
+            InetSocketAddress addr = convertAnyAddress((InetSocketAddress) sc.localAddress());
             cc.writeAndFlush(new DatagramPacket(cc.alloc().buffer().writeZero(512),  addr)).sync();
 
             readLatch.await();


### PR DESCRIPTION
Motivation:

38ccefcba70c870aab7977e888559d833f2fe3b7 added a test for datagram writes with non zero reader index but only tested io_uring. We should just move the test and so test all different transport implementations

Modifications:

Move testcode to shared testsuite

Result:

Better test coverage
