### PR TITLE
Avoid leak presence detector in leak profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -620,7 +620,11 @@
     <profile>
       <id>leak</id>
       <properties>
-        <argLine.leak>-Dio.netty.leakDetectionLevel=paranoid -Dio.netty.leakDetection.targetRecords=32</argLine.leak>
+        <argLine.leak>
+          -Dio.netty.leakDetectionLevel=paranoid
+          -Dio.netty.leakDetection.targetRecords=32
+          -Dio.netty.test.leakPresenceDetection.disabled=true
+        </argLine.leak>
       </properties>
     </profile>
     <profile>

--- a/testsuite-common/src/main/java/io/netty/util/test/LeakPresenceExtension.java
+++ b/testsuite-common/src/main/java/io/netty/util/test/LeakPresenceExtension.java
@@ -21,7 +21,9 @@ import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExecutionCondition;
 
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
@@ -44,13 +46,27 @@ import java.util.concurrent.TimeUnit;
  * in a test are assigned to the test resource scope.
  */
 public final class LeakPresenceExtension
-        implements BeforeAllCallback, BeforeEachCallback, AfterEachCallback, AfterAllCallback {
+        implements ExecutionCondition, BeforeAllCallback, BeforeEachCallback, AfterEachCallback, AfterAllCallback {
+
+    static final String LEAK_PRESENCE_DETECTION_DISABLED_PROPERTY =
+            "io.netty.test.leakPresenceDetection.disabled";
 
     private static final Object SCOPE_KEY = new Object();
     private static final Object PREVIOUS_SCOPE_KEY = new Object();
 
     static {
-        System.setProperty("io.netty.customResourceLeakDetector", WithTransferableScope.class.getName());
+        if (!Boolean.getBoolean(LEAK_PRESENCE_DETECTION_DISABLED_PROPERTY)) {
+            System.setProperty("io.netty.customResourceLeakDetector", WithTransferableScope.class.getName());
+        }
+    }
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+        if (Boolean.getBoolean(LEAK_PRESENCE_DETECTION_DISABLED_PROPERTY)) {
+            return ConditionEvaluationResult.disabled(
+                    "Leak presence detection disabled by " + LEAK_PRESENCE_DETECTION_DISABLED_PROPERTY);
+        }
+        return ConditionEvaluationResult.enabled("Leak presence detection enabled");
     }
 
     @Override

--- a/testsuite-common/src/test/java/io/netty/util/test/LeakPresenceExtensionTest.java
+++ b/testsuite-common/src/test/java/io/netty/util/test/LeakPresenceExtensionTest.java
@@ -17,6 +17,7 @@ package io.netty.util.test;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.platform.testkit.engine.EngineExecutionResults;
 import org.junit.platform.testkit.engine.EngineTestKit;
 
@@ -33,6 +34,27 @@ class LeakPresenceExtensionTest {
         results.containerEvents().failed().assertThatEvents().isEmpty();
         results.testEvents().failed().assertThatEvents().isEmpty();
         results.testEvents().succeeded().assertThatEvents().hasSize(2);
+    }
+
+    @Test
+    void explicitExtensionTestIsSkippedWhenLeakPresenceDetectionIsDisabled() {
+        String previous = System.getProperty(LeakPresenceExtension.LEAK_PRESENCE_DETECTION_DISABLED_PROPERTY);
+        System.setProperty(LeakPresenceExtension.LEAK_PRESENCE_DETECTION_DISABLED_PROPERTY, "true");
+        try {
+            EngineExecutionResults results = EngineTestKit.engine("junit-jupiter")
+                    .selectors(selectClass(ExplicitExtensionTest.class))
+                    .execute();
+
+            results.containerEvents().failed().assertThatEvents().isEmpty();
+            results.containerEvents().skipped().assertThatEvents().hasSize(1);
+            results.testEvents().succeeded().assertThatEvents().isEmpty();
+        } finally {
+            if (previous == null) {
+                System.clearProperty(LeakPresenceExtension.LEAK_PRESENCE_DETECTION_DISABLED_PROPERTY);
+            } else {
+                System.setProperty(LeakPresenceExtension.LEAK_PRESENCE_DETECTION_DISABLED_PROPERTY, previous);
+            }
+        }
     }
 
     @Test
@@ -68,6 +90,13 @@ class LeakPresenceExtensionTest {
     static class InheritedChildTest extends InheritedParentTest {
         @Test
         void childTest() {
+        }
+    }
+
+    @ExtendWith(LeakPresenceExtension.class)
+    static class ExplicitExtensionTest {
+        @Test
+        void test() {
         }
     }
 }


### PR DESCRIPTION
Motivation:

The `leak` Maven profile replaces the default JUnit extension autodetection argLine with paranoid Netty leak detection. Explicit tests that use `@ExtendWith(LeakPresenceExtension.class)` can still load `LeakPresenceExtension`, whose static initializer installs `WithTransferableScope` globally via `io.netty.customResourceLeakDetector`.

In handler tests, classes run concurrently, so this can route unrelated tests through the leak presence detector without a per-test scope and trigger `Resource created outside test?` failures.

Modification:

Add a dedicated `io.netty.test.leakPresenceDetection.disabled` system property to the `leak` profile.

When this property is set, `LeakPresenceExtension`:

- skips installing the leak presence detector globally
- disables tests that explicitly opt into the extension through the extension's own `ExecutionCondition`

The existing strict missing-scope behavior in `WithTransferableScope.currentScope()` is unchanged.

Result:

The `leak` profile uses paranoid leak detection without enabling incompatible leak presence detection for explicit extension tests, avoiding cross-test contamination in parallel test runs.

Verified with:

- `./mvnw -pl testsuite-common -am -Dtest=LeakPresenceExtensionTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -Pleak -pl handler -am -Dtest=OpenSslCredentialBuilderTest,OpenSslEngineTest -Dsurefire.failIfNoSpecifiedTests=false test`

Resolves #17067