### PR TITLE
Add RFC 10008 QUERY Method support (#16966)

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderNames.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderNames.java
@@ -50,6 +50,10 @@ public final class HttpHeaderNames {
      */
     public static final AsciiString ACCEPT_PATCH = AsciiString.cached("accept-patch");
     /**
+     * {@code "accept-query"}
+     */
+    public static final AsciiString ACCEPT_QUERY = AsciiString.cached("accept-query");
+    /**
      * {@code "access-control-allow-credentials"}
      */
     public static final AsciiString ACCESS_CONTROL_ALLOW_CREDENTIALS =

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpMethod.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpMethod.java
@@ -86,6 +86,12 @@ public class HttpMethod implements Comparable<HttpMethod> {
     public static final HttpMethod CONNECT = new HttpMethod(AsciiString.cached("CONNECT"));
 
     /**
+     * The QUERY method requests that the request target process the enclosed content in a safe and
+     * idempotent manner and then respond with the result of that processing.
+     */
+    public static final HttpMethod QUERY = new HttpMethod(AsciiString.cached("QUERY"));
+
+    /**
      * Returns the {@link HttpMethod} represented by the specified name.
      * If the specified name is a standard HTTP method name, a cached instance
      * will be returned.  Otherwise, a new instance will be returned.
@@ -109,6 +115,8 @@ public class HttpMethod implements Comparable<HttpMethod> {
             return HttpMethod.DELETE;
         } else if (name.equals("TRACE")) {
             return HttpMethod.TRACE;
+        } else if (name.equals("QUERY")) {
+            return HttpMethod.QUERY;
         }
         return new HttpMethod(name);
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpHeaderValidationUtilTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpHeaderValidationUtilTest.java
@@ -50,6 +50,7 @@ public class HttpHeaderValidationUtilTest {
         list.add(header(false, HttpHeaderNames.ACCEPT_LANGUAGE));
         list.add(header(false, HttpHeaderNames.ACCEPT_RANGES));
         list.add(header(false, HttpHeaderNames.ACCEPT_PATCH));
+        list.add(header(false, HttpHeaderNames.ACCEPT_QUERY));
         list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS));
         list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS));
         list.add(header(false, HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS));

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpMethodTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpMethodTest.java
@@ -37,6 +37,7 @@ public class HttpMethodTest {
     public void valueOfReturnsCachedInstanceForKnownMethods() {
         assertSame(HttpMethod.GET, HttpMethod.valueOf("GET"));
         assertSame(HttpMethod.POST, HttpMethod.valueOf("POST"));
+        assertSame(HttpMethod.QUERY, HttpMethod.valueOf("QUERY"));
     }
 
     @Test

--- a/microbench/src/main/java/io/netty/handler/codec/http/HttpMethodMapBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http/HttpMethodMapBenchmark.java
@@ -37,6 +37,7 @@ import static io.netty.handler.codec.http.HttpMethod.PATCH;
 import static io.netty.handler.codec.http.HttpMethod.POST;
 import static io.netty.handler.codec.http.HttpMethod.PUT;
 import static io.netty.handler.codec.http.HttpMethod.TRACE;
+import static io.netty.handler.codec.http.HttpMethod.QUERY;
 import static io.netty.util.internal.MathUtil.findNextPositivePowerOfTwo;
 
 @State(Scope.Benchmark)
@@ -61,6 +62,7 @@ public class HttpMethodMapBenchmark extends AbstractMicrobenchmark {
                 "POST",
                 "PUT",
                 "PATCH",
+                "QUERY",
                 "DELETE",
                 "TRACE",
                 "CONNECT"
@@ -98,6 +100,7 @@ public class HttpMethodMapBenchmark extends AbstractMicrobenchmark {
         OLD_MAP.put(DELETE.toString(), DELETE);
         OLD_MAP.put(TRACE.toString(), TRACE);
         OLD_MAP.put(CONNECT.toString(), CONNECT);
+        OLD_MAP.put(QUERY.toString(), QUERY);
 
         NEW_MAP = new SimpleStringMap<HttpMethod>(
                 new SimpleStringMap.Node<HttpMethod>(OPTIONS.toString(), OPTIONS),
@@ -106,6 +109,7 @@ public class HttpMethodMapBenchmark extends AbstractMicrobenchmark {
                 new SimpleStringMap.Node<HttpMethod>(POST.toString(), POST),
                 new SimpleStringMap.Node<HttpMethod>(PUT.toString(), PUT),
                 new SimpleStringMap.Node<HttpMethod>(PATCH.toString(), PATCH),
+                new SimpleStringMap.Node<HttpMethod>(QUERY.toString(), QUERY),
                 new SimpleStringMap.Node<HttpMethod>(DELETE.toString(), DELETE),
                 new SimpleStringMap.Node<HttpMethod>(TRACE.toString(), TRACE),
                 new SimpleStringMap.Node<HttpMethod>(CONNECT.toString(), CONNECT));


### PR DESCRIPTION
Motivation:

Add basic blocks for RFC 10008 (The HTTP QUERY method)

Modification:

Added the QUERY HttpMethod as well as the Accept-Query header constant

Result:

Downstream consumers have an easier time implementing RFC 10008
