### PR TITLE
IoUring: fix TCP Fast Open initial writes with readerIndex and composites (#16929)

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketConnectTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketConnectTest.java
@@ -18,6 +18,7 @@ package io.netty.testsuite.transport.socket;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandler;
@@ -36,9 +37,11 @@ import java.io.ByteArrayOutputStream;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 import static io.netty.buffer.ByteBufUtil.writeAscii;
 import static io.netty.buffer.UnpooledByteBufAllocator.DEFAULT;
@@ -196,7 +199,42 @@ public class SocketConnectTest extends AbstractSocketTest {
         });
     }
 
+    @Test
+    @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
+    public void testWriteWithFastOpenBeforeConnectDirectBufferReaderIndex(TestInfo testInfo) throws Throwable {
+        run(testInfo, (serverBootstrap, bootstrap) ->
+                testWriteWithFastOpenBeforeConnect(serverBootstrap, bootstrap,
+                        channel -> directBufferWithReaderIndex(
+                                channel, "BAD-PREFIX-", "[fastopen-reader-index]"),
+                        "[fastopen-reader-index]"));
+    }
+
+    @Test
+    @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
+    public void testWriteWithFastOpenBeforeConnectCompositeBuffer(TestInfo testInfo) throws Throwable {
+        run(testInfo, (serverBootstrap, bootstrap) ->
+                testWriteWithFastOpenBeforeConnect(serverBootstrap, bootstrap,
+                        channel -> compositeBuffer(channel, "[fastopen-", "composite-", "data]"),
+                        "[fastopen-composite-data]"));
+    }
+
+    @Test
+    @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
+    public void testWriteWithFastOpenBeforeConnectCompositeBufferReaderIndex(TestInfo testInfo) throws Throwable {
+        run(testInfo, (serverBootstrap, bootstrap) ->
+                testWriteWithFastOpenBeforeConnect(serverBootstrap, bootstrap,
+                        channel -> compositeBufferWithReaderIndex(
+                                channel, "BAD-PREFIX-", "[fastopen-", "composite-reader-", "index]"),
+                        "[fastopen-composite-reader-index]"));
+    }
+
     public void testWriteWithFastOpenBeforeConnect(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+        testWriteWithFastOpenBeforeConnect(sb, cb, channel -> writeAscii(DEFAULT, "[fastopen]"), "[fastopen]");
+    }
+
+    protected void testWriteWithFastOpenBeforeConnect(ServerBootstrap sb, Bootstrap cb,
+                                                      Function<Channel, ByteBuf> initialDataFactory,
+                                                      String expectedInitialData) throws Throwable {
         enableTcpFastOpen(sb, cb);
         sb.childOption(ChannelOption.AUTO_READ, true);
         cb.option(ChannelOption.AUTO_READ, true);
@@ -209,25 +247,58 @@ public class SocketConnectTest extends AbstractSocketTest {
         });
 
         Channel sc = sb.bind().get();
-        connectAndVerifyDataTransfer(cb, sc);
-        connectAndVerifyDataTransfer(cb, sc);
+        connectAndVerifyDataTransfer(cb, sc, initialDataFactory, expectedInitialData);
+        connectAndVerifyDataTransfer(cb, sc, initialDataFactory, expectedInitialData);
     }
 
