### PR TITLE
Reconcile `AbstractCoalescingBufferQueue` readableBytes when it drain…

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
@@ -23,6 +23,7 @@ import io.netty.handler.codec.http2.Http2CodecUtil.SimpleChannelPromiseAggregato
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;
+import io.netty.util.ReferenceCountUtil;
 
 import java.util.ArrayDeque;
 import java.util.Queue;
@@ -31,6 +32,7 @@ import static io.netty.handler.codec.http.HttpStatusClass.INFORMATIONAL;
 import static io.netty.handler.codec.http2.Http2Error.INTERNAL_ERROR;
 import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
+import static io.netty.handler.codec.http2.Http2Exception.streamError;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 import static java.lang.Integer.MAX_VALUE;
@@ -494,6 +496,20 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder, Ht
             Promise<Void> writePromise = ctx.<Void>newPromise().addListener(this);
             ByteBuf toWrite = queue.remove(ctx.alloc(), writableData, writePromise);
             dataSize = queue.readableBytes();
+
+            // The queue reported writableData readable bytes but produced fewer: a queued buffer was released or
+            // consumed while still referenced by the queue, so the stream's data is corrupted. Fail the stream.
+            int producedBytes = toWrite.readableBytes();
+            if (producedBytes < writableData) {
+                ReferenceCountUtil.safeRelease(toWrite);
+                // Set dataSize and padding to 0 to signal that the whole frame was consumed, so it is removed and
+                // its bytes are returned to flow control (matching the error path above).
+                padding = dataSize = 0;
+                writePromise.tryFailure(streamError(stream.id(), INTERNAL_ERROR,
+                        "Stream %d flow-controlled queue produced %d bytes but reported %d",
+                        stream.id(), producedBytes, writableData));
+                return;
+            }
 
             // Determine how much padding to write.
             int writablePadding = min(allowedBytes - writableData, padding);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
@@ -319,6 +319,31 @@ public class DefaultHttp2ConnectionEncoderTest {
     }
 
     @Test
+    public void writeDataFailsStreamWhenFlowControlledQueueUnderDelivers() throws Exception {
+        createStream(STREAM_ID, false);
+        ByteBuf data = wrappedBuffer(new byte[10]);
+        Promise<Void> promise = newPromise();
+        // Include padding so we also cover that dataSize and padding are reset on failure.
+        encoder.writeData(ctx, STREAM_ID, data, 10, false, promise);
+        FlowControlled fc = payloadCaptor.getValue();
+        assertEquals(20, fc.size());
+
+        // Simulate a queued buffer being consumed out from under the queue
+        data.skipBytes(data.readableBytes());
+
+        fc.write(ctx, 20);
+
+        // Expect the stream to fail rather than emitting any frames
+        assertFalse(promise.isSuccess());
+        assertInstanceOf(Http2Exception.class, promise.cause());
+        assertEquals(Http2Error.INTERNAL_ERROR, ((Http2Exception) promise.cause()).error());
+        assertTrue(writtenData.isEmpty());
+        // The frame reports as fully consumed so it is removed and its bytes return to flow control.
+        assertEquals(0, fc.size());
+        assertEquals(0, data.refCnt());
+    }
+
+    @Test
     public void headersWriteForUnknownStreamShouldCreateStream() throws Exception {
         writeAllFlowControlledFrames();
         final int streamId = 6;

--- a/transport/src/main/java/io/netty/channel/AbstractCoalescingBufferQueue.java
+++ b/transport/src/main/java/io/netty/channel/AbstractCoalescingBufferQueue.java
@@ -132,6 +132,7 @@ public abstract class AbstractCoalescingBufferQueue {
             aggregatePromise.addHandler((CompletionHandler<Void>) entry);
             bufAndListenerPairs.poll();
         }
+        reconcileReadableBytes();
         return result;
     }
 
