### PR TITLE
Stop DateFormatter trailing token from running past the parse end

### DIFF
--- a/codec-base/src/main/java/io/netty/handler/codec/DateFormatter.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/DateFormatter.java
@@ -388,8 +388,10 @@ public final class DateFormatter {
             }
         }
 
-        // terminate trailing token
-        return tokenStart != -1 && parseToken(txt, tokenStart, txt.length());
+        // terminate trailing token at end (the parse bound), not txt.length(): when parsing a
+        // substring (end < txt.length(), e.g. a cookie Expires value followed by more attributes)
+        // the trailing token must not run past end.
+        return tokenStart != -1 && parseToken(txt, tokenStart, end);
     }
 
     private boolean normalizeAndValidate() {

--- a/codec-base/src/main/java/io/netty/handler/codec/DateFormatter.java
+++ b/codec-base/src/main/java/io/netty/handler/codec/DateFormatter.java
@@ -388,9 +388,7 @@ public final class DateFormatter {
             }
         }
 
-        // terminate trailing token at end (the parse bound), not txt.length(): when parsing a
-        // substring (end < txt.length(), e.g. a cookie Expires value followed by more attributes)
-        // the trailing token must not run past end.
+        // terminate trailing token at end, not txt.length(), so a substring parse doesn't overrun
         return tokenStart != -1 && parseToken(txt, tokenStart, end);
     }
 

--- a/codec-base/src/test/java/io/netty/handler/codec/DateFormatterTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/DateFormatterTest.java
@@ -39,10 +39,7 @@ public class DateFormatterTest {
 
     @Test
     public void testParseHttpDateSubstringDoesNotOverrunEnd() {
-        // RFC 6265 cookie-date tokens are order-independent; here the completing token (the year)
-        // is last. When the date is parsed as a substring (end < length, e.g. an Expires value
-        // followed by another cookie attribute), the trailing token must stop at end, not run to
-        // the end of the whole string.
+        // Set-Cookie header format with the date anywhere but last (RFC 6265 tokens are unordered).
         String dateText = "Sun 08:49:37 06 Nov 1994";
         assertEquals(DATE, parseHttpDate(dateText));
         assertEquals(DATE, parseHttpDate(dateText + "; Path=/", 0, dateText.length()));

--- a/codec-base/src/test/java/io/netty/handler/codec/DateFormatterTest.java
+++ b/codec-base/src/test/java/io/netty/handler/codec/DateFormatterTest.java
@@ -38,6 +38,17 @@ public class DateFormatterTest {
     }
 
     @Test
+    public void testParseHttpDateSubstringDoesNotOverrunEnd() {
+        // RFC 6265 cookie-date tokens are order-independent; here the completing token (the year)
+        // is last. When the date is parsed as a substring (end < length, e.g. an Expires value
+        // followed by another cookie attribute), the trailing token must stop at end, not run to
+        // the end of the whole string.
+        String dateText = "Sun 08:49:37 06 Nov 1994";
+        assertEquals(DATE, parseHttpDate(dateText));
+        assertEquals(DATE, parseHttpDate(dateText + "; Path=/", 0, dateText.length()));
+    }
+
+    @Test
     public void testParseWithDoubleDigitDay() {
         assertEquals(DATE, parseHttpDate("Sun, 06 Nov 1994 08:49:37 GMT"));
     }


### PR DESCRIPTION
## Problem

`DateFormatter.parseHttpDate(txt, start, end)` is documented to parse only the `[start, end)` substring. Its tokenizer loop correctly stops at `end`, but the **trailing token** — the one still open when the loop finishes — was terminated at `txt.length()` instead of `end`:

```java
// terminate trailing token
return tokenStart != -1 && parseToken(txt, tokenStart, txt.length());
```

When `end < txt.length()` and the date's *last* token is the one that completes the parse, the trailing token swallows the bytes after `end` and fails to parse.

This is reachable in practice through cookies. A `Set-Cookie` header like `foo=bar; Expires=<date>; Path=/` makes `ClientCookieDecoder` call `parseHttpDate(header, start, end)` with `end` pointing at the `;` before `Path`. RFC 6265 §5.1.1 cookie-date tokens are **order-independent**, so a valid date whose year (or day) is the last token — e.g. `Sun 08:49:37 06 Nov 1994` — parses fine in isolation but returns `null` as a substring, silently dropping the expiry and downgrading the cookie to a session cookie.

Standard `Sun, 06 Nov 1994 08:49:37 GMT` ordering does not trigger it (the time token completes the parse mid-loop, before the trailing `GMT`), which is why existing tests miss it.

## Fix

Terminate the trailing token at `end` rather than `txt.length()`. Since `end <= txt.length()` always, this only ever shrinks the trailing token to the intended bound; the full-string `parseHttpDate(txt)` path (where `end == txt.length()`) is unaffected.

Added a `DateFormatterTest` case that parses such a date both in isolation and as a substring and asserts they agree.

## Result

`parseHttpDate` honours the `end` bound for the trailing token; valid order-independent cookie dates followed by other attributes now parse correctly. Full `DateFormatterTest` (14) passes.