### PR TITLE
Correctly release and fail queued traffic-shaping writes on close

### DIFF
--- a/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
@@ -585,9 +585,7 @@ public abstract class AbstractTrafficShapingHandler extends ChannelDuplexHandler
      */
     static void releaseAndFailQueuedWrite(Object msg, ChannelPromise promise, Throwable cause) {
         ReferenceCountUtil.safeRelease(msg);
-        if (!promise.isDone()) {
-            promise.tryFailure(cause);
-        }
+        promise.tryFailure(cause);
     }
 
     @Override

--- a/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
@@ -32,7 +32,6 @@ import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
-import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -581,10 +580,17 @@ public abstract class AbstractTrafficShapingHandler extends ChannelDuplexHandler
     abstract void submitWrite(
             ChannelHandlerContext ctx, Object msg, long size, long delay, long now, ChannelPromise promise);
 
-    static void releaseAndFailQueuedWrite(Object msg, ChannelPromise promise) {
+    /**
+     * Releases the given {@code msg} and fails the given {@code promise} with the supplied {@code cause}.
+     * <p>
+     * The {@code cause} is intentionally passed in (instead of being created here) so that callers draining a queue
+     * of pending writes can allocate a single exception instance once and reuse it for every promise, avoiding the
+     * cost of {@link Throwable#fillInStackTrace()} per element.
+     */
+    static void releaseAndFailQueuedWrite(Object msg, ChannelPromise promise, Throwable cause) {
         ReferenceCountUtil.safeRelease(msg);
         if (!promise.isDone()) {
-            promise.tryFailure(new ClosedChannelException());
+            promise.tryFailure(cause);
         }
     }
 
@@ -630,12 +636,12 @@ public abstract class AbstractTrafficShapingHandler extends ChannelDuplexHandler
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder(290)
-            .append("TrafficShaping with Write Limit: ").append(writeLimit)
-            .append(" Read Limit: ").append(readLimit)
-            .append(" CheckInterval: ").append(checkInterval)
-            .append(" maxDelay: ").append(maxWriteDelay)
-            .append(" maxSize: ").append(maxWriteSize)
-            .append(" and Counter: ");
+                .append("TrafficShaping with Write Limit: ").append(writeLimit)
+                .append(" Read Limit: ").append(readLimit)
+                .append(" CheckInterval: ").append(checkInterval)
+                .append(" maxDelay: ").append(maxWriteDelay)
+                .append(" maxSize: ").append(maxWriteSize)
+                .append(" and Counter: ");
         if (trafficCounter != null) {
             builder.append(trafficCounter);
         } else {

--- a/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
@@ -28,9 +28,11 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.FileRegion;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
+import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -578,6 +580,11 @@ public abstract class AbstractTrafficShapingHandler extends ChannelDuplexHandler
 
     abstract void submitWrite(
             ChannelHandlerContext ctx, Object msg, long size, long delay, long now, ChannelPromise promise);
+
+    static void releaseAndFailQueuedWrite(Object msg, ChannelPromise promise) {
+        ReferenceCountUtil.safeRelease(msg);
+        promise.tryFailure(new ClosedChannelException());
+    }
 
     @Override
     public void channelRegistered(ChannelHandlerContext ctx) throws Exception {

--- a/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
@@ -636,12 +636,12 @@ public abstract class AbstractTrafficShapingHandler extends ChannelDuplexHandler
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder(290)
-                .append("TrafficShaping with Write Limit: ").append(writeLimit)
-                .append(" Read Limit: ").append(readLimit)
-                .append(" CheckInterval: ").append(checkInterval)
-                .append(" maxDelay: ").append(maxWriteDelay)
-                .append(" maxSize: ").append(maxWriteSize)
-                .append(" and Counter: ");
+            .append("TrafficShaping with Write Limit: ").append(writeLimit)
+            .append(" Read Limit: ").append(readLimit)
+            .append(" CheckInterval: ").append(checkInterval)
+            .append(" maxDelay: ").append(maxWriteDelay)
+            .append(" maxSize: ").append(maxWriteSize)
+            .append(" and Counter: ");
         if (trafficCounter != null) {
             builder.append(trafficCounter);
         } else {

--- a/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
@@ -583,7 +583,9 @@ public abstract class AbstractTrafficShapingHandler extends ChannelDuplexHandler
 
     static void releaseAndFailQueuedWrite(Object msg, ChannelPromise promise) {
         ReferenceCountUtil.safeRelease(msg);
-        promise.tryFailure(new ClosedChannelException());
+        if (!promise.isDone()) {
+            promise.tryFailure(new ClosedChannelException());
+        }
     }
 
     @Override

--- a/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
@@ -582,10 +582,6 @@ public abstract class AbstractTrafficShapingHandler extends ChannelDuplexHandler
 
     /**
      * Releases the given {@code msg} and fails the given {@code promise} with the supplied {@code cause}.
-     * <p>
-     * The {@code cause} is intentionally passed in (instead of being created here) so that callers draining a queue
-     * of pending writes can allocate a single exception instance once and reuse it for every promise, avoiding the
-     * cost of {@link Throwable#fillInStackTrace()} per element.
      */
     static void releaseAndFailQueuedWrite(Object msg, ChannelPromise promise, Throwable cause) {
         ReferenceCountUtil.safeRelease(msg);

--- a/handler/src/main/java/io/netty/handler/traffic/ChannelTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/ChannelTrafficShapingHandler.java
@@ -15,7 +15,6 @@
  */
 package io.netty.handler.traffic;
 
-import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 
@@ -150,10 +149,9 @@ public class ChannelTrafficShapingHandler extends AbstractTrafficShapingHandler 
                 }
             } else {
                 for (ToSend toSend : messagesQueue) {
-                    if (toSend.toSend instanceof ByteBuf) {
-                        ((ByteBuf) toSend.toSend).release();
-                    }
+                    releaseAndFailQueuedWrite(toSend.toSend, toSend.promise);
                 }
+                queueSize = 0;
             }
             messagesQueue.clear();
         }

--- a/handler/src/main/java/io/netty/handler/traffic/ChannelTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/ChannelTrafficShapingHandler.java
@@ -18,6 +18,7 @@ package io.netty.handler.traffic;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 
+import java.nio.channels.ClosedChannelException;
 import java.util.ArrayDeque;
 import java.util.concurrent.TimeUnit;
 
@@ -148,8 +149,9 @@ public class ChannelTrafficShapingHandler extends AbstractTrafficShapingHandler 
                     ctx.write(toSend.toSend, toSend.promise);
                 }
             } else {
+                ClosedChannelException cause = new ClosedChannelException();
                 for (ToSend toSend : messagesQueue) {
-                    releaseAndFailQueuedWrite(toSend.toSend, toSend.promise);
+                    releaseAndFailQueuedWrite(toSend.toSend, toSend.promise, cause);
                 }
                 queueSize = 0;
             }

