### PR TITLE
`HttpObjectEncoder` / `DefaultHttp2FrameWriter`: fix buffer leak when a `Throwable` is thrown during header encoding

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectEncoder.java
@@ -331,19 +331,26 @@ public abstract class HttpObjectEncoder<H extends HttpMessage> extends MessageTo
             final int headersAndContentSize = (int) headersEncodedSizeAccumulator +
                                                   (accountForContentSize? content.readableBytes() : 0);
             final ByteBuf buf = ctx.alloc().buffer(headersAndContentSize);
+            boolean handedOff = false;
+            try {
+                encodeInitialLine(buf, m);
 
-            encodeInitialLine(buf, m);
+                sanitizeHeadersBeforeEncode(m, state == ST_CONTENT_ALWAYS_EMPTY);
 
-            sanitizeHeadersBeforeEncode(m, state == ST_CONTENT_ALWAYS_EMPTY);
+                encodeHeaders(m.headers(), buf);
+                ByteBufUtil.writeShortBE(buf, CRLF_SHORT);
 
-            encodeHeaders(m.headers(), buf);
-            ByteBufUtil.writeShortBE(buf, CRLF_SHORT);
+                // don't consider the copyContent case here: the statistics is just related the headers
+                headersEncodedSizeAccumulator = HEADERS_WEIGHT_NEW * padSizeForAccumulation(buf.readableBytes()) +
+                        HEADERS_WEIGHT_HISTORICAL * headersEncodedSizeAccumulator;
 
-            // don't consider the copyContent case here: the statistics is just related the headers
-            headersEncodedSizeAccumulator = HEADERS_WEIGHT_NEW * padSizeForAccumulation(buf.readableBytes()) +
-                    HEADERS_WEIGHT_HISTORICAL * headersEncodedSizeAccumulator;
-
-            encodeByteBufHttpContent(state, ctx, buf, content, msg.trailingHeaders(), out);
+                handedOff = true;
+                encodeByteBufHttpContent(state, ctx, buf, content, msg.trailingHeaders(), out);
+            } finally {
+                if (!handedOff) {
+                    buf.release();
+                }
+            }
         } finally {
             msg.release();
         }
@@ -521,19 +528,27 @@ public abstract class HttpObjectEncoder<H extends HttpMessage> extends MessageTo
         assert state == ST_INIT;
 
         ByteBuf buf = ctx.alloc().buffer((int) headersEncodedSizeAccumulator);
-        // Encode the message.
-        encodeInitialLine(buf, m);
-        state = isContentAlwaysEmpty(m) ? ST_CONTENT_ALWAYS_EMPTY :
-                HttpUtil.isTransferEncodingChunked(m) ? ST_CONTENT_CHUNK : ST_CONTENT_NON_CHUNK;
+        boolean success = false;
+        try {
+            // Encode the message.
+            encodeInitialLine(buf, m);
+            state = isContentAlwaysEmpty(m) ? ST_CONTENT_ALWAYS_EMPTY :
+                    HttpUtil.isTransferEncodingChunked(m) ? ST_CONTENT_CHUNK : ST_CONTENT_NON_CHUNK;
 
-        sanitizeHeadersBeforeEncode(m, state == ST_CONTENT_ALWAYS_EMPTY);
+            sanitizeHeadersBeforeEncode(m, state == ST_CONTENT_ALWAYS_EMPTY);
 
-        encodeHeaders(m.headers(), buf);
-        ByteBufUtil.writeShortBE(buf, CRLF_SHORT);
+            encodeHeaders(m.headers(), buf);
+            ByteBufUtil.writeShortBE(buf, CRLF_SHORT);
 
-        headersEncodedSizeAccumulator = HEADERS_WEIGHT_NEW * padSizeForAccumulation(buf.readableBytes()) +
-                HEADERS_WEIGHT_HISTORICAL * headersEncodedSizeAccumulator;
-        return buf;
+            headersEncodedSizeAccumulator = HEADERS_WEIGHT_NEW * padSizeForAccumulation(buf.readableBytes()) +
+                    HEADERS_WEIGHT_HISTORICAL * headersEncodedSizeAccumulator;
+            success = true;
+            return buf;
+        } finally {
+            if (!success) {
+                buf.release();
+            }
+        }
     }
 
     /**

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseEncoderTest.java
@@ -15,19 +15,31 @@
 */
 package io.netty.handler.codec.http;
 
