### PR TITLE
Correctly release and fail queued traffic-shaping writes on close (#16959)

### DIFF
--- a/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
@@ -28,7 +28,7 @@ import io.netty.channel.FileRegion;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.CompletionHandler;
-import io.netty.util.concurrent.Promise;
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -577,6 +577,14 @@ public abstract class AbstractTrafficShapingHandler implements ChannelInboundHan
 
     abstract void submitWrite(
             ChannelHandlerContext ctx, Object msg, long size, long delay, long now, CompletionHandler<Void> handler);
+
+    /**
+     * Releases the given {@code msg} and fails the given {@code promise} with the supplied {@code cause}.
+     */
+    static void releaseAndFailQueuedWrite(Object msg, CompletionHandler<Void> handler, Throwable cause) {
+        ReferenceCountUtil.safeRelease(msg);
+        handler.failure(cause);
+    }
 
     @Override
     public void channelRegistered(ChannelHandlerContext ctx) throws Exception {

--- a/handler/src/main/java/io/netty/handler/traffic/ChannelTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/ChannelTrafficShapingHandler.java
@@ -15,10 +15,10 @@
  */
 package io.netty.handler.traffic;
 
-import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.concurrent.CompletionHandler;
 
+import java.nio.channels.ClosedChannelException;
 import java.util.ArrayDeque;
 import java.util.concurrent.TimeUnit;
 
@@ -148,12 +148,12 @@ public class ChannelTrafficShapingHandler extends AbstractTrafficShapingHandler 
                     queueSize -= size;
                     ctx.write(toSend.toSend, toSend.handler);
                 }
-            } else {
+            } else if (!messagesQueue.isEmpty()) {
+                ClosedChannelException cause = new ClosedChannelException();
                 for (ToSend toSend : messagesQueue) {
-                    if (toSend.toSend instanceof ByteBuf) {
-                        ((ByteBuf) toSend.toSend).release();
-                    }
+                    releaseAndFailQueuedWrite(toSend.toSend, toSend.handler, cause);
                 }
+                queueSize = 0;
             }
             messagesQueue.clear();
         }

--- a/handler/src/main/java/io/netty/handler/traffic/GlobalChannelTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/GlobalChannelTrafficShapingHandler.java
@@ -19,7 +19,6 @@ import static io.netty.util.internal.ObjectUtil.checkNotNullWithIAE;
 import static io.netty.util.internal.ObjectUtil.checkPositive;
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
-import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelHandlerContext;
@@ -29,6 +28,7 @@ import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
+import java.nio.channels.ClosedChannelException;
 import java.util.AbstractCollection;
 import java.util.ArrayDeque;
 import java.util.Collection;
@@ -497,13 +497,13 @@ public class GlobalChannelTrafficShapingHandler extends AbstractTrafficShapingHa
                         queuesSize.addAndGet(-size);
                         ctx.write(toSend.toSend, toSend.handler);
                     }
-                } else {
+                } else if (!perChannel.messagesQueue.isEmpty()) {
                     queuesSize.addAndGet(-perChannel.queueSize);
+                    ClosedChannelException cause = new ClosedChannelException();
                     for (ToSend toSend : perChannel.messagesQueue) {
-                        if (toSend.toSend instanceof ByteBuf) {
-                            ((ByteBuf) toSend.toSend).release();
-                        }
+                        releaseAndFailQueuedWrite(toSend.toSend, toSend.handler, cause);
                     }
+                    perChannel.queueSize = 0;
                 }
                 perChannel.messagesQueue.clear();
             }

--- a/handler/src/main/java/io/netty/handler/traffic/GlobalTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/GlobalTrafficShapingHandler.java
@@ -15,13 +15,13 @@
  */
 package io.netty.handler.traffic;
 
-import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.concurrent.CompletionHandler;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.internal.ObjectUtil;
 
+import java.nio.channels.ClosedChannelException;
 import java.util.ArrayDeque;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -279,13 +279,13 @@ public class GlobalTrafficShapingHandler extends AbstractTrafficShapingHandler {
                         queuesSize.addAndGet(-size);
                         ctx.write(toSend.toSend, toSend.handler);
                     }
-                } else {
+                } else if (!perChannel.messagesQueue.isEmpty()) {
                     queuesSize.addAndGet(-perChannel.queueSize);
+                    ClosedChannelException cause = new ClosedChannelException();
                     for (ToSend toSend : perChannel.messagesQueue) {
-                        if (toSend.toSend instanceof ByteBuf) {
-                            ((ByteBuf) toSend.toSend).release();
-                        }
+                        releaseAndFailQueuedWrite(toSend.toSend, toSend.handler, cause);
                     }
+                    perChannel.queueSize = 0;
                 }
                 perChannel.messagesQueue.clear();
             }

