### PR TITLE
Add opt-in validation of mandatory pseudo-header fields for HTTP/2

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2ConnectionHandlerBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2ConnectionHandlerBuilder.java
@@ -99,6 +99,7 @@ public abstract class AbstractHttp2ConnectionHandlerBuilder<T extends Http2Conne
     // * mutually exclusive against codec() and
     // * OK to use with server() and connection()
     private Boolean validateHeaders;
+    private Boolean validateRequiredPseudoHeaders;
     private Http2FrameLogger frameLogger;
     private SensitivityDetector headerSensitivityDetector;
     private Boolean encoderEnforceMaxConcurrentStreams;
@@ -261,6 +262,7 @@ public abstract class AbstractHttp2ConnectionHandlerBuilder<T extends Http2Conne
         enforceConstraint("codec", "connection", connection);
         enforceConstraint("codec", "frameLogger", frameLogger);
         enforceConstraint("codec", "validateHeaders", validateHeaders);
+        enforceConstraint("codec", "validateRequiredPseudoHeaders", validateRequiredPseudoHeaders);
         enforceConstraint("codec", "headerSensitivityDetector", headerSensitivityDetector);
         enforceConstraint("codec", "encoderEnforceMaxConcurrentStreams", encoderEnforceMaxConcurrentStreams);
 
@@ -292,6 +294,25 @@ public abstract class AbstractHttp2ConnectionHandlerBuilder<T extends Http2Conne
     protected B validateHeaders(boolean validateHeaders) {
         enforceNonCodecConstraints("validateHeaders");
         this.validateHeaders = validateHeaders;
+        return self();
+    }
+
+    /**
+     * Returns if mandatory pseudo-header fields are validated according to
+     * <a href="https://www.rfc-editor.org/rfc/rfc9113.html#section-8.3">RFC 9113, 8.3</a>. Disabled by default.
+     */
+    protected boolean isValidateRequiredPseudoHeaders() {
+        return validateRequiredPseudoHeaders != null ? validateRequiredPseudoHeaders : false;
+    }
+
+    /**
+     * Sets if request and response {@code HEADERS} that omit a mandatory pseudo-header field are rejected,
+     * according to <a href="https://www.rfc-editor.org/rfc/rfc9113.html#section-8.3">RFC 9113, 8.3</a>.
+     * Disabled by default.
+     */
+    protected B validateRequiredPseudoHeaders(boolean validateRequiredPseudoHeaders) {
+        enforceNonCodecConstraints("validateRequiredPseudoHeaders");
+        this.validateRequiredPseudoHeaders = validateRequiredPseudoHeaders;
         return self();
     }
 
@@ -643,7 +664,8 @@ public abstract class AbstractHttp2ConnectionHandlerBuilder<T extends Http2Conne
         }
 
         DefaultHttp2ConnectionDecoder decoder = new DefaultHttp2ConnectionDecoder(connection, encoder, reader,
-            promisedRequestVerifier(), isAutoAckSettingsFrame(), isAutoAckPingFrame(), isValidateHeaders());
+            promisedRequestVerifier(), isAutoAckSettingsFrame(), isAutoAckPingFrame(), isValidateHeaders(),
+            isValidateRequiredPseudoHeaders());
         return buildFromCodec(decoder, encoder);
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -17,9 +17,11 @@ package io.netty.handler.codec.http2;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpStatusClass;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http2.Http2Connection.Endpoint;
+import io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -63,6 +65,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
     private final boolean autoAckPing;
     private final Http2Connection.PropertyKey contentLengthKey;
     private final boolean validateHeaders;