+import io.netty.buffer.AbstractByteBufAllocator;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.FileRegion;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.EncoderException;
 import io.netty.util.CharsetUtil;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.io.IOException;
 import java.nio.channels.WritableByteChannel;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.concurrent.ExecutionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HttpResponseEncoderTest {
@@ -398,5 +410,157 @@ public class HttpResponseEncoderTest {
 
         assertEquals(responseText.toString(), written.toString());
         assertFalse(channel.finish());
+    }
+
+    @Test
+    public void testInitHttpMessageHeaderEncodingFailureReleasesBuffer() throws Exception {
+        final TrackingFailingAllocator allocator = new TrackingFailingAllocator();
+        final EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseEncoder());
+        channel.config().setAllocator(allocator);
+
+        final DefaultHttpResponse response =
+                new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK, new ThrowingHeaders());
+
+        ExecutionException e = assertThrows(ExecutionException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                channel.writeAndFlush(response).get();
+            }
+        });
+        assertInstanceOf(EncoderException.class, e.getCause());
+        assertInstanceOf(OutOfMemoryError.class, e.getCause().getCause());
+
+        assertAllTrackedBuffersReleased(allocator);
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    public void testFullHttpMessageHeaderEncodingFailureReleasesBuffer() throws Exception {
+        final TrackingFailingAllocator allocator = new TrackingFailingAllocator();
+        final EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseEncoder());
+        channel.config().setAllocator(allocator);
+
+        final DefaultFullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1,
+                HttpResponseStatus.OK, Unpooled.EMPTY_BUFFER, new ThrowingHeaders(), new DefaultHttpHeaders());
+
+        ExecutionException e = assertThrows(ExecutionException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                channel.writeAndFlush(response).get();
+            }
+        });
+        assertInstanceOf(EncoderException.class, e.getCause());
+        assertInstanceOf(OutOfMemoryError.class, e.getCause().getCause());
+
+        assertAllTrackedBuffersReleased(allocator);
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    public void testChunkedContentLengthAllocationFailureDoesNotDoubleReleaseHeaderBuffer() throws Exception {
+        final TrackingFailingAllocator allocator = new TrackingFailingAllocator(3);
+        final EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseEncoder());
+        channel.config().setAllocator(allocator);
+
+        final DefaultFullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1,
+                HttpResponseStatus.OK, Unpooled.copiedBuffer("1", CharsetUtil.US_ASCII));
+        HttpUtil.setTransferEncodingChunked(response, true);
+
+        EncoderException e = assertThrows(EncoderException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                channel.writeOutbound(response);
+            }
+        });
+        assertInstanceOf(OutOfMemoryError.class, e.getCause());
+
+        for (;;) {
+            ByteBuf buf = channel.readOutbound();
+            if (buf == null) {
+                break;
+            }
+            buf.release();
+        }
+
+        assertAllTrackedBuffersReleased(allocator);
+        channel.finishAndReleaseAll();
+    }
+
+    private static void assertAllTrackedBuffersReleased(TrackingFailingAllocator allocator) {
+        assertFalse(allocator.allocated.isEmpty(), "expected at least one buffer to be allocated");
+        for (ByteBuf buf : allocator.allocated) {
+            assertEquals(0, buf.refCnt(), "expected tracked buffer to be released: " + buf);
+        }
+    }
+
+    /**
+     * A {@link ByteBufAllocator} that throws an {@link OutOfMemoryError} when asked to allocate a buffer with a
+     * given {@code initialCapacity}, and otherwise delegates to an unpooled allocator while tracking every
+     * successfully allocated buffer for leak verification.
+     */
+    private static final class TrackingFailingAllocator extends AbstractByteBufAllocator {
+        private static final int NEVER_FAIL = -1;
+
+        private final ByteBufAllocator delegate = new UnpooledByteBufAllocator(false);
+        private final List<ByteBuf> allocated = new ArrayList<ByteBuf>();
+        private final int failOnInitialCapacity;
+
+        TrackingFailingAllocator() {
+            this(NEVER_FAIL);
+        }
+
+        TrackingFailingAllocator(int failOnInitialCapacity) {
+            super(false);
+            this.failOnInitialCapacity = failOnInitialCapacity;
+        }
+
+        private void failIfTargeted(int initialCapacity) {
+            if (failOnInitialCapacity != NEVER_FAIL && initialCapacity == failOnInitialCapacity) {
+                throw new OutOfMemoryError("simulated allocation failure for capacity " + initialCapacity);
+            }
+        }
+
+        @Override
+        protected ByteBuf newHeapBuffer(int initialCapacity, int maxCapacity) {
+            failIfTargeted(initialCapacity);
+            ByteBuf buf = delegate.heapBuffer(initialCapacity, maxCapacity);
+            allocated.add(buf);
+            return buf;
+        }
+
+        @Override
+        protected ByteBuf newDirectBuffer(int initialCapacity, int maxCapacity) {
+            failIfTargeted(initialCapacity);
+            ByteBuf buf = delegate.directBuffer(initialCapacity, maxCapacity);
+            allocated.add(buf);
+            return buf;
+        }
+
+        @Override
+        public boolean isDirectBufferPooled() {
+            return delegate.isDirectBufferPooled();
+        }
+    }
+
+    private static final class ThrowingHeaders extends DefaultHttpHeaders {
+        @Override
+        public Iterator<Entry<CharSequence, CharSequence>> iteratorCharSequence() {
+            return new Iterator<Entry<CharSequence, CharSequence>>() {
+                @Override
+                public boolean hasNext() {
+                    return true;
+                }
+
+                @Override
+                public Entry<CharSequence, CharSequence> next() {
+                    throw new OutOfMemoryError("simulated header encoding failure");
+                }
+
+                @Override
+                public void remove() {
+                    throw new UnsupportedOperationException();
+                }
+            };
+        }
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
@@ -360,6 +360,7 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
     public ChannelFuture writePushPromise(ChannelHandlerContext ctx, int streamId,
             int promisedStreamId, Http2Headers headers, int padding, ChannelPromise promise) {
         ByteBuf headerBlock = null;
+        ByteBuf fragment = null;
         SimpleChannelPromiseAggregator promiseAggregator =
                 new SimpleChannelPromiseAggregator(promise, ctx.channel(), ctx.executor());
         try {
@@ -376,7 +377,7 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
             // INT_FIELD_LENGTH is for the length of the promisedStreamId
             int nonFragmentLength = INT_FIELD_LENGTH + padding;
             int maxFragmentLength = maxFrameSize - nonFragmentLength;
-            ByteBuf fragment = headerBlock.readRetainedSlice(min(headerBlock.readableBytes(), maxFragmentLength));
+            fragment = headerBlock.readRetainedSlice(min(headerBlock.readableBytes(), maxFragmentLength));
 
             flags.endOfHeaders(!headerBlock.isReadable());
 
@@ -391,6 +392,7 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
 
             // Write the first fragment.
             ctx.write(fragment, promiseAggregator.newPromise());
+            fragment = null;
 
             // Write out the padding, if any.
             if (paddingBytes(padding) > 0) {
@@ -407,6 +409,9 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
             promiseAggregator.doneAllocatingPromises();
             PlatformDependent.throwException(t);
         } finally {
+            if (fragment != null) {
+                fragment.release();
+            }
             if (headerBlock != null) {
                 headerBlock.release();
             }
@@ -498,6 +503,7 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
             int streamId, Http2Headers headers, int padding, boolean endStream,
             boolean hasPriority, int streamDependency, short weight, boolean exclusive, ChannelPromise promise) {
         ByteBuf headerBlock = null;
+        ByteBuf fragment = null;
         SimpleChannelPromiseAggregator promiseAggregator =
                 new SimpleChannelPromiseAggregator(promise, ctx.channel(), ctx.executor());
         try {
@@ -518,7 +524,7 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
             // Read the first fragment (possibly everything).
             int nonFragmentBytes = padding + flags.getNumPriorityBytes();
             int maxFragmentLength = maxFrameSize - nonFragmentBytes;
-            ByteBuf fragment = headerBlock.readRetainedSlice(min(headerBlock.readableBytes(), maxFragmentLength));
+            fragment = headerBlock.readRetainedSlice(min(headerBlock.readableBytes(), maxFragmentLength));
 
             // Set the end of headers flag for the first frame.
             flags.endOfHeaders(!headerBlock.isReadable());
@@ -538,6 +544,7 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
 
             // Write the first fragment.
             ctx.write(fragment, promiseAggregator.newPromise());
+            fragment = null;
 
             // Write out the padding, if any.
             if (paddingBytes(padding) > 0) {
@@ -554,6 +561,9 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
             promiseAggregator.doneAllocatingPromises();
             PlatformDependent.throwException(t);
         } finally {
+            if (fragment != null) {
+                fragment.release();
+            }
             if (headerBlock != null) {
                 headerBlock.release();
             }
@@ -569,33 +579,46 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
         Http2Flags flags = new Http2Flags();
 
         if (headerBlock.isReadable()) {
-
             int fragmentReadableBytes;
             ByteBuf buf = null;
-
-            do {
-                fragmentReadableBytes = min(headerBlock.readableBytes(), maxFrameSize);
-                ByteBuf fragment = headerBlock.readRetainedSlice(fragmentReadableBytes);
-
-                if (headerBlock.isReadable()) {
-                    if (buf == null) {
-                        buf = ctx.alloc().buffer(CONTINUATION_FRAME_HEADER_LENGTH);
-                        writeFrameHeaderInternal(buf, fragmentReadableBytes, CONTINUATION, flags, streamId);
+            try {
+                do {
+                    fragmentReadableBytes = min(headerBlock.readableBytes(), maxFrameSize);
+                    ByteBuf fragment = headerBlock.readRetainedSlice(fragmentReadableBytes);
+                    boolean fragmentWritten = false;
+                    try {
+                        if (headerBlock.isReadable()) {
+                            if (buf == null) {
+                                buf = ctx.alloc().buffer(CONTINUATION_FRAME_HEADER_LENGTH);
+                                writeFrameHeaderInternal(buf, fragmentReadableBytes, CONTINUATION, flags, streamId);
+                            }
+                            ctx.write(buf.retainedSlice(), promiseAggregator.newPromise());
+                        } else {
+                            // The frame header is different for the last frame, so re-allocate and release
+                            // the old buffer
+                            if (buf != null) {
+                                buf.release();
+                                buf = null;
+                            }
+                            flags = flags.endOfHeaders(true);
+                            buf = ctx.alloc().buffer(CONTINUATION_FRAME_HEADER_LENGTH);
+                            writeFrameHeaderInternal(buf, fragmentReadableBytes, CONTINUATION, flags, streamId);
+                            ctx.write(buf, promiseAggregator.newPromise());
+                            buf = null;
+                        }
+                        ctx.write(fragment, promiseAggregator.newPromise());
+                        fragmentWritten = true;
+                    } finally {
+                        if (!fragmentWritten) {
+                            fragment.release();
+                        }
                     }
-                    ctx.write(buf.retainedSlice(), promiseAggregator.newPromise());
-                } else {
-                    // The frame header is different for the last frame, so re-allocate and release the old buffer
-                    if (buf != null) {
-                       buf.release();
-                    }
-                    flags = flags.endOfHeaders(true);
-                    buf = ctx.alloc().buffer(CONTINUATION_FRAME_HEADER_LENGTH);
-                    writeFrameHeaderInternal(buf, fragmentReadableBytes, CONTINUATION, flags, streamId);
-                    ctx.write(buf, promiseAggregator.newPromise());
+                } while (headerBlock.isReadable());
+            } finally {
+                if (buf != null) {
+                    buf.release();
                 }
-                ctx.write(fragment, promiseAggregator.newPromise());
-
-            } while (headerBlock.isReadable());
+            }
         }
         return promiseAggregator;
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriterTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriterTest.java
@@ -14,7 +14,9 @@
  */
 package io.netty.handler.codec.http2;
 
+import io.netty.buffer.AbstractByteBufAllocator;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.Channel;
@@ -34,10 +36,14 @@ import org.mockito.stubbing.Answer;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 /**
@@ -357,6 +363,116 @@ public class DefaultHttp2FrameWriterTest {
                 (byte) 0x0F, // weight = 15 (implicit +1)
         });
         assertEquals(expectedOutbound, outbound);
+    }
+
+    @Test
+    public void writeHeadersReleasesHeaderBlockWhenFrameHeaderAllocationFails() {
+        TrackingFailingAllocator allocator =
+                new TrackingFailingAllocator(Http2CodecUtil.HEADERS_FRAME_HEADER_LENGTH);
+        when(ctx.alloc()).thenReturn(allocator);
+
+        int streamId = 1;
+        Http2Headers headers = new DefaultHttp2Headers()
+                .method("GET").path("/").authority("foo.com").scheme("https");
+
+        assertThrows(OutOfMemoryError.class,
+                () -> frameWriter.writeHeaders(ctx, streamId, headers, 0, true, promise));
+
+        assertAllTrackedBuffersReleased(allocator);
+    }
+
+    @Test
+    public void writePushPromiseReleasesHeaderBlockWhenFrameHeaderAllocationFails() {
+        TrackingFailingAllocator allocator =
+                new TrackingFailingAllocator(Http2CodecUtil.PUSH_PROMISE_FRAME_HEADER_LENGTH);
+        when(ctx.alloc()).thenReturn(allocator);
+
+        int streamId = 1;
+        int promisedStreamId = 2;
+        Http2Headers headers = new DefaultHttp2Headers()
+                .method("GET").path("/").authority("foo.com").scheme("https");
+
+        assertThrows(OutOfMemoryError.class,
+                () -> frameWriter.writePushPromise(ctx, streamId, promisedStreamId, headers, 0, promise));
+
+        assertAllTrackedBuffersReleased(allocator);
+    }
+
+    @Test
+    public void writeContinuationFramesReleasesHeaderBlockWhenFrameHeaderAllocationFails() throws Exception {
+        int streamId = 1;
+        Http2Headers headers = new DefaultHttp2Headers()
+                .method("GET").path("/").authority("foo.com").scheme("https");
+        final Http2Headers largeHeaders = dummyHeaders(headers, 60);
+
+        http2HeadersEncoder.configuration().maxHeaderListSize(Integer.MAX_VALUE);
+        frameWriter.headersConfiguration().maxHeaderListSize(Integer.MAX_VALUE);
+        frameWriter.maxFrameSize(Http2CodecUtil.MAX_FRAME_SIZE_LOWER_BOUND);
+
+        TrackingFailingAllocator allocator =
+                new TrackingFailingAllocator(Http2CodecUtil.CONTINUATION_FRAME_HEADER_LENGTH);
+        when(ctx.alloc()).thenReturn(allocator);
+
+        assertThrows(OutOfMemoryError.class,
+                () -> frameWriter.writeHeaders(ctx, streamId, largeHeaders, 0, true, promise));
+
+        assertAllTrackedBuffersReleased(allocator);
+    }
+
+    private static void assertAllTrackedBuffersReleased(TrackingFailingAllocator allocator) {
+        assertFalse(allocator.allocated.isEmpty(), "expected at least one buffer to be allocated");
+        for (ByteBuf buf : allocator.allocated) {
+            assertEquals(0, buf.refCnt(), "expected tracked buffer to be fully released");
+        }
+    }
+
+    /**
+     * A {@link ByteBufAllocator} that throws an {@link OutOfMemoryError} when asked to allocate a buffer with a
+     * given {@code initialCapacity}, and otherwise delegates to an unpooled allocator while tracking every
+     * successfully allocated buffer for leak verification.
+     */
+    private static final class TrackingFailingAllocator extends AbstractByteBufAllocator {
+        private static final int NEVER_FAIL = -1;
+
+        private final ByteBufAllocator delegate = new UnpooledByteBufAllocator(false);
+        private final List<ByteBuf> allocated = new ArrayList<ByteBuf>();
+        private final int failOnInitialCapacity;
+
+        TrackingFailingAllocator() {
+            this(NEVER_FAIL);
+        }
+
+        TrackingFailingAllocator(int failOnInitialCapacity) {
+            super(false);
+            this.failOnInitialCapacity = failOnInitialCapacity;
+        }
+
+        private void failIfTargeted(int initialCapacity) {
+            if (failOnInitialCapacity != NEVER_FAIL && initialCapacity == failOnInitialCapacity) {
+                throw new OutOfMemoryError("simulated allocation failure for capacity " + initialCapacity);
+            }
+        }
+
+        @Override
+        protected ByteBuf newHeapBuffer(int initialCapacity, int maxCapacity) {
+            failIfTargeted(initialCapacity);
+            ByteBuf buf = delegate.heapBuffer(initialCapacity, maxCapacity);
+            allocated.add(buf);
+            return buf;
+        }
+
+        @Override
+        protected ByteBuf newDirectBuffer(int initialCapacity, int maxCapacity) {
+            failIfTargeted(initialCapacity);
+            ByteBuf buf = delegate.directBuffer(initialCapacity, maxCapacity);
+            allocated.add(buf);
+            return buf;
+        }
+
+        @Override
+        public boolean isDirectBufferPooled() {
+            return delegate.isDirectBufferPooled();
+        }
     }
 
     private byte[] headerPayload(int streamId, Http2Headers headers, byte padding) throws Http2Exception, IOException {


### PR DESCRIPTION
### Motivation

Fixes #17088. Same class of bug as the `SslHandler` leak fixed in #17059: a header buffer is allocated, then a `Throwable` (typically `OutOfMemoryError`) is thrown before the buffer is handed off, leaving it unreleased. #6729 reported the exact symptom on `HttpObjectEncoder.encodeHeaders` back in 2017 but couldn't be reproduced on demand and was closed; the root cause was never fixed.

Affected paths:
- HTTP/1 — `encodeInitHttpMessage()` and `encodeFullHttpMessage()` in `HttpObjectEncoder`: `buf` from `ctx.alloc().buffer(...)` leaks if `encodeHeaders()` throws before it is added to `out`.
- HTTP/2 — `writeHeadersInternal()`, `writePushPromise()` and `writeContinuationFrames()` in `DefaultHttp2FrameWriter`: the retained `fragment` / frame-header buffer leaks if a later allocation throws after the fragment is sliced off the header block.

With pooled direct buffers this leaks off-heap memory the GC cannot reclaim, so repeated OOME on these paths ends in `OutOfDirectMemoryError` / process death.

### Modification

- `HttpObjectEncoder`: guard the header buffer with a success/handed-off flag and release it in a `finally` unless ownership was transferred. In `encodeFullHttpMessage()` the flag is set immediately before `encodeByteBufHttpContent()` so the chunked path — where `buf` is already added to `out` before `encodeChunkedHttpContent()` can throw — does not double-release.
- `DefaultHttp2FrameWriter`: hoist `fragment` to method scope, null it right after `ctx.write(fragment, ...)`, and release it in `finally` if non-null. `writeContinuationFrames()` additionally guards the reused frame-header buffer with a per-fragment flag.
- Add tests to both modules using a tracking allocator that injects an `OutOfMemoryError` on a targeted allocation, asserting every tracked buffer reaches `refCnt() == 0` after the failure.

### Result

No buffer leak when a `Throwable` is thrown mid header encoding. The normal path is unchanged.

Measured with the tracking allocator (each OOME on these paths leaks exactly one header buffer, so the leak grows linearly with the number of affected requests):

| path | leak / request | before | after |
|---|---|---|---|
| `HttpObjectEncoder` init / full | 256 B | `refCnt == 1` | `0` |
| Http2 `writeHeaders` / `writePushPromise` | 256 B | `refCnt == 1` | `0` |
| Http2 `writeContinuationFrames` (large headers) | 64 KiB | `refCnt == 1` | `0` |

At scale on the 256 B paths that is ~244 MiB leaked per 1M affected requests; on the CONTINUATION path (large headers) ~61 GiB per 1M. After the fix the leak is `0` regardless of request count.
