### PR TITLE
Reject control characters at the boundary of the HTTP version token (#16971)

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpVersion.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpVersion.java
@@ -16,15 +16,14 @@
 package io.netty.handler.codec.http;
 
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
-import static io.netty.util.internal.ObjectUtil.checkNonEmptyAfterTrim;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.ObjectUtil;
 
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.Locale;
+
 
 /**
  * The version of HTTP or its derived protocols, such as
@@ -70,8 +69,6 @@ public class HttpVersion implements Comparable<HttpVersion> {
         if (text == HTTP_1_0_STRING) {
             return HTTP_1_0;
         }
-
-        text = text.trim();
 
         if (text.isEmpty()) {
             throw new IllegalArgumentException("text is empty (possibly HTTP/0.9)");
@@ -128,7 +125,12 @@ public class HttpVersion implements Comparable<HttpVersion> {
         // toUpperCase() without an explicit Locale uses the JVM default. In Turkish locale
         // (tr_TR) 'i' uppercases to 'İ' (U+0130), which would corrupt protocol strings such
         // as "icap/1.0" or any custom HTTP-derived scheme that contains a lowercase 'i'.
-        text = checkNonEmptyAfterTrim(text, "text").toUpperCase(Locale.US);
+        // Control characters or whitespace at the token boundary must fail the checks below.
+        ObjectUtil.checkNotNull(text, "text");
+        if (text.isEmpty()) {
+            throw new IllegalArgumentException("text must not be empty");
+        }
+        text = text.toUpperCase(Locale.US);
 
         if (strict) {
             // Only single digit major / minor version is allowed.
@@ -142,19 +144,41 @@ public class HttpVersion implements Comparable<HttpVersion> {
             majorVersion = toDecimal(text.charAt(5));
             minorVersion = toDecimal(text.charAt(7));
         } else {
-            Matcher m = VERSION_PATTERN.matcher(text);
-            if (!m.matches()) {
+            int slashIndex = text.indexOf('/');
+            int dotIndex = text.indexOf('.', slashIndex + 1);
+
+            if (slashIndex <= 0 || dotIndex <= slashIndex + 1
+                    || dotIndex >= text.length() - 1 || hasControlOrWhitespace(text, slashIndex)) {
                 throw new IllegalArgumentException("invalid version format: " + text);
             }
 
-            protocolName = m.group(1);
-            majorVersion = Integer.parseInt(m.group(2));
-            minorVersion = Integer.parseInt(m.group(3));
+            protocolName = text.substring(0, slashIndex);
+            majorVersion = parseInt(text, slashIndex + 1, dotIndex);
+            minorVersion = parseInt(text, dotIndex + 1, text.length());
         }
 
         this.text = protocolName + '/' + majorVersion + '.' + minorVersion;
         this.keepAliveDefault = keepAliveDefault;
         bytes = null;
+    }
+
+    private static boolean hasControlOrWhitespace(String s, int end) {
+        for (int i = 0; i < end; i++) {
+            char c = s.charAt(i);
+            if (Character.isISOControl(c) || Character.isWhitespace(c)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static int parseInt(String text, int start, int end) {
+        int result = 0;
+        for (int i = start; i < end; i++) {
+            char ch = text.charAt(i);
+            result = result * 10 + toDecimal(ch);
+        }
+        return result;
     }
 
     private static int toDecimal(final int value) {
@@ -187,13 +211,14 @@ public class HttpVersion implements Comparable<HttpVersion> {
             boolean keepAliveDefault, boolean bytes) {
         // See the comment in the (text, strict, keepAliveDefault) constructor for why this needs
         // an explicit Locale.US: avoids the Turkish-locale 'i' -> 'İ' corruption.
-        protocolName = checkNonEmptyAfterTrim(protocolName, "protocolName").toUpperCase(Locale.US);
+        ObjectUtil.checkNotNull(protocolName, "protocolName");
+        if (protocolName.isEmpty()) {
+            throw new IllegalArgumentException("protocolName must not be empty");
+        }
+        protocolName = protocolName.toUpperCase(Locale.US);
 
-        for (int i = 0; i < protocolName.length(); i ++) {
-            if (Character.isISOControl(protocolName.charAt(i)) ||
-                    Character.isWhitespace(protocolName.charAt(i))) {
-                throw new IllegalArgumentException("invalid character in protocolName");
-            }
+        if (hasControlOrWhitespace(protocolName, protocolName.length())) {
+            throw new IllegalArgumentException("invalid character in protocolName");
         }
 
         checkPositiveOrZero(majorVersion, "majorVersion");

--- a/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspVersions.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspVersions.java
@@ -39,14 +39,17 @@ public final class RtspVersions {
     public static HttpVersion valueOf(String text) {
         ObjectUtil.checkNotNull(text, "text");
 
+        if (text.isEmpty()) {
+            throw new IllegalArgumentException("text must not be empty");
+        }
         // toUpperCase() must specify Locale.US so the comparison against "RTSP/1.0" is not
         // affected by the JVM default locale (e.g. Turkish, where 'i' uppercases to 'İ').
-        text = text.trim().toUpperCase(Locale.US);
-        if ("RTSP/1.0".equals(text)) {
+        String upper = text.toUpperCase(Locale.US);
+        if ("RTSP/1.0".equals(upper)) {
             return RTSP_1_0;
         }
 
-        return new HttpVersion(text, true);
+        return new HttpVersion(upper, true);
     }
 
     private RtspVersions() {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -1265,4 +1265,31 @@ public class HttpRequestDecoderTest {
         assertTrue(request.decoderResult().isFailure());
         assertFalse(channel.finish());
     }
+
+    @Test
+    public void testNulInVersionTokenIsRejected() {
+        // A NUL right before the version token must be rejected.
+        testInvalidHeaders0("GET / " + (char) 0 + "HTTP/1.1\r\nHost: whatever\r\n\r\n");
+    }
+
+    @Test
+    public void testNulInMethodTokenIsRejected() {
+        // Control case: a NUL inside the method token is also rejected.
+        testInvalidHeaders0("GET" + (char) 0 + " / HTTP/1.1\r\nHost: whatever\r\n\r\n");
+    }
+
+    @Test
+    public void testNormalRequestStillDecodes() {
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder());
+        assertTrue(channel.writeInbound(Unpooled.copiedBuffer("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n",
+                CharsetUtil.US_ASCII)));
+        HttpRequest req = channel.readInbound();
+        assertNotNull(req);
+        assertTrue(req.decoderResult().isSuccess());
+        assertEquals(HttpVersion.HTTP_1_1, req.protocolVersion());
+        LastHttpContent last = channel.readInbound();
+        assertNotNull(last);
+        last.release();
+        assertFalse(channel.finish());
+    }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpVersionParsingTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpVersionParsingTest.java
@@ -119,6 +119,51 @@ public class HttpVersionParsingTest {
         });
     }
 
+    @Test
+    void testLeadingNulInStrictValueOfIsRejected() {
+        String text = (char) 0x00 + "HTTP/1.1";
+        assertThrows(IllegalArgumentException.class, () -> HttpVersion.valueOf(text, true),
+                "leading NUL must be rejected");
+    }
+
+    @Test
+    void testTrailingNulInStrictValueOfIsRejected() {
+        String text = "HTTP/1.1" + (char) 0x00;
+        assertThrows(IllegalArgumentException.class, () -> HttpVersion.valueOf(text, true),
+                "trailing NUL must be rejected");
+    }
+
+    @Test
+    void testLeadingControlCharInStrictValueOfIsRejected() {
+        // CR, LF, VT and FF must all be rejected in the version token.
+        for (int control : new int[] {0x0D, 0x0A, 0x0B, 0x0C}) {
+            String text = (char) control + "HTTP/1.1";
+            assertThrows(IllegalArgumentException.class, () -> HttpVersion.valueOf(text, true),
+                    "control char 0x" + Integer.toHexString(control) + " must be rejected");
+        }
+    }
+
+    @Test
+    void testLeadingSpaceInStrictValueOfIsRejected() {
+        // A leading space in the version token must be rejected.
+        assertThrows(IllegalArgumentException.class, () -> HttpVersion.valueOf(" HTTP/1.1", true),
+                "leading space must be rejected");
+    }
+
+    @Test
+    void testLeadingNulInNonStrictValueOfIsRejected() {
+        String text = (char) 0x00 + "HTTP/1.1";
+        assertThrows(IllegalArgumentException.class, () -> HttpVersion.valueOf(text),
+                "leading NUL must be rejected in non-strict mode too");
+    }
+
+    @Test
+    void testValidVersionsResolveCorrectly() {
+        assertSame(HttpVersion.HTTP_1_1, HttpVersion.valueOf("HTTP/1.1", true));
+        assertSame(HttpVersion.HTTP_1_0, HttpVersion.valueOf("HTTP/1.0"));
+        assertEquals("ICAP", HttpVersion.valueOf("icap/1.0").protocolName());
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {
             "HTTP ",

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpVersionParsingTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpVersionParsingTest.java
@@ -121,40 +121,60 @@ public class HttpVersionParsingTest {
 
     @Test
     void testLeadingNulInStrictValueOfIsRejected() {
-        String text = (char) 0x00 + "HTTP/1.1";
-        assertThrows(IllegalArgumentException.class, () -> HttpVersion.valueOf(text, true),
-                "leading NUL must be rejected");
+        final String text = (char) 0x00 + "HTTP/1.1";
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                HttpVersion.valueOf(text, true);
+            }
+        }, "leading NUL must be rejected");
     }
 
     @Test
     void testTrailingNulInStrictValueOfIsRejected() {
-        String text = "HTTP/1.1" + (char) 0x00;
-        assertThrows(IllegalArgumentException.class, () -> HttpVersion.valueOf(text, true),
-                "trailing NUL must be rejected");
+        final String text = "HTTP/1.1" + (char) 0x00;
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                HttpVersion.valueOf(text, true);
+            }
+        }, "trailing NUL must be rejected");
     }
 
     @Test
     void testLeadingControlCharInStrictValueOfIsRejected() {
         // CR, LF, VT and FF must all be rejected in the version token.
         for (int control : new int[] {0x0D, 0x0A, 0x0B, 0x0C}) {
-            String text = (char) control + "HTTP/1.1";
-            assertThrows(IllegalArgumentException.class, () -> HttpVersion.valueOf(text, true),
-                    "control char 0x" + Integer.toHexString(control) + " must be rejected");
+            final String text = (char) control + "HTTP/1.1";
+            assertThrows(IllegalArgumentException.class, new Executable() {
+                @Override
+                public void execute() throws Throwable {
+                    HttpVersion.valueOf(text, true);
+                }
+            }, "control char 0x" + Integer.toHexString(control) + " must be rejected");
         }
     }
 
     @Test
     void testLeadingSpaceInStrictValueOfIsRejected() {
         // A leading space in the version token must be rejected.
-        assertThrows(IllegalArgumentException.class, () -> HttpVersion.valueOf(" HTTP/1.1", true),
-                "leading space must be rejected");
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                HttpVersion.valueOf(" HTTP/1.1", true);
+            }
+        }, "leading space must be rejected");
     }
 
     @Test
     void testLeadingNulInNonStrictValueOfIsRejected() {
-        String text = (char) 0x00 + "HTTP/1.1";
-        assertThrows(IllegalArgumentException.class, () -> HttpVersion.valueOf(text),
-                "leading NUL must be rejected in non-strict mode too");
+        final String text = (char) 0x00 + "HTTP/1.1";
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                HttpVersion.valueOf(text);
+            }
+        }, "leading NUL must be rejected in non-strict mode too");
     }
 
     @Test


### PR DESCRIPTION
Motivation:

`HttpRequestDecoder` accepts a request whose HTTP-version token carries
a boundary control byte (`NUL`, `CR`, `LF`, `VT`, `FF`, …):

```bash
printf 'GET / \x00HTTP/1.1\r\nHost: localhost\r\n\r\n' | nc <host> <port>
```

`HttpVersion.valueOf(String, boolean)` ran `text.trim()` before matching
the version, and `String.trim()` removes every character with code point
`<= 0x20`. The boundary control byte was therefore silently stripped and
the surviving `"HTTP/1.1"` matched the cached constant, so the malformed
request decoded as a clean `HTTP/1.1` one.

The method token on the same request line already rejects such a byte
since #16723 (issue #15047), so the two tokens were inconsistent — this
is the same boundary-control-character / request-smuggling class, left
open for the version token.

Modification:

- `HttpVersion`: drop the `trim()` in `valueOf` and in the
`HttpVersion(String, boolean, boolean)` constructor. The existing strict
format check (`length == 8 && startsWith("HTTP/") && charAt(6) == '.'`)
now rejects a token padded with a control byte, and the non-strict path
rejects control/whitespace in the protocol name via
`hasControlOrWhitespace`. Without the `trim()`, `SP`/`HT` padding is
rejected too, mirroring the method-token behaviour from #16723.
- `RtspVersions.valueOf`: drop the `trim()` the same way.

`HttpRequestDecoder` already turns `createMessage` exceptions into a
decoder failure, so the wire effect is `decoderResult().isSuccess() ==
false` instead of a phantom `HTTP/1.1`.

Result:

Before this change `"GET / \x00HTTP/1.1\r\n…"` decoded successfully
(`decoderResult().isSuccess() == true`, `protocolVersion() ==
HTTP_1_1`); after it the decoder reports a failure, matching the
method-token behaviour. A clean `HTTP/1.1` request still decodes as
before.

```
Test set: io.netty.handler.codec.http.HttpVersionParsingTest
Tests run: 53, Failures: 0, Errors: 0, Skipped: 0
Test set: io.netty.handler.codec.http.HttpRequestDecoderTest
Tests run: 85, Failures: 0, Errors: 0, Skipped: 0
Test set: io.netty.handler.codec.rtsp.RtspDecoderTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
Test set: io.netty.handler.codec.rtsp.RtspEncoderTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
```

Fixes #16970

---------

Co-authored-by: Bryce Anderson <bl_anderson@apple.com>