@@ -152,7 +153,7 @@ public abstract class AbstractCoalescingBufferQueue {
 
         // Use isEmpty rather than readableBytes==0 as we may have a promise associated with an empty buffer.
         if (bufAndListenerPairs.isEmpty()) {
-            assert readableBytes == 0;
+            reconcileReadableBytes();
             return removeEmptyValue();
         }
         bytes = Math.min(bytes, readableBytes);
@@ -224,6 +225,7 @@ public abstract class AbstractCoalescingBufferQueue {
             throwException(cause);
         }
         decrementReadableBytes(originalBytes - bytes);
+        reconcileReadableBytes();
         return toReturn;
     }
 
@@ -298,6 +300,7 @@ public abstract class AbstractCoalescingBufferQueue {
                 }
             }
         }
+        reconcileReadableBytes();
         if (pending != null) {
             throw new IllegalStateException(pending);
         }
@@ -418,6 +421,7 @@ public abstract class AbstractCoalescingBufferQueue {
                 }
             }
         }
+        reconcileReadableBytes();
         if (pending != null) {
             throw new IllegalStateException(pending);
         }
@@ -434,5 +438,21 @@ public abstract class AbstractCoalescingBufferQueue {
     private void decrementReadableBytes(int decrement) {
         readableBytes -= decrement;
         assert readableBytes >= 0;
+    }
+
+    /**
+     * Resets readableBytes to 0 when the queue is empty. They can only diverge if a queued buffer was released
+     * or consumed while still referenced by the queue (similar to a reference-counting bug) after it was added,
+     * which would otherwise make remove(...) return empty buffers forever. Logged at error level because it
+     * always indicates a bug that needs to be found.
+     * See https://github.com/netty/netty/issues/16946
+     */
+    private void reconcileReadableBytes() {
+        if (readableBytes != 0 && bufAndListenerPairs.isEmpty()) {
+            logger.error("readableBytes is {} but the queue is empty: a queued buffer was released or consumed " +
+                    "while still referenced by the queue. This indicates a bug in the code that produced the " +
+                    "buffer. Resetting readableBytes to 0.", readableBytes);
+            decrementReadableBytes(readableBytes);
+        }
     }
 }

--- a/transport/src/test/java/io/netty/channel/CoalescingBufferQueueTest.java
+++ b/transport/src/test/java/io/netty/channel/CoalescingBufferQueueTest.java
@@ -19,6 +19,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.CompletionHandler;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;
 import org.junit.jupiter.api.AfterEach;
