### PR TITLE
Port 5.0 Strictly validate MQTT UTF-8 Encoded Strings 

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
@@ -26,6 +26,10 @@ import io.netty.util.CharsetUtil;
 import io.netty.util.Signal;
 import io.netty.util.internal.ObjectUtil;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CodingErrorAction;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -94,18 +98,41 @@ public final class MqttDecoder extends ByteToMessageDecoder {
 
     private final int maxBytesInMessage;
     private final int maxClientIdLength;
+    private final boolean strictUtf8Validation;
+    // Lazily-initialised UTF-8 decoder reused across calls in the same channel/decoder
+    // instance. ByteToMessageDecoder is invoked from a single thread per channel, so a non
+    // thread-safe CharsetDecoder is safe to cache here.
+    private CharsetDecoder utf8Decoder;
 
     public MqttDecoder() {
-      this(DEFAULT_MAX_BYTES_IN_MESSAGE, DEFAULT_MAX_CLIENT_ID_LENGTH);
+        this(DEFAULT_MAX_BYTES_IN_MESSAGE, DEFAULT_MAX_CLIENT_ID_LENGTH, true);
     }
 
     public MqttDecoder(int maxBytesInMessage) {
-        this(maxBytesInMessage, DEFAULT_MAX_CLIENT_ID_LENGTH);
+        this(maxBytesInMessage, DEFAULT_MAX_CLIENT_ID_LENGTH, true);
     }
 
     public MqttDecoder(int maxBytesInMessage, int maxClientIdLength) {
+        this(maxBytesInMessage, maxClientIdLength, true);
+    }
+
+    /**
+     * Creates a new {@link MqttDecoder}.
+     *
+     * @param maxBytesInMessage     the maximum number of bytes a decoded message may consume.
+     * @param maxClientIdLength     the maximum length of the Client Identifier (CONNECT payload).
+     * @param strictUtf8Validation  if {@code true} (default), every UTF-8 Encoded String is
+     *                              validated according to MQTT 3.1.1 and MQTT 5.0
+     *                              malformed UTF-8 sequences (including
+     *                              surrogates and overlong forms) and an embedded U+0000 are
+     *                              rejected as a Malformed Packet. If {@code false}, the legacy
+     *                              behaviour is preserved, malformed bytes are silently replaced
+     *                              with {@code U+FFFD} and U+0000 is accepted.
+     */
+    public MqttDecoder(int maxBytesInMessage, int maxClientIdLength, boolean strictUtf8Validation) {
         this.maxBytesInMessage = ObjectUtil.checkPositive(maxBytesInMessage, "maxBytesInMessage");
         this.maxClientIdLength = ObjectUtil.checkPositive(maxClientIdLength, "maxClientIdLength");
+        this.strictUtf8Validation = strictUtf8Validation;
     }
 
     @Override
@@ -696,11 +723,11 @@ public final class MqttDecoder extends ByteToMessageDecoder {
         }
     }
 
