### PR TITLE
Validate chunked-must-be-last regardless of HTTP version

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -849,24 +849,29 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
         }
         if (HttpUtil.isTransferEncodingChunked(message)) {
             this.chunked = true;
+            // The "chunked must be the last encoding" rule (RFC 9112 6.1) is not specific to
+            // HTTP/1.1 -- it applies to any message that carries a Transfer-Encoding header at
+            // all. This validation must not be gated on protocolVersion(), since a decoder
+            // configured with useRfc9112TransferEncoding(false) (see HttpDecoderConfig) can
+            // still reach this point for HTTP/1.0 and other non-1.1 messages, and the ordering
+            // requirement applies to those just as much as it does to HTTP/1.1.
+            // See https://datatracker.ietf.org/doc/html/rfc9112#name-message-body-length
+            Iterator<? extends CharSequence> encodingIt =
+                    message.headers().valueCharSequenceIterator(HttpHeaderNames.TRANSFER_ENCODING);
+            CharSequence v = null;
+            while (encodingIt.hasNext()) {
+                v = encodingIt.next();
+            }
+            final int vLen = v.length();
+            final int chunkedValueLength = HttpHeaderValues.CHUNKED.length();
+            // We only need to validate if we have more then the chunked value length contained as otherwise
+            // we know it is only chunked.
+            if (vLen > chunkedValueLength && !AsciiString.regionMatches(v, true, vLen - chunkedValueLength,
+                    HttpHeaderValues.CHUNKED, 0, chunkedValueLength)) {
+                    throw new IllegalArgumentException(
+                            "chunked must be the last encoding present in the Transfer-Encoding header");
+            }
             if (message.protocolVersion() == HttpVersion.HTTP_1_1) {
-                Iterator<? extends CharSequence> encodingIt =
-                        message.headers().valueCharSequenceIterator(HttpHeaderNames.TRANSFER_ENCODING);
-                // Validate that chunked is the last encoding.
-                // See https://datatracker.ietf.org/doc/html/rfc9112#name-message-body-length
-                CharSequence v = null;
-                while (encodingIt.hasNext()) {
-                    v = encodingIt.next();
-                }
-                final int vLen = v.length();
-                final int chunkedValueLength = HttpHeaderValues.CHUNKED.length();
-                // We only need to validate if we have more then the chunked value length contained as otherwise
-                // we know it is only chunked.
-                if (vLen > chunkedValueLength && !AsciiString.regionMatches(v, true, vLen - chunkedValueLength,
-                        HttpHeaderValues.CHUNKED, 0, chunkedValueLength)) {
-                        throw new IllegalArgumentException(
-                                "chunked must be the last encoding present in the Transfer-Encoding header");
-                }
                 if (!contentLengthFields.isEmpty()) {
                     handleTransferEncodingChunkedWithContentLength(message);
                 }
@@ -926,8 +931,13 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
      *     </li>
      * </ul>
      * <p>
-     * <strong>Note:</strong> This method is only called for {@code HTTP/1.1} requests. Earlier HTTP protocol versions
-     * do not support the {@code Transfer-Encoding} header, and will reject requests that include it.
+     * <strong>Note:</strong> This method is only called for {@code HTTP/1.1} requests. Under the
+     * default configuration, earlier HTTP protocol versions carrying a {@code Transfer-Encoding}
+     * header are rejected before reaching this point. However, if
+     * {@link HttpDecoderConfig#setUseRfc9112TransferEncoding(boolean)} is set to {@code false}
+     * (see above), that rejection does not happen — a non-{@code HTTP/1.1} message can then
+     * legitimately carry {@code Transfer-Encoding} without being rejected for it, though this
+     * method specifically remains {@code HTTP/1.1}-only and is not invoked for such messages.
      */
     @SuppressWarnings("unused")
     protected void handleTransferEncodingChunkedWithContentLength(HttpMessage message) {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -712,6 +712,49 @@ public class HttpRequestDecoderTest {
         testInvalidHeaders0(requestStr);
     }
 
+    // Regression: the chunked-must-be-last check was nested inside a protocolVersion() ==
+    // HTTP_1_1 condition, so it was silently skipped for HTTP/1.0 when
+    // useRfc9112TransferEncoding is disabled. See HttpObjectDecoder#readHeaders.
+    @Test
+    public void testChunkedNotLastInTransferEncodingHttp10WithRfc9112Disabled() {
+        String requestStr = "GET /some/path HTTP/1.0\r\n" +
+                "Transfer-Encoding: chunked, identity\r\n" +
+                "Content-Length: 1\r\n" +
+                "Host: netty.io\r\n\r\n" +
+                "a";
+        HttpDecoderConfig config = new HttpDecoderConfig().setUseRfc9112TransferEncoding(false);
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder(config));
+        assertTrue(channel.writeInbound(
+                Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
+        HttpRequest request = channel.readInbound();
+        assertInstanceOf(IllegalArgumentException.class, request.decoderResult().cause());
+        assertTrue(request.decoderResult().isFailure(),
+                "expected 'chunked must be last' to be enforced regardless of HTTP version "
+                        + "when Transfer-Encoding is legitimately present (useRfc9112TransferEncoding=false)");
+        channel.finishAndReleaseAll();
+    }
+
+    // Companion to the test above: confirms the fix isn't tied to identity being a no-op
+    // by using a real trailing encoding (gzip) instead.
+    @Test
+    public void testChunkedNotLastInTransferEncodingHttp10WithRfc9112DisabledNonNoOpEncoding() {
+        String requestStr = "GET /some/path HTTP/1.0\r\n" +
+                "Transfer-Encoding: chunked, gzip\r\n" +
+                "Content-Length: 1\r\n" +
+                "Host: netty.io\r\n\r\n" +
+                "a";
+        HttpDecoderConfig config = new HttpDecoderConfig().setUseRfc9112TransferEncoding(false);
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestDecoder(config));
+        assertTrue(channel.writeInbound(
+                Unpooled.copiedBuffer(requestStr, CharsetUtil.US_ASCII)));
+        HttpRequest request = channel.readInbound();
+        assertInstanceOf(IllegalArgumentException.class, request.decoderResult().cause());
+        assertTrue(request.decoderResult().isFailure(),
+                "expected 'chunked must be last' to be enforced regardless of the specific "
+                        + "trailing encoding value, matching the identity-trailing case above");
+        channel.finishAndReleaseAll();
+    }
+
     @Test
     public void testContentLengthAndTransferEncodingHeadersWithVerticalTab() {
         testContentLengthAndTransferEncodingHeadersWithInvalidSeparator((char) 0x0b, false);


### PR DESCRIPTION
### Motivation
RFC 9112 §6.1 requires that when a message uses Transfer-Encoding, "chunked" must be the last encoding listed — a value like `chunked, identity` is malformed. This rule was added to `HttpObjectDecoder` alongside the fix for CVE-2026-42581, nested inside a pre-existing `protocolVersion() == HttpVersion.HTTP_1_1` condition — the same condition that gates a different, older check (the Content-Length/Transfer-Encoding conflict handling).

Under the default configuration this is harmless: an earlier guard already rejects any Transfer-Encoding header on a non-1.1 message outright, so the ordering check's version scoping is not expected to be exercised under normal use. However, `HttpDecoderConfig#setUseRfc9112TransferEncoding(false)` is a documented opt-out for restoring RFC 7230 behavior, and under that configuration a non-1.1 message can legitimately carry Transfer-Encoding without being rejected for it. In that case, the inherited version gate meant the chunked-must-be-last check was silently skipped for HTTP/1.0 (and other non-1.1 versions) — a message with `Transfer-Encoding: chunked, identity` would decode successfully instead of being rejected.

### Modification

- Extracted the chunked-must-be-last check from inside the `protocolVersion() == HTTP_1_1` block in `HttpObjectDecoder#readHeaders` and gave it its own, version-independent condition, since the RFC 9112 ordering rule has no dependency on protocol version.

- Added two regression tests to `HttpRequestDecoderTest`: one reproducing the original scenario (HTTP/1.0, `useRfc9112TransferEncoding(false)`, `Transfer-Encoding: chunked, identity)`, and a companion using a non-no-op trailing encoding (`chunked, gzip`) confirming the fix isn't tied to the specific encoding that follows `chunked`.

- Corrected a pre-existing inaccuracy in `handleTransferEncodingChunkedWithContentLength`'s javadoc, which stated that earlier HTTP versions "will reject requests that include [Transfer-Encoding]" without qualification — true only under the default configuration, and already inaccurate before this change since `useRfc9112TransferEncoding(false)` predates it.

### Result

- The chunked-must-be-last validation now applies to any message carrying a Transfer-Encoding header, independent of protocol version or the `useRfc9112TransferEncoding` setting.