--- a/handler/src/main/java/io/netty/handler/traffic/ChannelTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/ChannelTrafficShapingHandler.java
@@ -148,7 +148,7 @@ public class ChannelTrafficShapingHandler extends AbstractTrafficShapingHandler 
                     queueSize -= size;
                     ctx.write(toSend.toSend, toSend.promise);
                 }
-            } else {
+            } else if (!messagesQueue.isEmpty()) {
                 ClosedChannelException cause = new ClosedChannelException();
                 for (ToSend toSend : messagesQueue) {
                     releaseAndFailQueuedWrite(toSend.toSend, toSend.promise, cause);

--- a/handler/src/main/java/io/netty/handler/traffic/GlobalChannelTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/GlobalChannelTrafficShapingHandler.java
@@ -29,6 +29,7 @@ import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
+import java.nio.channels.ClosedChannelException;
 import java.util.AbstractCollection;
 import java.util.ArrayDeque;
 import java.util.Collection;
@@ -496,8 +497,9 @@ public class GlobalChannelTrafficShapingHandler extends AbstractTrafficShapingHa
                     }
                 } else {
                     queuesSize.addAndGet(-perChannel.queueSize);
+                    ClosedChannelException cause = new ClosedChannelException();
                     for (ToSend toSend : perChannel.messagesQueue) {
-                        releaseAndFailQueuedWrite(toSend.toSend, toSend.promise);
+                        releaseAndFailQueuedWrite(toSend.toSend, toSend.promise, cause);
                     }
                     perChannel.queueSize = 0;
                 }

