### PR TITLE
Negotiate HTTP/2 response compression from the request's Accept-Encoding

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
@@ -59,7 +59,13 @@ import static io.netty.handler.codec.http.HttpHeaderValues.SNAPPY;
 /**
  * A decorating HTTP2 encoder that will compress data frames according to the {@code content-encoding} header for each
  * stream. The compression provided by this class will be applied to the data for the entire stream.
+ *
+ * @deprecated This encoder decides compression from the response {@code content-encoding} header alone and cannot
+ * see the request's {@code accept-encoding}, which leads to double-encoding of already-encoded bodies
+ * (see #14277). Prefer {@link NegotiatingCompressorHttp2ConnectionEncoder} together with
+ * {@link Http2RequestAcceptEncodingFrameListener}.
  */
+@Deprecated
 public class CompressorHttp2ConnectionEncoder extends DecoratingHttp2ConnectionEncoder {
     // We cannot remove this because it'll be breaking change
     public static final int DEFAULT_COMPRESSION_LEVEL = 6;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CompressionChannelFactory.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CompressionChannelFactory.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.codec.http2;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.compression.BrotliEncoder;
+import io.netty.handler.codec.compression.BrotliOptions;
+import io.netty.handler.codec.compression.CompressionOptions;
+import io.netty.handler.codec.compression.DeflateOptions;
+import io.netty.handler.codec.compression.SnappyFrameEncoder;
+import io.netty.handler.codec.compression.ZlibCodecFactory;
+import io.netty.handler.codec.compression.ZlibWrapper;
+import io.netty.handler.codec.compression.ZstdEncoder;
+import io.netty.handler.codec.compression.ZstdOptions;
+
+import static io.netty.handler.codec.http.HttpHeaderValues.BR;
+import static io.netty.handler.codec.http.HttpHeaderValues.DEFLATE;
+import static io.netty.handler.codec.http.HttpHeaderValues.GZIP;
+import static io.netty.handler.codec.http.HttpHeaderValues.SNAPPY;
+import static io.netty.handler.codec.http.HttpHeaderValues.ZSTD;
+
+/**
+ * Builds the {@link EmbeddedChannel} that compresses an HTTP/2 response body for a
+ * {@link NegotiatedEncoding}.
+ * <p>
+ * This mirrors the {@code content-encoding} branches of the deprecated
+ * {@code CompressorHttp2ConnectionEncoder} ({@code newContentCompressor}/{@code newCompressionChannel}),
+ * but sources the compression parameters from the negotiated {@link CompressionOptions} instead of a
+ * fixed, per-encoder configuration.
+ */
+final class Http2CompressionChannelFactory {
+
+    private Http2CompressionChannelFactory() {
+    }
+
+    /**
+     * Creates a new {@link EmbeddedChannel} that compresses data according to {@code negotiated}.
+     *
+     * @param ctx the context whose channel the returned {@link EmbeddedChannel} is modeled after
+     * @param negotiated the negotiated encoding and its matching compression options
+     * @return a new {@link EmbeddedChannel} that compresses written data, or {@code null} if
+     *         {@code negotiated}'s content encoding is not recognized
+     * @throws Http2Exception if the compressor could not be created for a recognized content encoding
+     */
+    static EmbeddedChannel newCompressionChannel(ChannelHandlerContext ctx, NegotiatedEncoding negotiated)
+            throws Http2Exception {
+        CharSequence contentEncoding = negotiated.contentEncoding;
+        CompressionOptions options = negotiated.options;
+        if (GZIP.contentEqualsIgnoreCase(contentEncoding)) {
+            return newZlibCompressionChannel(ctx, ZlibWrapper.GZIP, (DeflateOptions) options);
+        }
+        if (DEFLATE.contentEqualsIgnoreCase(contentEncoding)) {
+            return newZlibCompressionChannel(ctx, ZlibWrapper.ZLIB, (DeflateOptions) options);
+        }
+        if (BR.contentEqualsIgnoreCase(contentEncoding)) {
+            return newBrotliCompressionChannel(ctx, (BrotliOptions) options);
+        }
+        if (ZSTD.contentEqualsIgnoreCase(contentEncoding)) {
+            return newZstdCompressionChannel(ctx, (ZstdOptions) options);
+        }
+        if (SNAPPY.contentEqualsIgnoreCase(contentEncoding)) {
+            return newSnappyCompressionChannel(ctx);
+        }
+        // Unrecognized content-encoding: nothing to compress with.
+        return null;
+    }
+
+    private static EmbeddedChannel newZlibCompressionChannel(ChannelHandlerContext ctx, ZlibWrapper wrapper,
+            DeflateOptions options) {
+        Channel channel = ctx.channel();
+        return EmbeddedChannel.builder()
+                .channelId(channel.id())
+                .hasDisconnect(channel.metadata().hasDisconnect())
+                .config(channel.config())
+                .handlers(ZlibCodecFactory.newZlibEncoder(wrapper, options.compressionLevel(), options.windowBits(),
+                        options.memLevel()))
+                .build();
+    }
+
+    private static EmbeddedChannel newBrotliCompressionChannel(ChannelHandlerContext ctx, BrotliOptions options) {
+        Channel channel = ctx.channel();
+        return EmbeddedChannel.builder()
+                .channelId(channel.id())
+                .hasDisconnect(channel.metadata().hasDisconnect())
+                .config(channel.config())
+                .handlers(new BrotliEncoder(options.parameters()))
+                .build();
+    }
+
+    private static EmbeddedChannel newZstdCompressionChannel(ChannelHandlerContext ctx, ZstdOptions options) {
+        Channel channel = ctx.channel();
+        return EmbeddedChannel.builder()
+                .channelId(channel.id())
+                .hasDisconnect(channel.metadata().hasDisconnect())
+                .config(channel.config())
+                .handlers(new ZstdEncoder(options.compressionLevel(), options.blockSize(), options.maxEncodeSize()))
+                .build();
+    }
+
+    private static EmbeddedChannel newSnappyCompressionChannel(ChannelHandlerContext ctx) {
+        Channel channel = ctx.channel();
+        return EmbeddedChannel.builder()
+                .channelId(channel.id())
+                .hasDisconnect(channel.metadata().hasDisconnect())
+                .config(channel.config())
+                .handlers(new SnappyFrameEncoder())
+                .build();
+    }
+}

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ContentEncodingNegotiator.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ContentEncodingNegotiator.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.codec.http2;
+
+import io.netty.handler.codec.compression.Brotli;
+import io.netty.handler.codec.compression.BrotliOptions;
+import io.netty.handler.codec.compression.CompressionOptions;
+import io.netty.handler.codec.compression.DeflateOptions;
+import io.netty.handler.codec.compression.GzipOptions;
+import io.netty.handler.codec.compression.SnappyOptions;
+import io.netty.handler.codec.compression.ZstdOptions;
+import io.netty.util.internal.ObjectUtil;
+
+import static io.netty.handler.codec.http.HttpHeaderValues.BR;
+import static io.netty.handler.codec.http.HttpHeaderValues.DEFLATE;
+import static io.netty.handler.codec.http.HttpHeaderValues.GZIP;
+import static io.netty.handler.codec.http.HttpHeaderValues.SNAPPY;
+import static io.netty.handler.codec.http.HttpHeaderValues.ZSTD;
+
+/**
+ * Negotiates the {@code content-encoding} to apply to an HTTP/2 response based on the request's
+ * {@code accept-encoding} header value and the {@link CompressionOptions} configured for the server.
+ * <p>
+ * This mirrors the algorithm of {@code HttpContentCompressor.determineEncoding(String)}, adapted to operate
+ * on {@link CompressionOptions} instances instead of plain encoding names, and to be purely functional
+ * (no I/O, no side effects).
+ */
+final class Http2ContentEncodingNegotiator {
+
+    private BrotliOptions brotliOptions;
+    private GzipOptions gzipOptions;
+    private DeflateOptions deflateOptions;
+    private ZstdOptions zstdOptions;
+    private SnappyOptions snappyOptions;
+
+    Http2ContentEncodingNegotiator(CompressionOptions... options) {
+        ObjectUtil.checkNotNull(options, "options");
+        ObjectUtil.deepCheckNotNull("options", options);
+
+        for (CompressionOptions option : options) {
+            // BrotliOptions' class initialization depends on Brotli classes being on the classpath.
+            // The Brotli.isAvailable check ensures that BrotliOptions will only get instantiated if Brotli is on
+            // the classpath.
+            if (Brotli.isAvailable() && option instanceof BrotliOptions) {
+                brotliOptions = (BrotliOptions) option;
+            } else if (option instanceof GzipOptions) {
+                gzipOptions = (GzipOptions) option;
+            } else if (option instanceof DeflateOptions) {
+                deflateOptions = (DeflateOptions) option;
+            } else if (option instanceof ZstdOptions) {
+                zstdOptions = (ZstdOptions) option;
+            } else if (option instanceof SnappyOptions) {
+                snappyOptions = (SnappyOptions) option;
+            } else {
+                throw new IllegalArgumentException("Unsupported " + CompressionOptions.class.getSimpleName() +
+                        ": " + option);
+            }
+        }
+    }
+
+    /**
+     * Negotiates the encoding to apply for the given {@code accept-encoding} header value.
+     *
+     * @param acceptEncoding the request's {@code accept-encoding} header value, may be {@code null}
+     * @return the negotiated encoding, or {@code null} if {@code acceptEncoding} is {@code null}, unrecognized,
+     *         or does not match any of the encodings configured for this negotiator
+     */
+    @SuppressWarnings("FloatingPointEquality")
+    NegotiatedEncoding negotiate(CharSequence acceptEncoding) {
+        if (acceptEncoding == null) {
+            return null;
+        }
+        String value = acceptEncoding.toString();
+
+        float starQ = -1.0f;
+        float brQ = -1.0f;
+        float zstdQ = -1.0f;
+        float snappyQ = -1.0f;
+        float gzipQ = -1.0f;
+        float deflateQ = -1.0f;
+
+        int start = 0;
+        int length = value.length();
+        while (start < length) {
+            int comma = value.indexOf(',', start);
+            if (comma == -1) {
+                comma = length;
+            }
+            String encoding = value.substring(start, comma);
+            float q = 1.0f;
+            int equalsPos = encoding.indexOf('=');
+            if (equalsPos != -1) {
+                try {
+                    q = Float.parseFloat(encoding.substring(equalsPos + 1));
+                } catch (NumberFormatException e) {
+                    // Ignore encoding
+                    q = 0.0f;
+                }
+            }
+            if (encoding.contains("*")) {
+                starQ = q;
+            } else if (encoding.contains("br") && q > brQ) {
+                brQ = q;
+            } else if (encoding.contains("zstd") && q > zstdQ) {
+                zstdQ = q;
+            } else if (encoding.contains("snappy") && q > snappyQ) {
+                snappyQ = q;
+            } else if (encoding.contains("gzip") && q > gzipQ) {
+                gzipQ = q;
+            } else if (encoding.contains("deflate") && q > deflateQ) {
+                deflateQ = q;
+            }
+            start = comma + 1;
+        }
+        if (brQ > 0.0f || zstdQ > 0.0f || snappyQ > 0.0f || gzipQ > 0.0f || deflateQ > 0.0f) {
+            if (brQ != -1.0f && brQ >= zstdQ && brotliOptions != null) {
+                return new NegotiatedEncoding(BR, brotliOptions);
+            } else if (zstdQ != -1.0f && zstdQ >= snappyQ && zstdOptions != null) {
+                return new NegotiatedEncoding(ZSTD, zstdOptions);
+            } else if (snappyQ != -1.0f && snappyQ >= gzipQ && snappyOptions != null) {
+                return new NegotiatedEncoding(SNAPPY, snappyOptions);
+            } else if (gzipQ != -1.0f && gzipQ >= deflateQ && gzipOptions != null) {
+                return new NegotiatedEncoding(GZIP, gzipOptions);
+            } else if (deflateQ != -1.0f && deflateOptions != null) {
+                return new NegotiatedEncoding(DEFLATE, deflateOptions);
+            }
+        }
+        if (starQ > 0.0f) {
+            if (brQ == -1.0f && brotliOptions != null) {
+                return new NegotiatedEncoding(BR, brotliOptions);
+            }
+            if (zstdQ == -1.0f && zstdOptions != null) {
+                return new NegotiatedEncoding(ZSTD, zstdOptions);
+            }
+            if (snappyQ == -1.0f && snappyOptions != null) {
+                return new NegotiatedEncoding(SNAPPY, snappyOptions);
+            }
+            if (gzipQ == -1.0f && gzipOptions != null) {
+                return new NegotiatedEncoding(GZIP, gzipOptions);
+            }
+            if (deflateQ == -1.0f && deflateOptions != null) {
+                return new NegotiatedEncoding(DEFLATE, deflateOptions);
+            }
+        }
+        return null;
+    }
+}
+
+/**
+ * The result of a successful {@link Http2ContentEncodingNegotiator#negotiate(CharSequence)} call: the
+ * {@code content-encoding} value to set on the response, together with the matching {@link CompressionOptions}
+ * to configure the compressor with.
+ */
+final class NegotiatedEncoding {
+    final CharSequence contentEncoding;
+    final CompressionOptions options;
+
+    NegotiatedEncoding(CharSequence contentEncoding, CompressionOptions options) {
+        this.contentEncoding = contentEncoding;
+        this.options = options;
+    }
+}

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ContentEncodingNegotiator.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ContentEncodingNegotiator.java
@@ -46,7 +46,6 @@ final class Http2ContentEncodingNegotiator {
     private SnappyOptions snappyOptions;
 
     Http2ContentEncodingNegotiator(CompressionOptions... options) {
-        ObjectUtil.checkNotNull(options, "options");
         ObjectUtil.deepCheckNotNull("options", options);
 
         for (CompressionOptions option : options) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2RequestAcceptEncodingFrameListener.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2RequestAcceptEncodingFrameListener.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.codec.http2;
+
+import io.netty.channel.ChannelHandlerContext;
+
+import static io.netty.handler.codec.http.HttpHeaderNames.ACCEPT_ENCODING;
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+/**
+ * An HTTP/2 frame listener that captures the {@code accept-encoding} header of a request into a
+ * {@link Http2RequestAcceptEncodingPropertyKey} so it can be read again when the response for the same stream is
+ * written. This listener does not modify the headers in any way; the {@code accept-encoding} header remains
+ * visible to the application and to the delegate {@link Http2FrameListener}.
+ */
+public class Http2RequestAcceptEncodingFrameListener extends Http2FrameListenerDecorator {
+
+    private final Http2Connection connection;
+    private final Http2RequestAcceptEncodingPropertyKey key;
+
+    /**
+     * Create a new instance.
+     *
+     * @param connection the connection whose streams carry the captured {@code accept-encoding} value
+     * @param listener the delegate listener used by {@link Http2FrameListenerDecorator}
+     * @param key the shared property key used to store the captured {@code accept-encoding} value
+     */
+    public Http2RequestAcceptEncodingFrameListener(Http2Connection connection, Http2FrameListener listener,
+                                                    Http2RequestAcceptEncodingPropertyKey key) {
+        super(listener);
+        this.connection = checkNotNull(connection, "connection");
+        this.key = checkNotNull(key, "key");
+    }
+
+    @Override
+    public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int padding,
+                               boolean endStream) throws Http2Exception {
+        captureAcceptEncoding(streamId, headers);
+        listener.onHeadersRead(ctx, streamId, headers, padding, endStream);
+    }
+
+    @Override
+    public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int streamDependency,
+                               short weight, boolean exclusive, int padding, boolean endStream)
+            throws Http2Exception {
+        captureAcceptEncoding(streamId, headers);
+        listener.onHeadersRead(ctx, streamId, headers, streamDependency, weight, exclusive, padding, endStream);
+    }
+
+    private void captureAcceptEncoding(int streamId, Http2Headers headers) {
+        Http2Stream stream = connection.stream(streamId);
+        if (stream == null) {
+            return;
+        }
+        CharSequence acceptEncoding = headers.get(ACCEPT_ENCODING);
+        if (acceptEncoding != null) {
+            key.setAcceptEncoding(stream, acceptEncoding);
+        }
+    }
+}

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2RequestAcceptEncodingPropertyKey.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2RequestAcceptEncodingPropertyKey.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.codec.http2;
+
+/**
+ * A shared {@link Http2Connection.PropertyKey} used to capture and retrieve the {@code accept-encoding}
+ * header of a request on its {@link Http2Stream}, so that it can be read again when the response is
+ * written on the same stream.
+ * <p>
+ * A single instance of this class must be shared between the inbound frame listener that captures the
+ * value and the outbound encoder that reads it, so that both sides agree on the same
+ * {@link Http2Connection.PropertyKey}.
+ */
+public final class Http2RequestAcceptEncodingPropertyKey {
+
+    private final Http2Connection.PropertyKey key;
+
+    /**
+     * Create a new instance.
+     *
+     * @param connection the connection whose streams will carry the captured {@code accept-encoding} value
+     */
+    public Http2RequestAcceptEncodingPropertyKey(Http2Connection connection) {
+        this.key = connection.newKey();
+        connection.addListener(new Http2ConnectionAdapter() {
+            @Override
+            public void onStreamRemoved(Http2Stream stream) {
+                stream.removeProperty(key);
+            }
+        });
+    }
+
+    /**
+     * Returns the {@code accept-encoding} value previously captured for the given stream, or {@code null}
+     * if none was captured (or {@code stream} is {@code null}).
+     */
+    CharSequence acceptEncoding(Http2Stream stream) {
+        return stream == null ? null : (CharSequence) stream.getProperty(key);
+    }
+
+    /**
+     * Stores the {@code accept-encoding} value for the given stream.
+     */
+    void setAcceptEncoding(Http2Stream stream, CharSequence acceptEncoding) {
+        stream.setProperty(key, acceptEncoding);
+    }
+}

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/NegotiatingCompressorHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/NegotiatingCompressorHttp2ConnectionEncoder.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.codec.http2;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.compression.CompressionOptions;
+import io.netty.util.concurrent.PromiseCombiner;
+
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_ENCODING;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+/**
+ * A decorating HTTP/2 encoder that compresses response data frames based on a negotiation between the
+ * request's {@code accept-encoding} header (captured on the stream by
+ * {@link Http2RequestAcceptEncodingFrameListener}) and the {@link CompressionOptions} configured for this
+ * encoder.
+ * <p>
+ * Unlike the deprecated {@code CompressorHttp2ConnectionEncoder}, this encoder never compresses a response
+ * whose headers already contain a {@code content-encoding} value: such a body is assumed to already be
+ * encoded by the application, and compressing it again would double-encode it (see #14277).
+ */
+public class NegotiatingCompressorHttp2ConnectionEncoder extends DecoratingHttp2ConnectionEncoder {
+
+    private final Http2RequestAcceptEncodingPropertyKey acceptEncodingKey;
+    private final Http2ContentEncodingNegotiator negotiator;
+    private final Http2Connection.PropertyKey compressorPropertyKey;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param delegate the {@link Http2ConnectionEncoder} to delegate to
+     * @param acceptEncodingKey the shared key used to read the {@code accept-encoding} value captured for a
+     *                          stream by {@link Http2RequestAcceptEncodingFrameListener}
+     * @param compressionOptions the compression options this encoder is allowed to negotiate
+     */
+    public NegotiatingCompressorHttp2ConnectionEncoder(Http2ConnectionEncoder delegate,
+            Http2RequestAcceptEncodingPropertyKey acceptEncodingKey, CompressionOptions... compressionOptions) {
+        super(delegate);
+        this.acceptEncodingKey = checkNotNull(acceptEncodingKey, "acceptEncodingKey");
+        this.negotiator = new Http2ContentEncodingNegotiator(compressionOptions);
+        this.compressorPropertyKey = connection().newKey();
+        connection().addListener(new Http2ConnectionAdapter() {
+            @Override
+            public void onStreamRemoved(Http2Stream stream) {
+                final EmbeddedChannel compressor = stream.getProperty(compressorPropertyKey);
+                if (compressor != null) {
+                    cleanup(stream, compressor);
+                }
+            }
+        });
+    }
+
+    @Override
+    public ChannelFuture writeData(final ChannelHandlerContext ctx, final int streamId, final ByteBuf data,
+            int padding, final boolean endOfStream, final ChannelPromise promise) {
+        final Http2Stream stream = connection().stream(streamId);
+        final EmbeddedChannel channel = stream == null ? null : (EmbeddedChannel) stream.getProperty(
+                compressorPropertyKey);
+        if (channel == null) {
+            // The compressor may be null if no compression was negotiated for this stream.
+            return super.writeData(ctx, streamId, data, padding, endOfStream, promise);
+        }
+
+        try {
+            // The channel will release the buffer after being written
+            channel.writeOutbound(data);
+            ByteBuf buf = nextReadableBuf(channel);
+            if (buf == null) {
+                if (endOfStream) {
+                    if (channel.finish()) {
+                        buf = nextReadableBuf(channel);
+                    }
+                    return super.writeData(ctx, streamId, buf == null ? Unpooled.EMPTY_BUFFER : buf, padding,
+                            true, promise);
+                }
+                // END_STREAM is not set and the assumption is data is still forthcoming.
+                promise.setSuccess();
+                return promise;
+            }
+
+            PromiseCombiner combiner = new PromiseCombiner(ctx.executor());
+            for (;;) {
+                ByteBuf nextBuf = nextReadableBuf(channel);
+                boolean compressedEndOfStream = nextBuf == null && endOfStream;
+                if (compressedEndOfStream && channel.finish()) {
+                    nextBuf = nextReadableBuf(channel);
+                    compressedEndOfStream = nextBuf == null;
+                }
+
+                ChannelPromise bufPromise = ctx.newPromise();
+                combiner.add(bufPromise);
+                super.writeData(ctx, streamId, buf, padding, compressedEndOfStream, bufPromise);
+                if (nextBuf == null) {
+                    break;
+                }
+
+                padding = 0; // Padding is only communicated once on the first iteration
+                buf = nextBuf;
+            }
+            combiner.finish(promise);
+        } catch (Throwable cause) {
+            promise.tryFailure(cause);
+        } finally {
+            if (endOfStream) {
+                cleanup(stream, channel);
+            }
+        }
+        return promise;
+    }
+
+    @Override
+    public ChannelFuture writeHeaders(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int padding,
+            boolean endStream, ChannelPromise promise) {
+        try {
+            EmbeddedChannel compressor = prepareCompressor(ctx, streamId, headers, endStream);
+
+            // Write the headers and create the stream object.
+            ChannelFuture future = super.writeHeaders(ctx, streamId, headers, padding, endStream, promise);
+
+            // After the stream object has been created, then attach the compressor as a property for data
+            // compression.
+            bindCompressorToStream(compressor, streamId);
+
+            return future;
+        } catch (Throwable e) {
+            promise.tryFailure(e);
+        }
+        return promise;
+    }
+
+    @Override
+    public ChannelFuture writeHeaders(final ChannelHandlerContext ctx, final int streamId, final Http2Headers headers,
+            final int streamDependency, final short weight, final boolean exclusive, final int padding,
+            final boolean endOfStream, final ChannelPromise promise) {
+        try {
+            EmbeddedChannel compressor = prepareCompressor(ctx, streamId, headers, endOfStream);
+
+            // Write the headers and create the stream object.
+            ChannelFuture future = super.writeHeaders(ctx, streamId, headers, streamDependency, weight, exclusive,
+                    padding, endOfStream, promise);
+
+            // After the stream object has been created, then attach the compressor as a property for data
+            // compression.
+            bindCompressorToStream(compressor, streamId);
+
+            return future;
+        } catch (Throwable e) {
+            promise.tryFailure(e);
+        }
+        return promise;
+    }
+
+    /**
+     * Determines whether a new compressor is needed for the stream identified by {@code streamId}, and, if so,
+     * updates {@code headers} to reflect the negotiated {@code content-encoding}.
+     * <p>
+     * Compression is skipped (returns {@code null}) whenever:
+     * <ul>
+     *     <li>the stream ends with this frame ({@code endOfStream}), since there is no body to compress;</li>
+     *     <li>{@code headers} already contains a {@code content-encoding} value, meaning the body is assumed to
+     *     already be encoded by the application (the fix for #14277: never double-compress);</li>
+     *     <li>the request did not capture an {@code accept-encoding} value for this stream; or</li>
+     *     <li>{@link Http2ContentEncodingNegotiator#negotiate(CharSequence)} could not find a match.</li>
+     * </ul>
+     *
+     * @param ctx the context
+     * @param streamId the stream id for which the headers are being written
+     * @param headers the response headers being written
+     * @param endOfStream indicates if the stream has ended
+     * @return the compressor to use for {@code streamId}'s data frames, or {@code null} if none is needed
+     * @throws Http2Exception if the compressor could not be created
+     */
+    private EmbeddedChannel prepareCompressor(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
+            boolean endOfStream) throws Http2Exception {
+        if (endOfStream) {
+            return null;
+        }
+        if (headers.contains(CONTENT_ENCODING)) {
+            // The body is already encoded by the application. Compressing it again would double-encode it.
+            return null;
+        }
+        Http2Stream stream = connection().stream(streamId);
+        CharSequence acceptEncoding = acceptEncodingKey.acceptEncoding(stream);
+        if (acceptEncoding == null) {
+            return null;
+        }
+        NegotiatedEncoding negotiated = negotiator.negotiate(acceptEncoding);
+        if (negotiated == null) {
+            return null;
+        }
+        EmbeddedChannel channel = Http2CompressionChannelFactory.newCompressionChannel(ctx, negotiated);
+        if (channel == null) {
+            return null;
+        }
+        headers.set(CONTENT_ENCODING, negotiated.contentEncoding);
+        // The content length will be for the uncompressed data. Since we will compress the data this
+        // content-length will not be correct. Instead of queuing messages or delaying sending header frames...
+        // just remove the content-length header.
+        headers.remove(CONTENT_LENGTH);
+        return channel;
+    }
+
+    /**
+     * Called after the super class has written the headers and created any associated stream objects.
+     *
+     * @param compressor the compressor associated with the stream identified by {@code streamId}
+     * @param streamId the stream id for which the headers were written
+     */
+    private void bindCompressorToStream(EmbeddedChannel compressor, int streamId) {
+        if (compressor != null) {
+            Http2Stream stream = connection().stream(streamId);
+            if (stream != null) {
+                stream.setProperty(compressorPropertyKey, compressor);
+            }
+        }
+    }
+
+    /**
+     * Releases remaining content from {@link EmbeddedChannel} and removes the compressor from the
+     * {@link Http2Stream}.
+     *
+     * @param stream the stream that {@code compressor} compresses data for
+     * @param compressor the compressor for {@code stream}
+     */
+    void cleanup(Http2Stream stream, EmbeddedChannel compressor) {
+        compressor.finishAndReleaseAll();
+        stream.removeProperty(compressorPropertyKey);
+    }
+
+    /**
+     * Reads the next compressed {@link ByteBuf} from the {@link EmbeddedChannel}, or {@code null} if one does not
+     * exist.
+     *
+     * @param compressor the channel to read from
+     * @return the next compressed {@link ByteBuf} from the {@link EmbeddedChannel}, or {@code null} if one does not
+     *         exist
+     */
+    private static ByteBuf nextReadableBuf(EmbeddedChannel compressor) {
+        for (;;) {
+            final ByteBuf buf = compressor.readOutbound();
+            if (buf == null) {
+                return null;
+            }
+            if (!buf.isReadable()) {
+                buf.release();
+                continue;
+            }
+            return buf;
+        }
+    }
+}

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2CompressionChannelFactoryTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2CompressionChannelFactoryTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.codec.http2;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufInputStream;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.compression.StandardCompressionOptions;
+import io.netty.util.CharsetUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.InflaterInputStream;
+
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_ENCODING;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
+import static io.netty.handler.codec.http.HttpHeaderValues.BR;
+import static io.netty.handler.codec.http.HttpHeaderValues.DEFLATE;
+import static io.netty.handler.codec.http.HttpHeaderValues.GZIP;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+/**
+ * Tests for {@link Http2CompressionChannelFactory} and, since the two are tightly coupled,
+ * the compression negotiation performed by
+ * {@code writeHeaders} of {@link NegotiatingCompressorHttp2ConnectionEncoder}.
+ */
+public class Http2CompressionChannelFactoryTest {
+
+    @Mock
+    private Http2ConnectionEncoder delegate;
+
+    private DefaultHttp2Connection connection;
+    private Http2RequestAcceptEncodingPropertyKey acceptEncodingKey;
+    private NegotiatingCompressorHttp2ConnectionEncoder encoder;
+
+    @BeforeEach
+    public void setUp() {
+        initMocks(this);
+        connection = new DefaultHttp2Connection(true);
+        when(delegate.connection()).thenReturn(connection);
+        acceptEncodingKey = new Http2RequestAcceptEncodingPropertyKey(connection);
+        encoder = new NegotiatingCompressorHttp2ConnectionEncoder(delegate, acceptEncodingKey,
+                StandardCompressionOptions.gzip());
+        when(delegate.writeHeaders(any(ChannelHandlerContext.class), anyInt(), any(Http2Headers.class), anyInt(),
+                anyBoolean(), any(ChannelPromise.class))).thenReturn(mock(ChannelFuture.class));
+    }
+
+    @Test
+    public void newCompressionChannelForGzipProducesValidGzipStream() throws Exception {
+        EmbeddedChannel channel = new EmbeddedChannel();
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        when(ctx.channel()).thenReturn(channel);
+        NegotiatedEncoding negotiated = new NegotiatedEncoding(GZIP, StandardCompressionOptions.gzip());
+
+        EmbeddedChannel compressor = Http2CompressionChannelFactory.newCompressionChannel(ctx, negotiated);
+        try {
+            String payload = "hello world";
+            compressor.writeOutbound(Unpooled.copiedBuffer(payload, CharsetUtil.UTF_8));
+            assertTrue(compressor.finish());
+
+            ByteBuf compressed = readAllOutbound(compressor);
+            try {
+                assertTrue(compressed.readableBytes() > 2);
+                assertEquals(0x1f, compressed.getUnsignedByte(0) & 0xFF);
+                assertEquals(0x8b, compressed.getUnsignedByte(1) & 0xFF);
+                assertEquals(payload, gunzip(compressed));
+            } finally {
+                compressed.release();
+            }
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    public void newCompressionChannelForDeflateProducesValidZlibStream() throws Exception {
+        EmbeddedChannel channel = new EmbeddedChannel();
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        when(ctx.channel()).thenReturn(channel);
+        NegotiatedEncoding negotiated = new NegotiatedEncoding(DEFLATE, StandardCompressionOptions.deflate());
+
+        EmbeddedChannel compressor = Http2CompressionChannelFactory.newCompressionChannel(ctx, negotiated);
+        try {
+            String payload = "hello world";
+            compressor.writeOutbound(Unpooled.copiedBuffer(payload, CharsetUtil.UTF_8));
+            assertTrue(compressor.finish());
+
+            ByteBuf compressed = readAllOutbound(compressor);
+            try {
+                assertTrue(compressed.readableBytes() > 2);
+                assertEquals(0x78, compressed.getUnsignedByte(0) & 0xFF);
+                assertEquals(payload, inflateZlib(compressed));
+            } finally {
+                compressed.release();
+            }
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    public void newCompressionChannelReturnsNullForUnrecognizedContentEncoding() throws Http2Exception {
+        EmbeddedChannel channel = new EmbeddedChannel();
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        when(ctx.channel()).thenReturn(channel);
+        NegotiatedEncoding negotiated = new NegotiatedEncoding("x-unknown", StandardCompressionOptions.gzip());
+
+        try {
+            assertNull(Http2CompressionChannelFactory.newCompressionChannel(ctx, negotiated));
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    public void writeHeadersSkipsCompressionWhenContentEncodingAlreadyPresent() throws Http2Exception {
+        Http2Stream stream = connection.remote().createStream(3, false);
+        acceptEncodingKey.setAcceptEncoding(stream, "gzip");
+        Http2Headers headers = new DefaultHttp2Headers().status("200")
+                .set(CONTENT_ENCODING, BR)
+                .set(CONTENT_LENGTH, "100");
+        ChannelPromise promise = mock(ChannelPromise.class);
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+
+        encoder.writeHeaders(ctx, 3, headers, 0, false, promise);
+
+        assertEquals(BR.toString(), headers.get(CONTENT_ENCODING).toString());
+        assertEquals("100", headers.get(CONTENT_LENGTH).toString());
+        verify(delegate).writeHeaders(any(ChannelHandlerContext.class), eq(3), eq(headers), eq(0), eq(false),
+                eq(promise));
+    }
+
+    @Test
+    public void writeHeadersSkipsCompressionWhenNoAcceptEncodingCaptured() throws Http2Exception {
+        connection.remote().createStream(3, false);
+        Http2Headers headers = new DefaultHttp2Headers().status("200").set(CONTENT_LENGTH, "100");
+        ChannelPromise promise = mock(ChannelPromise.class);
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+
+        encoder.writeHeaders(ctx, 3, headers, 0, false, promise);
+
+        assertNull(headers.get(CONTENT_ENCODING));
+        assertEquals("100", headers.get(CONTENT_LENGTH).toString());
+    }
+
+    @Test
+    public void writeHeadersNegotiatesCompressionWhenAcceptEncodingMatches() throws Http2Exception {
+        Http2Stream stream = connection.remote().createStream(3, false);
+        acceptEncodingKey.setAcceptEncoding(stream, "gzip");
+        Http2Headers headers = new DefaultHttp2Headers().status("200").set(CONTENT_LENGTH, "100");
+        ChannelPromise promise = mock(ChannelPromise.class);
+        EmbeddedChannel underlying = new EmbeddedChannel();
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        when(ctx.channel()).thenReturn(underlying);
+
+        try {
+            encoder.writeHeaders(ctx, 3, headers, 0, false, promise);
+
+            assertEquals(GZIP.toString(), headers.get(CONTENT_ENCODING).toString());
+            assertNull(headers.get(CONTENT_LENGTH));
+        } finally {
+            stream.close();
+            underlying.finishAndReleaseAll();
+        }
+    }
+
+    private static ByteBuf readAllOutbound(EmbeddedChannel channel) {
+        CompositeByteBuf composite = Unpooled.compositeBuffer();
+        for (;;) {
+            ByteBuf buf = channel.readOutbound();
+            if (buf == null) {
+                break;
+            }
+            composite.addComponent(true, buf);
+        }
+        return composite;
+    }
+
+    private static String gunzip(ByteBuf compressed) throws IOException {
+        return inflate(new GZIPInputStream(new ByteBufInputStream(compressed.duplicate())));
+    }
+
+    private static String inflateZlib(ByteBuf compressed) throws IOException {
+        return inflate(new InflaterInputStream(new ByteBufInputStream(compressed.duplicate())));
+    }
+
+    private static String inflate(InputStream in) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        byte[] buffer = new byte[64];
+        int read;
+        while ((read = in.read(buffer)) != -1) {
+            out.write(buffer, 0, read);
+        }
+        return new String(out.toByteArray(), CharsetUtil.UTF_8);
+    }
+}

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ContentEncodingNegotiatorTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ContentEncodingNegotiatorTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.codec.http2;
+
+import io.netty.handler.codec.compression.StandardCompressionOptions;
+import org.junit.jupiter.api.Test;
+
+import static io.netty.handler.codec.http.HttpHeaderValues.BR;
+import static io.netty.handler.codec.http.HttpHeaderValues.GZIP;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class Http2ContentEncodingNegotiatorTest {
+
+    @Test
+    public void nullAcceptEncodingYieldsNoNegotiation() {
+        Http2ContentEncodingNegotiator negotiator =
+                new Http2ContentEncodingNegotiator(StandardCompressionOptions.gzip());
+
+        assertNull(negotiator.negotiate(null));
+    }
+
+    @Test
+    public void identityAcceptEncodingYieldsNoNegotiation() {
+        Http2ContentEncodingNegotiator negotiator =
+                new Http2ContentEncodingNegotiator(StandardCompressionOptions.gzip());
+
+        assertNull(negotiator.negotiate("identity"));
+    }
+
+    @Test
+    public void gzipAcceptEncodingNegotiatesGzip() {
+        Http2ContentEncodingNegotiator negotiator =
+                new Http2ContentEncodingNegotiator(StandardCompressionOptions.gzip());
+
+        NegotiatedEncoding negotiated = negotiator.negotiate("gzip");
+
+        assertEquals(GZIP.toString(), negotiated.contentEncoding.toString());
+    }
+
+    /**
+     * Mirrors {@code HttpContentCompressor.determineEncoding}: encodings are chosen by a fixed
+     * priority cascade ({@code br > zstd > snappy > gzip > deflate}), with each tier only compared
+     * against the next higher tier's q-value -- not by a single global q-value ranking across all
+     * tiers. Verified directly against {@code HttpContentCompressor.determineEncoding(
+     * "br;q=0.5, gzip;q=0.8")}, which likewise returns {@code "br"} when both encodings are
+     * configured.
+     */
+    @Test
+    public void brotliOutranksGzipRegardlessOfQValue() {
+        Http2ContentEncodingNegotiator negotiator = new Http2ContentEncodingNegotiator(
+                StandardCompressionOptions.gzip(), StandardCompressionOptions.brotli());
+
+        NegotiatedEncoding negotiated = negotiator.negotiate("br;q=0.5, gzip;q=0.8");
+
+        assertEquals(BR.toString(), negotiated.contentEncoding.toString());
+    }
+
+    @Test
+    public void unsupportedEncodingYieldsNoNegotiation() {
+        Http2ContentEncodingNegotiator negotiator =
+                new Http2ContentEncodingNegotiator(StandardCompressionOptions.gzip());
+
+        assertNull(negotiator.negotiate("br"));
+    }
+
+    @Test
+    public void wildcardAcceptEncodingNegotiatesOnlyConfiguredOption() {
+        Http2ContentEncodingNegotiator negotiator =
+                new Http2ContentEncodingNegotiator(StandardCompressionOptions.gzip());
+
+        NegotiatedEncoding negotiated = negotiator.negotiate("*");
+
+        assertEquals(GZIP.toString(), negotiated.contentEncoding.toString());
+    }
+}

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2RequestAcceptEncodingFrameListenerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2RequestAcceptEncodingFrameListenerTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.codec.http2;
+
+import io.netty.channel.ChannelHandlerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+/**
+ * Tests for {@link Http2RequestAcceptEncodingFrameListener}.
+ */
+public class Http2RequestAcceptEncodingFrameListenerTest {
+
+    @Mock
+    private Http2FrameListener delegate;
+    @Mock
+    private ChannelHandlerContext ctx;
+
+    private DefaultHttp2Connection connection;
+    private Http2RequestAcceptEncodingPropertyKey key;
+    private Http2RequestAcceptEncodingFrameListener listener;
+
+    @BeforeEach
+    public void setUp() {
+        initMocks(this);
+        connection = new DefaultHttp2Connection(true);
+        key = new Http2RequestAcceptEncodingPropertyKey(connection);
+        listener = new Http2RequestAcceptEncodingFrameListener(connection, delegate, key);
+    }
+
+    @Test
+    public void onHeadersReadFiveArgCapturesAcceptEncodingAndDelegatesUnmodifiedHeaders() throws Http2Exception {
+        Http2Stream stream = connection.remote().createStream(3, false);
+        Http2Headers headers = new DefaultHttp2Headers().set("accept-encoding", "gzip");
+
+        listener.onHeadersRead(ctx, 3, headers, 0, false);
+
+        assertEquals("gzip", key.acceptEncoding(stream));
+        assertEquals("gzip", headers.get("accept-encoding"));
+        verify(delegate).onHeadersRead(eq(ctx), eq(3), eq(headers), eq(0), eq(false));
+    }
+
+    @Test
+    public void onHeadersReadNineArgCapturesAcceptEncodingAndDelegatesUnmodifiedHeaders() throws Http2Exception {
+        Http2Stream stream = connection.remote().createStream(3, false);
+        Http2Headers headers = new DefaultHttp2Headers().set("accept-encoding", "gzip");
+
+        listener.onHeadersRead(ctx, 3, headers, 0, (short) 16, false, 0, false);
+
+        assertEquals("gzip", key.acceptEncoding(stream));
+        assertEquals("gzip", headers.get("accept-encoding"));
+        verify(delegate).onHeadersRead(eq(ctx), eq(3), eq(headers), eq(0), eq((short) 16), eq(false), eq(0),
+                eq(false));
+    }
+
+    @Test
+    public void onHeadersReadWithoutAcceptEncodingStoresNothing() throws Http2Exception {
+        Http2Stream stream = connection.remote().createStream(3, false);
+        Http2Headers headers = new DefaultHttp2Headers().set("x-foo", "bar");
+
+        listener.onHeadersRead(ctx, 3, headers, 0, false);
+
+        assertNull(key.acceptEncoding(stream));
+        verify(delegate).onHeadersRead(eq(ctx), eq(3), eq(headers), eq(0), eq(false));
+    }
+
+    @Test
+    public void onHeadersReadWithUnknownStreamDelegatesWithoutException() throws Http2Exception {
+        Http2Headers headers = new DefaultHttp2Headers().set("accept-encoding", "gzip");
+
+        listener.onHeadersRead(ctx, 99, headers, 0, false);
+
+        verify(delegate).onHeadersRead(eq(ctx), eq(99), eq(headers), eq(0), eq(false));
+    }
+}

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2RequestAcceptEncodingPropertyKeyTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2RequestAcceptEncodingPropertyKeyTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.codec.http2;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Tests for {@link Http2RequestAcceptEncodingPropertyKey}.
+ */
+public class Http2RequestAcceptEncodingPropertyKeyTest {
+
+    @Test
+    public void setAcceptEncodingStoresValueRetrievableFromStream() throws Http2Exception {
+        DefaultHttp2Connection connection = new DefaultHttp2Connection(true);
+        Http2RequestAcceptEncodingPropertyKey key = new Http2RequestAcceptEncodingPropertyKey(connection);
+        Http2Stream stream = connection.remote().createStream(3, false);
+
+        key.setAcceptEncoding(stream, "gzip");
+
+        assertEquals("gzip", key.acceptEncoding(stream));
+    }
+
+    @Test
+    public void acceptEncodingReturnsNullWhenNotSet() throws Http2Exception {
+        DefaultHttp2Connection connection = new DefaultHttp2Connection(true);
+        Http2RequestAcceptEncodingPropertyKey key = new Http2RequestAcceptEncodingPropertyKey(connection);
+        Http2Stream stream = connection.remote().createStream(3, false);
+
+        assertNull(key.acceptEncoding(stream));
+    }
+
+    @Test
+    public void acceptEncodingReturnsNullAfterStreamRemoved() throws Http2Exception {
+        DefaultHttp2Connection connection = new DefaultHttp2Connection(true);
+        Http2RequestAcceptEncodingPropertyKey key = new Http2RequestAcceptEncodingPropertyKey(connection);
+        Http2Stream stream = connection.remote().createStream(3, false);
+        key.setAcceptEncoding(stream, "gzip");
+
+        stream.close();
+
+        assertNull(key.acceptEncoding(stream));
+    }
+}

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2RequestResponseCompressionNegotiationTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2RequestResponseCompressionNegotiationTest.java
@@ -1,0 +1,448 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.codec.http2;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.compression.StandardCompressionOptions;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http2.Http2TestUtil.Http2Runnable;
+import io.netty.util.AsciiString;
+import io.netty.util.CharsetUtil;
+import io.netty.util.NetUtil;
+import io.netty.util.concurrent.Future;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+import static io.netty.handler.codec.http2.Http2TestUtil.runInChannel;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end test that wires {@link Http2RequestAcceptEncodingFrameListener} and
+ * {@link NegotiatingCompressorHttp2ConnectionEncoder} together over a real client-server socket connection. It
+ * verifies that a response already encoded by the application is never recompressed, that a plain response is
+ * compressed only when the request negotiates a matching encoding, and that content-length is stripped only when
+ * compression is actually applied (see #14277):
+ * <ul>
+ *     <li>a response whose body is already encoded by the application (has a {@code content-encoding} header)
+ *     is never compressed again, regardless of the request's {@code accept-encoding};</li>
+ *     <li>a plain response body is compressed only when the request negotiates a matching {@code accept-encoding}
+ *     value;</li>
+ *     <li>a plain response body is left untouched when the request has no {@code accept-encoding}.</li>
+ * </ul>
+ */
+public class Http2RequestResponseCompressionNegotiationTest {
+
+    private static final AsciiString GET = new AsciiString("GET");
+    private static final AsciiString PATH = new AsciiString("/some/path");
+
+    private ServerBootstrap sb;
+    private Bootstrap cb;
+    private Channel serverChannel;
+    private volatile Channel serverConnectedChannel;
+    private Channel clientChannel;
+    private Http2Connection clientConnection;
+    private Http2ConnectionEncoder clientEncoder;
+    private Http2ConnectionHandler clientHandler;
+
+    private final AtomicReference<Http2Headers> clientResponseHeaders = new AtomicReference<Http2Headers>();
+    private ByteArrayOutputStream clientOut;
+    private CountDownLatch clientLatch;
+
+    @AfterEach
+    public void teardown() throws InterruptedException {
+        if (clientChannel != null) {
+            clientChannel.close().sync();
+            clientChannel = null;
+        }
+        if (serverChannel != null) {
+            serverChannel.close().sync();
+            serverChannel = null;
+        }
+        final Channel serverConnectedChannel = this.serverConnectedChannel;
+        if (serverConnectedChannel != null) {
+            serverConnectedChannel.close().sync();
+            this.serverConnectedChannel = null;
+        }
+        if (sb != null) {
+            Future<?> serverGroup = sb.config().group().shutdownGracefully(0, 0, MILLISECONDS);
+            Future<?> serverChildGroup = sb.config().childGroup().shutdownGracefully(0, 0, MILLISECONDS);
+            serverGroup.sync();
+            serverChildGroup.sync();
+        }
+        if (cb != null) {
+            Future<?> clientGroup = cb.config().group().shutdownGracefully(0, 0, MILLISECONDS);
+            clientGroup.sync();
+        }
+    }
+
+    /**
+     * SPEC-a: a response body that is already compressed by the application (marked with a
+     * {@code content-encoding} response header) must never be compressed again by
+     * {@link NegotiatingCompressorHttp2ConnectionEncoder}, regardless of whether the request carries an
+     * {@code accept-encoding} header.
+     */
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void alreadyEncodedResponseIsNeverRecompressed(boolean clientSendsAcceptEncoding) throws Exception {
+        String plainText = "already-compressed-response-body";
+        byte[] gzippedOnce = gzip(plainText.getBytes(CharsetUtil.UTF_8));
+
+        bootstrapEnv(gzippedOnce, HttpHeaderValues.GZIP);
+        sendRequestAndAwaitResponse(clientSendsAcceptEncoding);
+
+        // The bytes that hit the wire must be exactly the single gzip payload the application produced.
+        assertArrayEquals(gzippedOnce, clientOut.toByteArray());
+        assertEquals(HttpHeaderValues.GZIP.toString(),
+                clientResponseHeaders.get().get(HttpHeaderNames.CONTENT_ENCODING).toString());
+
+        // A single pass of gunzip must yield the original plaintext; if the encoder had compressed it a
+        // second time, one gunzip pass would still yield gzip bytes instead of plaintext.
+        assertEquals(plainText, gunzip(clientOut.toByteArray()));
+    }
+
+    /**
+     * SPEC-b: a plain response body must be compressed when the request negotiates {@code accept-encoding: gzip}
+     * and the response has no pre-existing {@code content-encoding}.
+     */
+    @Test
+    public void responseIsCompressedWhenAcceptEncodingNegotiatesGzip() throws Exception {
+        String plainText = "hello world, please compress me over the wire";
+        byte[] plainBytes = plainText.getBytes(CharsetUtil.UTF_8);
+
+        bootstrapEnv(plainBytes, null);
+        sendRequestAndAwaitResponse(true);
+
+        assertEquals(HttpHeaderValues.GZIP.toString(),
+                clientResponseHeaders.get().get(HttpHeaderNames.CONTENT_ENCODING).toString());
+        byte[] wireBytes = clientOut.toByteArray();
+        assertFalse(Arrays.equals(plainBytes, wireBytes), "response body must actually be compressed on the wire");
+        assertEquals(plainText, gunzip(wireBytes));
+    }
+
+    /**
+     * SPEC-c: a plain response body must be left untouched when the request carries no {@code accept-encoding}
+     * header.
+     */
+    @Test
+    public void responseIsNotCompressedWhenNoAcceptEncoding() throws Exception {
+        String plainText = "hello world, do not compress me";
+        byte[] plainBytes = plainText.getBytes(CharsetUtil.UTF_8);
+
+        bootstrapEnv(plainBytes, null);
+        sendRequestAndAwaitResponse(false);
+
+        assertNull(clientResponseHeaders.get().get(HttpHeaderNames.CONTENT_ENCODING));
+        assertArrayEquals(plainBytes, clientOut.toByteArray());
+    }
+
+    /**
+     * CL-1: when the response is actually negotiated and compressed, the original (uncompressed) {@code
+     * content-length} the application set is no longer valid and must be stripped by
+     * {@link NegotiatingCompressorHttp2ConnectionEncoder} (see {@code prepareCompressor}, which removes
+     * {@code content-length} right after setting the negotiated {@code content-encoding}).
+     */
+    @Test
+    public void contentLengthIsRemovedWhenResponseIsCompressed() throws Exception {
+        String plainText = "hello world, please compress me over the wire";
+        byte[] plainBytes = plainText.getBytes(CharsetUtil.UTF_8);
+
+        bootstrapEnv(plainBytes, null, true);
+        sendRequestAndAwaitResponse(true);
+
+        assertEquals(HttpHeaderValues.GZIP.toString(),
+                clientResponseHeaders.get().get(HttpHeaderNames.CONTENT_ENCODING).toString());
+        assertNull(clientResponseHeaders.get().get(HttpHeaderNames.CONTENT_LENGTH));
+    }
+
+    /**
+     * CL-2: when compression is skipped because the response body is already encoded by the application
+     * ({@code content-encoding} already present), {@code prepareCompressor} returns before ever touching
+     * {@code content-length}, so a {@code content-length} set by the application must be preserved unchanged.
+     */
+    @Test
+    public void contentLengthIsPreservedWhenAlreadyEncodedResponseSkipsCompression() throws Exception {
+        String plainText = "already-compressed-response-body";
+        byte[] gzippedOnce = gzip(plainText.getBytes(CharsetUtil.UTF_8));
+
+        bootstrapEnv(gzippedOnce, HttpHeaderValues.GZIP, true);
+        sendRequestAndAwaitResponse(true);
+
+        assertEquals(HttpHeaderValues.GZIP.toString(),
+                clientResponseHeaders.get().get(HttpHeaderNames.CONTENT_ENCODING).toString());
+        assertEquals(String.valueOf(gzippedOnce.length),
+                clientResponseHeaders.get().get(HttpHeaderNames.CONTENT_LENGTH).toString());
+    }
+
+    /**
+     * CL-3: when no {@code accept-encoding} was negotiated at all, {@code prepareCompressor} returns before ever
+     * touching {@code content-length}, so a {@code content-length} set by the application must be preserved
+     * unchanged.
+     */
+    @Test
+    public void contentLengthIsPreservedWhenNoAcceptEncoding() throws Exception {
+        String plainText = "hello world, do not compress me";
+        byte[] plainBytes = plainText.getBytes(CharsetUtil.UTF_8);
+
+        bootstrapEnv(plainBytes, null, true);
+        sendRequestAndAwaitResponse(false);
+
+        assertNull(clientResponseHeaders.get().get(HttpHeaderNames.CONTENT_ENCODING));
+        assertEquals(String.valueOf(plainBytes.length),
+                clientResponseHeaders.get().get(HttpHeaderNames.CONTENT_LENGTH).toString());
+    }
+
+    private void sendRequestAndAwaitResponse(final boolean sendAcceptEncoding) throws Exception {
+        runInChannel(clientChannel, new Http2Runnable() {
+            @Override
+            public void run() throws Http2Exception {
+                Http2Headers requestHeaders = new DefaultHttp2Headers().method(GET).path(PATH);
+                if (sendAcceptEncoding) {
+                    requestHeaders.set(HttpHeaderNames.ACCEPT_ENCODING, HttpHeaderValues.GZIP);
+                }
+                clientEncoder.writeHeaders(ctxClient(), 3, requestHeaders, 0, true, newPromiseClient());
+                clientHandler.flush(ctxClient());
+            }
+        });
+        assertTrue(clientLatch.await(5, SECONDS));
+    }
+
+    private void bootstrapEnv(final byte[] responseBody, final CharSequence responseContentEncoding)
+            throws Exception {
+        bootstrapEnv(responseBody, responseContentEncoding, false);
+    }
+
+    private void bootstrapEnv(final byte[] responseBody, final CharSequence responseContentEncoding,
+            final boolean setContentLength) throws Exception {
+        final CountDownLatch prefaceWrittenLatch = new CountDownLatch(1);
+        clientOut = new ByteArrayOutputStream();
+        clientLatch = new CountDownLatch(1);
+        clientResponseHeaders.set(null);
+        sb = new ServerBootstrap();
+        cb = new Bootstrap();
+
+        final Http2Connection serverConnection = new DefaultHttp2Connection(true);
+        clientConnection = new DefaultHttp2Connection(false);
+        final Http2RequestAcceptEncodingPropertyKey acceptEncodingKey =
+                new Http2RequestAcceptEncodingPropertyKey(serverConnection);
+
+        final CountDownLatch serverChannelLatch = new CountDownLatch(1);
+        sb.group(new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory()));
+        sb.channel(NioServerSocketChannel.class);
+        sb.childHandler(new ChannelInitializer<Channel>() {
+            @Override
+            protected void initChannel(Channel ch) throws Exception {
+                serverConnectedChannel = ch;
+                ChannelPipeline p = ch.pipeline();
+                Http2FrameWriter frameWriter = new DefaultHttp2FrameWriter();
+                serverConnection.remote().flowController(
+                        new DefaultHttp2RemoteFlowController(serverConnection));
+                serverConnection.local().flowController(
+                        new DefaultHttp2LocalFlowController(serverConnection).frameWriter(frameWriter));
+
+                final Http2ConnectionEncoder encoder = new NegotiatingCompressorHttp2ConnectionEncoder(
+                        new DefaultHttp2ConnectionEncoder(serverConnection, frameWriter),
+                        acceptEncodingKey, StandardCompressionOptions.gzip());
+                Http2ConnectionDecoder decoder = new DefaultHttp2ConnectionDecoder(
+                        serverConnection, encoder, new DefaultHttp2FrameReader());
+
+                Http2FrameListener appServerListener = new Http2FrameAdapter() {
+                    @Override
+                    public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
+                                               int padding, boolean endOfStream) {
+                        writeResponse(ctx, streamId);
+                    }
+
+                    @Override
+                    public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
+                                               int streamDependency, short weight, boolean exclusive, int padding,
+                                               boolean endOfStream) {
+                        writeResponse(ctx, streamId);
+                    }
+
+                    private void writeResponse(ChannelHandlerContext ctx, int streamId) {
+                        Http2Headers responseHeaders =
+                                new DefaultHttp2Headers().status(HttpResponseStatus.OK.codeAsText());
+                        if (responseContentEncoding != null) {
+                            responseHeaders.set(HttpHeaderNames.CONTENT_ENCODING, responseContentEncoding);
+                        }
+                        if (setContentLength) {
+                            responseHeaders.setInt(HttpHeaderNames.CONTENT_LENGTH, responseBody.length);
+                        }
+                        ChannelPromise headersPromise = ctx.newPromise();
+                        encoder.writeHeaders(ctx, streamId, responseHeaders, 0, false, headersPromise);
+                        ChannelPromise dataPromise = ctx.newPromise();
+                        encoder.writeData(ctx, streamId, Unpooled.copiedBuffer(responseBody), 0, true, dataPromise);
+                        ctx.flush();
+                    }
+                };
+
+                Http2FrameListener listener = new Http2RequestAcceptEncodingFrameListener(
+                        serverConnection, appServerListener, acceptEncodingKey);
+
+                Http2ConnectionHandler connectionHandler = new Http2ConnectionHandlerBuilder()
+                        .frameListener(listener)
+                        .codec(decoder, encoder)
+                        .build();
+                p.addLast(connectionHandler);
+                serverChannelLatch.countDown();
+            }
+        });
+
+        cb.group(new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory()));
+        cb.channel(NioSocketChannel.class);
+        cb.handler(new ChannelInitializer<Channel>() {
+            @Override
+            protected void initChannel(Channel ch) throws Exception {
+                ChannelPipeline p = ch.pipeline();
+                Http2FrameWriter frameWriter = new DefaultHttp2FrameWriter();
+                clientConnection.remote().flowController(
+                        new DefaultHttp2RemoteFlowController(clientConnection));
+                clientConnection.local().flowController(
+                        new DefaultHttp2LocalFlowController(clientConnection).frameWriter(frameWriter));
+                clientEncoder = new DefaultHttp2ConnectionEncoder(clientConnection, frameWriter);
+
+                Http2ConnectionDecoder decoder = new DefaultHttp2ConnectionDecoder(
+                        clientConnection, clientEncoder, new DefaultHttp2FrameReader());
+
+                Http2FrameListener clientFrameListener = new Http2FrameAdapter() {
+                    @Override
+                    public int onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
+                                           boolean endOfStream) throws Http2Exception {
+                        int processedBytes = data.readableBytes() + padding;
+                        try {
+                            data.readBytes(clientOut, data.readableBytes());
+                        } catch (IOException e) {
+                            throw new Http2Exception(Http2Error.INTERNAL_ERROR, "failed to capture wire bytes", e);
+                        }
+                        if (endOfStream) {
+                            clientLatch.countDown();
+                        }
+                        return processedBytes;
+                    }
+
+                    @Override
+                    public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
+                                               int padding, boolean endOfStream) {
+                        clientResponseHeaders.set(headers);
+                        if (endOfStream) {
+                            clientLatch.countDown();
+                        }
+                    }
+
+                    @Override
+                    public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
+                                               int streamDependency, short weight, boolean exclusive, int padding,
+                                               boolean endOfStream) {
+                        onHeadersRead(ctx, streamId, headers, padding, endOfStream);
+                    }
+                };
+
+                clientHandler = new Http2ConnectionHandlerBuilder()
+                        .frameListener(clientFrameListener)
+                        // By default tests don't wait for server to gracefully shutdown streams
+                        .gracefulShutdownTimeoutMillis(0)
+                        .codec(decoder, clientEncoder)
+                        .build();
+                p.addLast(clientHandler);
+                p.addLast(new ChannelInboundHandlerAdapter() {
+                    @Override
+                    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                        if (evt == Http2ConnectionPrefaceAndSettingsFrameWrittenEvent.INSTANCE) {
+                            prefaceWrittenLatch.countDown();
+                            ctx.pipeline().remove(this);
+                        }
+                    }
+                });
+            }
+        });
+
+        serverChannel = sb.bind(new InetSocketAddress(0)).sync().channel();
+        int port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
+
+        ChannelFuture ccf = cb.connect(new InetSocketAddress(NetUtil.LOCALHOST, port));
+        assertTrue(ccf.awaitUninterruptibly().isSuccess());
+        clientChannel = ccf.channel();
+        assertTrue(prefaceWrittenLatch.await(5, SECONDS));
+        assertTrue(serverChannelLatch.await(5, SECONDS));
+    }
+
+    private ChannelHandlerContext ctxClient() {
+        return clientChannel.pipeline().firstContext();
+    }
+
+    private ChannelPromise newPromiseClient() {
+        return ctxClient().newPromise();
+    }
+
+    private static byte[] gzip(byte[] plain) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        GZIPOutputStream gzipOut = new GZIPOutputStream(out);
+        try {
+            gzipOut.write(plain);
+        } finally {
+            gzipOut.close();
+        }
+        return out.toByteArray();
+    }
+
+    private static String gunzip(byte[] compressed) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        GZIPInputStream gzipIn = new GZIPInputStream(new ByteArrayInputStream(compressed));
+        try {
+            byte[] buffer = new byte[256];
+            int read;
+            while ((read = gzipIn.read(buffer)) != -1) {
+                out.write(buffer, 0, read);
+            }
+        } finally {
+            gzipIn.close();
+        }
+        return out.toString(CharsetUtil.UTF_8.name());
+    }
+}


