### PR TITLE
Http3FrameCodec  handle fragmented payloads when skipping unknown frames

### DIFF
--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3FrameCodec.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3FrameCodec.java
@@ -213,8 +213,9 @@ final class Http3FrameCodec extends ByteToMessageDecoder implements ChannelOutbo
     }
 
     private static int skipBytes(ByteBuf in, int payLoadLength) {
-        in.skipBytes(payLoadLength);
-        return payLoadLength;
+        int length = Math.min(in.readableBytes(), payLoadLength);
+        in.skipBytes(length);
+        return length;
     }
 
     private int decodeFrame(ChannelHandlerContext ctx, long longType, int payLoadLength, ByteBuf in, List<Object> out) {

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3FrameCodecTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3FrameCodecTest.java
@@ -811,6 +811,24 @@ public class Http3FrameCodecTest {
         assertFalse(codecChannel.writeInbound(buffer));
     }
 
+    @ParameterizedTest(name = "{index}: maxBlockedStreams = {0}, delayQpackStreams = {1}")
+    @MethodSource("dataNoFragment")
+    public void testSkipFragmentedUnknown(int maxBlockedStreams, boolean delayQpackStreams) throws Exception {
+        setUp(maxBlockedStreams, delayQpackStreams);
+        ByteBuf first = Unpooled.buffer();
+        writeVariableLengthInteger(first, 0xa);
+        writeVariableLengthInteger(first, 10);
+        first.writeZero(3);
+
+        assertFalse(codecChannel.writeInbound(first));
+
+        ByteBuf second = Unpooled.buffer();
+        second.writeZero(7);
+
+        assertFalse(codecChannel.writeInbound(second));
+        assertFalse(codecChannel.finish());
+    }
+
     private void testInvalidHttp3Frame0(boolean delayQpackStreams, int type, int length, Http3ErrorCode code) {
         ByteBuf buffer = Unpooled.buffer();
         writeVariableLengthInteger(buffer, type);


### PR DESCRIPTION
Motivation:
The Http3FrameCodec#skipBytes is used to discard the payload of unknown (and non-reserved) HTTP/3 frame types. The current implementation unconditionally calls in.skipBytes(payLoadLength):
```
private static int skipBytes(ByteBuf in, int payLoadLength) {
    in.skipBytes(payLoadLength);
    return payLoadLength;
}
```
It is invoked from two places in decodeFrame(...):
The longType > Integer.MAX_VALUE && !Http3CodecUtils.isReservedFrameType(longType) branch.
The default branch when !Http3CodecUtils.isReservedFrameType(longType).
Neither call site verifies that in.readableBytes() >= payLoadLength (unlike the reserved-frame path which explicitly returns 0 when the payload is not yet fully available). As a result, when the payload of an unknown frame is fragmented across multiple inbound reads, ByteBuf#skipBytes throws IndexOutOfBoundsException and breaks the connection, although HTTP/3 explicitly requires unknown frame types to be ignored (see draft-ietf-quic-http 7.2.8 and grease frame types).
Modifications:
Make Http3FrameCodec#skipBytes skip only what is currently readable and return the number of bytes actually consumed:
```
int length = Math.min(in.readableBytes(), payLoadLength);
in.skipBytes(length);
return length;
```
This is consistent with the existing partial-consume contract of decodeFrame(...): the caller in decode(...) already handles read < payLoadLength by decrementing payLoadLength and resuming on the next invocation, keeping type set so the same skip path is taken again until the whole payload has been discarded.
Add Http3FrameCodecTest#testSkipFragmentedUnknown, a regression test that:
writes an unknown, non-reserved frame type (4611686018427387903L, which hits the longType > Integer.MAX_VALUE branch) with a declared payload length of 10;
feeds only 3 bytes of payload first, then the remaining 7 in a second writeInbound;
asserts that no exception is thrown, no frame is emitted, and the channel finishes cleanly.
Result:
Http3FrameCodec no longer throws IndexOutOfBoundsException when the payload of an unknown (non-reserved) HTTP/3 frame is delivered across multiple reads. Unknown frames are correctly skipped as required by the HTTP/3 specification.