### PR TITLE
Fix HTTP 2 PUSH_PROMISE stream association validation

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameReader.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameReader.java
@@ -343,6 +343,7 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
     }
 
     private void verifyPushPromiseFrame() throws Http2Exception {
+        verifyAssociatedWithAStream();
         verifyNotProcessingHeaders();
 
         // Subtract the length of the promised stream ID field, to determine the length of the

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameReaderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameReaderTest.java
@@ -341,6 +341,27 @@ public class DefaultHttp2FrameReaderTest {
     }
 
     @Test
+    public void failedWhenPushPromiseFrameNotAssociateWithStream() throws Http2Exception {
+        final ByteBuf input = Unpooled.buffer();
+        try {
+            writeFrameHeader(input, INT_FIELD_LENGTH, PUSH_PROMISE, new Http2Flags().endOfHeaders(true), 0);
+            input.writeInt(2);
+            Http2Exception ex = assertThrows(Http2Exception.class, new Executable() {
+                @Override
+                public void execute() throws Throwable {
+                    frameReader.readFrame(ctx, input, listener);
+                }
+            });
+            assertFalse(ex instanceof Http2Exception.StreamException);
+            assertEquals(Http2Error.PROTOCOL_ERROR, ex.error());
+            verify(listener, never()).onPushPromiseRead(any(ChannelHandlerContext.class), anyInt(), anyInt(),
+                    any(Http2Headers.class), anyInt());
+        } finally {
+            input.release();
+        }
+    }
+
+    @Test
     public void readPriorityFrame() throws Http2Exception {
         ByteBuf input = Unpooled.buffer();
         try {


### PR DESCRIPTION
Motivation:

`DefaultHttp2FrameReader` did not verify that `PUSH_PROMISE` frames are associated
with a stream before processing the frame-specific payload. As a result, a
`PUSH_PROMISE` frame with stream ID `0` was not rejected by the same stream
association validation used by DATA, HEADERS, PRIORITY, and RST_STREAM frames.

Per RFC 9113 section 6.6, `PUSH_PROMISE` frames identify the stream they are
associated with, and receipt of a `PUSH_PROMISE` frame with stream ID `0` MUST be
treated as a connection error of type `PROTOCOL_ERROR`.

Modifications:

- Add `verifyAssociatedWithAStream()` to `verifyPushPromiseFrame()`.
- Add a regression test for `PUSH_PROMISE` with stream ID `0`.
- Verify that the error is connection-level `PROTOCOL_ERROR`.
- Verify that `onPushPromiseRead(...)` is not invoked for the invalid frame.

Result:

Invalid `PUSH_PROMISE` frames with stream ID `0` are now rejected consistently
with other stream-associated HTTP/2 frame types.