### PR TITLE
Use Ticker in Http2MaxRstFrameListener for testability

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MaxRstFrameDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MaxRstFrameDecoder.java
@@ -27,25 +27,18 @@ import static io.netty.util.internal.ObjectUtil.checkPositive;
 final class Http2MaxRstFrameDecoder extends DecoratingHttp2ConnectionDecoder {
     private final int maxRstFramesPerWindow;
     private final int secondsPerWindow;
-    private final Ticker ticker;
 
     Http2MaxRstFrameDecoder(Http2ConnectionDecoder delegate, int maxRstFramesPerWindow, int secondsPerWindow) {
-        this(delegate, maxRstFramesPerWindow, secondsPerWindow, Ticker.systemTicker());
-    }
-
-    Http2MaxRstFrameDecoder(Http2ConnectionDecoder delegate, int maxRstFramesPerWindow, int secondsPerWindow,
-                            Ticker ticker) {
         super(delegate);
         this.maxRstFramesPerWindow = checkPositive(maxRstFramesPerWindow, "maxRstFramesPerWindow");
         this.secondsPerWindow = checkPositive(secondsPerWindow, "secondsPerWindow");
-        this.ticker = ticker;
     }
 
     @Override
     public void frameListener(Http2FrameListener listener) {
         if (listener != null) {
             super.frameListener(new Http2MaxRstFrameListener(
-                    listener, maxRstFramesPerWindow, secondsPerWindow, ticker));
+                    listener, maxRstFramesPerWindow, secondsPerWindow, Ticker.systemTicker()));
         } else {
             super.frameListener(null);
         }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MaxRstFrameDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MaxRstFrameDecoder.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.http2;
 
+import io.netty.util.concurrent.Ticker;
+
 import static io.netty.util.internal.ObjectUtil.checkPositive;
 
 
