### PR TITLE
Fix AdaptiveByteBuf._setLongLE calling checked setLongLE

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -2427,7 +2427,7 @@ final class AdaptivePoolingAllocator {
 
         @Override
         protected void _setLongLE(int index, long value) {
-            rootParent().setLongLE(idx(index), value);
+            rootParent()._setLongLE(idx(index), value);
         }
 
         @Override


### PR DESCRIPTION
Motivation:

AdaptiveByteBuf._setLongLE delegates to the checked setLongLE on the root parent, unlike all other _set/_get methods which use the unchecked underscore-prefixed variants. This adds redundant bounds checking and ensureAccessible() on every little-endian long write.

Modification:

Call rootParent()._setLongLE instead of rootParent().setLongLE.

Result:

_setLongLE now follows the same unchecked pattern as _setLong, _setInt, _setIntLE, etc.