### PR TITLE
Fix CompositeByteBuf addComponents cleanup on failure

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -372,24 +372,14 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
             final int cIndex, ByteBuf[] buffers, int arrOffset) {
         final int len = buffers.length, count = len - arrOffset;
 
-        int readableBytes = 0;
         int capacity = capacity();
-        for (int i = arrOffset; i < buffers.length; i++) {
-            ByteBuf b = buffers[i];
-            if (b == null) {
-                break;
-            }
-            readableBytes += b.readableBytes();
-
-            // Check if we would overflow.
-            // See https://github.com/netty/netty/issues/10194
-            checkForOverflow(capacity, readableBytes);
-        }
         // only set ci after we've shifted so that finally block logic is always correct
         int ci = Integer.MAX_VALUE;
+        boolean shifted = false;
         try {
             checkComponentIndex(cIndex);
             shiftComps(cIndex, count); // will increase componentCount
+            shifted = true;
             int nextOffset = cIndex > 0 ? components[cIndex - 1].endOffset : 0;
             for (ci = cIndex; arrOffset < len; arrOffset++, ci++) {
                 ByteBuf b = buffers[arrOffset];
@@ -397,11 +387,23 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
                     break;
                 }
                 Component c = newComponent(ensureAccessible(b), nextOffset);
+                int readableBytes = c.length();
+
+                // Check if we would overflow.
+                // See https://github.com/netty/netty/issues/10194
+                checkForOverflow(capacity, readableBytes);
+                capacity += readableBytes;
+
                 components[ci] = c;
                 nextOffset = c.endOffset;
             }
             return this;
         } finally {
+            if (!shifted) {
+                for (; arrOffset < len; ++arrOffset) {
+                    ReferenceCountUtil.safeRelease(buffers[arrOffset]);
+                }
+            }
             // ci is now the index following the last successfully added component
             if (ci < componentCount) {
                 if (ci < cIndex + count) {

--- a/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
@@ -1651,6 +1651,23 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
     }
 
     @Test
+    public void testAddComponentsReleasesBuffersOnInvalidIndex() {
+        final ByteBuf buffer = Unpooled.buffer(8).writeZero(8);
+        final CompositeByteBuf compositeByteBuf = compositeBuffer(Integer.MAX_VALUE);
+        try {
+            assertThrows(IndexOutOfBoundsException.class, new Executable() {
+                @Override
+                public void execute() {
+                    compositeByteBuf.addComponents(1, buffer);
+                }
+            });
+            assertEquals(0, buffer.refCnt());
+        } finally {
+            compositeByteBuf.release();
+        }
+    }
+
+    @Test
     public void testOverflowWhileAddingComponent() {
         int capacity = 1024 * 1024; // 1MB
         final ByteBuf buffer = Unpooled.buffer(capacity).writeZero(capacity);
@@ -1722,10 +1739,10 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
         final ByteBuf buffer = Unpooled.buffer(capacity).writeZero(capacity);
         final List<ByteBuf> buffers = new ArrayList<ByteBuf>();
         for (long i = 0; i <= Integer.MAX_VALUE; i += capacity) {
-            buffers.add(buffer.duplicate());
+            buffers.add(buffer.retainedDuplicate());
         }
         // Add one more
-        buffers.add(buffer.duplicate());
+        buffers.add(buffer.retainedDuplicate());
 
         try {
             assertThrows(IllegalArgumentException.class, new Executable() {


### PR DESCRIPTION
Motivation:

`CompositeByteBuf.addComponents(...)` can leak provided buffers if adding fails before the component array is shifted, for example with an invalid component index.

Modification:

Move the overflow check into the protected add loop and release unadopted buffers when failure happens before shifting. Add regression coverage for the invalid-index cleanup path.

Result:

`addComponents(...)` now releases provided buffers consistently on failure.