### PR TITLE
FlowControlHandler must comply with its fundamental goal (ensured message for each read request) - behaviour broken in 4.2.15.Final (#17050)

### DIFF
--- a/handler/src/main/java/io/netty/handler/flow/FlowControlHandler.java
+++ b/handler/src/main/java/io/netty/handler/flow/FlowControlHandler.java
@@ -67,7 +67,11 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 public class FlowControlHandler extends ChannelDuplexHandler {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(FlowControlHandler.class);
 
+    public static final boolean DEFAUT_RELEASE_MESSAGES = true;
+    public static final boolean DEFAUT_PROPAGATE_READ_COMPLETE = false;
+
     private final boolean releaseMessages;
+    private final boolean propagateReadComplete;
 
     private RecyclableArrayDeque queue;
 
@@ -96,16 +100,43 @@ public class FlowControlHandler extends ChannelDuplexHandler {
     private int unsatisfiedReads;
 
     /**
+     * {@code true} if a {@code read()} is currently in progress.
+     */
+    private boolean reading;
+
+    /**
      * {@code true} while a {@link #dequeue(ChannelHandlerContext)} loop is on the stack.
      */
     private boolean dequeuing;
 
     public FlowControlHandler() {
-        this(true);
+        this(DEFAUT_RELEASE_MESSAGES);
     }
 
+    /**
+     * Creates a new instance.
+     *
+     * @param releaseMessages
+     *        Release all queued messages when channel becomes inactive,
+     *        {@link #DEFAUT_RELEASE_MESSAGES} by default.
+     */
     public FlowControlHandler(boolean releaseMessages) {
+        this(releaseMessages, DEFAUT_PROPAGATE_READ_COMPLETE);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param releaseMessages
+     *        Release all queued messages when channel becomes inactive,
+     *        {@link #DEFAUT_RELEASE_MESSAGES} by default.
+     * @param propagateReadComplete
+     *        Propagate upstream {@link #channelReadComplete(ChannelHandlerContext) read-complete} events to downstream,
+     *        {@link #DEFAUT_PROPAGATE_READ_COMPLETE} by default.
+     */
+    public FlowControlHandler(boolean releaseMessages, boolean propagateReadComplete) {
         this.releaseMessages = releaseMessages;
+        this.propagateReadComplete = propagateReadComplete;
     }
 
     /**
@@ -162,25 +193,23 @@ public class FlowControlHandler extends ChannelDuplexHandler {
 
     @Override
     public void read(ChannelHandlerContext ctx) throws Exception {
-        if (!config.isAutoRead()) {
-            unsatisfiedReads++;
-        }
+        unsatisfiedReads++;
 
         boolean didSatisfyARead = dequeue(ctx);
-        boolean isAutoRead = config.isAutoRead();
-        if (!didSatisfyARead || isAutoRead) {
-            assert unsatisfiedReads > 0 || isAutoRead;
-            // We either could not satisfy the read or auto-read is on.
-            // In both cases we need to delegate the read upstream.
-            ctx.read();
+        if (config.isAutoRead()) {
+            readIfNeeded(ctx);
         } else if (unsatisfiedReads == 0 && !dequeuing) {
             // Auto-read is off, and we have satisfied all reads.
             // As such, we can complete the current read cycle. && !dequeueing makes sure we are completing the
             // read cycle only once in the top-most read() call.
             ctx.fireChannelReadComplete();
-        } else {
+        } else if (didSatisfyARead) {
             // Auto-read is off, and either reads are still unsatisfied or we are nested in a dequeue.
             // Wait for the outermost call, an upstream channelRead() or a channelReadComplete().
+        } else {
+            // We need to delegate the read upstream.
+            assert unsatisfiedReads > 0;
+            readIfNeeded(ctx);
         }
     }
 
@@ -201,11 +230,21 @@ public class FlowControlHandler extends ChannelDuplexHandler {
 
     @Override
     public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
-        // Upstream closed the read cycle. Collapse every outstanding read() into a single downstream
-        // channelReadComplete; spurious upstream completions with no pending read are dropped.
-        if (config.isAutoRead() || unsatisfiedReads > 0) {
-            unsatisfiedReads = 0;
+        reading = false;
+        if (propagateReadComplete || config.isAutoRead()) {
+            // Upstream closed the read cycle. Collapse every outstanding read() into a single downstream
+            // channelReadComplete; spurious upstream completions with no pending read are dropped.
             ctx.fireChannelReadComplete();
+        } else if (unsatisfiedReads > 0) {
+            // Upstream closed the read cycle, initiating the next one.
+            readIfNeeded(ctx);
+        }
+    }
+
+    private void readIfNeeded(ChannelHandlerContext ctx) {
+        if (!reading) {
+            reading = true;
+            ctx.read();
         }
     }
 

--- a/handler/src/main/java/io/netty/handler/flow/FlowControlHandler.java
+++ b/handler/src/main/java/io/netty/handler/flow/FlowControlHandler.java
@@ -255,6 +255,7 @@ public class FlowControlHandler extends ChannelDuplexHandler {
             ctx.read();
         }
     }
+
     private void fireChannelReadCompleteIfNeeded(ChannelHandlerContext ctx) {
         if (awaitingReadComplete) {
             awaitingReadComplete = false;

--- a/handler/src/main/java/io/netty/handler/flow/FlowControlHandler.java
+++ b/handler/src/main/java/io/netty/handler/flow/FlowControlHandler.java
@@ -105,6 +105,11 @@ public class FlowControlHandler extends ChannelDuplexHandler {
     private boolean reading;
 
     /**
+     * {@code true} if downstream is awaiting for readComplete event.
+     */
+    private boolean awaitingReadComplete;
+
+    /**
      * {@code true} while a {@link #dequeue(ChannelHandlerContext)} loop is on the stack.
      */
     private boolean dequeuing;
@@ -194,6 +199,7 @@ public class FlowControlHandler extends ChannelDuplexHandler {
     @Override
     public void read(ChannelHandlerContext ctx) throws Exception {
         unsatisfiedReads++;
+        awaitingReadComplete = true;
 
         boolean didSatisfyARead = dequeue(ctx);
         if (config.isAutoRead()) {
@@ -202,7 +208,7 @@ public class FlowControlHandler extends ChannelDuplexHandler {
             // Auto-read is off, and we have satisfied all reads.
             // As such, we can complete the current read cycle. && !dequeueing makes sure we are completing the
             // read cycle only once in the top-most read() call.
-            ctx.fireChannelReadComplete();
+            fireChannelReadCompleteIfNeeded(ctx);
         } else if (didSatisfyARead) {
             // Auto-read is off, and either reads are still unsatisfied or we are nested in a dequeue.
             // Wait for the outermost call, an upstream channelRead() or a channelReadComplete().
@@ -223,7 +229,7 @@ public class FlowControlHandler extends ChannelDuplexHandler {
 
         if (dequeue(ctx)) {
             if (!config.isAutoRead() && unsatisfiedReads == 0 && !dequeuing) {
-                ctx.fireChannelReadComplete();
+                fireChannelReadCompleteIfNeeded(ctx);
             }
         }
     }
@@ -231,10 +237,12 @@ public class FlowControlHandler extends ChannelDuplexHandler {
     @Override
     public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
         reading = false;
-        if (propagateReadComplete || config.isAutoRead()) {
+        if (config.isAutoRead()) {
             // Upstream closed the read cycle. Collapse every outstanding read() into a single downstream
             // channelReadComplete; spurious upstream completions with no pending read are dropped.
             ctx.fireChannelReadComplete();
+        } else if (propagateReadComplete) {
+            fireChannelReadCompleteIfNeeded(ctx);
         } else if (unsatisfiedReads > 0) {
             // Upstream closed the read cycle, initiating the next one.
             readIfNeeded(ctx);
@@ -245,6 +253,12 @@ public class FlowControlHandler extends ChannelDuplexHandler {
         if (!reading) {
             reading = true;
             ctx.read();
+        }
+    }
+    private void fireChannelReadCompleteIfNeeded(ChannelHandlerContext ctx) {
+        if (awaitingReadComplete) {
+            awaitingReadComplete = false;
+            ctx.fireChannelReadComplete();
         }
     }
 

--- a/handler/src/main/java/io/netty/handler/flow/FlowControlHandler.java
+++ b/handler/src/main/java/io/netty/handler/flow/FlowControlHandler.java
@@ -68,10 +68,8 @@ public class FlowControlHandler extends ChannelDuplexHandler {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(FlowControlHandler.class);
 
     public static final boolean DEFAUT_RELEASE_MESSAGES = true;
-    public static final boolean DEFAUT_PROPAGATE_READ_COMPLETE = false;
 
     private final boolean releaseMessages;
-    private final boolean propagateReadComplete;
 
     private RecyclableArrayDeque queue;
 
@@ -105,9 +103,9 @@ public class FlowControlHandler extends ChannelDuplexHandler {
     private boolean reading;
 
     /**
-     * {@code true} if downstream is awaiting for readComplete event.
+     * {@code true} if auto-read is "on" and downstream is awaiting for readComplete event.
      */
-    private boolean awaitingReadComplete;
+    private boolean autoReadComplete;
 
     /**
      * {@code true} while a {@link #dequeue(ChannelHandlerContext)} loop is on the stack.
@@ -126,22 +124,7 @@ public class FlowControlHandler extends ChannelDuplexHandler {
      *        {@link #DEFAUT_RELEASE_MESSAGES} by default.
      */
     public FlowControlHandler(boolean releaseMessages) {
-        this(releaseMessages, DEFAUT_PROPAGATE_READ_COMPLETE);
-    }
-
-    /**
-     * Creates a new instance.
-     *
-     * @param releaseMessages
-     *        Release all queued messages when channel becomes inactive,
-     *        {@link #DEFAUT_RELEASE_MESSAGES} by default.
-     * @param propagateReadComplete
-     *        Propagate upstream {@link #channelReadComplete(ChannelHandlerContext) read-complete} events to downstream,
-     *        {@link #DEFAUT_PROPAGATE_READ_COMPLETE} by default.
-     */
-    public FlowControlHandler(boolean releaseMessages, boolean propagateReadComplete) {
         this.releaseMessages = releaseMessages;
-        this.propagateReadComplete = propagateReadComplete;
     }
 
     /**
@@ -198,24 +181,26 @@ public class FlowControlHandler extends ChannelDuplexHandler {
 
     @Override
     public void read(ChannelHandlerContext ctx) throws Exception {
-        unsatisfiedReads++;
-        awaitingReadComplete = true;
+        if (!config.isAutoRead()) {
+            unsatisfiedReads++;
+            autoReadComplete = false;
+        }
 
-        boolean didSatisfyARead = dequeue(ctx);
-        if (config.isAutoRead()) {
-            readIfNeeded(ctx);
-        } else if (unsatisfiedReads == 0 && !dequeuing) {
-            // Auto-read is off, and we have satisfied all reads.
-            // As such, we can complete the current read cycle. && !dequeueing makes sure we are completing the
-            // read cycle only once in the top-most read() call.
-            fireChannelReadCompleteIfNeeded(ctx);
-        } else if (didSatisfyARead) {
-            // Auto-read is off, and either reads are still unsatisfied or we are nested in a dequeue.
-            // Wait for the outermost call, an upstream channelRead() or a channelReadComplete().
-        } else {
-            // We need to delegate the read upstream.
-            assert unsatisfiedReads > 0;
-            readIfNeeded(ctx);
+        boolean dequeued = dequeue(ctx);
+        if (dequeuing) {
+            // make sure we are invoking post-processors in the top-most read() call.
+            return;
+        }
+        if (dequeued && unsatisfiedReads == 0) {
+            if (config.isAutoRead()) {
+                autoReadComplete = true;
+            } else {
+                // We have satisfied all reads. As such, we can complete the current read cycle.
+                ctx.fireChannelReadComplete();
+            }
+        } else if (!reading) {
+            reading = true;
+            ctx.read();
         }
     }
 
@@ -227,9 +212,12 @@ public class FlowControlHandler extends ChannelDuplexHandler {
 
         queue.offer(msg);
 
-        if (dequeue(ctx)) {
-            if (!config.isAutoRead() && unsatisfiedReads == 0 && !dequeuing) {
-                fireChannelReadCompleteIfNeeded(ctx);
+        // If we are nested in a dequeue() call, delegating post-processing to the outermost call.
+        if (dequeue(ctx) && !dequeuing && unsatisfiedReads == 0) {
+            if (config.isAutoRead()) {
+                autoReadComplete = true;
+            } else {
+                ctx.fireChannelReadComplete();
             }
         }
     }
@@ -238,28 +226,16 @@ public class FlowControlHandler extends ChannelDuplexHandler {
     public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
         reading = false;
         if (config.isAutoRead()) {
-            // Upstream closed the read cycle. Collapse every outstanding read() into a single downstream
-            // channelReadComplete; spurious upstream completions with no pending read are dropped.
-            ctx.fireChannelReadComplete();
-        } else if (propagateReadComplete) {
-            fireChannelReadCompleteIfNeeded(ctx);
+            // When auto-read is enabled, all `read-complete` events are swallowed,
+            // except for the one followed immediately after all reads are satisfied.
+            if (autoReadComplete) {
+                autoReadComplete = false;
+                ctx.fireChannelReadComplete();
+            }
         } else if (unsatisfiedReads > 0) {
-            // Upstream closed the read cycle, initiating the next one.
-            readIfNeeded(ctx);
-        }
-    }
-
-    private void readIfNeeded(ChannelHandlerContext ctx) {
-        if (!reading) {
+            // Upstream completed the read cycle, initiating the next one.
             reading = true;
             ctx.read();
-        }
-    }
-
-    private void fireChannelReadCompleteIfNeeded(ChannelHandlerContext ctx) {
-        if (awaitingReadComplete) {
-            awaitingReadComplete = false;
-            ctx.fireChannelReadComplete();
         }
     }
 

--- a/handler/src/main/java/io/netty/handler/flow/FlowControlHandler.java
+++ b/handler/src/main/java/io/netty/handler/flow/FlowControlHandler.java
@@ -67,8 +67,6 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 public class FlowControlHandler extends ChannelDuplexHandler {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(FlowControlHandler.class);
 
-    public static final boolean DEFAUT_RELEASE_MESSAGES = true;
-
     private final boolean releaseMessages;
 
     private RecyclableArrayDeque queue;
@@ -113,7 +111,7 @@ public class FlowControlHandler extends ChannelDuplexHandler {
     private boolean dequeuing;
 
     public FlowControlHandler() {
-        this(DEFAUT_RELEASE_MESSAGES);
+        this(true);
     }
 
     /**
@@ -121,7 +119,7 @@ public class FlowControlHandler extends ChannelDuplexHandler {
      *
      * @param releaseMessages
      *        Release all queued messages when channel becomes inactive,
-     *        {@link #DEFAUT_RELEASE_MESSAGES} by default.
+     *        {@code true} by default.
      */
     public FlowControlHandler(boolean releaseMessages) {
         this.releaseMessages = releaseMessages;

--- a/handler/src/test/java/io/netty/handler/flow/FlowControlHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/flow/FlowControlHandlerTest.java
@@ -796,7 +796,6 @@ public class FlowControlHandlerTest {
                     }
                 });
 
-
         channel.config().setAutoRead(false);
         channel.register();
 

--- a/handler/src/test/java/io/netty/handler/flow/FlowControlHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/flow/FlowControlHandlerTest.java
@@ -847,7 +847,6 @@ public class FlowControlHandlerTest {
         channel.read();
         channel.read();
 
-
         channel.flushInbound(); // Trigger readComplete event
         assertEquals(Arrays.asList("#r", "1", "#r", "#r"), events);
 
@@ -1168,7 +1167,6 @@ public class FlowControlHandlerTest {
                         events.add("#rc");
                     }
                 });
-
 
         channel.config().setAutoRead(false);
         channel.register();

--- a/handler/src/test/java/io/netty/handler/flow/FlowControlHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/flow/FlowControlHandlerTest.java
@@ -713,7 +713,7 @@ public class FlowControlHandlerTest {
     }
 
     @Test
-    public void testSuppressingUpstreamReadCompletes() throws Exception {
+    public void testSuppressingUpstreamReadCompletesStrict() throws Exception {
         final AtomicInteger reads = new AtomicInteger();
         final AtomicInteger readCompletes = new AtomicInteger();
         final EmbeddedChannel channel = new EmbeddedChannel(
@@ -759,6 +759,65 @@ public class FlowControlHandlerTest {
 
         assertEquals(1, reads.get());
         assertEquals(1, readCompletes.get());
+
+        assertFalse(channel.finishAndReleaseAll());
+    }
+
+    @Test
+    public void testSuppressingUpstreamReadCompletesRelaxed() throws Exception {
+        final List<String> events = new ArrayList<>();
+        final EmbeddedChannel channel = new EmbeddedChannel(
+                false, false,
+                new ChannelDuplexHandler() {
+                    @Override
+                    public void read(ChannelHandlerContext ctx) throws Exception {
+                        events.add("#r");
+                        super.read(ctx);
+                    }
+                },
+                new FlowControlHandler(DEFAUT_RELEASE_MESSAGES, true),
+                new ChannelInboundHandlerAdapter() {
+                    @Override
+                    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                        events.add((String) msg);
+                    }
+
+                    @Override
+                    public void channelReadComplete(ChannelHandlerContext ctx) {
+                        events.add("#rc");
+                    }
+                });
+
+
+        channel.config().setAutoRead(false);
+        channel.register();
+
+        assertEquals(Collections.emptyList(), events);
+
+        channel.flushInbound();
+        channel.flushInbound();
+        channel.flushInbound();
+
+        assertEquals(Collections.emptyList(), events);
+
+        channel.read();
+        assertEquals(Collections.singletonList("#r"), events);
+
+        channel.writeInbound("1");
+        assertEquals(Arrays.asList("#r", "1", "#rc"), events);
+
+        channel.flushInbound();
+        channel.flushInbound();
+        assertEquals(Arrays.asList("#r", "1", "#rc"), events);
+
+        channel.read();
+        assertEquals(Arrays.asList("#r", "1", "#rc", "#r"), events);
+
+        channel.flushInbound();
+        assertEquals(Arrays.asList("#r", "1", "#rc", "#r", "#rc"), events);
+
+        channel.flushInbound();
+        assertEquals(Arrays.asList("#r", "1", "#rc", "#r", "#rc"), events);
 
         assertFalse(channel.finishAndReleaseAll());
     }

--- a/handler/src/test/java/io/netty/handler/flow/FlowControlHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/flow/FlowControlHandlerTest.java
@@ -721,58 +721,7 @@ public class FlowControlHandlerTest {
     }
 
     @Test
-    public void testSuppressingUpstreamReadCompletesStrict() throws Exception {
-        final AtomicInteger reads = new AtomicInteger();
-        final AtomicInteger readCompletes = new AtomicInteger();
-        final EmbeddedChannel channel = new EmbeddedChannel(
-                false, false,
-                new FlowControlHandler(),
-                new ChannelInboundHandlerAdapter() {
-                    @Override
-                    public void channelRead(ChannelHandlerContext ctx, Object msg) {
-                        reads.incrementAndGet();
-                    }
-
-                    @Override
-                    public void channelReadComplete(ChannelHandlerContext ctx) {
-                        readCompletes.incrementAndGet();
-                    }
-                });
-
-        channel.config().setAutoRead(false);
-        channel.register();
-
-        assertEquals(0, reads.get());
-        assertEquals(0, readCompletes.get());
-
-        channel.flushInbound();
-        channel.flushInbound();
-        channel.flushInbound();
-
-        assertEquals(0, reads.get());
-        assertEquals(0, readCompletes.get());
-
-        channel.read();
-        channel.writeOneInbound("msg").syncUninterruptibly();
-        assertEquals(1, reads.get());
-        assertEquals(1, readCompletes.get());
-
-        channel.flushInbound();
-        channel.flushInbound();
-        assertEquals(1, reads.get());
-        assertEquals(1, readCompletes.get());
-
-        channel.read();
-        channel.flushInbound();
-
-        assertEquals(1, reads.get());
-        assertEquals(1, readCompletes.get());
-
-        assertFalse(channel.finishAndReleaseAll());
-    }
-
-    @Test
-    public void testSuppressingUpstreamReadCompletesRelaxed() throws Exception {
+    public void testSuppressingUpstreamReadCompletes() throws Exception {
         final List<String> events = new ArrayList<>();
         final EmbeddedChannel channel = new EmbeddedChannel(
                 false, false,

--- a/handler/src/test/java/io/netty/handler/flow/FlowControlHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/flow/FlowControlHandlerTest.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.Test;
 import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.Callable;
@@ -53,8 +54,11 @@ import java.util.concurrent.Exchanger;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.IntStream;
 
-import static java.util.concurrent.TimeUnit.*;
+import static io.netty.handler.flow.FlowControlHandler.DEFAUT_RELEASE_MESSAGES;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -545,7 +549,7 @@ public class FlowControlHandlerTest {
         final long delayMillis = 100;
         final Queue<IdleStateEvent> userEvents = new LinkedBlockingQueue<IdleStateEvent>();
         final EmbeddedChannel channel = new EmbeddedChannel(false, false,
-            new FlowControlHandler(),
+            new FlowControlHandler(DEFAUT_RELEASE_MESSAGES, true),
             new IdleStateHandler(delayMillis, 0, 0, MILLISECONDS),
             new ChannelInboundHandlerAdapter() {
                 @Override
@@ -754,7 +758,7 @@ public class FlowControlHandlerTest {
         channel.flushInbound();
 
         assertEquals(1, reads.get());
-        assertEquals(2, readCompletes.get());
+        assertEquals(1, readCompletes.get());
 
         assertFalse(channel.finishAndReleaseAll());
     }
@@ -786,35 +790,44 @@ public class FlowControlHandlerTest {
         // Downstream issues a read() but upstream has no data and only fires channelReadComplete.
         // FlowControlHandler must forward that channelReadComplete to satisfy the outstanding read.
         channel.read();
-        channel.flushInbound();
 
         assertEquals(0, reads.get());
-        assertEquals(1, readCompletes.get());
+        assertEquals(0, readCompletes.get());
 
         // The empty read() could not be satisfied from the queue, so it was forwarded upstream exactly once.
         assertEquals(1, upstream.reads.get());
+
+        channel.flushInbound();
+        assertEquals(2, upstream.reads.get());
 
         assertFalse(channel.finishAndReleaseAll());
     }
 
     @Test
     public void testMultipleReadsOnEmptyQueue() throws Exception {
-        final AtomicInteger reads = new AtomicInteger();
-        final AtomicInteger readCompletes = new AtomicInteger();
+        final List<String> events = new ArrayList<>();
         final EmbeddedChannel channel = new EmbeddedChannel(
                 false, false,
+                new ChannelDuplexHandler() {
+                    @Override
+                    public void read(ChannelHandlerContext ctx) throws Exception {
+                        events.add("#r");
+                        super.read(ctx);
+                    }
+                },
                 new FlowControlHandler(),
                 new ChannelInboundHandlerAdapter() {
                     @Override
                     public void channelRead(ChannelHandlerContext ctx, Object msg) {
-                        reads.incrementAndGet();
+                        events.add((String) msg);
                     }
 
                     @Override
                     public void channelReadComplete(ChannelHandlerContext ctx) {
-                        readCompletes.incrementAndGet();
+                        events.add("#rc");
                     }
                 });
+
         channel.config().setAutoRead(false);
         channel.register();
 
@@ -822,37 +835,30 @@ public class FlowControlHandlerTest {
         channel.read();
         channel.read();
 
-        channel.writeOneInbound("msg1");
+        assertEquals(Collections.singletonList("#r"), events);
 
-        assertEquals(1, reads.get());
-        assertEquals(0, readCompletes.get());
+        channel.writeOneInbound("1");
+        assertEquals(Arrays.asList("#r", "1"), events);
 
-        channel.flushInbound();
-
-        assertEquals(1, reads.get());
-        assertEquals(1, readCompletes.get());
+        channel.flushInbound(); // Trigger readComplete event
+        assertEquals(Arrays.asList("#r", "1", "#r"), events);
 
         channel.read();
         channel.read();
         channel.read();
 
-        // empty read
-        channel.flushInbound();
 
-        assertEquals(1, reads.get());
-        assertEquals(2, readCompletes.get());
+        channel.flushInbound(); // Trigger readComplete event
+        assertEquals(Arrays.asList("#r", "1", "#r", "#r"), events);
 
-        // quick check that internal state is not broken
-        channel.writeOneInbound("msg2");
-        channel.flushInbound();
+        channel.writeInbound("2", "3", "4");
+        assertEquals(Arrays.asList("#r", "1", "#r", "#r", "2", "3", "4", "#r"), events);
 
-        assertEquals(1, reads.get());
-        assertEquals(2, readCompletes.get());
+        channel.flushInbound(); // Trigger readComplete event
+        assertEquals(Arrays.asList("#r", "1", "#r", "#r", "2", "3", "4", "#r", "#r"), events);
 
-        channel.read();
-
-        assertEquals(2, reads.get());
-        assertEquals(3, readCompletes.get());
+        channel.writeInbound("5", "6", "7");
+        assertEquals(Arrays.asList("#r", "1", "#r", "#r", "2", "3", "4", "#r", "#r", "5", "6", "#rc"), events);
 
         assertFalse(channel.finishAndReleaseAll());
     }
@@ -904,7 +910,7 @@ public class FlowControlHandlerTest {
         final AtomicInteger readCompletes = new AtomicInteger();
         final EmbeddedChannel channel = new EmbeddedChannel(
                 false, false,
-                new FlowControlHandler(),
+                new FlowControlHandler(DEFAUT_RELEASE_MESSAGES, true),
                 new ChannelInboundHandlerAdapter() {
                     @Override
                     public void channelRead(ChannelHandlerContext ctx, Object msg) {
@@ -945,20 +951,20 @@ public class FlowControlHandlerTest {
         channel.writeOneInbound("msg2").syncUninterruptibly();
 
         assertEquals(2, reads.get());
-        assertEquals(1, readCompletes.get());
+        assertEquals(0, readCompletes.get());
 
         // The third message is queued but not delivered as autoRead is off, and we have no unsatisfied reads anymore.
         channel.writeOneInbound("msg3").syncUninterruptibly();
 
-        assertEquals(2, reads.get());
-        assertEquals(1, readCompletes.get());
+        assertEquals(3, reads.get());
+        assertEquals(0, readCompletes.get());
 
         // Upstream fires channelReadComplete.
         channel.flushInbound();
 
         // As autoRead is off, FlowControlHandler is the one determining the end of the read cycle, not upstream.
         // It ignores the channelReadComplete.
-        assertEquals(2, reads.get());
+        assertEquals(3, reads.get());
         assertEquals(1, readCompletes.get());
 
         channel.config().setAutoRead(true);
@@ -1090,7 +1096,7 @@ public class FlowControlHandlerTest {
         // consumed the queued message.
         channel.read();
         assertEquals(5, reads.get());
-        assertEquals(2, upstream.reads.get());
+        assertEquals(1, upstream.reads.get());
 
         assertFalse(channel.finishAndReleaseAll());
     }
@@ -1131,6 +1137,62 @@ public class FlowControlHandlerTest {
 
         // The flush happens locally on removal; nothing is read upstream.
         assertEquals(0, upstream.reads.get());
+
+        assertFalse(channel.finishAndReleaseAll());
+    }
+
+    @Test
+    public void testHandlerRemovedFlushesQueuedSplitMessages() throws Exception {
+        final List<String> events = new ArrayList<>();
+        final AtomicInteger readMore = new AtomicInteger();
+        final EmbeddedChannel channel = new EmbeddedChannel(
+                false, false,
+                new ChannelDuplexHandler() {
+                    @Override
+                    public void read(ChannelHandlerContext ctx) throws Exception {
+                        events.add("#r");
+                        super.read(ctx);
+                    }
+                },
+                new SplitDecoder(), // Decode (split) one chunk into several messages
+                new FlowControlHandler(),
+                new ChannelInboundHandlerAdapter() {
+                    @Override
+                    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                        events.add((String) msg);
+                        IntStream.range(0, readMore.getAndSet(0)).forEach(i -> ctx.read());
+                    }
+
+                    @Override
+                    public void channelReadComplete(ChannelHandlerContext ctx) {
+                        events.add("#rc");
+                    }
+                });
+
+
+        channel.config().setAutoRead(false);
+        channel.register();
+
+        // With auto-read off and no read(), all six messages stay queued in the handler.
+        assertFalse(channel.writeInbound("abcdef"));
+        assertEquals(Collections.emptyList(), events);
+
+        channel.read();
+        assertEquals(Arrays.asList("a", "#rc"), events);
+
+        readMore.set(3); // Repeat read() +3 times from within channelRead()
+        channel.read();
+        assertEquals(Arrays.asList("a", "#rc", "b", "c", "d", "e", "#rc"), events);
+
+        // Removing the handler flushes the whole queue downstream, in order, then completes the batch once.
+        channel.pipeline().remove(FlowControlHandler.class);
+        assertEquals(Arrays.asList("a", "#rc", "b", "c", "d", "e", "#rc", "f", "#rc"), events);
+
+        channel.read();
+        assertEquals(Arrays.asList("a", "#rc", "b", "c", "d", "e", "#rc", "f", "#rc", "#r"), events);
+
+        assertFalse(channel.writeInbound("gh"));
+        assertEquals(Arrays.asList("a", "#rc", "b", "c", "d", "e", "#rc", "f", "#rc", "#r", "g", "h", "#rc"), events);
 
         assertFalse(channel.finishAndReleaseAll());
     }
@@ -1218,6 +1280,23 @@ public class FlowControlHandlerTest {
         public void read(ChannelHandlerContext ctx) throws Exception {
             reads.incrementAndGet();
             super.read(ctx);
+        }
+    }
+
+    private static class SplitDecoder extends ChannelInboundHandlerAdapter {
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) {
+            if (!(msg instanceof String)) {
+                ctx.fireChannelRead(msg);
+                return;
+            }
+            String text = (String) msg;
+            for (char c : text.toCharArray()) {
+                ctx.fireChannelRead(String.valueOf(c));
+            }
+            if (text.isEmpty()) {
+                ctx.fireChannelRead("");
+            }
         }
     }
 }

--- a/handler/src/test/java/io/netty/handler/flow/FlowControlHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/flow/FlowControlHandlerTest.java
@@ -47,16 +47,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Queue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Exchanger;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 
-import static io.netty.handler.flow.FlowControlHandler.DEFAUT_RELEASE_MESSAGES;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -547,33 +544,42 @@ public class FlowControlHandlerTest {
     @Test
     public void testSwallowedReadComplete() throws Exception {
         final long delayMillis = 100;
-        final Queue<IdleStateEvent> userEvents = new LinkedBlockingQueue<IdleStateEvent>();
+        final List<String> events = new ArrayList<>();
         final EmbeddedChannel channel = new EmbeddedChannel(false, false,
-            new FlowControlHandler(DEFAUT_RELEASE_MESSAGES, true),
+            new ChannelDuplexHandler() {
+                @Override
+                public void read(ChannelHandlerContext ctx) throws Exception {
+                    events.add("#r");
+                    super.read(ctx);
+                }
+            },
+            new FlowControlHandler(),
             new IdleStateHandler(delayMillis, 0, 0, MILLISECONDS),
             new ChannelInboundHandlerAdapter() {
                 @Override
                 public void channelActive(ChannelHandlerContext ctx) {
+                    events.add("#a");
                     ctx.fireChannelActive();
-                    ctx.read();
                 }
 
                 @Override
                 public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                    events.add((String) msg);
                     ctx.fireChannelRead(msg);
-                    ctx.read();
                 }
 
                 @Override
                 public void channelReadComplete(ChannelHandlerContext ctx) {
+                    events.add("#rc");
                     ctx.fireChannelReadComplete();
-                    ctx.read();
                 }
 
                 @Override
                 public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
                     if (evt instanceof IdleStateEvent) {
-                        userEvents.add((IdleStateEvent) evt);
+                        events.add("#ise:" + ((IdleStateEvent) evt).state());
+                    } else {
+                        events.add("#e:" + evt);
                     }
                     ctx.fireUserEventTriggered(evt);
                 }
@@ -586,17 +592,19 @@ public class FlowControlHandlerTest {
         channel.register();
 
         // Reset read timeout by some message
-        assertTrue(channel.writeInbound(Unpooled.EMPTY_BUFFER));
+        assertFalse(channel.writeInbound("1"));
         channel.flushInbound();
-        assertEquals(Unpooled.EMPTY_BUFFER, channel.readInbound());
+        channel.read();
 
-        // Emulate 'no more messages in NIO channel' on the next read attempt.
-        channel.flushInbound();
+        assertEquals(Arrays.asList("#a", "1", "#rc"), events);
+        assertEquals("1", channel.readInbound());
         assertNull(channel.readInbound());
 
+        // IdleStateHandler must be in `read-complete` state to treat read inactivity as idle.
         Thread.sleep(delayMillis + 20L);
         channel.runPendingTasks();
-        assertEquals(IdleStateEvent.FIRST_READER_IDLE_STATE_EVENT, userEvents.poll());
+        assertEquals(Arrays.asList("#a", "1", "#rc", "#ise:READER_IDLE"), events);
+
         assertFalse(channel.finish());
     }
 
@@ -775,7 +783,7 @@ public class FlowControlHandlerTest {
                         super.read(ctx);
                     }
                 },
-                new FlowControlHandler(DEFAUT_RELEASE_MESSAGES, true),
+                new FlowControlHandler(),
                 new ChannelInboundHandlerAdapter() {
                     @Override
                     public void channelRead(ChannelHandlerContext ctx, Object msg) {
@@ -814,10 +822,10 @@ public class FlowControlHandlerTest {
         assertEquals(Arrays.asList("#r", "1", "#rc", "#r"), events);
 
         channel.flushInbound();
-        assertEquals(Arrays.asList("#r", "1", "#rc", "#r", "#rc"), events);
+        assertEquals(Arrays.asList("#r", "1", "#rc", "#r", "#r"), events);
 
         channel.flushInbound();
-        assertEquals(Arrays.asList("#r", "1", "#rc", "#r", "#rc"), events);
+        assertEquals(Arrays.asList("#r", "1", "#rc", "#r", "#r", "#r"), events);
 
         assertFalse(channel.finishAndReleaseAll());
     }
@@ -923,61 +931,64 @@ public class FlowControlHandlerTest {
 
     @Test
     public void testCompleteReadOnUpstreamCompleteWhenAutoReadOn() throws Exception {
-        final AtomicInteger reads = new AtomicInteger();
-        final AtomicInteger readCompletes = new AtomicInteger();
+        final List<String> events = new ArrayList<>();
         final EmbeddedChannel channel = new EmbeddedChannel(
                 false, false,
                 new FlowControlHandler(),
                 new ChannelInboundHandlerAdapter() {
                     @Override
                     public void channelRead(ChannelHandlerContext ctx, Object msg) {
-                        reads.incrementAndGet();
+                        events.add((String) msg);
                     }
 
                     @Override
                     public void channelReadComplete(ChannelHandlerContext ctx) {
-                        readCompletes.incrementAndGet();
+                        events.add("#rc");
                     }
                 });
 
         assertTrue(channel.config().isAutoRead());
         channel.register();
 
-        channel.writeOneInbound("msg1").syncUninterruptibly();
-        channel.writeOneInbound("msg2").syncUninterruptibly();
-        channel.writeOneInbound("msg3").syncUninterruptibly();
+        channel.writeOneInbound("1").syncUninterruptibly();
+        channel.writeOneInbound("2").syncUninterruptibly();
+        channel.writeOneInbound("3").syncUninterruptibly();
 
         // All three messages must arrive before channelReadComplete signals end-of-batch.
-        assertEquals(3, reads.get());
         // As auto-read is on, FlowControlHandler should not fire a channelReadComplete on its own but should wait
         // for upstream to fire it.
-        assertEquals(0, readCompletes.get());
+        assertEquals(Arrays.asList("1", "2", "3"), events);
 
         // Upstream now fires channelReadComplete and FlowControlHandler should pass it through.
         channel.flushInbound();
 
-        assertEquals(3, reads.get());
-        assertEquals(1, readCompletes.get());
+        assertEquals(Arrays.asList("1", "2", "3", "#rc"), events);
 
         assertFalse(channel.finishAndReleaseAll());
     }
 
     @Test
     public void testSatisfyPendingReadsAfterDisablingAutoRead() throws Exception {
-        final AtomicInteger reads = new AtomicInteger();
-        final AtomicInteger readCompletes = new AtomicInteger();
-        final EmbeddedChannel channel = new EmbeddedChannel(
-                false, false,
-                new FlowControlHandler(DEFAUT_RELEASE_MESSAGES, true),
+        final List<String> events = new ArrayList<>();
+        final FlowControlHandler flowControlHandler = new FlowControlHandler();
+        final EmbeddedChannel channel = new EmbeddedChannel(false, false,
+                new ChannelDuplexHandler() {
+                    @Override
+                    public void read(ChannelHandlerContext ctx) throws Exception {
+                        events.add("#r");
+                        super.read(ctx);
+                    }
+                },
+                flowControlHandler,
                 new ChannelInboundHandlerAdapter() {
                     @Override
                     public void channelRead(ChannelHandlerContext ctx, Object msg) {
-                        reads.incrementAndGet();
+                        events.add((String) msg);
                     }
 
                     @Override
                     public void channelReadComplete(ChannelHandlerContext ctx) {
-                        readCompletes.incrementAndGet();
+                        events.add("#rc");
                     }
                 });
 
@@ -991,10 +1002,8 @@ public class FlowControlHandlerTest {
         channel.config().setAutoRead(true);
 
         // We got the first message with auto-read on. It immediately satisfies the first read.
-        channel.writeOneInbound("msg1").syncUninterruptibly();
-
-        assertEquals(1, reads.get());
-        assertEquals(0, readCompletes.get());
+        channel.writeInbound("1");
+        assertEquals(Arrays.asList("#r", "1", "#r"), events);
 
         channel.config().setAutoRead(false);
         channel.config().setAutoRead(true);
@@ -1002,39 +1011,31 @@ public class FlowControlHandlerTest {
         channel.config().setAutoRead(false);
 
         // sanity check: nothing should happen.
-        assertEquals(1, reads.get());
-        assertEquals(0, readCompletes.get());
+        assertEquals(Arrays.asList("#r", "1", "#r"), events);
 
         // The second message is delivered right away, satisfying the second read, and completing the batch.
-        channel.writeOneInbound("msg2").syncUninterruptibly();
-
-        assertEquals(2, reads.get());
-        assertEquals(0, readCompletes.get());
+        channel.writeInbound("2");
+        assertEquals(Arrays.asList("#r", "1", "#r", "2", "#rc"), events);
 
         // The third message is queued but not delivered as autoRead is off, and we have no unsatisfied reads anymore.
-        channel.writeOneInbound("msg3").syncUninterruptibly();
-
-        assertEquals(3, reads.get());
-        assertEquals(0, readCompletes.get());
+        channel.writeInbound("3");
+        assertEquals(Arrays.asList("#r", "1", "#r", "2", "#rc"), events);
 
         // Upstream fires channelReadComplete.
         channel.flushInbound();
 
         // As autoRead is off, FlowControlHandler is the one determining the end of the read cycle, not upstream.
         // It ignores the channelReadComplete.
-        assertEquals(3, reads.get());
-        assertEquals(1, readCompletes.get());
+        assertEquals(Arrays.asList("#r", "1", "#r", "2", "#rc"), events);
 
         channel.config().setAutoRead(true);
 
         // The third message is dequeued and delivered.
-        assertEquals(3, reads.get());
-        assertEquals(1, readCompletes.get());
+        assertEquals(Arrays.asList("#r", "1", "#r", "2", "#rc", "3"), events);
 
+        // Embedded channel triggers explicit read event, when auto-read is "on".
         channel.flushInbound();
-
-        assertEquals(3, reads.get());
-        assertEquals(2, readCompletes.get());
+        assertEquals(Arrays.asList("#r", "1", "#r", "2", "#rc", "3", "#rc", "#r"), events);
 
         assertFalse(channel.finishAndReleaseAll());
     }
@@ -1154,6 +1155,9 @@ public class FlowControlHandlerTest {
         // consumed the queued message.
         channel.read();
         assertEquals(5, reads.get());
+        assertEquals(0, upstream.reads.get());
+
+        channel.flushInbound();
         assertEquals(1, upstream.reads.get());
 
         assertFalse(channel.finishAndReleaseAll());


### PR DESCRIPTION
**Fixes #17050**

Motivation:

Recent changes #16837 ([link](https://github.com/netty/netty/pull/16837/changes#r3512883877)) and followup #16949 led to essential breaches of class main contract: ensured message for each read request.

Modification:

Trigger `read-complete` event only and only when all FlowControllerHandler-managed requests are properly propagated to the downstream.