### PR TITLE
Try to fix/stabilize a number of flaky tests

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
@@ -2767,45 +2767,42 @@ public abstract class AbstractByteBufTest {
         final AtomicReference<Throwable> innerThrowable = new AtomicReference<>();
         final CyclicBarrier barrier = new CyclicBarrier(11);
         for (int i = 0; i < 10; i++) {
-            new Thread(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        while (latch.getCount() > 0) {
-                            ByteBuf buf;
-                            if (slice) {
-                               buf = buffer.slice();
-                            } else {
-                               buf = buffer.duplicate();
-                            }
-                            TestGatheringByteChannel channel = new TestGatheringByteChannel();
+            new Thread(() -> {
+                try {
+                    while (latch.getCount() > 0) {
+                        ByteBuf buf;
+                        if (slice) {
+                           buf = buffer.slice();
+                        } else {
+                           buf = buffer.duplicate();
+                        }
+                        TestGatheringByteChannel channel = new TestGatheringByteChannel();
 
-                            while (buf.isReadable()) {
-                                try {
-                                    buf.readBytes(channel, buf.readableBytes());
-                                } catch (IOException e) {
-                                    // Never happens
-                                    return;
-                                }
+                        while (buf.isReadable()) {
+                            try {
+                                buf.readBytes(channel, buf.readableBytes());
+                            } catch (IOException e) {
+                                // Never happens
+                                return;
                             }
-                            assertArrayEquals(expectedBytes, channel.writtenBytes());
-                            latch.countDown();
                         }
-                    } catch (Throwable e) {
-                        innerThrowable.compareAndSet(null, e);
-                    } finally {
-                        try {
-                            barrier.await();
-                        } catch (Exception e) {
-                            // ignore
-                        }
+                        assertArrayEquals(expectedBytes, channel.writtenBytes());
+                        latch.countDown();
+                    }
+                } catch (Throwable e) {
+                    innerThrowable.compareAndSet(null, e);
+                } finally {
+                    try {
+                        barrier.await();
+                    } catch (Exception e) {
+                        // ignore
                     }
                 }
             }).start();
         }
         try {
             latch.await();
-            barrier.await(5, TimeUnit.SECONDS);
+            barrier.await(30, TimeUnit.SECONDS);
         } catch (Exception e) {
             Throwable inner = innerThrowable.get();
             if (inner != null) {
@@ -2851,45 +2848,42 @@ public abstract class AbstractByteBufTest {
         final AtomicReference<Throwable> innerThrowable = new AtomicReference<>();
         final CyclicBarrier barrier = new CyclicBarrier(11);
         for (int i = 0; i < 10; i++) {
-            new Thread(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        while (latch.getCount() > 0) {
-                            ByteBuf buf;
-                            if (slice) {
-                                buf = buffer.slice();
-                            } else {
-                                buf = buffer.duplicate();
-                            }
-                            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            new Thread(() -> {
+                try {
+                    while (latch.getCount() > 0) {
+                        ByteBuf buf;
+                        if (slice) {
+                            buf = buffer.slice();
+                        } else {
+                            buf = buffer.duplicate();
+                        }
+                        ByteArrayOutputStream out = new ByteArrayOutputStream();
 
-                            while (buf.isReadable()) {
-                                try {
-                                    buf.readBytes(out, buf.readableBytes());
-                                } catch (IOException e) {
-                                    // Never happens
-                                    return;
-                                }
+                        while (buf.isReadable()) {
+                            try {
+                                buf.readBytes(out, buf.readableBytes());
+                            } catch (IOException e) {
+                                // Never happens
+                                return;
                             }
-                            assertArrayEquals(expectedBytes, out.toByteArray());
-                            latch.countDown();
                         }
-                    } catch (Throwable e) {
-                        innerThrowable.compareAndSet(null, e);
-                    } finally {
-                        try {
-                            barrier.await();
-                        } catch (Exception e) {
-                            // ignore
-                        }
+                        assertArrayEquals(expectedBytes, out.toByteArray());
+                        latch.countDown();
+                    }
+                } catch (Throwable e) {
+                    innerThrowable.compareAndSet(null, e);
+                } finally {
+                    try {
+                        barrier.await();
+                    } catch (Exception e) {
+                        // ignore
                     }
                 }
             }).start();
         }
         try {
             latch.await();
-            barrier.await(5, TimeUnit.SECONDS);
+            barrier.await(30, TimeUnit.SECONDS);
         } catch (Exception e) {
             Throwable inner = innerThrowable.get();
             if (inner != null) {
@@ -2931,33 +2925,30 @@ public abstract class AbstractByteBufTest {
             final ByteBuf buffer, final byte[] expectedBytes, final boolean slice) throws Exception {
         final CyclicBarrier startBarrier = new CyclicBarrier(10);
         final CyclicBarrier endBarrier = new CyclicBarrier(11);
-        Callable<Void> callable = new Callable<Void>() {
-            @Override
-            public Void call() throws Exception {
-                startBarrier.await();
-                try {
-                    for (int i = 0; i < 6000; i++) {
-                        ByteBuf buf;
-                        if (slice) {
-                            buf = buffer.slice();
-                        } else {
-                            buf = buffer.duplicate();
-                        }
-
-                        byte[] array = new byte[8];
-                        buf.readBytes(array);
-
-                        assertArrayEquals(expectedBytes, array);
-
-                        Arrays.fill(array, (byte) 0);
-                        buf.getBytes(0, array);
-                        assertArrayEquals(expectedBytes, array);
+        Callable<Void> callable = () -> {
+            startBarrier.await();
+            try {
+                for (int i = 0; i < 6000; i++) {
+                    ByteBuf buf;
+                    if (slice) {
+                        buf = buffer.slice();
+                    } else {
+                        buf = buffer.duplicate();
                     }
-                } finally {
-                    endBarrier.await();
+
+                    byte[] array = new byte[8];
+                    buf.readBytes(array);
+
+                    assertArrayEquals(expectedBytes, array);
+
+                    Arrays.fill(array, (byte) 0);
+                    buf.getBytes(0, array);
+                    assertArrayEquals(expectedBytes, array);
                 }
-                return null;
+            } finally {
+                endBarrier.await();
             }
+            return null;
         };
         List<FutureTask<Void>> tasks = new ArrayList<>();
         for (int i = 0; i < 10; i++) {

--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
 import java.util.SplittableRandom;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.FutureTask;
@@ -417,7 +418,7 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
     }
 
     @Test
-    @Timeout(10)
+    @Timeout(30)
     public void testNumThreadCachesWithNoDirectArenas() throws Exception {
         int numHeapArenas = 1;
         final PooledByteBufAllocator allocator =
@@ -437,7 +438,7 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
     }
 
     @Test
-    @Timeout(10)
+    @Timeout(30)
     public void testNumThreadCachesAccountForDirectAndHeapArenas() throws Exception {
         int numArenas = 1;
         final PooledByteBufAllocator allocator =
@@ -457,7 +458,7 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
     }
 
     @Test
-    @Timeout(10)
+    @Timeout(30)
     public void testThreadCacheToArenaMappings() throws Exception {
         int numArenas = 2;
         final PooledByteBufAllocator allocator =
@@ -547,6 +548,13 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
                     task.get();
                     t.join();
                 } catch (InterruptedException e) {
+                    if (task.isDone()) {
+                        try {
+                            task.get();
+                        } catch (Exception taskException) {
+                            e.addSuppressed(new CompletionException("Task failed", taskException));
+                        }
+                    }
                     ThrowableUtil.interruptAndAttachAsyncStackTrace(t, e);
                     throw e;
                 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateDecoderTest.java
@@ -331,7 +331,7 @@ public class PerMessageDeflateDecoderTest {
         EmbeddedChannel decoderChannel = new EmbeddedChannel(new PerMessageDeflateDecoder(false, 0));
 
         TextWebSocketFrame emptyDeflateBlockFrame = new TextWebSocketFrame(true, WebSocketExtension.RSV1,
-                                                                           EMPTY_DEFLATE_BLOCK);
+                                                                           EMPTY_DEFLATE_BLOCK.duplicate());
 
         assertTrue(decoderChannel.writeInbound(emptyDeflateBlockFrame));
         TextWebSocketFrame emptyBufferFrame = decoderChannel.readInbound();

--- a/common/src/main/java/io/netty/util/Recycler.java
+++ b/common/src/main/java/io/netty/util/Recycler.java
@@ -435,6 +435,10 @@ public abstract class Recycler<T> {
     }
 
     private static final class GuardedLocalPool<T> extends LocalPool<DefaultHandle<T>, T> {
+        static {
+            // Eagerly initiate DefaultHandle class-loading.
+            int ignore = DefaultHandle.STATE_AVAILABLE;
+        }
 
         GuardedLocalPool(int maxCapacity) {
             super(maxCapacity);

--- a/common/src/main/java/io/netty/util/internal/ThrowableUtil.java
+++ b/common/src/main/java/io/netty/util/internal/ThrowableUtil.java
@@ -88,9 +88,10 @@ public final class ThrowableUtil {
      * @param cause The cause to attach a stack trace to.
      */
     public static void interruptAndAttachAsyncStackTrace(Thread thread, Throwable cause) {
+        Thread.State state = thread.getState();
         StackTraceElement[] stackTrace = thread.getStackTrace();
         InterruptedException asyncIE = new InterruptedException(
-                "Asynchronous interruption: " + thread);
+                "Asynchronous interruption: " + thread + " (" + state + ')');
         thread.interrupt();
         asyncIE.setStackTrace(stackTrace);
         addSuppressed(cause, asyncIE);

--- a/transport/src/test/java/io/netty/channel/nio/NioEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/nio/NioEventLoopTest.java
@@ -45,7 +45,9 @@ import java.nio.channels.spi.SelectorProvider;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -202,36 +204,36 @@ public class NioEventLoopTest extends AbstractEventLoopTest {
     @SuppressWarnings("deprecation")
     @Test
     public void testTaskRemovalOnShutdownThrowsNoUnsupportedOperationException() throws Exception {
-        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
-        final Runnable task = new Runnable() {
-            @Override
-            public void run() {
-                // NOOP
-            }
+        final AtomicReference<Throwable> error = new AtomicReference<>();
+        final AtomicBoolean loopStarted = new AtomicBoolean();
+        final Runnable task = () -> {
+            // NOOP
         };
         // Just run often enough to trigger it normally.
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < 250; i++) {
             EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
             final EventLoop loop = group.next();
 
-            Thread t = new Thread(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        for (;;) {
-                            loop.execute(task);
-                        }
-                    } catch (Throwable cause) {
-                        error.set(cause);
+            Thread t = new Thread(() -> {
+                try {
+                    for (;;) {
+                        loop.execute(task);
+                        loopStarted.set(true);
                     }
+                } catch (Throwable cause) {
+                    error.set(cause);
                 }
             });
             t.start();
+            do {
+                Thread.yield();
+            } while (!loopStarted.get());
             group.shutdownNow();
             t.join();
             group.terminationFuture().syncUninterruptibly();
             assertInstanceOf(RejectedExecutionException.class, error.get());
             error.set(null);
+            loopStarted.set(false);
         }
     }
 


### PR DESCRIPTION
Motivation:
These tests have been randomly failing recently.

Modification:
- Try to avoid `OutOfMemoryError` in `testTaskRemovalOnShutdownThrowsNoUnsupportedOperationException`
- Increase timeouts and add more diagnostics to `AbstractByteBufTests`
- Make `Recycler` eagerly class-load `DefaultHandle` to avoid it in the performance critical `getWith` method
- Capture more diagnostics for `PooledByteBufAllocatorTest`
- Fix `PerMessageDeflateDecoderTest`

Result:
More stable build