### PR TITLE
Update quiche to 0.29.2

### DIFF
--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -60,7 +60,7 @@
     <quicheHomeIncludeDir>${quicheHomeDir}/quiche/include</quicheHomeIncludeDir>
     <quicheRepository>https://github.com/cloudflare/quiche</quicheRepository>
     <quicheBranch>master</quicheBranch>
-    <quicheCommitSha>4f347477006bf7f928335d28f05056013f70b87e</quicheCommitSha>
+    <quicheCommitSha>839b23d0edcc98aa1cf90c2cf0797b8cc56d4f15</quicheCommitSha>
     <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
     <templateDir>${project.build.directory}/template</templateDir>
     <cargoTarget />

--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -60,7 +60,7 @@
     <quicheHomeIncludeDir>${quicheHomeDir}/quiche/include</quicheHomeIncludeDir>
     <quicheRepository>https://github.com/cloudflare/quiche</quicheRepository>
     <quicheBranch>master</quicheBranch>
-    <quicheCommitSha>839b23d0edcc98aa1cf90c2cf0797b8cc56d4f15</quicheCommitSha>
+    <quicheCommitSha>55886df3be579579207104c8e645825b6347a209</quicheCommitSha>
     <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
     <templateDir>${project.build.directory}/template</templateDir>
     <cargoTarget />

--- a/codec-native-quic/src/main/c/netty_quic_quiche.c
+++ b/codec-native-quic/src/main/c/netty_quic_quiche.c
@@ -707,11 +707,14 @@ static jlong netty_quiche_conn_new_scid(JNIEnv* env, jclass clazz, jlong conn, j
 static jbyteArray netty_quiche_conn_retired_scid_next(JNIEnv* env, jclass clazz, jlong conn) {
     const uint8_t *id = NULL;
     size_t len = 0;
+    jbyteArray array = NULL;
 
-    if (quiche_conn_retired_scid_next((quiche_conn *) conn, &id, &len)) {
-        return to_byte_array(env, id, len);
+    quiche_connection_id_iter* itr = quiche_conn_retired_scid_iter((quiche_conn *) conn);
+    if (quiche_connection_id_iter_next(itr, &id, &len)) {
+        array = to_byte_array(env, id, len);
     }
-    return NULL;
+    quiche_connection_id_iter_free(itr);
+    return array;
 }
 
 static jlong netty_quiche_conn_path_event_next(JNIEnv* env, jclass clazz, jlong conn) {

--- a/codec-native-quic/src/main/native-package/m4/custom.m4.template
+++ b/codec-native-quic/src/main/native-package/m4/custom.m4.template
@@ -29,7 +29,7 @@ AC_DEFUN([CUSTOM_M4_SETUP],
       esac
 
   dnl Update the compiler/linker flags
-  CFLAGS="$CFLAGS -std=gnu99 -fcommon -fvisibility=hidden -Werror -fno-omit-frame-pointer -Wunused -Wno-unused-value -O3 -I@BORINGSSL_INCLUDE_DIR@ -I@QUICHE_INCLUDE_DIR@ @EXTRA_CFLAGS@"
+  CFLAGS="$CFLAGS -std=gnu99 -fcommon -fvisibility=hidden -fno-omit-frame-pointer -Wunused -Wno-unused-value -O3 -I@BORINGSSL_INCLUDE_DIR@ -I@QUICHE_INCLUDE_DIR@ @EXTRA_CFLAGS@"
   CXXFLAGS="$CXXFLAGS"
   LDFLAGS="$LDFLAGS -L@BORINGSSL_LIB_DIR@ -lssl -lcrypto -L@QUICHE_LIB_DIR@ -lquiche @EXTRA_LDFLAGS@"
   AC_SUBST(CFLAGS)

--- a/codec-native-quic/src/main/native-package/m4/custom.m4.template
+++ b/codec-native-quic/src/main/native-package/m4/custom.m4.template
@@ -29,7 +29,7 @@ AC_DEFUN([CUSTOM_M4_SETUP],
       esac
 
   dnl Update the compiler/linker flags
-  CFLAGS="$CFLAGS -std=gnu99 -fvisibility=hidden -Werror -fno-omit-frame-pointer -Wunused -Wno-unused-value -O3 -I@BORINGSSL_INCLUDE_DIR@ -I@QUICHE_INCLUDE_DIR@ @EXTRA_CFLAGS@"
+  CFLAGS="$CFLAGS -std=gnu99 -fcommon -fvisibility=hidden -Werror -fno-omit-frame-pointer -Wunused -Wno-unused-value -O3 -I@BORINGSSL_INCLUDE_DIR@ -I@QUICHE_INCLUDE_DIR@ @EXTRA_CFLAGS@"
   CXXFLAGS="$CXXFLAGS"
   LDFLAGS="$LDFLAGS -L@BORINGSSL_LIB_DIR@ -lssl -lcrypto -L@QUICHE_LIB_DIR@ -lquiche @EXTRA_LDFLAGS@"
   AC_SUBST(CFLAGS)


### PR DESCRIPTION
Motivation:

Quiche 0.29.2 was released which fixes a possible crash due use-after-free.

Modifications:

- Update to 0.29.2
- Adjust API usage

Result:

No more possible crash