-    private static void connectAndVerifyDataTransfer(Bootstrap cb, Channel sc)
-            throws Exception {
+    private static void connectAndVerifyDataTransfer(Bootstrap cb, Channel sc,
+                                                     Function<Channel, ByteBuf> initialDataFactory,
+                                                     String expectedInitialData)
+            throws InterruptedException, ExecutionException {
         BufferingClientHandler handler = new BufferingClientHandler();
         cb.handler(handler);
         Future<Channel> register = cb.register();
         Channel channel = register.get();
-        Future<Void> write = channel.write(writeAscii(DEFAULT, "[fastopen]"));
+        Future<Void> write = channel.write(initialDataFactory.apply(channel));
         SocketAddress remoteAddress = sc.localAddress();
         channel.connect(remoteAddress).sync();
         channel.writeAndFlush(writeAscii(DEFAULT, "[normal data]")).sync();
         write.sync();
-        String expectedString = "[fastopen][normal data]";
+        String expectedString = expectedInitialData + "[normal data]";
         String result = handler.collectBuffer(expectedString.getBytes(US_ASCII).length);
         channel.disconnect().sync();
         assertEquals(expectedString, result);
+    }
+
+    private static ByteBuf directBufferWithReaderIndex(Channel channel, String prefix, String data) {
+        ByteBuf buffer = directBuffer(channel, prefix + data);
+        buffer.readerIndex(prefix.getBytes(US_ASCII).length);
+        return buffer;
+    }
+
+    private static ByteBuf compositeBufferWithReaderIndex(Channel channel, String prefix, String... parts) {
+        CompositeByteBuf buffer = channel.alloc().compositeDirectBuffer(parts.length + 1);
+        buffer.addComponent(true, directBuffer(channel, prefix));
+        for (String part : parts) {
+            buffer.addComponent(true, directBuffer(channel, part));
+        }
+        buffer.readerIndex(prefix.getBytes(US_ASCII).length);
+        return buffer;
+    }
+
+    private static ByteBuf compositeBuffer(Channel channel, String... parts) {
+        CompositeByteBuf buffer = channel.alloc().compositeDirectBuffer(parts.length);
+        for (String part : parts) {
+            buffer.addComponent(true, directBuffer(channel, part));
+        }
+        return buffer;
+    }
+
+    private static ByteBuf directBuffer(Channel channel, String data) {
+        byte[] bytes = data.getBytes(US_ASCII);
+        ByteBuf buffer = channel.alloc().directBuffer(bytes.length);
+        buffer.writeBytes(bytes);
+        return buffer;
     }
 
     protected void enableTcpFastOpen(ServerBootstrap sb, Bootstrap cb) {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -37,6 +37,7 @@ import io.netty.channel.unix.Buffer;
 import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.channel.unix.Errors;
 import io.netty.channel.unix.FileDescriptor;
+import io.netty.channel.unix.IovArray;
 import io.netty.channel.unix.UnixChannel;
 import io.netty.channel.unix.UnixChannelUtil;
 import io.netty.util.ReferenceCountUtil;
@@ -1041,8 +1042,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
                 if (initialData != null) {
                     msgHdrMemoryArray = new MsgHdrMemoryArray((short) 1);
                     MsgHdrMemory hdr = msgHdrMemoryArray.hdr(0);
-                    hdr.set(socket, inetSocketAddress, IoUring.memoryAddress(initialData),
-                            initialData.readableBytes(), (short) 0);
+                    fillTFOInitData(hdr, inetSocketAddress, initialData);
 
                     int fd = fd().intValue();
                     IoRegistration registration = registration();
@@ -1072,6 +1072,25 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         }
         connectPromise = promise;
         requestedRemoteAddress = remoteAddress;
+    }
+
+    private void fillTFOInitData(MsgHdrMemory hdr, InetSocketAddress inetSocketAddress,
+                                 ByteBuf initialData) throws Exception {
+        if (initialData.hasMemoryAddress()) {
+            hdr.set(socket, inetSocketAddress,
+                    initialData.memoryAddress() + initialData.readerIndex(),
+                    initialData.readableBytes(), (short) 0);
+        } else {
+            // Use an iovec array for CompositeByteBuf and other buffers without a memory address.
+            // If the shared IovArray has not enough space, the rest is sent after connect.
+            IoUringIoHandler handler = registration().attachment();
+            IovArray iovArray = handler.iovArray();
+            int iovOffset = iovArray.count();
+            iovArray.processMessage(initialData);
+            long iovArrayAddress = iovArray.memoryAddress(iovOffset);
+            int iovArrayLength = iovArray.count() - iovOffset;
+            hdr.setWithIovArrayAddress(socket, inetSocketAddress, iovArrayAddress, iovArrayLength, (short) 0);
+        }
     }
 
     private void submitConnect(InetSocketAddress inetSocketAddress) {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdr.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdr.java
@@ -55,7 +55,7 @@ final class MsgHdr {
         }
     }
 
-    static void set(ByteBuffer memory, ByteBuffer sockAddrMemory, int addressSize, ByteBuffer iovMemory, int iovLength,
+    static void set(ByteBuffer memory, ByteBuffer sockAddrMemory, int addressSize, long iovMemory, int iovLength,
                     ByteBuffer msgControl, int cmsgHdrDataOffset, short segmentSize) {
         int memoryPosition = memory.position();
         memory.putInt(memoryPosition + Native.MSGHDR_OFFSETOF_MSG_NAMELEN, addressSize);
@@ -74,19 +74,25 @@ final class MsgHdr {
         long sockAddr = sockAddrMemory == null ? 0 : Buffer.memoryAddress(sockAddrMemory);
         if (Native.SIZEOF_SIZE_T == 4) {
             memory.putInt(memoryPosition + Native.MSGHDR_OFFSETOF_MSG_NAME, (int) sockAddr);
-            memory.putInt(memoryPosition + Native.MSGHDR_OFFSETOF_MSG_IOV, (int) Buffer.memoryAddress(iovMemory));
+            memory.putInt(memoryPosition + Native.MSGHDR_OFFSETOF_MSG_IOV, (int) iovMemory);
             memory.putInt(memoryPosition + Native.MSGHDR_OFFSETOF_MSG_IOVLEN, iovLength);
             memory.putInt(memoryPosition + Native.MSGHDR_OFFSETOF_MSG_CONTROL, (int) msgControlAddr);
             memory.putInt(memoryPosition + Native.MSGHDR_OFFSETOF_MSG_CONTROLLEN, msgControlLen);
         } else {
             assert Native.SIZEOF_SIZE_T == 8;
             memory.putLong(memoryPosition + Native.MSGHDR_OFFSETOF_MSG_NAME, sockAddr);
-            memory.putLong(memoryPosition + Native.MSGHDR_OFFSETOF_MSG_IOV, Buffer.memoryAddress(iovMemory));
+            memory.putLong(memoryPosition + Native.MSGHDR_OFFSETOF_MSG_IOV, iovMemory);
             memory.putLong(memoryPosition + Native.MSGHDR_OFFSETOF_MSG_IOVLEN, iovLength);
             memory.putLong(memoryPosition + Native.MSGHDR_OFFSETOF_MSG_CONTROL, msgControlAddr);
             memory.putLong(memoryPosition + Native.MSGHDR_OFFSETOF_MSG_CONTROLLEN, msgControlLen);
         }
         // No flags (we assume the memory was memset before)
+    }
+
+    static void set(ByteBuffer memory, ByteBuffer sockAddrMemory, int addressSize, ByteBuffer iovMemory, int iovLength,
+                    ByteBuffer msgControl, int cmsgHdrDataOffset, short segmentSize) {
+        set(memory, sockAddrMemory, addressSize, Buffer.memoryAddress(iovMemory), iovLength,
+                msgControl, cmsgHdrDataOffset, segmentSize);
     }
 
     static void prepSendFd(ByteBuffer memory, int fd, ByteBuffer msgControl,

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemory.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/MsgHdrMemory.java
@@ -104,6 +104,24 @@ final class MsgHdrMemory {
     }
 
     void set(LinuxSocket socket, InetSocketAddress address, long bufferAddress , int length, short segmentSize) {
+        int addressLength = setSocketAddress(socket, address);
+        Iov.set(iovMemory, bufferAddress, length);
+        MsgHdr.set(msgHdrMemory, socketAddrMemory, addressLength, iovMemory, 1, cmsgDataMemory,
+                cmsgDataOffset, segmentSize);
+    }
+
+    void set(long iovArray, int length) {
+        MsgHdr.set(msgHdrMemory, iovArray, length);
+    }
+
+    void setWithIovArrayAddress(LinuxSocket socket, InetSocketAddress address,
+                                long iovArrayAddress, int iovArrayLength, short segmentSize) {
+        int addressLength = setSocketAddress(socket, address);
+        MsgHdr.set(msgHdrMemory, socketAddrMemory, addressLength, iovArrayAddress, iovArrayLength,
+                cmsgDataMemory, cmsgDataOffset, segmentSize);
+    }
+
+    private int setSocketAddress(LinuxSocket socket, InetSocketAddress address) {
         int addressLength;
         if (address == null) {
             addressLength = socket.protocolFamily() == SocketProtocolFamily.INET6 ?
@@ -118,13 +136,7 @@ final class MsgHdrMemory {
             addressLength = SockaddrIn.set(
                     socket.protocolFamily() == SocketProtocolFamily.INET6, socketAddrMemory, address);
         }
-        Iov.set(iovMemory, bufferAddress, length);
-        MsgHdr.set(msgHdrMemory, socketAddrMemory, addressLength, iovMemory, 1, cmsgDataMemory,
-                cmsgDataOffset, segmentSize);
-    }
-
-    void set(long iovArray, int length) {
-        MsgHdr.set(msgHdrMemory, iovArray, length);
+        return addressLength;
     }
 
     void setScmRightsFd(int fd) {


### PR DESCRIPTION
Motivation:

`AbstractIoUringChannel` uses `sendmsg(MSG_FASTOPEN)` for TCP Fast Open
initial data. This path did not handle all `ByteBuf` layouts correctly.

A `CompositeByteBuf` written before connect, for example:

```java
  ByteBuf initialData = alloc.compositeDirectBuffer()
          .addComponent(true, directBuffer("[fastopen-"))
          .addComponent(true, directBuffer("composite-"))
          .addComponent(true, directBuffer("data]"));
  channel.write(initialData);
  channel.connect(remote).sync();
```

fails with:

``` java
  Exception in thread "main" java.lang.UnsupportedOperationException
      at io.netty.buffer.CompositeByteBuf.internalNioBuffer(CompositeByteBuf.java:1681)
      at io.netty.channel.uring.IoUring.memoryAddress(IoUring.java:388)
```

A direct buffer with a non-zero readerIndex also sends from the wrong
offset:

``` java
  ByteBuf initialData = alloc.directBuffer();
  initialData.writeBytes("BAD-PREFIX-".getBytes(US_ASCII));
  initialData.writeBytes("EXPECTED-tfo-reader-index".getBytes(US_ASCII));
  initialData.readerIndex("BAD-PREFIX-".length());
```
expected: EXPECTED-tfo-reader-index
actual:   BAD-PREFIX-EXPECTED-tfo-r

 Modification:

- Use the readable region for direct ByteBuf initial data, and use an
IovArray backed msghdr for buffers without a memory address.

- Add the new TCP Fast Open cases to the shared socket test suite.

Result:

TCP Fast Open initial writes now work correctly with non-zero
readerIndex and CompositeByteBuf.
