### PR TITLE
Reject negative maxOrder in PooledByteBufAllocator

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -360,7 +360,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
     }
 
     private static int validateAndCalculateChunkSize(int pageSize, int maxOrder) {
-        if (maxOrder > 14) {
+        if (maxOrder < 0 || maxOrder > 14) {
             throw new IllegalArgumentException("maxOrder: " + maxOrder + " (expected: 0-14)");
         }
 

--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -46,6 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -77,6 +78,14 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
     @Override
     protected void trimCaches(PooledByteBufAllocator allocator) {
         allocator.trimCurrentThreadCache();
+    }
+
+    @Test
+    public void testRejectNegativeMaxOrder() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                () -> new PooledByteBufAllocator(true, 1, 1, 8192, -1, 0, 0, false));
+
+        assertEquals("maxOrder: -1 (expected: 0-14)", exception.getMessage());
     }
 
     @Test


### PR DESCRIPTION
Motivation:

The valid range of `maxOrder` is 0 to 14, but negative values were accepted because only the upper bound was validated. When configured through `io.netty.allocator.maxOrder`, a negative value may result in an invalid chunk size during static initialization.

Modification:

Validate the lower bound of `maxOrder` and add a regression test.

Result:

Negative `maxOrder` values are rejected with an `IllegalArgumentException`.