### PR TITLE
Support QPACK sensitivity detector for Never Indexed header fields (#17026)

### DIFF
--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ClientConnectionHandler.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ClientConnectionHandler.java
@@ -83,8 +83,40 @@ public class Http3ClientConnectionHandler extends Http3ConnectionHandler {
                                         @Nullable Http3SettingsFrame localSettings, boolean disableQpackDynamicTable,
                                         @Nullable Http3Settings.NonStandardHttp3SettingsValidator
                                                 nonStandardSettingsValidator) {
+        this(inboundControlStreamHandler, pushStreamHandlerFactory, unknownInboundStreamHandlerFactory,
+                localSettings, disableQpackDynamicTable, nonStandardSettingsValidator, null);
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param inboundControlStreamHandler           the {@link ChannelHandler} which will be notified about
+     *                                              {@link Http3RequestStreamFrame}s or {@code null} if the user is not
+     *                                              interested in these.
+     * @param pushStreamHandlerFactory              the {@link LongFunction} that will provide a custom
+     *                                              {@link ChannelHandler} for push streams {@code null} if no special
+     *                                              handling should be done. When present, push ID will be passed as an
+     *                                              argument to the {@link LongFunction}.
+     * @param unknownInboundStreamHandlerFactory    the {@link LongFunction} that will provide a custom
+     *                                              {@link ChannelHandler} for unknown inbound stream types or
+     *                                              {@code null} if no special handling should be done.
+     * @param localSettings                         the local {@link Http3SettingsFrame} that should be sent to the
+     *                                              remote peer or {@code null} if the default settings should be used.
+     * @param disableQpackDynamicTable              If QPACK dynamic table should be disabled.
+     * @param nonStandardSettingsValidator          the {@link Http3Settings.NonStandardHttp3SettingsValidator} to use
+     *                                              when validating settings that are non-standard.
+     * @param sensitivityDetector                   detector that marks sensitive headers for QPACK Never Indexed
+     *                                              encoding, or {@code null} to use the historical default.
+     */
+    public Http3ClientConnectionHandler(@Nullable ChannelHandler inboundControlStreamHandler,
+                                        @Nullable LongFunction<ChannelHandler> pushStreamHandlerFactory,
+                                        @Nullable LongFunction<ChannelHandler> unknownInboundStreamHandlerFactory,
+                                        @Nullable Http3SettingsFrame localSettings, boolean disableQpackDynamicTable,
+                                        @Nullable Http3Settings.NonStandardHttp3SettingsValidator
+                                                nonStandardSettingsValidator,
+                                        @Nullable QpackSensitivityDetector sensitivityDetector) {
         super(false, inboundControlStreamHandler, unknownInboundStreamHandlerFactory, localSettings,
-                disableQpackDynamicTable, nonStandardSettingsValidator);
+                disableQpackDynamicTable, nonStandardSettingsValidator, sensitivityDetector);
         this.pushStreamHandlerFactory = pushStreamHandlerFactory;
     }
 

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ConnectionHandler.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ConnectionHandler.java
@@ -62,6 +62,15 @@ public abstract class Http3ConnectionHandler implements ChannelInboundHandler {
                            @Nullable LongFunction<ChannelHandler> unknownInboundStreamHandlerFactory,
                            @Nullable Http3SettingsFrame localSettings, boolean disableQpackDynamicTable,
                            @Nullable Http3Settings.NonStandardHttp3SettingsValidator nonStandardSettingsValidator) {
+        this(server, inboundControlStreamHandler, unknownInboundStreamHandlerFactory, localSettings,
+                disableQpackDynamicTable, nonStandardSettingsValidator, null);
+    }
+
+    Http3ConnectionHandler(boolean server, @Nullable ChannelHandler inboundControlStreamHandler,
+                           @Nullable LongFunction<ChannelHandler> unknownInboundStreamHandlerFactory,
+                           @Nullable Http3SettingsFrame localSettings, boolean disableQpackDynamicTable,
+                           @Nullable Http3Settings.NonStandardHttp3SettingsValidator nonStandardSettingsValidator,
+                           @Nullable QpackSensitivityDetector sensitivityDetector) {
         this.unknownInboundStreamHandlerFactory = unknownInboundStreamHandlerFactory;
         this.disableQpackDynamicTable = disableQpackDynamicTable;
         if (nonStandardSettingsValidator != null) {
@@ -93,7 +102,7 @@ public abstract class Http3ConnectionHandler implements ChannelInboundHandler {
                         0L)
         );
         qpackDecoder = new QpackDecoder(maxTableCapacity, maxBlockedStreams);
-        qpackEncoder = new QpackEncoder();
+        qpackEncoder = new QpackEncoder(sensitivityDetector);
         codecFactory = Http3FrameCodec.newFactory(qpackDecoder, maxFieldSectionSize, qpackEncoder);
         remoteControlStreamHandler =  new Http3ControlStreamOutboundHandler(server, localSettings,
                 codecFactory.newCodec(Http3FrameTypeValidator.NO_VALIDATION, NO_STATE, NO_STATE,

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ServerConnectionHandler.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ServerConnectionHandler.java
@@ -87,8 +87,38 @@ public final class Http3ServerConnectionHandler extends Http3ConnectionHandler {
                                         @Nullable Http3SettingsFrame localSettings, boolean disableQpackDynamicTable,
                                         @Nullable Http3Settings.NonStandardHttp3SettingsValidator
                                                 nonStandardSettingsValidator) {
+        this(requestStreamHandler, inboundControlStreamHandler, unknownInboundStreamHandlerFactory,
+                localSettings, disableQpackDynamicTable, nonStandardSettingsValidator, null);
+    }
+
+    /**
+     * Create a new instance.
+     * @param requestStreamHandler                  the {@link ChannelHandler} that is used for each new request stream.
+     *                                              This handler will receive {@link Http3HeadersFrame} and
+     *                                              {@link Http3DataFrame}s.
+     * @param inboundControlStreamHandler           the {@link ChannelHandler} which will be notified about
+     *                                              {@link Http3RequestStreamFrame}s or {@code null} if the user is not
+     *                                              interested in these.
+     * @param unknownInboundStreamHandlerFactory    the {@link LongFunction} that will provide a custom
+     *                                              {@link ChannelHandler} for unknown inbound stream types or
+     *                                              {@code null} if no special handling should be done.
+     * @param localSettings                         the local {@link Http3SettingsFrame} that should be sent to the
+     *                                              remote peer or {@code null} if the default settings should be used.
+     * @param disableQpackDynamicTable              If QPACK dynamic table should be disabled.
+     * @param nonStandardSettingsValidator          the {@link Http3Settings.NonStandardHttp3SettingsValidator} to
+     *                                              use when validating settings that are non-standard.
+     * @param sensitivityDetector                   detector that marks sensitive headers for QPACK Never Indexed
+     *                                              encoding, or {@code null} to use the historical default.
+     */
+    public Http3ServerConnectionHandler(ChannelHandler requestStreamHandler,
+                                        @Nullable ChannelHandler inboundControlStreamHandler,
+                                        @Nullable LongFunction<ChannelHandler> unknownInboundStreamHandlerFactory,
+                                        @Nullable Http3SettingsFrame localSettings, boolean disableQpackDynamicTable,
+                                        @Nullable Http3Settings.NonStandardHttp3SettingsValidator
+                                                nonStandardSettingsValidator,
+                                        @Nullable QpackSensitivityDetector sensitivityDetector) {
         super(true, inboundControlStreamHandler, unknownInboundStreamHandlerFactory, localSettings,
-                disableQpackDynamicTable, nonStandardSettingsValidator);
+                disableQpackDynamicTable, nonStandardSettingsValidator, sensitivityDetector);
         this.requestStreamHandler = ObjectUtil.checkNotNull(requestStreamHandler, "requestStreamHandler");
     }
 

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/QpackEncoder.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/QpackEncoder.java
@@ -20,7 +20,9 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.codec.quic.QuicStreamChannel;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.collection.LongObjectHashMap;
+import io.netty.util.internal.ObjectUtil;
 
+import javax.annotation.Nullable;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Map;
@@ -42,23 +44,29 @@ final class QpackEncoder {
 
     private final QpackHuffmanEncoder huffmanEncoder;
     private final QpackEncoderDynamicTable dynamicTable;
+    private final QpackSensitivityDetector sensitivityDetector;
     private int maxBlockedStreams;
     private int blockedStreams;
     private LongObjectHashMap<Queue<Indices>> streamSectionTrackers;
 
-    QpackEncoder() {
-        this(new QpackEncoderDynamicTable());
+    QpackEncoder(@Nullable QpackSensitivityDetector sensitivityDetector) {
+        this(new QpackEncoderDynamicTable(), sensitivityDetector);
     }
 
-    QpackEncoder(QpackEncoderDynamicTable dynamicTable) {
+    QpackEncoder(QpackEncoderDynamicTable dynamicTable, @Nullable QpackSensitivityDetector sensitivityDetector) {
         huffmanEncoder = new QpackHuffmanEncoder();
-        this.dynamicTable = dynamicTable;
+        this.dynamicTable = ObjectUtil.checkNotNull(dynamicTable, "dynamicTable");
+        this.sensitivityDetector = sensitivityDetector == null ?
+                QpackSensitivityDetector.NEVER_SENSITIVE : sensitivityDetector;
     }
 
     /**
      * Encode the header field into the header block.
      *
-     * TODO: do we need to support sensitivity detector?
+     * <p>Fields for which {@link QpackSensitivityDetector#isSensitive(CharSequence, CharSequence)}
+     * returns {@code true} are encoded as literals with the
+     * <a href="https://www.rfc-editor.org/rfc/rfc9204.html#section-4.5.4">"Never Indexed"</a>
+     * ({@code N=1}) flag set, and are never inserted into the dynamic table.</p>
      */
     void encodeHeaders(QpackAttributes qpackAttributes, ByteBuf out, ByteBufAllocator allocator, long streamId,
                        Http3Headers headers) {
@@ -73,7 +81,13 @@ final class QpackEncoder {
             for (Map.Entry<CharSequence, CharSequence> header : headers) {
                 CharSequence name = header.getKey();
                 CharSequence value = header.getValue();
-                int dynamicTblIdx = encodeHeader(qpackAttributes, tmp, base, name, value);
+                int dynamicTblIdx;
+                if (sensitivityDetector.isSensitive(name, value)) {
+                    encodeSensitiveHeader(tmp, name, value);
+                    dynamicTblIdx = DYNAMIC_TABLE_ENCODE_NOT_POSSIBLE;
+                } else {
+                    dynamicTblIdx = encodeHeader(qpackAttributes, tmp, base, name, value);
+                }
                 if (dynamicTblIdx >= 0) {
                     int req = dynamicTable.addReferenceToEntry(name, value, dynamicTblIdx);
                     if (dynamicTblIdx > maxDynamicTblIdx) {
@@ -195,6 +209,31 @@ final class QpackEncoder {
     }
 
     /**
+     * Encode a header field that the {@link QpackSensitivityDetector} flagged as sensitive.
+     *
+     * <p>Sensitive fields are never inserted into the dynamic table and are encoded
+     * with the {@code "Never Indexed"} flag ({@code N=1}) so that intermediaries
+     * also avoid indexing them — see
+     * <a href="https://www.rfc-editor.org/rfc/rfc9204.html#section-7.1">RFC 9204 7.1</a>.
+     * </p>
+     */
+    private void encodeSensitiveHeader(ByteBuf out, CharSequence name, CharSequence value) {
+        final int index = QpackStaticTable.findFieldIndex(name, value);
+        if (index == QpackStaticTable.NOT_FOUND) {
+            encodeLiteral(out, name, value, true);
+        } else if ((index & QpackStaticTable.MASK_NAME_REF) == QpackStaticTable.MASK_NAME_REF) {
+            // Name-only match, reuse the cached lookup instead of calling getIndex(name) again.
+            encodeLiteralWithNameRefStaticTable(out, index ^ QpackStaticTable.MASK_NAME_REF, value, true);
+        } else {
+            // Exact (name, value) match in the static table, an indexed static reference
+            // does not leak more information than what is already public, and the
+            // intermediary cannot gain any compression benefit by inserting a copy into
+            // its own dynamic table (the entry is already there as part of the static table).
+            encodeIndexedStaticTable(out, index);
+        }
+    }
+
+    /**
      * Encode the header field into the header block.
      * @param qpackAttributes {@link QpackAttributes} for the channel.
      * @param out {@link ByteBuf} to which encoded header field is to be written.
@@ -209,7 +248,7 @@ final class QpackEncoder {
         int index = QpackStaticTable.findFieldIndex(name, value);
         if (index == QpackStaticTable.NOT_FOUND) {
             if (qpackAttributes.dynamicTableDisabled()) {
-                encodeLiteral(out, name, value);
+                encodeLiteral(out, name, value, false);
                 return DYNAMIC_TABLE_ENCODE_NOT_POSSIBLE;
             }
             return encodeWithDynamicTable(qpackAttributes, out, base, name, value);
@@ -228,7 +267,7 @@ final class QpackEncoder {
                 }
                 return dynamicTblIdx;
             }
-            encodeLiteralWithNameRefStaticTable(out, nameIdx, value);
+            encodeLiteralWithNameRefStaticTable(out, nameIdx, value, false);
         } else {
             encodeIndexedStaticTable(out, index);
         }
@@ -265,7 +304,7 @@ final class QpackEncoder {
                 return idx;
             }
         }
-        encodeLiteral(out, name, value);
+        encodeLiteral(out, name, value, false);
         return idx;
     }
 
@@ -376,7 +415,11 @@ final class QpackEncoder {
                     //   +---+---+---+-------------------+
                     //   |  Name String (Length bytes)   |
                     //   +---+---------------------------+
-                    // TODO: Force H = 1 till we support sensitivity detector
+                    // Names are always Huffman-encoded (H = 1). RFC 9204 makes
+                    // Huffman a pure size/CPU tradeoff and does not tie it to the
+                    // sensitivity of the field; whether intermediaries may index
+                    // the field is controlled separately by the N bit on the
+                    // matching literal field line.
                     encodeLengthPrefixedHuffmanEncodedLiteral(insert, (byte) 0b0110_0000, 5, name);
                 }
                 //    0   1   2   3   4   5   6   7
@@ -427,7 +470,8 @@ final class QpackEncoder {
         encodePrefixedInteger(out, (byte) 0b0001_0000, 4, index - base);
     }
 
-    private void encodeLiteralWithNameRefStaticTable(ByteBuf out, int nameIndex, CharSequence value) {
+    private void encodeLiteralWithNameRefStaticTable(ByteBuf out, int nameIndex, CharSequence value,
+                                                     boolean neverIndex) {
         // https://www.rfc-editor.org/rfc/rfc9204.html#name-literal-field-line-with-nam
         //     0   1   2   3   4   5   6   7
         //   +---+---+---+---+---+---+---+---+
@@ -437,8 +481,10 @@ final class QpackEncoder {
         //   +---+---------------------------+
         //   |  Value String (Length bytes)  |
         //   +-------------------------------+
-        // TODO: Force N = 0 till we support sensitivity detector
-        encodePrefixedInteger(out, (byte) 0b0101_0000, 4, nameIndex);
+        //
+        // T = 1 (static table). N is driven by the sensitivity detector.
+        final byte prefix = (byte) (0b0101_0000 | (neverIndex ? 0b0010_0000 : 0));
+        encodePrefixedInteger(out, prefix, 4, nameIndex);
         encodeStringLiteral(out, value);
     }
 
@@ -452,8 +498,11 @@ final class QpackEncoder {
         //   +---+---------------------------+
         //   |  Value String (Length bytes)  |
         //   +-------------------------------+
-        // TODO: Force N = 0 till we support sensitivity detector
-        encodePrefixedInteger(out, (byte) 0b0101_0000, 4, base - nameIndex - 1);
+        //
+        // T = 0 (dynamic table). Sensitive headers are routed through
+        // encodeSensitiveHeader() which bypasses the dynamic table entirely, so
+        // anything reaching this method is non-sensitive and N is always 0.
+        encodePrefixedInteger(out, (byte) 0b0100_0000, 4, base - nameIndex - 1);
         encodeStringLiteral(out, value);
     }
 
@@ -467,12 +516,15 @@ final class QpackEncoder {
         //   +---+---------------------------+
         //   |  Value String (Length bytes)  |
         //   +-------------------------------+
-        // TODO: Force N = 0 till we support sensitivity detector
-        encodePrefixedInteger(out, (byte) 0b0000_0000, 4, nameIndex - base);
+        //
+        // Same as above post-base references only exist for entries in the
+        // encoder's dynamic table, so sensitive headers never reach here and
+        // N is always 0.
+        encodePrefixedInteger(out, (byte) 0, 3, nameIndex - base);
         encodeStringLiteral(out, value);
     }
 
-    private void encodeLiteral(ByteBuf out, CharSequence name, CharSequence value) {
+    private void encodeLiteral(ByteBuf out, CharSequence name, CharSequence value, boolean neverIndex) {
         // https://www.rfc-editor.org/rfc/rfc9204.html#name-literal-field-line-with-lit
         //   0   1   2   3   4   5   6   7
         //   +---+---+---+---+---+---+---+---+
@@ -484,8 +536,10 @@ final class QpackEncoder {
         //   +---+---------------------------+
         //   |  Value String (Length bytes)  |
         //   +-------------------------------+
-        // TODO: Force N = 0 & H = 1 till we support sensitivity detector
-        encodeLengthPrefixedHuffmanEncodedLiteral(out, (byte) 0b0010_1000, 3, name);
+        //
+        // H = 1 (Huffman) is always set for the name length prefix.
+        final byte prefix = (byte) (0b0010_1000 | (neverIndex ? 0b0001_0000 : 0));
+        encodeLengthPrefixedHuffmanEncodedLiteral(out, prefix, 3, name);
         encodeStringLiteral(out, value);
     }
 
@@ -500,7 +554,9 @@ final class QpackEncoder {
         // +---+---------------------------+
         // |  String Data (Length octets)  |
         // +-------------------------------+
-        // TODO: Force H = 1 till we support sensitivity detector
+        // String values are always Huffman-encoded (H = 1). RFC 9204 treats the
+        // H bit as a pure size/CPU choice; whether intermediaries may index the
+        // field is controlled separately by the N bit on the literal field line.
         encodeLengthPrefixedHuffmanEncodedLiteral(out, (byte) 0b1000_0000, 7, value);
     }
 

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/QpackSensitivityDetector.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/QpackSensitivityDetector.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http3;
+
+/**
+ * Determines whether a header field is sensitive, in which case the QPACK encoder
+ * <ul>
+ *   <li>MUST NOT insert it into the dynamic table, and</li>
+ *   <li>MUST encode it as a literal with the "Never Indexed" ({@code N=1}) flag
+ *       set as defined in
+ *       <a href="https://www.rfc-editor.org/rfc/rfc9204.html#section-4.5.4">RFC 9204 4.5.4</a>
+ *       through <a href="https://www.rfc-editor.org/rfc/rfc9204.html#section-4.5.7">4.5.7</a>.</li>
+ * </ul>
+ *
+ * <p>This mirrors {@code io.netty.handler.codec.http2.Http2HeadersEncoder.SensitivityDetector}
+ * from the HTTP/2 / HPACK side.</p>
+ *
+ * <p>Setting {@code N=1} prevents intermediaries from inserting the field into
+ * their own dynamic tables, which mitigates information disclosure via
+ * compression-based side channels (RFC 9204 7.1) for credentials such as
+ * {@code Authorization}, {@code Cookie}, {@code Set-Cookie} and
+ * {@code Proxy-Authorization}.</p>
+ * If the object can be dynamically modified and shared across multiple connections it may need to be thread safe.
+ */
+public interface QpackSensitivityDetector {
+
+    /**
+     * Treats every header field as non-sensitive. This is the historical default
+     * behaviour of the QPACK encoder and is the backward-compatible choice.
+     */
+    QpackSensitivityDetector NEVER_SENSITIVE = (name, value) -> false;
+
+    /**
+     * Treats every header field as sensitive.
+     */
+    QpackSensitivityDetector ALWAYS_SENSITIVE = (name, value) -> true;
+
+    /**
+     * Determine if a header {@code name}/{@code value} pair is sensitive.
+     *
+     * @param name  the header field name.
+     * @param value the header field value.
+     * @return {@code true} if the field is sensitive and must be encoded with
+     *         {@code N=1} and excluded from the dynamic table; {@code false}
+     *         otherwise.
+     */
+    boolean isSensitive(CharSequence name, CharSequence value);
+}

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3ClientConnectionHandlerTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3ClientConnectionHandlerTest.java
@@ -15,7 +15,13 @@
  */
 package io.netty.handler.codec.http3;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.handler.codec.quic.QuicStreamChannel;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Http3ClientConnectionHandlerTest extends AbtractHttp3ConnectionHandlerTest {
 
@@ -31,5 +37,25 @@ public class Http3ClientConnectionHandlerTest extends AbtractHttp3ConnectionHand
     @Override
     protected void assertBidirectionalStreamHandled(EmbeddedQuicChannel channel, QuicStreamChannel streamChannel) {
         Http3TestUtils.verifyClose(Http3ErrorCode.H3_STREAM_CREATION_ERROR, channel);
+    }
+
+    @Test
+    public void customSensitivityDetectorIsForwardedToQpackEncoder() {
+        Http3ClientConnectionHandler handler = new Http3ClientConnectionHandler(
+                null, null, null, null,
+                true, null, QpackSensitivityDetector.ALWAYS_SENSITIVE);
+
+        Http3Headers headers = new DefaultHttp3Headers(false);
+        headers.add("x-custom", "value");
+        ByteBuf out = Unpooled.buffer();
+        try {
+            handler.qpackEncoder.encodeHeaders(new QpackAttributes(null, true), out,
+                    UnpooledByteBufAllocator.DEFAULT, 1L, headers);
+            byte first = out.getByte(2);
+            assertEquals(1, (first & 0b0001_0000) >>> 4,
+                    "N bit must be set when ALWAYS_SENSITIVE is configured");
+        } finally {
+            out.release();
+        }
     }
 }

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3ControlStreamInboundHandlerTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3ControlStreamInboundHandlerTest.java
@@ -61,7 +61,7 @@ public class Http3ControlStreamInboundHandlerTest extends
     @Override
     protected void setUp(boolean server) {
         super.setUp(server);
-        qpackEncoder = new QpackEncoder();
+        qpackEncoder = new QpackEncoder(QpackSensitivityDetector.NEVER_SENSITIVE);
         remoteControlStreamHandler = new Http3ControlStreamOutboundHandler(server, new DefaultHttp3SettingsFrame(),
                 new ChannelInboundHandler() { });
     }

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3FrameCodecTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3FrameCodecTest.java
@@ -108,7 +108,7 @@ public class Http3FrameCodecTest {
         qpackEncoderHandler = new QpackEncoderHandler(maxTableCapacity, decoder);
         encoderStream = (EmbeddedQuicStreamChannel) parent.createStream(QuicStreamType.UNIDIRECTIONAL,
                 new ChannelOutboundHandler() { }).get();
-        encoder = new QpackEncoder();
+        encoder = new QpackEncoder(QpackSensitivityDetector.NEVER_SENSITIVE);
         qpackDecoderHandler = new QpackDecoderHandler(encoder);
         decoderStream = (EmbeddedQuicStreamChannel) parent.createStream(QuicStreamType.UNIDIRECTIONAL,
                 new ChannelOutboundHandler() { }).get();

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3ServerConnectionHandlerTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3ServerConnectionHandlerTest.java
@@ -15,10 +15,15 @@
  */
 package io.netty.handler.codec.http3;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelInboundHandler;
 import io.netty.handler.codec.quic.QuicStreamChannel;
+import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class Http3ServerConnectionHandlerTest extends AbtractHttp3ConnectionHandlerTest {
@@ -41,5 +46,25 @@ public class Http3ServerConnectionHandlerTest extends AbtractHttp3ConnectionHand
     @Override
     protected void assertBidirectionalStreamHandled(EmbeddedQuicChannel channel, QuicStreamChannel streamChannel) {
         assertNotNull(streamChannel.pipeline().context(REQUEST_HANDLER));
+    }
+
+    @Test
+    public void customSensitivityDetectorIsForwardedToQpackEncoder() {
+        Http3ServerConnectionHandler handler = new Http3ServerConnectionHandler(
+                REQUEST_HANDLER, null, null, null,
+                true, null, QpackSensitivityDetector.ALWAYS_SENSITIVE);
+
+        Http3Headers headers = new DefaultHttp3Headers(false);
+        headers.add("x-custom", "value");
+        ByteBuf out = Unpooled.buffer();
+        try {
+            handler.qpackEncoder.encodeHeaders(new QpackAttributes(null, true), out,
+                    UnpooledByteBufAllocator.DEFAULT, 1L, headers);
+            byte first = out.getByte(2);
+            assertEquals(1, (first & 0b0001_0000) >>> 4,
+                    "N bit must be set when ALWAYS_SENSITIVE is configured");
+        } finally {
+            out.release();
+        }
     }
 }

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3UnidirectionalStreamInboundHandlerTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3UnidirectionalStreamInboundHandlerTest.java
@@ -51,7 +51,7 @@ public class Http3UnidirectionalStreamInboundHandlerTest {
 
     private void setup(boolean server) {
         parent = new EmbeddedQuicChannel(server);
-        qpackEncoder = new QpackEncoder();
+        qpackEncoder = new QpackEncoder(QpackSensitivityDetector.NEVER_SENSITIVE);
         qpackDecoder = new QpackDecoder(0, 0);
         localControlStreamHandler = new Http3ControlStreamInboundHandler(server, null, qpackEncoder,
                 remoteControlStreamHandler);

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/QpackDecoderHandlerTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/QpackDecoderHandlerTest.java
@@ -333,7 +333,7 @@ public class QpackDecoderHandlerTest {
         encoderStream = (EmbeddedQuicStreamChannel) parent.createStream(QuicStreamType.UNIDIRECTIONAL,
                 new QpackEncoderHandler(maxTableCapacity, decoder)).get();
         attributes.encoderStream(encoderStream);
-        encoder = new QpackEncoder(dynamicTable);
+        encoder = new QpackEncoder(dynamicTable, QpackSensitivityDetector.NEVER_SENSITIVE);
         encoder.configureDynamicTable(attributes, maxTableCapacity, 0);
         decoderStream = (EmbeddedQuicStreamChannel) parent.createStream(QuicStreamType.UNIDIRECTIONAL,
                 new QpackDecoderHandler(encoder)).get();

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/QpackEncoderDecoderTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/QpackEncoderDecoderTest.java
@@ -53,6 +53,7 @@ public class QpackEncoderDecoderTest {
     private QpackEncoderDynamicTable encDynamicTable;
     private QpackDecoderDynamicTable decDynamicTable;
     private BlockingQueue<Callable<Void>> suspendedEncoderInstructions;
+    private QpackSensitivityDetector sensitivityDetector = QpackSensitivityDetector.NEVER_SENSITIVE;
 
     private final QpackDecoderStateSyncStrategy syncStrategy = mock(QpackDecoderStateSyncStrategy.class);
     private final Http3Headers encHeaders = new DefaultHttp3Headers();
@@ -409,6 +410,107 @@ public class QpackEncoderDecoderTest {
         assertThrows(QpackException.class, () -> decode(out, decHeaders));
     }
 
+    @Test
+    public void sensitiveHeaderIsNotInsertedIntoDynamicTable() throws Exception {
+        sensitivityDetector = (name, value) -> "authorization".contentEquals(name);
+        setup(128, 0);
+
+        encHeaders.add("authorization", "Bearer secret");
+        encHeaders.add("foo", "bar");
+        encode(out, encHeaders);
+
+        // Only the non-sensitive sibling should consume a dynamic-table slot.
+        verifyRequiredInsertCount(1);
+        assertThat("Sensitive header must not be inserted into the encoder dynamic table.",
+                encDynamicTable.getEntryIndex("authorization", "Bearer secret"),
+                is(QpackEncoderDynamicTable.NOT_FOUND));
+        assertThat("Non-sensitive header must still be inserted into the encoder dynamic table.",
+                encDynamicTable.getEntryIndex("foo", "bar"), greaterThanOrEqualTo(0));
+
+        decode(out, decHeaders);
+        assertThat(decDynamicTable.insertCount(), is(1));
+        assertThat(decHeaders.size(), is(2));
+        verifyDecodedHeader("authorization", "Bearer secret");
+        verifyDecodedHeader("foo", "bar");
+    }
+
+    @Test
+    public void sensitiveHeaderWithStaticExactMatchUsesIndexedStatic() throws Exception {
+        sensitivityDetector = QpackSensitivityDetector.ALWAYS_SENSITIVE;
+        setup(128, 0);
+
+        encHeaders.add(":method", "GET");
+        encode(out, encHeaders);
+
+        verifyRequiredInsertCount(0);
+        assertThat("No dynamic-table insert expected for sensitive static exact match.",
+                encDynamicTable.insertCount(), is(0));
+
+        // First literal byte (byte 2) is an indexed-field-line with T=1.
+        assertThat("Section prefix required_insert_count byte must be 0.", (int) out.getByte(0), is(0));
+        assertThat("Section prefix delta_base byte must be 0.",            (int) out.getByte(1), is(0));
+        int firstLiteralByte = out.getByte(2) & 0xFF;
+        assertThat("Indexed-static-reference literal must start with 0b11 prefix.",
+                firstLiteralByte & 0b1100_0000, is(0b1100_0000));
+
+        decode(out, decHeaders);
+        assertThat(decDynamicTable.insertCount(), is(0));
+        assertThat(decHeaders.size(), is(1));
+        verifyDecodedHeader(":method", "GET");
+    }
+
+    @Test
+    public void sensitiveHeaderWithStaticNameRefSetsNeverIndexBit() throws Exception {
+        sensitivityDetector = QpackSensitivityDetector.ALWAYS_SENSITIVE;
+        setup(128, 0);
+
+        encHeaders.add(":authority", "netty.quic");
+        encode(out, encHeaders);
+
+        verifyRequiredInsertCount(0);
+        assertThat("No dynamic-table insert expected for sensitive header.",
+                encDynamicTable.insertCount(), is(0));
+
+        // Layout 0 1 N T NameIndex(4+); N is bit 5, T is bit 4 (=1 for static).
+        int firstLiteralByte = out.getByte(2) & 0xFF;
+        assertThat("High two bits must be 01 for literal-with-name-ref.",
+                firstLiteralByte & 0b1100_0000, is(0b0100_0000));
+        assertThat("Never-Indexed (N) bit must be set for sensitive header.",
+                firstLiteralByte & 0b0010_0000, is(0b0010_0000));
+        assertThat("T bit must be 1 (static table).",
+                firstLiteralByte & 0b0001_0000, is(0b0001_0000));
+
+        decode(out, decHeaders);
+        assertThat(decDynamicTable.insertCount(), is(0));
+        assertThat(decHeaders.size(), is(1));
+        verifyDecodedHeader(":authority", "netty.quic");
+    }
+
+    @Test
+    public void sensitiveHeaderWithLiteralNameSetsNeverIndexBit() throws Exception {
+        sensitivityDetector = QpackSensitivityDetector.ALWAYS_SENSITIVE;
+        setup(128, 0);
+
+        encHeaders.add("x-secret", "shhh");
+        encode(out, encHeaders);
+
+        verifyRequiredInsertCount(0);
+        assertThat("No dynamic-table insert expected for sensitive header.",
+                encDynamicTable.insertCount(), is(0));
+
+        // Layout 0 0 1 N H NameLen(3+); N is bit 4, H is bit 3 (=1, Huffman).
+        int firstLiteralByte = out.getByte(2) & 0xFF;
+        assertThat("High three bits must be 001 for literal-with-literal-name.",
+                firstLiteralByte & 0b1110_0000, is(0b0010_0000));
+        assertThat("Never-Indexed (N) bit must be set for sensitive header.",
+                firstLiteralByte & 0b0001_0000, is(0b0001_0000));
+
+        decode(out, decHeaders);
+        assertThat(decDynamicTable.insertCount(), is(0));
+        assertThat(decHeaders.size(), is(1));
+        verifyDecodedHeader("x-secret", "shhh");
+    }
+
     private void resetState() {
         out.clear();
         encHeaders.clear();
@@ -472,7 +574,7 @@ public class QpackEncoderDecoderTest {
         encDynamicTable = new QpackEncoderDynamicTable(16, expectedTableFreePercentage);
         decDynamicTable = new QpackDecoderDynamicTable();
         decoder = new QpackDecoder(maxTableCapacity, maxBlockedStreams, decDynamicTable, syncStrategy);
-        encoder = new QpackEncoder(encDynamicTable);
+        encoder = new QpackEncoder(encDynamicTable, sensitivityDetector);
         if (maxBlockedStreams > 0) {
             suspendedEncoderInstructions = new LinkedBlockingQueue<>();
         }

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/QpackSensitivityDetectorTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/QpackSensitivityDetectorTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http3;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class QpackSensitivityDetectorTest {
+
+    @Test
+    void neverSensitiveAlwaysReturnsFalse() {
+        assertNotNull(QpackSensitivityDetector.NEVER_SENSITIVE);
+        assertFalse(QpackSensitivityDetector.NEVER_SENSITIVE.isSensitive("authorization", "Bearer x"));
+        assertFalse(QpackSensitivityDetector.NEVER_SENSITIVE.isSensitive("cookie", "sid=abc"));
+        assertFalse(QpackSensitivityDetector.NEVER_SENSITIVE.isSensitive("", ""));
+    }
+
+    @Test
+    void alwaysSensitiveAlwaysReturnsTrue() {
+        assertNotNull(QpackSensitivityDetector.ALWAYS_SENSITIVE);
+        assertTrue(QpackSensitivityDetector.ALWAYS_SENSITIVE.isSensitive("authorization", "Bearer x"));
+        assertTrue(QpackSensitivityDetector.ALWAYS_SENSITIVE.isSensitive(":path", "/"));
+        assertTrue(QpackSensitivityDetector.ALWAYS_SENSITIVE.isSensitive("", ""));
+    }
+
+    @Test
+    void customDetectorFlagsCredentialHeaders() {
+        QpackSensitivityDetector detector = (name, value) -> {
+            String n = name.toString().toLowerCase();
+            return "authorization".equals(n)
+                    || "cookie".equals(n)
+                    || "set-cookie".equals(n)
+                    || "proxy-authorization".equals(n);
+        };
+
+        assertTrue(detector.isSensitive("Authorization", "Bearer secret"));
+        assertTrue(detector.isSensitive("cookie", "sid=abc"));
+        assertTrue(detector.isSensitive("Set-Cookie", "sid=abc; HttpOnly"));
+        assertTrue(detector.isSensitive("Proxy-Authorization", "Basic xxx"));
+
+        assertFalse(detector.isSensitive("content-type", "text/plain"));
+        assertFalse(detector.isSensitive(":method", "GET"));
+    }
+}
+

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/QpackStreamHandlerTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/QpackStreamHandlerTest.java
@@ -32,7 +32,7 @@ public class QpackStreamHandlerTest {
 
         EmbeddedQuicStreamChannel channel =
                 (EmbeddedQuicStreamChannel) parent.createStream(QuicStreamType.UNIDIRECTIONAL,
-                        new QpackDecoderHandler(new QpackEncoder())).get();
+                        new QpackDecoderHandler(new QpackEncoder(QpackSensitivityDetector.NEVER_SENSITIVE))).get();
         assertFalse(channel.finish());
         verifyClose(1, Http3ErrorCode.H3_CLOSED_CRITICAL_STREAM, parent);
     }
@@ -44,7 +44,7 @@ public class QpackStreamHandlerTest {
 
         EmbeddedQuicStreamChannel channel =
                 (EmbeddedQuicStreamChannel) parent.createStream(QuicStreamType.UNIDIRECTIONAL,
-                        new QpackDecoderHandler(new QpackEncoder())).get();
+                        new QpackDecoderHandler(new QpackEncoder(QpackSensitivityDetector.NEVER_SENSITIVE))).get();
         assertFalse(channel.finish());
     }
 
@@ -55,7 +55,7 @@ public class QpackStreamHandlerTest {
 
         EmbeddedQuicStreamChannel channel =
                 (EmbeddedQuicStreamChannel) parent.createStream(QuicStreamType.UNIDIRECTIONAL,
-                        new QpackDecoderHandler(new QpackEncoder())).get();
+                        new QpackDecoderHandler(new QpackEncoder(QpackSensitivityDetector.NEVER_SENSITIVE))).get();
         ByteBuf buffer = Unpooled.buffer();
         assertFalse(channel.writeInbound(buffer));
         assertEquals(0, buffer.refCnt());


### PR DESCRIPTION
Motivation:

QPACK (RFC 9204 4.5 / 7.1) defines an `N` ("Never Indexed") flag on
literal
field lines that tells intermediaries the field MUST NOT be inserted
into
their dynamic table. The current `QpackEncoder` hard-codes `N = 0` for
every
literal and unconditionally lets the dynamic table absorb
every field. Users have no way to mark sensitive fields such as
`Authorization`, `Cookie`, `Set-Cookie` or `Proxy-Authorization`.

Modifications:

- New `QpackSensitivityDetector` interface, mirroring HPACK's
  `Http2HeadersEncoder.SensitivityDetector`, with `NEVER_SENSITIVE` and
  `ALWAYS_SENSITIVE` constants. No built-in header list.
- New `QpackEncoder` constructor accepting a detector; existing
constructors
  delegate with `NEVER_SENSITIVE` — byte-for-byte backward-compatible.
- New `encodeSensitiveHeader` path used when the detector returns
`true`:
  exact static-table match indexed static; static name match literal
  with static-name-ref + N=1; otherwise pure literal + N=1. The field is
  never inserted into the dynamic table.

Result:

HTTP/3 services can mark sensitive headers as Never Indexed, matching
the
existing HPACK implementation. No behaviour change for users who do not
opt in.

---------

Co-authored-by: Norman Maurer <norman_maurer@apple.com>
