### PR TITLE
AsciiString.cached(String) should sanitize the provided String (#13749)

### DIFF
--- a/common/src/main/java/io/netty/util/AsciiString.java
+++ b/common/src/main/java/io/netty/util/AsciiString.java
@@ -1386,14 +1386,27 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
     }
 
     /**
-     * Returns an {@link AsciiString} containing the given string and retains/caches the input
-     * string for later use in {@link #toString()}.
+     * Returns an {@link AsciiString} containing the given string and retains/caches the
+     * input string for later use in {@link #toString()}.
+     * If the input contains only Latin-1 characters (0-255), the original string is reused
+     * to preserve identity for faster equality checks. Otherwise, the string is reconstructed
+     * from the Latin-1 byte content to guarantee consistency (the constructor's {@link #c2b(char)}
+     * converts non-Latin-1 characters to {@code '?'}).
      * Used for the constants (which already stored in the JVM's string table) and in cases
      * where the guaranteed use of the {@link #toString()} method.
      */
     public static AsciiString cached(String string) {
         AsciiString asciiString = new AsciiString(string);
         asciiString.string = string;
+        // Check if the input contains any non-Latin-1 characters that would have been
+        // truncated to '?' by c2b() during construction. If so, reconstruct the cached
+        // string from the byte array to ensure consistency.
+        for (int i = 0; i < string.length(); i++) {
+            if (string.charAt(i) > MAX_CHAR_VALUE) {
+                asciiString.string = asciiString.toString(0);
+                break;
+            }
+        }
         return asciiString;
     }
 

--- a/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
+++ b/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
@@ -552,4 +552,66 @@ public class AsciiStringCharacterTest {
         assertFalse(AsciiString.regionMatchesAscii(str, false, -1, hello, 0, 5));
         assertFalse(AsciiString.regionMatchesAscii(str, false, 0, hello, -1, 5));
     }
+
+    @Test
+    public void testCachedWithAsciiString() {
+        // Pure ASCII strings should reuse the original string to preserve identity
+        String ascii = "hello";
+        AsciiString cached = AsciiString.cached(ascii);
+        assertEquals(ascii, cached.toString());
+        assertSame(ascii, cached.toString());
+        assertEquals(ascii.length(), cached.length());
+        assertTrue(cached.contentEquals(ascii));
+    }
+
+    @Test
+    public void testCachedWithAsciiLatin1String() {
+        // Latin-1 strings (chars 128-255) should reuse the original string to preserve identity
+        String latin1 = "h" + (char) 233 + "llo"; // héllo
+        AsciiString cached = AsciiString.cached(latin1);
+        assertEquals(latin1, cached.toString());
+        assertSame(latin1, cached.toString());
+        assertEquals(latin1.length(), cached.length());
+        assertTrue(cached.contentEquals(latin1));
+    }
+
+    @Test
+    public void testCachedSanitizesNonLatin1String() {
+        // Chars > 255 should be sanitized to '?' in the cached string to match the byte content
+        String nonLatin1 = "test" + (char) 0x1234 + "ing";
+        AsciiString cached = AsciiString.cached(nonLatin1);
+        // The char 0x1234 gets converted to '?' by c2b, so toString should reflect that
+        assertEquals("test?ing", cached.toString());
+    }
+
+    @Test
+    public void testCachedEmptyString() {
+        AsciiString cached = AsciiString.cached("");
+        assertEquals("", cached.toString());
+        assertTrue(cached.isEmpty());
+    }
+
+    @Test
+    public void testCachedStringMatchesByteContent() {
+        // The cached string should always match the byte content round-trip
+        String nonLatin1 = "a" + (char) 0x4321 + "b";
+        AsciiString cached = AsciiString.cached(nonLatin1);
+        // Manually compute the expected sanitized string from the byte array
+        StringBuilder expected = new StringBuilder();
+        for (byte b : cached.toByteArray()) {
+            expected.append((char) (b & 0xFF));
+        }
+        assertEquals(expected.toString(), cached.toString());
+    }
+
+    @Test
+    public void testCachedWithAllAsciiConstants() {
+        // Constants used in the codebase should be unaffected
+        AsciiString host = AsciiString.cached("host");
+        assertEquals("host", host.toString());
+        AsciiString method = AsciiString.cached(":method");
+        assertEquals(":method", method.toString());
+        AsciiString status = AsciiString.cached(":status");
+        assertEquals(":status", status.toString());
+    }
 }


### PR DESCRIPTION
## Motivation

`AsciiString.cached(String)` stored the original String reference directly in `asciiString.string`, bypassing the `c2b()` Latin-1 byte conversion performed in the constructor. When strings contained non-Latin-1 characters (>255), the byte array would get `'?'` in those positions (via `c2b` truncation), but `toString()` still returned the unsanitized original. This broke the invariant that the cached string matches the Latin-1 byte content exactly, preventing use of the cached string for fast equality comparisons (e.g., `String::contentEquals` with vectorized JVM intrinsics).

## Modification

In `AsciiString.cached(String)`, the method now first sets the cached string to the original input (preserving identity for fast `equals()` checks), then scans the input for non-Latin-1 characters. If any are found, the cached string is reconstructed from the byte array via `toString(0)` to ensure consistency with the Latin-1 byte content. The Javadoc was updated to document this behavior.

Added 6 test methods (`AsciiStringCharacterTest.java`) covering pure ASCII, Latin-1, non-Latin-1 sanitization, empty strings, byte-content round-trip, and real-world constant preservation. Tests for pure ASCII and Latin-1 strings assert that the original String identity is preserved (`assertSame`).

## Result

For pure ASCII/Latin-1 inputs, the original String identity is preserved (enabling faster equality checks for interned constants).
For non-Latin-1 inputs, the cached string is sanitized to match the Latin-1 byte content.

Closes #13749