### PR TITLE
Add `.editorconfig` to enforce consistent coding style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,42 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.java]
+indent_style = space
+indent_size = 4
+max_line_length = 120
+
+[*.c]
+indent_style = space
+indent_size = 4
+
+[*.h]
+indent_style = space
+indent_size = 4
+
+[*.xml]
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml,json,js,css}]
+indent_style = space
+indent_size = 2
+
+[*.{md,txt}]
+indent_style = space
+indent_size = 2
+
+[*.properties]
+indent_style = space
+indent_size = 2
+
+[*.sh]
+indent_style = space
+indent_size = 4
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
## Motivation

The Netty project has well-established coding conventions defined in its checkstyle configuration, but these are only enforced at build time and require specific tooling setup. Without an `.editorconfig` file, each IDE and editor must be configured individually to match the project's style, leading to inconsistent formatting, unnecessary whitespace changes in commits, and friction for contributors.

`.editorconfig` is auto-detected by IntelliJ IDEA, VS Code, and many other editors — no plugin or configuration required. This lowers the barrier for new contributors and ensures consistent style out of the box.

## Modification

Added `.editorconfig` at the project root with settings derived from the project's existing conventions, verified against actual source files and the canonical checkstyle configuration at [`netty-build/common/src/main/resources/io/netty/checkstyle.xml`](https://github.com/netty/netty-build/blob/master/common/src/main/resources/io/netty/checkstyle.xml) — `LineLength = 120`, `FileTabCharacter` (tab prohibition), `NewlineCheck` (LF), `NewlineAtEndOfFile`, trailing whitespace prohibition, UTF-8 charset:

| File type | Indent | Details |
|-----------|--------|---------|
| `*.java` | 4 spaces | 120-char max line width |
| `*.c`, `*.h` | 4 spaces | Native transport code |
| `*.xml` | 4 spaces | POM and config files |
| `*.{yml,yaml,json,js,css}` | 2 spaces | Build configs, web assets |
| `*.{md,txt}` | 2 spaces | Documentation |
| `*.properties` | 2 spaces | Maven wrapper, native-image config |
| `*.sh` | 4 spaces | Build and CI scripts |
| `Makefile` | tab | Required by GNU make |

Global defaults for all files: UTF-8 encoding, LF line endings, final newline at end of file, no trailing whitespace.

## Result

This is a formatting-only convention change with no behavioral impact. It ensures every editor shows code with the correct style automatically and provides the necessary foundation for automatic code formatters to enforce consistent style in CI pipelines.

Addresses [netty#15642](https://github.com/netty/netty/discussions/15642).