### PR DESCRIPTION
### Motivation

When an app already compresses a response body and sets `Content-Encoding: gzip` itself, `CompressorHttp2ConnectionEncoder` compresses it a second time — the body goes out double-gzipped and `Content-Length` is dropped, so a client that decodes `Content-Encoding` once is left with still-compressed bytes. `HttpContentCompressor` doesn't hit this on HTTP/1 because it's duplex and passes an already-encoded body through; the HTTP/2 encoder is write-only and never sees the request's `Accept-Encoding`, so it can't tell "compress this" from "already compressed".

### Modification

Rather than change that encoder, this adds the missing request-side path:

- `Http2RequestAcceptEncodingFrameListener` captures a request's `Accept-Encoding` per stream into a shared `Http2Connection.PropertyKey`.
- `NegotiatingCompressorHttp2ConnectionEncoder` reads that property to negotiate the encoding, and skips compression when `Content-Encoding` is already set the way `HttpContentCompressor` does on HTTP/1.
- Both share one `PropertyKey`, so they run over the same stream.
- The existing `CompressorHttp2ConnectionEncoder` is left as-is and deprecated.

This follows the direction discussed on #9158 (@fru1tworld's listener/encoder sketch, @ejona86's `PropertyKey` idea).

### Result

An already-encoded HTTP/2 response is no longer recompressed, and plain responses are compressed only when the request negotiates a matching encoding. Existing users of `CompressorHttp2ConnectionEncoder` are unaffected. New API surface, HTTP/2 only, so it doesn't affect 4.1.

Fixes #14277
Fixes #9158