### PR TITLE
Crc32c: Use JDK CRC32C intrinsics via ByteBufChecksum delegation (#13834)

### DIFF
--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/JdkCrc32cByteBufChecksum.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/JdkCrc32cByteBufChecksum.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.buffer.ByteBuf;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.util.zip.Checksum;
+
+/**
+ * A {@link ByteBufChecksum} implementation that wraps the JDK's CRC32C
+ * ({@code java.util.zip.CRC32C}) using the {@link Checksum} interface.
+ * <p>
+ * This class uses the JDK's CRC32C which has {@code @IntrinsicCandidate}
+ * methods leveraging CPU-level CRC32C instructions (SSE 4.2 {@code crc32} on x86,
+ * ARMv8 CRC instructions). For non-heap {@link ByteBuf}s, it uses the direct
+ * {@link ByteBuffer} path internally.
+ * <p>
+ * <strong>Note:</strong> This class uses reflection to avoid a compile-time
+ * dependency on {@code java.util.zip.CRC32C}, which is only available since Java 9.
+ * It must only be loaded on Java 9 or later.
+ */
+final class JdkCrc32cByteBufChecksum extends ByteBufChecksum {
+
+    private static final Constructor<?> CRC32C_CTOR;
+    private static final Method UPDATE_BB;
+
+    static {
+        try {
+            Class<?> crc32cClass = Class.forName("java.util.zip.CRC32C");
+            CRC32C_CTOR = crc32cClass.getConstructor();
+            UPDATE_BB = crc32cClass.getMethod("update", ByteBuffer.class);
+        } catch (Exception e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private final Checksum checksum;
+
+    JdkCrc32cByteBufChecksum() {
+        try {
+            checksum = (Checksum) CRC32C_CTOR.newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create CRC32C instance", e);
+        }
+    }
+
+    @Override
+    public void update(int b) {
+        checksum.update(b);
+    }
+
+    @Override
+    public void update(byte[] b, int off, int len) {
+        checksum.update(b, off, len);
+    }
+
+    @Override
+    public void update(ByteBuf buf, int off, int len) {
+        if (buf.hasArray()) {
+            update(buf.array(), buf.arrayOffset() + off, len);
+        } else {
+            invokeUpdateBb(CompressionUtil.safeNioBuffer(buf, off, len));
+        }
+    }
+
+    private void invokeUpdateBb(ByteBuffer buf) {
+        try {
+            UPDATE_BB.invoke(checksum, buf);
+        } catch (Exception e) {
+            throw new RuntimeException("CRC32C.update(ByteBuffer) failed", e);
+        }
+    }
+
+    @Override
+    public long getValue() {
+        return checksum.getValue();
+    }
+
+    @Override
+    public void reset() {
+        checksum.reset();
+    }
+}

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/JdkCrc32cByteBufChecksumWithWorkaround.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/JdkCrc32cByteBufChecksumWithWorkaround.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.buffer.ByteBuf;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.util.zip.Checksum;
+
+/**
+ * A {@link ByteBufChecksum} implementation that wraps the JDK's CRC32C
+ * ({@code java.util.zip.CRC32C}) using the {@link Checksum} interface.
+ * <p>
+ * This class includes a workaround for
+ * <a href="https://bugs.openjdk.org/browse/JDK-8357145">JDK-8357145</a>,
+ * which affects JDK 22 through 24 when updating from a direct {@link ByteBuffer}.
+ * Use this class only when running on JDK versions where the workaround is
+ * required.
+ * <p>
+ * <strong>Note:</strong> This class uses reflection to avoid a compile-time
+ * dependency on {@code java.util.zip.CRC32C}, which is only available since Java 9.
+ * It must only be loaded on Java 9 or later.
+ */
+final class JdkCrc32cByteBufChecksumWithWorkaround extends ByteBufChecksum {
+
+    private static final Constructor<?> CRC32C_CTOR;
+    private static final Method UPDATE_BB;
+
+    static {
+        try {
+            Class<?> crc32cClass = Class.forName("java.util.zip.CRC32C");
+            CRC32C_CTOR = crc32cClass.getConstructor();
+            UPDATE_BB = crc32cClass.getMethod("update", ByteBuffer.class);
+        } catch (Exception e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private final Checksum checksum;
+    private byte[] scratchBuffer;
+
+    JdkCrc32cByteBufChecksumWithWorkaround() {
+        try {
+            checksum = (Checksum) CRC32C_CTOR.newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create CRC32C instance", e);
+        }
+    }
+
+    @Override
+    public void update(int b) {
+        checksum.update(b);
+    }
+
+    @Override
+    public void update(byte[] b, int off, int len) {
+        checksum.update(b, off, len);
+    }
+
+    @Override
+    public void update(ByteBuf buf, int off, int len) {
+        if (buf.hasArray()) {
+            update(buf.array(), buf.arrayOffset() + off, len);
+        } else {
+            ByteBuffer byteBuffer = CompressionUtil.safeNioBuffer(buf, off, len);
+            if (byteBuffer.isDirect()) {
+                // Work-around for https://bugs.openjdk.org/browse/JDK-8357145
+                if (scratchBuffer == null || scratchBuffer.length < len) {
+                    scratchBuffer = new byte[len];
+                }
+                ByteBuffer copy = ByteBuffer.wrap(scratchBuffer, 0, len);
+                copy.put(byteBuffer).flip();
+                invokeUpdateBb(copy);
+                return;
+            }
+            invokeUpdateBb(byteBuffer);
+        }
+    }
+
+    private void invokeUpdateBb(ByteBuffer buf) {
+        try {
+            UPDATE_BB.invoke(checksum, buf);
+        } catch (Exception e) {
+            throw new RuntimeException("CRC32C.update(ByteBuffer) failed", e);
+        }
+    }
+
+    @Override
+    public long getValue() {
+        return checksum.getValue();
+    }
+
+    @Override
+    public void reset() {
+        checksum.reset();
+    }
+}

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/Snappy.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/Snappy.java
@@ -19,8 +19,11 @@ import io.netty.buffer.ByteBuf;
 import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.internal.MathUtil;
 import io.netty.util.internal.SystemPropertyUtil;
+import io.netty.util.internal.PlatformDependent;
 
 import java.util.Arrays;
+
+import java.util.function.Supplier;
 
 /**
  * Uncompresses an input {@link ByteBuf} encoded with Snappy compression into an
@@ -36,6 +39,22 @@ public final class Snappy {
     // used as a return value to indicate that we haven't yet read our full preamble
     private static final int PREAMBLE_NOT_FULL = -1;
     private static final int NOT_ENOUGH_INPUT = -1;
+
+    private static final Supplier<ByteBufChecksum> CRC32C_SUPPLIER;
+
+    static {
+        Supplier<ByteBufChecksum> supplier;
+        if (PlatformDependent.javaVersion() >= 9) {
+            if (PlatformDependent.javaVersion() >= 22 && PlatformDependent.javaVersion() < 25) {
+                supplier = JdkCrc32cByteBufChecksumWithWorkaround::new;
+            } else {
+                supplier = JdkCrc32cByteBufChecksum::new;
+            }
+        } else {
+            supplier = Crc32c::new;
+        }
+        CRC32C_SUPPLIER = supplier;
+    }
 
     // constants for the tag types
     private static final int LITERAL = 0;
@@ -666,7 +685,7 @@ public final class Snappy {
      * @param data The input data to calculate the CRC32C checksum of
      */
     static int calculateChecksum(ByteBuf data, int offset, int length) {
-        Crc32c crc32 = new Crc32c();
+        ByteBufChecksum crc32 = CRC32C_SUPPLIER.get();
         try {
             crc32.update(data, offset, length);
             return maskChecksum(crc32.getValue());


### PR DESCRIPTION
## Motivation:

Netty's `Crc32c` class uses a pure-Java lookup table for CRC32C computation without CPU intrinsics. OpenJDK's `java.util.zip.CRC32C` (Java 9+) has `@HotSpotIntrinsicCandidate` `updateBytes()` using SSE 4.2/ARM CRC instructions, providing significantly better throughput.

Currently, `Snappy.calculateChecksum()` creates a `Crc32c` instance directly, leaving JDF CRC32C hardware intrinsics unused.

## Modification:

- Added `JdkCrc32cByteBufChecksum` (Java 9+): wraps `java.util.zip.CRC32C` via the `Checksum` interface using reflection, with a direct `update(ByteBuffer)` path for efficient direct buffer processing.
- Added `JdkCrc32cByteBufChecksumWithWorkaround` (JDK 22-24): same approach but works around JDK-8357145 by copying direct buffer contents to a heap `byte[]` before delegation.
- Modified `Snappy.java`: replaced `new Crc32c()` with a `ByteBufChecksum` supplier selected at class init time based on `javaVersion()`:
  * JDK < 9: pure-Java table-based `Crc32c` (unchanged)
  * JDK 9-21, 25+: `JdkCrc32cByteBufChecksum` (hardware intrinsics)
  * JDK 22-24: `JdkCrc32cByteBufChecksumWithWorkaround` (bug workaround)
- `Crc32c.java` remains untouched as a pure table-based fallback.

## Result:

Snappy CRC32C checksums now use JDK hardware intrinsics on Java 9+.

Fixes #13834.
