### PR TITLE
Do not clear user-provided caches when DnsNameResolver is closed

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/Cache.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/Cache.java
@@ -115,7 +115,7 @@ abstract class Cache<E> {
      */
     final List<? extends E> get(String hostname) {
         Entries entries = resolveCache.get(hostname);
-        return entries == null ? null : entries.get();
+        return entries == null ? null : entries.getIfNotExpired();
     }
 
     /**
@@ -168,6 +168,19 @@ abstract class Cache<E> {
         Entries(String hostname) {
             super(Collections.<E>emptyList());
             this.hostname = hostname;
+        }
+
+        List<E> getIfNotExpired() {
+            ScheduledFuture<?> expirationFuture = this.expirationFuture;
+            // The expiration task may have been cancelled when its EventLoop was shut down. The future still
+            // tracks the original deadline, so also expire entries lazily to ensure we never return them past
+            // their TTL.
+            if (expirationFuture != null && expirationFuture.getDelay(TimeUnit.NANOSECONDS) <= 0) {
+                resolveCache.remove(hostname, this);
+                clearAndCancel();
+                return null;
+            }
+            return get();
         }
 
         void add(E e, int ttl, EventLoop loop) {

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolverGroup.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolverGroup.java
@@ -35,6 +35,10 @@ import java.util.concurrent.ConcurrentMap;
 
 /**
  * A {@link AddressResolverGroup} of {@link DnsNameResolver}s.
+ * <p>
+ * Caches provided through the {@link DnsNameResolverBuilder} are not cleared when this group is closed. The caller
+ * that provides a cache is responsible for its lifecycle. Caches created internally by this group are shared by its
+ * member resolvers and cleared when the group is closed.
  */
 public class DnsAddressResolverGroup extends AddressResolverGroup<InetSocketAddress> {
 
@@ -42,6 +46,10 @@ public class DnsAddressResolverGroup extends AddressResolverGroup<InetSocketAddr
 
     private final ConcurrentMap<String, Promise<InetAddress>> resolvesInProgress = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, Promise<List<InetAddress>>> resolveAllsInProgress = new ConcurrentHashMap<>();
+
+    private DnsCache ownedResolveCache;
+    private DnsCnameCache ownedCnameCache;
+    private AuthoritativeDnsServerCache ownedAuthoritativeDnsServerCache;
 
     public DnsAddressResolverGroup(DnsNameResolverBuilder dnsResolverBuilder) {
         this.dnsResolverBuilder = withSharedCaches(dnsResolverBuilder.copy());
@@ -61,12 +69,48 @@ public class DnsAddressResolverGroup extends AddressResolverGroup<InetSocketAddr
         dnsResolverBuilder.datagramChannelFactory(channelFactory).nameServerProvider(nameServerProvider);
     }
 
-    private static DnsNameResolverBuilder withSharedCaches(DnsNameResolverBuilder dnsResolverBuilder) {
+    private DnsNameResolverBuilder withSharedCaches(DnsNameResolverBuilder dnsResolverBuilder) {
         /// To avoid each member of the group having its own cache we either use the configured cache
         // or create a new one to share among the entire group.
-        return dnsResolverBuilder.resolveCache(dnsResolverBuilder.getOrNewCache())
-                .cnameCache(dnsResolverBuilder.getOrNewCnameCache())
-                .authoritativeDnsServerCache(dnsResolverBuilder.getOrNewAuthoritativeDnsServerCache());
+        boolean hasResolveCache = dnsResolverBuilder.hasResolveCache();
+        boolean hasCnameCache = dnsResolverBuilder.hasCnameCache();
+        boolean hasAuthoritativeDnsServerCache = dnsResolverBuilder.hasAuthoritativeDnsServerCache();
+
+        DnsCache resolveCache = dnsResolverBuilder.getOrNewCache();
+        DnsCnameCache cnameCache = dnsResolverBuilder.getOrNewCnameCache();
+        AuthoritativeDnsServerCache authoritativeDnsServerCache =
+                dnsResolverBuilder.getOrNewAuthoritativeDnsServerCache();
+
+        // Remember the caches that were created for this group, so they can be cleared once the group is
+        // closed. Caches that were configured by the user might still be shared with other resolvers and so
+        // must be left untouched on close. See https://github.com/netty/netty/issues/17040
+        if (!hasResolveCache) {
+            ownedResolveCache = resolveCache;
+        }
+        if (!hasCnameCache) {
+            ownedCnameCache = cnameCache;
+        }
+        if (!hasAuthoritativeDnsServerCache) {
+            ownedAuthoritativeDnsServerCache = authoritativeDnsServerCache;
+        }
+
+        return dnsResolverBuilder.resolveCache(resolveCache)
+                .cnameCache(cnameCache)
+                .authoritativeDnsServerCache(authoritativeDnsServerCache);
+    }
+
+    @Override
+    public void close() {
+        super.close();
+        if (ownedResolveCache != null) {
+            ownedResolveCache.clear();
+        }
+        if (ownedCnameCache != null) {
+            ownedCnameCache.clear();
+        }
+        if (ownedAuthoritativeDnsServerCache != null) {
+            ownedAuthoritativeDnsServerCache.clear();
+        }
     }
 
     @SuppressWarnings("deprecation")

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -306,6 +306,9 @@ public class DnsNameResolver extends InetNameResolver {
     private final DnsResolveChannelProvider resolveChannelProvider;
     private final Bootstrap socketBootstrap;
     private final boolean retryWithTcpOnTimeout;
+    private final boolean clearResolveCacheOnClose;
+    private final boolean clearCnameCacheOnClose;
+    private final boolean clearAuthoritativeDnsServerCacheOnClose;
 
     private final int maxNumConsolidation;
     private final Map<DnsQuestion, Promise<AddressedEnvelope<? extends DnsResponse,
@@ -418,7 +421,6 @@ public class DnsNameResolver extends InetNameResolver {
              searchDomains, ndots, decodeIdn, false, 0, DnsNameResolverChannelStrategy.ChannelPerResolver);
     }
 
-    @SuppressWarnings("deprecation")
     DnsNameResolver(
             EventLoop eventLoop,
             ChannelFactory<? extends DatagramChannel> channelFactory,
@@ -427,6 +429,43 @@ public class DnsNameResolver extends InetNameResolver {
             final DnsCache resolveCache,
             final DnsCnameCache cnameCache,
             final AuthoritativeDnsServerCache authoritativeDnsServerCache,
+            SocketAddress localAddress,
+            DnsQueryLifecycleObserverFactory dnsQueryLifecycleObserverFactory,
+            long queryTimeoutMillis,
+            ResolvedAddressTypes resolvedAddressTypes,
+            boolean recursionDesired,
+            int maxQueriesPerResolve,
+            boolean traceEnabled,
+            final int maxPayloadSize,
+            boolean optResourceEnabled,
+            HostsFileEntriesResolver hostsFileEntriesResolver,
+            DnsServerAddressStreamProvider dnsServerAddressStreamProvider,
+            DnsServerAddressStream queryDnsServerAddressStream,
+            String[] searchDomains,
+            int ndots,
+            boolean decodeIdn,
+            boolean completeOncePreferredResolved,
+            int maxNumConsolidation, DnsNameResolverChannelStrategy datagramChannelStrategy) {
+        this(eventLoop, channelFactory, socketChannelFactory, retryWithTcpOnTimeout, resolveCache, true,
+                cnameCache, true, authoritativeDnsServerCache, true, localAddress,
+                dnsQueryLifecycleObserverFactory, queryTimeoutMillis, resolvedAddressTypes, recursionDesired,
+                maxQueriesPerResolve, traceEnabled, maxPayloadSize, optResourceEnabled, hostsFileEntriesResolver,
+                dnsServerAddressStreamProvider, queryDnsServerAddressStream, searchDomains, ndots, decodeIdn,
+                completeOncePreferredResolved, maxNumConsolidation, datagramChannelStrategy);
+    }
+
+    @SuppressWarnings("deprecation")
+    DnsNameResolver(
+            EventLoop eventLoop,
+            ChannelFactory<? extends DatagramChannel> channelFactory,
+            ChannelFactory<? extends SocketChannel> socketChannelFactory,
+            boolean retryWithTcpOnTimeout,
+            final DnsCache resolveCache,
+            boolean clearResolveCacheOnClose,
+            final DnsCnameCache cnameCache,
+            boolean clearCnameCacheOnClose,
+            final AuthoritativeDnsServerCache authoritativeDnsServerCache,
+            boolean clearAuthoritativeDnsServerCacheOnClose,
             SocketAddress localAddress,
             DnsQueryLifecycleObserverFactory dnsQueryLifecycleObserverFactory,
             long queryTimeoutMillis,
@@ -458,7 +497,9 @@ public class DnsNameResolver extends InetNameResolver {
                 checkNotNull(dnsServerAddressStreamProvider, "dnsServerAddressStreamProvider");
         this.queryDnsServerAddressStream = checkNotNull(queryDnsServerAddressStream, "queryDnsServerAddressStream");
         this.resolveCache = checkNotNull(resolveCache, "resolveCache");
+        this.clearResolveCacheOnClose = clearResolveCacheOnClose;
         this.cnameCache = checkNotNull(cnameCache, "cnameCache");
+        this.clearCnameCacheOnClose = clearCnameCacheOnClose;
         this.dnsQueryLifecycleObserverFactory = traceEnabled ?
                 dnsQueryLifecycleObserverFactory instanceof NoopDnsQueryLifecycleObserverFactory ?
                         new LoggingDnsQueryLifeCycleObserverFactory() :
@@ -515,6 +556,7 @@ public class DnsNameResolver extends InetNameResolver {
         }
         preferredAddressType = preferredAddressType(this.resolvedAddressTypes);
         this.authoritativeDnsServerCache = checkNotNull(authoritativeDnsServerCache, "authoritativeDnsServerCache");
+        this.clearAuthoritativeDnsServerCacheOnClose = clearAuthoritativeDnsServerCacheOnClose;
         nameServerComparator = new NameServerComparator(addressType(preferredAddressType));
         this.maxNumConsolidation = maxNumConsolidation;
         if (maxNumConsolidation > 0) {
@@ -715,15 +757,22 @@ public class DnsNameResolver extends InetNameResolver {
 
     /**
      * Closes the internal datagram channel used for sending and receiving DNS messages, and clears all DNS resource
-     * records from the cache. Attempting to send a DNS query or to resolve a domain name will fail once this method
-     * has been called.
+     * records from the caches that were created by this resolver. Caches that were provided by the user via
+     * {@link DnsNameResolverBuilder} are not cleared as they might still be shared with other resolvers.
+     * Attempting to send a DNS query or to resolve a domain name will fail once this method has been called.
      */
     @Override
     public void close() {
         resolveChannelProvider.close();
-        resolveCache.clear();
-        cnameCache.clear();
-        authoritativeDnsServerCache.clear();
+        if (clearResolveCacheOnClose) {
+            resolveCache.clear();
+        }
+        if (clearCnameCacheOnClose) {
+            cnameCache.clear();
+        }
+        if (clearAuthoritativeDnsServerCacheOnClose) {
+            authoritativeDnsServerCache.clear();
+        }
     }
 
     @Override

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -256,6 +256,9 @@ public final class DnsNameResolverBuilder {
 
     /**
      * Sets the cache for resolution results.
+     * <p>
+     * The provided cache is not cleared when the resolver or a {@link DnsAddressResolverGroup} using this builder
+     * is closed. The caller is responsible for the cache lifecycle.
      *
      * @param resolveCache the DNS resolution results cache
      * @return {@code this}
@@ -267,6 +270,9 @@ public final class DnsNameResolverBuilder {
 
     /**
      * Sets the cache for {@code CNAME} mappings.
+     * <p>
+     * The provided cache is not cleared when the resolver or a {@link DnsAddressResolverGroup} using this builder
+     * is closed. The caller is responsible for the cache lifecycle.
      *
      * @param cnameCache the cache used to cache {@code CNAME} mappings for a domain.
      * @return {@code this}
@@ -289,6 +295,9 @@ public final class DnsNameResolverBuilder {
 
     /**
      * Sets the cache for authoritative NS servers
+     * <p>
+     * The provided cache is not cleared when the resolver or a {@link DnsAddressResolverGroup} using this builder
+     * is closed. The caller is responsible for the cache lifecycle.
      *
      * @param authoritativeDnsServerCache the authoritative NS servers cache
      * @return {@code this}
@@ -302,6 +311,9 @@ public final class DnsNameResolverBuilder {
 
     /**
      * Sets the cache for authoritative NS servers
+     * <p>
+     * The provided cache is not cleared when the resolver or a {@link DnsAddressResolverGroup} using this builder
+     * is closed. The caller is responsible for the cache lifecycle.
      *
      * @param authoritativeDnsServerCache the authoritative NS servers cache
      * @return {@code this}
@@ -588,6 +600,18 @@ public final class DnsNameResolverBuilder {
         return this;
     }
 
+   boolean hasResolveCache() {
+        return resolveCache != null;
+    }
+
+   boolean hasCnameCache() {
+        return cnameCache != null;
+    }
+
+   boolean hasAuthoritativeDnsServerCache() {
+        return authoritativeDnsServerCache != null;
+    }
+
    DnsCache getOrNewCache() {
         if (this.resolveCache != null) {
             return this.resolveCache;
@@ -681,6 +705,13 @@ public final class DnsNameResolverBuilder {
             logger.debug("authoritativeDnsServerCache and TTLs are mutually exclusive. TTLs are ignored.");
         }
 
+        // Only clear caches on close that were created by the resolver itself. Caches that were provided by
+        // the user might still be shared with other resolvers and so must be left untouched on close.
+        // See https://github.com/netty/netty/issues/17040
+        boolean clearResolveCacheOnClose = this.resolveCache == null;
+        boolean clearCnameCacheOnClose = this.cnameCache == null;
+        boolean clearAuthoritativeDnsServerCacheOnClose = this.authoritativeDnsServerCache == null;
+
         DnsCache resolveCache = getOrNewCache();
         DnsCnameCache cnameCache = getOrNewCnameCache();
         AuthoritativeDnsServerCache authoritativeDnsServerCache = getOrNewAuthoritativeDnsServerCache();
@@ -694,8 +725,11 @@ public final class DnsNameResolverBuilder {
                 socketChannelFactory,
                 retryOnTimeout,
                 resolveCache,
+                clearResolveCacheOnClose,
                 cnameCache,
+                clearCnameCacheOnClose,
                 authoritativeDnsServerCache,
+                clearAuthoritativeDnsServerCacheOnClose,
                 localAddress,
                 dnsQueryLifecycleObserverFactory,
                 queryTimeoutMillis,

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DefaultDnsCacheTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DefaultDnsCacheTest.java
@@ -73,6 +73,39 @@ public class DefaultDnsCacheTest {
     }
 
     @Test
+    public void testExpireAfterEventLoopShutdown() throws Throwable {
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        EventLoopGroup verificationGroup = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        final DefaultDnsCache cache = new DefaultDnsCache();
+
+        try {
+            EventLoop loop = group.next();
+            cache.cache("netty.io", null, NetUtil.LOCALHOST, 1, loop);
+            assertNotNull(cache.get("netty.io", null));
+
+            group.shutdownGracefully(0, 1, TimeUnit.SECONDS).syncUninterruptibly();
+
+            Throwable error = verificationGroup.next().schedule(new Callable<Throwable>() {
+                @Override
+                public Throwable call() {
+                    try {
+                        assertNull(cache.get("netty.io", null));
+                        return null;
+                    } catch (Throwable cause) {
+                        return cause;
+                    }
+                }
+            }, 1, TimeUnit.SECONDS).get();
+            if (error != null) {
+                throw error;
+            }
+        } finally {
+            group.shutdownGracefully();
+            verificationGroup.shutdownGracefully();
+        }
+    }
+
+    @Test
     public void testExpireWithDifferentTTLs() {
         testExpireWithTTL0(1);
         testExpireWithTTL0(1000);

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsAddressResolverGroupTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsAddressResolverGroupTest.java
@@ -15,14 +15,18 @@
  */
 package io.netty.resolver.dns;
 
+import io.netty.channel.ChannelFactory;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.local.LocalIoHandler;
 import io.netty.channel.nio.NioIoHandler;
+import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.resolver.AddressResolver;
 import io.netty.resolver.InetSocketAddressResolver;
+import io.netty.resolver.NameResolver;
+import io.netty.util.NetUtil;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;
@@ -32,9 +36,17 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.channels.UnsupportedAddressTypeException;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -77,16 +89,18 @@ public class DnsAddressResolverGroupTest {
         DnsNameResolverBuilder builder = new DnsNameResolverBuilder()
                 .eventLoop(loop).datagramChannelType(NioDatagramChannel.class);
         DnsAddressResolverGroup resolverGroup = new DnsAddressResolverGroup(builder);
-        EventLoopGroup defaultEventLoopGroup = new MultiThreadIoEventLoopGroup(1, LocalIoHandler.newFactory());
+        EventLoopGroup defaultEventLoopGroup = new MultiThreadIoEventLoopGroup(2, LocalIoHandler.newFactory());
         EventLoop eventLoop1 = defaultEventLoopGroup.next();
         EventLoop eventLoop2 = defaultEventLoopGroup.next();
         try {
+            assertNotSame(eventLoop1, eventLoop2);
             final Promise<InetSocketAddress> promise1 = loop.newPromise();
             InetSocketAddressResolver resolver1 = (InetSocketAddressResolver) resolverGroup.getResolver(eventLoop1);
             InetAddress address1 =
                     resolve(resolver1, InetSocketAddress.createUnresolved("netty.io", 80), promise1);
             final Promise<InetSocketAddress> promise2 = loop.newPromise();
             InetSocketAddressResolver resolver2 = (InetSocketAddressResolver) resolverGroup.getResolver(eventLoop2);
+            assertNotSame(resolver1, resolver2);
             InetAddress address2 =
                     resolve(resolver2, InetSocketAddress.createUnresolved("netty.io", 80), promise2);
             assertSame(address1, address2);
@@ -94,6 +108,139 @@ public class DnsAddressResolverGroupTest {
             resolverGroup.close();
             group.shutdownGracefully();
             defaultEventLoopGroup.shutdownGracefully();
+        }
+    }
+
+    @Test
+    public void testEventLoopTerminationDoesNotClearGroupSharedCache() {
+        EventLoopGroup group1 = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        EventLoopGroup group2 = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        EventLoop eventLoop1 = group1.next();
+        EventLoop eventLoop2 = group2.next();
+        final AtomicReference<DnsNameResolver> resolver1Ref = new AtomicReference<>();
+        final AtomicReference<DnsNameResolver> resolver2Ref = new AtomicReference<>();
+
+        DnsNameResolverBuilder builder = new DnsNameResolverBuilder()
+                .datagramChannelType(NioDatagramChannel.class);
+        DnsAddressResolverGroup resolverGroup = new DnsAddressResolverGroup(builder) {
+            @Override
+            protected NameResolver<InetAddress> newNameResolver(
+                    EventLoop eventLoop, ChannelFactory<? extends DatagramChannel> channelFactory,
+                    DnsServerAddressStreamProvider nameServerProvider) throws Exception {
+                DnsNameResolver resolver = (DnsNameResolver)
+                        super.newNameResolver(eventLoop, channelFactory, nameServerProvider);
+                if (eventLoop == eventLoop1) {
+                    resolver1Ref.set(resolver);
+                } else if (eventLoop == eventLoop2) {
+                    resolver2Ref.set(resolver);
+                }
+                return resolver;
+            }
+        };
+
+        try {
+            AddressResolver<InetSocketAddress> resolver1 = resolverGroup.getResolver(eventLoop1);
+            AddressResolver<InetSocketAddress> resolver2 = resolverGroup.getResolver(eventLoop2);
+            assertNotSame(resolver1, resolver2);
+
+            DnsCache resolveCache = resolver1Ref.get().resolveCache();
+            assertSame(resolveCache, resolver2Ref.get().resolveCache());
+            resolveCache.cache("netty.io", null, NetUtil.LOCALHOST, 3600, eventLoop1);
+
+            group1.shutdownGracefully(0, 1, TimeUnit.SECONDS).syncUninterruptibly();
+
+            List<? extends DnsCacheEntry> entries = resolveCache.get("netty.io", null);
+            assertNotNull(entries);
+            assertFalse(entries.isEmpty());
+
+            resolverGroup.close();
+            entries = resolveCache.get("netty.io", null);
+            assertTrue(entries == null || entries.isEmpty());
+        } finally {
+            resolverGroup.close();
+            group1.shutdownGracefully();
+            group2.shutdownGracefully();
+        }
+    }
+
+    @Test
+    public void testCloseDoesNotClearProvidedCaches() {
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        final EventLoop loop = group.next();
+        DnsCache resolveCache = new DefaultDnsCache();
+        DnsCnameCache cnameCache = new DefaultDnsCnameCache();
+        AuthoritativeDnsServerCache authoritativeDnsServerCache = new DefaultAuthoritativeDnsServerCache();
+        try {
+            DnsNameResolverBuilder builder = new DnsNameResolverBuilder()
+                    .eventLoop(loop)
+                    .datagramChannelType(NioDatagramChannel.class)
+                    .resolveCache(resolveCache)
+                    .cnameCache(cnameCache)
+                    .authoritativeDnsServerCache(authoritativeDnsServerCache);
+            DnsAddressResolverGroup resolverGroup = new DnsAddressResolverGroup(builder);
+            // Instantiate a resolver so closing the group also closes the resolver.
+            resolverGroup.getResolver(loop);
+
+            resolveCache.cache("netty.io", null, NetUtil.LOCALHOST, 3600, loop);
+            cnameCache.cache("netty.io", "mapping.netty.io", 3600, loop);
+            authoritativeDnsServerCache.cache(
+                    "netty.io", new InetSocketAddress(NetUtil.LOCALHOST, 53), 3600, loop);
+            resolverGroup.close();
+
+            List<? extends DnsCacheEntry> entries = resolveCache.get("netty.io", null);
+            assertNotNull(entries);
+            assertFalse(entries.isEmpty());
+            assertEquals("mapping.netty.io", cnameCache.get("netty.io"));
+            assertNotNull(authoritativeDnsServerCache.get("netty.io"));
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+    @Test
+    public void testCloseClearsCachesCreatedByGroup() {
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        final EventLoop loop = group.next();
+        try {
+            DnsNameResolverBuilder builder = new DnsNameResolverBuilder()
+                    .eventLoop(loop)
+                    .datagramChannelType(NioDatagramChannel.class);
+            final AtomicReference<DnsNameResolver> resolverRef = new AtomicReference<>();
+            DnsAddressResolverGroup resolverGroup = new DnsAddressResolverGroup(builder) {
+                @Override
+                protected NameResolver<InetAddress> newNameResolver(
+                        EventLoop eventLoop, ChannelFactory<? extends DatagramChannel> channelFactory,
+                        DnsServerAddressStreamProvider nameServerProvider) throws Exception {
+                    NameResolver<InetAddress> resolver =
+                            super.newNameResolver(eventLoop, channelFactory, nameServerProvider);
+                    resolverRef.set((DnsNameResolver) resolver);
+                    return resolver;
+                }
+            };
+            resolverGroup.getResolver(loop);
+
+            DnsCache resolveCache = resolverRef.get().resolveCache();
+            DnsCnameCache cnameCache = resolverRef.get().cnameCache();
+            AuthoritativeDnsServerCache authoritativeDnsServerCache =
+                    resolverRef.get().authoritativeDnsServerCache();
+            resolveCache.cache("netty.io", null, NetUtil.LOCALHOST, 3600, loop);
+            cnameCache.cache("netty.io", "mapping.netty.io", 3600, loop);
+            authoritativeDnsServerCache.cache(
+                    "netty.io", new InetSocketAddress(NetUtil.LOCALHOST, 53), 3600, loop);
+            List<? extends DnsCacheEntry> entries = resolveCache.get("netty.io", null);
+            assertNotNull(entries);
+            assertFalse(entries.isEmpty());
+            assertEquals("mapping.netty.io", cnameCache.get("netty.io"));
+            assertNotNull(authoritativeDnsServerCache.get("netty.io"));
+
+            resolverGroup.close();
+
+            entries = resolveCache.get("netty.io", null);
+            assertTrue(entries == null || entries.isEmpty());
+            assertNull(cnameCache.get("netty.io"));
+            assertNull(authoritativeDnsServerCache.get("netty.io"));
+        } finally {
+            group.shutdownGracefully();
         }
     }
 

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverBuilderTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverBuilderTest.java
@@ -21,6 +21,7 @@ import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.handler.codec.dns.DnsRecord;
+import io.netty.util.NetUtil;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -152,6 +153,35 @@ assertThat(resolver.queryDnsServerAddressStream()).isInstanceOf(ThreadLocalNameS
         assertThat(resolver.queryTimeoutMillis()).isEqualTo(0);
     }
 
+    @Test
+    void testCloseDoesNotClearProvidedCaches() {
+        TestDnsCache testDnsCache = new TestDnsCache();
+        TestDnsCnameCache testDnsCnameCache = new TestDnsCnameCache();
+        TestAuthoritativeDnsServerCache testAuthoritativeDnsServerCache = new TestAuthoritativeDnsServerCache();
+        resolver = builder.resolveCache(testDnsCache)
+                .cnameCache(testDnsCnameCache)
+                .authoritativeDnsServerCache(testAuthoritativeDnsServerCache)
+                .build();
+
+        resolver.close();
+
+        assertThat(testDnsCache.clearCalls).isZero();
+        assertThat(testDnsCnameCache.clearCalls).isZero();
+        assertThat(testAuthoritativeDnsServerCache.clearCalls).isZero();
+    }
+
+    @Test
+    void testCloseClearsCachesCreatedByResolver() {
+        resolver = builder.build();
+        DnsCache resolveCache = resolver.resolveCache();
+        resolveCache.cache("netty.io", null, NetUtil.LOCALHOST, 3600, GROUP.next());
+        assertThat(resolveCache.get("netty.io", null)).isNotEmpty();
+
+        resolver.close();
+
+        assertThat(resolveCache.get("netty.io", null)).isNullOrEmpty();
+    }
+
     private static void checkDefaultDnsCache(DefaultDnsCache dnsCache,
             int expectedMaxTtl, int expectedMinTtl, int expectedNegativeTtl) {
         assertThat(dnsCache.maxTtl()).isEqualTo(expectedMaxTtl);
@@ -174,9 +204,11 @@ assertThat(resolver.queryDnsServerAddressStream()).isInstanceOf(ThreadLocalNameS
 
     private static final class TestDnsCache implements DnsCache {
 
+        int clearCalls;
+
         @Override
         public void clear() {
-            //no-op
+            clearCalls++;
         }
 
         @Override
@@ -203,6 +235,8 @@ assertThat(resolver.queryDnsServerAddressStream()).isInstanceOf(ThreadLocalNameS
 
     private static final class TestDnsCnameCache implements DnsCnameCache {
 
+        int clearCalls;
+
         @Override
         public String get(String hostname) {
             return null;
@@ -215,7 +249,7 @@ assertThat(resolver.queryDnsServerAddressStream()).isInstanceOf(ThreadLocalNameS
 
         @Override
         public void clear() {
-            //no-op
+            clearCalls++;
         }
 
         @Override
@@ -225,6 +259,8 @@ assertThat(resolver.queryDnsServerAddressStream()).isInstanceOf(ThreadLocalNameS
     }
 
     private static final class TestAuthoritativeDnsServerCache implements AuthoritativeDnsServerCache {
+
+        int clearCalls;
 
         @Override
         public DnsServerAddressStream get(String hostname) {
@@ -238,7 +274,7 @@ assertThat(resolver.queryDnsServerAddressStream()).isInstanceOf(ThreadLocalNameS
 
         @Override
         public void clear() {
-            //no-op
+            clearCalls++;
         }
 
         @Override

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -2780,14 +2780,14 @@ public class DnsNameResolverTest {
     @ParameterizedTest
     @EnumSource(DnsNameResolverChannelStrategy.class)
     @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
-    public void testCachesClearedOnClose(DnsNameResolverChannelStrategy strategy) throws Exception {
-        final CountDownLatch resolveLatch = new CountDownLatch(1);
-        final CountDownLatch authoritativeLatch = new CountDownLatch(1);
+    public void testProvidedCachesNotClearedOnClose(DnsNameResolverChannelStrategy strategy) throws Exception {
+        final AtomicInteger resolveClearCalls = new AtomicInteger();
+        final AtomicInteger authoritativeClearCalls = new AtomicInteger();
 
         DnsNameResolver resolver = newResolver(strategy).resolveCache(new DnsCache() {
             @Override
             public void clear() {
-                resolveLatch.countDown();
+                resolveClearCalls.incrementAndGet();
             }
 
             @Override
@@ -2814,7 +2814,7 @@ public class DnsNameResolverTest {
         }).authoritativeDnsServerCache(new DnsCache() {
             @Override
             public void clear() {
-                authoritativeLatch.countDown();
+                authoritativeClearCalls.incrementAndGet();
             }
 
             @Override
@@ -2840,8 +2840,8 @@ public class DnsNameResolverTest {
         }).build();
 
         resolver.close();
-        resolveLatch.await();
-        authoritativeLatch.await();
+        assertEquals(0, resolveClearCalls.get());
+        assertEquals(0, authoritativeClearCalls.get());
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Motivation:

`DnsNameResolver.close()` unconditionally clears the resolve, CNAME and
authoritative DNS server caches. When a cache is shared, closing one resolver
or terminating one `EventLoop` can therefore discard entries that other
resolvers still use.

There is a related TTL edge case: cache expiration is scheduled on the
`EventLoop` that inserts an entry. If that loop shuts down, the scheduled task
is cancelled and an externally owned cache could otherwise continue returning
the entry after its TTL.

Modifications:

* Track ownership independently for all three DNS caches and clear only
  resolver-owned caches when `DnsNameResolver` closes.
* Let `DnsAddressResolverGroup` own and close only the shared caches it creates;
  leave caller-provided caches untouched.
* Expire cache entries lazily when `EventLoop` shutdown cancels their scheduled
  expiration task.
* Document the cache lifecycle contract on `DnsNameResolverBuilder` and
  `DnsAddressResolverGroup`.
* Add regression coverage for distinct `EventLoop`s, all three cache types,
  caller-owned versus group-owned cleanup, and TTL expiration after the
  scheduling `EventLoop` shuts down.

Result:

Fixes #17040.

Closing a `DnsNameResolver` or `DnsAddressResolverGroup` no longer clears
externally provided `DnsCache`, `DnsCnameCache` or
`AuthoritativeDnsServerCache` instances. Other resolvers keep their shared
entries, internally created caches are still cleared by their owner, and
entries cannot outlive their TTL if the scheduling `EventLoop` shuts down.

Verification:

* `./mvnw -B -ntp -pl resolver-dns -DskipH3Spec=true verify`
* 326 tests passed; 0 failures; 0 errors; 17 skipped.