--- a/handler/src/test/java/io/netty/handler/traffic/TrafficShapingHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/traffic/TrafficShapingHandlerTest.java
@@ -16,8 +16,12 @@
 
 package io.netty.handler.traffic;
 
+import java.nio.channels.ClosedChannelException;
+
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufHolder;
+import io.netty.buffer.DefaultByteBufHolder;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -25,6 +29,7 @@ import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalChannel;
 import io.netty.channel.local.LocalIoHandler;
@@ -33,18 +38,23 @@ import io.netty.util.Attribute;
 import io.netty.util.CharsetUtil;
 import io.netty.util.concurrent.DefaultEventExecutorGroup;
 import io.netty.util.concurrent.EventExecutorGroup;
+import io.netty.util.concurrent.Promise;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Disabled("FIX implementation")
 public class TrafficShapingHandlerTest {
 
     private static final long READ_LIMIT_BYTES_PER_SECOND = 1;
     private static final EventExecutorGroup SES = new DefaultEventExecutorGroup(1);
+    private static final long WRITE_LIMIT_BYTES_PER_SECOND = 1;
     private static final EventLoopGroup GROUP = new MultiThreadIoEventLoopGroup(1, LocalIoHandler.newFactory());
 
     @AfterAll
@@ -71,6 +81,47 @@ public class TrafficShapingHandlerTest {
         } finally {
             trafficHandler2.release();
         }
+    }
+
+    @Test
+    public void testQueuedWritesReleasedAndFailedOnClose() throws Exception {
+        testQueuedWritesReleasedAndFailedOnClose0(new ChannelTrafficShapingHandler(
+                WRITE_LIMIT_BYTES_PER_SECOND, 0, 0));
+
+        GlobalTrafficShapingHandler trafficHandler1 =
+                new GlobalTrafficShapingHandler(SES.next(), WRITE_LIMIT_BYTES_PER_SECOND, 0, 0);
+        try {
+            testQueuedWritesReleasedAndFailedOnClose0(trafficHandler1);
+        } finally {
+            trafficHandler1.release();
+        }
+
+        GlobalChannelTrafficShapingHandler trafficHandler2 =
+                new GlobalChannelTrafficShapingHandler(SES.next(), WRITE_LIMIT_BYTES_PER_SECOND, 0,
+                        WRITE_LIMIT_BYTES_PER_SECOND, 0, 0);
+        try {
+            testQueuedWritesReleasedAndFailedOnClose0(trafficHandler2);
+        } finally {
+            trafficHandler2.release();
+        }
+    }
+
+    private static void testQueuedWritesReleasedAndFailedOnClose0(AbstractTrafficShapingHandler trafficHandler)
+            throws Exception {
+        EmbeddedChannel ch = new EmbeddedChannel(trafficHandler);
+        ByteBufHolder holder = new DefaultByteBufHolder(Unpooled.buffer(64).writeZero(64));
+        Promise<Void> promise = ch.newPromise();
+
+        ch.writeOneOutbound(holder, promise);
+        assertFalse(promise.isDone());
+        assertNull(ch.readOutbound());
+        assertEquals(1, holder.refCnt());
+
+        ch.close().syncUninterruptibly();
+        assertEquals(0, holder.refCnt());
+        assertTrue(promise.isDone());
+        assertTrue(promise.cause() instanceof ClosedChannelException);
+        assertFalse(ch.finishAndReleaseAll());
     }
 
     private void testHandlerRemove0(final AbstractTrafficShapingHandler trafficHandler)


### PR DESCRIPTION
Motivation:
The AbstractTrafficShapingHandler#calculateSize supports ByteBuf,
ByteBufHolder, and FileRegion, so traffic-shaping handlers may queue
delayed ByteBufHolder messages such as HTTP content.
When a channel becomes inactive and queued writes are discarded,
ChannelTrafficShapingHandler, GlobalTrafficShapingHandler, and
GlobalChannelTrafficShapingHandler only release messages that are direct
ByteBuf instances. This leaks queued ByteBufHolder / other
ReferenceCounted messages. The corresponding write promises are also
left incomplete even though the messages will never be written.

Modifications:
• Add a shared queued-write cleanup helper in
AbstractTrafficShapingHandler.
• Use ReferenceCountUtil.safeRelease(...) instead of instanceof ByteBuf
checks.
•	Fail discarded queued write promises with ClosedChannelException.
• Reset per-channel queue size after discarded queued writes are cleaned
up.
•	Add tests covering queued ByteBufHolder writes for:
◦	ChannelTrafficShapingHandler
◦	GlobalTrafficShapingHandler
◦	GlobalChannelTrafficShapingHandler

Result:
Queued delayed writes are cleaned up consistently when the channel is
closed: reference-counted messages are released and callers waiting on
write promises are notified with failure. Internal queue-size accounting
is left in a clean state on removal.

---------

Co-authored-by: Norman Maurer <norman_maurer@apple.com>
