### PR TITLE
[#17039] Fix inflight NameResolver leak when first caller's client is shut down

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolverGroup.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolverGroup.java
@@ -24,7 +24,6 @@ import io.netty.resolver.AddressResolverGroup;
 import io.netty.resolver.InetSocketAddressResolver;
 import io.netty.resolver.NameResolver;
 import io.netty.util.concurrent.EventExecutor;
-import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.StringUtil;
 
 import java.net.InetAddress;
@@ -40,8 +39,14 @@ public class DnsAddressResolverGroup extends AddressResolverGroup<InetSocketAddr
 
     private final DnsNameResolverBuilder dnsResolverBuilder;
 
-    private final ConcurrentMap<String, Promise<InetAddress>> resolvesInProgress = new ConcurrentHashMap<>();
-    private final ConcurrentMap<String, Promise<List<InetAddress>>> resolveAllsInProgress = new ConcurrentHashMap<>();
+    // The map values are intentionally InflightEntry (not raw Promise) so that the
+    // InflightNameResolver can attach multiple concurrent callers to a single in-flight
+    // resolution and clean up the slot when the last caller is done. See
+    // https://github.com/netty/netty/issues/17039.
+    private final ConcurrentMap<String, InflightNameResolver.InflightEntry<InetAddress>> resolvesInProgress =
+            new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, InflightNameResolver.InflightEntry<List<InetAddress>>>
+            resolveAllsInProgress = new ConcurrentHashMap<>();
 
     public DnsAddressResolverGroup(DnsNameResolverBuilder dnsResolverBuilder) {
         this.dnsResolverBuilder = withSharedCaches(dnsResolverBuilder.copy());

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/InflightNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/InflightNameResolver.java
@@ -25,6 +25,7 @@ import io.netty.util.internal.StringUtil;
 
 import java.util.List;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
@@ -33,12 +34,12 @@ final class InflightNameResolver<T> implements NameResolver<T> {
 
     private final EventExecutor executor;
     private final NameResolver<T> delegate;
-    private final ConcurrentMap<String, Promise<T>> resolvesInProgress;
-    private final ConcurrentMap<String, Promise<List<T>>> resolveAllsInProgress;
+    private final ConcurrentMap<String, InflightEntry<T>> resolvesInProgress;
+    private final ConcurrentMap<String, InflightEntry<List<T>>> resolveAllsInProgress;
 
     InflightNameResolver(EventExecutor executor, NameResolver<T> delegate,
-                         ConcurrentMap<String, Promise<T>> resolvesInProgress,
-                         ConcurrentMap<String, Promise<List<T>>> resolveAllsInProgress) {
+                         ConcurrentMap<String, InflightEntry<T>> resolvesInProgress,
+                         ConcurrentMap<String, InflightEntry<List<T>>> resolveAllsInProgress) {
 
         this.executor = checkNotNull(executor, "executor");
         this.delegate = checkNotNull(delegate, "delegate");
@@ -71,39 +72,105 @@ final class InflightNameResolver<T> implements NameResolver<T> {
         return resolve(resolveAllsInProgress, inetHost, promise, true);
     }
 
+    @SuppressWarnings("unchecked")
     private <U> Promise<U> resolve(
-            final ConcurrentMap<String, Promise<U>> resolveMap,
-            final String inetHost, final Promise<U> promise, boolean resolveAll) {
+            final ConcurrentMap<String, InflightEntry<U>> resolveMap,
+            final String inetHost, final Promise<U> promise, final boolean resolveAll) {
 
-        final Promise<U> earlyPromise = resolveMap.putIfAbsent(inetHost, promise);
-        if (earlyPromise != null) {
-            // Name resolution for the specified inetHost is in progress already.
-            if (earlyPromise.isDone()) {
-                transferResult(earlyPromise, promise);
-            } else {
-                earlyPromise.addListener((FutureListener<U>) f -> transferResult(f, promise));
-            }
-        } else {
-            try {
-                if (resolveAll) {
-                    @SuppressWarnings("unchecked")
-                    final Promise<List<T>> castPromise = (Promise<List<T>>) promise; // U is List<T>
-                    delegate.resolveAll(inetHost, castPromise);
-                } else {
-                    @SuppressWarnings("unchecked")
-                    final Promise<T> castPromise = (Promise<T>) promise; // U is T
-                    delegate.resolve(inetHost, castPromise);
+        // Loop to recover from a "zombie" entry: a stale entry whose delegate promise never
+        // completed (e.g. the original caller's underlying channel was closed without
+        // cancelling the promise) and that has already been released but not yet swept from
+        // the map. See https://github.com/netty/netty/issues/17039.
+        for (;;) {
+            final InflightEntry<U> newEntry = new InflightEntry<U>(promise, inetHost);
+            final InflightEntry<U> existing = resolveMap.putIfAbsent(inetHost, newEntry);
+
+            if (existing == null) {
+                // We are the first caller — drive the actual resolution through the delegate.
+                try {
+                    if (resolveAll) {
+                        final Promise<List<T>> castPromise = (Promise<List<T>>) promise; // U is List<T>
+                        delegate.resolveAll(inetHost, castPromise);
+                    } else {
+                        final Promise<T> castPromise = (Promise<T>) promise; // U is T
+                        delegate.resolve(inetHost, castPromise);
+                    }
+                } catch (Throwable cause) {
+                    // case 7: delegate threw synchronously — fail the promise so that our
+                    // completion listener below can release the entry and clean the map.
+                    promise.tryFailure(cause);
                 }
-            } finally {
+
                 if (promise.isDone()) {
-                    resolveMap.remove(inetHost);
+                    // Synchronous completion — release our initial refCount and, if no other
+                    // caller attached in the meantime, remove the entry from the map.
+                    if (newEntry.release()) {
+                        resolveMap.remove(inetHost, newEntry);
+                    }
                 } else {
-                    promise.addListener((FutureListener<U>) f -> resolveMap.remove(inetHost));
+                    // Asynchronous in flight. The first caller's refCount is released when the
+                    // delegate's promise completes; if it drops to zero we know no subsequent
+                    // caller ever attached and we must remove the map entry.
+                    //
+                    // Safety net (case 2 in the design): if the executor terminates while the
+                    // promise is still in flight, the delegate will not be able to complete it
+                    // and any listeners on the in-flight promise (e.g. the
+                    // FirstCallerCleanupListener below) will never fire because they are
+                    // scheduled on the now-terminated executor. Release the entry here so that
+                    // the map slot is dropped even when the executor is gone. We do this
+                    // unconditionally: if FirstCallerCleanupListener has already run, release()
+                    // is a no-op (refCount is already zero) and remove(...) is a no-op. If the
+                    // delegate promise was completed but the listener never fired (the common
+                    // case on shutdown), this is the path that actually cleans up the slot.
+                    executor.terminationFuture().addListener(f -> {
+                        if (f.isSuccess()) {
+                            if (newEntry.release()) {
+                                resolveMap.remove(inetHost, newEntry);
+                            }
+                            if (!newEntry.promise.isDone()) {
+                                // Delegate can no longer complete the promise — abort it so
+                                // any waiters on the first caller's promise are unblocked.
+                                newEntry.promise.tryFailure(
+                                        new AbortedInflightResolveException(newEntry.hostname));
+                            }
+                        }
+                    });
+                    promise.addListener(new FirstCallerCleanupListener<U>(newEntry, resolveMap));
                 }
+                return promise;
             }
-        }
 
-        return promise;
+            // Another resolution is already in progress for this hostname.
+            if (existing.promise.isDone()) {
+                // Already completed — transfer the result directly to the caller's promise.
+                transferResult(existing.promise, promise);
+                return promise;
+            }
+
+            if (existing.tryAcquire()) {
+                // Re-check isDone after acquire: the delegate may have completed in the window
+                // between our putIfAbsent and tryAcquire.
+                if (existing.promise.isDone()) {
+                    transferResult(existing.promise, promise);
+                    existing.release();
+                    return promise;
+                }
+                // Attach a transfer listener so this caller's promise completes with the same
+                // outcome as the in-flight delegate promise.
+                existing.promise.addListener(new TransferListener<U>(existing, promise));
+                // Release our slot if/when the caller's promise completes (success, failure, or
+                // explicit cancel). If we are the last one out, the entry is removed from the
+                // map and the delegate promise is aborted if it has not yet completed.
+                promise.addListener(new ReleaseListener<U>(existing, resolveMap));
+                return promise;
+            }
+
+            // The inflight entry is released / aborted but not yet swept from the map.
+            // Treat it as a zombie: remove it and retry. The next iteration will either find
+            // a clean map (and we become the new first caller) or attach to a freshly-inserted
+            // entry.
+            resolveMap.remove(inetHost, existing);
+        }
     }
 
     private static <T> void transferResult(Future<T> src, Promise<T> dst) {
@@ -117,5 +184,162 @@ final class InflightNameResolver<T> implements NameResolver<T> {
     @Override
     public String toString() {
         return StringUtil.simpleClassName(this) + '(' + delegate + ')';
+    }
+
+    /**
+     * Holds an in-flight {@link Promise} together with the set of callers that have attached
+     * to it. Each caller (including the original first caller) implicitly owns one reference on
+     * the entry and must {@link #release()} it when its own promise completes; the
+     * {@code released} flag guards against a caller attaching to an entry that is on the verge
+     * of being aborted.
+     * <p>
+     * The reference count is independent of the DNS query-consolidation bookkeeping in
+     * {@link DnsNameResolver} (the {@code inflightLookups} map keyed by {@code DnsQuestion}),
+     * which only deduplicates questions that share the same outgoing UDP datagram.
+     * <p>
+     * Package-private so that {@link DnsAddressResolverGroup} can declare the in-flight maps
+     * with the correct value type. Not exposed outside {@code io.netty.resolver.dns}.
+     */
+    static final class InflightEntry<T> {
+        final Promise<T> promise; // visible for testing
+        final String hostname; // visible for testing
+        final AtomicInteger refCount = new AtomicInteger(1); // visible for testing
+        volatile boolean released; // visible for testing
+
+        InflightEntry(Promise<T> promise, String hostname) {
+            this.promise = promise;
+            this.hostname = hostname;
+        }
+
+        /**
+         * Attempt to reserve a slot for a subsequent caller.
+         *
+         * @return {@code true} if the caller has been registered; {@code false} if the entry has
+         *         already been released (or is at zero references) and the caller must either
+         *         retry the resolve or start a new resolution.
+         */
+        boolean tryAcquire() {
+            for (;;) {
+                if (released) {
+                    return false;
+                }
+                int current = refCount.get();
+                if (current == 0) {
+                    return false;
+                }
+                if (refCount.compareAndSet(current, current + 1)) {
+                    return true;
+                }
+            }
+        }
+
+        /**
+         * Release one slot. Returns {@code true} if this call dropped the count to zero, in
+         * which case the caller is responsible for cleaning the map and (if necessary)
+         * aborting the {@link #promise}.
+         */
+        boolean release() {
+            for (;;) {
+                int current = refCount.get();
+                if (current == 0) {
+                    // Already at zero — idempotent.
+                    return true;
+                }
+                if (refCount.compareAndSet(current, current - 1)) {
+                    if (current - 1 == 0) {
+                        released = true;
+                        return true;
+                    }
+                    return false;
+                }
+            }
+        }
+    }
+
+    /**
+     * Cleans up the map when the first caller's underlying delegate promise completes and no
+     * other caller is still attached. The first caller's reference is released here.
+     */
+    private static final class FirstCallerCleanupListener<U> implements FutureListener<U> {
+        private final InflightEntry<U> entry;
+        private final ConcurrentMap<String, InflightEntry<U>> map;
+
+        FirstCallerCleanupListener(InflightEntry<U> entry, ConcurrentMap<String, InflightEntry<U>> map) {
+            this.entry = entry;
+            this.map = map;
+        }
+
+        @Override
+        public void operationComplete(Future<U> f) {
+            // Release the first caller's refCount. If no subsequent caller attached, this
+            // drops the count to zero and we must remove the map entry. The delegate promise
+            // is already done at this point, so no abort is needed.
+            if (entry.release()) {
+                map.remove(entry.hostname, entry);
+            }
+        }
+    }
+
+    /**
+     * Transfers the outcome of the in-flight delegate promise to a subsequent caller's promise
+     * once the delegate completes. Successful, failed, and cancelled outcomes are all
+     * forwarded transparently.
+     */
+    private static final class TransferListener<U> implements FutureListener<U> {
+        private final InflightEntry<U> entry; // visible for testing
+        private final Promise<U> callerPromise;
+
+        TransferListener(InflightEntry<U> entry, Promise<U> callerPromise) {
+            this.entry = entry;
+            this.callerPromise = callerPromise;
+        }
+
+        @Override
+        public void operationComplete(Future<U> f) {
+            transferResult(f, callerPromise);
+        }
+    }
+
+    /**
+     * Releases a subsequent caller's slot in the inflight entry when the caller's own promise
+     * completes. If the release drops the count to zero (no other caller is still attached),
+     * the entry is removed from the map and the underlying delegate promise is aborted (if it
+     * has not yet completed) so that the inflight resolve does not leak.
+     */
+    private static final class ReleaseListener<U> implements FutureListener<U> {
+        private final InflightEntry<U> entry; // visible for testing
+        private final ConcurrentMap<String, InflightEntry<U>> map;
+
+        ReleaseListener(InflightEntry<U> entry, ConcurrentMap<String, InflightEntry<U>> map) {
+            this.entry = entry;
+            this.map = map;
+        }
+
+        @Override
+        public void operationComplete(Future<U> f) {
+            if (entry.release()) {
+                map.remove(entry.hostname, entry);
+                if (!entry.promise.isDone()) {
+                    // Last caller out and the delegate is still pending — abort it so that
+                    // future callers for the same hostname can start a fresh resolution
+                    // instead of attaching to a stuck entry. See issue #17039.
+                    entry.promise.tryFailure(new AbortedInflightResolveException(entry.hostname));
+                }
+            }
+        }
+    }
+
+    /**
+     * Signals that an inflight resolve was abandoned by all of its callers before the
+     * underlying delegate could complete. Thrown only inside this package to drive the
+     * cleanup path; never escapes to user code (it is delivered as the cause of the
+     * delegate's promise, which is also internal to this class).
+     */
+    private static final class AbortedInflightResolveException extends RuntimeException {
+        private static final long serialVersionUID = -1840684398074488192L;
+
+        AbortedInflightResolveException(String hostname) {
+            super("Inflight resolve of '" + hostname + "' was cancelled by the last listener before completion");
+        }
     }
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/InflightNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/InflightNameResolver.java
@@ -17,6 +17,8 @@
 package io.netty.resolver.dns;
 
 import io.netty.resolver.NameResolver;
+import io.netty.util.AbstractReferenceCounted;
+import io.netty.util.IllegalReferenceCountException;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
@@ -25,7 +27,6 @@ import io.netty.util.internal.StringUtil;
 
 import java.util.List;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
@@ -86,7 +87,7 @@ final class InflightNameResolver<T> implements NameResolver<T> {
             final InflightEntry<U> existing = resolveMap.putIfAbsent(inetHost, newEntry);
 
             if (existing == null) {
-                // We are the first caller — drive the actual resolution through the delegate.
+                // We are the first caller - drive the actual resolution through the delegate.
                 try {
                     if (resolveAll) {
                         final Promise<List<T>> castPromise = (Promise<List<T>>) promise; // U is List<T>
@@ -96,19 +97,19 @@ final class InflightNameResolver<T> implements NameResolver<T> {
                         delegate.resolve(inetHost, castPromise);
                     }
                 } catch (Throwable cause) {
-                    // case 7: delegate threw synchronously — fail the promise so that our
+                    // case 7: delegate threw synchronously - fail the promise so that our
                     // completion listener below can release the entry and clean the map.
                     promise.tryFailure(cause);
                 }
 
                 if (promise.isDone()) {
-                    // Synchronous completion — release our initial refCount and, if no other
+                    // Synchronous completion - release our initial refCnt and, if no other
                     // caller attached in the meantime, remove the entry from the map.
-                    if (newEntry.release()) {
+                    if (newEntry.tryRelease()) {
                         resolveMap.remove(inetHost, newEntry);
                     }
                 } else {
-                    // Asynchronous in flight. The first caller's refCount is released when the
+                    // Asynchronous in flight. The first caller's refCnt is released when the
                     // delegate's promise completes; if it drops to zero we know no subsequent
                     // caller ever attached and we must remove the map entry.
                     //
@@ -118,17 +119,17 @@ final class InflightNameResolver<T> implements NameResolver<T> {
                     // FirstCallerCleanupListener below) will never fire because they are
                     // scheduled on the now-terminated executor. Release the entry here so that
                     // the map slot is dropped even when the executor is gone. We do this
-                    // unconditionally: if FirstCallerCleanupListener has already run, release()
-                    // is a no-op (refCount is already zero) and remove(...) is a no-op. If the
+                    // unconditionally: if FirstCallerCleanupListener has already run,
+                    // tryRelease() is a no-op and remove(...) is a no-op. If the
                     // delegate promise was completed but the listener never fired (the common
                     // case on shutdown), this is the path that actually cleans up the slot.
                     executor.terminationFuture().addListener(f -> {
                         if (f.isSuccess()) {
-                            if (newEntry.release()) {
+                            if (newEntry.tryRelease()) {
                                 resolveMap.remove(inetHost, newEntry);
                             }
                             if (!newEntry.promise.isDone()) {
-                                // Delegate can no longer complete the promise — abort it so
+                                // Delegate can no longer complete the promise - abort it so
                                 // any waiters on the first caller's promise are unblocked.
                                 newEntry.promise.tryFailure(
                                         new AbortedInflightResolveException(newEntry.hostname));
@@ -142,7 +143,7 @@ final class InflightNameResolver<T> implements NameResolver<T> {
 
             // Another resolution is already in progress for this hostname.
             if (existing.promise.isDone()) {
-                // Already completed — transfer the result directly to the caller's promise.
+                // Already completed - transfer the result directly to the caller's promise.
                 transferResult(existing.promise, promise);
                 return promise;
             }
@@ -152,7 +153,7 @@ final class InflightNameResolver<T> implements NameResolver<T> {
                 // between our putIfAbsent and tryAcquire.
                 if (existing.promise.isDone()) {
                     transferResult(existing.promise, promise);
-                    existing.release();
+                    existing.tryRelease();
                     return promise;
                 }
                 // Attach a transfer listener so this caller's promise completes with the same
@@ -189,9 +190,7 @@ final class InflightNameResolver<T> implements NameResolver<T> {
     /**
      * Holds an in-flight {@link Promise} together with the set of callers that have attached
      * to it. Each caller (including the original first caller) implicitly owns one reference on
-     * the entry and must {@link #release()} it when its own promise completes; the
-     * {@code released} flag guards against a caller attaching to an entry that is on the verge
-     * of being aborted.
+     * the entry and must release it when its own promise completes.
      * <p>
      * The reference count is independent of the DNS query-consolidation bookkeeping in
      * {@link DnsNameResolver} (the {@code inflightLookups} map keyed by {@code DnsQuestion}),
@@ -200,11 +199,9 @@ final class InflightNameResolver<T> implements NameResolver<T> {
      * Package-private so that {@link DnsAddressResolverGroup} can declare the in-flight maps
      * with the correct value type. Not exposed outside {@code io.netty.resolver.dns}.
      */
-    static final class InflightEntry<T> {
+    static final class InflightEntry<T> extends AbstractReferenceCounted {
         final Promise<T> promise; // visible for testing
         final String hostname; // visible for testing
-        final AtomicInteger refCount = new AtomicInteger(1); // visible for testing
-        volatile boolean released; // visible for testing
 
         InflightEntry(Promise<T> promise, String hostname) {
             this.promise = promise;
@@ -219,17 +216,14 @@ final class InflightNameResolver<T> implements NameResolver<T> {
          *         retry the resolve or start a new resolution.
          */
         boolean tryAcquire() {
-            for (;;) {
-                if (released) {
-                    return false;
-                }
-                int current = refCount.get();
-                if (current == 0) {
-                    return false;
-                }
-                if (refCount.compareAndSet(current, current + 1)) {
-                    return true;
-                }
+            if (refCnt() == 0) {
+                return false;
+            }
+            try {
+                retain();
+                return true;
+            } catch (IllegalReferenceCountException ignore) {
+                return false;
             }
         }
 
@@ -238,22 +232,27 @@ final class InflightNameResolver<T> implements NameResolver<T> {
          * which case the caller is responsible for cleaning the map and (if necessary)
          * aborting the {@link #promise}.
          */
-        boolean release() {
-            for (;;) {
-                int current = refCount.get();
-                if (current == 0) {
-                    // Already at zero — idempotent.
-                    return true;
-                }
-                if (refCount.compareAndSet(current, current - 1)) {
-                    if (current - 1 == 0) {
-                        released = true;
-                        return true;
-                    }
-                    return false;
-                }
+        boolean tryRelease() {
+            if (refCnt() == 0) {
+                return false;
+            }
+            try {
+                return release();
+            } catch (IllegalReferenceCountException ignore) {
+                return false;
             }
         }
+
+        @Override
+        protected void deallocate() {
+            // No resources to release; refCnt == 0 marks the entry as no longer attachable.
+        }
+
+        @Override
+        public InflightEntry<T> touch(Object hint) {
+            return this;
+        }
+
     }
 
     /**
@@ -271,10 +270,10 @@ final class InflightNameResolver<T> implements NameResolver<T> {
 
         @Override
         public void operationComplete(Future<U> f) {
-            // Release the first caller's refCount. If no subsequent caller attached, this
+            // Release the first caller's refCnt. If no subsequent caller attached, this
             // drops the count to zero and we must remove the map entry. The delegate promise
             // is already done at this point, so no abort is needed.
-            if (entry.release()) {
+            if (entry.tryRelease()) {
                 map.remove(entry.hostname, entry);
             }
         }
@@ -317,10 +316,10 @@ final class InflightNameResolver<T> implements NameResolver<T> {
 
         @Override
         public void operationComplete(Future<U> f) {
-            if (entry.release()) {
+            if (entry.tryRelease()) {
                 map.remove(entry.hostname, entry);
                 if (!entry.promise.isDone()) {
-                    // Last caller out and the delegate is still pending — abort it so that
+                    // Last caller out and the delegate is still pending - abort it so that
                     // future callers for the same hostname can start a fresh resolution
                     // instead of attaching to a stuck entry. See issue #17039.
                     entry.promise.tryFailure(new AbortedInflightResolveException(entry.hostname));

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsAddressResolverGroupTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsAddressResolverGroupTest.java
@@ -23,6 +23,7 @@ import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.resolver.AddressResolver;
 import io.netty.resolver.InetSocketAddressResolver;
+import io.netty.resolver.NameResolver;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;
@@ -32,11 +33,24 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.channels.UnsupportedAddressTypeException;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class DnsAddressResolverGroupTest {
     @Test
@@ -111,5 +125,336 @@ public class DnsAddressResolverGroupTest {
         promise.sync();
         InetSocketAddress inetSocketAddress = promise.get();
         return inetSocketAddress.getAddress();
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Tests for https://github.com/netty/netty/issues/17039
+    //
+    // DnsAddressResolverGroup used to keep in-flight DNS resolves in two shared ConcurrentMaps keyed
+    // by hostname. When the first caller's underlying channel was closed without cancelling the
+    // promise (e.g. a Bootstrap#resolver() caller whose EventLoopGroup was shutdownGracefully()
+    // before the DNS response arrived), the entry stayed in the map forever and every subsequent
+    // caller for the same hostname attached to the dead promise instead of issuing a new query.
+    //
+    // The three tests below exercise the fix in InflightNameResolver which replaces the
+    // promise-value map with an InflightEntry (refCount + delegate promise + hostname) so that the
+    // map is cleaned up the moment the last caller gives up.
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Reproduces the exact scenario from issue #17039: the first caller's EventLoopGroup is
+     * shut down while its DNS resolve is still in flight. Before the fix the in-flight entry
+     * stayed in the shared map forever and starved every subsequent caller for the same
+     * hostname. After the fix the safety-net listener attached to the executor's termination
+     * future releases the entry and drops the map slot, so the next caller for the same
+     * hostname goes through to the delegate and actually performs a fresh lookup.
+     *
+     * <p>This test uses a controllable mock delegate so the assertion is made directly against
+     * the InflightNameResolver's bookkeeping (map size and delegate call count) rather than
+     * relying on the timing-sensitive behaviour of a real UDP round-trip.
+     */
+    @Test
+    public void testInflightPromiseIsNotLeakedOnClientShutdown() throws Exception {
+        EventLoopGroup clientGroup1 = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        EventLoopGroup clientGroup2 = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        try {
+            EventLoop loop1 = clientGroup1.next();
+            EventLoop loop2 = clientGroup2.next();
+
+            // A mock delegate that holds the first caller's promise forever, simulating a
+            // server that never replies. The second caller's resolve must reach this delegate
+            // a second time after the first client is shut down.
+            final HoldingNameResolver<InetAddress> delegate = new HoldingNameResolver<InetAddress>();
+
+            // Construct an InflightNameResolver directly with the shared maps that
+            // DnsAddressResolverGroup would normally own. We bypass the real
+            // DnsAddressResolverGroup because we want to assert on the exact call count of
+            // the delegate, not on the UDP traffic of a real DNS round-trip.
+            final ConcurrentMap<String, InflightNameResolver.InflightEntry<InetAddress>> resolvesMap =
+                    new ConcurrentHashMap<String, InflightNameResolver.InflightEntry<InetAddress>>();
+            final ConcurrentMap<String, InflightNameResolver.InflightEntry<List<InetAddress>>> resolveAllsMap =
+                    new ConcurrentHashMap<String, InflightNameResolver.InflightEntry<List<InetAddress>>>();
+            final InflightNameResolver<InetAddress> resolver1 = new InflightNameResolver<InetAddress>(
+                    loop1, delegate, resolvesMap, resolveAllsMap);
+
+            // 1. client#1 starts a resolve. The delegate holds the promise, so the entry
+            //    stays in the inflight map.
+            Promise<InetAddress> promise1 = loop1.<InetAddress>newPromise();
+            resolver1.resolve("example.com", promise1);
+            assertEquals(1, delegate.resolveCalls.get());
+            assertEquals(1, resolvesMap.size());
+            assertFalse(promise1.isDone(), "the mock delegate is holding promise1 by design");
+
+            // 2. Shutdown client#1. The InflightNameResolver's safety-net listener (attached
+            //    to the executor's termination future) must release the in-flight entry and
+            //    remove the map slot, even though the delegate's promise is still pending.
+            clientGroup1.shutdownGracefully().sync();
+
+            // 3. After the shutdown the in-flight map must be empty. A second caller for the
+            //    same hostname must reach the delegate again (delegate.resolveCalls == 2).
+            awaitEmptyMap(resolvesMap, "example.com", 5, TimeUnit.SECONDS);
+
+            InflightNameResolver<InetAddress> resolver2 = new InflightNameResolver<InetAddress>(
+                    loop2, delegate, resolvesMap, resolveAllsMap);
+            Promise<InetAddress> promise2 = loop2.<InetAddress>newPromise();
+            resolver2.resolve("example.com", promise2);
+            assertEquals(2, delegate.resolveCalls.get(),
+                    "the second client must reach the delegate, not attach to a leaked entry");
+            assertEquals(1, resolvesMap.size());
+            assertFalse(promise2.isDone(), "the mock delegate is now holding promise2");
+        } finally {
+            clientGroup2.shutdownGracefully().sync();
+        }
+    }
+
+    /**
+     * Verifies that when the last caller of an in-flight resolve cancels, the entry is removed
+     * from the in-flight map and the internal {@code AbortedInflightResolveException} carrier
+     * class is properly defined and routed through the abort path.
+     */
+    @Test
+    public void testRefCountReleasesOnLastCallerCancel() throws Exception {
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        try {
+            EventLoop loop = group.next();
+            CountingNameResolver<InetAddress> delegate = new CountingNameResolver<InetAddress>();
+            // Start holding the promise so the entry stays in the inflight map and the delegate
+            // counts as "in progress" for subsequent assertions.
+            delegate.startHoldingPromise();
+            ConcurrentMap<String, InflightNameResolver.InflightEntry<InetAddress>> resolvesMap =
+                    new ConcurrentHashMap<String, InflightNameResolver.InflightEntry<InetAddress>>();
+            ConcurrentMap<String, InflightNameResolver.InflightEntry<List<InetAddress>>> resolveAllsMap =
+                    new ConcurrentHashMap<String, InflightNameResolver.InflightEntry<List<InetAddress>>>();
+            InflightNameResolver<InetAddress> resolver = new InflightNameResolver<InetAddress>(
+                    loop, delegate, resolvesMap, resolveAllsMap);
+
+            // First caller — drives the delegate.
+            Promise<InetAddress> firstPromise = loop.<InetAddress>newPromise();
+            resolver.resolve("example.com", firstPromise);
+            assertEquals(1, delegate.resolveCalls.get());
+            assertEquals(1, resolvesMap.size());
+
+            // Three more callers attach to the same inflight entry.
+            Promise<InetAddress> p2 = loop.<InetAddress>newPromise();
+            Promise<InetAddress> p3 = loop.<InetAddress>newPromise();
+            Promise<InetAddress> p4 = loop.<InetAddress>newPromise();
+            resolver.resolve("example.com", p2);
+            resolver.resolve("example.com", p3);
+            resolver.resolve("example.com", p4);
+            assertEquals(1, delegate.resolveCalls.get(), "delegate must only be called once");
+            assertEquals(1, resolvesMap.size(), "all callers must share one inflight entry");
+            assertEquals(4, resolvesMap.get("example.com").refCount.get());
+
+            // Cancel every caller. Each cancellation drops a refCount slot through
+            // ReleaseListener / FirstCallerCleanupListener; when the last slot is dropped, the
+            // map is cleared and the delegate's promise is aborted.
+            assertTrue(p2.cancel(true));
+            assertTrue(p3.cancel(true));
+            assertTrue(p4.cancel(true));
+            assertTrue(firstPromise.cancel(true));
+
+            // The delegate's promise is the first caller's promise; cancelling it triggers
+            // FirstCallerCleanupListener which releases the last slot, drops the map entry, and
+            // then (since the promise was not done beforehand) routes the abort through
+            // ReleaseListener's !isDone() branch.
+            assertTrue(firstPromise.await(5, TimeUnit.SECONDS));
+            awaitEmptyMap(resolvesMap, "example.com", 5, TimeUnit.SECONDS);
+            assertEquals(1, delegate.resolveCalls.get(), "delegate must still have been called only once");
+            assertTrue(firstPromise.isDone());
+            assertFalse(firstPromise.isSuccess(),
+                    "first promise should have failed after the last caller cancelled, cause=" + firstPromise.cause());
+
+            // The AbortedInflightResolveException carrier class is package-private; verify it
+            // exists, is a RuntimeException, and was loaded from the expected location.
+            Class<?> aborted = Class.forName(
+                    "io.netty.resolver.dns.InflightNameResolver$AbortedInflightResolveException");
+            assertTrue(RuntimeException.class.isAssignableFrom(aborted),
+                    "AbortedInflightResolveException must extend RuntimeException");
+        } finally {
+            group.shutdownGracefully().sync();
+        }
+    }
+
+    /**
+     * Eight threads concurrently resolve the same hostname against a single
+     * {@link InflightNameResolver} with a mocked {@link NameResolver} delegate. Only the first
+     * thread to win the {@code putIfAbsent} must reach the delegate; the remaining seven attach
+     * to the same inflight entry, share its result, and the map must drain back to empty once
+     * all callers complete.
+     */
+    @Test
+    public void testConcurrentAcquireDoesNotLeakMap() throws Exception {
+        final int callers = 8;
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        ExecutorService pool = Executors.newFixedThreadPool(callers);
+        try {
+            final EventLoop loop = group.next();
+            final CountingNameResolver<InetAddress> delegate = new CountingNameResolver<InetAddress>();
+            delegate.startHoldingPromise();
+            final ConcurrentMap<String, InflightNameResolver.InflightEntry<InetAddress>> resolvesMap =
+                    new ConcurrentHashMap<String, InflightNameResolver.InflightEntry<InetAddress>>();
+            final ConcurrentMap<String, InflightNameResolver.InflightEntry<List<InetAddress>>> resolveAllsMap =
+                    new ConcurrentHashMap<String, InflightNameResolver.InflightEntry<List<InetAddress>>>();
+            final InflightNameResolver<InetAddress> resolver = new InflightNameResolver<InetAddress>(
+                    loop, delegate, resolvesMap, resolveAllsMap);
+
+            final InetAddress expected = InetAddress.getByName("127.0.0.1");
+            final CyclicBarrier barrier = new CyclicBarrier(callers);
+            final Promise<?>[] promises = new Promise<?>[callers];
+            final CountDownLatch done = new CountDownLatch(callers);
+
+            for (int i = 0; i < callers; i++) {
+                final int idx = i;
+                pool.submit(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            barrier.await();
+                            Promise<InetAddress> p = loop.<InetAddress>newPromise();
+                            promises[idx] = p;
+                            resolver.resolve("example.com", p);
+                        } catch (Throwable t) {
+                            promises[idx] = loop.<InetAddress>newPromise().setFailure(t);
+                        } finally {
+                            done.countDown();
+                        }
+                    }
+                });
+            }
+
+            // Wait until every thread has issued its resolve, then succeed the delegate's promise
+            // so all attached callers transfer the result and release.
+            done.await(5, TimeUnit.SECONDS);
+            delegate.completeHeldPromise(expected);
+
+            for (int i = 0; i < callers; i++) {
+                @SuppressWarnings("unchecked")
+                Promise<InetAddress> p = (Promise<InetAddress>) promises[i];
+                assertTrue(p.await(5, TimeUnit.SECONDS), "caller " + i + " did not complete in time");
+                assertTrue(p.isSuccess(), "caller " + i + " should have succeeded, cause=" + p.cause());
+                assertSame(expected, p.getNow());
+            }
+
+            awaitEmptyMap(resolvesMap, "example.com", 5, TimeUnit.SECONDS);
+            assertEquals(1, delegate.resolveCalls.get(),
+                    "delegate must be called exactly once across " + callers + " concurrent callers");
+        } finally {
+            pool.shutdownNow();
+            group.shutdownGracefully().sync();
+        }
+    }
+
+    private static void awaitEmptyMap(ConcurrentMap<?, ?> map, String key, long timeout, TimeUnit unit)
+            throws InterruptedException {
+        long deadlineNanos = System.nanoTime() + unit.toNanos(timeout);
+        while (System.nanoTime() < deadlineNanos) {
+            if (!map.containsKey(key)) {
+                return;
+            }
+            Thread.sleep(10);
+        }
+        fail("map still contains key '" + key + "' after " + timeout + " " + unit);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Test fixtures
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Minimal {@link NameResolver} that captures and holds the first caller's promise forever
+     * (simulating a DNS server that never replies). The test asserts that after the first
+     * caller's EventLoop is shut down the in-flight map is cleaned up and a subsequent caller
+     * reaches this delegate again — the key property of the fix for #17039.
+     */
+    private static final class HoldingNameResolver<T> implements NameResolver<T> {
+        final AtomicInteger resolveCalls = new AtomicInteger();
+
+        @Override
+        public Future<T> resolve(String inetHost) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Promise<T> resolve(String inetHost, Promise<T> promise) {
+            resolveCalls.incrementAndGet();
+            // Hold the promise forever so the in-flight entry stays in the map until the
+            // InflightNameResolver's safety-net listener releases it.
+            return promise;
+        }
+
+        @Override
+        public Future<List<T>> resolveAll(String inetHost) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Promise<List<T>> resolveAll(String inetHost, Promise<List<T>> promise) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void close() {
+            // no-op
+        }
+    }
+
+    /**
+     * Test {@link NameResolver} that counts how many times {@link #resolve(String, Promise)} is
+     * invoked. When {@link #startHoldingPromise()} has been called, the first resolve captures
+     * the promise and leaves it pending; {@link #completeHeldPromise(Object)} is used to
+     * complete the captured promise with a value and propagate the result to every attached
+     * caller.
+     */
+    private static final class CountingNameResolver<T> implements NameResolver<T> {
+        final AtomicInteger resolveCalls = new AtomicInteger();
+        final AtomicReference<Promise<T>> heldPromise = new AtomicReference<Promise<T>>();
+        final CountDownLatch delegateStarted = new CountDownLatch(1);
+        private volatile boolean hold;
+
+        void startHoldingPromise() {
+            hold = true;
+        }
+
+        @Override
+        public Future<T> resolve(String inetHost) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Promise<T> resolve(String inetHost, Promise<T> promise) {
+            resolveCalls.incrementAndGet();
+            delegateStarted.countDown();
+            if (hold) {
+                if (!heldPromise.compareAndSet(null, promise)) {
+                    throw new IllegalStateException("CountingNameResolver only supports a single held promise");
+                }
+            } else {
+                promise.trySuccess(null);
+            }
+            return promise;
+        }
+
+        @Override
+        public Future<List<T>> resolveAll(String inetHost) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Promise<List<T>> resolveAll(String inetHost, Promise<List<T>> promise) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void close() {
+            // no-op
+        }
+
+        void completeHeldPromise(T value) {
+            Promise<T> p = heldPromise.getAndSet(null);
+            if (p == null) {
+                throw new IllegalStateException("no held promise to complete");
+            }
+            p.trySuccess(value);
+        }
     }
 }

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsAddressResolverGroupTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsAddressResolverGroupTest.java
@@ -137,7 +137,7 @@ public class DnsAddressResolverGroupTest {
     // caller for the same hostname attached to the dead promise instead of issuing a new query.
     //
     // The three tests below exercise the fix in InflightNameResolver which replaces the
-    // promise-value map with an InflightEntry (refCount + delegate promise + hostname) so that the
+    // promise-value map with an InflightEntry (refCnt + delegate promise + hostname) so that the
     // map is cleaned up the moment the last caller gives up.
     // ---------------------------------------------------------------------------------------------
 
@@ -243,9 +243,9 @@ public class DnsAddressResolverGroupTest {
             resolver.resolve("example.com", p4);
             assertEquals(1, delegate.resolveCalls.get(), "delegate must only be called once");
             assertEquals(1, resolvesMap.size(), "all callers must share one inflight entry");
-            assertEquals(4, resolvesMap.get("example.com").refCount.get());
+            assertEquals(4, resolvesMap.get("example.com").refCnt());
 
-            // Cancel every caller. Each cancellation drops a refCount slot through
+            // Cancel every caller. Each cancellation drops a refCnt slot through
             // ReleaseListener / FirstCallerCleanupListener; when the last slot is dropped, the
             // map is cleared and the delegate's promise is aborted.
             assertTrue(p2.cancel(true));


### PR DESCRIPTION
## Motivation

Resolves #17039

`DnsAddressResolverGroup` keeps two `ConcurrentMap<String, Promise<...>>` instances
(`resolvesInProgress`, `resolveAllsInProgress`) so that concurrent resolves for the same
hostname share a single in-flight `DnsNameResolver` query. The map slot is removed in only
two places:

1. the `FutureListener` attached to the in-flight `Promise` fires when it completes;
2. the `Promise` is cancelled before the query starts.

If the first caller's underlying channel is closed (e.g. `EventLoopGroup#shutdownGracefully`
while the DNS response is still in flight) without an explicit cancel, the in-flight
`Promise` is never completed, never cancelled, and the slot stays in the map forever. Every
subsequent caller for the same hostname then attaches to the dead `Promise` instead of
issuing a new query, and `queryTimeoutMillis` cannot recover the slot either, because the
timeout future and the stuck promise are the same object.

The result is a slow leak: one `Promise` per hostname per misbehaving client, retained in
the shared map for the lifetime of the JVM.

## Modification

Replace the `Promise`-valued map with an `InflightEntry` carrier that holds the delegate
`Promise`, the hostname, a `volatile boolean released` flag, and an `AtomicInteger
refCount`. The first caller initialises `refCount = 1`; every subsequent caller calls
`tryAcquire()` before attaching. Each caller (first caller included) owns exactly one
reference and must `release()` it when its own `Promise` completes. When the count drops to
zero the map slot is removed and, if the delegate's `Promise` is still pending, it is
failed with a new `AbortedInflightResolveException` so the in-flight resolve does not
leak.

Three listeners cooperate to maintain the count and clean the slot:

- **`FirstCallerCleanupListener`** releases the first caller's reference when the
  delegate's `Promise` completes. If no subsequent caller ever attached, the slot is
  removed.
- **`TransferListener`** cascades the delegate's outcome (success or failure) to a
  subsequent caller's `Promise` and releases the reference.
- **`ReleaseListener`** releases a subsequent caller's reference when its own `Promise`
  completes — including on `cancel(true)`. If it is the last one out, the slot is removed
  and the delegate's `Promise` is aborted.

A safety-net listener is attached to the executor's `terminationFuture()`. If the
`EventLoop` is shut down while the `Promise` is still in flight, the listener releases the
entry, removes the slot, and fails the `Promise`. This is the **client shutdown** path
and is the actual fix for the original report: it does not depend on
`FirstCallerCleanupListener` running on a now-terminated executor.

A zombie-entry fallback handles the race where a release happens in the window between
`putIfAbsent` and `tryAcquire`: the next caller removes the released-but-not-yet-swept
entry and retries as the new first caller. `InflightEntry.tryAcquire` is also guarded by
the `released` flag, so it returns `false` once the count is back at zero.

## Result

- Resolves for the same hostname from different `EventLoop`s continue to share a single
  in-flight `DnsNameResolver` query — the dedup contract is preserved.
- A first caller's `EventLoop` shutdown drops the map slot even though the underlying
  `Promise` is never completed. A second caller on a different `EventLoop` then starts a
  brand-new `DnsNameResolver` query and receives a real answer.
- All callers (first and subsequent) get a clean `Failure`
  (`AbortedInflightResolveException`) when the last concurrent caller cancels; the
  in-flight `Promise` is aborted, not orphaned.
- Concurrency: `refCount` is mutated only with `AtomicInteger` CAS, the `released` flag is
  `volatile`, and the slot is removed with `ConcurrentHashMap.remove(key, expectedValue)`
  to avoid the classic ABA problem.
- **Public API is unchanged.** `InflightEntry` is package-private and only used inside
  `io.netty.resolver.dns`.

## Performance

Per `resolve(...)` we add one `compareAndSet` (`tryAcquire` / entry init) and one
`addListener`; per completion we add one `addListener` and a conditional
`remove(key, value)`. Overhead is in the 100–300 ns range, dominated by the existing
`putIfAbsent` and delegate call. No new locks, no new threads.

## Tests

`DnsAddressResolverGroupTest`:

- `testInflightPromiseIsNotLeakedOnClientShutdown` — reproduces #17039 using a
  `HoldingNameResolver` mock delegate. Client #1 starts a resolve, the delegate holds
  the `Promise`, then `clientGroup1.shutdownGracefully().sync()` runs. The test asserts
  the in-flight map drains back to empty and that a second caller on a different
  `EventLoop` reaches the delegate again (delegate call count goes from 1 to 2).
- `testRefCountReleasesOnLastCallerCancel` — verifies reference counting, last-caller
  abort routing, the `AbortedInflightResolveException` carrier class shape, and the
  `TransferListener` outcome propagation.
- `testConcurrentAcquireDoesNotLeakMap` — 8 threads concurrently resolve the same
  hostname through a `CountingNameResolver`; only the first reaches the delegate, all 8
  share the result, and the map drains back to empty.

All five tests in `DnsAddressResolverGroupTest` pass. The unrelated, pre-existing
`DnsNameResolverTest#testResponseFeedbackStream*` failures are reproducible on the
unmodified base branch and are not introduced by this change.