--- a/handler/src/main/java/io/netty/handler/traffic/GlobalChannelTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/GlobalChannelTrafficShapingHandler.java
@@ -495,7 +495,7 @@ public class GlobalChannelTrafficShapingHandler extends AbstractTrafficShapingHa
                         queuesSize.addAndGet(-size);
                         ctx.write(toSend.toSend, toSend.promise);
                     }
-                } else {
+                } else if (!perChannel.messagesQueue.isEmpty()) {
                     queuesSize.addAndGet(-perChannel.queueSize);
                     ClosedChannelException cause = new ClosedChannelException();
                     for (ToSend toSend : perChannel.messagesQueue) {

--- a/handler/src/main/java/io/netty/handler/traffic/GlobalChannelTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/GlobalChannelTrafficShapingHandler.java
@@ -19,7 +19,6 @@ import static io.netty.util.internal.ObjectUtil.checkNotNullWithIAE;
 import static io.netty.util.internal.ObjectUtil.checkPositive;
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
-import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelConfig;
@@ -498,10 +497,9 @@ public class GlobalChannelTrafficShapingHandler extends AbstractTrafficShapingHa
                 } else {
                     queuesSize.addAndGet(-perChannel.queueSize);
                     for (ToSend toSend : perChannel.messagesQueue) {
-                        if (toSend.toSend instanceof ByteBuf) {
-                            ((ByteBuf) toSend.toSend).release();
-                        }
+                        releaseAndFailQueuedWrite(toSend.toSend, toSend.promise);
                     }
+                    perChannel.queueSize = 0;
                 }
                 perChannel.messagesQueue.clear();
             }

--- a/handler/src/main/java/io/netty/handler/traffic/GlobalTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/GlobalTrafficShapingHandler.java
@@ -15,7 +15,6 @@
  */
 package io.netty.handler.traffic;
 
-import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -279,10 +278,9 @@ public class GlobalTrafficShapingHandler extends AbstractTrafficShapingHandler {
                 } else {
                     queuesSize.addAndGet(-perChannel.queueSize);
                     for (ToSend toSend : perChannel.messagesQueue) {
-                        if (toSend.toSend instanceof ByteBuf) {
-                            ((ByteBuf) toSend.toSend).release();
-                        }
+                        releaseAndFailQueuedWrite(toSend.toSend, toSend.promise);
                     }
+                    perChannel.queueSize = 0;
                 }
                 perChannel.messagesQueue.clear();
             }

--- a/handler/src/main/java/io/netty/handler/traffic/GlobalTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/GlobalTrafficShapingHandler.java
@@ -276,7 +276,7 @@ public class GlobalTrafficShapingHandler extends AbstractTrafficShapingHandler {
                         queuesSize.addAndGet(-size);
                         ctx.write(toSend.toSend, toSend.promise);
                     }