@@ -25,17 +27,25 @@ import static io.netty.util.internal.ObjectUtil.checkPositive;
 final class Http2MaxRstFrameDecoder extends DecoratingHttp2ConnectionDecoder {
     private final int maxRstFramesPerWindow;
     private final int secondsPerWindow;
+    private final Ticker ticker;
 
     Http2MaxRstFrameDecoder(Http2ConnectionDecoder delegate, int maxRstFramesPerWindow, int secondsPerWindow) {
+        this(delegate, maxRstFramesPerWindow, secondsPerWindow, Ticker.systemTicker());
+    }
+
+    Http2MaxRstFrameDecoder(Http2ConnectionDecoder delegate, int maxRstFramesPerWindow, int secondsPerWindow,
+                            Ticker ticker) {
         super(delegate);
         this.maxRstFramesPerWindow = checkPositive(maxRstFramesPerWindow, "maxRstFramesPerWindow");
         this.secondsPerWindow = checkPositive(secondsPerWindow, "secondsPerWindow");
+        this.ticker = ticker;
     }
 
     @Override
     public void frameListener(Http2FrameListener listener) {
         if (listener != null) {
-            super.frameListener(new Http2MaxRstFrameListener(listener, maxRstFramesPerWindow, secondsPerWindow));
+            super.frameListener(new Http2MaxRstFrameListener(
+                    listener, maxRstFramesPerWindow, secondsPerWindow, ticker));
         } else {
             super.frameListener(null);
         }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MaxRstFrameListener.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MaxRstFrameListener.java
@@ -35,25 +35,19 @@ final class Http2MaxRstFrameListener extends Http2FrameListenerDecorator {
     private long lastRstFrameNano;
     private int receivedRstInWindow;
 
-    Http2MaxRstFrameListener(Http2FrameListener listener, int maxRstFramesPerWindow, int secondsPerWindow) {
-        this(listener, maxRstFramesPerWindow, secondsPerWindow, Ticker.systemTicker());
-    }
-
     Http2MaxRstFrameListener(Http2FrameListener listener, int maxRstFramesPerWindow, int secondsPerWindow,
                              Ticker ticker) {
         super(listener);
         this.maxRstFramesPerWindow = maxRstFramesPerWindow;
         this.nanosPerWindow = TimeUnit.SECONDS.toNanos(secondsPerWindow);
         this.ticker = ticker;
+        this.lastRstFrameNano = ticker.nanoTime() - nanosPerWindow;
     }
 
     @Override
     public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode) throws Http2Exception {
         long currentNano = ticker.nanoTime();
-        // receivedRstInWindow == 0 means this is the very first RST observed by this listener, so we set
-        // the window to now rather than to construction time. This branch also handles the regular window
-        // reset since both cases initialize the counter to 1.
-        if (receivedRstInWindow == 0 || currentNano - lastRstFrameNano >= nanosPerWindow) {
+        if (currentNano - lastRstFrameNano >= nanosPerWindow) {
             lastRstFrameNano = currentNano;
             receivedRstInWindow = 1;
         } else {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MaxRstFrameListener.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MaxRstFrameListener.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.concurrent.Ticker;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -30,19 +31,29 @@ final class Http2MaxRstFrameListener extends Http2FrameListenerDecorator {
 
     private final long nanosPerWindow;
     private final int maxRstFramesPerWindow;
-    private long lastRstFrameNano = System.nanoTime();
+    private final Ticker ticker;
+    private long lastRstFrameNano;
     private int receivedRstInWindow;
 
     Http2MaxRstFrameListener(Http2FrameListener listener, int maxRstFramesPerWindow, int secondsPerWindow) {
+        this(listener, maxRstFramesPerWindow, secondsPerWindow, Ticker.systemTicker());
+    }
+
+    Http2MaxRstFrameListener(Http2FrameListener listener, int maxRstFramesPerWindow, int secondsPerWindow,
+                             Ticker ticker) {
         super(listener);
         this.maxRstFramesPerWindow = maxRstFramesPerWindow;
         this.nanosPerWindow = TimeUnit.SECONDS.toNanos(secondsPerWindow);
+        this.ticker = ticker;
     }
 
     @Override
     public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode) throws Http2Exception {
-        long currentNano = System.nanoTime();
-        if (currentNano - lastRstFrameNano >= nanosPerWindow) {
+        long currentNano = ticker.nanoTime();
+        // receivedRstInWindow == 0 means this is the very first RST observed by this listener, so we set
+        // the window to now rather than to construction time. This branch also handles the regular window
+        // reset since both cases initialize the counter to 1.
+        if (receivedRstInWindow == 0 || currentNano - lastRstFrameNano >= nanosPerWindow) {
             lastRstFrameNano = currentNano;
             receivedRstInWindow = 1;
         } else {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MaxRstFrameListenerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MaxRstFrameListenerTest.java
@@ -67,25 +67,4 @@ public class Http2MaxRstFrameListenerTest {
         listener.onRstStreamRead(ctx, 1, Http2Error.STREAM_CLOSED.code());
         verify(frameListener, times(2)).onRstStreamRead(eq(ctx), anyInt(), eq(Http2Error.STREAM_CLOSED.code()));
     }
-
-    @Test
-    public void testWindowOnFirstFrameNotOnConstruction() throws Http2Exception {
-        // max = 2 RST per 10s window.
-        listener = new Http2MaxRstFrameListener(frameListener, 2, 10, ticker);
-
-        // Stay idle for nearly the full configured window before the first frame arrives.
-        ticker.advance(9, TimeUnit.SECONDS);
-
-        // 1st and 2nd frame at t=9s: fit within budget. Window is set here.
-        listener.onRstStreamRead(ctx, 1, Http2Error.STREAM_CLOSED.code());
-        listener.onRstStreamRead(ctx, 2, Http2Error.STREAM_CLOSED.code());
-
-        // 3rd frame just past the original construction window, but still well within
-        // the first-frame window. With the bug this would silently reset; with the fix it trips.
-        ticker.advance(2, TimeUnit.SECONDS); // t = 11s, only 2s since the first frame
-        Http2Exception ex = assertThrows(Http2Exception.class,
-                () -> listener.onRstStreamRead(ctx, 3, Http2Error.STREAM_CLOSED.code()));
-        assertEquals(Http2Error.ENHANCE_YOUR_CALM, ex.error());
-        verify(frameListener, times(2)).onRstStreamRead(eq(ctx), anyInt(), eq(Http2Error.STREAM_CLOSED.code()));
-    }
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MaxRstFrameListenerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MaxRstFrameListenerTest.java
@@ -15,10 +15,13 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.concurrent.MockTicker;
+import io.netty.util.concurrent.Ticker;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 import org.mockito.Mock;
+
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -35,6 +38,8 @@ public class Http2MaxRstFrameListenerTest {
     @Mock
     private ChannelHandlerContext ctx;
 
+    private final MockTicker ticker = Ticker.newMockTicker();
+
     private Http2MaxRstFrameListener listener;
 
     @BeforeEach
@@ -44,25 +49,43 @@ public class Http2MaxRstFrameListenerTest {
 
     @Test
     public void testMaxRstFramesReached() throws Http2Exception {
-        listener = new Http2MaxRstFrameListener(frameListener, 1, 10);
+        listener = new Http2MaxRstFrameListener(frameListener, 1, 10, ticker);
         listener.onRstStreamRead(ctx, 1, Http2Error.STREAM_CLOSED.code());
 
-        Http2Exception ex = assertThrows(Http2Exception.class, new Executable() {
-            @Override
-            public void execute() throws Throwable {
-                listener.onRstStreamRead(ctx, 2, Http2Error.STREAM_CLOSED.code());
-            }
-        });
+        Http2Exception ex = assertThrows(Http2Exception.class,
+                () -> listener.onRstStreamRead(ctx, 2, Http2Error.STREAM_CLOSED.code()));
         assertEquals(Http2Error.ENHANCE_YOUR_CALM, ex.error());
         verify(frameListener, times(1)).onRstStreamRead(eq(ctx), anyInt(), eq(Http2Error.STREAM_CLOSED.code()));
     }
 
     @Test
-    public void testRstFrames() throws Exception {
-        listener = new Http2MaxRstFrameListener(frameListener, 1, 1);
+    public void testRstFramesWindowReset() throws Exception {
+        listener = new Http2MaxRstFrameListener(frameListener, 1, 1, ticker);
         listener.onRstStreamRead(ctx, 1, Http2Error.STREAM_CLOSED.code());
-        Thread.sleep(1100);
+        // Advance past the window so the counter resets.
+        ticker.advance(1, TimeUnit.SECONDS);
         listener.onRstStreamRead(ctx, 1, Http2Error.STREAM_CLOSED.code());
+        verify(frameListener, times(2)).onRstStreamRead(eq(ctx), anyInt(), eq(Http2Error.STREAM_CLOSED.code()));
+    }
+
+    @Test
+    public void testWindowOnFirstFrameNotOnConstruction() throws Http2Exception {
+        // max = 2 RST per 10s window.
+        listener = new Http2MaxRstFrameListener(frameListener, 2, 10, ticker);
+
+        // Stay idle for nearly the full configured window before the first frame arrives.
+        ticker.advance(9, TimeUnit.SECONDS);
+
+        // 1st and 2nd frame at t=9s: fit within budget. Window is set here.
+        listener.onRstStreamRead(ctx, 1, Http2Error.STREAM_CLOSED.code());
+        listener.onRstStreamRead(ctx, 2, Http2Error.STREAM_CLOSED.code());
+
+        // 3rd frame just past the original construction window, but still well within
+        // the first-frame window. With the bug this would silently reset; with the fix it trips.
+        ticker.advance(2, TimeUnit.SECONDS); // t = 11s, only 2s since the first frame
+        Http2Exception ex = assertThrows(Http2Exception.class,
+                () -> listener.onRstStreamRead(ctx, 3, Http2Error.STREAM_CLOSED.code()));
+        assertEquals(Http2Error.ENHANCE_YOUR_CALM, ex.error());
         verify(frameListener, times(2)).onRstStreamRead(eq(ctx), anyInt(), eq(Http2Error.STREAM_CLOSED.code()));
     }
 }


### PR DESCRIPTION
Motivation:
`Http2MaxRstFrameListener` reads the current time directly via
`System.nanoTime()`, which makes the rate-limiting logic hard to test
deterministically. The accompanying test had to rely on real time and
sleeps, which is both slow and flaky.


Modifications:
* Make Http2MaxRstFrameListener use an injectable Ticker instead of
  System.nanoTime(); Http2MaxRstFrameDecoder forwards it.
* Replace Thread.sleep in Http2MaxRstFrameListenerTest with MockTicker
  

Result:
Tests run deterministically without sleeping.
No public API change.