@@ -195,6 +196,93 @@ public class CoalescingBufferQueueTest {
         assertTrue(emptyPromise.isSuccess());
         assertEquals(0, cat.refCnt());
         assertEquals(0, empty.refCnt());
+    }
+
+    // If a queued buffer's readable bytes shrink after enqueue (released or consumed out from under the queue),
+    // the queue must still report 0 readable bytes once drained.
+    // See https://github.com/netty/netty/issues/16946
+    @Test
+    public void testReadableBytesResetWhenQueuedBufferConsumedExternally() {
+        // Not used in this test.
+        cat.release();
+        mouse.release();
+
+        ByteBuf buffer = Unpooled.buffer().writeZero(292);
+        writeQueue.add(buffer);
+        assertEquals(292, writeQueue.readableBytes());
+
+        // Consume the buffer out from under the queue (e.g. a pooled buffer released and reused).
+        buffer.skipBytes(buffer.readableBytes());
+
+        ByteBuf removed = writeQueue.remove(channel.alloc(), Integer.MAX_VALUE, newPromise());
+        assertFalse(removed.isReadable());
+        removed.release();
+        assertQueueSize(0, true);
+
+        // A subsequent remove must not resurrect phantom readable bytes.
+        ByteBuf removedAgain = writeQueue.remove(channel.alloc(), Integer.MAX_VALUE, newPromise());
+        assertFalse(removedAgain.isReadable());
+        removedAgain.release();
+        assertQueueSize(0, true);
+    }
+
+    @Test
+    public void testReadableBytesResetWhenReleaseAndFailAllSeesConsumedBuffer() {
+        cat.release();
+        mouse.release();
+
+        ByteBuf buffer = Unpooled.buffer().writeZero(292);
+        writeQueue.add(buffer);
+        assertEquals(292, writeQueue.readableBytes());
+
+        buffer.skipBytes(buffer.readableBytes());
+        writeQueue.releaseAndFailAll(channel, new RuntimeException());
+
+        assertQueueSize(0, true);
+        assertEquals(0, buffer.refCnt());
+    }
+
+    @Test
+    public void testReadableBytesResetWhenWriteAndRemoveAllSeesConsumedBuffer() throws Exception {
+        cat.release();
+        mouse.release();
+
+        EmbeddedChannel ch = new EmbeddedChannel(new ChannelOutboundHandler() {
+            @Override
+            public void write(ChannelHandlerContext ctx, Object msg, CompletionHandler<Void> promise) {
+                ReferenceCountUtil.release(msg);
+                promise.success(null);
+            }
+        }, new ChannelHandler() { });
+        CoalescingBufferQueue queue = new CoalescingBufferQueue();
+
+        ByteBuf buffer = Unpooled.buffer().writeZero(292);
+        queue.add(buffer);
+        assertEquals(292, queue.readableBytes());
+
+        buffer.skipBytes(buffer.readableBytes());
+        queue.writeAndRemoveAll(ch.pipeline().lastContext());
+
+        assertTrue(queue.isEmpty());
+        assertEquals(0, queue.readableBytes());
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testReadableBytesResetWhenRemoveFirstSeesConsumedBuffer() {
+        cat.release();
+        mouse.release();
+
+        ByteBuf buffer = Unpooled.buffer().writeZero(292);
+        writeQueue.add(buffer);
+        assertEquals(292, writeQueue.readableBytes());
+
+        buffer.skipBytes(buffer.readableBytes());
+        ByteBuf removed = writeQueue.removeFirst(newPromise());
+        assertSame(buffer, removed);
+        removed.release();
+
+        assertQueueSize(0, true);
     }
 
     @Test


### PR DESCRIPTION
…s, and fail stuck HTTP/2 streams instead of spinning empty DATA frames (#16947)

**Motivation:**

On a proxy doing HTTP/2 egress we OOMed when the remote flow controller spun writing empty DATA frames (~134M) into an already-unwritable channel. This is the OOM from #11959, still reachable on `4.2.12.Final` despite #14220 - that fix only closed the exception-in-`remove` route and left two gaps:

* `CoalescingBufferQueue.remove(...)` can leave `readableBytes > 0` with an empty deque -> it decrements by a buffer's *live* readable bytes, and its empty-queue early return asserts rather than reconciles
* Also `writeAllocatedBytes` re-writes a frame that makes no progress without ever checking channel writability.

Full investigation and heap dump in #16946.

**Modification:**

* `AbstractCoalescingBufferQueue` - add a `reconcileReadableBytes()` (called at the `remove(...)` early return and after the drain loop) so an empty queue always reports 0 readable bytes.
* `DefaultHttp2RemoteFlowController.writeAllocatedBytes` - if the head frame is given a positive budget but is neither removed nor shrinks across two consecutive iterations, fail the stream via cancel path instead.
* Tests cover the queue desync, the stuck-frame spin (failing the stream), and a single no-progress pass (tolerated).

**Result:**

The queue can't report bytes it can't produce, and the flow controller can't emit empty DATA frames unboundedly - a wedged stream fails cleanly instead of OOMing the connection. No public API change.

Fixes #16946

---------

Co-authored-by: Norman Maurer <norman_maurer@apple.com>

(cherry picked from commit a5d4f289e914c3d6b5b78ac31583e6f95312d8f4)