### PR TITLE
Merge branches from forks (#17063)

### DIFF
--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/Bzip2BlockDecompressor.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/Bzip2BlockDecompressor.java
@@ -293,6 +293,9 @@ final class Bzip2BlockDecompressor {
                 crc.updateCRC(nextByte);
             } else {
                 if (++rleAccumulator == 4) {
+                    if (bwtBytesDecoded >= bwtBlockLength) {
+                        throw new DecompressionException("malformed RLE: run-length byte missing at end of block");
+                    }
                     // Accumulation complete, start repetition
                     int rleRepeat = decodeNextBWTByte() + 1;
                     this.rleRepeat = rleRepeat;

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/Bzip2DecoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/Bzip2DecoderTest.java
@@ -22,12 +22,16 @@ import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.CompletionException;
 
 import static io.netty.handler.codec.compression.Bzip2Constants.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class Bzip2DecoderTest extends AbstractDecoderTest {
@@ -150,6 +154,89 @@ public class Bzip2DecoderTest extends AbstractDecoderTest {
         final ByteBuf in = Unpooled.wrappedBuffer(data);
         assertThrows(DecompressionException.class,
                 () -> writeInboundDestroyAndExpectDecompressionException(in), "start pointer invalid");
+    }
+
+    /**
+     * Regression test for the infinite-loop in {@link Bzip2BlockDecompressor#read()}.
+     *
+     * <p>The bzip2 block below is hand-crafted so that its inverse-BWT output is exactly
+     * four consecutive 'A' bytes with no trailing run-length count byte. This is a
+     * malformed-stream
+     *
+     * <p>Stream construction (bit-level, MSB first after the byte-aligned header):
+     * <pre>
+     *   Bytes  0– 3   "BZh1"                  stream header (block size 1 = 100 000 bytes)
+     *   Bytes  4– 9   0x314159265359           block-header magic (pi)
+     *   Bytes 10–13   0x00000000               block CRC — intentionally wrong; a
+     *                                           DecompressionException from checkCRC() is the
+     *                                           expected outcome after the fix is applied
+     *   --- bit-level section (read via Bzip2BitReader, MSB-first) ---
+     *    1 bit          randomized = 0
+     *   24 bits         bwtStartPointer = 0
+     *   16 bits         huffmanInUse16 = 0x0800 (group 4, bytes 0x40–0x4F present)
+     *   16 bits         group-4 symbol bitmap = 0x4000 (only 0x41 = 'A' present)
+     *    3 bits         totalTables = 2 (minimum allowed)
+     *   15 bits         totalSelectors = 1
+     *    1 bit          selector[0] unary-coded as 0 → table 0
+     *    8 bits         table 0: initial length 2 (5 bits = 00010), then three 0-delta
+     *                   bits for RUNA/RUNB/EOB → all code lengths = 2
+     *    8 bits         table 1: identical to table 0
+     *    6 bits         Huffman data: RUNB(01) RUNA(00) EOB(10)
+     *                   RUNB first: repeatCount=2, RUNA: repeatCount=4, EOB flushes
+     *                   4 copies of huffmanSymbolMap[0]='A' into the BWT block.
+     *                   bwtBlockLength = 4 with NO trailing count byte → triggers the bug.
+     *   48 bits         end-of-stream magic 0x177245 0x385090
+     *   32 bits         stream CRC = 0
+     * </pre>
+     */
+    @Test
+    public void testRleOffByOneDoesNotCauseInfiniteLoop() {
+        final byte[] malformed = {
+            0x42, 0x5A, 0x68, 0x31,                                    // "BZh1"
+            0x31, 0x41, 0x59, 0x26, 0x53, 0x59,                        // block magic
+            0x00, 0x00, 0x00, 0x00,                                     // block CRC
+            // bit-level section (MSB-first packing, computed field-by-field):
+            0x00, 0x00, 0x00, 0x04, 0x00, 0x20,                        // random+bwtPtr+inUse16 start
+            0x00, 0x20, 0x00, 0x21, 0x01, 0x04,                        // inUse16 end+grp4+tbls+sel+tbl0
+            (byte) 0x85, (byte) 0xDC, (byte) 0x91, 0x4E, 0x14, 0x24,  // tbl1+data+EOS magic
+            0x00, 0x00, 0x00, 0x00, 0x00                               // stream CRC + padding
+        };
+
+        EmbeddedChannel ch = new EmbeddedChannel(new Bzip2Decoder());
+        assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
+            assertThrows(DecompressionException.class, () -> {
+                ch.writeInbound(Unpooled.wrappedBuffer(malformed));
+                ch.finishAndReleaseAll();
+            });
+        }, "Bzip2Decoder hung: bwtBytesDecoded overshot bwtBlockLength and the " +
+           "equality termination check was permanently false");
+    }
+
+    /**
+     * Verifies that a well-formed bzip2 block whose inverse-BWT output ends with exactly
+     * four consecutive identical bytes followed by a run-length count byte is decoded
+     * correctly and terminates cleanly.
+     *
+     * <p>Compressing {@code "AAAA"}: bzip2's pre-BWT RLE encodes a run of exactly 4
+     * identical bytes as {@code [A,A,A,A,0x00]} (the four bytes plus count-byte 0,
+     * meaning zero additional copies beyond the initial four).  The post-BWT RLE
+     * decoder in {@link Bzip2BlockDecompressor#read()} must reach
+     * {@code rleAccumulator == 4}, read the count byte, and then terminate cleanly
+     * when {@code bwtBytesDecoded} reaches {@code bwtBlockLength == 5}.
+     */
+    @Test
+    public void testWellFormedFourByteRleRunAtBlockEnd() throws Exception {
+        byte[] compressed = compress(new byte[]{'A', 'A', 'A', 'A'});
+        channel.writeInbound(Unpooled.wrappedBuffer(compressed));
+        ByteBuf decoded = channel.readInbound();
+        assertNotNull(decoded, "expected decoded output for well-formed AAAA block");
+        try {
+            byte[] result = new byte[decoded.readableBytes()];
+            decoded.readBytes(result);
+            assertArrayEquals(new byte[]{'A', 'A', 'A', 'A'}, result);
+        } finally {
+            decoded.release();
+        }
     }
 
     @Override

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordDecoder.java
@@ -16,7 +16,6 @@
 package io.netty.handler.codec.dns;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.CorruptedFrameException;
 
 /**
@@ -97,9 +96,17 @@ public class DefaultDnsRecordDecoder implements DnsRecordDecoder {
                     name, dnsClass, timeToLive, decodeName0(in.duplicate().setIndex(offset, offset + length)));
         }
         if (type == DnsRecordType.CNAME || type == DnsRecordType.NS) {
-            return new DefaultDnsRawRecord(name, type, dnsClass, timeToLive,
-                                           DnsCodecUtil.decompressDomainName(
-                                                   in.duplicate().setIndex(offset, offset + length)));
+            ByteBuf decompressed = DnsCodecUtil.decompressDomainName(
+                    in.duplicate().setIndex(offset, offset + length));
+            try {
+                DnsRecord record = new DefaultDnsRawRecord(name, type, dnsClass, timeToLive, decompressed);
+                decompressed = null;
+                return record;
+            } finally {
+                if (decompressed != null) {
+                    decompressed.release();
+                }
+            }
         }
         if (type ==  DnsRecordType.MX) {
             // MX RDATA: 16-bit preference + exchange (domain name, possibly compressed)
@@ -108,25 +115,40 @@ public class DefaultDnsRecordDecoder implements DnsRecordDecoder {
             }
             final int pref = in.getUnsignedShort(offset);
             ByteBuf exchange = null;
+            ByteBuf out = null;
             try {
                 exchange = DnsCodecUtil.decompressDomainName(
                         in.duplicate().setIndex(offset + 2, offset + length));
 
                 // Build decompressed RDATA = [preference][expanded exchange name]
-                final ByteBuf out = in.alloc().buffer(2 + exchange.readableBytes());
+                out = in.alloc().buffer(2 + exchange.readableBytes());
                 out.writeShort(pref);
                 out.writeBytes(exchange);
 
-                return new DefaultDnsRawRecord(name, type, dnsClass, timeToLive, out);
+                DnsRecord record = new DefaultDnsRawRecord(name, type, dnsClass, timeToLive, out);
+                out = null;
+                return record;
             } finally {
                 if (exchange != null) {
                     exchange.release();
                 }
+                if (out != null) {
+                    out.release();
+                }
             }
         }
 
-        return new DefaultDnsRawRecord(
-                name, type, dnsClass, timeToLive, in.retainedDuplicate().setIndex(offset, offset + length));
+        ByteBuf content = in.retainedDuplicate();
+        try {
+            content.setIndex(offset, offset + length);
+            DnsRecord record = new DefaultDnsRawRecord(name, type, dnsClass, timeToLive, content);
+            content = null;
+            return record;
+        } finally {
+            if (content != null) {
+                content.release();
+            }
+        }
     }
 
     /**

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsCodecUtil.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsCodecUtil.java
@@ -153,7 +153,12 @@ final class DnsCodecUtil {
     static ByteBuf decompressDomainName(ByteBuf compression) {
         String domainName = decodeDomainName(compression);
         ByteBuf result = compression.alloc().buffer(domainName.length() << 1);
-        encodeDomainName(domainName, result);
+        try {
+            encodeDomainName(domainName, result);
+        } catch (Throwable cause) {
+            result.release();
+            throw cause;
+        }
         return result;
     }
 }

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessage.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessage.java
@@ -101,8 +101,8 @@ public final class HAProxyMessage extends AbstractReferenceCounted {
         ObjectUtil.checkNotNull(tlvs, "tlvs");
         AddressFamily addrFamily = proxiedProtocol.addressFamily();
 
-        checkAddress(sourceAddress, addrFamily);
-        checkAddress(destinationAddress, addrFamily);
+        checkAddress(sourceAddress, addrFamily, protocolVersion);
+        checkAddress(destinationAddress, addrFamily, protocolVersion);
         checkPort(sourcePort, addrFamily);
         checkPort(destinationPort, addrFamily);
 
@@ -470,11 +470,12 @@ public final class HAProxyMessage extends AbstractReferenceCounted {
     /**
      * Validate an address (IPv4, IPv6, Unix Socket)
      *
-     * @param address                    human-readable address
-     * @param addrFamily                 the {@link AddressFamily} to check the address against
-     * @throws IllegalArgumentException  if the address is invalid
+     * @param address    human-readable address
+     * @param addrFamily the {@link AddressFamily} to check the address against
+     * @param version    the protocol version
+     * @throws IllegalArgumentException if the address is invalid
      */
-    private static void checkAddress(String address, AddressFamily addrFamily) {
+    private static void checkAddress(String address, AddressFamily addrFamily, HAProxyProtocolVersion version) {
         ObjectUtil.checkNotNull(addrFamily, "addrFamily");
 
         switch (addrFamily) {
@@ -487,6 +488,15 @@ public final class HAProxyMessage extends AbstractReferenceCounted {
                 ObjectUtil.checkNotNull(address, "address");
                 if (address.getBytes(CharsetUtil.US_ASCII).length > 108) {
                     throw new IllegalArgumentException("invalid AF_UNIX address: " + address);
+                }
+                if (version == HAProxyProtocolVersion.V1) {
+                    // V1 is text-based and uses CR LF as header delimiters, and space as field delimiter.
+                    for (int i = 0, len = address.length(); i < len; i++) {
+                        char c = address.charAt(i);
+                        if (c == '\r' || c == '\n' || c == ' ') {
+                            throw new IllegalArgumentException("invalid AF_UNIX address: " + address);
+                        }
+                    }
                 }
                 return;
         }

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessageDecoder.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyMessageDecoder.java
@@ -173,7 +173,7 @@ public class HAProxyMessageDecoder extends ByteToMessageDecoder {
         }
 
         int idx = buffer.readerIndex();
-        return match(BINARY_PREFIX, buffer, idx) ? buffer.getByte(idx + BINARY_PREFIX_LENGTH) : 1;
+        return match(BINARY_PREFIX, buffer, idx) ? buffer.getUnsignedByte(idx + BINARY_PREFIX_LENGTH) : 1;
     }
 
     /**

--- a/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HAProxyMessageDecoderTest.java
+++ b/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HAProxyMessageDecoderTest.java
@@ -1216,6 +1216,14 @@ public class HAProxyMessageDecoderTest {
     }
 
     @Test
+    public void testInvalidProtocolUnsigned() {
+        final ByteBuf invalidData = buffer().writeBytes(
+                new byte[] { 0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A, (byte) 0xFF });
+        invalidData.writeZero(64);
+        assertThrows(HAProxyProtocolException.class, () -> ch.writeInbound(invalidData));
+    }
+
+    @Test
     public void testNestedTLV() throws Exception {
         ByteArrayOutputStream headerWriter = new ByteArrayOutputStream();
         //src_ip = "AAAA", dst_ip = "BBBB", src_port = "CC", dst_port = "DD"

--- a/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HaProxyMessageEncoderTest.java
+++ b/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HaProxyMessageEncoderTest.java
@@ -25,6 +25,8 @@ import io.netty.util.ByteProcessor;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -398,6 +400,44 @@ public class HaProxyMessageEncoderTest {
                         invalidUnixAddress, "/var/run/dst.sock", 0, 0);
             }
         });
+    }
+
+    @ParameterizedTest
+    @ValueSource(chars = {'\r', '\n', ' '})
+    public void testIllegalCharacterInV1UnixAddress(char illegal) {
+        final String invalidUnixAddress = "/var/run/dst" + illegal + ".sock";
+        final String fineUnixAddress = "/var/run/dst.sock";
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() {
+                new HAProxyMessage(
+                        HAProxyProtocolVersion.V1, HAProxyCommand.PROXY, HAProxyProxiedProtocol.UNIX_STREAM,
+                        invalidUnixAddress, fineUnixAddress, 0, 0);
+            }
+        });
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() {
+                new HAProxyMessage(
+                        HAProxyProtocolVersion.V1, HAProxyCommand.PROXY, HAProxyProxiedProtocol.UNIX_STREAM,
+                        fineUnixAddress, invalidUnixAddress, 0, 0);
+            }
+        });
+    }
+
+    @ParameterizedTest
+    @ValueSource(chars = {'\r', '\n', ' '})
+    public void testIllegalV1UnixCharactersAreFineInV2(char illegal) {
+        final String suspectUnixAddress = "/var/run/dst" + illegal + ".sock";
+        final String fineUnixAddress = "/var/run/dst.sock";
+        new HAProxyMessage(
+                HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.UNIX_STREAM,
+                suspectUnixAddress, fineUnixAddress, 0, 0)
+                .release();
+        new HAProxyMessage(
+                HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.UNIX_STREAM,
+                fineUnixAddress, suspectUnixAddress, 0, 0)
+                .release();
     }
 
     @Test

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpConstants.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpConstants.java
@@ -67,6 +67,16 @@ public final class HttpConstants {
     public static final byte DOUBLE_QUOTE = '"';
 
     /**
+     * Backslash '\'
+     */
+    public static final byte BACKSLASH = '\\';
+
+    /**
+     * ASCII DEL character code
+     */
+    public static final byte DEL = 0x7F;
+
+    /**
      * Default character set (UTF-8)
      */
     public static final Charset DEFAULT_CHARSET = CharsetUtil.UTF_8;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentEncoder.java
@@ -65,12 +65,18 @@ public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpReque
     private static final CharSequence ZERO_LENGTH_HEAD = "HEAD";
     private static final CharSequence ZERO_LENGTH_CONNECT = "CONNECT";
 
+    private final int maxPipelineDepth;
     private final Queue<CharSequence> acceptEncodingQueue = new ArrayDeque<CharSequence>();
     private EmbeddedChannel encoder;
     private State state = State.AWAIT_HEADERS;
 
     public HttpContentEncoder() {
+        this(128);
+    }
+
+    public HttpContentEncoder(int maxPipelineDepth) {
         super(HttpRequest.class, HttpObject.class);
+        this.maxPipelineDepth = ObjectUtil.checkPositive(maxPipelineDepth, "maxPipelineDepth");
     }
 
     @Override
@@ -80,6 +86,9 @@ public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpReque
 
     @Override
     protected void decode(ChannelHandlerContext ctx, HttpRequest msg, List<Object> out) throws Exception {
+        if (maxPipelineDepth <= acceptEncodingQueue.size()) {
+            throw new IllegalStateException("maxPipelineDepth exceeded: " + maxPipelineDepth);
+        }
         CharSequence acceptEncoding;
         List<String> acceptEncodingHeaders = msg.headers().getAll(ACCEPT_ENCODING);
         switch (acceptEncodingHeaders.size()) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsHandler.java
@@ -155,7 +155,7 @@ public class CorsHandler implements ChannelInboundHandler, ChannelOutboundHandle
             if (corsConfig.origins().contains(requestOrigin)) {
                 return corsConfig;
             }
-            if (corsConfig.isNullOriginAllowed() || NULL_ORIGIN.equals(requestOrigin)) {
+            if (corsConfig.isNullOriginAllowed() && NULL_ORIGIN.equals(requestOrigin)) {
                 return corsConfig;
             }
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/DiskFileUpload.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/DiskFileUpload.java
@@ -75,7 +75,7 @@ public class DiskFileUpload extends AbstractDiskHttpData implements FileUpload {
 
     @Override
     public void setFilename(String filename) {
-        this.filename = ObjectUtil.checkNotNull(filename, "filename");
+        this.filename = FileUploadUtil.validateFileNameForMultiPart(filename);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/FileUpload.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/FileUpload.java
@@ -31,7 +31,10 @@ public interface FileUpload extends HttpData {
     String getFilename();
 
     /**
-     * Set the original filename
+     * Set the original filename.
+     * <p>
+     * <strong>Note:</strong> This method validates that the filename is safe for including in an HTTP request,
+     * and will throw an exception if that's not the case.
      */
     void setFilename(String filename);
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/FileUploadUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/FileUploadUtil.java
@@ -15,6 +15,9 @@
  */
 package io.netty.handler.codec.http.multipart;
 
+import io.netty.handler.codec.http.HttpConstants;
+import io.netty.util.internal.ObjectUtil;
+
 final class FileUploadUtil {
 
     private FileUploadUtil() { }
@@ -29,5 +32,25 @@ final class FileUploadUtil {
 
     static int compareTo(FileUpload upload1, FileUpload upload2) {
         return upload1.getName().compareToIgnoreCase(upload2.getName());
+    }
+
+    /**
+     * Control characters, the DEL character, double-quote, and backslash are either disallowed or strongly discouraged,
+     * depending on which {@code multipart/form-data} specification you read.
+     * This method conservatively rejects all of them, and is used for <em>outbound</em> (encoding) filenames.
+     * @param filename The filename to check.
+     * @return The validated filename, unchanged.
+     */
+    static String validateFileNameForMultiPart(String filename) {
+        int length = ObjectUtil.checkNotNull(filename, "filename").length();
+        for (int i = 0; i < length; i++) {
+            char c = filename.charAt(i);
+            if (c < HttpConstants.SP /*control character block*/ || c == HttpConstants.DEL ||
+                    c == HttpConstants.DOUBLE_QUOTE || c == HttpConstants.BACKSLASH) {
+                throw new IllegalArgumentException(
+                        String.format("Illegal filename character 0x%02x at index %d", (int) c, i));
+            }
+        }
+        return filename;
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
@@ -1283,10 +1283,15 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
                 sb.append(HttpConstants.SP_CHAR);
                 break;
             case HttpConstants.DOUBLE_QUOTE:
-                // nothing added, just removes it
+            case HttpConstants.BACKSLASH:
+                // nothing added, just removes double quote and backslash
                 break;
             default:
-                sb.append(nextChar);
+                if (nextChar < HttpConstants.SP || nextChar == HttpConstants.DEL) {
+                    sb.append(HttpConstants.SP_CHAR);
+                } else {
+                    sb.append(nextChar);
+                }
                 break;
             }
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/MemoryFileUpload.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/MemoryFileUpload.java
@@ -57,7 +57,7 @@ public class MemoryFileUpload extends AbstractMemoryHttpData implements FileUplo
 
     @Override
     public void setFilename(String filename) {
-        this.filename = ObjectUtil.checkNotNull(filename, "filename");
+        this.filename = FileUploadUtil.validateFileNameForMultiPart(filename);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker07.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker07.java
@@ -134,8 +134,16 @@ public class WebSocketServerHandshaker07 extends WebSocketServerHandshaker {
         if (!GET.equals(method)) {
             throw new WebSocketServerHandshakeException("Invalid WebSocket handshake method: " + method, req);
         }
-
-        CharSequence key = req.headers().get(HttpHeaderNames.SEC_WEBSOCKET_KEY);
+        HttpHeaders reqHeaders = req.headers();
+        if (!reqHeaders.containsValue(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE, true)) {
+            throw new WebSocketServerHandshakeException(
+                    "not a WebSocket request: a |Connection| header must include a token 'Upgrade'", req);
+        }
+        if (!reqHeaders.contains(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET, true)) {
+            throw new WebSocketServerHandshakeException(
+                    "not a WebSocket request: an |Upgrade| header must containing the value 'websocket'", req);
+        }
+        CharSequence key = reqHeaders.get(HttpHeaderNames.SEC_WEBSOCKET_KEY);
         if (key == null) {
             throw new WebSocketServerHandshakeException("not a WebSocket request: missing key", req);
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker08.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker08.java
@@ -142,7 +142,16 @@ public class WebSocketServerHandshaker08 extends WebSocketServerHandshaker {
             throw new WebSocketServerHandshakeException("Invalid WebSocket handshake method: " + method, req);
         }
 
-        CharSequence key = req.headers().get(HttpHeaderNames.SEC_WEBSOCKET_KEY);
+        HttpHeaders reqHeaders = req.headers();
+        if (!reqHeaders.containsValue(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE, true)) {
+            throw new WebSocketServerHandshakeException(
+                    "not a WebSocket request: a |Connection| header must include a token 'Upgrade'", req);
+        }
+        if (!reqHeaders.contains(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET, true)) {
+            throw new WebSocketServerHandshakeException(
+                    "not a WebSocket request: an |Upgrade| header must containing the value 'websocket'", req);
+        }
+        CharSequence key = reqHeaders.get(HttpHeaderNames.SEC_WEBSOCKET_KEY);
         if (key == null) {
             throw new WebSocketServerHandshakeException("not a WebSocket request: missing key", req);
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13.java
@@ -147,12 +147,12 @@ public class WebSocketServerHandshaker13 extends WebSocketServerHandshaker {
         HttpHeaders reqHeaders = req.headers();
         if (!reqHeaders.containsValue(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE, true)) {
             throw new WebSocketServerHandshakeException(
-                    "not a WebSocket request: a |Connection| header must includes a token 'Upgrade'", req);
+                    "not a WebSocket request: a |Connection| header must include a token 'Upgrade'", req);
         }
 
         if (!reqHeaders.contains(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET, true)) {
             throw new WebSocketServerHandshakeException(
-                    "not a WebSocket request: a |Upgrade| header must containing the value 'websocket'", req);
+                    "not a WebSocket request: an |Upgrade| header must containing the value 'websocket'", req);
         }
 
         String key = reqHeaders.get(HttpHeaderNames.SEC_WEBSOCKET_KEY);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13.java
@@ -152,7 +152,7 @@ public class WebSocketServerHandshaker13 extends WebSocketServerHandshaker {
 
         if (!reqHeaders.contains(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET, true)) {
             throw new WebSocketServerHandshakeException(
-                    "not a WebSocket request: an |Upgrade| header must containing the value 'websocket'", req);
+                    "not a WebSocket request: a |Upgrade| header must containing the value 'websocket'", req);
         }
 
         String key = reqHeaders.get(HttpHeaderNames.SEC_WEBSOCKET_KEY);

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameDecoder.java
@@ -50,7 +50,9 @@ public class SpdyFrameDecoder {
 
     protected final SpdyFrameDecoderDelegate delegate;
     protected final int spdyVersion;
+    static final int DEFAULT_MAX_NUM_SETTINGS = 64;
     private final int maxChunkSize;
+    private final int maxNumSettings;
 
     private int frameType;
     private State state;
@@ -92,9 +94,18 @@ public class SpdyFrameDecoder {
      * Creates a new instance with the specified parameters.
      */
     public SpdyFrameDecoder(SpdyVersion spdyVersion, SpdyFrameDecoderDelegate delegate, int maxChunkSize) {
+        this(spdyVersion, delegate, maxChunkSize, DEFAULT_MAX_NUM_SETTINGS);
+    }
+
+    /**
+     * Creates a new instance with the specified parameters.
+     */
+    public SpdyFrameDecoder(SpdyVersion spdyVersion, SpdyFrameDecoderDelegate delegate,
+                            int maxChunkSize, int maxNumSettings) {
         this.spdyVersion = ObjectUtil.checkNotNull(spdyVersion, "spdyVersion").version();
         this.delegate = ObjectUtil.checkNotNull(delegate, "delegate");
         this.maxChunkSize = ObjectUtil.checkPositive(maxChunkSize, "maxChunkSize");
+        this.maxNumSettings = ObjectUtil.checkPositive(maxNumSettings, "maxNumSettings");
         state = State.READ_COMMON_HEADER;
     }
 
@@ -249,6 +260,10 @@ public class SpdyFrameDecoder {
                     if ((length & 0x07) != 0 || length >> 3 != numSettings) {
                         state = State.FRAME_ERROR;
                         delegate.readFrameError("Invalid SETTINGS Frame");
+                    } else if (numSettings > maxNumSettings) {
+                        state = State.FRAME_ERROR;
+                        delegate.readFrameError("Invalid SETTINGS Frame (allowed number of settings exceeded: "
+                                + numSettings + " > " + maxNumSettings + ')');
                     } else {
                         state = State.READ_SETTING;
                         delegate.readSettingsFrame(clear);

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHeaderBlockZlibDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHeaderBlockZlibDecoder.java
@@ -29,12 +29,27 @@ final class SpdyHeaderBlockZlibDecoder extends SpdyHeaderBlockRawDecoder {
     private static final SpdyProtocolException INVALID_HEADER_BLOCK =
             new SpdyProtocolException("Invalid Header Block");
 
+    // Legitimate header blocks are bounded by maxHeaderSize, but framing overhead (the header
+    // count and the per-header name/value length prefixes) means the decompressed size of a
+    // wire-legitimate header block can exceed maxHeaderSize itself. A generous multiplier is used
+    // instead of an equal cap so this never rejects well-formed header blocks, while still
+    // preventing a maliciously compressible header block from forcing an effectively unbounded
+    // number of Inflater#inflate() calls on the calling (event-loop) thread.
+    private static final int MAX_DECOMPRESSED_SIZE_MULTIPLIER = 16;
+
     private final Inflater decompressor = new Inflater();
+    private final long maxDecompressedSize;
 
     private ByteBuf decompressed;
+    private long totalInflated;
 
     SpdyHeaderBlockZlibDecoder(SpdyVersion spdyVersion, int maxHeaderSize) {
         super(spdyVersion, maxHeaderSize);
+        maxDecompressedSize = calculateMaxDecompressedSizePerBlock(maxHeaderSize);
+    }
+
+    static long calculateMaxDecompressedSizePerBlock(int maxHeaderSize) {
+        return (long) maxHeaderSize * MAX_DECOMPRESSED_SIZE_MULTIPLIER;
     }
 
     @Override
@@ -44,6 +59,11 @@ final class SpdyHeaderBlockZlibDecoder extends SpdyHeaderBlockRawDecoder {
         int numBytes;
         do {
             numBytes = decompress(alloc, frame);
+            totalInflated += numBytes;
+            if (totalInflated > maxDecompressedSize) {
+                throw new SpdyProtocolException(
+                        "Decompressed header block exceeds " + maxDecompressedSize + " bytes");
+            }
         } while (numBytes > 0);
 
         // z_stream has an internal 64-bit hold buffer
@@ -107,6 +127,7 @@ final class SpdyHeaderBlockZlibDecoder extends SpdyHeaderBlockRawDecoder {
     void endHeaderBlock(SpdyHeadersFrame frame) throws Exception {
         super.endHeaderBlock(frame);
         releaseBuffer();
+        totalInflated = 0;
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpDecoder.java
@@ -140,13 +140,13 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
     }
 
     @Override
-    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+    public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
         // Release any outstanding messages from the map
         for (Map.Entry<Integer, FullHttpMessage> entry : messageMap.entrySet()) {
             ReferenceCountUtil.safeRelease(entry.getValue());
         }
         messageMap.clear();
-        super.channelInactive(ctx);
+        super.handlerRemoved(ctx);
     }
 
     protected FullHttpMessage putMessage(int streamId, FullHttpMessage message) {
@@ -202,8 +202,9 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
                     return;
                 }
 
+                FullHttpRequest httpRequestWithEntity = null;
                 try {
-                    FullHttpRequest httpRequestWithEntity = createHttpRequest(spdySynStreamFrame, ctx.alloc());
+                    httpRequestWithEntity = createHttpRequest(spdySynStreamFrame, ctx.alloc());
 
                     // Set the Stream-ID, Associated-To-Stream-ID, and Priority as headers
                     httpRequestWithEntity.headers().setInt(Names.STREAM_ID, streamId);
@@ -211,8 +212,11 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
                     httpRequestWithEntity.headers().setInt(Names.PRIORITY, spdySynStreamFrame.priority());
 
                     out.add(httpRequestWithEntity);
-
+                    httpRequestWithEntity = null;
                 } catch (Throwable ignored) {
+                    if (httpRequestWithEntity != null) {
+                        httpRequestWithEntity.release();
+                    }
                     SpdyRstStreamFrame spdyRstStreamFrame =
                         new DefaultSpdyRstStreamFrame(streamId, SpdyStreamStatus.PROTOCOL_ERROR);
                     ctx.writeAndFlush(spdyRstStreamFrame);
@@ -232,19 +236,28 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
                     return;
                 }
 
+                FullHttpRequest httpRequestWithEntity = null;
                 try {
-                    FullHttpRequest httpRequestWithEntity = createHttpRequest(spdySynStreamFrame, ctx.alloc());
+                    httpRequestWithEntity = createHttpRequest(spdySynStreamFrame, ctx.alloc());
 
                     // Set the Stream-ID as a header
                     httpRequestWithEntity.headers().setInt(Names.STREAM_ID, streamId);
 
                     if (spdySynStreamFrame.isLast()) {
                         out.add(httpRequestWithEntity);
+                        httpRequestWithEntity = null;
                     } else {
                         // Request body will follow in a series of Data Frames
-                        putMessage(streamId, httpRequestWithEntity);
+                        FullHttpMessage old = putMessage(streamId, httpRequestWithEntity);
+                        httpRequestWithEntity = null;
+                        if (old != null) {
+                            old.release();
+                        }
                     }
                 } catch (Throwable t) {
+                    if (httpRequestWithEntity != null) {
+                        httpRequestWithEntity.release();
+                    }
                     // If a client sends a SYN_STREAM without all of the getMethod, url (host and path),
                     // scheme, and version headers the server must reply with an HTTP 400 BAD REQUEST reply.
                     // Also sends HTTP 400 BAD REQUEST reply if header name/value pairs are invalid
@@ -271,9 +284,9 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
                 return;
             }
 
+            FullHttpResponse httpResponseWithEntity = null;
             try {
-                FullHttpResponse httpResponseWithEntity =
-                   createHttpResponse(spdySynReplyFrame, ctx.alloc());
+                httpResponseWithEntity = createHttpResponse(spdySynReplyFrame, ctx.alloc());
 
                 // Set the Stream-ID as a header
                 httpResponseWithEntity.headers().setInt(Names.STREAM_ID, streamId);
@@ -281,11 +294,19 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
                 if (spdySynReplyFrame.isLast()) {
                     HttpUtil.setContentLength(httpResponseWithEntity, 0);
                     out.add(httpResponseWithEntity);
+                    httpResponseWithEntity = null;
                 } else {
                     // Response body will follow in a series of Data Frames
-                    putMessage(streamId, httpResponseWithEntity);
+                    FullHttpMessage old = putMessage(streamId, httpResponseWithEntity);
+                    httpResponseWithEntity = null;
+                    if (old != null) {
+                        old.release();
+                    }
                 }
             } catch (Throwable t) {
+                if (httpResponseWithEntity != null) {
+                    httpResponseWithEntity.release();
+                }
                 // If a client receives a SYN_REPLY without valid getStatus and version headers
                 // the client must reply with a RST_STREAM frame indicating a PROTOCOL_ERROR
                 SpdyRstStreamFrame spdyRstStreamFrame =
@@ -321,11 +342,19 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
                         if (spdyHeadersFrame.isLast()) {
                             HttpUtil.setContentLength(fullHttpMessage, 0);
                             out.add(fullHttpMessage);
+                            fullHttpMessage = null;
                         } else {
                             // Response body will follow in a series of Data Frames
-                            putMessage(streamId, fullHttpMessage);
+                            FullHttpMessage old = putMessage(streamId, fullHttpMessage);
+                            fullHttpMessage = null;
+                            if (old != null) {
+                                old.release();
+                            }
                         }
                     } catch (Throwable t) {
+                        if (fullHttpMessage != null) {
+                            fullHttpMessage.release();
+                        }
                         // If a client receives a SYN_REPLY without valid getStatus and version headers
                         // the client must reply with a RST_STREAM frame indicating a PROTOCOL_ERROR
                         SpdyRstStreamFrame spdyRstStreamFrame =
@@ -345,7 +374,10 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
 
             if (spdyHeadersFrame.isLast()) {
                 HttpUtil.setContentLength(fullHttpMessage, fullHttpMessage.content().readableBytes());
-                removeMessage(streamId);
+                FullHttpMessage removed = removeMessage(streamId);
+                if (removed != null && removed != fullHttpMessage) {
+                    removed.release();
+                }
                 out.add(fullHttpMessage);
             }
 
@@ -362,7 +394,11 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
 
             ByteBuf content = fullHttpMessage.content();
             if (content.readableBytes() > maxContentLength - spdyDataFrame.content().readableBytes()) {
-                removeMessage(streamId);
+                FullHttpMessage removed = removeMessage(streamId);
+                if (removed != null && removed != fullHttpMessage) {
+                    removed.release();
+                }
+                fullHttpMessage.release();
                 throw new TooLongFrameException(
                         "HTTP content length exceeded " + maxContentLength + " bytes: "
                                 + spdyDataFrame.content().readableBytes());
@@ -374,7 +410,10 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
 
             if (spdyDataFrame.isLast()) {
                 HttpUtil.setContentLength(fullHttpMessage, content.readableBytes());
-                removeMessage(streamId);
+                FullHttpMessage removed = removeMessage(streamId);
+                if (removed != null && removed != fullHttpMessage) {
+                    removed.release();
+                }
                 out.add(fullHttpMessage);
             }
 
@@ -382,7 +421,10 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
 
             SpdyRstStreamFrame spdyRstStreamFrame = (SpdyRstStreamFrame) msg;
             int streamId = spdyRstStreamFrame.streamId();
-            removeMessage(streamId);
+            FullHttpMessage removed = removeMessage(streamId);
+            if (removed != null) {
+                removed.release();
+            }
         }
     }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentEncoderTest.java
@@ -22,6 +22,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.CodecException;
+import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.EncoderException;
 import io.netty.handler.codec.MessageToByteEncoder;
@@ -43,6 +44,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class HttpContentEncoderTest {
 
     private static final class TestEncoder extends HttpContentEncoder {
+
+        TestEncoder() {
+        }
+
+        TestEncoder(int maxPipelineDepth) {
+            super(maxPipelineDepth);
+        }
+
         @Override
         protected Result beginEncode(HttpResponse httpResponse, String acceptEncoding) {
             return new Result("test", new EmbeddedChannel(new MessageToByteEncoder<ByteBuf>() {
@@ -427,6 +436,18 @@ public class HttpContentEncoderTest {
 
         assertTrue(channelInactiveCalled.get());
         assertEquals(0, content.refCnt());
+    }
+
+    @Test
+    public void testPipelineDepthLimited() throws Exception {
+        EmbeddedChannel ch = new EmbeddedChannel(new TestEncoder(2));
+        ch.writeInbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/"));
+        ch.writeInbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/"));
+
+        assertThrows(DecoderException.class, () -> ch.writeInbound(
+                new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/")));
+
+        ch.finishAndReleaseAll();
     }
 
     private static void assertEmptyResponse(EmbeddedChannel ch) {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cors/CorsHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cors/CorsHandlerTest.java
@@ -665,6 +665,24 @@ public class CorsHandlerTest {
         assertFalse(ch.finish());
     }
 
+    @Test
+    public void shortCircuitWithNullOriginNotAllowedShouldBeForbidden() throws Exception {
+        final CorsConfig config = forOrigin("http://localhost:8080").shortCircuit().build();
+        final HttpResponse response = simpleRequest(config, "null");
+        assertEquals(FORBIDDEN, response.status());
+        assertEquals("0", response.headers().get(CONTENT_LENGTH));
+        assertTrue(ReferenceCountUtil.release(response));
+    }
+
+    @Test
+    public void shortCircuitWithNullOriginAllowedShouldSucceed() throws Exception {
+        final CorsConfig config = forOrigin("http://localhost:8080").allowNullOrigin().shortCircuit().build();
+        final HttpResponse response = simpleRequest(config, "null");
+        assertEquals(OK, response.status());
+        assertEquals("null", response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN));
+        assertTrue(ReferenceCountUtil.release(response));
+    }
+
     private static HttpResponse simpleRequest(final CorsConfig config, final String origin) throws Exception {
         return simpleRequest(config, origin, null);
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/DiskFileUploadTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/DiskFileUploadTest.java
@@ -19,10 +19,13 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.HttpConstants;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.PlatformDependent;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -32,6 +35,7 @@ import java.io.InputStream;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -286,5 +290,26 @@ public class DiskFileUploadTest {
         } finally {
             f1.delete();
         }
+    }
+
+    @ParameterizedTest
+    @ValueSource(bytes = {
+            0x00,
+            HttpConstants.CR,
+            HttpConstants.LF,
+            0x19,
+            HttpConstants.DEL,
+            HttpConstants.DOUBLE_QUOTE,
+            HttpConstants.BACKSLASH})
+    void filenameCannotContainIllegalCharacters(byte illegal) {
+        assertIllegalFilename(((char) illegal) + "f");
+        assertIllegalFilename("f" + ((char) illegal) + "f");
+        assertIllegalFilename("f" + ((char) illegal));
+    }
+
+    private static void assertIllegalFilename(String filename) {
+        assertThatThrownBy(() -> new DiskFileUpload("f", filename, "plain/text", null, null, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Illegal filename character");
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostMultiPartRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostMultiPartRequestDecoderTest.java
@@ -96,6 +96,50 @@ public class HttpPostMultiPartRequestDecoderTest {
     }
 
     @Test
+    public void decodeMustCleanFilenameCharacters() {
+        String content = "\n--861fbeab-cd20-470c-9609-d40a0f704466\r\n" +
+                "content-disposition: form-data; " +
+                "name=\"file\"; filename=\" dir\\file\0\u007F÷.txt \"\r\n" +
+                "content-type: text/plain\r\n" +
+                "Content-Length: 1\r\n\r\n" +
+                "x\r\n--861fbeab-cd20-470c-9609-d40a0f704466--\r\n";
+        FullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/upload",
+                Unpooled.copiedBuffer(content, CharsetUtil.UTF_8));
+        req.headers().set("content-type", "multipart/form-data; boundary=861fbeab-cd20-470c-9609-d40a0f704466");
+        req.headers().set("content-length", content.length());
+
+        HttpPostMultipartRequestDecoder test = new HttpPostMultipartRequestDecoder(req);
+        FileUpload httpData = (FileUpload) test.getBodyHttpDatas("file").get(0);
+        try {
+            assertEquals("dirfile  ÷.txt", httpData.getFilename());
+        } finally {
+            test.destroy();
+        }
+    }
+
+    @Test
+    public void decodeMustCleanFilenamePercentEncodedCharacters() {
+        String content = "\n--861fbeab-cd20-470c-9609-d40a0f704466\r\n" +
+                "content-disposition: form-data; " +
+                "name=\"file\"; filename*=UTF-8''\"%20dir\\file%00%13%7F÷.txt%20\"\r\n" +
+                "content-type: text/plain\r\n" +
+                "Content-Length: 1\r\n\r\n" +
+                "x\r\n--861fbeab-cd20-470c-9609-d40a0f704466--\r\n";
+        FullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/upload",
+                Unpooled.copiedBuffer(content, CharsetUtil.UTF_8));
+        req.headers().set("content-type", "multipart/form-data; boundary=861fbeab-cd20-470c-9609-d40a0f704466");
+        req.headers().set("content-length", content.length());
+
+        HttpPostMultipartRequestDecoder test = new HttpPostMultipartRequestDecoder(req);
+        FileUpload httpData = (FileUpload) test.getBodyHttpDatas("file").get(0);
+        try {
+            assertEquals("dirfile   ÷.txt", httpData.getFilename());
+        } finally {
+            test.destroy();
+        }
+    }
+
+    @Test
     public void testDelimiterExceedLeftSpaceInCurrentBuffer() {
         String delimiter = "--861fbeab-cd20-470c-9609-d40a0f704466";
         String suffix = '\n' + delimiter + "--\n";

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/MemoryFileUploadTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/MemoryFileUploadTest.java
@@ -15,8 +15,12 @@
  */
 package io.netty.handler.codec.http.multipart;
 
+import io.netty.handler.codec.http.HttpConstants;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MemoryFileUploadTest {
@@ -26,5 +30,26 @@ public class MemoryFileUploadTest {
         MemoryFileUpload f1 =
                 new MemoryFileUpload("m1", "m1", "application/json", null, null, 100);
         assertEquals(f1, f1);
+    }
+
+    @ParameterizedTest
+    @ValueSource(bytes = {
+            0x00,
+            HttpConstants.CR,
+            HttpConstants.LF,
+            0x19,
+            HttpConstants.DEL,
+            HttpConstants.DOUBLE_QUOTE,
+            HttpConstants.BACKSLASH})
+    void filenameCannotContainIllegalCharacters(byte illegal) {
+        assertIllegalFilename(((char) illegal) + "f");
+        assertIllegalFilename("f" + ((char) illegal) + "f");
+        assertIllegalFilename("f" + ((char) illegal));
+    }
+
+    private static void assertIllegalFilename(String filename) {
+        assertThatThrownBy(() -> new MemoryFileUpload("f", filename, "plain/text", null, null, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Illegal filename character");
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker00Test.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker00Test.java
@@ -128,4 +128,19 @@ public class WebSocketServerHandshaker00Test extends WebSocketServerHandshakerTe
         content.release();
         req.release();
     }
+
+    @Override
+    public void testHandshakeExceptionWhenConnectionHeaderIsAbsent() {
+        // ignore
+    }
+
+    @Override
+    public void testHandshakeExceptionWhenInvalidConnectionHeader() {
+        // ignore
+    }
+
+    @Override
+    public void testHandshakeExceptionWhenInvalidUpgradeHeader() {
+        // ignore
+    }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13Test.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13Test.java
@@ -113,7 +113,7 @@ public class WebSocketServerHandshaker13Test extends WebSocketServerHandshakerTe
             }
         });
 
-        assertEquals("not a WebSocket request: a |Connection| header must includes a token 'Upgrade'",
+        assertEquals("not a WebSocket request: a |Connection| header must include a token 'Upgrade'",
                      exception.getMessage());
         assertTrue(request.release());
     }
@@ -139,7 +139,7 @@ public class WebSocketServerHandshaker13Test extends WebSocketServerHandshakerTe
             }
         });
 
-        assertEquals("not a WebSocket request: a |Connection| header must includes a token 'Upgrade'",
+        assertEquals("not a WebSocket request: a |Connection| header must include a token 'Upgrade'",
                      exception.getMessage());
         assertTrue(request.release());
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshakerTest.java
@@ -38,6 +38,7 @@ import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.CharsetUtil;
 import io.netty.util.concurrent.Future;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import static io.netty.handler.codec.http.HttpResponseStatus.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -176,5 +177,82 @@ public abstract class WebSocketServerHandshakerTest {
         }
 
         assertFalse(channel.finish());
+    }
+
+    @Test
+    public void testHandshakeExceptionWhenConnectionHeaderIsAbsent() {
+        final WebSocketServerHandshaker serverHandshaker = newHandshaker("ws://example.com/chat",
+                "chat", WebSocketDecoderConfig.DEFAULT);
+        final FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
+                "ws://example.com/chat");
+        request.headers()
+                .set(HttpHeaderNames.HOST, "server.example.com")
+                .set(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET)
+                .set(HttpHeaderNames.SEC_WEBSOCKET_KEY, "dGhlIHNhbXBsZSBub25jZQ==")
+                .set(HttpHeaderNames.SEC_WEBSOCKET_ORIGIN, "http://example.com")
+                .set(HttpHeaderNames.SEC_WEBSOCKET_PROTOCOL, "chat, superchat")
+                .set(HttpHeaderNames.SEC_WEBSOCKET_VERSION, "13");
+        Throwable exception = assertThrows(WebSocketServerHandshakeException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                serverHandshaker.handshake(null, request, null, null);
+            }
+        });
+
+        assertEquals("not a WebSocket request: a |Connection| header must include a token 'Upgrade'",
+                exception.getMessage());
+        assertTrue(request.release());
+    }
+
+    @Test
+    public void testHandshakeExceptionWhenInvalidConnectionHeader() {
+        final WebSocketServerHandshaker serverHandshaker = newHandshaker("ws://example.com/chat",
+                "chat", WebSocketDecoderConfig.DEFAULT);
+        final FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
+                "ws://example.com/chat");
+        request.headers()
+                .set(HttpHeaderNames.HOST, "server.example.com")
+                .set(HttpHeaderNames.CONNECTION, "close")
+                .set(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET)
+                .set(HttpHeaderNames.SEC_WEBSOCKET_KEY, "dGhlIHNhbXBsZSBub25jZQ==")
+                .set(HttpHeaderNames.SEC_WEBSOCKET_ORIGIN, "http://example.com")
+                .set(HttpHeaderNames.SEC_WEBSOCKET_PROTOCOL, "chat, superchat")
+                .set(HttpHeaderNames.SEC_WEBSOCKET_VERSION, "13");
+        Throwable exception = assertThrows(WebSocketServerHandshakeException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                serverHandshaker.handshake(null, request, null, null);
+            }
+        });
+
+        assertEquals("not a WebSocket request: a |Connection| header must include a token 'Upgrade'",
+                exception.getMessage());
+        assertTrue(request.release());
+    }
+
+    @Test
+    public void testHandshakeExceptionWhenInvalidUpgradeHeader() {
+        final WebSocketServerHandshaker serverHandshaker = newHandshaker("ws://example.com/chat",
+                "chat", WebSocketDecoderConfig.DEFAULT);
+        final FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
+                "ws://example.com/chat");
+        request.headers()
+                .set(HttpHeaderNames.HOST, "server.example.com")
+                .set(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE)
+                .set(HttpHeaderNames.UPGRADE, "my_websocket")
+                .set(HttpHeaderNames.SEC_WEBSOCKET_KEY, "dGhlIHNhbXBsZSBub25jZQ==")
+                .set(HttpHeaderNames.SEC_WEBSOCKET_ORIGIN, "http://example.com")
+                .set(HttpHeaderNames.SEC_WEBSOCKET_PROTOCOL, "chat, superchat")
+                .set(HttpHeaderNames.SEC_WEBSOCKET_VERSION, "13");
+        Throwable exception = assertThrows(WebSocketServerHandshakeException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                serverHandshaker.handshake(null, request, null, null);
+            }
+        });
+
+        assertEquals("not a WebSocket request: an |Upgrade| header must containing the value 'websocket'",
+                exception.getMessage());
+        assertTrue(request.release());
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyFrameDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyFrameDecoderTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Random;
 
 import static io.netty.handler.codec.spdy.SpdyCodecUtil.SPDY_HEADER_SIZE;
+import static io.netty.handler.codec.spdy.SpdyFrameDecoder.DEFAULT_MAX_NUM_SETTINGS;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -818,6 +819,31 @@ public class SpdyFrameDecoderTest {
         ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(0); // invalid num_settings
+        for (int i = 0; i < numSettings; i++) {
+            buf.writeByte(idFlags);
+            buf.writeMedium(id);
+            buf.writeInt(value);
+        }
+
+        decoder.decode(buf);
+        verify(delegate).readFrameError(anyString());
+        assertFalse(buf.isReadable());
+        buf.release();
+    }
+
+    @Test
+    public void testSpdySettingsFrameContainTooManySettings() throws Exception {
+        short type = 4;
+        byte flags = 0;
+        int numSettings = DEFAULT_MAX_NUM_SETTINGS * 2;
+        int length = 8 * numSettings + 4;
+        byte idFlags = 0;
+        int id = RANDOM.nextInt() & 0x00FFFFFF;
+        int value = RANDOM.nextInt();
+
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
+        encodeControlFrameHeader(buf, type, flags, length);
+        buf.writeInt(numSettings);
         for (int i = 0; i < numSettings; i++) {
             buf.writeByte(idFlags);
             buf.writeMedium(id);

--- a/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyHeaderBlockZlibDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyHeaderBlockZlibDecoderTest.java
@@ -23,6 +23,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
+import java.io.ByteArrayOutputStream;
+import java.util.zip.Deflater;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -35,6 +38,9 @@ public class SpdyHeaderBlockZlibDecoderTest {
     private static final byte[] zlibSyncFlush = {0x00, 0x00, 0x00, (byte) 0xff, (byte) 0xff};
 
     private static final int maxHeaderSize = 8192;
+
+    private static final long MAX_DECOMPRESSED_SIZE =
+            SpdyHeaderBlockZlibDecoder.calculateMaxDecompressedSizePerBlock(maxHeaderSize);
 
     private static final String name = "name";
     private static final String value = "value";
@@ -241,5 +247,69 @@ public class SpdyHeaderBlockZlibDecoderTest {
         });
 
         headerBlock.release();
+    }
+
+    @Test
+    public void testHeaderBlockAtDecompressionCapIsAccepted() throws Exception {
+        long valueLength = MAX_DECOMPRESSED_SIZE - headerBlockOverhead();
+        ByteBuf headerBlock = Unpooled.wrappedBuffer(deflate(buildHeaderBlock((int) valueLength)));
+
+        decoder.decode(ByteBufAllocator.DEFAULT, headerBlock, frame);
+        decoder.endHeaderBlock(frame);
+
+        assertFalse(frame.isInvalid());
+        assertTrue(frame.isTruncated());
+
+        headerBlock.release();
+    }
+
+    @Test
+    public void testHeaderBlockExceedingDecompressionCapThrows() throws Exception {
+        long valueLength = MAX_DECOMPRESSED_SIZE - headerBlockOverhead() + 1;
+        final ByteBuf headerBlock = Unpooled.wrappedBuffer(deflate(buildHeaderBlock((int) valueLength)));
+
+        assertThrows(SpdyProtocolException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                decoder.decode(ByteBufAllocator.DEFAULT, headerBlock, frame);
+            }
+        });
+
+        headerBlock.release();
+    }
+
+    // 4 bytes for the header count, 4 bytes for the name length, the 1-byte name itself,
+    // and 4 bytes for the value length: everything but the value payload.
+    private static long headerBlockOverhead() {
+        return 4 + 4 + 1 + 4;
+    }
+
+    private static byte[] buildHeaderBlock(int valueLength) {
+        ByteBuf buf = Unpooled.buffer((int) headerBlockOverhead() + valueLength);
+        buf.writeInt(1); // number of Name/Value pairs
+        buf.writeInt(1); // length of name
+        buf.writeByte('n');
+        buf.writeInt(valueLength);
+        buf.writeZero(valueLength);
+
+        byte[] bytes = new byte[buf.readableBytes()];
+        buf.readBytes(bytes);
+        buf.release();
+        return bytes;
+    }
+
+    private static byte[] deflate(byte[] input) {
+        Deflater deflater = new Deflater(Deflater.BEST_COMPRESSION);
+        deflater.setInput(input);
+        deflater.finish();
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        byte[] chunk = new byte[8192];
+        while (!deflater.finished()) {
+            int n = deflater.deflate(chunk);
+            out.write(chunk, 0, n);
+        }
+        deflater.end();
+        return out.toByteArray();
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingDecompressorFrameListener.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingDecompressorFrameListener.java
@@ -29,6 +29,8 @@ import io.netty.handler.codec.compression.ZlibCodecFactory;
 import io.netty.handler.codec.compression.ZlibWrapper;
 import io.netty.handler.codec.compression.SnappyFrameDecoder;
 
+import java.nio.channels.ClosedChannelException;
+
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_ENCODING;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
 import static io.netty.handler.codec.http.HttpHeaderValues.BR;
@@ -427,6 +429,15 @@ public class DelegatingDecompressorFrameListener extends Http2FrameListenerDecor
                 this.dataDecompressed = false;
                 this.targetCtx = ctx;
 
+                if (!decompressor.isOpen()) {
+                    // Directly throw an exception in this case which we will handle in the catch block below.
+                    // This is required as otherwise it will impossible for us to know if the used EmbeddedChannel
+                    // did throw because it was closed already or because of other reasons. We need this knowledge
+                    // to know if we need to call data.release() ourselves after it was retained or not. This is needed
+                    // as EmbeddedChannel will not release the buffer if it throws because it was not open.
+                    // This mimics what EmbeddedChannel will throw.
+                    throw new ClosedChannelException();
+                }
                 // call retain here as it will call release after its written to the channel
                 decompressor.writeInbound(data.retain());
                 if (endOfStream) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
@@ -833,12 +833,16 @@ public final class HttpConversionUtil {
         void translateHeaders(Iterable<Entry<CharSequence, CharSequence>> inputHeaders) throws Http2Exception {
             // lazily created as needed
             StringBuilder cookies = null;
+            boolean hostHeaderFound = false;
 
             for (Entry<CharSequence, CharSequence> entry : inputHeaders) {
                 final CharSequence name = entry.getKey();
                 final CharSequence value = entry.getValue();
                 AsciiString translatedName = translations.get(name);
                 if (translatedName != null) {
+                    if (translatedName.contentEqualsIgnoreCase(HttpHeaderNames.HOST)) {
+                        hostHeaderFound = true;
+                    }
                     output.add(translatedName, AsciiString.of(value));
                 } else if (!Http2Headers.PseudoHeaderName.isPseudoHeader(name)) {
                     // https://tools.ietf.org/html/rfc7540#section-8.1.2.3
@@ -856,6 +860,20 @@ public final class HttpConversionUtil {
                             cookies.append("; ");
                         }
                         cookies.append(value);
+                    } else if (contentEqualsIgnoreCase(HttpHeaderNames.HOST, name)) {
+                        // https://www.rfc-editor.org/rfc/rfc9113#section-8.3.1 requires that intermediaries
+                        // translating to HTTP/1.x treat a literal 'host' header that conflicts with ':authority'
+                        // as malformed, and RFC 9110 section 7.2 requires 'Host' be sent as a single field-value.
+                        // Reject the request rather than emitting an HTTP/1.x message with duplicate Host headers.
+                        if (hostHeaderFound) {
+                            if (!contentEqualsIgnoreCase(output.get(HttpHeaderNames.HOST), value)) {
+                                throw streamError(streamId, PROTOCOL_ERROR,
+                                        "Conflicting ':authority' and 'host' headers found");
+                            }
+                        } else {
+                            hostHeaderFound = true;
+                            output.add(name, value);
+                        }
                     } else {
                         output.add(name, value);
                     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
@@ -382,6 +382,38 @@ public class HttpConversionUtilTest {
     }
 
     @Test
+    public void addHttp2ToHttpHeadersDeduplicatesMatchingAuthorityAndHost() throws Http2Exception {
+        Http2Headers inHeaders = new DefaultHttp2Headers();
+        inHeaders.authority("example.com");
+        inHeaders.add(HOST, "example.com");
+
+        HttpHeaders outHeaders = new DefaultHttpHeaders();
+
+        HttpConversionUtil.addHttp2ToHttpHeaders(5, inHeaders, outHeaders, HttpVersion.HTTP_1_1, false, true);
+        assertEquals(1, outHeaders.getAll(HOST).size());
+        assertEquals("example.com", outHeaders.get(HOST));
+    }
+
+    @Test
+    public void addHttp2ToHttpHeadersRejectsConflictingAuthorityAndHost() {
+        final Http2Headers inHeaders = new DefaultHttp2Headers();
+        inHeaders.authority("public.example.com");
+        inHeaders.add(HOST, "internal-admin.local");
+
+        final HttpHeaders outHeaders = new DefaultHttpHeaders();
+
+        Http2Exception exception = assertThrows(Http2Exception.class, new Executable() {
+            @Override
+            public void execute() throws Http2Exception {
+                HttpConversionUtil.addHttp2ToHttpHeaders(5, inHeaders, outHeaders, HttpVersion.HTTP_1_1, false, true);
+            }
+        });
+        assertEquals(Http2Error.PROTOCOL_ERROR, exception.error());
+        // No Host header should have leaked through in an inconsistent state.
+        assertFalse(outHeaders.contains(HOST) && outHeaders.getAll(HOST).size() > 1);
+    }
+
+    @Test
     public void connectionSpecificHeadersShouldBeRemoved() {
         HttpHeaders inHeaders = new DefaultHttpHeaders();
         inHeaders.add(CONNECTION, "keep-alive");

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ClientConnectionHandler.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ClientConnectionHandler.java
@@ -84,7 +84,8 @@ public class Http3ClientConnectionHandler extends Http3ConnectionHandler {
                                         @Nullable Http3Settings.NonStandardHttp3SettingsValidator
                                                 nonStandardSettingsValidator) {
         this(inboundControlStreamHandler, pushStreamHandlerFactory, unknownInboundStreamHandlerFactory,
-                localSettings, disableQpackDynamicTable, nonStandardSettingsValidator, null);
+                localSettings, disableQpackDynamicTable, nonStandardSettingsValidator, null,
+                Http3CodecUtils.DEFAULT_MAX_UNKNOWN_FRAME_PAYLOAD_LENGTH);
     }
 
     /**
@@ -107,6 +108,7 @@ public class Http3ClientConnectionHandler extends Http3ConnectionHandler {
      *                                              when validating settings that are non-standard.
      * @param sensitivityDetector                   detector that marks sensitive headers for QPACK Never Indexed
      *                                              encoding, or {@code null} to use the historical default.
+     * @param maxUnknownFramePayloadLength          the maximum payload size of an unknown frame.
      */
     public Http3ClientConnectionHandler(@Nullable ChannelHandler inboundControlStreamHandler,
                                         @Nullable LongFunction<ChannelHandler> pushStreamHandlerFactory,
@@ -114,9 +116,11 @@ public class Http3ClientConnectionHandler extends Http3ConnectionHandler {
                                         @Nullable Http3SettingsFrame localSettings, boolean disableQpackDynamicTable,
                                         @Nullable Http3Settings.NonStandardHttp3SettingsValidator
                                                 nonStandardSettingsValidator,
-                                        @Nullable QpackSensitivityDetector sensitivityDetector) {
+                                        @Nullable QpackSensitivityDetector sensitivityDetector,
+                                        int maxUnknownFramePayloadLength) {
         super(false, inboundControlStreamHandler, unknownInboundStreamHandlerFactory, localSettings,
-                disableQpackDynamicTable, nonStandardSettingsValidator, sensitivityDetector);
+                disableQpackDynamicTable, nonStandardSettingsValidator, sensitivityDetector,
+                maxUnknownFramePayloadLength);
         this.pushStreamHandlerFactory = pushStreamHandlerFactory;
     }
 

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3CodecUtils.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3CodecUtils.java
@@ -64,6 +64,9 @@ final class Http3CodecUtils {
      */
     static final long DEFAULT_MAX_FIELD_SECTION_SIZE = 8192;
 
+    // Let's use 32kb as max
+    static final int DEFAULT_MAX_UNKNOWN_FRAME_PAYLOAD_LENGTH = 32 * 1024;
+
     private Http3CodecUtils() { }
 
     static long checkIsReservedFrameType(long type) {

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ConnectionHandler.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ConnectionHandler.java
@@ -57,20 +57,23 @@ public abstract class Http3ConnectionHandler implements ChannelInboundHandler {
      * @param localSettings                         the local {@link Http3SettingsFrame} that should be sent to the
      *                                              remote peer or {@code null} if the default settings should be used.
      * @param disableQpackDynamicTable              If QPACK dynamic table should be disabled.
+     * @param maxUnknownFramePayloadLength          the maximum payload size of an unknown frame.
      */
     Http3ConnectionHandler(boolean server, @Nullable ChannelHandler inboundControlStreamHandler,
                            @Nullable LongFunction<ChannelHandler> unknownInboundStreamHandlerFactory,
                            @Nullable Http3SettingsFrame localSettings, boolean disableQpackDynamicTable,
-                           @Nullable Http3Settings.NonStandardHttp3SettingsValidator nonStandardSettingsValidator) {
+                           @Nullable Http3Settings.NonStandardHttp3SettingsValidator nonStandardSettingsValidator,
+                           int maxUnknownFramePayloadLength) {
         this(server, inboundControlStreamHandler, unknownInboundStreamHandlerFactory, localSettings,
-                disableQpackDynamicTable, nonStandardSettingsValidator, null);
+                disableQpackDynamicTable, nonStandardSettingsValidator, null, maxUnknownFramePayloadLength);
     }
 
     Http3ConnectionHandler(boolean server, @Nullable ChannelHandler inboundControlStreamHandler,
                            @Nullable LongFunction<ChannelHandler> unknownInboundStreamHandlerFactory,
                            @Nullable Http3SettingsFrame localSettings, boolean disableQpackDynamicTable,
                            @Nullable Http3Settings.NonStandardHttp3SettingsValidator nonStandardSettingsValidator,
-                           @Nullable QpackSensitivityDetector sensitivityDetector) {
+                           @Nullable QpackSensitivityDetector sensitivityDetector,
+                           int maxUnknownFramePayloadLength) {
         this.unknownInboundStreamHandlerFactory = unknownInboundStreamHandlerFactory;
         this.disableQpackDynamicTable = disableQpackDynamicTable;
         if (nonStandardSettingsValidator != null) {
@@ -103,7 +106,8 @@ public abstract class Http3ConnectionHandler implements ChannelInboundHandler {
         );
         qpackDecoder = new QpackDecoder(maxTableCapacity, maxBlockedStreams);
         qpackEncoder = new QpackEncoder(sensitivityDetector);
-        codecFactory = Http3FrameCodec.newFactory(qpackDecoder, maxFieldSectionSize, qpackEncoder);
+        codecFactory = Http3FrameCodec.newFactory(
+                qpackDecoder, maxFieldSectionSize, maxUnknownFramePayloadLength, qpackEncoder);
         remoteControlStreamHandler =  new Http3ControlStreamOutboundHandler(server, localSettings,
                 codecFactory.newCodec(Http3FrameTypeValidator.NO_VALIDATION, NO_STATE, NO_STATE,
                         this.nonStandardSettingsValidator));

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3FrameCodec.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3FrameCodec.java
@@ -52,6 +52,7 @@ import static io.netty.handler.codec.http3.Http3CodecUtils.readVariableLengthInt
 import static io.netty.handler.codec.http3.Http3CodecUtils.writeVariableLengthInteger;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static io.netty.util.internal.ObjectUtil.checkPositive;
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
 /**
  * Decodes / encodes {@link Http3Frame}s.
@@ -59,6 +60,7 @@ import static io.netty.util.internal.ObjectUtil.checkPositive;
 final class Http3FrameCodec extends ByteToMessageDecoder implements ChannelOutboundHandler {
     private final Http3FrameTypeValidator validator;
     private final long maxHeaderListSize;
+    private final int maxUnknownFramePayloadLength;
     private final QpackDecoder qpackDecoder;
     private final QpackEncoder qpackEncoder;
     private final Http3RequestStreamCodecState encodeState;
@@ -73,23 +75,29 @@ final class Http3FrameCodec extends ByteToMessageDecoder implements ChannelOutbo
     private WriteResumptionListener writeResumptionListener;
 
     static Http3FrameCodecFactory newFactory(QpackDecoder qpackDecoder,
-                                             long maxHeaderListSize, QpackEncoder qpackEncoder) {
+                                             long maxHeaderListSize, int maxUnknownFramePayloadLength,
+                                             QpackEncoder qpackEncoder) {
         checkNotNull(qpackEncoder, "qpackEncoder");
         checkNotNull(qpackDecoder, "qpackDecoder");
+        checkPositive(maxHeaderListSize, "maxHeaderListSize");
+        checkPositive(maxUnknownFramePayloadLength, "maxUnknownFramePayloadLength");
 
         // QPACK decoder and encoder are shared between streams in a connection.
         return (validator, encodeState, decodeState,
                 nonStandardSettingsValidator) -> new Http3FrameCodec(validator, qpackDecoder,
-                maxHeaderListSize, qpackEncoder, encodeState, decodeState, nonStandardSettingsValidator);
+                maxHeaderListSize, maxUnknownFramePayloadLength, qpackEncoder,
+                encodeState, decodeState, nonStandardSettingsValidator);
     }
 
     Http3FrameCodec(Http3FrameTypeValidator validator, QpackDecoder qpackDecoder,
-                    long maxHeaderListSize, QpackEncoder qpackEncoder, Http3RequestStreamCodecState encodeState,
+                    long maxHeaderListSize, int maxUnknownFramePayloadLength,
+                    QpackEncoder qpackEncoder, Http3RequestStreamCodecState encodeState,
                     Http3RequestStreamCodecState decodeState,
                     Http3Settings.NonStandardHttp3SettingsValidator nonStandardSettingsValidator) {
         this.validator = checkNotNull(validator, "validator");
         this.qpackDecoder = checkNotNull(qpackDecoder, "qpackDecoder");
         this.maxHeaderListSize = checkPositive(maxHeaderListSize, "maxHeaderListSize");
+        this.maxUnknownFramePayloadLength = checkPositive(maxUnknownFramePayloadLength, "maxUnknownFramePayloadLength");
         this.qpackEncoder = checkNotNull(qpackEncoder, "qpackEncoder");
         this.encodeState = checkNotNull(encodeState, "encodeState");
         this.decodeState = checkNotNull(decodeState, "decodeState");
@@ -336,7 +344,8 @@ final class Http3FrameCodec extends ByteToMessageDecoder implements ChannelOutbo
                 }
                 // Handling reserved frame types
                 // https://tools.ietf.org/html/draft-ietf-quic-http-32#section-7.2.8
-                if (in.readableBytes() < payLoadLength) {
+                if (!enforceMaxPayloadLength(ctx, in, type, payLoadLength,
+                        maxUnknownFramePayloadLength, Http3ErrorCode.H3_EXCESSIVE_LOAD)) {
                     return 0;
                 }
                 out.add(new DefaultHttp3UnknownFrame(longType, in.readRetainedSlice(payLoadLength)));

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ServerConnectionHandler.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3ServerConnectionHandler.java
@@ -88,7 +88,8 @@ public final class Http3ServerConnectionHandler extends Http3ConnectionHandler {
                                         @Nullable Http3Settings.NonStandardHttp3SettingsValidator
                                                 nonStandardSettingsValidator) {
         this(requestStreamHandler, inboundControlStreamHandler, unknownInboundStreamHandlerFactory,
-                localSettings, disableQpackDynamicTable, nonStandardSettingsValidator, null);
+                localSettings, disableQpackDynamicTable, nonStandardSettingsValidator, null,
+                Http3CodecUtils.DEFAULT_MAX_UNKNOWN_FRAME_PAYLOAD_LENGTH);
     }
 
     /**
@@ -109,6 +110,7 @@ public final class Http3ServerConnectionHandler extends Http3ConnectionHandler {
      *                                              use when validating settings that are non-standard.
      * @param sensitivityDetector                   detector that marks sensitive headers for QPACK Never Indexed
      *                                              encoding, or {@code null} to use the historical default.
+     * @param maxUnknownFramePayloadLength          the maximum payload size of an unknown frame.
      */
     public Http3ServerConnectionHandler(ChannelHandler requestStreamHandler,
                                         @Nullable ChannelHandler inboundControlStreamHandler,
@@ -116,9 +118,11 @@ public final class Http3ServerConnectionHandler extends Http3ConnectionHandler {
                                         @Nullable Http3SettingsFrame localSettings, boolean disableQpackDynamicTable,
                                         @Nullable Http3Settings.NonStandardHttp3SettingsValidator
                                                 nonStandardSettingsValidator,
-                                        @Nullable QpackSensitivityDetector sensitivityDetector) {
+                                        @Nullable QpackSensitivityDetector sensitivityDetector,
+                                        int maxUnknownFramePayloadLength) {
         super(true, inboundControlStreamHandler, unknownInboundStreamHandlerFactory, localSettings,
-                disableQpackDynamicTable, nonStandardSettingsValidator, sensitivityDetector);
+                disableQpackDynamicTable, nonStandardSettingsValidator, sensitivityDetector,
+                maxUnknownFramePayloadLength);
         this.requestStreamHandler = ObjectUtil.checkNotNull(requestStreamHandler, "requestStreamHandler");
     }
 

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3ClientConnectionHandlerTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3ClientConnectionHandlerTest.java
@@ -43,7 +43,8 @@ public class Http3ClientConnectionHandlerTest extends AbtractHttp3ConnectionHand
     public void customSensitivityDetectorIsForwardedToQpackEncoder() {
         Http3ClientConnectionHandler handler = new Http3ClientConnectionHandler(
                 null, null, null, null,
-                true, null, QpackSensitivityDetector.ALWAYS_SENSITIVE);
+                true, null, QpackSensitivityDetector.ALWAYS_SENSITIVE,
+                Http3CodecUtils.DEFAULT_MAX_UNKNOWN_FRAME_PAYLOAD_LENGTH);
 
         Http3Headers headers = new DefaultHttp3Headers(false);
         headers.add("x-custom", "value");

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3FrameCodecTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3FrameCodecTest.java
@@ -94,6 +94,11 @@ public class Http3FrameCodecTest {
     private EmbeddedQuicStreamChannel codecChannel;
 
     private void setUp(int maxBlockedStreams, boolean delayQpackStreams) throws Exception {
+        setUp(maxBlockedStreams, delayQpackStreams, Integer.MAX_VALUE);
+    }
+
+    private void setUp(int maxBlockedStreams, boolean delayQpackStreams, int maxUnknownFramePayloadLength)
+            throws Exception {
         parent = new EmbeddedQuicChannel(true);
         qpackAttributes = new QpackAttributes(parent, false);
         Http3.setQpackAttributes(parent, qpackAttributes);
@@ -133,7 +138,8 @@ public class Http3FrameCodecTest {
                         Http3RequestStreamDecodeStateValidator decStateValidator =
                                 new Http3RequestStreamDecodeStateValidator();
                         ch.pipeline().addLast(new Http3FrameCodec(Http3FrameTypeValidator.NO_VALIDATION, decoder,
-                                MAX_HEADER_SIZE, encoder, encStateValidator, decStateValidator, (id, v) -> false));
+                                MAX_HEADER_SIZE, maxUnknownFramePayloadLength, encoder,
+                                encStateValidator, decStateValidator, (id, v) -> false));
                         ch.pipeline().addLast(encStateValidator);
                         ch.pipeline().addLast(decStateValidator);
                     }
@@ -376,6 +382,17 @@ public class Http3FrameCodecTest {
         setUp(maxBlockedStreams, delayQpackStreams);
         testFrameEncodedAndDecoded(fragmented, maxBlockedStreams, delayQpackStreams,
                 new DefaultHttp3UnknownFrame(Http3CodecUtils.MIN_RESERVED_FRAME_TYPE, Unpooled.buffer().writeLong(8)));
+    }
+
+    @ParameterizedTest(name = "{index}: fragmented = {0}, maxBlockedStreams = {1}, delayQpackStreams = {2}")
+    @MethodSource("data")
+    public void testHttp3UnknownFrameWithInvalidPayloadLength(
+            boolean fragmented, int maxBlockedStreams, boolean delayQpackStreams) throws Exception {
+        setUp(maxBlockedStreams, delayQpackStreams, 127);
+        assertThrows(Http3Exception.class, () ->
+                testFrameEncodedAndDecoded(fragmented, maxBlockedStreams, delayQpackStreams,
+                        new DefaultHttp3UnknownFrame(Http3CodecUtils.MIN_RESERVED_FRAME_TYPE,
+                                Unpooled.buffer().writeZero(128))));
     }
 
     // Reserved types that were used in HTTP/2 and should close the connection with an error

--- a/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3ServerConnectionHandlerTest.java
+++ b/codec-http3/src/test/java/io/netty/handler/codec/http3/Http3ServerConnectionHandlerTest.java
@@ -52,7 +52,8 @@ public class Http3ServerConnectionHandlerTest extends AbtractHttp3ConnectionHand
     public void customSensitivityDetectorIsForwardedToQpackEncoder() {
         Http3ServerConnectionHandler handler = new Http3ServerConnectionHandler(
                 REQUEST_HANDLER, null, null, null,
-                true, null, QpackSensitivityDetector.ALWAYS_SENSITIVE);
+                true, null, QpackSensitivityDetector.ALWAYS_SENSITIVE,
+                Http3CodecUtils.DEFAULT_MAX_UNKNOWN_FRAME_PAYLOAD_LENGTH);
 
         Http3Headers headers = new DefaultHttp3Headers(false);
         headers.add("x-custom", "value");

--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisArrayAggregator.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisArrayAggregator.java
@@ -98,6 +98,11 @@ public final class RedisArrayAggregator extends MessageToMessageDecoder<RedisMes
         out.add(msg);
     }
 
+    private CodecException clearAndCreateException(String msg) {
+        releaseAndClearDepths();
+        return new CodecException(msg);
+    }
+
     private RedisMessage decodeRedisArrayHeader(ArrayHeaderRedisMessage header) {
         if (header.isNull()) {
             return ArrayRedisMessage.NULL_INSTANCE;
@@ -106,18 +111,17 @@ public final class RedisArrayAggregator extends MessageToMessageDecoder<RedisMes
         } else if (header.length() > 0L) {
             // Currently, this codec doesn't support `long` length for arrays because Java's List.size() is int.
             if (header.length() > maxElements) {
-                throw new CodecException("this codec doesn't support longer length than " + maxElements);
+                throw clearAndCreateException("this codec doesn't support longer length than " + maxElements);
             }
 
             if (depths.size() >= maxNestedArrayDepth) {
-                releaseAndClearDepths();
-                throw new CodecException("max nested array depth exceeded: "  + maxNestedArrayDepth);
+                throw clearAndCreateException("max nested array depth exceeded: "  + maxNestedArrayDepth);
             }
             // start aggregating array
             depths.push(new AggregateState((int) header.length()));
             return null;
         } else {
-            throw new CodecException("bad length: " + header.length());
+            throw clearAndCreateException("bad length: " + header.length());
         }
     }
 

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeDecoder.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeDecoder.java
@@ -41,6 +41,9 @@ import static io.netty.util.internal.ObjectUtil.*;
  * {@code maxChunkSize} The maximum length of the content or each chunk.  If the content length (or the length of each
  * chunk) exceeds this value, the content or chunk ill be split into multiple {@link StompContentSubframe}s whose length
  * is {@code maxChunkSize} at maximum.
+ * <br>
+ * {@code maxNumHeaders} The maximum number of headers per frame.
+ * If this limit exceeded a {@link TooLongFrameException} will be raised.
  *
  * <h3>Chunked Content</h3>
  * <p>
@@ -53,6 +56,7 @@ public class StompSubframeDecoder extends ByteToMessageDecoder {
 
     private static final int DEFAULT_CHUNK_SIZE = 8132;
     private static final int DEFAULT_MAX_LINE_LENGTH = 1024;
+    private static final int DEFAULT_MAX_NUMBER_HEADERS = 128;
 
     /**
      * @deprecated this should never be used by an user!
@@ -80,7 +84,7 @@ public class StompSubframeDecoder extends ByteToMessageDecoder {
     }
 
     public StompSubframeDecoder(boolean validateHeaders) {
-        this(DEFAULT_MAX_LINE_LENGTH, DEFAULT_CHUNK_SIZE, validateHeaders);
+        this(DEFAULT_MAX_LINE_LENGTH, DEFAULT_CHUNK_SIZE, DEFAULT_MAX_NUMBER_HEADERS, validateHeaders);
     }
 
     public StompSubframeDecoder(int maxLineLength, int maxChunkSize) {
@@ -88,11 +92,17 @@ public class StompSubframeDecoder extends ByteToMessageDecoder {
     }
 
     public StompSubframeDecoder(int maxLineLength, int maxChunkSize, boolean validateHeaders) {
+        this(maxLineLength, maxChunkSize, DEFAULT_MAX_NUMBER_HEADERS, validateHeaders);
+    }
+
+    public StompSubframeDecoder(int maxLineLength, int maxChunkSize, int maxNumHeaders, boolean validateHeaders) {
         checkPositive(maxLineLength, "maxLineLength");
         checkPositive(maxChunkSize, "maxChunkSize");
+        checkPositive(maxNumHeaders, "maxNumHeaders");
+
         this.maxChunkSize = maxChunkSize;
         commandParser = new Utf8LineParser(new AppendableCharSequence(16), maxLineLength);
-        headerParser = new HeaderParser(new AppendableCharSequence(128), maxLineLength, validateHeaders);
+        headerParser = new HeaderParser(new AppendableCharSequence(128), maxLineLength, maxNumHeaders, validateHeaders);
     }
 
     @Override
@@ -358,39 +368,40 @@ public class StompSubframeDecoder extends ByteToMessageDecoder {
     private static final class HeaderParser extends Utf8LineParser {
 
         private final boolean validateHeaders;
-
+        private final int maxNumHeaders;
+        private int numHeaders;
         private String name;
         private boolean valid;
 
         private boolean shouldUnescape;
         private boolean unescapeInProgress;
 
-        HeaderParser(AppendableCharSequence charSeq, int maxLineLength, boolean validateHeaders) {
+        HeaderParser(AppendableCharSequence charSeq, int maxLineLength, int maxNumHeaders, boolean validateHeaders) {
             super(charSeq, maxLineLength);
             this.validateHeaders = validateHeaders;
+            this.maxNumHeaders = maxNumHeaders;
         }
 
         boolean parseHeader(StompHeadersSubframe headersSubframe, ByteBuf buf) {
             shouldUnescape = shouldUnescape(headersSubframe.command());
-            for (;;) {
-                AppendableCharSequence value = super.parse(buf);
-                if (value == null) {
-                    return false;
-                }
-                if (name == null && value.length() == 0) {
-                    return true;
-                }
-                if (valid) {
-                    headersSubframe.headers().add(name, value.toString());
-                } else if (validateHeaders) {
-                    if (StringUtil.isNullOrEmpty(name)) {
-                        throw new IllegalArgumentException("received an invalid header line '" + value + '\'');
-                    }
-                    String line = name + ':' + value;
-                    throw new IllegalArgumentException("a header value or name contains a prohibited character ':'"
-                            + ", " + line);
+            AppendableCharSequence value = super.parse(buf);
+            if (value == null || (name == null && value.length() == 0)) {
+                numHeaders = 0;
+                return false;
+            }
+
+            numHeaders++;
+            if (maxNumHeaders < numHeaders) {
+                throw new TooLongFrameException("maximum number of headers exceeded: " + maxNumHeaders);
+            }
+            if (valid) {
+                headersSubframe.headers().add(name, value.toString());
+            } else if (validateHeaders) {
+                if (StringUtil.isNullOrEmpty(name)) {
+                    throw new IllegalArgumentException("received an invalid header line '" + value + '\'');
                 }
             }
+            return true;
         }
 
         @Override

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeDecoder.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeDecoder.java
@@ -384,24 +384,30 @@ public class StompSubframeDecoder extends ByteToMessageDecoder {
 
         boolean parseHeader(StompHeadersSubframe headersSubframe, ByteBuf buf) {
             shouldUnescape = shouldUnescape(headersSubframe.command());
-            AppendableCharSequence value = super.parse(buf);
-            if (value == null || (name == null && value.length() == 0)) {
-                numHeaders = 0;
-                return false;
-            }
-
-            numHeaders++;
-            if (maxNumHeaders < numHeaders) {
-                throw new TooLongFrameException("maximum number of headers exceeded: " + maxNumHeaders);
-            }
-            if (valid) {
-                headersSubframe.headers().add(name, value.toString());
-            } else if (validateHeaders) {
-                if (StringUtil.isNullOrEmpty(name)) {
-                    throw new IllegalArgumentException("received an invalid header line '" + value + '\'');
+            for (;;) {
+                AppendableCharSequence value = super.parse(buf);
+                if (value == null) {
+                    return false;
+                }
+                if (name == null && value.isEmpty()) {
+                    numHeaders = 0;
+                    return true;
+                }
+                numHeaders++;
+                if (maxNumHeaders < numHeaders) {
+                    throw new TooLongFrameException("maximum number of headers exceeded: " + maxNumHeaders);
+                }
+                if (valid) {
+                    headersSubframe.headers().add(name, value.toString());
+                } else if (validateHeaders) {
+                    if (StringUtil.isNullOrEmpty(name)) {
+                        throw new IllegalArgumentException("received an invalid header line '" + value + '\'');
+                    }
+                    String line = name + ':' + value;
+                    throw new IllegalArgumentException("a header value or name contains a prohibited character ':'"
+                            + ", " + line);
                 }
             }
-            return true;
         }
 
         @Override
@@ -409,7 +415,7 @@ public class StompSubframeDecoder extends ByteToMessageDecoder {
             if (nextByte == StompConstants.COLON) {
                 if (name == null) {
                     AppendableCharSequence charSeq = charSequence();
-                    if (charSeq.length() != 0) {
+                    if (!charSeq.isEmpty()) {
                         name = charSeq.substring(0, charSeq.length());
                         charSeq.reset();
                         valid = true;

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeEncoder.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeEncoder.java
@@ -21,6 +21,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageEncoder;
 import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.internal.AppendableCharSequence;
+import io.netty.util.internal.PlatformDependent;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -105,7 +106,12 @@ public class StompSubframeEncoder extends MessageToMessageEncoder<StompSubframe>
         } else if (msg instanceof StompHeadersSubframe) {
             StompHeadersSubframe stompHeadersSubframe = (StompHeadersSubframe) msg;
             ByteBuf buf = ctx.alloc().buffer(headersSubFrameSize(stompHeadersSubframe));
-            encodeHeaders(stompHeadersSubframe, buf);
+            try {
+                encodeHeaders(stompHeadersSubframe, buf);
+            } catch (Exception e) {
+                buf.release();
+                PlatformDependent.throwException(e);
+            }
 
             out.add(convertHeadersSubFrame(stompHeadersSubframe, buf));
         } else if (msg instanceof StompContentSubframe) {
@@ -162,7 +168,12 @@ public class StompSubframeEncoder extends MessageToMessageEncoder<StompSubframe>
     private ByteBuf encodeFullFrame(StompFrame frame, ChannelHandlerContext ctx) {
         int contentReadableBytes = frame.content().readableBytes();
         ByteBuf buf = ctx.alloc().buffer(headersSubFrameSize(frame) + contentReadableBytes);
-        encodeHeaders(frame, buf);
+        try {
+            encodeHeaders(frame, buf);
+        } catch (Exception e) {
+            buf.release();
+            PlatformDependent.throwException(e);
+        }
 
         if (contentReadableBytes > 0) {
             buf.writeBytes(frame.content());
@@ -180,19 +191,27 @@ public class StompSubframeEncoder extends MessageToMessageEncoder<StompSubframe>
         LinkedHashMap<CharSequence, CharSequence> cache = ESCAPE_HEADER_KEY_CACHE.get();
         for (Entry<CharSequence, CharSequence> entry : frame.headers()) {
             CharSequence headerKey = entry.getKey();
+            CharSequence headerValue = entry.getValue();
+            if (headerKey.length() == 0) {
+                throw new IllegalArgumentException("STOMP " + command + " contains empty header name");
+            }
             if (shouldEscape) {
                 CharSequence cachedHeaderKey = cache.get(headerKey);
                 if (cachedHeaderKey == null) {
-                    cachedHeaderKey = escape(headerKey);
+                    cachedHeaderKey = escape(command, "header name", headerKey);
                     cache.put(headerKey, cachedHeaderKey);
                 }
                 headerKey = cachedHeaderKey;
+                headerValue = escape(command, "header value", headerValue);
+            } else {
+                // For CONNECT/CONNECTED: don't escape but REJECT illegal characters
+                validateNoIllegalCharacters(command, headerKey, "header name");
+                validateNoIllegalCharacters(command, headerValue, "header value");
             }
 
             ByteBufUtil.writeUtf8(buf, headerKey);
             buf.writeByte(StompConstants.COLON);
 
-            CharSequence headerValue = shouldEscape? escape(entry.getValue()) : entry.getValue();
             ByteBufUtil.writeUtf8(buf, headerValue);
             buf.writeByte(StompConstants.LF);
         }
@@ -215,7 +234,21 @@ public class StompSubframeEncoder extends MessageToMessageEncoder<StompSubframe>
         return command != StompCommand.CONNECT && command != StompCommand.CONNECTED;
     }
 
-    private static CharSequence escape(CharSequence input) {
+    private static void validateNoIllegalCharacters(StompCommand command, CharSequence value, String type) {
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (c == '\n' || c == '\r' || c == ':' || c == '\0') {
+                throw newIllegalCharacterException(command, type, i);
+            }
+        }
+    }
+
+    private static IllegalArgumentException newIllegalCharacterException(StompCommand command, String type, int index) {
+        return new IllegalArgumentException(
+                "STOMP " + command + " " + type + " contains illegal character at index " + index);
+    }
+
+    private static CharSequence escape(StompCommand command, String type, CharSequence input) {
         AppendableCharSequence builder = null;
         for (int i = 0; i < input.length(); i++) {
             char chr = input.charAt(i);
@@ -231,6 +264,9 @@ public class StompSubframeEncoder extends MessageToMessageEncoder<StompSubframe>
             } else if (chr == '\r') {
                 builder = escapeBuilder(builder, input, i);
                 builder.append("\\r");
+            } else if (chr == '\0') {
+                // The NUL character has no escape and is always illegal.
+                throw newIllegalCharacterException(command, type, i);
             } else if (builder != null) {
                 builder.append(chr);
             }

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeDecoderTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeDecoderTest.java
@@ -18,6 +18,7 @@ package io.netty.handler.codec.stomp;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.TooLongFrameException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,6 +27,7 @@ import static io.netty.handler.codec.stomp.StompTestConstants.*;
 import static io.netty.util.CharsetUtil.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -495,5 +497,37 @@ public class StompSubframeDecoderTest {
         content.release();
 
         assertNull(channel.readInbound());
+    }
+
+    @Test
+    void testMaxNumHeadersEnforced() throws Exception {
+        // limit to 1 header as CONNECT_FRAME has 2.
+        channel = new EmbeddedChannel(new StompSubframeDecoder(1024, 1024, 1, true));
+
+        ByteBuf incoming = Unpooled.wrappedBuffer(CONNECT_FRAME.getBytes(UTF_8));
+        assertTrue(channel.writeInbound(incoming));
+
+        StompHeadersSubframe headersSubFrame = channel.readInbound();
+        assertNotNull(headersSubFrame);
+        assertTrue(headersSubFrame.decoderResult().isFailure());
+
+        assertInstanceOf(TooLongFrameException.class,
+                headersSubFrame.decoderResult().cause());
+    }
+
+    @Test
+    void testMaxNumHeadersEnforcedForInvalidHeaders() throws Exception {
+        // limit to 1 header as CONNECT_FRAME has 2.
+        channel = new EmbeddedChannel(new StompSubframeDecoder(1024, 1024, 2, false));
+
+        ByteBuf incoming = Unpooled.wrappedBuffer(FRAME_WITH_INVALID_HEADER.getBytes(UTF_8));
+        assertTrue(channel.writeInbound(incoming));
+
+        StompHeadersSubframe headersSubFrame = channel.readInbound();
+        assertNotNull(headersSubFrame);
+        assertTrue(headersSubFrame.decoderResult().isFailure());
+
+        assertInstanceOf(TooLongFrameException.class,
+                headersSubFrame.decoderResult().cause());
     }
 }

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeEncoderTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeEncoderTest.java
@@ -18,15 +18,19 @@ package io.netty.handler.codec.stomp;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.EncoderException;
 import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.nio.charset.StandardCharsets;
 
 import static io.netty.handler.codec.stomp.StompTestConstants.SEND_FRAME_UTF8;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -124,13 +128,44 @@ public class StompSubframeEncoderTest {
     }
 
     @Test
+    void mustRejectNulCharacterInHeaders() {
+        // The NUL character has no escape and is always rejected.
+        StompFrame frame1 = new DefaultStompFrame(StompCommand.MESSAGE);
+        frame1.headers()
+                .add("header\0", "value");
+        assertThatThrownBy(() -> channel.writeOutbound(frame1))
+                .isInstanceOf(EncoderException.class)
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("illegal character");
+
+        StompFrame frame2 = new DefaultStompFrame(StompCommand.CONNECT);
+        frame2.headers()
+                .add("header", "value\0");
+        assertThatThrownBy(() -> channel.writeOutbound(frame2))
+                .isInstanceOf(EncoderException.class)
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("illegal character");
+    }
+
+    @Test
+    void mustRejectEmptyHeaderNames() {
+        StompFrame frame1 = new DefaultStompFrame(StompCommand.MESSAGE);
+        frame1.headers()
+                .add("", "value");
+        assertThatThrownBy(() -> channel.writeOutbound(frame1))
+                .isInstanceOf(EncoderException.class)
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("empty header name");
+    }
+
+    @Test
     void testNotEscapeStompHeadersForConnectCommand() throws Exception {
         String expectedStompFrame = "CONNECT\n"
-                + "colonHeaderName-::colonHeaderValue-:\n"
+                + "backslashHeaderName-\\:backslashHeaderValue-\\\n"
                 + '\n' + '\0';
         StompFrame connectFrame = new DefaultStompFrame(StompCommand.CONNECT);
         connectFrame.headers()
-                  .add("colonHeaderName-:", "colonHeaderValue-:");
+                  .add("backslashHeaderName-\\", "backslashHeaderValue-\\");
 
         assertTrue(channel.writeOutbound(connectFrame));
 
@@ -142,14 +177,34 @@ public class StompSubframeEncoderTest {
         assertTrue(stompBuffer.release());
     }
 
+    @ParameterizedTest
+    @ValueSource(chars = {'\r', '\n', '\0', ':'})
+    void mustRejectIllegalCharsInConnectCommandHeaders(char illegalChar) {
+        StompFrame connectFrame1 = new DefaultStompFrame(StompCommand.CONNECT);
+        connectFrame1.headers()
+                .add("header" + illegalChar, "value");
+        assertThatThrownBy(() -> channel.writeOutbound(connectFrame1))
+                .isInstanceOf(EncoderException.class)
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("illegal character");
+
+        StompFrame connectFrame2 = new DefaultStompFrame(StompCommand.CONNECT);
+        connectFrame2.headers()
+                .add("header", "value" + illegalChar);
+        assertThatThrownBy(() -> channel.writeOutbound(connectFrame2))
+                .isInstanceOf(EncoderException.class)
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("illegal character");
+    }
+
     @Test
     void testNotEscapeStompHeadersForConnectedCommand() throws Exception {
         String expectedStompFrame = "CONNECTED\n"
-                                    + "colonHeaderName-::colonHeaderValue-:\n"
+                                    + "backslashHeaderName-\\:backslashHeaderValue-\\\n"
                                     + '\n' + '\0';
         StompFrame connectedFrame = new DefaultStompFrame(StompCommand.CONNECTED);
         connectedFrame.headers()
-                    .add("colonHeaderName-:", "colonHeaderValue-:");
+                    .add("backslashHeaderName-\\", "backslashHeaderValue-\\");
 
         assertTrue(channel.writeOutbound(connectedFrame));
 
@@ -159,5 +214,25 @@ public class StompSubframeEncoderTest {
 
         assertEquals(expectedStompFrame, stompBuffer.toString(StandardCharsets.UTF_8));
         assertTrue(stompBuffer.release());
+    }
+
+    @ParameterizedTest
+    @ValueSource(chars = {'\r', '\n', '\0', ':'})
+    void mustRejectIllegalCharsInConnectedCommandHeaders(char illegalChar) {
+        StompFrame connectedFrame1 = new DefaultStompFrame(StompCommand.CONNECTED);
+        connectedFrame1.headers()
+                .add("header" + illegalChar, "name");
+        assertThatThrownBy(() -> channel.writeOutbound(connectedFrame1))
+                .isInstanceOf(EncoderException.class)
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("illegal character");
+
+        StompFrame connectedFrame2 = new DefaultStompFrame(StompCommand.CONNECTED);
+        connectedFrame2.headers()
+                .add("header", "name" + illegalChar);
+        assertThatThrownBy(() -> channel.writeOutbound(connectedFrame2))
+                .isInstanceOf(EncoderException.class)
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("illegal character");
     }
 }

--- a/codec-xml/pom.xml
+++ b/codec-xml/pom.xml
@@ -112,4 +112,3 @@
   </build>
 
 </project>
-

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlDecoder.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlDecoder.java
@@ -23,6 +23,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageDecoder;
 
+import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import java.util.List;
@@ -35,7 +36,17 @@ import java.util.List;
 
 public class XmlDecoder extends ByteToMessageDecoder {
 
-    private static final AsyncXMLInputFactory XML_INPUT_FACTORY = new InputFactoryImpl();
+    private static final AsyncXMLInputFactory XML_INPUT_FACTORY;
+
+    static {
+        // Disable risky features by default as we read from the network and so things are considered untrusted.
+        InputFactoryImpl factory = new InputFactoryImpl();
+        factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, Boolean.FALSE);
+        factory.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
+        factory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, Boolean.FALSE);
+        XML_INPUT_FACTORY = factory;
+    }
+
     private static final XmlDocumentEnd XML_DOCUMENT_END = XmlDocumentEnd.INSTANCE;
 
     private final AsyncXMLStreamReader<AsyncByteArrayFeeder> streamReader = XML_INPUT_FACTORY.createAsyncForByteArray();

--- a/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlFrameDecoder.java
+++ b/codec-xml/src/main/java/io/netty/handler/codec/xml/XmlFrameDecoder.java
@@ -88,6 +88,9 @@ public class XmlFrameDecoder extends ByteToMessageDecoder {
         boolean openingBracketFound = false;
         boolean atLeastOneXmlElementFound = false;
         boolean inCDATASection = false;
+        boolean inCommentBlock = false;
+        boolean inProcessingInstruction = false;
+        boolean inClosingTag = false;
         long openBracketsCount = 0;
         int length = 0;
         int leadingWhiteSpaceCount = 0;
@@ -110,22 +113,18 @@ public class XmlFrameDecoder extends ByteToMessageDecoder {
                 fail(ctx);
                 in.skipBytes(in.readableBytes());
                 return;
-            } else if (!inCDATASection && readByte == '<') {
+            } else if (inClosingTag && readByte == '<') {
+                fail(ctx);
+                in.skipBytes(in.readableBytes());
+                return;
+            } else if (!inCDATASection && !inCommentBlock && !inProcessingInstruction && readByte == '<') {
                 openingBracketFound = true;
 
                 if (i < bufferLength - 1) {
                     final byte peekAheadByte = in.getByte(i + 1);
                     if (peekAheadByte == '/') {
                         // found </, we must check if it is enclosed
-                        int peekFurtherAheadIndex = i + 2;
-                        while (peekFurtherAheadIndex <= bufferLength - 1) {
-                            //if we have </ and enclosing > we can decrement openBracketsCount
-                            if (in.getByte(peekFurtherAheadIndex) == '>') {
-                                openBracketsCount--;
-                                break;
-                            }
-                            peekFurtherAheadIndex++;
-                        }
+                        inClosingTag = true;
                     } else if (isValidStartCharForXmlElement(peekAheadByte)) {
                         atLeastOneXmlElementFound = true;
                         // char after < is a valid xml element start char,
@@ -135,6 +134,7 @@ public class XmlFrameDecoder extends ByteToMessageDecoder {
                         if (isCommentBlockStart(in, i)) {
                             // <!-- comment --> start found
                             openBracketsCount++;
+                            inCommentBlock = true;
                         } else if (isCDATABlockStart(in, i)) {
                             // <![CDATA[ start found
                             openBracketsCount++;
@@ -143,9 +143,10 @@ public class XmlFrameDecoder extends ByteToMessageDecoder {
                     } else if (peekAheadByte == '?') {
                         // <?xml ?> start found
                         openBracketsCount++;
+                        inProcessingInstruction = true;
                     }
                 }
-            } else if (!inCDATASection && readByte == '/') {
+            } else if (!inCDATASection && !inCommentBlock && !inProcessingInstruction && readByte == '/') {
                 if (i < bufferLength - 1 && in.getByte(i + 1) == '>') {
                     // found />, decrementing openBracketsCount
                     openBracketsCount--;
@@ -156,7 +157,22 @@ public class XmlFrameDecoder extends ByteToMessageDecoder {
                 if (i - 1 > -1) {
                     final byte peekBehindByte = in.getByte(i - 1);
 
-                    if (!inCDATASection) {
+                    if (inCommentBlock) {
+                        if (peekBehindByte == '-' && i - 2 > -1 && in.getByte(i - 2) == '-') {
+                            // a <!-- comment --> was closed
+                            openBracketsCount--;
+                            inCommentBlock = false;
+                        }
+                    } else if (inProcessingInstruction) {
+                        if (peekBehindByte == '?') {
+                            // an <?xml ?> tag was closed
+                            openBracketsCount--;
+                            inProcessingInstruction = false;
+                        }
+                    } else if (inClosingTag) {
+                        openBracketsCount--;
+                        inClosingTag = false;
+                    } else if (!inCDATASection) {
                         if (peekBehindByte == '?') {
                             // an <?xml ?> tag was closed
                             openBracketsCount--;
@@ -164,7 +180,7 @@ public class XmlFrameDecoder extends ByteToMessageDecoder {
                             // a <!-- comment --> was closed
                             openBracketsCount--;
                         }
-                    } else if (peekBehindByte == ']' && i - 2 > -1 && in.getByte(i - 2) == ']') {
+                    } else if (inCDATASection && peekBehindByte == ']' && i - 2 > -1 && in.getByte(i - 2) == ']') {
                         // a <![CDATA[...]]> block was closed
                         openBracketsCount--;
                         inCDATASection = false;

--- a/codec-xml/src/test/java/io/netty/handler/codec/xml/XmlFrameDecoderTest.java
+++ b/codec-xml/src/test/java/io/netty/handler/codec/xml/XmlFrameDecoderTest.java
@@ -122,6 +122,33 @@ public class XmlFrameDecoderTest {
     }
 
     @Test
+    public void testDecodeInvalidNestedClosingTag() throws Exception {
+        XmlFrameDecoder decoder = new XmlFrameDecoder(1048576);
+        final EmbeddedChannel ch = new EmbeddedChannel(decoder);
+        assertThrows(CorruptedFrameException.class, new Executable() {
+            @Override
+            public void execute() throws Exception {
+                ch.writeInbound(Unpooled.copiedBuffer("<a></</a>", CharsetUtil.UTF_8));
+            }
+        });
+        ch.finishAndReleaseAll();
+    }
+
+    @Test
+    public void testDecodeInvalidRepeatedClosingTags() throws Exception {
+        XmlFrameDecoder decoder = new XmlFrameDecoder(1048576);
+        final EmbeddedChannel ch = new EmbeddedChannel(decoder);
+        ch.writeInbound(Unpooled.copiedBuffer("</", CharsetUtil.UTF_8));
+        assertThrows(CorruptedFrameException.class, new Executable() {
+            @Override
+            public void execute() throws Exception {
+                ch.writeInbound(Unpooled.copiedBuffer("</", CharsetUtil.UTF_8));
+            }
+        });
+        ch.finishAndReleaseAll();
+    }
+
+    @Test
     public void testDecodeWithCDATABlock() throws Exception {
         final String xml = "<book>" +
                 "<![CDATA[K&R, a.k.a. Kernighan & Ritchie]]>" +
@@ -135,6 +162,46 @@ public class XmlFrameDecoderTest {
         final String xml = "<info>" +
                 "<![CDATA[Copyright 2012-2013,<br><a href=\"http://www.acme.com\">ACME Inc.<a>]]>" +
                 "</info>";
+        testDecodeWithXml(xml, xml);
+    }
+
+    @Test
+    public void testDecodeWithCDATABlockContainingClosingTagThenOpeningBracket() throws Exception {
+        final String xml = "<root>" +
+                "<![CDATA[close </a then open <b]]>" +
+                "</root>";
+        testDecodeWithXml(xml, xml);
+    }
+
+    @Test
+    public void testDecodeWithCommentContainingClosingTagThenOpeningBracket() throws Exception {
+        final String xml = "<root>" +
+                "<!-- close </a then open <b -->" +
+                "</root>";
+        testDecodeWithXml(xml, xml);
+    }
+
+    @Test
+    public void testDecodeWithCommentContainingClosingTag() throws Exception {
+        final String xml = "<root>" +
+                "<!-- close </a -->" +
+                "</root>";
+        testDecodeWithXml(xml, xml);
+    }
+
+    @Test
+    public void testDecodeWithProcessingInstructionContainingClosingTagThenOpeningBracket() throws Exception {
+        final String xml = "<root>" +
+                "<?pi close </a then open <b ?>" +
+                "</root>";
+        testDecodeWithXml(xml, xml);
+    }
+
+    @Test
+    public void testDecodeWithProcessingInstructionContainingClosingTag() throws Exception {
+        final String xml = "<root>" +
+                "<?pi close </a ?>" +
+                "</root>";
         testDecodeWithXml(xml, xml);
     }
 
@@ -159,6 +226,23 @@ public class XmlFrameDecoderTest {
     @Test
     public void testFraming() throws Exception {
         testDecodeWithXml(Arrays.asList("<abc", ">123</a", "bc>"), "<abc>123</abc>");
+    }
+
+    @Test
+    public void testFramingWithSplitClosingTag() throws Exception {
+        testDecodeWithXml(Arrays.asList("<abc>", "123</", "abc>"), "<abc>123</abc>");
+    }
+
+    @Test
+    public void testFramingWithCommentContainingClosingTagThenOpeningBracket() throws Exception {
+        final String frame = "<root><!-- close </a then open <b --></root>";
+        testDecodeWithXml(Arrays.asList("<root><!-- close </", "a then open <b --></root>"), frame);
+    }
+
+    @Test
+    public void testFramingWithProcessingInstructionContainingClosingTagThenOpeningBracket() throws Exception {
+        final String frame = "<root><?pi close </a then open <b ?></root>";
+        testDecodeWithXml(Arrays.asList("<root><?pi close </", "a then open <b ?></root>"), frame);
     }
 
     @Test

--- a/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspClient.java
+++ b/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspClient.java
@@ -33,6 +33,7 @@ import io.netty.resolver.dns.DnsNameResolver;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -50,6 +51,7 @@ import org.bouncycastle.cert.ocsp.OCSPException;
 import org.bouncycastle.cert.ocsp.OCSPReqBuilder;
 import org.bouncycastle.cert.ocsp.OCSPResp;
 import org.bouncycastle.operator.ContentVerifierProvider;
+import org.bouncycastle.operator.DigestCalculatorProvider;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentVerifierProviderBuilder;
 import org.bouncycastle.operator.jcajce.JcaDigestCalculatorProviderBuilder;
@@ -101,19 +103,22 @@ final class OcspClient {
      * @param issuer                {@link X509Certificate} issuer of client certificate
      * @param validateResponseNonce Set to {@code true} to enable OCSP response validation
      * @param ioTransport           {@link IoTransport} to use
-     * @return {@link Promise} of {@link BasicOCSPResp}
+     * @return                      {@link Promise} of {@link BasicOCSPResp}
      */
-    static Promise<BasicOCSPResp> query(final X509Certificate x509Certificate,
+    static void query(final X509Certificate x509Certificate,
                                         final X509Certificate issuer, final boolean validateResponseNonce,
-                                        final IoTransport ioTransport, final DnsNameResolver dnsNameResolver) {
+                                        final IoTransport ioTransport, final DnsNameResolver dnsNameResolver,
+                                        final Promise<BasicOCSPResp> responsePromise) {
         final EventLoop eventLoop = ioTransport.eventLoop();
-        final Promise<BasicOCSPResp> responsePromise = eventLoop.newPromise();
         eventLoop.execute(new Runnable() {
             @Override
             public void run() {
                 try {
-                    CertificateID certificateID = new CertificateID(new JcaDigestCalculatorProviderBuilder()
-                            .build().get(HASH_SHA1), new JcaX509CertificateHolder(issuer),
+                    DigestCalculatorProvider digestCalculatorProvider = new JcaDigestCalculatorProviderBuilder()
+                            .build();
+
+                    CertificateID certificateID = new CertificateID(digestCalculatorProvider.get(HASH_SHA1),
+                            new JcaX509CertificateHolder(issuer),
                             x509Certificate.getSerialNumber());
 
                     // Initialize OCSP Request Builder and add CertificateID into it.
@@ -159,23 +164,29 @@ final class OcspClient {
                         // If Future was successful then we have received OCSP response
                         // We will now validate it.
                         if (future.isSuccess()) {
+                            final Object responseObject;
                             try {
-                                BasicOCSPResp resp = (BasicOCSPResp) future.getNow().getResponseObject();
-                                validateResponse(responsePromise, resp, derNonce, issuer, validateResponseNonce);
-                            } catch (Throwable t) {
-                                responsePromise.tryFailure(t);
+                                responseObject = future.getNow().getResponseObject();
+                            } catch (OCSPException e) {
+                                responsePromise.setFailure(future.cause());
+                                return;
+                            }
+                            if (responseObject instanceof BasicOCSPResp) {
+                                validateResponse(x509Certificate, digestCalculatorProvider, responsePromise,
+                                        (BasicOCSPResp) responseObject, derNonce, issuer, validateResponseNonce);
+                            } else {
+                                responsePromise.tryFailure(new OCSPException("Unsupported OCSP response type: "
+                                        + (responseObject == null ? null : responseObject.getClass())));
                             }
                         } else {
                             responsePromise.tryFailure(future.cause());
                         }
                     });
-
                 } catch (Exception ex) {
                     responsePromise.tryFailure(ex);
                 }
             }
         });
-        return responsePromise;
     }
 
     /**
@@ -200,8 +211,7 @@ final class OcspClient {
                     .option(ChannelOption.TCP_NODELAY, true)
                     .channelFactory(ioTransport.socketChannel())
                     .attr(OcspServerCertificateValidator.OCSP_PIPELINE_ATTRIBUTE, Boolean.TRUE)
-                    .handler(new Initializer(responsePromise));
-
+                    .handler(new Initializer(responsePromise, 10 * 1000));
             dnsNameResolver.resolve(host).addListener((FutureListener<InetAddress>) future -> {
 
                 // If Future was successful then we have successfully resolved OCSP server address.
@@ -240,14 +250,26 @@ final class OcspClient {
         return responsePromise;
     }
 
-    private static void validateResponse(Promise<BasicOCSPResp> responsePromise, BasicOCSPResp basicResponse,
-                                         DEROctetString derNonce, X509Certificate issuer, boolean validateNonce) {
+    private static void validateResponse(
+            X509Certificate x509Certificate, DigestCalculatorProvider digestCalculatorProvider,
+            Promise<BasicOCSPResp> responsePromise, BasicOCSPResp basicResponse,
+            DEROctetString derNonce, X509Certificate issuer, boolean validateNonce) {
         try {
             // Validate number of responses. We only requested for 1 certificate
             // so number of responses must be 1. If not, we will throw an error.
             int responses = basicResponse.getResponses().length;
             if (responses != 1) {
-                throw new IllegalArgumentException("Expected number of responses was 1 but got: " + responses);
+                responsePromise.tryFailure(
+                        new IllegalArgumentException("Expected number of responses was 1 but got: " + responses));
+                return;
+            }
+
+            CertificateID respCertId = basicResponse.getResponses()[0].getCertID();
+            if (!respCertId.matchesIssuer(new JcaX509CertificateHolder(issuer), digestCalculatorProvider)
+                    || !respCertId.getSerialNumber().equals(x509Certificate.getSerialNumber())) {
+                responsePromise.tryFailure(
+                        new CertificateException("OCSP response CertID does not match queried certificate"));
+                return;
             }
 
             if (validateNonce) {
@@ -390,9 +412,11 @@ final class OcspClient {
     static final class Initializer extends ChannelInitializer<SocketChannel> {
 
         private final Promise<OCSPResp> responsePromise;
+        private final long timeoutMillis;
 
-        Initializer(Promise<OCSPResp> responsePromise) {
-            this.responsePromise = checkNotNull(responsePromise, "ResponsePromise");
+        Initializer(Promise<OCSPResp> responsePromise, long timeoutMillis) {
+            this.responsePromise = checkNotNull(responsePromise, "responsePromise");
+            this.timeoutMillis = ObjectUtil.checkPositive(timeoutMillis, "timeoutMillis");
         }
 
         @Override
@@ -400,7 +424,7 @@ final class OcspClient {
             ChannelPipeline pipeline = socketChannel.pipeline();
             pipeline.addLast(new HttpClientCodec());
             pipeline.addLast(new HttpObjectAggregator(OCSP_RESPONSE_MAX_SIZE));
-            pipeline.addLast(new OcspHttpHandler(responsePromise));
+            pipeline.addLast(new OcspHttpHandler(responsePromise, timeoutMillis));
         }
     }
 

--- a/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspHttpHandler.java
+++ b/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspHttpHandler.java
@@ -17,38 +17,53 @@ package io.netty.handler.ssl.ocsp;
 
 import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.ChannelInboundHandler;
+import io.netty.channel.ChannelOutboundHandler;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.util.concurrent.CompletionHandler;
+import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.bouncycastle.cert.ocsp.OCSPException;
 import org.bouncycastle.cert.ocsp.OCSPResp;
 
+import java.nio.channels.ClosedChannelException;
+import java.util.concurrent.TimeUnit;
+
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
-final class OcspHttpHandler extends SimpleChannelInboundHandler<FullHttpResponse> {
+final class OcspHttpHandler implements ChannelInboundHandler, ChannelOutboundHandler {
 
     private static final InternalLogger LOGGER = InternalLoggerFactory.getInstance(OcspHttpHandler.class);
     private final Promise<OCSPResp> responseFuture;
-
+    private final long timeoutMillis;
+    private Future<?> timeoutFuture;
     static final String OCSP_REQUEST_TYPE = "application/ocsp-request";
     static final String OCSP_RESPONSE_TYPE = "application/ocsp-response";
 
     /**
      * Create new {@link OcspHttpHandler} instance
      *
-     * @param responsePromise {@link Promise} of {@link OCSPResp}
+     * @param responsePromise   {@link Promise} of {@link OCSPResp}
+     * @param timeoutMillis     the timeout in milliseconds how long a response can take to before we fail the promise.
      */
-    OcspHttpHandler(Promise<OCSPResp> responsePromise) {
-        super(FullHttpResponse.class);
+    OcspHttpHandler(Promise<OCSPResp> responsePromise, long timeoutMillis) {
         this.responseFuture = checkNotNull(responsePromise, "ResponsePromise");
+        this.timeoutMillis = ObjectUtil.checkPositive(timeoutMillis, "timeoutMillis");
+        this.responseFuture.addListener(f -> {
+            if (timeoutFuture != null) {
+                timeoutFuture.cancel(true);
+            }
+        });
     }
 
     @Override
-    protected void channelRead0(ChannelHandlerContext ctx, FullHttpResponse response) throws Exception {
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        FullHttpResponse response = (FullHttpResponse) msg;
         try {
             // If DEBUG is enabled then log the response
             if (LOGGER.isDebugEnabled()) {
@@ -75,12 +90,34 @@ final class OcspHttpHandler extends SimpleChannelInboundHandler<FullHttpResponse
 
             responseFuture.trySuccess(new OCSPResp(ByteBufUtil.getBytes(response.content())));
         } finally {
-            ctx.channel().close();
+            response.release();
+            ctx.close();
         }
     }
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         responseFuture.tryFailure(cause);
+        ctx.close();
+    }
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, CompletionHandler<Void> handler) {
+        ctx.write(msg, handler);
+        timeoutFuture = ctx.executor().schedule(() -> {
+            if (!responseFuture.isDone()) {
+                responseFuture.tryFailure(new OCSPException("OCSP response was not received within "
+                        + timeoutMillis + "ms"));
+                ctx.close();
+            }
+        }, timeoutMillis, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) {
+        if (!responseFuture.isDone()) {
+            responseFuture.tryFailure(new ClosedChannelException());
+        }
+        ctx.fireChannelInactive();
     }
 }

--- a/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspServerCertificateValidator.java
+++ b/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspServerCertificateValidator.java
@@ -15,8 +15,10 @@
  */
 package io.netty.handler.ssl.ocsp;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInboundHandler;
+import io.netty.channel.ChannelOutboundHandler;
+import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 import io.netty.resolver.dns.DnsNameResolver;
@@ -31,6 +33,7 @@ import org.bouncycastle.cert.ocsp.SingleResp;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.Date;
+import java.util.List;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
@@ -39,7 +42,7 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
  * using OCSP. Once TLS handshake is completed, {@link SslHandshakeCompletionEvent#SUCCESS} is fired, validator
  * will perform certificate validation using OCSP over HTTP/1.1 with the server's certificate issuer OCSP responder.
  */
-public class OcspServerCertificateValidator implements ChannelInboundHandler {
+public class OcspServerCertificateValidator extends ByteToMessageDecoder implements ChannelOutboundHandler {
     /**
      * An attribute used to mark all channels created by the {@link OcspServerCertificateValidator}.
      */
@@ -50,6 +53,8 @@ public class OcspServerCertificateValidator implements ChannelInboundHandler {
     private final boolean validateNonce;
     private final IoTransport ioTransport;
     private final DnsNameResolver dnsNameResolver;
+    private boolean ocspQueryInProgress;
+    private boolean readPending;
 
     /**
      * Create a new {@link OcspServerCertificateValidator} instance without nonce validation
@@ -126,9 +131,12 @@ public class OcspServerCertificateValidator implements ChannelInboundHandler {
     }
 
     @Override
-    public void userEventTriggered(final ChannelHandlerContext ctx, final Object evt) throws Exception {
-        ctx.fireUserEventTriggered(evt);
+    protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
+        // Just buffer until the handler is removed which will happen once we did finish the OCSP processing.
+    }
 
+    @Override
+    public void userEventTriggered(final ChannelHandlerContext ctx, final Object evt) throws Exception {
         if (evt instanceof SslHandshakeCompletionEvent) {
             SslHandshakeCompletionEvent sslHandshakeCompletionEvent = (SslHandshakeCompletionEvent) evt;
 
@@ -141,55 +149,85 @@ public class OcspServerCertificateValidator implements ChannelInboundHandler {
                         .getPeerCertificates();
 
                 assert certificates.length >= 2 : "There must an end-entity certificate and issuer certificate";
-
-                Promise<BasicOCSPResp> ocspRespPromise = OcspClient.query((X509Certificate) certificates[0],
-                        (X509Certificate) certificates[1], validateNonce, ioTransport, dnsNameResolver);
-
+                Promise<BasicOCSPResp> ocspRespPromise = ctx.executor().newPromise();
+                OcspClient.query((X509Certificate) certificates[0], (X509Certificate) certificates[1],
+                        validateNonce, ioTransport, dnsNameResolver, ocspRespPromise);
+                ocspQueryInProgress = true;
                 ocspRespPromise.addListener(future -> {
-                    // If Future is success then we have successfully received OCSP response
-                    // from OCSP responder. We will validate it now and process.
-                    if (future.isSuccess()) {
-                        SingleResp response = future.getNow().getResponses()[0];
+                    ocspQueryInProgress = false;
+                    try {
+                        // If Future is success then we have successfully received OCSP response
+                        // from OCSP responder. We will validate it now and process.
+                        if (future.isSuccess()) {
+                            SingleResp response = future.getNow().getResponses()[0];
 
-                        Date current = new Date();
-                        if (!(current.after(response.getThisUpdate()) &&
-                                current.before(response.getNextUpdate()))) {
-                            ctx.fireExceptionCaught(new IllegalStateException("OCSP Response is out-of-date"));
-                        }
+                            Date current = new Date();
+                            Date thisUpdate = response.getThisUpdate();
+                        Date nextUpdate = response.getNextUpdate();
+                        if (thisUpdate == null || !current.after(thisUpdate) ||
+                                    (nextUpdate != null && !current.before(nextUpdate))) {
+                                ctx.fireExceptionCaught(new IllegalStateException("OCSP Response is out-of-date"));
+                                return;
+                            }
 
-                        OcspResponse.Status status;
-                        if (response.getCertStatus() == null) {
-                            // 'null' means certificate is valid
-                            status = OcspResponse.Status.VALID;
-                        } else if (response.getCertStatus() instanceof RevokedStatus) {
-                            status = OcspResponse.Status.REVOKED;
+                            OcspResponse.Status status;
+                            if (response.getCertStatus() == null) {
+                                // 'null' means certificate is valid
+                                status = OcspResponse.Status.VALID;
+                            } else if (response.getCertStatus() instanceof RevokedStatus) {
+                                status = OcspResponse.Status.REVOKED;
+                            } else {
+                                status = OcspResponse.Status.UNKNOWN;
+                            }
+
+                            ctx.fireUserEventTriggered(new OcspValidationEvent(
+                                    new OcspResponse(status, response.getThisUpdate(), response.getNextUpdate())));
+
+                            // If Certificate is not VALID and 'closeAndThrowIfNotValid' is set
+                            // to 'true' then close the channel and throw an exception.
+                            if (status != OcspResponse.Status.VALID && closeAndThrowIfNotValid) {
+                                // Certificate is not valid. Throw
+                                ctx.fireExceptionCaught(new OCSPException(
+                                        "Certificate not valid. Status: " + status));
+                                ctx.close();
+                            }
                         } else {
-                            status = OcspResponse.Status.UNKNOWN;
+                            ctx.fireExceptionCaught(future.cause());
+                            if (closeAndThrowIfNotValid) {
+                                ctx.close();
+                            }
                         }
-
-                        ctx.fireUserEventTriggered(new OcspValidationEvent(
-                                new OcspResponse(status, response.getThisUpdate(), response.getNextUpdate())));
-
-                        // If Certificate is not VALID and 'closeAndThrowIfNotValid' is set
-                        // to 'true' then close the channel and throw an exception.
-                        if (status != OcspResponse.Status.VALID && closeAndThrowIfNotValid) {
-                            ctx.channel().close();
-                            // Certificate is not valid. Throw
-                            ctx.fireExceptionCaught(new OCSPException(
-                                    "Certificate not valid. Status: " + status));
+                    } finally {
+                        ctx.fireUserEventTriggered(evt);
+                        // Lets remove ourselves from the pipeline because we are done processing validation.
+                        ctx.pipeline().remove(this);
+                        if (readPending) {
+                            readPending = false;
+                            ctx.read();
                         }
-                    } else {
-                        ctx.fireExceptionCaught(future.cause());
                     }
                 });
+            } else {
+                ctx.fireUserEventTriggered(evt);
             }
-            // Lets remove ourselves from the pipeline because we are done processing validation.
-            ctx.pipeline().remove(this);
+        } else {
+            ctx.fireUserEventTriggered(evt);
         }
     }
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-        ctx.channel().close();
+        ctx.close();
+    }
+
+    @Override
+    public void read(ChannelHandlerContext ctx) {
+        // Let's stop reading until we are done with the processing of the OCSP query.
+        if (ocspQueryInProgress) {
+            readPending = true;
+        } else {
+            readPending = false;
+            ctx.read();
+        }
     }
 }

--- a/handler-ssl-ocsp/src/main/java/module-info.yml
+++ b/handler-ssl-ocsp/src/main/java/module-info.yml
@@ -17,6 +17,7 @@ requires:
   - module: io.netty.common
   - module: io.netty.buffer
   - module: io.netty.handler
+  - module: io.netty.codec
   - module: io.netty.codec.http
   - module: io.netty.transport
   - module: io.netty.resolver.dns

--- a/handler-ssl-ocsp/src/test/java/io/netty/handler/ssl/ocsp/OcspClientTest.java
+++ b/handler-ssl-ocsp/src/test/java/io/netty/handler/ssl/ocsp/OcspClientTest.java
@@ -15,9 +15,31 @@
  */
 package io.netty.handler.ssl.ocsp;
 
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandler;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
+import io.netty.channel.socket.nio.NioDatagramChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
 import io.netty.pkitesting.CertificateBuilder;
 import io.netty.pkitesting.X509Bundle;
+import io.netty.resolver.dns.DnsNameResolver;
+import io.netty.util.concurrent.CompletionHandler;
 import io.netty.util.concurrent.Promise;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.DEROctetString;
+import org.bouncycastle.asn1.ocsp.OCSPResponse;
+import org.bouncycastle.asn1.ocsp.OCSPResponseStatus;
+import org.bouncycastle.asn1.ocsp.ResponseBytes;
+import org.bouncycastle.asn1.x509.AccessDescription;
+import org.bouncycastle.asn1.x509.AuthorityInformationAccess;
+import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateHolder;
 import org.bouncycastle.cert.ocsp.BasicOCSPResp;
@@ -25,6 +47,7 @@ import org.bouncycastle.cert.ocsp.BasicOCSPRespBuilder;
 import org.bouncycastle.cert.ocsp.CertificateID;
 import org.bouncycastle.cert.ocsp.CertificateStatus;
 import org.bouncycastle.cert.ocsp.OCSPException;
+import org.bouncycastle.cert.ocsp.OCSPRespBuilder;
 import org.bouncycastle.cert.ocsp.RespID;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
@@ -35,6 +58,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import javax.net.ssl.HttpsURLConnection;
 import java.io.IOException;
+import java.net.SocketAddress;
 import java.net.URL;
 import java.security.cert.X509Certificate;
 import java.util.Date;
@@ -42,6 +66,7 @@ import java.util.concurrent.ExecutionException;
 
 import static io.netty.handler.ssl.ocsp.OcspServerCertificateValidator.createDefaultResolver;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -61,8 +86,10 @@ class OcspClientTest extends AbstractOcspTest {
             X509Certificate serverCert = certs[0];
             X509Certificate certIssuer = certs[1];
 
-            Promise<BasicOCSPResp> promise = OcspClient.query(serverCert, certIssuer, false,
-                    createDefaultTransport(), createDefaultResolver(createDefaultTransport()));
+            IoTransport transport = createDefaultTransport();
+            Promise<BasicOCSPResp> promise = transport.eventLoop().newPromise();
+            OcspClient.query(serverCert, certIssuer, false,
+                    transport, createDefaultResolver(transport), promise);
             BasicOCSPResp basicOCSPResp = promise.get();
 
             // 'null' means certificate is valid
@@ -145,6 +172,81 @@ class OcspClientTest extends AbstractOcspTest {
         assertThrows(OCSPException.class, () ->
                 OcspClient.validateSignature(resp, issuerBundle.getCertificate())
         );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"unrelated-certificate", "non-basic-response-type", "null-response-bytes"})
+    void testCertIdBypass(String scenario) throws Exception {
+        X509Bundle caRoot = new CertificateBuilder()
+                .algorithm(CertificateBuilder.Algorithm.rsa2048)
+                .subject("CN=TrustedRootCA")
+                .setIsCertificateAuthority(true)
+                .buildSelfSigned();
+
+        GeneralName ocspName = new GeneralName(GeneralName.uniformResourceIdentifier, "http://localhost/");
+        AuthorityInformationAccess aia = new AuthorityInformationAccess(
+                new AccessDescription(AccessDescription.id_ad_ocsp, ocspName));
+        X509Bundle targetCert = new CertificateBuilder()
+                .algorithm(CertificateBuilder.Algorithm.rsa2048)
+                .subject("CN=TargetServer")
+                .addExtensionOctetString("1.3.6.1.5.5.7.1.1", false, aia.getEncoded())
+                .buildIssuedBy(caRoot);
+
+        byte[] forgedResponseEncoded = forgedResponse(scenario, caRoot);
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        try {
+            IoTransport transport = IoTransport.create(group.next(), loop -> {
+                NioSocketChannel channel = new NioSocketChannel(loop);
+                channel.pipeline().addFirst(new ChannelOutboundHandler() {
+                    @Override
+                    public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress,
+                                        SocketAddress localAddress, CompletionHandler<Void> handler) {
+                        handler.success(null);
+
+                        ctx.executor().execute(() -> {
+                            ctx.pipeline().fireChannelActive();
+                            DefaultFullHttpResponse httpResponse = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1,
+                                    HttpResponseStatus.OK, Unpooled.wrappedBuffer(forgedResponseEncoded));
+                            httpResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/ocsp-response");
+                            httpResponse.headers().set(HttpHeaderNames.CONTENT_LENGTH,
+                                    httpResponse.content().readableBytes());
+
+                            ctx.pipeline().fireChannelRead(httpResponse);
+                        });
+                    }
+                });
+                return channel;
+            }, NioDatagramChannel::new);
+
+            DnsNameResolver resolver = OcspServerCertificateValidator.createDefaultResolver(transport);
+            Promise<BasicOCSPResp> promise = transport.eventLoop().newPromise();
+            OcspClient.query(
+                    targetCert.getCertificate(), caRoot.getCertificate(), false,
+                    transport, resolver, promise);
+
+            promise.await();
+
+            assertFalse(promise.isSuccess());
+            resolver.close();
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+    private static byte[] forgedResponse(String scenario, X509Bundle caRoot) throws Exception {
+        if ("non-basic-response-type".equals(scenario)) {
+            ResponseBytes responseBytes = new ResponseBytes(
+                                       new ASN1ObjectIdentifier("1.2.3.4.5"),
+                    new DEROctetString(new byte[]{ 0x30, 0x00 }));
+                        return new OCSPResponse(new OCSPResponseStatus(OCSPResponseStatus.SUCCESSFUL), responseBytes)
+                                        .getEncoded();
+        }
+        if ("null-response-bytes".equals(scenario)) {
+            return new OCSPResponse(new OCSPResponseStatus(OCSPResponseStatus.UNAUTHORIZED), null).getEncoded();
+        }
+        X509CertificateHolder caHolder = new JcaX509CertificateHolder(caRoot.getCertificate());
+        BasicOCSPResp forgedBasicResp = createBasicOcspResponse(caRoot, new X509CertificateHolder[]{caHolder});
+        return new OCSPRespBuilder().build(OCSPRespBuilder.SUCCESSFUL, forgedBasicResp).getEncoded();
     }
 
     private static BasicOCSPResp createBasicOcspResponse(X509Bundle responderBundle,


### PR DESCRIPTION
---

Stomp: Limit headers per frame
83ce0a8
Motivation:

We need to enforce a lmit of headers per frame as otherwise a remote peer can flood us.

Modifications:

- Enforce limit of number of headers
- Add unit test

Result:

Guard against high memory usage caused by frames with unbound number of headers

---

DNS: Don't leak buffer in DNS Record Decoder via Malformed Domain Names
50649d7
Motivation:

We missed to release allocated buffers in case of maformed domain names.

Modifications:

Correctly release buffers in all cases

Result:

No more memory leak on malformed domain names

---

SPDY: Limit max number of settings per settings frame
0b0b899
Motivation:

There was no real limit of how many settings a settings frame could include and so could result in very high memory usage on the receiver side.

Modifications:

- Add a default limit of 64
- Add unit test

Result:

Guard against high memory usage by default

---

HaProxy: Correctly treat version as unsigned byte
94b04f7
Motivation:

We did not correctly tread the version as unsigned byte which could cause us to buffer received bytes forever and so cause an OOME

Modifications:

- Correctly treat version as unsigned byte
- Add unit test

Result:

Correctly detect invalid version and not buffer forever

---

SPDY: Correctly release message once removed from internal storage
4ff0898
Motivation:

We missed to release the stored FullHttpMessage in some cases which could result in a memory leak

Modifications:

- Add missing release calls
- Also release when handler is removed before channel becomes inactive

Result:

No more leaks

---

CORS: Correctly handle origin
afca14b
Motivation:

Netty's CorsHandler provides a shortCircuit() configuration designed to reject unauthorized cross-origin requests immediately, acting as a security control before requests reach the application.
However, due to a logical operator error in the origin evaluation process, this protection can be entirely bypassed. An attacker can bypass the short-circuit mechanism by sending a request with an Origin: null header.
This failure forwards unauthorized requests to the backend application, bypassing intended access controls.

Modifications:

- Replace || with &&

Result:

Fix bypass

---

XML: Disable risky features when decoding XML
ee10fe7
Motivation:

We did not diable external entities, DTD and replacing of entity references when creating the AsyncXMLInputFactory, which means we were in the mercy of the defaults of aalto-xml.

Modifications:

- Set properties to disable risky features and so reduce risk when decoding XML via the network

Result:

Minimize risk when decoding XML from untrusted sources

---

HTTP2: Don't leak buffer when using compression and the stream is clo…
e9cec3f
…sed while still decompress data

Motivation:

We need to ensure we not leak the buffer if the used EmbeddedChannel is already closed when trying to decompress data. This can happen if we receive an END_STREAM in between.

Modifications:

- Explicit check if the EmbeddedChannel is open before retain the buffer

Result:

No more leak

---

Redis: Clear partial state and release messages before throwing excep…
5f5c65b
…tion

Motivation:

We did not always clear the partial state and release nested message before throwing exception which could lead to unnessary memory usage until the channel is finally closed

Modifications:

Always clear partial state and release messages before throwing

Result:

Clear state and release memory in a timely manner when exception accours

---

HTTP3: Limit the max payload length of unknown frames
cfcfb97
Motivation:

We need to limit the max payload length of unknown frames to same sane default so we not risk to run out of memory.

Modifications:

- Add a default limit
- Allow user to specify limit via constructor
- Add unit test

Result:

Limit the max length of payloads for unknown frames

---

OCSP: Correctly validate cert id matches
dec6f8e
Motivation:

We did miss to also validate the cert id and so could be affected by replay attacks

Modifications:

- Add validation of cert id
- Add unit test

Result:

Correctly validate cert

---

OCSP: TOCTOU in OcspServerCertificateValidator
1c7bf68
Motivation:

Netty's OcspServerCertificateValidator forwards the SslHandshakeCompletionEvent before the asynchronous OCSP validation completes. This allows the client's downstream handlers to send sensitive application data (e.g., HTTP requests) to a revoked server before the channel is closed by the OCSP check.

Modifications:

- Correctly only fire the event after we did the ocsp check
- Enforce some sort of timeout for the OCSP query
- Buffer bytes until we were able to process the OCSP query
- Add missing early return

Result:

Only fire event / forward data after the OCSP processing is done

---

Improve OCSP response validity-window handling in OcspServerCertifica…
e091e0f
…teValidator

Motivation:

The thisUpdate / nextUpdate fields of an OCSP response are optional, and
the freshness check did not always stop processing a response that
failed the window check.

Modifications:

Handle absent thisUpdate / nextUpdate and return once an out-of-date
response is detected.

Result:

More robust and consistent OCSP response validity-window handling.

---

Validate STOMP CONNECT/CONNECTED command headers
536d64a
Motivation:
The CONNECT/CONNECTED command headers do not support escaping, but we still need to validate that they contain no illegal characters.

Additionally, the NUL ascii character has no escape sequence and is always illegal.

The only normally-escaped character that CONNECT/CONNECTED commands pass through raw is the backslash.

Modification:
- Update the test to match the specification exactly.
- Add validation to CONNECT/CONNECTED command headers.
- Add a throws case in `escape` for the NUL character.

Result:
It's no longer possible to inject headers or smuggle commands through STOMP CONNECT/CONNECTED headers.

---

Add multipart filename validation
15c62b0
Motivation:
The rules for encoding filenames in `multipart/form-data` means we have to avoid certain characters to prevent parser-desync problems, and to ensure spec compliance.

Modification:
- The DiskFileUpload and MemoryFileUpload constructor and setFilename methods now validate that the given filename is safe to be included verbatim into the multipart filename field, and will throw an exception if not.
- The HttpPostMultipartRequestDecoder now nerfs all illegal characters - even those delivered through percent encoding - to prevent round-trip validation errors.

Result:
Parser-desync and smuggling through the multipart/form-data filename field is no longer possible.

---

HAProxy: Reject illegal characters in UNIX socket files
409621c
Motivation:
The PROXY V1 protocol for HAProxy uses CR LF bytes as header delimiters, and space as header field delimiters.
This means these characters are not allowed within the fields, and must be rejected.
The V2 protocol has no such problem because it uses a TLV binary encoding.

Modification:
Add checks and throw an exception from the HAProxyMessage constructor if AF_UNIX socket addresses contain CR, LF, or space, and the protocol version is V1.
Add tests to verify the exception is thrown on V1, and not on V2.

Result:
PROXY field injection through AF_UNIX socket filenames is prevented.

---

Bzip2: Correctly detect malformated stream and not infinite loop
0b7fb9b
Motivation:

Due a bug we could end up in an infinite loop while read from the bzip2 stream

Modifications:

- Correctly detect malformated stream and throw exception
- Add unit tests

Result:

Correctly throw exception when malformated stream is detected

---

HTTP/2: Lack of Host Header Deduplication in HTTP/2→HTTP/1.x Translat…
0ff87c6
…ion Leads to Request Routing Bypass

Motivation:

Netty's HTTP/2-to-HTTP/1.x translation layer (`Http2StreamFrameToHttpObjectCodec` and `InboundHttp2ToHttpAdapter`) fails to deduplicate or validate `Host` headers when an HTTP/2 client supplies both the `:authority` pseudo-header and a literal `host` header in a single HEADERS frame. The translator maps `:authority` to `Host` and separately copies the literal `host` header, producing an `HttpRequest` object containing two `Host` headers with attacker-controlled differing values.

Modifications:

- Detect duplicated host headers and if detected throw stream error
- add unit test

Result:

Correctly detect invalid headers during translation

---

HTTP: Enforce pipeline limit in HttpContentEncoder
1d5cdac
Motivation:

We did not enforce any pipeline limit and so it was possible for a remote peer to cause A DOS

Modifications:

- Add constructor that allows to set a limit (use default of 128).
- Add unit test

Result:

Guard against DOS caused by concurrent pipelined requests

---

SPDY: Limit the maximum number of bytes that can be decompressed per …
69562fa
…header block.

Motivation:

We should limit the number of bytes that can be dcompressed per header block to guard against DOS attacks

Modifications:

- Add some limit
- Add unit tests

Result:

Limit the number of bytes for compressed header blocks

---

Avoid repeated closing-tag scans in XmlFrameDecoder
efb0044
Motivation:

XmlFrameDecoder scanned forward from every closing tag start to find a terminating '>'. Repeated malformed closing tags could therefore force repeated scans over the cumulated buffer.

Modification:

Track a pending closing tag in the main decode loop, reject nested '<' before the closing tag terminator, and cover malformed repeated closing tags plus valid split closing tags in tests.

Result:

Malformed repeated closing tags fail fast while valid split closing tags continue to frame correctly.

---

WebSockets: V07/V08 handshaker missing Connection/Upgrade validation
52addff
Motivation:

An attacker can force WebSocket upgrade via the lax V07 (or V08) handshaker by sending Sec-WebSocket-Version: 7 and omitting Connection: Upgrade / Upgrade: websocket headers, completing a protocol switch that a proxy would not recognize as an Upgrade request and enabling HTTP request smuggling / protocol-confusion attacks.

Modifications:

- Add header checks
- Add unit testing

Result:

Correctly validate headers for V07 and V08

Co-authored-by: Norman Maurer <norman_maurer@apple.com>
Co-authored-by: Violeta Georgieva <696661+violetagg@users.noreply.github.com>
Co-authored-by: yawkat <jonas.konrad@oracle.com>