+    private final boolean validateRequiredPseudoHeaders;
 
     public DefaultHttp2ConnectionDecoder(Http2Connection connection,
                                          Http2ConnectionEncoder encoder,
@@ -129,7 +132,39 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
                                          boolean autoAckSettings,
                                          boolean autoAckPing,
                                          boolean validateHeaders) {
+        this(connection, encoder, frameReader, requestVerifier, autoAckSettings, autoAckPing, validateHeaders, false);
+    }
+
+    /**
+     * Create a new instance.
+     * @param connection The {@link Http2Connection} associated with this decoder.
+     * @param encoder The {@link Http2ConnectionEncoder} associated with this decoder.
+     * @param frameReader Responsible for reading/parsing the raw frames. As opposed to this object which applies
+     *                    h2 semantics on top of the frames.
+     * @param requestVerifier Determines if push promised streams are valid.
+     * @param autoAckSettings {@code false} to disable automatically applying and sending settings acknowledge frame.
+     *                        The {@code Http2ConnectionEncoder} is expected to be an instance of
+     *                        {@link Http2SettingsReceivedConsumer} and will apply the earliest received but not yet
+     *                        ACKed SETTINGS when writing the SETTINGS ACKs. {@code true} to enable automatically
+     *                        applying and sending settings acknowledge frame.
+     * @param autoAckPing {@code false} to disable automatically sending ping acknowledge frame. {@code true} to enable
+     *                    automatically sending ping ack frame.
+     * @param validateHeaders {@code true} to validate headers according to
+     *                        <a href="https://tools.ietf.org/html/rfc7540#section-8.1.2.6">RFC 7540, 8.1.2.6</a>.
+     * @param validateRequiredPseudoHeaders {@code true} to reject request/response HEADERS that omit a mandatory
+     *        pseudo-header field, according to
+     *        <a href="https://www.rfc-editor.org/rfc/rfc9113.html#section-8.3">RFC 9113, 8.3</a>.
+     */
+    public DefaultHttp2ConnectionDecoder(Http2Connection connection,
+                                         Http2ConnectionEncoder encoder,
+                                         Http2FrameReader frameReader,
+                                         Http2PromisedRequestVerifier requestVerifier,
+                                         boolean autoAckSettings,
+                                         boolean autoAckPing,
+                                         boolean validateHeaders,
+                                         boolean validateRequiredPseudoHeaders) {
         this.validateHeaders = validateHeaders;
+        this.validateRequiredPseudoHeaders = validateRequiredPseudoHeaders;
         this.autoAckPing = autoAckPing;
         if (autoAckSettings) {
             settingsReceivedConsumer = null;
@@ -240,6 +275,48 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
                 if (isEnd) {
                     stream.removeProperty(contentLengthKey);
                 }
+            }
+        }
+    }
+
+    /**
+     * Validates that an initial request or response HEADERS frame carries the mandatory pseudo-header fields,
+     * as required by <a href="https://www.rfc-editor.org/rfc/rfc9113.html#section-8.3">RFC 9113, 8.3</a>.
+     * Trailers and informational (1xx) responses are handled by the caller and do not reach this method.
+     */
+    private static void validateRequiredPseudoHeaders(boolean server, int streamId, Http2Headers headers)
+            throws Http2Exception {
+        if (server) {
+            // Request pseudo-header fields (RFC 9113, 8.3.1).
+            CharSequence method = headers.method();
+            if (method == null) {
+                throw streamError(streamId, PROTOCOL_ERROR,
+                        "Request is missing mandatory :method pseudo-header field.");
+            }
+            // CONNECT (RFC 9113, 8.5) omits :scheme/:path and carries :authority; extended CONNECT (RFC 8441),
+            // identified by :protocol, follows the regular :scheme/:path rules.
+            if (HttpMethod.CONNECT.asciiName().contentEquals(method) &&
+                    !headers.contains(PseudoHeaderName.PROTOCOL.value())) {
+                if (headers.authority() == null) {
+                    throw streamError(streamId, PROTOCOL_ERROR,
+                            "CONNECT request is missing mandatory :authority pseudo-header field.");
+                }
+            } else {
+                if (headers.scheme() == null) {
+                    throw streamError(streamId, PROTOCOL_ERROR,
+                            "Request is missing mandatory :scheme pseudo-header field.");
+                }
+                CharSequence path = headers.path();
+                if (path == null || path.length() == 0) {
+                    throw streamError(streamId, PROTOCOL_ERROR,
+                            "Request is missing mandatory :path pseudo-header field.");
+                }
+            }
+        } else {
+            // Response pseudo-header fields (RFC 9113, 8.3.2).
+            if (headers.status() == null) {
+                throw streamError(streamId, PROTOCOL_ERROR,
+                        "Response is missing mandatory :status pseudo-header field.");
             }
         }
     }
