### PR TITLE
Fix client/server inconsistency in SslCredential support matrix

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
@@ -342,6 +342,20 @@ public final class OpenSslServerContext extends OpenSslContext {
                 enableOcsp, keyStore, resumptionController, options, null);
     }
 
+    OpenSslServerContext(
+            X509Certificate[] trustCertCollection, TrustManagerFactory trustManagerFactory,
+            X509Certificate[] keyCertChain, PrivateKey key, String keyPassword, KeyManagerFactory keyManagerFactory,
+            Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn,
+            long sessionCacheSize, long sessionTimeout, ClientAuth clientAuth, String[] protocols, boolean startTls,
+            boolean enableOcsp, String keyStore, ResumptionController resumptionController,
+            Map.Entry<SslContextOption<?>, Object>[] options,
+            List<OpenSslCredential> credentials)
+            throws SSLException {
+        this(trustCertCollection, trustManagerFactory, keyCertChain, key, keyPassword, keyManagerFactory, ciphers,
+                cipherFilter, toNegotiator(apn), sessionCacheSize, sessionTimeout, clientAuth, protocols, startTls,
+                enableOcsp, keyStore, resumptionController, options, credentials);
+    }
+
     @SuppressWarnings("deprecation")
     private OpenSslServerContext(
             X509Certificate[] trustCertCollection, TrustManagerFactory trustManagerFactory,

--- a/handler/src/main/java/io/netty/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContext.java
@@ -526,7 +526,8 @@ public abstract class SslContext {
             return new OpenSslServerContext(
                     trustCertCollection, trustManagerFactory, keyCertChain, key, keyPassword,
                     keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout,
-                    clientAuth, protocols, startTls, enableOcsp, keyStoreType, resumptionController, ctxOptions);
+                    clientAuth, protocols, startTls, enableOcsp, keyStoreType, resumptionController, ctxOptions,
+                    credentials);
         case OPENSSL_REFCNT:
             verifyNullSslContextProvider(provider, sslContextProvider);
             return new ReferenceCountedOpenSslServerContext(

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -1916,4 +1916,68 @@ public class OpenSslEngineTest extends SSLEngineTest {
             ReferenceCountUtil.release(serverContext);
         }
     }
+
+    @Test
+    public void testServerSelectsAddedCredentialWithOpenSslProvider() throws Exception {
+        assumeTrue(OpenSslCredential.isAvailable());
+
+        // The base/legacy certificate is RSA; the ECDSA certificate is supplied ONLY via
+        // addCredentials(). A client that offers only an ECDSA-auth cipher therefore forces the
+        // server to select the added ECDSA credential. This must work for the default OPENSSL
+        // provider (not just OPENSSL_REFCNT): newServerContextInternal must forward the credentials
+        // to OpenSslServerContext, otherwise they are silently dropped and the handshake fails with
+        // NO_SHARED_CIPHER.
+        OpenSslCredential rsaCredential = OpenSslCredentialBuilder
+                .forX509(rsaCert.getKeyPair().getPrivate(), rsaCert.getCertificate())
+                .build();
+        OpenSslCredential ecdsaCredential = OpenSslCredentialBuilder
+                .forX509(ecdsaCert.getKeyPair().getPrivate(), ecdsaCert.getCertificate())
+                .build();
+
+        SslContext serverSslContext = null;
+        SslContext clientSslContext = null;
+        SSLEngine clientEngine = null;
+        SSLEngine serverEngine = null;
+        try {
+            serverSslContext = SslContextBuilder
+                    .forServer(rsaCert.getKeyPair().getPrivate(), rsaCert.getCertificate())
+                    .sslProvider(SslProvider.OPENSSL)
+                    .addCredentials(rsaCredential, ecdsaCredential)
+                    .protocols("TLSv1.2")
+                    .ciphers(Arrays.asList("TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+                            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"))
+                    .build();
+
+            clientSslContext = SslContextBuilder.forClient()
+                    .sslProvider(SslProvider.OPENSSL)
+                    .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                    .protocols("TLSv1.2")
+                    .ciphers(Arrays.asList("TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"))
+                    .build();
+
+            clientEngine = clientSslContext.newEngine(UnpooledByteBufAllocator.DEFAULT);
+            serverEngine = serverSslContext.newEngine(UnpooledByteBufAllocator.DEFAULT);
+
+            handshake(BufferType.Direct, false, clientEngine, serverEngine);
+
+            X509Certificate served =
+                    (X509Certificate) clientEngine.getSession().getPeerCertificates()[0];
+            assertEquals("EC", served.getPublicKey().getAlgorithm());
+        } finally {
+            if (clientEngine != null) {
+                cleanupClientSslEngine(clientEngine);
+            }
+            if (serverEngine != null) {
+                cleanupServerSslEngine(serverEngine);
+            }
+            if (clientSslContext != null) {
+                cleanupClientSslContext(clientSslContext);
+            }
+            if (serverSslContext != null) {
+                cleanupServerSslContext(serverSslContext);
+            }
+            ReferenceCountUtil.safeRelease(rsaCredential);
+            ReferenceCountUtil.safeRelease(ecdsaCredential);
+        }
+    }
 }


### PR DESCRIPTION
Motivation:

SslContextBuilder.addCredentials(...) (the OpenSslCredential API from #15919) is honored for the client context and for the OPENSSL_REFCNT server context, but is silently dropped for the default OPENSSL server provider.

As a result, a server built with SslProvider.OPENSSL (the default server provider) plus addCredentials(...) never installs those credentials on the SSL_CTX, so they aren't available for cipher-/sigalg-based certificate selection.

Modification:

- SslContext.newServerContextInternal: pass credentials to OpenSslServerContext in the OPENSSL branch (matching the OPENSSL_REFCNT branch and the client path).
- OpenSslServerContext: add a package-private constructor overload that accepts List<OpenSslCredential> credentials and forwards it to the existing credential-aware constructor (mirroring OpenSslClientContext), instead of always delegating null.
- OpenSslEngineTest: add testServerSelectsAddedCredentialWithOpenSslProvider — a default-OPENSSL server whose ECDSA certificate is supplied only via addCredentials (base/legacy cert is RSA), driven by an ECDSA-only client, asserting the served leaf is EC. Fails with NO_SHARED_CIPHER before the fix, passes after.

Result:

addCredentials(...) is now honored for the default OPENSSL server provider, not just OPENSSL_REFCNT. Dual-cert servers select the correct certificate per the negotiated cipher (TLS 1.2) / signature algorithm (TLS 1.3) without requiring OPENSSL_REFCNT, and the new regression test guards the behavior.
