### PR TITLE
Fix propagation of startTls for client SslContext handlers

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslClientContext.java
@@ -88,7 +88,7 @@ public final class OpenSslClientContext extends OpenSslContext {
     @Deprecated
     public OpenSslClientContext(File certChainFile, TrustManagerFactory trustManagerFactory) throws SSLException {
         this(certChainFile, trustManagerFactory, null, null, null, null, null,
-                IdentityCipherSuiteFilter.INSTANCE, null, 0, 0);
+             IdentityCipherSuiteFilter.INSTANCE, null, 0, 0);
     }
 
     /**
@@ -137,7 +137,7 @@ public final class OpenSslClientContext extends OpenSslContext {
                                 CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn,
                                 long sessionCacheSize, long sessionTimeout) throws SSLException {
         this(certChainFile, trustManagerFactory, null, null, null, null,
-                ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout);
+             ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout);
     }
 
     /**
@@ -215,11 +215,11 @@ public final class OpenSslClientContext extends OpenSslContext {
         boolean supportJdkSignatureFallback = isJdkSignatureFallbackEnabled(options);
         try {
             OpenSslKeyMaterialProvider.validateKeyMaterialSupported(keyCertChain, key, keyPassword,
-                    supportJdkSignatureFallback);
+                                                                    supportJdkSignatureFallback);
             sessionContext = newSessionContext(this, ctx, engines, trustCertCollection, trustManagerFactory,
-                    keyCertChain, key, keyPassword, keyManagerFactory, keyStore,
-                    sessionCacheSize, sessionTimeout, resumptionController,
-                    supportJdkSignatureFallback);
+                                               keyCertChain, key, keyPassword, keyManagerFactory, keyStore,
+                                               sessionCacheSize, sessionTimeout, resumptionController,
+                                               supportJdkSignatureFallback);
             success = true;
         } finally {
             if (!success) {

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslClientContext.java
@@ -88,7 +88,7 @@ public final class OpenSslClientContext extends OpenSslContext {
     @Deprecated
     public OpenSslClientContext(File certChainFile, TrustManagerFactory trustManagerFactory) throws SSLException {
         this(certChainFile, trustManagerFactory, null, null, null, null, null,
-             IdentityCipherSuiteFilter.INSTANCE, null, 0, 0);
+                IdentityCipherSuiteFilter.INSTANCE, null, 0, 0);
     }
 
     /**
@@ -137,7 +137,7 @@ public final class OpenSslClientContext extends OpenSslContext {
                                 CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn,
                                 long sessionCacheSize, long sessionTimeout) throws SSLException {
         this(certChainFile, trustManagerFactory, null, null, null, null,
-             ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout);
+                ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout);
     }
 
     /**
@@ -181,7 +181,7 @@ public final class OpenSslClientContext extends OpenSslContext {
         this(toX509CertificatesInternal(trustCertCollectionFile), trustManagerFactory,
                 toX509CertificatesInternal(keyCertChainFile), toPrivateKeyInternal(keyFile, keyPassword),
                 keyPassword, keyManagerFactory, ciphers, cipherFilter, apn, null, sessionCacheSize,
-                sessionTimeout, false, KeyStore.getDefaultType(), null, null, null, EMPTY_MAP_ENTRY, null);
+                sessionTimeout, false, false, KeyStore.getDefaultType(), null, null, null, EMPTY_MAP_ENTRY, null);
     }
 
     OpenSslClientContext(X509Certificate[] trustCertCollection, TrustManagerFactory trustManagerFactory,
@@ -194,17 +194,32 @@ public final class OpenSslClientContext extends OpenSslContext {
                          Map.Entry<SslContextOption<?>, Object>[] options,
                          List<OpenSslCredential> credentials)
             throws SSLException {
-        super(ciphers, cipherFilter, apn, SSL.SSL_MODE_CLIENT, keyCertChain, ClientAuth.NONE, protocols, false,
+        this(trustCertCollection, trustManagerFactory, keyCertChain, key, keyPassword, keyManagerFactory, ciphers,
+                cipherFilter, apn, protocols, sessionCacheSize, sessionTimeout, false, enableOcsp, keyStore,
+                endpointIdentificationAlgorithm, serverNames, resumptionController, options, credentials);
+    }
+
+    OpenSslClientContext(X509Certificate[] trustCertCollection, TrustManagerFactory trustManagerFactory,
+                         X509Certificate[] keyCertChain, PrivateKey key, String keyPassword,
+                         KeyManagerFactory keyManagerFactory, Iterable<String> ciphers,
+                         CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn, String[] protocols,
+                         long sessionCacheSize, long sessionTimeout, boolean startTls, boolean enableOcsp,
+                         String keyStore, String endpointIdentificationAlgorithm, List<SNIServerName> serverNames,
+                         ResumptionController resumptionController,
+                         Map.Entry<SslContextOption<?>, Object>[] options,
+                         List<OpenSslCredential> credentials)
+            throws SSLException {
+        super(ciphers, cipherFilter, apn, SSL.SSL_MODE_CLIENT, keyCertChain, ClientAuth.NONE, protocols, startTls,
                 endpointIdentificationAlgorithm, enableOcsp, serverNames, resumptionController, options, credentials);
         boolean success = false;
         boolean supportJdkSignatureFallback = isJdkSignatureFallbackEnabled(options);
         try {
             OpenSslKeyMaterialProvider.validateKeyMaterialSupported(keyCertChain, key, keyPassword,
-                                                                    supportJdkSignatureFallback);
+                    supportJdkSignatureFallback);
             sessionContext = newSessionContext(this, ctx, engines, trustCertCollection, trustManagerFactory,
-                                               keyCertChain, key, keyPassword, keyManagerFactory, keyStore,
-                                               sessionCacheSize, sessionTimeout, resumptionController,
-                                               supportJdkSignatureFallback);
+                    keyCertChain, key, keyPassword, keyManagerFactory, keyStore,
+                    sessionCacheSize, sessionTimeout, resumptionController,
+                    supportJdkSignatureFallback);
             success = true;
         } finally {
             if (!success) {

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslClientContext.java
@@ -65,15 +65,30 @@ public final class ReferenceCountedOpenSslClientContext extends ReferenceCounted
                                          ResumptionController resumptionController,
                                          Map.Entry<SslContextOption<?>, Object>[] options,
                                          List<OpenSslCredential> credentials) throws SSLException {
+        this(trustCertCollection, trustManagerFactory, keyCertChain, key, keyPassword, keyManagerFactory, ciphers,
+                cipherFilter, apn, protocols, sessionCacheSize, sessionTimeout, false, enableOcsp, keyStore,
+                endpointIdentificationAlgorithm, serverNames, resumptionController, options, credentials);
+    }
+
+    ReferenceCountedOpenSslClientContext(X509Certificate[] trustCertCollection, TrustManagerFactory trustManagerFactory,
+                                         X509Certificate[] keyCertChain, PrivateKey key, String keyPassword,
+                                         KeyManagerFactory keyManagerFactory, Iterable<String> ciphers,
+                                         CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn,
+                                         String[] protocols, long sessionCacheSize, long sessionTimeout,
+                                         boolean startTls, boolean enableOcsp, String keyStore,
+                                         String endpointIdentificationAlgorithm, List<SNIServerName> serverNames,
+                                         ResumptionController resumptionController,
+                                         Map.Entry<SslContextOption<?>, Object>[] options,
+                                         List<OpenSslCredential> credentials) throws SSLException {
         super(ciphers, cipherFilter, toNegotiator(apn), SSL.SSL_MODE_CLIENT, keyCertChain,
-              ClientAuth.NONE, protocols, false, endpointIdentificationAlgorithm, enableOcsp, true,
+                ClientAuth.NONE, protocols, startTls, endpointIdentificationAlgorithm, enableOcsp, true,
                 serverNames, resumptionController, options, credentials);
         boolean success = false;
         try {
             sessionContext = newSessionContext(this, ctx, engines, trustCertCollection, trustManagerFactory,
-                                               keyCertChain, key, keyPassword, keyManagerFactory, keyStore,
-                                               sessionCacheSize, sessionTimeout, resumptionController,
-                                               isJdkSignatureFallbackEnabled(options));
+                    keyCertChain, key, keyPassword, keyManagerFactory, keyStore,
+                    sessionCacheSize, sessionTimeout, resumptionController,
+                    isJdkSignatureFallbackEnabled(options));
             success = true;
         } finally {
             if (!success) {

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslClientContext.java
@@ -81,14 +81,14 @@ public final class ReferenceCountedOpenSslClientContext extends ReferenceCounted
                                          Map.Entry<SslContextOption<?>, Object>[] options,
                                          List<OpenSslCredential> credentials) throws SSLException {
         super(ciphers, cipherFilter, toNegotiator(apn), SSL.SSL_MODE_CLIENT, keyCertChain,
-                ClientAuth.NONE, protocols, startTls, endpointIdentificationAlgorithm, enableOcsp, true,
+              ClientAuth.NONE, protocols, startTls, endpointIdentificationAlgorithm, enableOcsp, true,
                 serverNames, resumptionController, options, credentials);
         boolean success = false;
         try {
             sessionContext = newSessionContext(this, ctx, engines, trustCertCollection, trustManagerFactory,
-                    keyCertChain, key, keyPassword, keyManagerFactory, keyStore,
-                    sessionCacheSize, sessionTimeout, resumptionController,
-                    isJdkSignatureFallbackEnabled(options));
+                                               keyCertChain, key, keyPassword, keyManagerFactory, keyStore,
+                                               sessionCacheSize, sessionTimeout, resumptionController,
+                                               isJdkSignatureFallbackEnabled(options));
             success = true;
         } finally {
             if (!success) {

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -118,7 +118,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
     static final boolean SERVER_ENABLE_SESSION_TICKET =
             SystemPropertyUtil.getBoolean("jdk.tls.server.enableSessionTicketExtension", false);
 
-     static final boolean SERVER_ENABLE_SESSION_TICKET_TLSV13 =
+    static final boolean SERVER_ENABLE_SESSION_TICKET_TLSV13 =
             SystemPropertyUtil.getBoolean("jdk.tls.server.enableSessionTicketExtension", true);
 
     static final boolean SERVER_ENABLE_SESSION_CACHE =
@@ -574,7 +574,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
     @Override
     protected SslHandler newHandler(ByteBufAllocator alloc, String peerHost, int peerPort,
                                     boolean startTls, Executor executor) {
-        return new SslHandler(newEngine0(alloc, peerHost, peerPort, false), false, executor, resumptionController);
+        return new SslHandler(newEngine0(alloc, peerHost, peerPort, false), startTls, executor, resumptionController);
     }
 
     SSLEngine newEngine0(ByteBufAllocator alloc, String peerHost, int peerPort, boolean jdkCompatibilityMode) {
@@ -764,7 +764,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
     }
 
     static X509TrustManager chooseTrustManager(TrustManager[] managers,
-                                                         ResumptionController resumptionController) {
+                                               ResumptionController resumptionController) {
         for (TrustManager m : managers) {
             if (m instanceof X509TrustManager) {
                 X509TrustManager tm = (X509TrustManager) m;
@@ -951,7 +951,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
 
     static void setKeyMaterial(long ctx, X509Certificate[] keyCertChain, PrivateKey key, String keyPassword)
             throws SSLException {
-         /* Load the certificate file and private key. */
+        /* Load the certificate file and private key. */
         long keyBio = 0;
         long keyCertChainBio = 0;
         long keyCertChainBio2 = 0;