@@ -388,6 +465,10 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
             }
 
             if (!isTrailers) {
+                if (validateRequiredPseudoHeaders && !isInformational) {
+                    // Reject initial request/response HEADERS that omit a mandatory pseudo-header (RFC 9113, 8.3).
+                    validateRequiredPseudoHeaders(connection.isServer(), stream.id(), headers);
+                }
                 // extract the content-length header
                 List<? extends CharSequence> contentLength = headers.getAll(HttpHeaderNames.CONTENT_LENGTH);
                 if (contentLength != null && !contentLength.isEmpty()) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandlerBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandlerBuilder.java
@@ -32,6 +32,11 @@ public final class Http2ConnectionHandlerBuilder
     }
 
     @Override
+    public Http2ConnectionHandlerBuilder validateRequiredPseudoHeaders(boolean validateRequiredPseudoHeaders) {
+        return super.validateRequiredPseudoHeaders(validateRequiredPseudoHeaders);
+    }
+
+    @Override
     public Http2ConnectionHandlerBuilder initialSettings(Http2Settings settings) {
         return super.initialSettings(settings);
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodecBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodecBuilder.java
@@ -110,6 +110,11 @@ public class Http2FrameCodecBuilder extends
     }
 
     @Override
+    public Http2FrameCodecBuilder validateRequiredPseudoHeaders(boolean validateRequiredPseudoHeaders) {
+        return super.validateRequiredPseudoHeaders(validateRequiredPseudoHeaders);
+    }
+
+    @Override
     public Http2FrameLogger frameLogger() {
         return super.frameLogger();
     }
@@ -239,7 +244,8 @@ public class Http2FrameCodecBuilder extends
                 encoder = new StreamBufferingEncoder(encoder);
             }
             Http2ConnectionDecoder decoder = new DefaultHttp2ConnectionDecoder(connection, encoder, frameReader,
-                    promisedRequestVerifier(), isAutoAckSettingsFrame(), isAutoAckPingFrame(), isValidateHeaders());
+                    promisedRequestVerifier(), isAutoAckSettingsFrame(), isAutoAckPingFrame(), isValidateHeaders(),
+                    isValidateRequiredPseudoHeaders());
             int maxConsecutiveEmptyDataFrames = decoderEnforceMaxConsecutiveEmptyDataFrames();
             if (maxConsecutiveEmptyDataFrames > 0) {
                 decoder = new Http2EmptyDataFrameConnectionDecoder(decoder, maxConsecutiveEmptyDataFrames);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodecBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodecBuilder.java
@@ -128,6 +128,11 @@ public class Http2MultiplexCodecBuilder
     }
 
     @Override
+    public Http2MultiplexCodecBuilder validateRequiredPseudoHeaders(boolean validateRequiredPseudoHeaders) {
+        return super.validateRequiredPseudoHeaders(validateRequiredPseudoHeaders);
+    }
+
+    @Override
     public Http2FrameLogger frameLogger() {
         return super.frameLogger();
     }
