### PR TITLE
Decouple QUIC token validation from ODCID derivation

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicTokenHandler.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicTokenHandler.java
@@ -25,6 +25,88 @@ import java.net.InetSocketAddress;
 public interface QuicTokenHandler {
 
     /**
+     * The result of a token validation.
+     */
+    final class TokenValidationResult {
+        private static final TokenValidationResult INVALID_TOKEN = new TokenValidationResult(-1, false);
+        private static final TokenValidationResult ODCID_FROM_DESTINATION_CONNECTION_ID =
+                new TokenValidationResult(-1, true);
+
+        private final int tokenOffset;
+        private final boolean odcidFromDestinationConnectionId;
+
+        private TokenValidationResult(int tokenOffset, boolean odcidFromDestinationConnectionId) {
+            this.tokenOffset = tokenOffset;
+            this.odcidFromDestinationConnectionId = odcidFromDestinationConnectionId;
+        }
+
+        /**
+         * Returns a result that indicates the token is invalid.
+         *
+         * @return  the invalid token result.
+         */
+        public static TokenValidationResult invalidToken() {
+            return INVALID_TOKEN;
+        }
+
+        /**
+         * Returns a result that indicates the token is valid and the ODCID should be taken from the token suffix
+         * starting at the specified offset.
+         *
+         * @param offset    the start index of the ODCID in the token.
+         * @return          the validation result.
+         */
+        public static TokenValidationResult odcidFromToken(int offset) {
+            if (offset < 0) {
+                throw new IllegalArgumentException("offset must be >= 0");
+            }
+            return new TokenValidationResult(offset, false);
+        }
+
+        /**
+         * Returns a result that indicates the token is valid and the ODCID should be taken from the current
+         * destination connection id of the Initial packet.
+         *
+         * @return  the validation result.
+         */
+        public static TokenValidationResult odcidFromDestinationConnectionId() {
+            return ODCID_FROM_DESTINATION_CONNECTION_ID;
+        }
+
+        /**
+         * Returns {@code true} if the token is valid.
+         *
+         * @return  {@code true} if the token is valid.
+         */
+        public boolean isValid() {
+            return this != INVALID_TOKEN;
+        }
+
+        /**
+         * Returns {@code true} if the ODCID should be taken from the current destination connection id.
+         *
+         * @return  {@code true} if the ODCID should be taken from the current destination connection id.
+         */
+        public boolean usesDestinationConnectionIdAsOdcid() {
+            return odcidFromDestinationConnectionId;
+        }
+
+        ByteBuf originalDestinationConnectionId(ByteBuf token, ByteBuf dcid) {
+            if (!isValid()) {
+                throw new IllegalStateException("token is not valid");
+            }
+            if (odcidFromDestinationConnectionId) {
+                return dcid.slice();
+            }
+            if (tokenOffset > token.readableBytes()) {
+                throw new IllegalArgumentException("offset " + tokenOffset + " exceeds token length "
+                        + token.readableBytes());
+            }
+            return token.slice(tokenOffset, token.readableBytes() - tokenOffset);
+        }
+    }
+
+    /**
      * Generate a new token for the given destination connection id and address. This token is written to {@code out}.
      * If no token should be generated and so no token validation should take place at all this method should return
      * {@code false}.
@@ -45,6 +127,19 @@ public interface QuicTokenHandler {
      * @return          the start index after the token or {@code -1} if the token was not valid.
      */
     int validateToken(ByteBuf token, InetSocketAddress address);
+
+    /**
+     * Validate the token and return a structured result that determines how the ODCID should be derived.
+     *
+     * @param token     the {@link ByteBuf} that contains the token. The ownership is not transferred.
+     * @param address   the {@link InetSocketAddress} of the sender.
+     * @param dcid      the destination connection id of the current Initial packet.
+     * @return          the validation result.
+     */
+    default TokenValidationResult validateToken(ByteBuf token, InetSocketAddress address, ByteBuf dcid) {
+        int offset = validateToken(token, address);
+        return offset == -1 ? TokenValidationResult.invalidToken() : TokenValidationResult.odcidFromToken(offset);
+    }
 
     /**
      * Return the maximal token length.

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicTokenHandler.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicTokenHandler.java
@@ -19,6 +19,8 @@ import io.netty.buffer.ByteBuf;
 
 import java.net.InetSocketAddress;
 
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
+
 /**
  * Handle token related operations.
  */
@@ -57,10 +59,7 @@ public interface QuicTokenHandler {
          * @return          the validation result.
          */
         public static TokenValidationResult odcidFromToken(int offset) {
-            if (offset < 0) {
-                throw new IllegalArgumentException("offset must be >= 0");
-            }
-            return new TokenValidationResult(offset, false);
+            return new TokenValidationResult(checkPositiveOrZero(offset, "offset"), false);
         }
 
         /**
@@ -133,7 +132,7 @@ public interface QuicTokenHandler {
      *
      * @param token     the {@link ByteBuf} that contains the token. The ownership is not transferred.
      * @param address   the {@link InetSocketAddress} of the sender.
-     * @param dcid      the destination connection id of the current Initial packet.
+     * @param dcid      the destination connection id of the current Initial packet. The ownership is not transferred.
      * @return          the validation result.
      */
     default TokenValidationResult validateToken(ByteBuf token, InetSocketAddress address, ByteBuf dcid) {

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicTokenHandler.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicTokenHandler.java
@@ -81,15 +81,6 @@ public interface QuicTokenHandler {
             return this != INVALID_TOKEN;
         }
 
-        /**
-         * Returns {@code true} if the ODCID should be taken from the current destination connection id.
-         *
-         * @return  {@code true} if the ODCID should be taken from the current destination connection id.
-         */
-        public boolean usesDestinationConnectionIdAsOdcid() {
-            return odcidFromDestinationConnectionId;
-        }
-
         ByteBuf originalDestinationConnectionId(ByteBuf token, ByteBuf dcid) {
             if (!isValid()) {
                 throw new IllegalStateException("token is not valid");

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicTokenHandler.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicTokenHandler.java
@@ -54,6 +54,9 @@ public interface QuicTokenHandler {
         /**
          * Returns a result that indicates the token is valid and the ODCID should be taken from the token suffix
          * starting at the specified offset.
+         * <p>
+         * This is typically used for tokens from Retry packets; see
+         * {@link QuicTokenHandler#validateToken(ByteBuf, InetSocketAddress, ByteBuf)}.
          *
          * @param offset    the start index of the ODCID in the token.
          * @return          the validation result.
@@ -65,6 +68,9 @@ public interface QuicTokenHandler {
         /**
          * Returns a result that indicates the token is valid and the ODCID should be taken from the current
          * destination connection id of the Initial packet.
+         * <p>
+         * This is typically used for tokens from NEW_TOKEN frames; see
+         * {@link QuicTokenHandler#validateToken(ByteBuf, InetSocketAddress, ByteBuf)}.
          *
          * @return  the validation result.
          */
@@ -110,9 +116,13 @@ public interface QuicTokenHandler {
     boolean writeToken(ByteBuf out, ByteBuf dcid, InetSocketAddress address);
 
     /**
-     * Validate the token and return the offset, {@code -1} is returned if the token is not valid.
+     * Validate the token and return the offset, {@code -1} is returned if the token is not valid. The returned offset
+     * identifies where the ODCID starts in the token. Implementations that support tokens from NEW_TOKEN frames should
+     * override {@link #validateToken(ByteBuf, InetSocketAddress, ByteBuf)}.
      *
-     * @param token     the {@link ByteBuf} that contains the token. The ownership is not transferred.
+     * @param token     the {@link ByteBuf} that contains the token. The caller retains ownership of the buffer:
+     *                  implementations must not release it and must retain, duplicate or copy it before using it after
+     *                  this method returns.
      * @param address   the {@link InetSocketAddress} of the sender.
      * @return          the start index after the token or {@code -1} if the token was not valid.
      */
@@ -120,10 +130,29 @@ public interface QuicTokenHandler {
 
     /**
      * Validate the token and return a structured result that determines how the ODCID should be derived.
+     * <p>
+     * RFC 9000 distinguishes tokens sent in Retry packets from tokens sent in NEW_TOKEN frames, and requires token
+     * construction to let the server identify how the token was provided to the client; see RFC 9000 Sections 8.1.1,
+     * 8.1.2 and 8.1.3.
+     * <p>
+     * A token from a Retry packet, as described in RFC 9000 Section 8.1.2 and carried by the Retry packet in
+     * Section 17.2.5, validates the same connection attempt after the server selected a new connection id. In this
+     * case the result should identify the original destination connection id from the client's first Initial packet.
+     * Use {@link TokenValidationResult#odcidFromToken(int)} if the token stores that connection id as a suffix, which
+     * is the convention used by the legacy {@link #validateToken(ByteBuf, InetSocketAddress)} method.
+     * <p>
+     * A token from a NEW_TOKEN frame, as described in RFC 9000 Section 8.1.3, validates a future connection attempt.
+     * No Retry packet has been sent for that new attempt, so the original destination connection id is the destination
+     * connection id of the current Initial packet as described in RFC 9000 Section 7.2. Use
+     * {@link TokenValidationResult#odcidFromDestinationConnectionId()} for this case.
      *
-     * @param token     the {@link ByteBuf} that contains the token. The ownership is not transferred.
+     * @param token     the {@link ByteBuf} that contains the token. The caller retains ownership of the buffer:
+     *                  implementations must not release it and must retain, duplicate or copy it before using it after
+     *                  this method returns.
      * @param address   the {@link InetSocketAddress} of the sender.
-     * @param dcid      the destination connection id of the current Initial packet. The ownership is not transferred.
+     * @param dcid      the destination connection id of the current Initial packet. The caller retains ownership of the
+     *                  buffer: implementations must not release it and must retain, duplicate or copy it before using
+     *                  it after this method returns.
      * @return          the validation result.
      */
     default TokenValidationResult validateToken(ByteBuf token, InetSocketAddress address, ByteBuf dcid) {

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicServerCodec.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicServerCodec.java
@@ -153,7 +153,7 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
             return null;
         }
 
-        final int offset;
+        final QuicTokenHandler.TokenValidationResult validationResult;
         boolean noToken = false;
         if (!token.isReadable()) {
             // Clear buffers so we can reuse these.
@@ -181,14 +181,14 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
                 writePacket(ctx, written, out, sender);
                 return null;
             }
-            offset = 0;
+            validationResult = null;
             noToken = true;
         } else {
             // Slice the token before pass it ot the QuicTokenHandler as the implementation might modify
             // the readerIndex.
             // See https://github.com/netty/netty-incubator-codec-quic/issues/742
-            offset = tokenHandler.validateToken(token.slice(), sender);
-            if (offset == -1) {
+            validationResult = tokenHandler.validateToken(token.slice(), sender, dcid);
+            if (!validationResult.isValid()) {
                 if (LOGGER.isDebugEnabled()) {
                     LOGGER.debug("invalid token: {}", token.toString(CharsetUtil.US_ASCII));
                 }
@@ -221,8 +221,9 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
         } else {
             scidAddr = Quiche.readerMemoryAddress(dcid);
             scidLen = localConnIdLength;
-            ocidLen = token.readableBytes() - offset;
-            ocidAddr = Quiche.memoryAddress(token, offset, ocidLen);
+            ByteBuf odcid = validationResult.originalDestinationConnectionId(token, dcid);
+            ocidLen = odcid.readableBytes();
+            ocidAddr = Quiche.memoryAddress(odcid, odcid.readerIndex(), ocidLen);
             // Now create the key to store the channel in the map.
             byte[] bytes = new byte[localConnIdLength];
             dcid.getBytes(dcid.readerIndex(), bytes);

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicServerCodec.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicServerCodec.java
@@ -24,6 +24,7 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.util.AttributeKey;
 import io.netty.util.CharsetUtil;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.jetbrains.annotations.Nullable;
@@ -184,10 +185,11 @@ final class QuicheQuicServerCodec extends QuicheQuicCodec {
             validationResult = null;
             noToken = true;
         } else {
-            // Slice the token before pass it ot the QuicTokenHandler as the implementation might modify
+            // Slice the token and dcid before pass it to the QuicTokenHandler as the implementation might modify
             // the readerIndex.
             // See https://github.com/netty/netty-incubator-codec-quic/issues/742
-            validationResult = tokenHandler.validateToken(token.slice(), sender, dcid);
+            validationResult = ObjectUtil.checkNotNull(
+                    tokenHandler.validateToken(token.slice(), sender, dcid.slice()), "validationResult");
             if (!validationResult.isValid()) {
                 if (LOGGER.isDebugEnabled()) {
                     LOGGER.debug("invalid token: {}", token.toString(CharsetUtil.US_ASCII));

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/InsecureQuicTokenHandlerTest.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/InsecureQuicTokenHandlerTest.java
@@ -55,7 +55,6 @@ public class InsecureQuicTokenHandlerTest extends AbstractQuicTest {
             QuicTokenHandler.TokenValidationResult result =
                     QuicTokenHandler.TokenValidationResult.odcidFromDestinationConnectionId();
             assertThat(result.isValid()).isTrue();
-            assertThat(result.usesDestinationConnectionIdAsOdcid()).isTrue();
             assertEquals(dcid, result.originalDestinationConnectionId(token, dcid));
         } finally {
             token.release();
@@ -89,7 +88,6 @@ public class InsecureQuicTokenHandlerTest extends AbstractQuicTest {
             QuicTokenHandler.TokenValidationResult result =
                     InsecureQuicTokenHandler.INSTANCE.validateToken(out, validAddress, dcid);
             assertThat(result.isValid()).isTrue();
-            assertThat(result.usesDestinationConnectionIdAsOdcid()).isFalse();
             assertEquals(dcid, result.originalDestinationConnectionId(out, dcid));
 
             // Use another address and check that the validate fails.

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/InsecureQuicTokenHandlerTest.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/InsecureQuicTokenHandlerTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class InsecureQuicTokenHandlerTest extends AbstractQuicTest {
 
@@ -44,6 +45,22 @@ public class InsecureQuicTokenHandlerTest extends AbstractQuicTest {
     @Test
     public void testTokenProcessingIpv6() throws UnknownHostException {
         testTokenProcessing(false);
+    }
+
+    @Test
+    public void testTokenValidationResultCanUseDestinationConnectionIdAsOdcid() {
+        ByteBuf token = Unpooled.buffer().writeInt(1);
+        ByteBuf dcid = Unpooled.wrappedBuffer(new byte[] { 1, 2, 3, 4 });
+        try {
+            QuicTokenHandler.TokenValidationResult result =
+                    QuicTokenHandler.TokenValidationResult.odcidFromDestinationConnectionId();
+            assertThat(result.isValid()).isTrue();
+            assertThat(result.usesDestinationConnectionIdAsOdcid()).isTrue();
+            assertEquals(dcid, result.originalDestinationConnectionId(token, dcid));
+        } finally {
+            token.release();
+            dcid.release();
+        }
     }
 
     private static void testTokenProcessing(boolean ipv4) throws UnknownHostException {
@@ -69,9 +86,16 @@ public class InsecureQuicTokenHandlerTest extends AbstractQuicTest {
             InsecureQuicTokenHandler.INSTANCE.writeToken(out, dcid, validAddress);
             assertThat(out.readableBytes()).isLessThanOrEqualTo(InsecureQuicTokenHandler.INSTANCE.maxTokenLength());
             assertNotEquals(-1, InsecureQuicTokenHandler.INSTANCE.validateToken(out, validAddress));
+            QuicTokenHandler.TokenValidationResult result =
+                    InsecureQuicTokenHandler.INSTANCE.validateToken(out, validAddress, dcid);
+            assertThat(result.isValid()).isTrue();
+            assertThat(result.usesDestinationConnectionIdAsOdcid()).isFalse();
+            assertEquals(dcid, result.originalDestinationConnectionId(out, dcid));
 
             // Use another address and check that the validate fails.
             assertEquals(-1, InsecureQuicTokenHandler.INSTANCE.validateToken(out, invalidAddress));
+            assertSame(QuicTokenHandler.TokenValidationResult.invalidToken(),
+                    InsecureQuicTokenHandler.INSTANCE.validateToken(out, invalidAddress, dcid));
         } finally {
             dcid.release();
             out.release();

--- a/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
@@ -42,7 +42,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import javax.net.ssl.ManagerFactoryParameters;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
-import javax.net.ssl.SSLEngine;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509ExtendedTrustManager;
 import javax.security.auth.x500.X500Principal;
@@ -221,6 +220,30 @@ public class SslErrorTest {
             return new TrustManager[] { new X509ExtendedTrustManager() {
 
                 @Override
+                public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket)
+                        throws CertificateException {
+                    throw exception;
+                }
+
+                @Override
+                public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket)
+                        throws CertificateException {
+                    throw exception;
+                }
+
+                @Override
+                public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine engine)
+                        throws CertificateException {
+                    throw exception;
+                }
+
+                @Override
+                public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine)
+                        throws CertificateException {
+                    throw exception;
+                }
+
+                @Override
                 public void checkClientTrusted(X509Certificate[] x509Certificates, String s)
                         throws CertificateException {
                     throw exception;
@@ -228,30 +251,6 @@ public class SslErrorTest {
 
                 @Override
                 public void checkServerTrusted(X509Certificate[] x509Certificates, String s)
-                        throws CertificateException {
-                    throw exception;
-                }
-
-                @Override
-                public void checkClientTrusted(X509Certificate[] x509Certificates, String s, Socket socket)
-                        throws CertificateException {
-                    throw exception;
-                }
-
-                @Override
-                public void checkServerTrusted(X509Certificate[] x509Certificates, String s, Socket socket)
-                        throws CertificateException {
-                    throw exception;
-                }
-
-                @Override
-                public void checkClientTrusted(X509Certificate[] x509Certificates, String s, SSLEngine sslEngine)
-                        throws CertificateException {
-                    throw exception;
-                }
-
-                @Override
-                public void checkServerTrusted(X509Certificate[] x509Certificates, String s, SSLEngine sslEngine)
                         throws CertificateException {
                     throw exception;
                 }

--- a/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
@@ -41,10 +41,12 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.net.ssl.ManagerFactoryParameters;
 import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLEngine;
 import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
+import javax.net.ssl.X509ExtendedTrustManager;
 import javax.security.auth.x500.X500Principal;
 import java.io.File;
+import java.net.Socket;
 import java.security.KeyStore;
 import java.security.cert.CRLReason;
 import java.security.cert.CertPathValidatorException;
@@ -215,7 +217,7 @@ public class SslErrorTest {
 
         @Override
         protected TrustManager[] engineGetTrustManagers() {
-            return new TrustManager[] { new X509TrustManager() {
+            return new TrustManager[] { new X509ExtendedTrustManager() {
 
                 @Override
                 public void checkClientTrusted(X509Certificate[] x509Certificates, String s)
@@ -225,6 +227,30 @@ public class SslErrorTest {
 
                 @Override
                 public void checkServerTrusted(X509Certificate[] x509Certificates, String s)
+                        throws CertificateException {
+                    throw exception;
+                }
+
+                @Override
+                public void checkClientTrusted(X509Certificate[] x509Certificates, String s, Socket socket)
+                        throws CertificateException {
+                    throw exception;
+                }
+
+                @Override
+                public void checkServerTrusted(X509Certificate[] x509Certificates, String s, Socket socket)
+                        throws CertificateException {
+                    throw exception;
+                }
+
+                @Override
+                public void checkClientTrusted(X509Certificate[] x509Certificates, String s, SSLEngine sslEngine)
+                        throws CertificateException {
+                    throw exception;
+                }
+
+                @Override
+                public void checkServerTrusted(X509Certificate[] x509Certificates, String s, SSLEngine sslEngine)
                         throws CertificateException {
                     throw exception;
                 }


### PR DESCRIPTION
fixes #17025 
I have verified the checklist
## Background
This PR fixes QUIC token validation for cases where a valid token does not encode the original destination connection ID in the token bytes.

## Cause
`QuicTokenHandler.validateToken(ByteBuf, InetSocketAddress)` only returned an offset, and `QuicheQuicServerCodec` always interpreted `token[offset..]` as the ODCID.

That works for Retry-style tokens, but it cannot express valid token flows where the ODCID should come from the current Initial packet DCID instead.

## Changes
- add `QuicTokenHandler.TokenValidationResult`
- add a new default overload: `validateToken(ByteBuf token, InetSocketAddress address, ByteBuf dcid)`
- keep the existing `validateToken(ByteBuf, InetSocketAddress)` method for compatibility
- update `QuicheQuicServerCodec` to derive the ODCID from the structured validation result instead of always slicing it from the token
- add regression coverage for the result-based token validation path in `InsecureQuicTokenHandlerTest`

## Verification
- `./mvnw -pl codec-classes-quic -am -DskipTests package`
- `export PATH=/opt/homebrew/bin:/opt/homebrew/opt/libtool/libexec/gnubin:$PATH;HTTPS_PROXY=socks5://127.0.0.1:7890 ALL_PROXY=socks5://127.0.0.1:7890 ./mvnw -pl codec-native-quic -am -DskipTests package`
- `export PATH=/opt/homebrew/bin:/opt/homebrew/opt/libtool/libexec/gnubin:$PATH;HTTPS_PROXY=socks5://127.0.0.1:7890 ALL_PROXY=socks5://127.0.0.1:7890 ./mvnw -pl codec-native-quic -am -Dsurefire.failIfNoSpecifiedTests=false -Dtest=InsecureQuicTokenHandlerTest,QuicChannelConnectTest#testConnectWithTokenValidation test`