-                } else {
+                } else if (!perChannel.messagesQueue.isEmpty()) {
                     queuesSize.addAndGet(-perChannel.queueSize);
                     ClosedChannelException cause = new ClosedChannelException();
                     for (ToSend toSend : perChannel.messagesQueue) {

--- a/handler/src/main/java/io/netty/handler/traffic/GlobalTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/GlobalTrafficShapingHandler.java
@@ -22,6 +22,7 @@ import io.netty.channel.ChannelPromise;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.internal.ObjectUtil;
 
+import java.nio.channels.ClosedChannelException;
 import java.util.ArrayDeque;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -277,8 +278,9 @@ public class GlobalTrafficShapingHandler extends AbstractTrafficShapingHandler {
                     }
                 } else {
                     queuesSize.addAndGet(-perChannel.queueSize);
+                    ClosedChannelException cause = new ClosedChannelException();
                     for (ToSend toSend : perChannel.messagesQueue) {
-                        releaseAndFailQueuedWrite(toSend.toSend, toSend.promise);
+                        releaseAndFailQueuedWrite(toSend.toSend, toSend.promise, cause);
                     }
                     perChannel.queueSize = 0;
                 }

--- a/handler/src/test/java/io/netty/handler/traffic/TrafficShapingHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/traffic/TrafficShapingHandlerTest.java
@@ -16,18 +16,23 @@
 
 package io.netty.handler.traffic;
 
+import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufHolder;
+import io.netty.buffer.DefaultByteBufHolder;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalChannel;
 import io.netty.channel.local.LocalIoHandler;
@@ -37,12 +42,16 @@ import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TrafficShapingHandlerTest {
 
     private static final long READ_LIMIT_BYTES_PER_SECOND = 1;
+    private static final long WRITE_LIMIT_BYTES_PER_SECOND = 1;
     private static final ScheduledExecutorService SES = Executors.newSingleThreadScheduledExecutor();
     private static final EventLoopGroup GROUP = new MultiThreadIoEventLoopGroup(1, LocalIoHandler.newFactory());
 
@@ -70,6 +79,46 @@ public class TrafficShapingHandlerTest {
         } finally {
             trafficHandler2.release();
         }
+    }
+
+    @Test
+    public void testQueuedWritesReleasedAndFailedOnClose() {
+        testQueuedWritesReleasedAndFailedOnClose0(new ChannelTrafficShapingHandler(
+                WRITE_LIMIT_BYTES_PER_SECOND, 0, 0));
+
+        GlobalTrafficShapingHandler trafficHandler1 =
+                new GlobalTrafficShapingHandler(SES, WRITE_LIMIT_BYTES_PER_SECOND, 0, 0);
+        try {
+            testQueuedWritesReleasedAndFailedOnClose0(trafficHandler1);
+        } finally {
+            trafficHandler1.release();
+        }
+
+        GlobalChannelTrafficShapingHandler trafficHandler2 =
+                new GlobalChannelTrafficShapingHandler(SES, WRITE_LIMIT_BYTES_PER_SECOND, 0,
+                        WRITE_LIMIT_BYTES_PER_SECOND, 0, 0);
+        try {
+            testQueuedWritesReleasedAndFailedOnClose0(trafficHandler2);
+        } finally {
+            trafficHandler2.release();
+        }
+    }
+
+    private static void testQueuedWritesReleasedAndFailedOnClose0(AbstractTrafficShapingHandler trafficHandler) {
+        EmbeddedChannel ch = new EmbeddedChannel(trafficHandler);
+        ByteBufHolder holder = new DefaultByteBufHolder(Unpooled.buffer(64).writeZero(64));
+        ChannelPromise promise = ch.newPromise();
+
+        ch.writeOneOutbound(holder, promise);
+        assertFalse(promise.isDone());
+        assertNull(ch.readOutbound());
+        assertEquals(1, holder.refCnt());
+
+        ch.close().syncUninterruptibly();
+        assertEquals(0, holder.refCnt());
+        assertTrue(promise.isDone());
+        assertTrue(promise.cause() instanceof ClosedChannelException);
+        assertFalse(ch.finishAndReleaseAll());
     }
 
     private void testHandlerRemove0(final AbstractTrafficShapingHandler trafficHandler)


### PR DESCRIPTION
Motivation:
The AbstractTrafficShapingHandler#calculateSize supports ByteBuf, ByteBufHolder, and FileRegion, so traffic-shaping handlers may queue delayed ByteBufHolder messages such as HTTP content.
When a channel becomes inactive and queued writes are discarded, ChannelTrafficShapingHandler, GlobalTrafficShapingHandler, and GlobalChannelTrafficShapingHandler only release messages that are direct ByteBuf instances. This leaks queued ByteBufHolder / other ReferenceCounted messages. The corresponding write promises are also left incomplete even though the messages will never be written.
Modifications:
	•	Add a shared queued-write cleanup helper in AbstractTrafficShapingHandler.
	•	Use ReferenceCountUtil.safeRelease(...) instead of instanceof ByteBuf checks.
	•	Fail discarded queued write promises with ClosedChannelException.
	•	Reset per-channel queue size after discarded queued writes are cleaned up.
	•	Add tests covering queued ByteBufHolder writes for:
	◦	ChannelTrafficShapingHandler
	◦	GlobalTrafficShapingHandler
	◦	GlobalChannelTrafficShapingHandler
Result:
Queued delayed writes are cleaned up consistently when the channel is closed: reference-counted messages are released and callers waiting on write promises are notified with failure. Internal queue-size accounting is left in a clean state on removal.