### PR TITLE
FlowControlHandler: respect auto-read when toggled while dequeueing (#16949)

### DIFF
--- a/handler/src/main/java/io/netty/handler/flow/FlowControlHandler.java
+++ b/handler/src/main/java/io/netty/handler/flow/FlowControlHandler.java
@@ -96,6 +96,11 @@ public class FlowControlHandler implements ChannelInboundHandler, ChannelOutboun
      */
     private int unsatisfiedReads;
 
+    /**
+     * {@code true} while a {@link #dequeue(ChannelHandlerContext)} loop is on the stack.
+     */
+    private boolean dequeuing;
+
     public FlowControlHandler() {
         this(true);
     }
@@ -142,7 +147,8 @@ public class FlowControlHandler implements ChannelInboundHandler, ChannelOutboun
     @Override
     public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
         if (!isQueueEmpty()) {
-            dequeueAll(ctx);
+            unsatisfiedReads = queue.size();
+            dequeue(ctx);
             ctx.fireChannelReadComplete();
         }
         destroy();
@@ -156,22 +162,25 @@ public class FlowControlHandler implements ChannelInboundHandler, ChannelOutboun
 
     @Override
     public void read(ChannelHandlerContext ctx) {
-        if (config.isAutoRead()) {
-            dequeueAll(ctx);
-            ctx.read();
-        } else {
+        if (!config.isAutoRead()) {
             unsatisfiedReads++;
+        }
 
-            if (dequeueOne(ctx)) {
-                if (unsatisfiedReads == 0) {
-                    ctx.fireChannelReadComplete();
-                }
-            } else {
-                // Could not satisfy the read() from the queue.
-                // We need to request data from upstream so we can satisfy the read() in channelRead() or
-                // channelReadComplete() if it is going to be an empty read.
-                ctx.read();
-            }
+        boolean didSatisfyARead = dequeue(ctx);
+        boolean isAutoRead = config.isAutoRead();
+        if (!didSatisfyARead || isAutoRead) {
+            assert unsatisfiedReads > 0 || isAutoRead;
+            // We either could not satisfy the read or auto-read is on.
+            // In both cases we need to delegate the read upstream.
+            ctx.read();
+        } else if (unsatisfiedReads == 0 && !dequeuing) {
+            // Auto-read is off, and we have satisfied all reads.
+            // As such, we can complete the current read cycle. && !dequeueing makes sure we are completing the
+            // read cycle only once in the top-most read() call.
+            ctx.fireChannelReadComplete();
+        } else {
+            // Auto-read is off, and either reads are still unsatisfied or we are nested in a dequeue.
+            // Wait for the outermost call, an upstream channelRead() or a channelReadComplete().
         }
     }
 
@@ -183,12 +192,8 @@ public class FlowControlHandler implements ChannelInboundHandler, ChannelOutboun
 
         queue.offer(msg);
 
-        if (config.isAutoRead()) {
-            dequeueAll(ctx);
-        } else if (unsatisfiedReads > 0) {
-            dequeueOne(ctx);
-
-            if (unsatisfiedReads == 0) {
+        if (dequeue(ctx)) {
+            if (!config.isAutoRead() && unsatisfiedReads == 0 && !dequeuing) {
                 ctx.fireChannelReadComplete();
             }
         }
@@ -204,45 +209,44 @@ public class FlowControlHandler implements ChannelInboundHandler, ChannelOutboun
         }
     }
 
-    private boolean dequeueOne(ChannelHandlerContext ctx) {
-        return dequeue(ctx, 1) > 0;
-    }
-
-    private int dequeueAll(ChannelHandlerContext ctx) {
-        return dequeue(ctx, -1);
-    }
-
     /**
-     * Dequeues up to {@code maxConsume} messages, fires them downstream and
-     * updates {@code unsatisfiedReads} accordingly. If {@code maxConsume} is negative,
-     * there is no upper limit on the number of messages to dequeue and fire downstream.
+     * Dequeues messages while auto-read is enabled or downstream reads are unsatisfied, and updates
+     * {@code unsatisfiedReads} accordingly.
      *
      * @see #read(ChannelHandlerContext)
      * @see #channelRead(ChannelHandlerContext, Object)
      */
-    private int dequeue(ChannelHandlerContext ctx, int maxConsume) {
-        int consumed = 0;
+    private boolean dequeue(ChannelHandlerContext ctx) {
+        boolean didSatisfyARead = false;
 
-        // fireChannelRead(...) may call ctx.read() and so this method may be re-entered. Because of that
-        // we need to check if queue was set to null in the meantime and, if so, break out of the loop.
-        while (queue != null && (consumed < maxConsume || maxConsume < 0)) {
-            Object msg = queue.poll();
-            if (msg == null) {
-                break;
+        boolean wasDequeuing = dequeuing;
+        dequeuing = true;
+        try {
+            // fireChannelRead(...) may call ctx.read() and so this method may be re-entered. Because of that
+            // we need to check if queue was set to null in the meantime and, if so, break out of the loop.
+            while (queue != null && (config.isAutoRead() || unsatisfiedReads > 0)) {
+                Object msg = queue.poll();
+                if (msg == null) {
+                    break;
+                }
+
+                if (unsatisfiedReads > 0) {
+                    unsatisfiedReads--;
+                }
+                ctx.fireChannelRead(msg);
+
+                didSatisfyARead = true;
             }
 
-            ++consumed;
-            ctx.fireChannelRead(msg);
+            if (queue != null && queue.isEmpty()) {
+                queue.recycle();
+                queue = null;
+            }
+
+            return didSatisfyARead;
+        } finally {
+            dequeuing = wasDequeuing;
         }
-
-        if (queue != null && queue.isEmpty()) {
-            queue.recycle();
-            queue = null;
-        }
-
-        unsatisfiedReads = Math.max(unsatisfiedReads - consumed, 0);
-
-        return consumed;
     }
 
     /**

--- a/handler/src/test/java/io/netty/handler/flow/FlowControlHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/flow/FlowControlHandlerTest.java
@@ -43,6 +43,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.CountDownLatch;
@@ -625,10 +627,12 @@ public class FlowControlHandlerTest {
 
     @Test
     public void testCompletingReadWithNonEmptyQueue() throws Exception {
+        final UpstreamReadCounter upstream = new UpstreamReadCounter();
         final AtomicInteger reads = new AtomicInteger();
         final AtomicInteger readCompletes = new AtomicInteger();
         final EmbeddedChannel channel = new EmbeddedChannel(
                 false, false,
+                upstream,
                 new FlowControlHandler(),
                 new ChannelInboundHandler() {
                     @Override
@@ -656,6 +660,9 @@ public class FlowControlHandlerTest {
         channel.read();
         assertEquals(2, reads.get());
         assertEquals(2, readCompletes.get());
+
+        // Every read() was satisfied straight from the queue, so none was forwarded upstream.
+        assertEquals(0, upstream.reads.get());
 
         assertFalse(channel.finishAndReleaseAll());
     }
@@ -713,10 +720,12 @@ public class FlowControlHandlerTest {
 
     @Test
     public void testEmptyRead() throws Exception {
+        final UpstreamReadCounter upstream = new UpstreamReadCounter();
         final AtomicInteger reads = new AtomicInteger();
         final AtomicInteger readCompletes = new AtomicInteger();
         final EmbeddedChannel channel = new EmbeddedChannel(
                 false, false,
+                upstream,
                 new FlowControlHandler(),
                 new ChannelInboundHandler() {
                     @Override
@@ -740,6 +749,9 @@ public class FlowControlHandlerTest {
 
         assertEquals(0, reads.get());
         assertEquals(1, readCompletes.get());
+
+        // The empty read() could not be satisfied from the queue, so it was forwarded upstream exactly once.
+        assertEquals(1, upstream.reads.get());
 
         assertFalse(channel.finishAndReleaseAll());
     }
@@ -922,6 +934,222 @@ public class FlowControlHandlerTest {
         assertFalse(channel.finishAndReleaseAll());
     }
 
+    @Test
+    public void testAutoReadDisabledDuringDequeueStopsDelivery() throws Exception {
+        final UpstreamReadCounter upstream = new UpstreamReadCounter();
+        final AtomicInteger reads = new AtomicInteger();
+        final AtomicInteger readCompletes = new AtomicInteger();
+        final EmbeddedChannel channel = new EmbeddedChannel(false, false,
+                upstream,
+                new FlowControlHandler(),
+                new ChannelInboundHandler() {
+                    @Override
+                    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                        reads.incrementAndGet();
+                        ctx.channel().config().setAutoRead(false);
+                    }
+
+                    @Override
+                    public void channelReadComplete(ChannelHandlerContext ctx) {
+                        readCompletes.incrementAndGet();
+                    }
+                });
+        channel.config().setAutoRead(false);
+        channel.register();
+
+        // Begin with auto-read on while the queue is empty: that forwards a single read upstream and delivers
+        // nothing.
+        channel.config().setAutoRead(true);
+        assertEquals(0, reads.get());
+        assertEquals(1, upstream.reads.get());
+
+        // Messages now arrive with auto-read on. The handler disables auto-read while processing the first, so
+        // messages 2..5 stay queued: delivery stops after one and the cycle completes once (from channelRead).
+        channel.writeInbound("1", "2", "3", "4", "5");
+        assertEquals(1, reads.get());
+        assertEquals(1, readCompletes.get());
+        assertEquals(1, upstream.reads.get());
+
+        // A trailing upstream channelReadComplete (auto-read off, no read outstanding) is dropped.
+        channel.flushInbound();
+        assertEquals(1, readCompletes.get());
+
+        // Resume: re-enabling auto-read starts draining the four queued messages, but the handler disables it
+        // again while processing the first. The dequeue must observe the renewed setAutoRead(false), release
+        // exactly one more, and complete once (from read()). The message was served from the queue, so nothing
+        // is read further upstream.
+        channel.config().setAutoRead(true);
+        assertEquals(2, reads.get());
+        assertEquals(2, readCompletes.get());
+        assertEquals(1, upstream.reads.get());
+
+        assertFalse(channel.finishAndReleaseAll());
+    }
+
+    @Test
+    public void testReentrantReadIsSatisfiedFromQueue() throws Exception {
+        final UpstreamReadCounter upstream = new UpstreamReadCounter();
+        final AtomicInteger reads = new AtomicInteger();
+        final AtomicInteger readCompletes = new AtomicInteger();
+        EmbeddedChannel channel = new EmbeddedChannel(false, false,
+                upstream,
+                new FlowControlHandler(),
+                new ChannelInboundHandler() {
+                    @Override
+                    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                        if (reads.incrementAndGet() == 1) {
+                            ctx.read();
+                        }
+                    }
+
+                    @Override
+                    public void channelReadComplete(ChannelHandlerContext ctx) {
+                        readCompletes.incrementAndGet();
+                    }
+                });
+        channel.config().setAutoRead(false);
+        channel.register();
+        channel.writeInbound("1", "2");
+
+        channel.read();
+
+        assertEquals(2, reads.get());
+        assertEquals(0, upstream.reads.get());
+        assertEquals(1, readCompletes.get());
+
+        assertFalse(channel.finishAndReleaseAll());
+    }
+
+    @Test
+    public void testAutoReadEnabledDuringDequeueDrainsRemaining() throws Exception {
+        final UpstreamReadCounter upstream = new UpstreamReadCounter();
+        final AtomicInteger reads = new AtomicInteger();
+        final EmbeddedChannel channel = new EmbeddedChannel(false, false,
+                upstream,
+                new FlowControlHandler(),
+                new ChannelInboundHandler() {
+                    @Override
+                    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                        reads.incrementAndGet();
+                        // Resume the connection while "processing" each released message.
+                        ctx.channel().config().setAutoRead(true);
+                    }
+                });
+        channel.config().setAutoRead(false);
+        channel.register();
+
+        // Auto-read off: all five messages are held in the queue, nothing read upstream.
+        channel.writeInbound("1", "2", "3", "4", "5");
+        assertEquals(0, reads.get());
+        assertEquals(0, upstream.reads.get());
+
+        // A single read() delivers the first message; the handler re-enables auto-read from inside channelRead,
+        // which drains the whole remaining queue. With the queue empty and auto-read on, FlowControlHandler
+        // then reads further upstream twice: once for the transparent resume, once for the read() that
+        // consumed the queued message.
+        channel.read();
+        assertEquals(5, reads.get());
+        assertEquals(2, upstream.reads.get());
+
+        assertFalse(channel.finishAndReleaseAll());
+    }
+
+    @Test
+    public void testHandlerRemovedFlushesQueuedMessages() throws Exception {
+        final UpstreamReadCounter upstream = new UpstreamReadCounter();
+        final List<Object> received = new ArrayList<Object>();
+        final AtomicInteger readCompletes = new AtomicInteger();
+        final FlowControlHandler flow = new FlowControlHandler();
+        final EmbeddedChannel channel = new EmbeddedChannel(false, false,
+                upstream,
+                flow,
+                new ChannelInboundHandler() {
+                    @Override
+                    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                        received.add(msg);
+                    }
+
+                    @Override
+                    public void channelReadComplete(ChannelHandlerContext ctx) {
+                        readCompletes.incrementAndGet();
+                    }
+                });
+        channel.config().setAutoRead(false);
+        channel.register();
+
+        // With auto-read off and no read(), all five messages stay queued in the handler.
+        channel.writeInbound("1", "2", "3", "4", "5");
+        assertEquals(0, received.size());
+        assertEquals(0, readCompletes.get());
+
+        // Removing the handler flushes the whole queue downstream, in order, then completes the batch once.
+        channel.pipeline().remove(flow);
+        assertEquals(Arrays.asList("1", "2", "3", "4", "5"), received);
+        assertEquals(1, readCompletes.get());
+        assertTrue(flow.isQueueEmpty());
+
+        // The flush happens locally on removal; nothing is read upstream.
+        assertEquals(0, upstream.reads.get());
+
+        assertFalse(channel.finishAndReleaseAll());
+    }
+
+    @Test
+    public void testChannelInactiveReleasesQueuedMessages() throws Exception {
+        final UpstreamReadCounter upstream = new UpstreamReadCounter();
+        final FlowControlHandler flow = new FlowControlHandler();
+        final EmbeddedChannel channel = new EmbeddedChannel(false, false,
+                upstream, flow, new ChannelInboundHandler() { });
+        channel.config().setAutoRead(false);
+        channel.register();
+
+        ByteBuf msg1 = Unpooled.buffer().writeByte(1);
+        ByteBuf msg2 = Unpooled.buffer().writeByte(2);
+
+        // Auto-read off: the buffers are held in the handler's queue, not delivered downstream.
+        channel.writeInbound(msg1, msg2);
+        assertFalse(flow.isQueueEmpty());
+        assertEquals(1, msg1.refCnt());
+        assertEquals(1, msg2.refCnt());
+
+        // Closing fires channelInactive, which destroys the queue and releases the held buffers.
+        channel.close().syncUninterruptibly();
+        assertEquals(0, msg1.refCnt());
+        assertEquals(0, msg2.refCnt());
+        assertTrue(flow.isQueueEmpty());
+
+        // Nothing was ever read upstream.
+        assertEquals(0, upstream.reads.get());
+    }
+
+    @Test
+    public void testReleaseMessagesFalseDoesNotReleaseQueuedMessages() throws Exception {
+        final UpstreamReadCounter upstream = new UpstreamReadCounter();
+        final FlowControlHandler flow = new FlowControlHandler(false);
+        final EmbeddedChannel channel = new EmbeddedChannel(false, false,
+                upstream, flow, new ChannelInboundHandler() { });
+        channel.config().setAutoRead(false);
+        channel.register();
+
+        ByteBuf msg1 = Unpooled.buffer().writeByte(1);
+        ByteBuf msg2 = Unpooled.buffer().writeByte(2);
+
+        channel.writeInbound(msg1, msg2);
+        assertFalse(flow.isQueueEmpty());
+
+        // releaseMessages == false: destroy() discards the queue but must not release the buffers.
+        channel.close().syncUninterruptibly();
+        assertEquals(1, msg1.refCnt());
+        assertEquals(1, msg2.refCnt());
+        assertTrue(flow.isQueueEmpty());
+
+        // Nothing was ever read upstream.
+        assertEquals(0, upstream.reads.get());
+
+        msg1.release();
+        msg2.release();
+    }
+
     /**
      * This is a fictional message decoder. It decodes each {@code byte}
      * into three strings.
@@ -935,6 +1163,20 @@ public class FlowControlHandlerTest {
                 out.add("3");
             }
             in.readerIndex(in.readableBytes());
+        }
+    }
+
+    /**
+     * Counts the {@code read()} events {@link FlowControlHandler} forwards upstream. Placed at the head side
+     * of the handler.
+     */
+    private static final class UpstreamReadCounter implements ChannelOutboundHandler {
+        final AtomicInteger reads = new AtomicInteger();
+
+        @Override
+        public void read(ChannelHandlerContext ctx) {
+            reads.incrementAndGet();
+            ctx.read();
         }
     }
 }


### PR DESCRIPTION
`FlowControlHandler` does not respect changes to the channel's auto-read
setting while flushing the queue. As such, a downstream handler that
disables auto-read from within `channelRead()` cannot stop
`FlowControlHandler` from flushing the rest of the queue.

- Merge `dequeueOne()` and `dequeueAll()` into a single `dequeue()` loop
that re-checks `config.isAutoRead()` and `unsatisfiedReads` before every
message.
- Add tests for auto-read toggled on and off from `channelRead` and
re-entrant reads satisfied from the queue, plus previously missing
coverage for handler removal, `channelInactive` release, and
`releaseMessages = false`.

A downstream handler that disables auto-read from `channelRead()` now
stops delivery of the rest of the queue.

Fixes #16945

Co-authored-by: Norman Maurer <norman_maurer@apple.com>
