### PR TITLE
Optimize redundant bounds checking in ByteBuf.setBytes

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledDirectByteBuf.java
@@ -236,7 +236,7 @@ final class PooledDirectByteBuf extends PooledByteBuf<ByteBuffer> {
     public ByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length) {
         checkSrcIndex(index, length, srcIndex, src.capacity());
         if (src.hasArray()) {
-            setBytes(index, src.array(), src.arrayOffset() + srcIndex, length);
+            _internalNioBuffer(index, length, false).put(src.array(), src.arrayOffset() + srcIndex, length);
         } else if (src.nioBufferCount() > 0) {
             for (ByteBuffer bb: src.nioBuffers(srcIndex, length)) {
                 int bbLen = bb.remaining();

--- a/buffer/src/main/java/io/netty/buffer/PooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledHeapByteBuf.java
@@ -179,7 +179,7 @@ class PooledHeapByteBuf extends PooledByteBuf<byte[]> {
         if (src.hasMemoryAddress() && PlatformDependent.hasUnsafe()) {
             PlatformDependent.copyMemory(src.memoryAddress() + srcIndex, memory, idx(index), length);
         } else if (src.hasArray()) {
-            setBytes(index, src.array(), src.arrayOffset() + srcIndex, length);
+            System.arraycopy(src.array(), src.arrayOffset() + srcIndex, memory, idx(index), length);
         } else {
             src.getBytes(srcIndex, memory, idx(index), length);
         }

--- a/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
@@ -248,7 +248,7 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
         if (src.hasMemoryAddress() && PlatformDependent.hasUnsafe()) {
             PlatformDependent.copyMemory(src.memoryAddress() + srcIndex, array, index, length);
         } else  if (src.hasArray()) {
-            setBytes(index, src.array(), src.arrayOffset() + srcIndex, length);
+            System.arraycopy(src.array(), src.arrayOffset() + srcIndex, array, index, length);
         } else {
             src.getBytes(srcIndex, array, index, length);
         }


### PR DESCRIPTION
## Motivation

When `ByteBuf.setBytes(int index, ByteBuf src, int srcIndex, int length)` is called with an array-backed source (`src.hasArray() == true`), the old code delegated to `setBytes(int index, byte[] src, int srcIndex, int length)`, which performs a second `checkSrcIndex` against `src.array().length`. This check is redundant because the outer `checkSrcIndex` already validated the operation against `src.capacity()`, and for array-backed buffers `capacity = array.length - arrayOffset`, so the outer check strictly dominates the inner one.

## Modification

Three `ByteBuf` implementations are affected by this pattern — `UnpooledHeapByteBuf`, `PooledHeapByteBuf`, and `PooledDirectByteBuf`. All three had their `setBytes(int index, ByteBuf src, int srcIndex, int length)` method modified to copy directly from the source array instead of routing through the `setBytes(byte[], ...)` overload:

- **`UnpooledHeapByteBuf`**: `setBytes(index, src.array(), ...)` → `System.arraycopy(src.array(), src.arrayOffset() + srcIndex, array, index, length)`
- **`PooledHeapByteBuf`**: `setBytes(index, src.array(), ...)` → `System.arraycopy(src.array(), src.arrayOffset() + srcIndex, memory, idx(index), length)`
- **`PooledDirectByteBuf`**: `setBytes(index, src.array(), ...)` → `_internalNioBuffer(index, length, false).put(src.array(), src.arrayOffset() + srcIndex, length)`

The `PooledUnsafeDirectByteBuf` and `UnpooledUnsafeDirectByteBuf` classes already used a direct copy path in their `hasArray()` branch and did not need changes.

Note: `PooledDirectByteBuf` extends `PooledByteBuf<ByteBuffer>` — its internal `memory` field is a *direct* (off-heap) `ByteBuffer`, not a `byte[]`. `System.arraycopy()` only supports copying between Java heap arrays, so the direct buffer path requires `_internalNioBuffer().put()` instead. The heap-buffer variants (`UnpooledHeapByteBuf`, `PooledHeapByteBuf`) use `System.arraycopy()` directly since their memory is a `byte[]`.

No behavior change — this is purely an internal optimization that removes redundant bounds checking from the hottest code path in buffer-to-buffer transfers.

## Result

- **No more redundant `checkSrcIndex`**: the first check against `src.capacity()` is the only one needed
- **Faster transfers** from array-backed sources to any buffer type

Closes #14824