### PR TITLE
Enable extension of Http3ClientConnectionHandler to support higher-level protocols such as WebTransport.

### DIFF
--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ClientConnectionHandler.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ClientConnectionHandler.java
@@ -22,7 +22,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.function.LongFunction;
 
-public final class Http3ClientConnectionHandler extends Http3ConnectionHandler {
+public class Http3ClientConnectionHandler extends Http3ConnectionHandler {
 
     private final LongFunction<ChannelHandler> pushStreamHandlerFactory;
 
@@ -89,7 +89,7 @@ public final class Http3ClientConnectionHandler extends Http3ConnectionHandler {
     }
 
     @Override
-    void initBidirectionalStream(ChannelHandlerContext ctx, QuicStreamChannel channel) {
+    protected void initBidirectionalStream(ChannelHandlerContext ctx, QuicStreamChannel channel) {
         // See https://datatracker.ietf.org/doc/html/rfc9114#name-bidirectional-streams
         // https://datatracker.ietf.org/doc/html/rfc9114#section-6.1-3
         Http3CodecUtils.connectionError(ctx, Http3ErrorCode.H3_STREAM_CREATION_ERROR,
@@ -97,7 +97,7 @@ public final class Http3ClientConnectionHandler extends Http3ConnectionHandler {
     }
 
     @Override
-    void initUnidirectionalStream(ChannelHandlerContext ctx, QuicStreamChannel streamChannel) {
+    protected void initUnidirectionalStream(ChannelHandlerContext ctx, QuicStreamChannel streamChannel) {
         final long maxTableCapacity = maxTableCapacity();
         streamChannel.pipeline().addLast(
                 new Http3UnidirectionalStreamInboundClientHandler(codecFactory, nonStandardSettingsValidator,

--- a/pom.xml
+++ b/pom.xml
@@ -1308,7 +1308,6 @@
                   <new>method void io.netty.handler.codec.http3.Http3ClientConnectionHandler::initBidirectionalStream(io.netty.channel.ChannelHandlerContext, io.netty.handler.codec.quic.QuicStreamChannel)</new>
                   <justification>Allow applications to customize initialization of bidirectional streams by subclassing.</justification>
                 </item>
-
                 <item>
                   <ignore>true</ignore>
                   <code>java.method.visibilityIncreased</code>

--- a/pom.xml
+++ b/pom.xml
@@ -1304,6 +1304,19 @@
               <differences>
                 <item>
                   <ignore>true</ignore>
+                  <code>java.method.visibilityIncreased</code>
+                  <new>method void io.netty.handler.codec.http3.Http3ClientConnectionHandler::initBidirectionalStream(io.netty.channel.ChannelHandlerContext, io.netty.handler.codec.quic.QuicStreamChannel)</new>
+                  <justification>Allow applications to customize initialization of bidirectional streams by subclassing.</justification>
+                </item>
+
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.visibilityIncreased</code>
+                  <new>method void io.netty.handler.codec.http3.Http3ClientConnectionHandler::initUnidirectionalStream(io.netty.channel.ChannelHandlerContext, io.netty.handler.codec.quic.QuicStreamChannel)</new>
+                  <justification>Allow applications to customize initialization of unidirectional streams by subclassing.</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
                   <code>java.class.externalClassExposedInAPI</code>
                   <regex>true</regex>
                   <package>io\.netty\..*</package>


### PR DESCRIPTION
**Motivation**

Enable extension of `Http3ClientConnectionHandler` to support higher-level protocols such as WebTransport.

Two approaches were considered:

1. Make `Http3ClientConnectionHandler` extensible.
2. Make `Http3ConnectionHandler` extensible.

This PR adopts **option 1**.

**Changes**

* Removed the `final` modifier from `Http3ClientConnectionHandler`.
* Changed `initBidirectionalStream(...)` and `initUnidirectionalStream(...)` from package-private to `protected`.

**Result**

Fixes #16992 
