### PR TITLE
Update lz4-java to 1.11.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1428,6 +1428,18 @@
                 </item>
                 <item>
                   <ignore>true</ignore>
+                  <code>java.class.externalClassExposedInAPI</code>
+                  <new>class net.jpountz.lz4.LZ4JNIFastResetCompressor</new>
+                  <justification>The optional lz4-java dependency exposes this class through LZ4Factory, which is part of Netty's public API to allow users to customize LZ4 implementations.</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.externalClassExposedInAPI</code>
+                  <new>class net.jpountz.lz4.LZ4JNIHCFastResetCompressor</new>
+                  <justification>The optional lz4-java dependency exposes this class through LZ4Factory, which is part of Netty's public API to allow users to customize LZ4 implementations.</justification>
+                </item>
+                <item>
+                  <ignore>true</ignore>
                   <code>java.field.removed</code>
                   <classQualifiedName>io.netty.util.internal.InternalThreadLocalMap</classQualifiedName>
                   <justification>Ignore cache padding.</justification>

--- a/pom.xml
+++ b/pom.xml
@@ -1063,7 +1063,7 @@
       <dependency>
         <groupId>at.yawk.lz4</groupId>
         <artifactId>lz4-java</artifactId>
-        <version>1.10.1</version>
+        <version>1.11.1</version>
       </dependency>
       <dependency>
         <groupId>com.github.jponge</groupId>


### PR DESCRIPTION
Motivation:

Update the optional LZ4 Java dependency used by Netty's compression codec to the latest published `at.yawk.lz4:lz4-java` release.

(Resolves https://github.com/yawkat/lz4-java/security/advisories/GHSA-xx22-p4ch-683r )

Modification:

Bump the managed `at.yawk.lz4:lz4-java` dependency version from `1.10.1` to `1.11.1` in the root `pom.xml`.

Also extend the Revapi differences allowlist for the two `net.jpountz.lz4` JNI fast-reset compressor classes that the updated dependency exposes through `LZ4Factory`, which Netty already exposes as part of its public LZ4 customization API.

Result:

The codec module continues to inherit the centrally managed dependency version, and the API compatibility check accounts for the updated dependency's newly exposed supplementary types. Locally verified with:

- `git diff --check`
- `JAVA_HOME=/usr/lib/jvm/java-25-openjdk MAVEN_USER_HOME=/tmp/opencode/m2-netty ./mvnw -N -DskipTests validate`
- `JAVA_HOME=/usr/lib/jvm/java-25-openjdk MAVEN_USER_HOME=/tmp/opencode/m2-netty ./mvnw -B -ntp --file pom.xml verify -DskipTests=true` passed through the previously failing `netty-codec` Revapi check; the local run later stopped in native epoll setup because this environment lacks the native build/source artifact setup.

No associated issue.