### PR TITLE
Add HttpContentCompressor constructor with ability to specify desired maxPipelineDepth

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
@@ -185,6 +185,26 @@ public class HttpContentCompressor extends HttpContentEncoder {
      *        if the default should be used.
      */
     public HttpContentCompressor(int contentSizeThreshold, CompressionOptions... compressionOptions) {
+        this(contentSizeThreshold, DEFAULT_MAX_PIPELINE_DEPTH, compressionOptions);
+    }
+
+    /**
+     * Create a new {@link HttpContentCompressor} instance with specified
+     * {@link CompressionOptions}s
+     *
+     * @param contentSizeThreshold
+     *        The response body is compressed when the size of the response
+     *        body exceeds the threshold. The value should be a non negative
+     *        number. {@code 0} will enable compression for all responses.
+     * @param maxPipelineDepth
+     *        The maximum allowed depth of the encoding pipeline queue, the default
+     *        value is set to {@link DEFAULT_MAX_PIPELINE_DEPTH}
+     * @param compressionOptions {@link CompressionOptions} or {@code null}
+     *        if the default should be used.
+     */
+    public HttpContentCompressor(int contentSizeThreshold, int maxPipelineDepth,
+            CompressionOptions... compressionOptions) {
+        super(maxPipelineDepth);
         this.contentSizeThreshold = ObjectUtil.checkPositiveOrZero(contentSizeThreshold, "contentSizeThreshold");
         BrotliOptions brotliOptions = null;
         GzipOptions gzipOptions = null;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentEncoder.java
@@ -55,6 +55,7 @@ import static io.netty.handler.codec.http.HttpHeaderNames.*;
  * converts them into {@link ByteBuf}s.
  */
 public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpRequest, HttpObject> {
+    public static final int DEFAULT_MAX_PIPELINE_DEPTH = 128;
 
     private enum State {
         PASS_THROUGH,
@@ -71,7 +72,7 @@ public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpReque
     private State state = State.AWAIT_HEADERS;
 
     public HttpContentEncoder() {
-        this(128);
+        this(DEFAULT_MAX_PIPELINE_DEPTH);
     }
 
     public HttpContentEncoder(int maxPipelineDepth) {


### PR DESCRIPTION
Motivation:

In scope of https://github.com/netty/netty/pull/17063, the `HttpContentEncoder` got a new property `maxPipelineDepth` and the respective constructor variant. However, the subclasses, notably `HttpContentCompressor` have not been updated to allow changing `maxPipelineDepth` and always use the default `128`.

Modification:

Add `HttpContentCompressor` constructor variant with ability to specify desired `maxPipelineDepth`. It would help us to absorb the change through configuration setting.

@chrisvest would appreciate your feedback, thank you.
