### PR TITLE
Fix SelfSignCertificate initialization in tests

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/util/CachedSelfSignedCertificate.java
+++ b/handler/src/test/java/io/netty/handler/ssl/util/CachedSelfSignedCertificate.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.ssl.util;
 
+import io.netty.util.LeakPresenceDetector;
+
 import java.security.cert.CertificateException;
 
 public final class CachedSelfSignedCertificate {
@@ -39,11 +41,13 @@ public final class CachedSelfSignedCertificate {
         public static final Object INSTANCE = createInstance();
 
         private static Object createInstance() {
-            try {
-                return new SelfSignedCertificate();
-            } catch (CertificateException e) {
-                return e;
-            }
+            return LeakPresenceDetector.staticInitializer(() -> {
+                try {
+                    return new SelfSignedCertificate();
+                } catch (CertificateException e) {
+                    return e;
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
Motivation:
The SelfSignedCertificate may allocate ByteBuf instances, which have leak detection. The CachedSelfSignedCertificate then stores the SelfSignedCertificate in a static field. The LeakPresenceDetector sees this as an allocation outside of a test scope.

Modification:
Tell the LeakPresenceDetector that we're allocating for a static field.

Result:
No more errors from the LeakPresenceDetector about self signed certificates.
