### PR TITLE
Reset UTF-8 decode state on CR in StompSubframeDecoder

### DIFF
--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeDecoder.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeDecoder.java
@@ -288,6 +288,8 @@ public class StompSubframeDecoder extends ReplayingDecoder<State> {
         @Override
         public boolean process(byte nextByte) throws Exception {
             if (nextByte == StompConstants.CR) {
+                interim = 0;
+                nextRead = false;
                 ++lineLength;
                 return true;
             }

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeDecoderTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeDecoderTest.java
@@ -443,4 +443,57 @@ public class StompSubframeDecoderTest {
         assertEquals("received an invalid escape header sequence 'custom_invalid\\t'",
                      headersSubFrame.decoderResult().cause().getMessage());
     }
+
+    @Test
+    public void testCRResetsUtf8DecodeState() {
+        // When a CR byte appears during a multi-byte UTF-8 sequence, the parser's interim state
+        // should be cleared so that subsequent bytes are decoded correctly.
+        // Bug: CR is skipped without resetting interim/nextRead, so the next byte gets
+        // incorrectly combined with dirty UTF-8 state, producing garbage characters.
+        //
+        // Craft a header value where:
+        // - 0xC3 starts a 2-byte UTF-8 sequence (sets interim)
+        // - 0x0D (CR) is skipped but should clear interim state
+        // - 0x41 ('A') should be decoded as plain ASCII 'A', not combined with dirty interim
+        channel = new EmbeddedChannel(new StompSubframeDecoder());
+
+        ByteBuf incoming = Unpooled.buffer();
+        // CONNECT command line
+        incoming.writeBytes("CONNECT\r\n".getBytes(UTF_8));
+        // header with multi-byte UTF-8 start byte (0xC3), then CR, then ASCII 'A'
+        incoming.writeByte((byte) 'h');
+        incoming.writeByte((byte) 'e');
+        incoming.writeByte((byte) 'a');
+        incoming.writeByte((byte) 'd');
+        incoming.writeByte((byte) 'e');
+        incoming.writeByte((byte) 'r');
+        incoming.writeByte((byte) ':');
+        // 0xC3 starts a 2-byte UTF-8 sequence - sets interim state
+        incoming.writeByte((byte) 0xC3);
+        // CR (0x0D) - should be skipped AND clear the interim UTF-8 state
+        incoming.writeByte((byte) 0x0D);
+        // 'A' - should be decoded as plain 'A' since CR should have reset state
+        incoming.writeByte((byte) 'A');
+        // end of header line
+        incoming.writeByte((byte) '\n');
+        // empty line to end headers
+        incoming.writeByte((byte) '\n');
+        // null byte to end frame
+        incoming.writeByte((byte) '\0');
+
+        assertTrue(channel.writeInbound(incoming));
+
+        StompHeadersSubframe frame = channel.readInbound();
+        assertNotNull(frame);
+        assertEquals(StompCommand.CONNECT, frame.command());
+        // The header value should be just "A" (CR is skipped, UTF-8 state reset)
+        // With the bug, it would contain corrupted UTF-8 combining 0xC3 with 'A'
+        assertEquals("A", frame.headers().get("header"));
+
+        StompContentSubframe content = channel.readInbound();
+        assertSame(LastStompContentSubframe.EMPTY_LAST_CONTENT, content);
+        content.release();
+
+        assertNull(channel.readInbound());
+    }
 }


### PR DESCRIPTION
Motivation:

When a CR (`0x0D`) byte appears in the middle of a multi-byte UTF-8 sequence within a STOMP header line, `Utf8LineParser.process` takes the CR branch and returns early **without clearing its partial UTF-8 decode state** (`interim` / `nextRead`). The next byte is then combined with the stale state and decoded incorrectly, corrupting the decoded value.

For example, a header value made of the bytes `0xC3 0x0D 0x41` (`0xC3` starts a 2-byte sequence, `CR`, then `A`) decodes to `Á` instead of `A`.

Modifications:

Clear `interim` and `nextRead` in the CR branch of `Utf8LineParser.process`, so that a CR resets the UTF-8 decode state. CR is an ASCII control byte and is never a valid UTF-8 lead or continuation byte, so if it interrupts a multi-byte sequence that sequence is malformed and the partial state should be discarded.

Result:

Bytes following a CR are decoded correctly. Adds a regression test (`StompSubframeDecoderTest#testCRResetsUtf8DecodeState`) that fails before this change (`expected: <A> but was: <Á>`) and passes after it. The full `StompSubframeDecoderTest` suite continues to pass.