### PR TITLE
OpenSSL: Allow to obtain used named group via OpenSslSession

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ExtendedOpenSslSession.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ExtendedOpenSslSession.java
@@ -252,6 +252,11 @@ abstract class ExtendedOpenSslSession extends ExtendedSSLSession implements Open
     }
 
     @Override
+    public String getNamedGroup() {
+        return wrapped.getNamedGroup();
+    }
+
+    @Override
     public boolean equals(Object o) {
         return wrapped.equals(o);
     }

--- a/handler/src/main/java/io/netty/handler/ssl/GroupsConverter.java
+++ b/handler/src/main/java/io/netty/handler/ssl/GroupsConverter.java
@@ -34,6 +34,10 @@ final class GroupsConverter {
                 return "P-521";
             case "x25519":
                 return "X25519";
+            case "x448":
+                return "X448";
+            case "x25519mlkem786":
+                return "X25519MLKEM768";
             default:
                 return key;
         }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslSession.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslSession.java
@@ -34,6 +34,15 @@ public interface OpenSslSession extends SSLSession {
      */
     boolean hasPeerCertificates();
 
+    /**
+     * Returns the used named group or {@code null} if none was used or if it can't be determined.
+     *
+     * @return  the named group
+     */
+    default String getNamedGroup() {
+        return null;
+    }
+
     @Override
     OpenSslSessionContext getSessionContext();
 }

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -2489,6 +2489,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
         // Updated once a new handshake is started and so the SSLSession reused.
         private long lastAccessed = -1;
 
+        private volatile String namedGroup;
         private volatile int applicationBufferSize = MAX_PLAINTEXT_LENGTH;
         private volatile Certificate[] localCertificateChain;
         private volatile Map<String, Object> keyValueStorage = new ConcurrentHashMap<String, Object>();
@@ -2653,7 +2654,11 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                     }
                     this.cipher = toJavaCipherSuite(cipher, protocol);
                     this.protocol = protocol;
-
+                    try {
+                        this.namedGroup = SSL.getGroupName(ssl);
+                    } catch (Exception e) {
+                        throw new SSLException(e);
+                    }
                     if (clientMode) {
                         if (isEmpty(peerCertificateChain)) {
                             peerCerts = EmptyArrays.EMPTY_CERTIFICATES;
@@ -2723,6 +2728,11 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                     x509PeerCerts[certPos] = new LazyJavaxX509Certificate(chain[i]);
                 }
             }
+        }
+
+        @Override
+        public String getNamedGroup() {
+            return namedGroup;
         }
 
         @Override

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -2656,7 +2656,10 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                     this.protocol = protocol;
                     try {
                         String groupName = SSL.getGroupName(ssl);
-                        groupName = GroupsConverter.toOpenSsl(groupName); // Normalize group name (BoringSSL/OpenSSL)
+                        if (groupName != null) {
+                            // Normalize group name across BoringSSL/OpenSSL versions.
+                            groupName = GroupsConverter.toOpenSsl(groupName);
+                        }
                         this.namedGroup = groupName;
                     } catch (Exception e) {
                         throw new SSLException(e);

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -2655,7 +2655,9 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                     this.cipher = toJavaCipherSuite(cipher, protocol);
                     this.protocol = protocol;
                     try {
-                        this.namedGroup = SSL.getGroupName(ssl);
+                        String groupName = SSL.getGroupName(ssl);
+                        groupName = GroupsConverter.toOpenSsl(groupName); // Normalize group name (BoringSSL/OpenSSL)
+                        this.namedGroup = groupName;
                     } catch (Exception e) {
                         throw new SSLException(e);
                     }

--- a/handler/src/test/java/io/netty/handler/ssl/PkiTestingTlsTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/PkiTestingTlsTest.java
@@ -40,11 +40,15 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import javax.net.ssl.SNIHostName;
 import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSession;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PkiTestingTlsTest {
 
@@ -282,6 +286,19 @@ public class PkiTestingTlsTest {
                                             if (evt instanceof SslHandshakeCompletionEvent) {
                                                 SslHandshakeCompletionEvent shce = (SslHandshakeCompletionEvent) evt;
                                                 if (shce.isSuccess()) {
+                                                    SSLSession session = handler.engine().getSession();
+                                                    if (session instanceof OpenSslSession) {
+                                                        String namedGroup = ((OpenSslSession) handler.engine()
+                                                                .getSession()).getNamedGroup();
+                                                        if (groups != null) {
+                                                            assertTrue(Arrays.asList(groups).contains(namedGroup));
+                                                        } else {
+                                                            // If not specified explicit we will still use
+                                                            // what we can support.
+                                                            assertTrue(Arrays.asList(OpenSsl.NAMED_GROUPS)
+                                                                    .contains(namedGroup));
+                                                        }
+                                                    }
                                                     promise.setSuccess(shce);
                                                 } else {
                                                     promise.setFailure(shce.cause());

--- a/handler/src/test/java/io/netty/handler/ssl/PkiTestingTlsTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/PkiTestingTlsTest.java
@@ -40,7 +40,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -48,7 +47,7 @@ import javax.net.ssl.SNIHostName;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSession;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PkiTestingTlsTest {
 
@@ -290,14 +289,7 @@ public class PkiTestingTlsTest {
                                                     if (session instanceof OpenSslSession) {
                                                         String namedGroup = ((OpenSslSession) handler.engine()
                                                                 .getSession()).getNamedGroup();
-                                                        if (groups != null) {
-                                                            assertTrue(Arrays.asList(groups).contains(namedGroup));
-                                                        } else {
-                                                            // If not specified explicit we will still use
-                                                            // what we can support.
-                                                            assertTrue(Arrays.asList(OpenSsl.NAMED_GROUPS)
-                                                                    .contains(namedGroup));
-                                                        }
+                                                        assertThat(OpenSsl.NAMED_GROUPS).contains(namedGroup);
                                                     }
                                                     promise.setSuccess(shce);
                                                 } else {
@@ -309,8 +301,7 @@ public class PkiTestingTlsTest {
                                         }
 
                                         @Override
-                                        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause)
-                                                throws Exception {
+                                        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
                                             if (!promise.tryFailure(cause)) {
                                                 ctx.fireExceptionCaught(cause);
                                             }


### PR DESCRIPTION
Motivation:

It is useful to know which named group was used (for example to detect if PQC was used).

Modifications:

- Add new method to OpenSslSession to allow gathering the information
- Add unit test
- Update tcnative so we can access the used named group

Result:

Be able to detect which named group was used