@@ -997,7 +997,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
                 Boolean policy = (Boolean) entry.getValue();
                 allowJdkFallback = policy.booleanValue();
             } else if (option == OpenSslContextOption.PRIVATE_KEY_METHOD ||
-                       option == OpenSslContextOption.ASYNC_PRIVATE_KEY_METHOD) {
+                    option == OpenSslContextOption.ASYNC_PRIVATE_KEY_METHOD) {
                 // if the user has set a private key method already we don't want to support
                 // fallback.
                 return false;

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -764,7 +764,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
     }
 
     static X509TrustManager chooseTrustManager(TrustManager[] managers,
-                                               ResumptionController resumptionController) {
+                                                         ResumptionController resumptionController) {
         for (TrustManager m : managers) {
             if (m instanceof X509TrustManager) {
                 X509TrustManager tm = (X509TrustManager) m;
@@ -951,7 +951,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
 
     static void setKeyMaterial(long ctx, X509Certificate[] keyCertChain, PrivateKey key, String keyPassword)
             throws SSLException {
-        /* Load the certificate file and private key. */
+         /* Load the certificate file and private key. */
         long keyBio = 0;
         long keyCertChainBio = 0;
         long keyCertChainBio2 = 0;
@@ -997,7 +997,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
                 Boolean policy = (Boolean) entry.getValue();
                 allowJdkFallback = policy.booleanValue();
             } else if (option == OpenSslContextOption.PRIVATE_KEY_METHOD ||
-                    option == OpenSslContextOption.ASYNC_PRIVATE_KEY_METHOD) {
+                       option == OpenSslContextOption.ASYNC_PRIVATE_KEY_METHOD) {
                 // if the user has set a private key method already we don't want to support
                 // fallback.
                 return false;

--- a/handler/src/main/java/io/netty/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContext.java
@@ -290,7 +290,7 @@ public abstract class SslContext {
     public static SslContext newServerContext(
             SslProvider provider, File certChainFile, File keyFile, String keyPassword) throws SSLException {
         return newServerContext(provider, certChainFile, keyFile, keyPassword, null, IdentityCipherSuiteFilter.INSTANCE,
-                                null, 0, 0);
+                null, 0, 0);
     }
 
     /**
@@ -320,8 +320,8 @@ public abstract class SslContext {
             Iterable<String> ciphers, Iterable<String> nextProtocols,
             long sessionCacheSize, long sessionTimeout) throws SSLException {
         return newServerContext(provider, certChainFile, keyFile, keyPassword,
-                                ciphers, IdentityCipherSuiteFilter.INSTANCE,
-                                toApplicationProtocolConfig(nextProtocols), sessionCacheSize, sessionTimeout);
+                ciphers, IdentityCipherSuiteFilter.INSTANCE,
+                toApplicationProtocolConfig(nextProtocols), sessionCacheSize, sessionTimeout);
     }
 
     /**
@@ -383,9 +383,9 @@ public abstract class SslContext {
      */
     @Deprecated
     public static SslContext newServerContext(SslProvider provider,
-            File certChainFile, File keyFile, String keyPassword,
-            Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn,
-            long sessionCacheSize, long sessionTimeout) throws SSLException {
+                                              File certChainFile, File keyFile, String keyPassword,
+                                              Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn,
+                                              long sessionCacheSize, long sessionTimeout) throws SSLException {
         return newServerContext(provider, null, null, certChainFile, keyFile, keyPassword, null,
                 ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout, KeyStore.getDefaultType());
     }
@@ -476,11 +476,11 @@ public abstract class SslContext {
             long sessionCacheSize, long sessionTimeout, String keyStore) throws SSLException {
         try {
             return newServerContextInternal(provider, null, toX509Certificates(trustCertCollectionFile),
-                                            trustManagerFactory, toX509Certificates(keyCertChainFile),
-                                            toPrivateKey(keyFile, keyPassword),
-                                            keyPassword, keyManagerFactory, ciphers, cipherFilter, apn,
-                                            sessionCacheSize, sessionTimeout, ClientAuth.NONE, null,
-                                            false, false, null, keyStore, null, null);
+                    trustManagerFactory, toX509Certificates(keyCertChainFile),
+                    toPrivateKey(keyFile, keyPassword),
+                    keyPassword, keyManagerFactory, ciphers, cipherFilter, apn,
+                    sessionCacheSize, sessionTimeout, ClientAuth.NONE, null,
+                    false, false, null, keyStore, null, null);
         } catch (Exception e) {
             if (e instanceof SSLException) {
                 throw (SSLException) e;
@@ -508,34 +508,34 @@ public abstract class SslContext {
         ResumptionController resumptionController = new ResumptionController();
 
         switch (provider) {
-        case JDK:
-            if (enableOcsp) {
-                throw new IllegalArgumentException("OCSP is not supported with this SslProvider: " + provider);
-            }
-            if (credentials != null && !credentials.isEmpty()) {
-                throw new IllegalArgumentException(
-                        "OpenSslCredential is not supported with SslProvider.JDK. " +
-                                "Use SslProvider.OPENSSL or SslProvider.OPENSSL_REFCNT instead.");
-            }
-            return new JdkSslServerContext(sslContextProvider,
-                    trustCertCollection, trustManagerFactory, keyCertChain, key, keyPassword,
-                    keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout,
-                    clientAuth, protocols, startTls, secureRandom, keyStoreType, resumptionController);
-        case OPENSSL:
-            verifyNullSslContextProvider(provider, sslContextProvider);
-            return new OpenSslServerContext(
-                    trustCertCollection, trustManagerFactory, keyCertChain, key, keyPassword,
-                    keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout,
-                    clientAuth, protocols, startTls, enableOcsp, keyStoreType, resumptionController, ctxOptions);
-        case OPENSSL_REFCNT:
-            verifyNullSslContextProvider(provider, sslContextProvider);
-            return new ReferenceCountedOpenSslServerContext(
-                    trustCertCollection, trustManagerFactory, keyCertChain, key, keyPassword,
-                    keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout,
-                    clientAuth, protocols, startTls, enableOcsp, keyStoreType, resumptionController, ctxOptions,
-                    credentials);
-        default:
-            throw new Error("Unexpected provider: " + provider);
+            case JDK:
+                if (enableOcsp) {
+                    throw new IllegalArgumentException("OCSP is not supported with this SslProvider: " + provider);
+                }
+                if (credentials != null && !credentials.isEmpty()) {
+                    throw new IllegalArgumentException(
+                            "OpenSslCredential is not supported with SslProvider.JDK. " +
+                                    "Use SslProvider.OPENSSL or SslProvider.OPENSSL_REFCNT instead.");
+                }
+                return new JdkSslServerContext(sslContextProvider,
+                        trustCertCollection, trustManagerFactory, keyCertChain, key, keyPassword,
+                        keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout,
+                        clientAuth, protocols, startTls, secureRandom, keyStoreType, resumptionController);
+            case OPENSSL:
+                verifyNullSslContextProvider(provider, sslContextProvider);
+                return new OpenSslServerContext(
+                        trustCertCollection, trustManagerFactory, keyCertChain, key, keyPassword,
+                        keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout,
+                        clientAuth, protocols, startTls, enableOcsp, keyStoreType, resumptionController, ctxOptions);
+            case OPENSSL_REFCNT:
+                verifyNullSslContextProvider(provider, sslContextProvider);
+                return new ReferenceCountedOpenSslServerContext(
+                        trustCertCollection, trustManagerFactory, keyCertChain, key, keyPassword,
+                        keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout,
+                        clientAuth, protocols, startTls, enableOcsp, keyStoreType, resumptionController, ctxOptions,
+                        credentials);
+            default:
+                throw new Error("Unexpected provider: " + provider);
         }
     }
 
@@ -838,21 +838,21 @@ public abstract class SslContext {
      */
     @Deprecated
     public static SslContext newClientContext(
-        SslProvider provider,
-        File trustCertCollectionFile, TrustManagerFactory trustManagerFactory,
-        File keyCertChainFile, File keyFile, String keyPassword,
-        KeyManagerFactory keyManagerFactory,
-        Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn,
-        long sessionCacheSize, long sessionTimeout) throws SSLException {
+            SslProvider provider,
+            File trustCertCollectionFile, TrustManagerFactory trustManagerFactory,
+            File keyCertChainFile, File keyFile, String keyPassword,
+            KeyManagerFactory keyManagerFactory,
+            Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn,
+            long sessionCacheSize, long sessionTimeout) throws SSLException {
         try {
             return newClientContextInternal(provider, null,
-                                            toX509Certificates(trustCertCollectionFile), trustManagerFactory,
-                                            toX509Certificates(keyCertChainFile), toPrivateKey(keyFile, keyPassword),
-                                            keyPassword, keyManagerFactory, ciphers, cipherFilter,
-                                            apn, null, sessionCacheSize, sessionTimeout, false,
-                                            null, KeyStore.getDefaultType(),
-                                            defaultEndpointVerificationAlgorithm,
-                                            Collections.emptyList(), null, null);
+                    toX509Certificates(trustCertCollectionFile), trustManagerFactory,
+                    toX509Certificates(keyCertChainFile), toPrivateKey(keyFile, keyPassword),
+                    keyPassword, keyManagerFactory, ciphers, cipherFilter,
+                    apn, null, sessionCacheSize, sessionTimeout, false,
+                    false, null, KeyStore.getDefaultType(),
+                    defaultEndpointVerificationAlgorithm,
+                    Collections.emptyList(), null, null);
         } catch (Exception e) {
             if (e instanceof SSLException) {
                 throw (SSLException) e;
@@ -868,6 +868,23 @@ public abstract class SslContext {
             X509Certificate[] keyCertChain, PrivateKey key, String keyPassword, KeyManagerFactory keyManagerFactory,
             Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn, String[] protocols,
             long sessionCacheSize, long sessionTimeout, boolean enableOcsp,
+            SecureRandom secureRandom, String keyStoreType, String endpointIdentificationAlgorithm,
+            List<SNIServerName> serverNames,
+            Map.Entry<SslContextOption<?>, Object>[] options,
+            List<OpenSslCredential> credentials) throws SSLException {
+        return newClientContextInternal(provider, sslContextProvider, trustCert, trustManagerFactory, keyCertChain, key,
+                keyPassword, keyManagerFactory, ciphers, cipherFilter, apn, protocols, sessionCacheSize, sessionTimeout,
+                false, enableOcsp, secureRandom, keyStoreType, endpointIdentificationAlgorithm, serverNames, options,
+                credentials);
+    }
+
+    static SslContext newClientContextInternal(
+            SslProvider provider,
+            Provider sslContextProvider,
+            X509Certificate[] trustCert, TrustManagerFactory trustManagerFactory,
+            X509Certificate[] keyCertChain, PrivateKey key, String keyPassword, KeyManagerFactory keyManagerFactory,
+            Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn, String[] protocols,
+            long sessionCacheSize, long sessionTimeout, boolean startTls, boolean enableOcsp,
             SecureRandom secureRandom, String keyStoreType, String endpointIdentificationAlgorithm,
             List<SNIServerName> serverNames,
             Map.Entry<SslContextOption<?>, Object>[] options,
@@ -899,16 +916,16 @@ public abstract class SslContext {
                 return new OpenSslClientContext(
                         trustCert, trustManagerFactory, keyCertChain, key, keyPassword,
                         keyManagerFactory, ciphers, cipherFilter, apn, protocols, sessionCacheSize, sessionTimeout,
-                        enableOcsp, keyStoreType, endpointIdentificationAlgorithm, serverNames, resumptionController,
-                        options, credentials);
+                        startTls, enableOcsp, keyStoreType, endpointIdentificationAlgorithm, serverNames,
+                        resumptionController, options, credentials);
             case OPENSSL_REFCNT:
                 verifyNullSslContextProvider(provider, sslContextProvider);
                 OpenSsl.ensureAvailability();
                 return new ReferenceCountedOpenSslClientContext(
                         trustCert, trustManagerFactory, keyCertChain, key, keyPassword,
                         keyManagerFactory, ciphers, cipherFilter, apn, protocols, sessionCacheSize, sessionTimeout,
-                        enableOcsp, keyStoreType, endpointIdentificationAlgorithm, serverNames, resumptionController,
-                        options, credentials);
+                        startTls, enableOcsp, keyStoreType, endpointIdentificationAlgorithm, serverNames,
+                        resumptionController, options, credentials);
             default:
                 throw new Error("Unexpected provider: " + provider);
         }
@@ -1200,9 +1217,9 @@ public abstract class SslContext {
      * @return generated {@link KeyStore}.
      */
     protected static KeyStore buildKeyStore(X509Certificate[] certChain, PrivateKey key,
-                                  char[] keyPasswordChars, String keyStoreType)
+                                            char[] keyPasswordChars, String keyStoreType)
             throws KeyStoreException, NoSuchAlgorithmException,
-                   CertificateException, IOException {
+            CertificateException, IOException {
         if (keyStoreType == null) {
             keyStoreType = KeyStore.getDefaultType();
         }
@@ -1213,9 +1230,9 @@ public abstract class SslContext {
     }
 
     protected static PrivateKey toPrivateKey(File keyFile, String keyPassword) throws NoSuchAlgorithmException,
-                                                                NoSuchPaddingException, InvalidKeySpecException,
-                                                                InvalidAlgorithmParameterException,
-                                                                KeyException, IOException {
+            NoSuchPaddingException, InvalidKeySpecException,
+            InvalidAlgorithmParameterException,
+            KeyException, IOException {
         return toPrivateKey(keyFile, keyPassword, true);
     }
 
@@ -1239,10 +1256,10 @@ public abstract class SslContext {
     }
 
     protected static PrivateKey toPrivateKey(InputStream keyInputStream, String keyPassword)
-                                                                throws NoSuchAlgorithmException,
-                                                                NoSuchPaddingException, InvalidKeySpecException,
-                                                                InvalidAlgorithmParameterException,
-                                                                KeyException, IOException {
+            throws NoSuchAlgorithmException,
+            NoSuchPaddingException, InvalidKeySpecException,
+            InvalidAlgorithmParameterException,
+            KeyException, IOException {
         if (keyInputStream == null) {
             return null;
         }
@@ -1394,9 +1411,9 @@ public abstract class SslContext {
     }
 
     protected static KeyManagerFactory buildKeyManagerFactory(X509Certificate[] certChainFile,
-                                                    String keyAlgorithm, PrivateKey key,
-                                                    String keyPassword, KeyManagerFactory kmf,
-                                                    String keyStore)
+                                                              String keyAlgorithm, PrivateKey key,
+                                                              String keyPassword, KeyManagerFactory kmf,
+                                                              String keyStore)
             throws KeyStoreException, NoSuchAlgorithmException, IOException,
             CertificateException, UnrecoverableKeyException {
         if (keyAlgorithm == null) {

--- a/handler/src/main/java/io/netty/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContext.java
@@ -290,7 +290,7 @@ public abstract class SslContext {
     public static SslContext newServerContext(
             SslProvider provider, File certChainFile, File keyFile, String keyPassword) throws SSLException {
         return newServerContext(provider, certChainFile, keyFile, keyPassword, null, IdentityCipherSuiteFilter.INSTANCE,
-                null, 0, 0);
+                                null, 0, 0);
     }
 
     /**
@@ -320,8 +320,8 @@ public abstract class SslContext {
             Iterable<String> ciphers, Iterable<String> nextProtocols,
             long sessionCacheSize, long sessionTimeout) throws SSLException {
         return newServerContext(provider, certChainFile, keyFile, keyPassword,
-                ciphers, IdentityCipherSuiteFilter.INSTANCE,
-                toApplicationProtocolConfig(nextProtocols), sessionCacheSize, sessionTimeout);
+                                ciphers, IdentityCipherSuiteFilter.INSTANCE,
+                                toApplicationProtocolConfig(nextProtocols), sessionCacheSize, sessionTimeout);
     }
 
     /**
@@ -383,9 +383,9 @@ public abstract class SslContext {
      */
     @Deprecated
     public static SslContext newServerContext(SslProvider provider,
-                                              File certChainFile, File keyFile, String keyPassword,
-                                              Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn,
-                                              long sessionCacheSize, long sessionTimeout) throws SSLException {
+            File certChainFile, File keyFile, String keyPassword,
+            Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn,
+            long sessionCacheSize, long sessionTimeout) throws SSLException {
         return newServerContext(provider, null, null, certChainFile, keyFile, keyPassword, null,
                 ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout, KeyStore.getDefaultType());
     }
@@ -476,11 +476,11 @@ public abstract class SslContext {
             long sessionCacheSize, long sessionTimeout, String keyStore) throws SSLException {
         try {
             return newServerContextInternal(provider, null, toX509Certificates(trustCertCollectionFile),
-                    trustManagerFactory, toX509Certificates(keyCertChainFile),
-                    toPrivateKey(keyFile, keyPassword),
-                    keyPassword, keyManagerFactory, ciphers, cipherFilter, apn,
-                    sessionCacheSize, sessionTimeout, ClientAuth.NONE, null,
-                    false, false, null, keyStore, null, null);
+                                            trustManagerFactory, toX509Certificates(keyCertChainFile),
+                                            toPrivateKey(keyFile, keyPassword),
+                                            keyPassword, keyManagerFactory, ciphers, cipherFilter, apn,
+                                            sessionCacheSize, sessionTimeout, ClientAuth.NONE, null,
+                                            false, false, null, keyStore, null, null);
         } catch (Exception e) {
             if (e instanceof SSLException) {
                 throw (SSLException) e;
@@ -508,34 +508,34 @@ public abstract class SslContext {
         ResumptionController resumptionController = new ResumptionController();
 
         switch (provider) {
-            case JDK:
-                if (enableOcsp) {
-                    throw new IllegalArgumentException("OCSP is not supported with this SslProvider: " + provider);
-                }
-                if (credentials != null && !credentials.isEmpty()) {
-                    throw new IllegalArgumentException(
-                            "OpenSslCredential is not supported with SslProvider.JDK. " +
-                                    "Use SslProvider.OPENSSL or SslProvider.OPENSSL_REFCNT instead.");
-                }
-                return new JdkSslServerContext(sslContextProvider,
-                        trustCertCollection, trustManagerFactory, keyCertChain, key, keyPassword,
-                        keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout,
-                        clientAuth, protocols, startTls, secureRandom, keyStoreType, resumptionController);
-            case OPENSSL:
-                verifyNullSslContextProvider(provider, sslContextProvider);
-                return new OpenSslServerContext(
-                        trustCertCollection, trustManagerFactory, keyCertChain, key, keyPassword,
-                        keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout,
-                        clientAuth, protocols, startTls, enableOcsp, keyStoreType, resumptionController, ctxOptions);
-            case OPENSSL_REFCNT:
-                verifyNullSslContextProvider(provider, sslContextProvider);
-                return new ReferenceCountedOpenSslServerContext(
-                        trustCertCollection, trustManagerFactory, keyCertChain, key, keyPassword,
-                        keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout,
-                        clientAuth, protocols, startTls, enableOcsp, keyStoreType, resumptionController, ctxOptions,
-                        credentials);
-            default:
-                throw new Error("Unexpected provider: " + provider);
+        case JDK:
+            if (enableOcsp) {
+                throw new IllegalArgumentException("OCSP is not supported with this SslProvider: " + provider);
+            }
+            if (credentials != null && !credentials.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "OpenSslCredential is not supported with SslProvider.JDK. " +
+                                "Use SslProvider.OPENSSL or SslProvider.OPENSSL_REFCNT instead.");
+            }
+            return new JdkSslServerContext(sslContextProvider,
+                    trustCertCollection, trustManagerFactory, keyCertChain, key, keyPassword,
+                    keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout,
+                    clientAuth, protocols, startTls, secureRandom, keyStoreType, resumptionController);
+        case OPENSSL:
+            verifyNullSslContextProvider(provider, sslContextProvider);
+            return new OpenSslServerContext(
+                    trustCertCollection, trustManagerFactory, keyCertChain, key, keyPassword,
+                    keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout,
+                    clientAuth, protocols, startTls, enableOcsp, keyStoreType, resumptionController, ctxOptions);
+        case OPENSSL_REFCNT:
+            verifyNullSslContextProvider(provider, sslContextProvider);
+            return new ReferenceCountedOpenSslServerContext(
+                    trustCertCollection, trustManagerFactory, keyCertChain, key, keyPassword,
+                    keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout,
+                    clientAuth, protocols, startTls, enableOcsp, keyStoreType, resumptionController, ctxOptions,
+                    credentials);
+        default:
+            throw new Error("Unexpected provider: " + provider);
         }
     }
 
@@ -838,21 +838,21 @@ public abstract class SslContext {
      */
     @Deprecated
     public static SslContext newClientContext(
-            SslProvider provider,
-            File trustCertCollectionFile, TrustManagerFactory trustManagerFactory,
-            File keyCertChainFile, File keyFile, String keyPassword,
-            KeyManagerFactory keyManagerFactory,
-            Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn,
-            long sessionCacheSize, long sessionTimeout) throws SSLException {
+        SslProvider provider,
+        File trustCertCollectionFile, TrustManagerFactory trustManagerFactory,
+        File keyCertChainFile, File keyFile, String keyPassword,
+        KeyManagerFactory keyManagerFactory,
+        Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn,
+        long sessionCacheSize, long sessionTimeout) throws SSLException {
         try {
             return newClientContextInternal(provider, null,
-                    toX509Certificates(trustCertCollectionFile), trustManagerFactory,
-                    toX509Certificates(keyCertChainFile), toPrivateKey(keyFile, keyPassword),
-                    keyPassword, keyManagerFactory, ciphers, cipherFilter,
-                    apn, null, sessionCacheSize, sessionTimeout, false,
-                    false, null, KeyStore.getDefaultType(),
-                    defaultEndpointVerificationAlgorithm,
-                    Collections.emptyList(), null, null);
+                                            toX509Certificates(trustCertCollectionFile), trustManagerFactory,
+                                            toX509Certificates(keyCertChainFile), toPrivateKey(keyFile, keyPassword),
+                                            keyPassword, keyManagerFactory, ciphers, cipherFilter,
+                                            apn, null, sessionCacheSize, sessionTimeout, false,
+                                            null, KeyStore.getDefaultType(),
+                                            defaultEndpointVerificationAlgorithm,
+                                            Collections.emptyList(), null, null);
         } catch (Exception e) {
             if (e instanceof SSLException) {
                 throw (SSLException) e;
@@ -1217,9 +1217,9 @@ public abstract class SslContext {
      * @return generated {@link KeyStore}.
      */
     protected static KeyStore buildKeyStore(X509Certificate[] certChain, PrivateKey key,
-                                            char[] keyPasswordChars, String keyStoreType)
+                                  char[] keyPasswordChars, String keyStoreType)
             throws KeyStoreException, NoSuchAlgorithmException,
-            CertificateException, IOException {
+                   CertificateException, IOException {
         if (keyStoreType == null) {
             keyStoreType = KeyStore.getDefaultType();
         }
@@ -1230,9 +1230,9 @@ public abstract class SslContext {
     }
 
     protected static PrivateKey toPrivateKey(File keyFile, String keyPassword) throws NoSuchAlgorithmException,
-            NoSuchPaddingException, InvalidKeySpecException,
-            InvalidAlgorithmParameterException,
-            KeyException, IOException {
+                                                                NoSuchPaddingException, InvalidKeySpecException,
+                                                                InvalidAlgorithmParameterException,
+                                                                KeyException, IOException {
         return toPrivateKey(keyFile, keyPassword, true);
     }
 
@@ -1256,10 +1256,10 @@ public abstract class SslContext {
     }
 
     protected static PrivateKey toPrivateKey(InputStream keyInputStream, String keyPassword)
-            throws NoSuchAlgorithmException,
-            NoSuchPaddingException, InvalidKeySpecException,
-            InvalidAlgorithmParameterException,
-            KeyException, IOException {
+                                                                throws NoSuchAlgorithmException,
+                                                                NoSuchPaddingException, InvalidKeySpecException,
+                                                                InvalidAlgorithmParameterException,
+                                                                KeyException, IOException {
         if (keyInputStream == null) {
             return null;
         }
@@ -1411,9 +1411,9 @@ public abstract class SslContext {
     }
 
     protected static KeyManagerFactory buildKeyManagerFactory(X509Certificate[] certChainFile,
-                                                              String keyAlgorithm, PrivateKey key,
-                                                              String keyPassword, KeyManagerFactory kmf,
-                                                              String keyStore)
+                                                    String keyAlgorithm, PrivateKey key,
+                                                    String keyPassword, KeyManagerFactory kmf,
+                                                    String keyStore)
             throws KeyStoreException, NoSuchAlgorithmException, IOException,
             CertificateException, UnrecoverableKeyException {
         if (keyAlgorithm == null) {

--- a/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
@@ -420,7 +420,7 @@ public final class SslContextBuilder {
      *     password-protected
      */
     public SslContextBuilder keyManager(InputStream keyCertChainInputStream, InputStream keyInputStream,
-            String keyPassword) {
+                                        String keyPassword) {
         X509Certificate[] keyCertChain;
         PrivateKey key;
         try {
@@ -756,15 +756,15 @@ public final class SslContextBuilder {
     public SslContext build() throws SSLException {
         if (forServer) {
             return SslContext.newServerContextInternal(provider, sslContextProvider, trustCertCollection,
-                trustManagerFactory, keyCertChain, key, keyPassword, keyManagerFactory,
-                ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout, clientAuth, protocols, startTls,
-                enableOcsp, secureRandom, keyStoreType, toArray(options.entrySet(), EMPTY_ENTRIES),
-                credentials);
+                    trustManagerFactory, keyCertChain, key, keyPassword, keyManagerFactory,
+                    ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout, clientAuth, protocols, startTls,
+                    enableOcsp, secureRandom, keyStoreType, toArray(options.entrySet(), EMPTY_ENTRIES),
+                    credentials);
         } else {
             return SslContext.newClientContextInternal(provider, sslContextProvider, trustCertCollection,
-                trustManagerFactory, keyCertChain, key, keyPassword, keyManagerFactory,
-                ciphers, cipherFilter, apn, protocols, sessionCacheSize,
-                    sessionTimeout, enableOcsp, secureRandom, keyStoreType, endpointIdentificationAlgorithm,
+                    trustManagerFactory, keyCertChain, key, keyPassword, keyManagerFactory,
+                    ciphers, cipherFilter, apn, protocols, sessionCacheSize,
+                    sessionTimeout, startTls, enableOcsp, secureRandom, keyStoreType, endpointIdentificationAlgorithm,
                     serverNames, toArray(options.entrySet(), EMPTY_ENTRIES), credentials);
         }
     }

--- a/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
@@ -420,7 +420,7 @@ public final class SslContextBuilder {
      *     password-protected
      */
     public SslContextBuilder keyManager(InputStream keyCertChainInputStream, InputStream keyInputStream,
-                                        String keyPassword) {
+            String keyPassword) {
         X509Certificate[] keyCertChain;
         PrivateKey key;
         try {
@@ -756,15 +756,15 @@ public final class SslContextBuilder {
     public SslContext build() throws SSLException {
         if (forServer) {
             return SslContext.newServerContextInternal(provider, sslContextProvider, trustCertCollection,
-                    trustManagerFactory, keyCertChain, key, keyPassword, keyManagerFactory,
-                    ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout, clientAuth, protocols, startTls,
-                    enableOcsp, secureRandom, keyStoreType, toArray(options.entrySet(), EMPTY_ENTRIES),
-                    credentials);
+                trustManagerFactory, keyCertChain, key, keyPassword, keyManagerFactory,
+                ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout, clientAuth, protocols, startTls,
+                enableOcsp, secureRandom, keyStoreType, toArray(options.entrySet(), EMPTY_ENTRIES),
+                credentials);
         } else {
             return SslContext.newClientContextInternal(provider, sslContextProvider, trustCertCollection,
-                    trustManagerFactory, keyCertChain, key, keyPassword, keyManagerFactory,
-                    ciphers, cipherFilter, apn, protocols, sessionCacheSize,
-                    sessionTimeout, startTls, enableOcsp, secureRandom, keyStoreType, endpointIdentificationAlgorithm,
+                trustManagerFactory, keyCertChain, key, keyPassword, keyManagerFactory,
+                ciphers, cipherFilter, apn, protocols, sessionCacheSize,
+                sessionTimeout, startTls, enableOcsp, secureRandom, keyStoreType, endpointIdentificationAlgorithm,
                     serverNames, toArray(options.entrySet(), EMPTY_ENTRIES), credentials);
         }
     }


### PR DESCRIPTION

Fix propagation of startTls for client SslContext handlers

Motivation:

`SslContextBuilder.startTls(true)` is not consistently propagated when creating client-side `SslContext` instances. As a result, a handler created via `newHandler(...)`, especially through the executor-based overloads and the `OPENSSL_REFCNT` provider path, may behave as if `startTls` was `false`.

This is inconsistent with the builder configuration and with the existing `SslHandler` STARTTLS semantics.

Modifications:

- Propagate the configured `startTls` flag from `SslContextBuilder` into client context creation.
- Add compatibility-preserving internal overloads for client context constructors instead of replacing the existing signatures.
- Pass `startTls` through `ReferenceCountedOpenSslContext.newHandler(..., Executor)` instead of hard-coding `false`.



Result:

Client-side handlers created from `SslContextBuilder.startTls(true)` now preserve STARTTLS behavior across OpenSSL ref-counted providers, including executor-based handler creation.

If there is no issue then describe the changes introduced by this PR.
