### PR TITLE
Reject control characters at the boundary of the HTTP version token

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpVersion.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpVersion.java
@@ -21,7 +21,6 @@ import io.netty.util.internal.ObjectUtil;
 
 import java.util.Locale;
 
-import static io.netty.util.internal.ObjectUtil.checkNonEmptyAfterTrim;
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
 /**
@@ -66,8 +65,6 @@ public class HttpVersion implements Comparable<HttpVersion> {
         if (text == HTTP_1_0_STRING) {
             return HTTP_1_0;
         }
-
-        text = text.trim();
 
         if (text.isEmpty()) {
             throw new IllegalArgumentException("text is empty (possibly HTTP/0.9)");
@@ -124,7 +121,13 @@ public class HttpVersion implements Comparable<HttpVersion> {
         // toUpperCase() without an explicit Locale uses the JVM default. In Turkish locale
         // (tr_TR) 'i' uppercases to 'İ' (U+0130), which would corrupt protocol strings such
         // as "icap/1.0" or any custom HTTP-derived scheme that contains a lowercase 'i'.
-        text = checkNonEmptyAfterTrim(text, "text").toUpperCase(Locale.US);
+        // trim() is intentionally absent: control characters at the token boundary must not
+        // be silently discarded — they should cause the strict format check to fail instead.
+        ObjectUtil.checkNotNull(text, "text");
+        if (text.isEmpty()) {
+            throw new IllegalArgumentException("text must not be empty");
+        }
+        text = text.toUpperCase(Locale.US);
 
         if (strict) {
             // Only single digit major / minor version is allowed.
@@ -142,7 +145,7 @@ public class HttpVersion implements Comparable<HttpVersion> {
             int dotIndex = text.indexOf('.', slashIndex + 1);
 
             if (slashIndex <= 0 || dotIndex <= slashIndex + 1
-                    || dotIndex >= text.length() - 1 || hasWhitespace(text, slashIndex)) {
+                    || dotIndex >= text.length() - 1 || hasControlOrWhitespace(text, slashIndex)) {
                 throw new IllegalArgumentException("invalid version format: " + text);
             }
 
@@ -156,9 +159,10 @@ public class HttpVersion implements Comparable<HttpVersion> {
         bytes = null;
     }
 
-    private static boolean hasWhitespace(String s, int end) {
+    private static boolean hasControlOrWhitespace(String s, int end) {
         for (int i = 0; i < end; i++) {
-            if (Character.isWhitespace(s.charAt(i))) {
+            char c = s.charAt(i);
+            if (Character.isISOControl(c) || Character.isWhitespace(c)) {
                 return true;
             }
         }
@@ -204,13 +208,14 @@ public class HttpVersion implements Comparable<HttpVersion> {
             boolean keepAliveDefault, boolean bytes) {
         // See the comment in the (text, strict, keepAliveDefault) constructor for why this needs
         // an explicit Locale.US: avoids the Turkish-locale 'i' -> 'İ' corruption.
-        protocolName = checkNonEmptyAfterTrim(protocolName, "protocolName").toUpperCase(Locale.US);
+        ObjectUtil.checkNotNull(protocolName, "protocolName");
+        if (protocolName.isEmpty()) {
+            throw new IllegalArgumentException("protocolName must not be empty");
+        }
+        protocolName = protocolName.toUpperCase(Locale.US);
 
-        for (int i = 0; i < protocolName.length(); i ++) {
-            if (Character.isISOControl(protocolName.charAt(i)) ||
-                    Character.isWhitespace(protocolName.charAt(i))) {
-                throw new IllegalArgumentException("invalid character in protocolName");
-            }
+        if (hasControlOrWhitespace(protocolName, protocolName.length())) {
+            throw new IllegalArgumentException("invalid character in protocolName");
         }
 
         checkPositiveOrZero(majorVersion, "majorVersion");

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpVersion.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpVersion.java
@@ -121,8 +121,7 @@ public class HttpVersion implements Comparable<HttpVersion> {
         // toUpperCase() without an explicit Locale uses the JVM default. In Turkish locale
         // (tr_TR) 'i' uppercases to 'İ' (U+0130), which would corrupt protocol strings such
         // as "icap/1.0" or any custom HTTP-derived scheme that contains a lowercase 'i'.
-        // trim() is intentionally absent: control characters at the token boundary must not
-        // be silently discarded — they should cause the strict format check to fail instead.
+        // Control characters or whitespace at the token boundary must fail the checks below.
         ObjectUtil.checkNotNull(text, "text");
         if (text.isEmpty()) {
             throw new IllegalArgumentException("text must not be empty");

--- a/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspVersions.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspVersions.java
@@ -49,7 +49,7 @@ public final class RtspVersions {
             return RTSP_1_0;
         }
 
-        return new HttpVersion(text, true);
+        return new HttpVersion(upper, true);
     }
 
     private RtspVersions() {

--- a/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspVersions.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspVersions.java
@@ -44,7 +44,7 @@ public final class RtspVersions {
         }
         // toUpperCase() must specify Locale.US so the comparison against "RTSP/1.0" is not
         // affected by the JVM default locale (e.g. Turkish, where 'i' uppercases to 'İ').
-        // trim() is intentionally absent: control characters must not be silently discarded.
+        // Control characters in the version token must be rejected.
         String upper = text.toUpperCase(Locale.US);
         if ("RTSP/1.0".equals(upper)) {
             return RTSP_1_0;

--- a/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspVersions.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspVersions.java
@@ -44,7 +44,6 @@ public final class RtspVersions {
         }
         // toUpperCase() must specify Locale.US so the comparison against "RTSP/1.0" is not
         // affected by the JVM default locale (e.g. Turkish, where 'i' uppercases to 'İ').
-        // Control characters in the version token must be rejected.
         String upper = text.toUpperCase(Locale.US);
         if ("RTSP/1.0".equals(upper)) {
             return RTSP_1_0;

--- a/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspVersions.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspVersions.java
@@ -39,10 +39,14 @@ public final class RtspVersions {
     public static HttpVersion valueOf(String text) {
         ObjectUtil.checkNotNull(text, "text");
 
+        if (text.isEmpty()) {
+            throw new IllegalArgumentException("text must not be empty");
+        }
         // toUpperCase() must specify Locale.US so the comparison against "RTSP/1.0" is not
         // affected by the JVM default locale (e.g. Turkish, where 'i' uppercases to 'İ').
-        text = text.trim().toUpperCase(Locale.US);
-        if ("RTSP/1.0".equals(text)) {
+        // trim() is intentionally absent: control characters must not be silently discarded.
+        String upper = text.toUpperCase(Locale.US);
+        if ("RTSP/1.0".equals(upper)) {
             return RTSP_1_0;
         }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -1268,13 +1268,13 @@ public class HttpRequestDecoderTest {
 
     @Test
     public void testNulInVersionTokenIsRejected() {
-        // A NUL right before the version token must be rejected, not trimmed away.
+        // A NUL right before the version token must be rejected.
         testInvalidHeaders0("GET / " + (char) 0 + "HTTP/1.1\r\nHost: whatever\r\n\r\n");
     }
 
     @Test
     public void testNulInMethodTokenIsRejected() {
-        // Control case: a NUL inside the method token is rejected the same way as in the version token.
+        // Control case: a NUL inside the method token is also rejected.
         testInvalidHeaders0("GET" + (char) 0 + " / HTTP/1.1\r\nHost: whatever\r\n\r\n");
     }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -1268,50 +1268,14 @@ public class HttpRequestDecoderTest {
 
     @Test
     public void testNulInVersionTokenIsRejected() {
-        // "GET / \x00HTTP/1.1\r\nHost: example.com\r\n\r\n" - NUL right before the version token.
-        ByteBuf singleSp = Unpooled.buffer();
-        singleSp.writeCharSequence("GET / ", CharsetUtil.US_ASCII);
-        singleSp.writeByte(0x00);
-        singleSp.writeCharSequence("HTTP/1.1\r\nHost: example.com\r\n\r\n", CharsetUtil.US_ASCII);
-
-        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
-        assertTrue(channel.writeInbound(singleSp));
-        HttpRequest req = channel.readInbound();
-        assertNotNull(req);
-        assertTrue(req.decoderResult().isFailure());
-        assertInstanceOf(IllegalArgumentException.class, req.decoderResult().cause());
-        assertFalse(channel.finishAndReleaseAll());
-
-        // Same, but with two spaces between the URI and the version token.
-        ByteBuf doubleSp = Unpooled.buffer();
-        doubleSp.writeCharSequence("GET /  ", CharsetUtil.US_ASCII);
-        doubleSp.writeByte(0x00);
-        doubleSp.writeCharSequence("HTTP/1.1\r\nHost: example.com\r\n\r\n", CharsetUtil.US_ASCII);
-
-        EmbeddedChannel channel2 = new EmbeddedChannel(new HttpRequestDecoder());
-        assertTrue(channel2.writeInbound(doubleSp));
-        HttpRequest req2 = channel2.readInbound();
-        assertNotNull(req2);
-        assertTrue(req2.decoderResult().isFailure());
-        assertInstanceOf(IllegalArgumentException.class, req2.decoderResult().cause());
-        assertFalse(channel2.finishAndReleaseAll());
+        // A NUL right before the version token must be rejected, not trimmed away.
+        testInvalidHeaders0("GET / " + (char) 0 + "HTTP/1.1\r\nHost: whatever\r\n\r\n");
     }
 
     @Test
-    public void testTrailingNulInVersionTokenIsRejected() {
-        // "GET / HTTP/1.1\x00\r\nHost: example.com\r\n\r\n" - NUL right after the version token.
-        ByteBuf buf = Unpooled.buffer();
-        buf.writeCharSequence("GET / HTTP/1.1", CharsetUtil.US_ASCII);
-        buf.writeByte(0x00);
-        buf.writeCharSequence("\r\nHost: example.com\r\n\r\n", CharsetUtil.US_ASCII);
-
-        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
-        assertTrue(channel.writeInbound(buf));
-        HttpRequest req = channel.readInbound();
-        assertNotNull(req);
-        assertTrue(req.decoderResult().isFailure());
-        assertInstanceOf(IllegalArgumentException.class, req.decoderResult().cause());
-        assertFalse(channel.finishAndReleaseAll());
+    public void testNulInMethodTokenIsRejected() {
+        // Control case: a NUL inside the method token is rejected the same way as in the version token.
+        testInvalidHeaders0("GET" + (char) 0 + " / HTTP/1.1\r\nHost: whatever\r\n\r\n");
     }
 
     @Test
@@ -1325,24 +1289,7 @@ public class HttpRequestDecoderTest {
         assertEquals(HttpVersion.HTTP_1_1, req.protocolVersion());
         LastHttpContent last = channel.readInbound();
         assertNotNull(last);
-        last.release();
-        assertFalse(channel.finishAndReleaseAll());
-    }
-
-    @Test
-    public void testNulInMethodTokenIsRejected() {
-        // Control case: a NUL inside the method token is rejected the same way as in the version token.
-        ByteBuf buf = Unpooled.buffer();
-        buf.writeCharSequence("GET", CharsetUtil.US_ASCII);
-        buf.writeByte(0x00);
-        buf.writeCharSequence(" / HTTP/1.1\r\nHost: example.com\r\n\r\n", CharsetUtil.US_ASCII);
-
-        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
-        assertTrue(channel.writeInbound(buf));
-        HttpRequest req = channel.readInbound();
-        assertNotNull(req);
-        assertTrue(req.decoderResult().isFailure());
-        assertInstanceOf(IllegalArgumentException.class, req.decoderResult().cause());
-        assertFalse(channel.finishAndReleaseAll());
+        assertTrue(last.release());
+        assertFalse(channel.finish());
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -1280,7 +1280,7 @@ public class HttpRequestDecoderTest {
         assertNotNull(req);
         assertTrue(req.decoderResult().isFailure());
         assertInstanceOf(IllegalArgumentException.class, req.decoderResult().cause());
-        channel.finishAndReleaseAll();
+        assertFalse(channel.finishAndReleaseAll());
 
         // Same, but with two spaces between the URI and the version token.
         ByteBuf doubleSp = Unpooled.buffer();
@@ -1294,7 +1294,7 @@ public class HttpRequestDecoderTest {
         assertNotNull(req2);
         assertTrue(req2.decoderResult().isFailure());
         assertInstanceOf(IllegalArgumentException.class, req2.decoderResult().cause());
-        channel2.finishAndReleaseAll();
+        assertFalse(channel2.finishAndReleaseAll());
     }
 
     @Test
@@ -1311,7 +1311,7 @@ public class HttpRequestDecoderTest {
         assertNotNull(req);
         assertTrue(req.decoderResult().isFailure());
         assertInstanceOf(IllegalArgumentException.class, req.decoderResult().cause());
-        channel.finishAndReleaseAll();
+        assertFalse(channel.finishAndReleaseAll());
     }
 
     @Test
@@ -1323,7 +1323,10 @@ public class HttpRequestDecoderTest {
         assertNotNull(req);
         assertTrue(req.decoderResult().isSuccess());
         assertEquals(HttpVersion.HTTP_1_1, req.protocolVersion());
-        channel.finishAndReleaseAll();
+        LastHttpContent last = channel.readInbound();
+        assertNotNull(last);
+        last.release();
+        assertFalse(channel.finishAndReleaseAll());
     }
 
     @Test
@@ -1340,6 +1343,6 @@ public class HttpRequestDecoderTest {
         assertNotNull(req);
         assertTrue(req.decoderResult().isFailure());
         assertInstanceOf(IllegalArgumentException.class, req.decoderResult().cause());
-        channel.finishAndReleaseAll();
+        assertFalse(channel.finishAndReleaseAll());
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -1266,11 +1266,6 @@ public class HttpRequestDecoderTest {
         assertFalse(channel.finish());
     }
 
-    // Regression tests for #16970: a control byte at the version-token boundary used to be silently
-    // removed by HttpVersion.valueOf()'s String.trim() (which strips every char <= 0x20), so the
-    // decoder accepted a malformed request as a clean HTTP/1.1 one. The method token was already
-    // protected by #16723. NUL bytes are written directly to the buffer so the source stays ASCII.
-
     @Test
     public void testNulInVersionTokenIsRejected() {
         // "GET / \x00HTTP/1.1\r\nHost: example.com\r\n\r\n" - NUL right before the version token.
@@ -1280,9 +1275,11 @@ public class HttpRequestDecoderTest {
         singleSp.writeCharSequence("HTTP/1.1\r\nHost: example.com\r\n\r\n", CharsetUtil.US_ASCII);
 
         EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
-        channel.writeInbound(singleSp);
+        assertTrue(channel.writeInbound(singleSp));
         HttpRequest req = channel.readInbound();
+        assertNotNull(req);
         assertTrue(req.decoderResult().isFailure());
+        assertInstanceOf(IllegalArgumentException.class, req.decoderResult().cause());
         channel.finishAndReleaseAll();
 
         // Same, but with two spaces between the URI and the version token.
@@ -1292,9 +1289,11 @@ public class HttpRequestDecoderTest {
         doubleSp.writeCharSequence("HTTP/1.1\r\nHost: example.com\r\n\r\n", CharsetUtil.US_ASCII);
 
         EmbeddedChannel channel2 = new EmbeddedChannel(new HttpRequestDecoder());
-        channel2.writeInbound(doubleSp);
+        assertTrue(channel2.writeInbound(doubleSp));
         HttpRequest req2 = channel2.readInbound();
+        assertNotNull(req2);
         assertTrue(req2.decoderResult().isFailure());
+        assertInstanceOf(IllegalArgumentException.class, req2.decoderResult().cause());
         channel2.finishAndReleaseAll();
     }
 
@@ -1307,18 +1306,21 @@ public class HttpRequestDecoderTest {
         buf.writeCharSequence("\r\nHost: example.com\r\n\r\n", CharsetUtil.US_ASCII);
 
         EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
-        channel.writeInbound(buf);
+        assertTrue(channel.writeInbound(buf));
         HttpRequest req = channel.readInbound();
+        assertNotNull(req);
         assertTrue(req.decoderResult().isFailure());
+        assertInstanceOf(IllegalArgumentException.class, req.decoderResult().cause());
         channel.finishAndReleaseAll();
     }
 
     @Test
     public void testNormalRequestStillDecodes() {
         EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
-        channel.writeInbound(Unpooled.copiedBuffer("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n",
-                CharsetUtil.US_ASCII));
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n",
+                CharsetUtil.US_ASCII)));
         HttpRequest req = channel.readInbound();
+        assertNotNull(req);
         assertTrue(req.decoderResult().isSuccess());
         assertEquals(HttpVersion.HTTP_1_1, req.protocolVersion());
         channel.finishAndReleaseAll();
@@ -1326,15 +1328,18 @@ public class HttpRequestDecoderTest {
 
     @Test
     public void testNulInMethodTokenIsRejected() {
-        // Control case for contrast: NUL before the method is already rejected since #16723.
+        // Control case: a NUL inside the method token is rejected the same way as in the version token.
         ByteBuf buf = Unpooled.buffer();
+        buf.writeCharSequence("GET", CharsetUtil.US_ASCII);
         buf.writeByte(0x00);
-        buf.writeCharSequence("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n", CharsetUtil.US_ASCII);
+        buf.writeCharSequence(" / HTTP/1.1\r\nHost: example.com\r\n\r\n", CharsetUtil.US_ASCII);
 
         EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
-        channel.writeInbound(buf);
+        assertTrue(channel.writeInbound(buf));
         HttpRequest req = channel.readInbound();
+        assertNotNull(req);
         assertTrue(req.decoderResult().isFailure());
+        assertInstanceOf(IllegalArgumentException.class, req.decoderResult().cause());
         channel.finishAndReleaseAll();
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -1289,7 +1289,7 @@ public class HttpRequestDecoderTest {
         assertEquals(HttpVersion.HTTP_1_1, req.protocolVersion());
         LastHttpContent last = channel.readInbound();
         assertNotNull(last);
-        assertTrue(last.release());
+        last.release();
         assertFalse(channel.finish());
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -1265,4 +1265,76 @@ public class HttpRequestDecoderTest {
         assertTrue(request.decoderResult().isFailure());
         assertFalse(channel.finish());
     }
+
+    // Regression tests for #16970: a control byte at the version-token boundary used to be silently
+    // removed by HttpVersion.valueOf()'s String.trim() (which strips every char <= 0x20), so the
+    // decoder accepted a malformed request as a clean HTTP/1.1 one. The method token was already
+    // protected by #16723. NUL bytes are written directly to the buffer so the source stays ASCII.
+
+    @Test
+    public void testNulInVersionTokenIsRejected() {
+        // "GET / \x00HTTP/1.1\r\nHost: example.com\r\n\r\n" - NUL right before the version token.
+        ByteBuf singleSp = Unpooled.buffer();
+        singleSp.writeCharSequence("GET / ", CharsetUtil.US_ASCII);
+        singleSp.writeByte(0x00);
+        singleSp.writeCharSequence("HTTP/1.1\r\nHost: example.com\r\n\r\n", CharsetUtil.US_ASCII);
+
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
+        channel.writeInbound(singleSp);
+        HttpRequest req = channel.readInbound();
+        assertTrue(req.decoderResult().isFailure());
+        channel.finishAndReleaseAll();
+
+        // Same, but with two spaces between the URI and the version token.
+        ByteBuf doubleSp = Unpooled.buffer();
+        doubleSp.writeCharSequence("GET /  ", CharsetUtil.US_ASCII);
+        doubleSp.writeByte(0x00);
+        doubleSp.writeCharSequence("HTTP/1.1\r\nHost: example.com\r\n\r\n", CharsetUtil.US_ASCII);
+
+        EmbeddedChannel channel2 = new EmbeddedChannel(new HttpRequestDecoder());
+        channel2.writeInbound(doubleSp);
+        HttpRequest req2 = channel2.readInbound();
+        assertTrue(req2.decoderResult().isFailure());
+        channel2.finishAndReleaseAll();
+    }
+
+    @Test
+    public void testTrailingNulInVersionTokenIsRejected() {
+        // "GET / HTTP/1.1\x00\r\nHost: example.com\r\n\r\n" - NUL right after the version token.
+        ByteBuf buf = Unpooled.buffer();
+        buf.writeCharSequence("GET / HTTP/1.1", CharsetUtil.US_ASCII);
+        buf.writeByte(0x00);
+        buf.writeCharSequence("\r\nHost: example.com\r\n\r\n", CharsetUtil.US_ASCII);
+
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
+        channel.writeInbound(buf);
+        HttpRequest req = channel.readInbound();
+        assertTrue(req.decoderResult().isFailure());
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    public void testNormalRequestStillDecodes() {
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
+        channel.writeInbound(Unpooled.copiedBuffer("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n",
+                CharsetUtil.US_ASCII));
+        HttpRequest req = channel.readInbound();
+        assertTrue(req.decoderResult().isSuccess());
+        assertEquals(HttpVersion.HTTP_1_1, req.protocolVersion());
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    public void testNulInMethodTokenIsRejected() {
+        // Control case for contrast: NUL before the method is already rejected since #16723.
+        ByteBuf buf = Unpooled.buffer();
+        buf.writeByte(0x00);
+        buf.writeCharSequence("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n", CharsetUtil.US_ASCII);
+
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
+        channel.writeInbound(buf);
+        HttpRequest req = channel.readInbound();
+        assertTrue(req.decoderResult().isFailure());
+        channel.finishAndReleaseAll();
+    }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpVersionParsingTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpVersionParsingTest.java
@@ -109,6 +109,56 @@ public class HttpVersionParsingTest {
         );
     }
 
+    // Regression tests for #16970: a boundary control byte on the version token used to be silently
+    // removed by String.trim() (which strips every char <= 0x20), so a malformed version was accepted
+    // as a clean one. This is the same request-smuggling class #16723 closed for the method token.
+    // Control bytes are built with (char) casts so the source stays ASCII-only.
+
+    @Test
+    void testLeadingNulInStrictValueOfIsRejected() {
+        String text = (char) 0x00 + "HTTP/1.1";
+        assertThrows(IllegalArgumentException.class, () -> HttpVersion.valueOf(text, true),
+                "leading NUL must not be trimmed away");
+    }
+
+    @Test
+    void testTrailingNulInStrictValueOfIsRejected() {
+        String text = "HTTP/1.1" + (char) 0x00;
+        assertThrows(IllegalArgumentException.class, () -> HttpVersion.valueOf(text, true),
+                "trailing NUL must not be trimmed away");
+    }
+
+    @Test
+    void testLeadingControlCharInStrictValueOfIsRejected() {
+        // CR, LF, VT and FF were all silently removed by the previous String.trim().
+        for (int control : new int[] {0x0D, 0x0A, 0x0B, 0x0C}) {
+            String text = (char) control + "HTTP/1.1";
+            assertThrows(IllegalArgumentException.class, () -> HttpVersion.valueOf(text, true),
+                    "control char 0x" + Integer.toHexString(control) + " must be rejected");
+        }
+    }
+
+    @Test
+    void testLeadingSpaceInStrictValueOfIsRejected() {
+        // Previously trim() removed the leading space and "HTTP/1.1" was accepted.
+        assertThrows(IllegalArgumentException.class, () -> HttpVersion.valueOf(" HTTP/1.1", true),
+                "leading space must not be trimmed away");
+    }
+
+    @Test
+    void testLeadingNulInNonStrictValueOfIsRejected() {
+        String text = (char) 0x00 + "HTTP/1.1";
+        assertThrows(IllegalArgumentException.class, () -> HttpVersion.valueOf(text),
+                "leading NUL must be rejected in non-strict mode too");
+    }
+
+    @Test
+    void testStandardVersionsStillResolveAfterFix() {
+        assertSame(HttpVersion.HTTP_1_1, HttpVersion.valueOf("HTTP/1.1", true));
+        assertSame(HttpVersion.HTTP_1_0, HttpVersion.valueOf("HTTP/1.0"));
+        assertEquals("ICAP", HttpVersion.valueOf("icap/1.0").protocolName());
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {
             "HTTP ",

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpVersionParsingTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpVersionParsingTest.java
@@ -135,7 +135,7 @@ public class HttpVersionParsingTest {
 
     @Test
     void testLeadingSpaceInStrictValueOfIsRejected() {
-        // A leading space must be rejected, not silently accepted as "HTTP/1.1".
+        // A leading space in the version token must be rejected.
         assertThrows(IllegalArgumentException.class, () -> HttpVersion.valueOf(" HTTP/1.1", true),
                 "leading space must be rejected");
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpVersionParsingTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpVersionParsingTest.java
@@ -109,28 +109,23 @@ public class HttpVersionParsingTest {
         );
     }
 
-    // Regression tests for #16970: a boundary control byte on the version token used to be silently
-    // removed by String.trim() (which strips every char <= 0x20), so a malformed version was accepted
-    // as a clean one. This is the same request-smuggling class #16723 closed for the method token.
-    // Control bytes are built with (char) casts so the source stays ASCII-only.
-
     @Test
     void testLeadingNulInStrictValueOfIsRejected() {
         String text = (char) 0x00 + "HTTP/1.1";
         assertThrows(IllegalArgumentException.class, () -> HttpVersion.valueOf(text, true),
-                "leading NUL must not be trimmed away");
+                "leading NUL must be rejected");
     }
 
     @Test
     void testTrailingNulInStrictValueOfIsRejected() {
         String text = "HTTP/1.1" + (char) 0x00;
         assertThrows(IllegalArgumentException.class, () -> HttpVersion.valueOf(text, true),
-                "trailing NUL must not be trimmed away");
+                "trailing NUL must be rejected");
     }
 
     @Test
     void testLeadingControlCharInStrictValueOfIsRejected() {
-        // CR, LF, VT and FF were all silently removed by the previous String.trim().
+        // CR, LF, VT and FF must all be rejected in the version token.
         for (int control : new int[] {0x0D, 0x0A, 0x0B, 0x0C}) {
             String text = (char) control + "HTTP/1.1";
             assertThrows(IllegalArgumentException.class, () -> HttpVersion.valueOf(text, true),
@@ -140,9 +135,9 @@ public class HttpVersionParsingTest {
 
     @Test
     void testLeadingSpaceInStrictValueOfIsRejected() {
-        // Previously trim() removed the leading space and "HTTP/1.1" was accepted.
+        // A leading space must be rejected, not silently accepted as "HTTP/1.1".
         assertThrows(IllegalArgumentException.class, () -> HttpVersion.valueOf(" HTTP/1.1", true),
-                "leading space must not be trimmed away");
+                "leading space must be rejected");
     }
 
     @Test

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpVersionParsingTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpVersionParsingTest.java
@@ -148,7 +148,7 @@ public class HttpVersionParsingTest {
     }
 
     @Test
-    void testStandardVersionsStillResolveAfterFix() {
+    void testValidVersionsResolveCorrectly() {
         assertSame(HttpVersion.HTTP_1_1, HttpVersion.valueOf("HTTP/1.1", true));
         assertSame(HttpVersion.HTTP_1_0, HttpVersion.valueOf("HTTP/1.0"));
         assertEquals("ICAP", HttpVersion.valueOf("icap/1.0").protocolName());


### PR DESCRIPTION
Motivation:

`HttpRequestDecoder` accepts a request whose HTTP-version token carries a boundary control byte (`NUL`, `CR`, `LF`, `VT`, `FF`, …):

```bash
printf 'GET / \x00HTTP/1.1\r\nHost: localhost\r\n\r\n' | nc <host> <port>
# decoded as a clean HTTP/1.1 request; no decoder failure
```

`HttpVersion.valueOf(String, boolean)` ran `text.trim()` before matching the version, and `String.trim()` removes every character with code point `<= 0x20`. The boundary control byte was therefore silently stripped and the surviving `"HTTP/1.1"` matched the cached constant, so the malformed request decoded as a clean `HTTP/1.1` one.

The method token on the same request line already rejects such a byte since #16723 (issue #15047), so the two tokens were inconsistent — this is the same boundary-control-character / request-smuggling class, left open for the version token.

Modification:

- `HttpVersion`: drop the `trim()` in `valueOf` and in the `HttpVersion(String, boolean, boolean)` constructor. The existing strict format check (`length == 8 && startsWith("HTTP/") && charAt(6) == '.'`) now rejects a token padded with a control byte, and the non-strict path rejects control/whitespace in the protocol name via `hasControlOrWhitespace`. Without the `trim()`, `SP`/`HT` padding is rejected too, mirroring the method-token behaviour from #16723.
- `RtspVersions.valueOf`: drop the `trim()` the same way.

`HttpRequestDecoder` already turns `createMessage` exceptions into a decoder failure, so the wire effect is `decoderResult().isSuccess() == false` instead of a phantom `HTTP/1.1`.

Result:

Before this change `"GET / \x00HTTP/1.1\r\n…"` decoded successfully (`decoderResult().isSuccess() == true`, `protocolVersion() == HTTP_1_1`); after it the decoder reports a failure, matching the method-token behaviour. A clean `HTTP/1.1` request still decodes as before.

```
Test set: io.netty.handler.codec.http.HttpVersionParsingTest
Tests run: 53, Failures: 0, Errors: 0, Skipped: 0
Test set: io.netty.handler.codec.http.HttpRequestDecoderTest
Tests run: 85, Failures: 0, Errors: 0, Skipped: 0
Test set: io.netty.handler.codec.rtsp.RtspDecoderTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
Test set: io.netty.handler.codec.rtsp.RtspEncoderTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
```

Fixes #16970
