### PR TITLE
[Refactor] Useful helper method getOrDefault & cleaner abstraction (#16927)

### DIFF
--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ClientConnectionHandler.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ClientConnectionHandler.java
@@ -90,7 +90,8 @@ public final class Http3ClientConnectionHandler extends Http3ConnectionHandler {
 
     @Override
     void initBidirectionalStream(ChannelHandlerContext ctx, QuicStreamChannel channel) {
-        // See https://tools.ietf.org/html/draft-ietf-quic-http-32#section-6.1
+        // See https://datatracker.ietf.org/doc/html/rfc9114#name-bidirectional-streams
+        // https://datatracker.ietf.org/doc/html/rfc9114#section-6.1-3
         Http3CodecUtils.connectionError(ctx, Http3ErrorCode.H3_STREAM_CREATION_ERROR,
                 "Server initiated bidirectional streams are not allowed", true);
     }

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ConnectionHandler.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ConnectionHandler.java
@@ -27,12 +27,10 @@ import org.jetbrains.annotations.Nullable;
 import java.util.function.LongFunction;
 
 import static io.netty.handler.codec.http3.Http3RequestStreamCodecState.NO_STATE;
-import static io.netty.handler.codec.http3.Http3SettingsFrame.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS;
-import static io.netty.handler.codec.http3.Http3SettingsFrame.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY;
 import static java.lang.Math.toIntExact;
 
 /**
- * Handler that handles <a href="https://tools.ietf.org/html/draft-ietf-quic-http-32">HTTP3</a> connections.
+ * Handler that handles <a href="https://datatracker.ietf.org/doc/html/rfc9114">HTTP3</a> connections.
  */
 public abstract class Http3ConnectionHandler implements ChannelInboundHandler {
     final Http3FrameCodecFactory codecFactory;
@@ -76,10 +74,24 @@ public abstract class Http3ConnectionHandler implements ChannelInboundHandler {
         } else {
             localSettings = DefaultHttp3SettingsFrame.copyOf(localSettings);
         }
-        Long maxFieldSectionSize = localSettings.getOrDefault(Http3SettingsFrame.HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE,
-                Http3CodecUtils.DEFAULT_MAX_FIELD_SECTION_SIZE);
-        this.maxTableCapacity = localSettings.getOrDefault(HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY, 0);
-        int maxBlockedStreams = toIntExact(localSettings.getOrDefault(HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS, 0));
+        Long maxFieldSectionSize = localSettings
+                .settings()
+                .getOrDefault(
+                        Http3SettingIdentifier.HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE.id(),
+                        Http3CodecUtils.DEFAULT_MAX_FIELD_SECTION_SIZE
+                );
+        this.maxTableCapacity = localSettings
+                .settings()
+                .getOrDefault(
+                        Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY.id(),
+                        0L
+                );
+        int maxBlockedStreams = toIntExact(localSettings
+                .settings()
+                .getOrDefault(
+                        Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id(),
+                        0L)
+        );
         qpackDecoder = new QpackDecoder(maxTableCapacity, maxBlockedStreams);
         qpackEncoder = new QpackEncoder();
         codecFactory = Http3FrameCodec.newFactory(qpackDecoder, maxFieldSectionSize, qpackEncoder);
@@ -94,9 +106,9 @@ public abstract class Http3ConnectionHandler implements ChannelInboundHandler {
         if (!controlStreamCreationInProgress && Http3.getLocalControlStream(ctx.channel()) == null) {
             controlStreamCreationInProgress = true;
             QuicChannel channel = (QuicChannel) ctx.channel();
-            // Once the channel became active we need to create an unidirectional stream and write the
+            // Once the channel became active we need to create a unidirectional stream and write the
             // Http3SettingsFrame to it. This needs to be the first frame on this stream.
-            // https://tools.ietf.org/html/draft-ietf-quic-http-32#section-6.2.1.
+            // https://datatracker.ietf.org/doc/html/rfc9114#name-control-streams
             channel.createStream(QuicStreamType.UNIDIRECTIONAL, remoteControlStreamHandler)
                     .addListener(f -> {
                         if (!f.isSuccess()) {

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ControlStreamInboundHandler.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ControlStreamInboundHandler.java
@@ -37,8 +37,6 @@ import static io.netty.handler.codec.http3.Http3ErrorCode.H3_FRAME_UNEXPECTED;
 import static io.netty.handler.codec.http3.Http3ErrorCode.H3_ID_ERROR;
 import static io.netty.handler.codec.http3.Http3ErrorCode.H3_MISSING_SETTINGS;
 import static io.netty.handler.codec.http3.Http3ErrorCode.QPACK_ENCODER_STREAM_ERROR;
-import static io.netty.handler.codec.http3.Http3SettingsFrame.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS;
-import static io.netty.handler.codec.http3.Http3SettingsFrame.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY;
 import static io.netty.handler.codec.http3.QpackUtil.toIntOrThrow;
 import static io.netty.util.internal.ThrowableUtil.unknownStackTrace;
 
@@ -150,8 +148,20 @@ final class Http3ControlStreamInboundHandler extends Http3FrameTypeInboundValida
         }
         quicChannel.createStream(QuicStreamType.UNIDIRECTIONAL,
                 new QPackEncoderStreamInitializer(qpackEncoder, qpackAttributes,
-                        settingsFrame.getOrDefault(HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY, 0),
-                        settingsFrame.getOrDefault(HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS, 0)))
+                        settingsFrame
+                                .settings()
+                                .getOrDefault(
+                                        Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY.id(),
+                                        0L
+                                ),
+                        settingsFrame
+                                .settings()
+                                .getOrDefault(
+                                        Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id(),
+                                        0L
+                                )
+                        )
+                )
                 .addListener(closeOnFailure);
         quicChannel.createStream(QuicStreamType.UNIDIRECTIONAL, new QPackDecoderStreamInitializer(qpackAttributes))
                 .addListener(closeOnFailure);

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3Settings.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3Settings.java
@@ -115,6 +115,19 @@ public final class Http3Settings implements Iterable<Map.Entry<Long, Long>> {
     }
 
     /**
+     * Returns the value associated with the specified setting identifier,
+     * or {@code defaultValue} if no value is present for the given key.
+     *
+     * @param key the numeric setting identifier
+     * @param defaultValue the value to return if the setting is not present
+     * @return the configured value for the specified key, or {@code defaultValue},
+     * if the key is not found
+     */
+    public long getOrDefault(long key, long defaultValue) {
+        return settings.getOrDefault(key, defaultValue);
+    }
+
+    /**
      * Returns the {@code QPACK_MAX_TABLE_CAPACITY} value.
      *
      * @return the current QPACK maximum table capacity, or {@code null} if not set

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3SettingsFrame.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3SettingsFrame.java
@@ -91,8 +91,7 @@ public interface Http3SettingsFrame extends Http3ControlStreamFrame, Iterable<Ma
      */
     @Deprecated
     default Long getOrDefault(long key, long defaultValue) {
-        final Long val = get(key);
-        return val == null ? defaultValue : val;
+       return settings().getOrDefault(key, defaultValue);
     }
 
     /**

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/QpackEncoderDynamicTable.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/QpackEncoderDynamicTable.java
@@ -69,7 +69,7 @@ final class QpackEncoderDynamicTable {
     /**
      * <a href="https://www.rfc-editor.org/rfc/rfc9204.html#name-maximum-dynamic-table-capac">
      *     Maximum capacity of the table</a>. This is set once based on the
-     *     {@link Http3SettingsFrame#HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY} received by the remote peer.
+     *     {@link Http3SettingIdentifier#HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY} received by the remote peer.
      */
     private long maxTableCapacity = -1;
 

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/DefaultHttp3SettingsFrameTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/DefaultHttp3SettingsFrameTest.java
@@ -41,6 +41,7 @@ class DefaultHttp3SettingsFrameTest {
 
         assertNotNull(frame.settings());
         assertFalse(frame.iterator().hasNext());
+        assertNull(frame.settings().qpackMaxTableCapacity());
         assertNull(frame.get(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY.id()));
     }
 
@@ -48,12 +49,17 @@ class DefaultHttp3SettingsFrameTest {
     void testPutAndGetDelegatesToSettings() {
         DefaultHttp3SettingsFrame frame = new DefaultHttp3SettingsFrame();
 
-        frame.put(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY.id(), 256L);
-        frame.put(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id(), 8L);
-
+        frame.settings().put(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY.id(), 256L);
         assertEquals(256L, frame.settings().qpackMaxTableCapacity());
+
+        frame.settings().put(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id(), 8L);
         assertEquals(8L, frame.settings().qpackBlockedStreams());
-        assertEquals(8L, frame.get(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id()));
+
+        frame.put(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY.id(), 512L);
+        assertEquals(512L, frame.get(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY.id()));
+
+        frame.put(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id(), 16L);
+        assertEquals(16L, frame.get(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id()));
     }
 
     @Test
@@ -73,6 +79,7 @@ class DefaultHttp3SettingsFrameTest {
         // Modify settings externally and verify frame sees update
         settings.qpackBlockedStreams(3);
         assertEquals(3L, frame.get(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id()));
+        assertEquals(3L, frame.settings().qpackBlockedStreams());
     }
 
     @Test

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3FrameCodecTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3FrameCodecTest.java
@@ -97,10 +97,12 @@ public class Http3FrameCodecTest {
         parent = new EmbeddedQuicChannel(true);
         qpackAttributes = new QpackAttributes(parent, false);
         Http3.setQpackAttributes(parent, qpackAttributes);
-        final Http3SettingsFrame settings = new DefaultHttp3SettingsFrame();
+        final Http3SettingsFrame http3SettingsFrame = new DefaultHttp3SettingsFrame();
         maxTableCapacity = 1024L;
-        settings.put(Http3SettingsFrame.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY, maxTableCapacity);
-        settings.put(Http3SettingsFrame.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS, (long) maxBlockedStreams);
+        http3SettingsFrame.settings().put(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY.id(),
+                maxTableCapacity);
+        http3SettingsFrame.settings().put(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id(),
+                (long) maxBlockedStreams);
         decoder = new QpackDecoder(maxTableCapacity, maxBlockedStreams);
         decoder.setDynamicTableCapacity(maxTableCapacity);
         qpackEncoderHandler = new QpackEncoderHandler(maxTableCapacity, decoder);
@@ -272,17 +274,17 @@ public class Http3FrameCodecTest {
             boolean fragmented, int maxBlockedStreams, boolean delayQpackStreams) throws Exception {
         setUp(maxBlockedStreams, delayQpackStreams);
         Http3SettingsFrame settingsFrame = new DefaultHttp3SettingsFrame();
-        settingsFrame.put(Http3SettingsFrame.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY, 100L);
-        settingsFrame.put(Http3SettingsFrame.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS, 1L);
-        settingsFrame.put(Http3SettingsFrame.HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE, 128L);
-        settingsFrame.put(Http3SettingsFrame.HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL, 0L);
-        settingsFrame.put(Http3SettingIdentifier.HTTP3_SETTINGS_H3_DATAGRAM.id(), 1L);
+        settingsFrame.settings().put(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY.id(), 100L);
+        settingsFrame.settings().put(Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id(), 1L);
+        settingsFrame.settings().put(Http3SettingIdentifier.HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE.id(), 128L);
+        settingsFrame.settings().put(Http3SettingIdentifier.HTTP3_SETTINGS_ENABLE_CONNECT_PROTOCOL.id(), 0L);
+        settingsFrame.settings().put(Http3SettingIdentifier.HTTP3_SETTINGS_H3_DATAGRAM.id(), 1L);
         // Ensure we can encode and decode all sizes correctly.
         // unknown settings id/key will be ignored
-        settingsFrame.put(63, 63L);
-        settingsFrame.put(16383, 16383L);
-        settingsFrame.put(1073741823, 1073741823L);
-        settingsFrame.put(4611686018427387903L, 4611686018427387903L);
+        settingsFrame.settings().put(63, 63L);
+        settingsFrame.settings().put(16383, 16383L);
+        settingsFrame.settings().put(1073741823, 1073741823L);
+        settingsFrame.settings().put(4611686018427387903L, 4611686018427387903L);
         testFrameEncodedAndDecoded(
                 fragmented, maxBlockedStreams, delayQpackStreams, settingsFrame);
     }
@@ -530,9 +532,11 @@ public class Http3FrameCodecTest {
         Http3CodecUtils.writeVariableLengthInteger(buffer, Http3CodecUtils.HTTP3_SETTINGS_FRAME_TYPE);
         Http3CodecUtils.writeVariableLengthInteger(buffer, 4);
         // Write the key and some random value... Both should be only 1 byte long each.
-        Http3CodecUtils.writeVariableLengthInteger(buffer, Http3SettingsFrame.HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE);
+        Http3CodecUtils.writeVariableLengthInteger(buffer,
+                Http3SettingIdentifier.HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE.id());
         Http3CodecUtils.writeVariableLengthInteger(buffer, 1);
-        Http3CodecUtils.writeVariableLengthInteger(buffer, Http3SettingsFrame.HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE);
+        Http3CodecUtils.writeVariableLengthInteger(buffer,
+                Http3SettingIdentifier.HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE.id());
         Http3CodecUtils.writeVariableLengthInteger(buffer, 1);
 
         testDecodeInvalidSettings(delayQpackStreams, buffer);

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3SettingsTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3SettingsTest.java
@@ -107,6 +107,28 @@ public class Http3SettingsTest {
     }
 
     @Test
+    void testDefaultGet() {
+        Http3Settings settings = new Http3Settings();
+
+        assertNull(settings.get(Http3SettingIdentifier.HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE.id()));
+
+        assertEquals(Long.MAX_VALUE, settings
+                .getOrDefault(
+                        Http3SettingIdentifier.HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE.id(),
+                        Long.MAX_VALUE)
+        );
+        assertEquals(Long.MIN_VALUE, settings
+                .getOrDefault(
+                        Http3SettingIdentifier.HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE.id(),
+                        Long.MIN_VALUE)
+        );
+
+        assertNull(settings.put(Http3SettingIdentifier.HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE.id(), 1000L));
+
+        assertEquals(1000L, settings.get(Http3SettingIdentifier.HTTP3_SETTINGS_MAX_FIELD_SECTION_SIZE.id()));
+    }
+
+    @Test
     void testForEachConsumer() {
         Http3Settings settings = new Http3Settings()
                 .qpackMaxTableCapacity(5)

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/QpackDecoderHandlerTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/QpackDecoderHandlerTest.java
@@ -24,7 +24,7 @@ import java.util.function.Consumer;
 
 import static io.netty.handler.codec.http3.Http3.setQpackAttributes;
 import static io.netty.handler.codec.http3.Http3ErrorCode.QPACK_DECODER_STREAM_ERROR;
-import static io.netty.handler.codec.http3.Http3SettingsFrame.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY;
+import static io.netty.handler.codec.http3.Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY;
 import static io.netty.handler.codec.http3.QpackUtil.encodePrefixedInteger;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
@@ -327,8 +327,8 @@ public class QpackDecoderHandlerTest {
         parent = new EmbeddedQuicChannel(true);
         attributes = new QpackAttributes(parent, false);
         setQpackAttributes(parent, attributes);
-        Http3SettingsFrame settings = new DefaultHttp3SettingsFrame();
-        settings.put(HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY, maxTableCapacity);
+        Http3SettingsFrame settingsFrame = new DefaultHttp3SettingsFrame();
+        settingsFrame.settings().put(HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY.id(), maxTableCapacity);
         QpackDecoder decoder = new QpackDecoder(maxTableCapacity, 0);
         encoderStream = (EmbeddedQuicStreamChannel) parent.createStream(QuicStreamType.UNIDIRECTIONAL,
                 new QpackEncoderHandler(maxTableCapacity, decoder)).get();

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/QpackDecoderTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/QpackDecoderTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.Collection;
 import java.util.function.BiConsumer;
 
-import static io.netty.handler.codec.http3.Http3SettingsFrame.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY;
+import static io.netty.handler.codec.http3.Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY;
 import static io.netty.handler.codec.http3.QpackDecoderStateSyncStrategy.ackEachInsert;
 import static io.netty.handler.codec.http3.QpackUtil.MAX_UNSIGNED_INT;
 import static java.lang.Math.toIntExact;
@@ -203,8 +203,8 @@ public class QpackDecoderTest {
         long maxTableCapacity = MAX_UNSIGNED_INT;
         inserted = 0;
         this.maxEntries = toIntExact(QpackUtil.maxEntries(maxTableCapacity));
-        final DefaultHttp3SettingsFrame settings = new DefaultHttp3SettingsFrame();
-        settings.put(HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY, maxTableCapacity);
+        final DefaultHttp3SettingsFrame settingsFrame = new DefaultHttp3SettingsFrame();
+        settingsFrame.settings().put(HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY.id(), maxTableCapacity);
         table = new QpackDecoderDynamicTable();
         EmbeddedQuicChannel parent = new EmbeddedQuicChannel(true);
         attributes = new QpackAttributes(parent, false);

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/QpackEncoderDecoderTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/QpackEncoderDecoderTest.java
@@ -31,8 +31,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import static io.netty.buffer.UnpooledByteBufAllocator.DEFAULT;
-import static io.netty.handler.codec.http3.Http3SettingsFrame.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS;
-import static io.netty.handler.codec.http3.Http3SettingsFrame.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY;
+import static io.netty.handler.codec.http3.Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS;
+import static io.netty.handler.codec.http3.Http3SettingIdentifier.HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY;
 import static io.netty.handler.codec.quic.QuicStreamType.UNIDIRECTIONAL;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -461,9 +461,9 @@ public class QpackEncoderDecoderTest {
         attributes = new QpackAttributes(parent, false);
         Http3.setQpackAttributes(parent, attributes);
         maxEntries = Math.toIntExact(QpackUtil.maxEntries(maxTableCapacity));
-        DefaultHttp3SettingsFrame localSettings = new DefaultHttp3SettingsFrame();
-        localSettings.put(HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY, maxTableCapacity);
-        localSettings.put(HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS, (long) maxBlockedStreams);
+        DefaultHttp3SettingsFrame localSettingsFrame = new DefaultHttp3SettingsFrame();
+        localSettingsFrame.settings().put(HTTP3_SETTINGS_QPACK_MAX_TABLE_CAPACITY.id(), maxTableCapacity);
+        localSettingsFrame.settings().put(HTTP3_SETTINGS_QPACK_BLOCKED_STREAMS.id(), (long) maxBlockedStreams);
         if (maxBlockedStreams > 0) {
             // section acknowledgment will implicitly ack insert count.
             stateSyncStrategyAckNextInsert = false;


### PR DESCRIPTION
**Motivation**

While working on the WebTransport implementation, I found it useful to
have a helper method for retrieving HTTP/3 settings with a fallback
value when a setting identifier is not present.

**Modification**

* Added a `getOrDefault(...)` method to `Http3Settings`.
* The method returns the configured value for a setting identifier or
the provided default value if the identifier is not present.
* Refactoring some deprecated methods

**Result**

* Simplifies retrieval of optional HTTP/3 settings from a cleaner
abstraction.
* Returns a default value when the requested setting identifier is
absent.

**Testing**

* Added unit tests covering both existing and missing setting
identifiers.