-    private static Result<String> decodeString(ByteBuf buffer) {
+    private Result<String> decodeString(ByteBuf buffer) {
         return decodeString(buffer, 0, Integer.MAX_VALUE);
     }
 
-    private static Result<String> decodeString(ByteBuf buffer, int minBytes, int maxBytes) {
+    private Result<String> decodeString(ByteBuf buffer, int minBytes, int maxBytes) {
         int size = decodeMsbLsb(buffer);
         int numberOfBytesConsumed = 2;
         if (size < minBytes || size > maxBytes) {
@@ -708,9 +735,56 @@ public final class MqttDecoder extends ByteToMessageDecoder {
             numberOfBytesConsumed += size;
             return new Result<String>(null, numberOfBytesConsumed);
         }
-        String s = buffer.readString(size, CharsetUtil.UTF_8);
+        final String s;
+        if (strictUtf8Validation) {
+            s = readStrictUtf8(buffer, size);
+        } else {
+            s = buffer.readString(size, CharsetUtil.UTF_8);
+        }
         numberOfBytesConsumed += size;
         return new Result<String>(s, numberOfBytesConsumed);
+    }
+
+    /**
+     * Reads {@code length} bytes from {@code buffer} and decodes them as a strictly validated
+     * UTF-8 Encoded String per MQTT 3.1.1 and MQTT 5.0.
+     * Throws a {@link DecoderException} if the sequence is malformed or contains U+0000.
+     */
+    private String readStrictUtf8(ByteBuf buffer, int length) {
+        if (length == 0) {
+            return "";
+        }
+        final int readerIndex = buffer.readerIndex();
+        final ByteBuffer nioBuf;
+        if (buffer.nioBufferCount() == 1) {
+            nioBuf = buffer.nioBuffer(readerIndex, length);
+        } else {
+            // Composite/multi-component buffer: copy out to ensure a contiguous view for the
+            // CharsetDecoder. Strict UTF-8 validation requires examining all bytes anyway.
+            byte[] tmp = new byte[length];
+            buffer.getBytes(readerIndex, tmp);
+            nioBuf = ByteBuffer.wrap(tmp);
+        }
+        if (utf8Decoder == null) {
+            utf8Decoder = CharsetUtil.UTF_8.newDecoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT);
+        }
+        utf8Decoder.reset();
+        final String s;
+        try {
+            s = utf8Decoder.decode(nioBuf).toString();
+        } catch (CharacterCodingException e) {
+            buffer.skipBytes(length);
+            throw new DecoderException("invalid UTF-8 string in MQTT packet", e);
+        }
+        buffer.skipBytes(length);
+        // The UTF-8 Encoded String MUST NOT include an encoding
+        // of the null character U+0000. If received, this is a Malformed Packet.
+        if (s.indexOf('\u0000') >= 0) {
+            throw new DecoderException("MQTT UTF-8 Encoded String must not contain U+0000");
+        }
+        return s;
     }
 
     /**
@@ -788,7 +862,7 @@ public final class MqttDecoder extends ByteToMessageDecoder {
         }
     }
 
-    private static Result<MqttProperties> decodeProperties(ByteBuf buffer) {
+    private Result<MqttProperties> decodeProperties(ByteBuf buffer) {
         final long propertiesLength = decodeVariableByteInteger(buffer);
         int totalPropertiesLength = unpackA(propertiesLength);
         int numberOfBytesConsumed = unpackB(propertiesLength);

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
@@ -518,7 +518,7 @@ public class MqttCodecTest {
 
         validateFixedHeaders(message.fixedHeader(), decodedMessage.fixedHeader());
         validateConnectVariableHeader(message.variableHeader(),
-                (MqttConnectVariableHeader) decodedMessage.variableHeader());
+            (MqttConnectVariableHeader) decodedMessage.variableHeader());
         validateDecoderExceptionTooLargeMessage(decodedMessage);
     }
 
@@ -537,7 +537,7 @@ public class MqttCodecTest {
 
         validateFixedHeaders(message.fixedHeader(), decodedMessage.fixedHeader());
         validateConnectVariableHeader(message.variableHeader(),
-                (MqttConnectVariableHeader) decodedMessage.variableHeader());
+            (MqttConnectVariableHeader) decodedMessage.variableHeader());
         validateDecoderExceptionTooLargeMessage(decodedMessage);
     }
 
@@ -572,7 +572,7 @@ public class MqttCodecTest {
 
         validateFixedHeaders(message.fixedHeader(), decodedMessage.fixedHeader());
         validatePublishVariableHeader(message.variableHeader(),
-                (MqttPublishVariableHeader) decodedMessage.variableHeader());
+            (MqttPublishVariableHeader) decodedMessage.variableHeader());
         validateDecoderExceptionTooLargeMessage(decodedMessage);
     }
 

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
@@ -18,6 +18,7 @@ package io.netty.handler.codec.mqtt;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -61,6 +62,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -516,7 +518,7 @@ public class MqttCodecTest {
 
         validateFixedHeaders(message.fixedHeader(), decodedMessage.fixedHeader());
         validateConnectVariableHeader(message.variableHeader(),
-            (MqttConnectVariableHeader) decodedMessage.variableHeader());
+                (MqttConnectVariableHeader) decodedMessage.variableHeader());
         validateDecoderExceptionTooLargeMessage(decodedMessage);
     }
 
@@ -535,7 +537,7 @@ public class MqttCodecTest {
 
         validateFixedHeaders(message.fixedHeader(), decodedMessage.fixedHeader());
         validateConnectVariableHeader(message.variableHeader(),
-            (MqttConnectVariableHeader) decodedMessage.variableHeader());
+                (MqttConnectVariableHeader) decodedMessage.variableHeader());
         validateDecoderExceptionTooLargeMessage(decodedMessage);
     }
 
@@ -570,7 +572,7 @@ public class MqttCodecTest {
 
         validateFixedHeaders(message.fixedHeader(), decodedMessage.fixedHeader());
         validatePublishVariableHeader(message.variableHeader(),
-            (MqttPublishVariableHeader) decodedMessage.variableHeader());
+                (MqttPublishVariableHeader) decodedMessage.variableHeader());
         validateDecoderExceptionTooLargeMessage(decodedMessage);
     }
 
@@ -1213,7 +1215,7 @@ public class MqttCodecTest {
         assertArrayEquals(expected.grantedQoSLevels().toArray(), actual.grantedQoSLevels().toArray());
     }
 
-   private static void validateDecoderExceptionTooLargeMessage(MqttMessage message) {
+    private static void validateDecoderExceptionTooLargeMessage(MqttMessage message) {
         assertNull(message.payload());
         assertTrue(message.decoderResult().isFailure());
         Throwable cause = message.decoderResult().cause();
@@ -1245,5 +1247,151 @@ public class MqttCodecTest {
         final MqttProperties expectedProps = expected.properties();
         final MqttProperties actualProps = actual.properties();
         validateProperties(expectedProps, actualProps);
+    }
+
+    /**
+     * Builds a minimal MQTT 3.1.1 CONNECT packet whose ClientId field contains the supplied
+     * raw bytes (length prefix is computed automatically). Protocol = "MQTT", level = 4,
+     * clean-session flag set, keepalive 60.
+     */
+    private static ByteBuf buildConnectWithClientIdBytes(byte[] clientIdBytes) {
+        ByteBuf buf = Unpooled.buffer();
+        // variable header (10 bytes) + ClientId field (2 + N bytes); test packets stay small,
+        // so a single-byte Remaining Length is sufficient.
+        int remainingLength = 10 + 2 + clientIdBytes.length;
+        buf.writeByte(0x10); // CONNECT
+        buf.writeByte(remainingLength);
+        // Variable header
+        buf.writeShort(4);
+        buf.writeBytes(new byte[] {'M', 'Q', 'T', 'T'});
+        buf.writeByte(0x04); // protocol level (MQTT 3.1.1)
+        buf.writeByte(0x02); // clean session
+        buf.writeShort(60);  // keep alive
+        // Payload: ClientId
+        buf.writeShort(clientIdBytes.length);
+        buf.writeBytes(clientIdBytes);
+        return buf;
+    }
+
+    private static MqttMessage decodeUtf8TestPacket(MqttDecoder decoder, ByteBuf in) throws Exception {
+        EmbeddedChannel channel = new EmbeddedChannel(decoder);
+        try {
+            channel.writeInbound(in);
+            return channel.readInbound();
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    private static void assertMalformedUtf8(MqttMessage msg) {
+        assertNotNull(msg);
+        assertTrue(msg.decoderResult().isFailure(), "expected decoder failure but got: " + msg);
+        assertInstanceOf(DecoderException.class, msg.decoderResult().cause());
+    }
+
+    @Test
+    public void invalidTwoByteUtf8SequenceIsRejectedByDefault() throws Exception {
+        // 0xC3 must be followed by a 10xxxxxx continuation byte; 0x28 is not.
+        ByteBuf packet = buildConnectWithClientIdBytes(new byte[] {(byte) 0xC3, 0x28});
+        assertMalformedUtf8(decodeUtf8TestPacket(new MqttDecoder(), packet));
+    }
+
+    @Test
+    public void truncatedMultibyteUtf8SequenceIsRejected() throws Exception {
+        // Lone 0xC3 with no continuation byte at all (string ends mid-sequence).
+        ByteBuf packet = buildConnectWithClientIdBytes(new byte[] {(byte) 0xC3});
+        assertMalformedUtf8(decodeUtf8TestPacket(new MqttDecoder(), packet));
+    }
+
+    @Test
+    public void overlongNullUtf8EncodingIsRejected() throws Exception {
+        // 0xC0 0x80 is the (invalid) Modified-UTF-8 overlong encoding of U+0000.
+        ByteBuf packet = buildConnectWithClientIdBytes(new byte[] {(byte) 0xC0, (byte) 0x80});
+        assertMalformedUtf8(decodeUtf8TestPacket(new MqttDecoder(), packet));
+    }
+
+    @Test
+    public void isolatedHighSurrogateUtf8IsRejected() throws Exception {
+        // 0xED 0xA0 0x80 = U+D800, an unpaired UTF-16 high surrogate; not valid UTF-8.
+        ByteBuf packet = buildConnectWithClientIdBytes(new byte[] {(byte) 0xED, (byte) 0xA0, (byte) 0x80});
+        assertMalformedUtf8(decodeUtf8TestPacket(new MqttDecoder(), packet));
+    }
+
+    @Test
+    public void fiveByteOverlongUtf8SequenceIsRejected() throws Exception {
+        // 0xF8 starts a 5-byte sequence which is not allowed by RFC 3629.
+        ByteBuf packet = buildConnectWithClientIdBytes(
+                new byte[] {(byte) 0xF8, (byte) 0x88, (byte) 0x80, (byte) 0x80, (byte) 0x80});
+        assertMalformedUtf8(decodeUtf8TestPacket(new MqttDecoder(), packet));
+    }
+
+    @Test
+    public void embeddedNullCharacterInUtf8StringIsRejected() throws Exception {
+        // U+0000 must cause Malformed Packet.
+        ByteBuf packet = buildConnectWithClientIdBytes(new byte[] {'a', 0x00, 'b'});
+        assertMalformedUtf8(decodeUtf8TestPacket(new MqttDecoder(), packet));
+    }
+
+    @Test
+    public void wellFormedMultibyteUtf8IsAccepted() throws Exception {
+        byte[] cid = {'h', 'e', 'l', 'l', 'o'};
+        ByteBuf packet = buildConnectWithClientIdBytes(cid);
+        MqttMessage msg = decodeUtf8TestPacket(new MqttDecoder(), packet);
+        assertNotNull(msg);
+        try {
+            assertTrue(msg.decoderResult().isSuccess(),
+                    "expected success but got: " + msg.decoderResult().cause());
+            assertInstanceOf(MqttConnectMessage.class, msg);
+            assertEquals("hello", ((MqttConnectMessage) msg).payload().clientIdentifier());
+        } finally {
+            ReferenceCountUtil.release(msg);
+        }
+    }
+
+    @Test
+    public void emptyClientIdIsAcceptedUnderStrictUtf8() throws Exception {
+        ByteBuf packet = buildConnectWithClientIdBytes(new byte[0]);
+        MqttMessage msg = decodeUtf8TestPacket(new MqttDecoder(), packet);
+        assertNotNull(msg);
+        try {
+            assertTrue(msg.decoderResult().isSuccess());
+        } finally {
+            ReferenceCountUtil.release(msg);
+        }
+    }
+
+    @Test
+    public void legacyModeAcceptsMalformedUtf8AsReplacementChar() throws Exception {
+        ByteBuf packet = buildConnectWithClientIdBytes(new byte[] {(byte) 0xC3, 0x28});
+        MqttDecoder lenient = new MqttDecoder(8 * 1024 * 1024, 23, false);
+        MqttMessage msg = decodeUtf8TestPacket(lenient, packet);
+        assertNotNull(msg);
+        try {
+            assertTrue(msg.decoderResult().isSuccess(),
+                    "lenient mode should accept malformed UTF-8");
+            assertInstanceOf(MqttConnectMessage.class, msg);
+            String cid = ((MqttConnectMessage) msg).payload().clientIdentifier();
+            assertNotNull(cid);
+            // java.lang.String inserts U+FFFD for malformed input. Exact length is JDK
+            // implementation defined; just make sure decoding did not throw.
+            assertTrue(cid.indexOf('\uFFFD') >= 0 || cid.length() > 0,
+                    "expected replacement char or non-empty result");
+        } finally {
+            ReferenceCountUtil.release(msg);
+        }
+    }
+
+    @Test
+    public void legacyModeAcceptsEmbeddedNullCharacter() throws Exception {
+        ByteBuf packet = buildConnectWithClientIdBytes(new byte[] {'a', 0x00, 'b'});
+        MqttDecoder lenient = new MqttDecoder(8 * 1024 * 1024, 23, false);
+        MqttMessage msg = decodeUtf8TestPacket(lenient, packet);
+        assertNotNull(msg);
+        try {
+            assertTrue(msg.decoderResult().isSuccess());
+            assertEquals("a\u0000b", ((MqttConnectMessage) msg).payload().clientIdentifier());
+        } finally {
+            ReferenceCountUtil.release(msg);
+        }
     }
 }


### PR DESCRIPTION
Motivation:
Per MQTT 3.1.1 [MQTT-1.5.3-1] / MQTT 5.0 [MQTT-1.5.4-1], the character data in a UTF-8 Encoded String MUST be well-formed UTF-8 as defined by the Unicode specification and restated in RFC 3629. In particular it MUST NOT contain encodings of code points between U+D800 and U+DFFF, overlong sequences, or sequences longer than 4 bytes. If received, the Control Packet MUST be treated as a Malformed Packet.
MqttDecoder currently decodes every UTF-8 Encoded String via ByteBuf#readString(size, UTF_8), which delegates to new String(bytes, UTF_8). That constructor uses replacement semantics: malformed UTF-8 sequences are silently replaced with U+FFFD instead of being reported, and an embedded U+0000 byte is accepted. This affects every UTF-8 Encoded String in MQTT, including ClientId, Will Topic, Topic Name (PUBLISH / SUBSCRIBE / UNSUBSCRIBE filter), User Name, and the MQTT 5 string properties (Content Type, Response Topic, Reason String, Authentication Method, Server Reference, User Property, …). Beyond spec compliance, silently rewriting these fields can cause routing/ACL/identity mismatches between the wire representation and what the application sees.
Modifications:
	•	MqttDecoder now performs strict UTF-8 validation by default:
	◦	UTF-8 strings are decoded through a per-instance CharsetDecoder configured with CodingErrorAction.REPORT for both onMalformedInput and onUnmappableCharacter. Any CharacterCodingException is converted to a DecoderException.
	◦	After successful decoding, the resulting String is scanned for U+0000; if present, a DecoderException is thrown.
	◦	The exceptions propagate through the existing decode error path (MqttMessageFactory.newInvalidMessage), so callers continue to receive a single MqttMessage with decoderResult().isFailure() == true, matching the existing behaviour for other malformed-packet conditions (e.g. non-zero reserved flag).
	•	A new opt-out constructor MqttDecoder(int maxBytesInMessage, int maxClientIdLength, boolean strictUtf8Validation) is provided for users that need to retain the historical replacement-char behaviour. The pre-existing constructors delegate to it with strictUtf8Validation = true.
	•	The previously-static decodeString and decodeProperties helpers are converted to instance methods to access the new flag (the surrounding variable-header / payload decoders were already instance methods that call them; no signature changes for any other helpers).
	•	New tests in MqttCodecTest exercise:
	◦	invalid 2-byte continuation (0xC3 0x28)
	◦	truncated multi-byte sequence at end-of-string (lone 0xC3)
	◦	Modified-UTF-8 overlong NUL (0xC0 0x80)
	◦	isolated UTF-16 high surrogate (0xED 0xA0 0x80 → U+D800)
	◦	5-byte sequence forbidden by RFC 3629 (0xF8 …)
	◦	embedded U+0000
	◦	well-formed multi-byte UTF-8 ("hello") decodes successfully
	◦	empty ClientId is still accepted under strict mode
	◦	legacy mode (strictUtf8Validation = false) still accepts malformed UTF-8 (replaced with U+FFFD) and embedded U+0000
Result:
	•	MQTT spec [MQTT-1.5.3-1/2] and [MQTT-1.5.4-1/2] are enforced for every UTF-8 Encoded String parsed by MqttDecoder (ClientId, Will Topic, Topic Name, Topic Filter, User Name, MQTT 5 string properties, including User Property key/value pairs).
	•	Behaviour change: packets that previously decoded into messages containing U+FFFD or U+0000 will now be reported as malformed. Users relying on the old behaviour can opt out via the new constructor flag.
	•	No API removed; the existing MqttDecoder(), MqttDecoder(int) and MqttDecoder(int, int) constructors remain source- and binary- compatible.