### PR TITLE
Fix leak in ReferenceCountedOpenSslEngine.addCredential

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -41,6 +41,7 @@ import java.nio.ReadOnlyBufferException;
 import java.security.AlgorithmConstraints;
 import java.security.Principal;
 import java.security.cert.Certificate;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -155,6 +156,8 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
     private HandshakeState handshakeState = HandshakeState.NOT_STARTED;
     private boolean receivedShutdown;
     private volatile boolean destroyed;
+    // Credentials added via addCredential(); released in shutdown() to balance the retain() in addCredential().
+    private List<OpenSslCredential> engineCredentials;
     private volatile String applicationProtocol;
     private volatile boolean needTask;
     private boolean hasTLSv13Cipher;
@@ -594,6 +597,12 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
             // the finalizer as well.
             if (engines != null) {
                 engines.remove(ssl);
+            }
+            if (engineCredentials != null) {
+                for (OpenSslCredential credential : engineCredentials) {
+                    credential.release();
+                }
+                engineCredentials = null;
             }
             SSL.freeSSL(ssl);
             ssl = networkBIO = 0;
@@ -2346,6 +2355,10 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
             credential.retain();
             try {
                 SSL.addCredential(ssl, pointer.credentialAddress());
+                if (engineCredentials == null) {
+                    engineCredentials = new ArrayList<>();
+                }
+                engineCredentials.add(credential);
             } catch (Exception e) {
                 credential.release();
                 throw new SSLException("Failed to add credential to SSL engine", e);
@@ -2359,6 +2372,11 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
      *
      * <p>This method returns the credential that was ultimately chosen by the TLS handshake.
      * It's useful for introspection after the handshake completes.
+     *
+     * <p><strong>Lifetime warning:</strong> the returned {@link OpenSslCredential} is a
+     * <em>borrowed</em> reference backed by a native pointer owned by BoringSSL. It is only valid
+     * while this engine is alive. Do <em>not</em> retain the returned credential and use it after
+     * {@link #shutdown()} has been called — doing so will access freed native memory.
      *
      * <p>This is a BoringSSL-specific feature.
      *

--- a/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
@@ -512,6 +512,11 @@ public final class SslContextBuilder {
      * or {@link SslProvider#OPENSSL_REFCNT}.
      * Check {@link OpenSslCredential#isAvailable()} to verify that the feature is supported.
      *
+     * <p><strong>Lifetime:</strong> this builder does <em>not</em> retain the credential. The
+     * caller must ensure the credential remains alive (refcount {@code > 0}) until {@link #build()}
+     * returns. {@link #build()} will retain its own reference via the constructed
+     * {@link SslContext}.
+     *
      * @param credential the credential to add
      * @return this builder for chaining
      * @see OpenSslCredentialBuilder

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslCredentialBuilderTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslCredentialBuilderTest.java
@@ -17,9 +17,11 @@ package io.netty.handler.ssl;
 
 import io.netty.pkitesting.CertificateBuilder;
 import io.netty.pkitesting.X509Bundle;
+import io.netty.util.test.LeakPresenceExtension;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -27,6 +29,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 /**
  * Unit tests for {@link OpenSslCredentialBuilder}.
  */
+@ExtendWith(LeakPresenceExtension.class)
 public class OpenSslCredentialBuilderTest {
 
     private static X509Bundle cert;

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -27,12 +27,14 @@ import io.netty.pkitesting.CertificateBuilder;
 import io.netty.pkitesting.X509Bundle;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
+import io.netty.util.test.LeakPresenceExtension;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -85,6 +87,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+@ExtendWith(LeakPresenceExtension.class)
 public class OpenSslEngineTest extends SSLEngineTest {
     private static final String PREFERRED_APPLICATION_LEVEL_PROTOCOL = "my-protocol-http2";
     private static final String FALLBACK_APPLICATION_LEVEL_PROTOCOL = "my-protocol-http1_1";
@@ -1880,6 +1883,37 @@ public class OpenSslEngineTest extends SSLEngineTest {
         } finally {
             ReferenceCountUtil.safeRelease(rsaCredential);
             ReferenceCountUtil.safeRelease(ecdsaCredential);
+        }
+    }
+
+    @Test
+    public void addCredentialRetainsAndShutdownReleases() throws Exception {
+        assumeTrue(OpenSslCredential.isAvailable());
+
+        OpenSslCredential credential = OpenSslCredentialBuilder
+                .forX509(rsaCert.getKeyPair().getPrivate(), rsaCert.getCertificate())
+                .build();
+
+        SslContext serverContext = SslContextBuilder
+                .forServer(rsaCert.getKeyPair().getPrivate(), rsaCert.getCertificate())
+                .sslProvider(SslProvider.OPENSSL_REFCNT)
+                .build();
+
+        try {
+            ReferenceCountedOpenSslEngine engine =
+                    (ReferenceCountedOpenSslEngine) serverContext.newEngine(UnpooledByteBufAllocator.DEFAULT);
+            try {
+                assertThat(credential.refCnt()).isEqualTo(1);
+                engine.addCredential(credential);
+                assertThat(credential.refCnt()).isEqualTo(2);
+                engine.shutdown();
+                assertThat(credential.refCnt()).isEqualTo(1);
+            } finally {
+                ReferenceCountUtil.release(engine);
+            }
+        } finally {
+            ReferenceCountUtil.safeRelease(credential);
+            ReferenceCountUtil.release(serverContext);
         }
     }
 }


### PR DESCRIPTION
Motivation:

Currently there is asymmetry / inconsistency in the retain/free model for the context and engine entry points of SslCredential objects.

Modification:

Free references on engine shutdown, add ref count test, clarify reference behavior on docstrings, and annotate SslCredential tests with leak presence detectors.

Result:

Reference count is consistent between context and engine entry points
