### PR TITLE
SslHandler: Fix possible buffer leak when an OOME is thrown during allocation

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -885,10 +885,10 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                         }
                         result = wrap(alloc, engine, buf, out);
                     }
-                } catch (SSLException e) {
-                    // Either wrapMultiple(...) or wrap(...) did throw. In this case we need to release the buffer
-                    // that we removed from pendingUnencryptedWrites before failing the promise and rethrowing it.
-                    // Failing to do so would result in a buffer leak.
+                } catch (Throwable e) {
+                    // Either wrapMultiple(...), wrap(...) or allocateOutNetBuf(...) did throw.
+                    // In this case we need to release the buffer that we removed from pendingUnencryptedWrites
+                    // before failing the promise and rethrowing it. Failing to do so would result in a buffer leak.
                     // See https://github.com/netty/netty/issues/14644
                     //
                     // We don't need to release out here as this is done in a finally block already.


### PR DESCRIPTION
Motivation:

When SslHandler throws an OOME during allocating a new out buffer we need to ensure we still release the original buffer to not leak.

Modifications:

- Catch Throwable and rethrow after releasing

Result:

Fixes https://github.com/netty/netty/issues/17057
