### PR TITLE
FastLz: Guard decompression against truncated input

### DIFF
--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/FastLz.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/FastLz.java
@@ -408,6 +408,10 @@ final class FastLz {
      */
     static int decompress(final ByteBuf input, final int inOffset, final int inLength,
                           final ByteBuf output, final int outOffset, final int outLength) {
+        if (inLength == 0) {
+            return 0;
+        }
+
         //int level = ((*(const flzuint8*)input) >> 5) + 1;
         final int level = (input.getByte(inOffset) >> 5) + 1;
         if (level != LEVEL_1 && level != LEVEL_2) {
@@ -440,19 +444,31 @@ final class FastLz {
                 int code;
                 if (len == 6) {
                     if (level == LEVEL_1) {
+                        if (ip >= inLength) {
+                            return 0;
+                        }
                         // len += *ip++;
                         len += input.getUnsignedByte(inOffset + ip++);
                     } else {
                         do {
+                            if (ip >= inLength) {
+                                return 0;
+                            }
                             code = input.getUnsignedByte(inOffset + ip++);
                             len += code;
                         } while (code == 255);
                     }
                 }
                 if (level == LEVEL_1) {
+                    if (ip >= inLength) {
+                        return 0;
+                    }
                     //  ref -= *ip++;
                     ref -= input.getUnsignedByte(inOffset + ip++);
                 } else {
+                    if (ip >= inLength) {
+                        return 0;
+                    }
                     code = input.getUnsignedByte(inOffset + ip++);
                     ref -= code;
 
@@ -460,6 +476,9 @@ final class FastLz {
                     // if(FASTLZ_UNEXPECT_CONDITIONAL(code==255))
                     // if(FASTLZ_EXPECT_CONDITIONAL(ofs==(31 << 8)))
                     if (code == 255 && ofs == 31 << 8) {
+                        if (ip + 2 > inLength) {
+                            return 0;
+                        }
                         ofs = input.getUnsignedByte(inOffset + ip++) << 8;
                         ofs += input.getUnsignedByte(inOffset + ip++);
 

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/FastLzFrameDecoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/FastLzFrameDecoderTest.java
@@ -25,30 +25,29 @@ public class FastLzFrameDecoderTest {
 
     @Test
     public void testCompressedBlockWithEmptyPayload() {
-        EmbeddedChannel channel = new EmbeddedChannel(new FastLzFrameDecoder());
-        try {
-            assertThrows(DecompressionException.class, () -> channel.writeInbound(Unpooled.wrappedBuffer(new byte[] {
-                    'F', 'L', 'Z',
-                    0x01,
-                    0x00, 0x00,
-                    0x00, 0x01
-            })));
-        } finally {
-            channel.finishAndReleaseAll();
-        }
+        assertDecompressionException(new byte[] {
+                'F', 'L', 'Z',
+                0x01,
+                0x00, 0x00,
+                0x00, 0x01
+        });
     }
 
     @Test
     public void testCompressedBlockWithTruncatedMatch() {
+        assertDecompressionException(new byte[] {
+                'F', 'L', 'Z',
+                0x01,
+                0x00, 0x03,
+                0x00, 0x04,
+                0x00, 'A', 0x20
+        });
+    }
+
+    private static void assertDecompressionException(byte[] input) {
         EmbeddedChannel channel = new EmbeddedChannel(new FastLzFrameDecoder());
         try {
-            assertThrows(DecompressionException.class, () -> channel.writeInbound(Unpooled.wrappedBuffer(new byte[] {
-                    'F', 'L', 'Z',
-                    0x01,
-                    0x00, 0x03,
-                    0x00, 0x04,
-                    0x00, 'A', 0x20
-            })));
+            assertThrows(DecompressionException.class, () -> channel.writeInbound(Unpooled.wrappedBuffer(input)));
         } finally {
             channel.finishAndReleaseAll();
         }

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/FastLzFrameDecoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/FastLzFrameDecoderTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class FastLzFrameDecoderTest {
+
+    @Test
+    public void testCompressedBlockWithEmptyPayload() {
+        EmbeddedChannel channel = new EmbeddedChannel(new FastLzFrameDecoder());
+        try {
+            assertThrows(DecompressionException.class, () -> channel.writeInbound(Unpooled.wrappedBuffer(new byte[] {
+                    'F', 'L', 'Z',
+                    0x01,
+                    0x00, 0x00,
+                    0x00, 0x01
+            })));
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    public void testCompressedBlockWithTruncatedMatch() {
+        EmbeddedChannel channel = new EmbeddedChannel(new FastLzFrameDecoder());
+        try {
+            assertThrows(DecompressionException.class, () -> channel.writeInbound(Unpooled.wrappedBuffer(new byte[] {
+                    'F', 'L', 'Z',
+                    0x01,
+                    0x00, 0x03,
+                    0x00, 0x04,
+                    0x00, 'A', 0x20
+            })));
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

Malformed FastLZ compressed blocks can declare input that is empty or ends in the middle of match metadata. FastLz.decompress should treat these blocks as corrupted input instead of reading past the supplied chunk length.

Modification:

Return 0 for empty compressed input and check the input length before reading optional match length and distance bytes. Add FastLzFrameDecoder regression coverage for empty compressed payloads and truncated match metadata.

Result:

Malformed FastLZ compressed blocks now fail through the decoder as DecompressionException instead of triggering ByteBuf bounds exceptions.

Security impact:

This is not considered a security issue. Malformed compressed input can already cause the decoder to fail the channel, and the previous behavior was a Java `ByteBuf` bounds exception rather than native memory corruption, data disclosure, or privilege boundary bypass. The change makes the failure mode consistent by treating truncated FastLZ blocks as corrupted input and surfacing the existing `DecompressionException` path.