@@ -254,7 +259,8 @@ public class Http2MultiplexCodecBuilder
                 encoder = new StreamBufferingEncoder(encoder);
             }
             Http2ConnectionDecoder decoder = new DefaultHttp2ConnectionDecoder(connection, encoder, frameReader,
-                    promisedRequestVerifier(), isAutoAckSettingsFrame(), isAutoAckPingFrame(), isValidateHeaders());
+                    promisedRequestVerifier(), isAutoAckSettingsFrame(), isAutoAckPingFrame(), isValidateHeaders(),
+                    isValidateRequiredPseudoHeaders());
             int maxConsecutiveEmptyDataFrames = decoderEnforceMaxConsecutiveEmptyDataFrames();
             if (maxConsecutiveEmptyDataFrames > 0) {
                 decoder = new Http2EmptyDataFrameConnectionDecoder(decoder, maxConsecutiveEmptyDataFrames);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerBuilder.java
@@ -33,6 +33,11 @@ public final class HttpToHttp2ConnectionHandlerBuilder extends
     }
 
     @Override
+    public HttpToHttp2ConnectionHandlerBuilder validateRequiredPseudoHeaders(boolean validateRequiredPseudoHeaders) {
+        return super.validateRequiredPseudoHeaders(validateRequiredPseudoHeaders);
+    }
+
+    @Override
     public HttpToHttp2ConnectionHandlerBuilder initialSettings(Http2Settings settings) {
         return super.initialSettings(settings);
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
@@ -601,6 +601,141 @@ public class DefaultHttp2ConnectionDecoderTest {
         assertThat(ex.getMessage()).contains(pseudoHeader);
     }
 
+    // Builds a decoder with validateRequiredPseudoHeaders enabled, primed past the preface.
+    private Http2FrameListener strictDecode() throws Exception {
+        DefaultHttp2ConnectionDecoder strict = new DefaultHttp2ConnectionDecoder(
+                connection, encoder, reader, ALWAYS_VERIFY, true, true, true, true);
+        strict.lifecycleManager(lifecycleManager);
+        strict.frameListener(listener);
+        decode(strict).onSettingsRead(ctx, new Http2Settings());
+        return decode(strict);
+    }
+
+    private static Http2Headers request() {
+        return new DefaultHttp2Headers().method("GET").scheme("https").authority("example.org").path("/");
+    }
+
+    private Http2Exception assertHeadersRejected(final Http2FrameListener dec, final Http2Headers headers,
+            final boolean endOfStream) throws Http2Exception {
+        Http2Exception ex = assertThrows(Http2Exception.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                dec.onHeadersRead(ctx, STREAM_ID, headers, 0, endOfStream);
+            }
+        });
+        assertEquals(PROTOCOL_ERROR, ex.error());
+        verify(listener, never()).onHeadersRead(eq(ctx), eq(STREAM_ID), eq(headers), eq(0),
+                eq(DEFAULT_PRIORITY_WEIGHT), eq(false), eq(0), eq(endOfStream));
+        return ex;
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {":method", ":scheme", ":path"})
+    public void requestMissingMandatoryPseudoHeaderRejectedWhenEnabled(String missing) throws Exception {
+        when(connection.isServer()).thenReturn(true);
+        Http2Headers headers = request();
+        headers.remove(missing);
+        assertThat(assertHeadersRejected(strictDecode(), headers, true).getMessage()).contains(missing);
+    }
+
+    @Test
+    public void requestEmptyPathRejectedWhenEnabled() throws Exception {
+        when(connection.isServer()).thenReturn(true);
+        // Disable header-level validation so the empty :path reaches the decoder's own check.
+        Http2Headers headers = new DefaultHttp2Headers(false)
+                .method("GET").scheme("https").authority("example.org").path("");
+        assertThat(assertHeadersRejected(strictDecode(), headers, true).getMessage()).contains(":path");
+    }
+
+    @Test
+    public void emptyRequestRejectedWhenEnabled() throws Exception {
+        when(connection.isServer()).thenReturn(true);
+        assertHeadersRejected(strictDecode(), EmptyHttp2Headers.INSTANCE, true);
+    }
+
+    @Test
+    public void validRequestAcceptedWhenEnabled() throws Exception {
+        when(connection.isServer()).thenReturn(true);
+        Http2Headers headers = request();
+        strictDecode().onHeadersRead(ctx, STREAM_ID, headers, 0, true);
+        verify(listener).onHeadersRead(eq(ctx), eq(STREAM_ID), eq(headers), eq(0),
+                eq(DEFAULT_PRIORITY_WEIGHT), eq(false), eq(0), eq(true));
+    }
+
+    @Test
+    public void connectRequestWithoutSchemeAndPathAcceptedWhenEnabled() throws Exception {
+        when(connection.isServer()).thenReturn(true);
+        // A CONNECT request (RFC 9113, 8.5) omits :scheme and :path and only carries :authority.
+        Http2Headers headers = new DefaultHttp2Headers().method("CONNECT").authority("example.org:443");
+        strictDecode().onHeadersRead(ctx, STREAM_ID, headers, 0, false);
+        verify(listener).onHeadersRead(eq(ctx), eq(STREAM_ID), eq(headers), eq(0),
+                eq(DEFAULT_PRIORITY_WEIGHT), eq(false), eq(0), eq(false));
+    }
+
+    @Test
+    public void connectRequestMissingAuthorityRejectedWhenEnabled() throws Exception {
+        when(connection.isServer()).thenReturn(true);
+        Http2Headers headers = new DefaultHttp2Headers().method("CONNECT");
+        assertThat(assertHeadersRejected(strictDecode(), headers, false).getMessage()).contains(":authority");
+    }
+
+    @Test
+    public void extendedConnectRequiresSchemeAndPathWhenEnabled() throws Exception {
+        when(connection.isServer()).thenReturn(true);
+        // Extended CONNECT (RFC 8441) is identified by :protocol and must include :scheme and :path.
+        Http2Headers headers = new DefaultHttp2Headers().method("CONNECT").authority("example.org");
+        headers.add(Http2Headers.PseudoHeaderName.PROTOCOL.value(), "websocket");
+        assertThat(assertHeadersRejected(strictDecode(), headers, false).getMessage()).contains(":scheme");
+    }
+
+    @Test
+    public void extendedConnectAcceptedWhenEnabled() throws Exception {
+        when(connection.isServer()).thenReturn(true);
+        Http2Headers headers = new DefaultHttp2Headers().method("CONNECT").scheme("https")
+                .authority("example.org").path("/chat");
+        headers.add(Http2Headers.PseudoHeaderName.PROTOCOL.value(), "websocket");
+        strictDecode().onHeadersRead(ctx, STREAM_ID, headers, 0, false);
+        verify(listener).onHeadersRead(eq(ctx), eq(STREAM_ID), eq(headers), eq(0),
+                eq(DEFAULT_PRIORITY_WEIGHT), eq(false), eq(0), eq(false));
+    }
+
+    @Test
+    public void responseMissingStatusRejectedWhenEnabled() throws Exception {
+        // isServer() defaults to false, so inbound HEADERS are treated as a response.
+        assertThat(assertHeadersRejected(strictDecode(), EmptyHttp2Headers.INSTANCE, true).getMessage())
+                .contains(":status");
+    }
+
+    @Test
+    public void validResponseAcceptedWhenEnabled() throws Exception {
+        Http2Headers headers = new DefaultHttp2Headers().status("200");
+        strictDecode().onHeadersRead(ctx, STREAM_ID, headers, 0, true);
+        verify(listener).onHeadersRead(eq(ctx), eq(STREAM_ID), eq(headers), eq(0),
+                eq(DEFAULT_PRIORITY_WEIGHT), eq(false), eq(0), eq(true));
+    }
+
+    @Test
+    public void trailersNotRequiredToCarryPseudoHeadersWhenEnabled() throws Exception {
+        when(connection.isServer()).thenReturn(true);
+        Http2FrameListener dec = strictDecode();
+        // Valid initial request headers.
+        dec.onHeadersRead(ctx, STREAM_ID, request(), 0, false);
+        // Trailers carry no pseudo-headers and must still be accepted (check applies to initial HEADERS only).
+        Http2Headers trailers = new DefaultHttp2Headers().add("x-trailer", "value");
+        dec.onHeadersRead(ctx, STREAM_ID, trailers, 0, true);
+        verify(listener).onHeadersRead(eq(ctx), eq(STREAM_ID), eq(trailers), eq(0),
+                eq(DEFAULT_PRIORITY_WEIGHT), eq(false), eq(0), eq(true));
+    }
+
+    @Test
+    public void defaultDecoderDoesNotValidateMandatoryPseudoHeaders() throws Exception {
+        when(connection.isServer()).thenReturn(true);
+        // The default decoder has validateRequiredPseudoHeaders disabled, so an empty request is accepted.
+        decode().onHeadersRead(ctx, STREAM_ID, EmptyHttp2Headers.INSTANCE, 0, true);
+        verify(listener).onHeadersRead(eq(ctx), eq(STREAM_ID), eq(EmptyHttp2Headers.INSTANCE), eq(0),
+                eq(DEFAULT_PRIORITY_WEIGHT), eq(false), eq(0), eq(true));
+    }
+
     @Test
     public void tooManyHeadersEOSThrows() throws Exception {
         tooManyHeaderThrows(true);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
@@ -336,6 +336,7 @@ public class Http2FrameCodecTest {
         Object msg;
         while ((msg = inboundHandler.readInboundMessageOrUserEvent()) != null) {
             assertFalse(msg instanceof Http2HeadersFrame);
+            ReferenceCountUtil.release(msg);
         }
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
@@ -317,6 +317,29 @@ public class Http2FrameCodecTest {
     }
 
     @Test
+    public void validateRequiredPseudoHeadersOptionRejectsMalformedRequest() throws Exception {
+        // Verify the builder option is propagated into the decoder end-to-end.
+        setUp(Http2FrameCodecBuilder.forServer().validateRequiredPseudoHeaders(true), new Http2Settings());
+
+        Http2Headers malformed = new DefaultHttp2Headers().method(HttpMethod.GET.asciiName());
+        frameInboundWriter.writeInboundHeaders(3, malformed, 31, false);
+
+        // The malformed request (no :scheme/:path) must be rejected with a PROTOCOL_ERROR stream error.
+        Http2FrameStreamException e = assertThrows(Http2FrameStreamException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                inboundHandler.checkException();
+            }
+        });
+        assertEquals(Http2Error.PROTOCOL_ERROR, e.error());
+        // It must not be delivered as a HEADERS frame.
+        Object msg;
+        while ((msg = inboundHandler.readInboundMessageOrUserEvent()) != null) {
+            assertFalse(msg instanceof Http2HeadersFrame);
+        }
+    }
+
+    @Test
     public void receiveRstStream() throws Exception {
         frameInboundWriter.writeInboundHeaders(3, request, 31, false);
 


### PR DESCRIPTION
Motivation:

RFC 9113 Section 8.3 requires HTTP/2 requests to include `:method`, `:scheme` and `:path`, and responses to include `:status`. Netty's message API (HttpConversionUtil) already rejects a missing :method, :path or :status, but the raw frame API
(Http2FrameCodec / Http2MultiplexHandler) does not validate this and accepts requests and responses with missing required pseudo-headers.

This is reported in #10633 and #13630.

Modification:

Add an optional `validateRequiredPseudoHeaders` setting (disabled by default) to `DefaultHttp2ConnectionDecoder` and the HTTP/2 builders. When enabled, initial request and response HEADERS that omit a required pseudo-header are rejected with
a `PROTOCOL_ERROR` stream error. `CONNECT` and extended `CONNECT` requests are handled according to RFC 9113 Section 8.5 and RFC 8441.

Result:

The raw frame API can now opt into RFC 9113 Section 8.3 required-pseudo-header
validation, while preserving existing behavior by default.