### PR TITLE
Update lz4-java to 1.11.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -951,7 +951,7 @@
       <dependency>
         <groupId>at.yawk.lz4</groupId>
         <artifactId>lz4-java</artifactId>
-        <version>1.11.0</version>
+        <version>1.11.1</version>
       </dependency>
       <dependency>
         <groupId>com.github.jponge</groupId>


### PR DESCRIPTION
Motivation:

Manual port of #17060 to `4.2`; the automatic port failed due to cherry-pick conflicts.

Update the optional LZ4 Java dependency used by Netty's compression codec to the latest published `at.yawk.lz4:lz4-java` release.

(Resolves https://github.com/yawkat/lz4-java/security/advisories/GHSA-xx22-p4ch-683r )

Modification:

Bump the managed `at.yawk.lz4:lz4-java` dependency version from `1.11.0` to `1.11.1` in the root `pom.xml`.

The 4.2 branch already has the Revapi differences allowlist entries for the two `net.jpountz.lz4` JNI fast-reset compressor classes exposed through `LZ4Factory`, so no additional Revapi configuration changes were needed.

Result:

The `netty-codec-compression` module continues to inherit the centrally managed dependency version. Locally verified with:

- `git diff --check`
- `JAVA_HOME=/usr/lib/jvm/java-25-openjdk MAVEN_USER_HOME=/tmp/opencode/m2-netty-4.2 ./mvnw -N -DskipTests validate`
- `JAVA_HOME=/usr/lib/jvm/java-25-openjdk MAVEN_USER_HOME=/tmp/opencode/m2-netty-4.2 ./mvnw -pl codec-compression -DskipTests help:effective-pom -Doutput=/tmp/opencode/netty-4.2-effective-codec-compression-pom.xml` and confirmed the effective POM contains `at.yawk.lz4:lz4-java:1.11.1`.

No associated issue.