### PR TITLE
IoUring: preserve readPending when rescheduling cancelled reads

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -798,6 +798,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
                                 // in the meantime. If this is the case we need to schedule the read to ensure
                                 // we do not stall.
                                 if (pending) {
+                                    readPending = true;
                                     doBeginReadNow();
                                 }
                             } else if (rearm) {
@@ -815,6 +816,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
                         // in the meantime. If this is the case we need to schedule the read to ensure
                         // we do not stall.
                         if (pending) {
+                            readPending = true;
                             doBeginReadNow();
                         }
                     } else if (multishot && rearm) {


### PR DESCRIPTION
Motivation:

Fix a read stall reported in #17049. With autoRead disabled, an explicit read can be lost when a cancelled RECV completion races with an active multishot POLL_ADD.

```text
T0  A multishot POLL_ADD(POLLIN) is active.

T1  Netty submits a normal RECV.

T2  clearRead() cancels the RECV.
    -> readPending = false

T3  user calls channel.read() before the cancel CQE arrives.
    -> readPending = true
    -> doBeginReadNow() skips submitting RECV because POLL_ADD is still active

T4  the cancelled RECV completes with -ECANCELED.
    -> pending is captured as true
    -> completion handling clears readPending = false

T5  current behavior:
    -> doBeginReadNow() is called, but readPending is already false
    -> later POLLIN only sets socketHasMoreData
    -> no RECV is submitted, so the response stalls
``` 

One-shot POLL_ADD usually avoids this because its POLLIN completion clears the poll state first. Multishot POLL_ADD remains scheduled, so the later cancelled RECV completion can clear the only readPending signal.

This race depends on CQE ordering, so it is hard to cover with a stable unit test.

Modification:

Restore readPending before rescheduling a read when a cancelled read completion observed a pending read. This also covers the equivalent one-shot POLLIN interleaving.

Result:

Fixes #17049.

please review @normanmaurer @violetagg @ankitggits
 
