### PR TITLE
IpFilter: Deprecate constructor which use accept by default

### DIFF
--- a/handler/src/main/java/io/netty/handler/ipfilter/RuleBasedIpFilter.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/RuleBasedIpFilter.java
@@ -53,7 +53,9 @@ public class RuleBasedIpFilter extends AbstractRemoteAddressFilter<InetSocketAdd
      * <p> {@code acceptIfNotFound} is set to {@code true}. </p>
      *
      * @param rules An array of {@link IpFilterRule} containing all rules.
+     * @deprecated Use {@link RuleBasedIpFilter#RuleBasedIpFilter(boolean, IpFilterRule...)}
      */
+    @Deprecated
     public RuleBasedIpFilter(IpFilterRule... rules) {
         this(true, rules);
     }


### PR DESCRIPTION
Motivation:

We should better let the user explicit configure if something should be accepted by default or not so it's not done by mistake.

Modifications:

- Deprecate constructor which accept by default

Result:

Make user aware of default behaviour
