### PR TITLE
Allow WebSocket extension negotiation to be disabled per response

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandler.java
@@ -206,13 +206,25 @@ public class WebSocketServerExtensionHandler extends ChannelDuplexHandler {
         super.write(ctx, response, promise);
     }
 
+    /**
+     * Returns {@code true} if WebSocket extensions negotiated from the request should be acknowledged for this
+     * response.
+     * <p>
+     * This method can be overridden to make the final extension negotiation decision when the handshake response is
+     * written.
+     */
+    protected boolean isExtensionNegotiationEnabled(ChannelHandlerContext ctx, HttpResponse response) {
+        return true;
+    }
+
     private void handlePotentialUpgrade(final ChannelHandlerContext ctx,
                                         ChannelPromise promise, HttpResponse httpResponse,
                                         final List<WebSocketServerExtension> validExtensionsList) {
         HttpHeaders headers = httpResponse.headers();
 
         if (WebSocketExtensionUtil.isWebsocketUpgrade(headers)) {
-            if (validExtensionsList != null && !validExtensionsList.isEmpty()) {
+            if (isExtensionNegotiationEnabled(ctx, httpResponse)
+                    && validExtensionsList != null && !validExtensionsList.isEmpty()) {
                 String headerValue = headers.getAsString(HttpHeaderNames.SEC_WEBSOCKET_EXTENSIONS);
                 List<WebSocketExtensionData> extraExtensions =
                   new ArrayList<>(extensionHandshakers.size());

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandlerTest.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.codec.http.websocketx.extensions;
 
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.HttpHeaderNames;
@@ -209,6 +210,45 @@ public class WebSocketServerExtensionHandlerTest {
 
         verify(fallbackHandshakerMock).handshakeExtension(webSocketExtensionDataMatcher("unknown"));
         verify(fallbackHandshakerMock).handshakeExtension(webSocketExtensionDataMatcher("unknown2"));
+    }
+
+    @Test
+    public void testExtensionNegotiationDisabledForResponse() {
+        // initialize
+        when(mainHandshakerMock.handshakeExtension(webSocketExtensionDataMatcher("main"))).
+                thenReturn(mainExtensionMock);
+
+        when(mainExtensionMock.rsv()).thenReturn(WebSocketExtension.RSV1);
+
+        // execute
+        WebSocketServerExtensionHandler extensionHandler =
+                new WebSocketServerExtensionHandler(mainHandshakerMock) {
+                    @Override
+                    protected boolean isExtensionNegotiationEnabled(ChannelHandlerContext ctx, HttpResponse response) {
+                        return false;
+                    }
+                };
+        EmbeddedChannel ch = new EmbeddedChannel(extensionHandler);
+
+        HttpRequest req = newUpgradeRequest("main");
+        ch.writeInbound(req);
+
+        HttpResponse res = newUpgradeResponse(null);
+        ch.writeOutbound(res);
+
+        HttpResponse res2 = ch.readOutbound();
+
+        // test
+        assertNull(ch.pipeline().context(extensionHandler));
+        assertFalse(res2.headers().contains(HttpHeaderNames.SEC_WEBSOCKET_EXTENSIONS));
+        assertNull(ch.pipeline().get(DummyDecoder.class));
+        assertNull(ch.pipeline().get(DummyEncoder.class));
+
+        verify(mainHandshakerMock).handshakeExtension(webSocketExtensionDataMatcher("main"));
+        verify(mainExtensionMock, times(2)).rsv();
+        verify(mainExtensionMock, never()).newReponseData();
+        verify(mainExtensionMock, never()).newExtensionEncoder();
+        verify(mainExtensionMock, never()).newExtensionDecoder();
     }
 
     @Test


### PR DESCRIPTION
Motivation:

Frameworks may install `WebSocketServerExtensionHandler` globally in the server pipeline, but still need to decline WebSocket extension negotiation for a specific accepted WebSocket response.

One example is a framework-level WebSocket API where compression is enabled globally, but an individual WebSocket endpoint chooses to disable compression. The server should still accept the WebSocket upgrade and exchange plain WebSocket frames; it should only omit the negotiated extension response header and avoid installing extension encoder/decoder handlers for that response.

Modification:

Add a response marker that lets `WebSocketServerExtensionHandler` skip extension negotiation for that response.

Add coverage verifying that the upgrade response is forwarded without negotiating extensions when the marker is present.

Result:

Applications and frameworks can decide per WebSocket response whether negotiated extensions should be accepted, without adding private headers or removing the extension handler from the pipeline.
