### PR TITLE
Hold back trailing CR for length-less multipart parts

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
@@ -1217,9 +1217,12 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
             }
             posDelimiter = HttpPostBodyUtil.findLastLineBreak(undecodedChunk, startReaderIndex + lastPosition);
             // No LineBreak, however CR can be at the end of the buffer, LF not yet there (issue #11668)
-            // Check if last CR (if any) shall not be in the content (definedLength vs actual length + buffer - 1)
+            // Check if last CR (if any) shall not be in the content (definedLength vs actual length + buffer - 1).
+            // For length-less parts (definedLength == 0, e.g. a field without Content-Length) we can't use the
+            // length equality, so hold a trailing CR back too: it may be the CR of a future boundary CRLF.
             if (posDelimiter < 0 &&
-                httpData.definedLength() == httpData.length() + readableBytes - 1 &&
+                (httpData.definedLength() == httpData.length() + readableBytes - 1 ||
+                 httpData.definedLength() == 0) &&
                 undecodedChunk.getByte(readableBytes + startReaderIndex - 1) == HttpConstants.CR) {
                 // Last CR shall precede a future LF
                 lastPosition = 0;

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostMultiPartRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostMultiPartRequestDecoderTest.java
@@ -43,6 +43,32 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class HttpPostMultiPartRequestDecoderTest {
 
     @Test
+    public void testHeaderlessFieldTrailingCrSplitAcrossChunks() throws Exception {
+        // A field without Content-Length (the RFC 7578 norm). The chunk boundary falls between the
+        // value's trailing CR and the boundary's LF; the CR must not leak into the decoded value.
+        String boundary = "boundary";
+        String prefix = "--" + boundary + "\r\n" +
+                        "Content-Disposition: form-data; name=\"field1\"\r\n\r\n";
+        String value = "value1";
+        String suffix = "\r\n--" + boundary + "--\r\n";
+        byte[] full = (prefix + value + suffix).getBytes(CharsetUtil.US_ASCII);
+        int afterCr = (prefix + value + "\r").length();
+
+        HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/upload");
+        request.headers().set(HttpHeaderNames.CONTENT_TYPE, "multipart/form-data; boundary=" + boundary);
+
+        HttpDataFactory factory = new DefaultHttpDataFactory(false);
+        HttpPostMultipartRequestDecoder decoder = new HttpPostMultipartRequestDecoder(factory, request);
+        decoder.offer(new DefaultHttpContent(Unpooled.wrappedBuffer(full, 0, afterCr)));
+        decoder.offer(new DefaultHttpContent(Unpooled.wrappedBuffer(full, afterCr, full.length - afterCr)));
+        decoder.offer(new DefaultLastHttpContent());
+
+        Attribute field = (Attribute) decoder.getBodyHttpDatas().get(0);
+        assertEquals("value1", field.getValue());
+        decoder.destroy();
+    }
+
+    @Test
     public void testDecodeFullHttpRequestWithNoContentTypeHeader() {
         FullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
         try {


### PR DESCRIPTION
## Problem

The trailing-CR guard added for #11668 in `HttpPostMultipartRequestDecoder.loadDataMultipartOptimized` only fires when the part has a **known length**:

```java
if (posDelimiter < 0 &&
    httpData.definedLength() == httpData.length() + readableBytes - 1 &&
    undecodedChunk.getByte(readableBytes + startReaderIndex - 1) == HttpConstants.CR) {
    // hold the trailing CR back as a possible boundary-CRLF prefix
}
```

A multipart field **without a `Content-Length`** — the RFC 7578 norm for form fields — has `definedLength() == 0`, so the length equality never holds. When a network chunk boundary falls between the value's trailing `\r` and the boundary's `\n`, that `\r` is wrongly kept as part of the value: `value1` decodes as `value1\r`.

## Fix

Also hold the trailing `CR` back when `definedLength() == 0` (length-less part): without a known length we can't use the equality to distinguish the CR from a boundary CRLF prefix, so we defer it to the next chunk — exactly what the known-length branch already does (and the existing held-back-CR plumbing handles the next chunk correctly, whether it turns out to be the boundary or more content). Parts with a known length are unaffected.

Added a test that feeds a length-less field split between the value's CR and the boundary LF.

## Result

Length-less multipart fields no longer leak a trailing `\r` into their value when the boundary CRLF is split across chunks. Full multipart decoder test suite (64 tests across the 4 decoder test classes) passes.