### PR TITLE
Snappy: Guard decoder against invalid chunk lengths

### DIFF
--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/SnappyFrameDecoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/SnappyFrameDecoder.java
@@ -47,10 +47,14 @@ public class SnappyFrameDecoder extends ByteToMessageDecoder {
     private static final int SNAPPY_IDENTIFIER_LEN = 6;
     // See https://github.com/google/snappy/blob/1.1.9/framing_format.txt#L95
     private static final int MAX_UNCOMPRESSED_DATA_SIZE = 65536 + 4;
+    // An uncompressed chunk contains a 4-byte masked checksum followed by the data.
+    private static final int MIN_UNCOMPRESSED_DATA_SIZE = 4;
     // See https://github.com/google/snappy/blob/1.1.9/framing_format.txt#L82
     private static final int MAX_DECOMPRESSED_DATA_SIZE = 65536;
     // See https://github.com/google/snappy/blob/1.1.9/framing_format.txt#L82
     private static final int MAX_COMPRESSED_CHUNK_SIZE = 16777216 - 1;
+    // A compressed chunk contains a 4-byte masked checksum followed by a Snappy stream.
+    private static final int MIN_COMPRESSED_CHUNK_SIZE = 5;
 
     private final Snappy snappy = new Snappy();
     private final boolean validateChecksums;
@@ -163,6 +167,10 @@ public class SnappyFrameDecoder extends ByteToMessageDecoder {
                         throw new DecompressionException("Received UNCOMPRESSED_DATA larger than " +
                                 MAX_UNCOMPRESSED_DATA_SIZE + " bytes");
                     }
+                    if (chunkLength < MIN_UNCOMPRESSED_DATA_SIZE) {
+                        throw new DecompressionException("Received UNCOMPRESSED_DATA with invalid chunk length: " +
+                                chunkLength);
+                    }
 
                     if (inSize < 4 + chunkLength) {
                         return;
@@ -185,6 +193,10 @@ public class SnappyFrameDecoder extends ByteToMessageDecoder {
                     if (chunkLength > MAX_COMPRESSED_CHUNK_SIZE) {
                         throw new DecompressionException("Received COMPRESSED_DATA that contains" +
                                 " chunk that exceeds " + MAX_COMPRESSED_CHUNK_SIZE + " bytes");
+                    }
+                    if (chunkLength < MIN_COMPRESSED_CHUNK_SIZE) {
+                        throw new DecompressionException("Received COMPRESSED_DATA with invalid chunk length: " +
+                                chunkLength);
                     }
 
                     if (inSize < 4 + chunkLength) {

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/SnappyFrameDecoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/SnappyFrameDecoderTest.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -177,6 +179,26 @@ public class SnappyFrameDecoderTest {
         actual.release();
     }
 
+    @ParameterizedTest
+    @CsvSource({
+            "false, 0", "false, 1", "false, 2", "false, 3", "false, 4",
+            "true, 0", "true, 1", "true, 2", "true, 3", "true, 4"
+    })
+    public void testCompressedDataWithTooShortChunkLengthThrowsException(
+            boolean validateChecksums, int chunkLength) {
+        assertInvalidChunkLength(validateChecksums, (byte) 0x00, chunkLength);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "false, 0", "false, 1", "false, 2", "false, 3",
+            "true, 0", "true, 1", "true, 2", "true, 3"
+    })
+    public void testUncompressedDataWithTooShortChunkLengthThrowsException(
+            boolean validateChecksums, int chunkLength) {
+        assertInvalidChunkLength(validateChecksums, (byte) 0x01, chunkLength);
+    }
+
     // The following two tests differ in only the checksum provided for the literal
     // uncompressed string "netty"
 
@@ -218,6 +240,34 @@ public class SnappyFrameDecoderTest {
 
             expected.release();
             actual.release();
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    private static void assertInvalidChunkLength(boolean validateChecksums, byte chunkType, int chunkLength) {
+        final EmbeddedChannel channel = new EmbeddedChannel(new SnappyFrameDecoder(validateChecksums));
+        try {
+            final byte[] input = new byte[14 + chunkLength];
+            input[0] = (byte) 0xff;
+            input[1] = 0x06;
+            input[4] = 0x73;
+            input[5] = 0x4e;
+            input[6] = 0x61;
+            input[7] = 0x50;
+            input[8] = 0x70;
+            input[9] = 0x59;
+            input[10] = chunkType;
+            input[11] = (byte) chunkLength;
+            final ByteBuf in = channel.alloc().buffer(input.length);
+            in.writeBytes(input);
+
+            assertThrows(DecompressionException.class, new Executable() {
+                @Override
+                public void execute() {
+                    channel.writeInbound(in);
+                }
+            });
         } finally {
             channel.finishAndReleaseAll();
         }

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/SnappyFrameDecoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/SnappyFrameDecoderTest.java
@@ -248,19 +248,22 @@ public class SnappyFrameDecoderTest {
     private static void assertInvalidChunkLength(boolean validateChecksums, byte chunkType, int chunkLength) {
         final EmbeddedChannel channel = new EmbeddedChannel(new SnappyFrameDecoder(validateChecksums));
         try {
-            final byte[] input = new byte[14 + chunkLength];
-            input[0] = (byte) 0xff;
-            input[1] = 0x06;
-            input[4] = 0x73;
-            input[5] = 0x4e;
-            input[6] = 0x61;
-            input[7] = 0x50;
-            input[8] = 0x70;
-            input[9] = 0x59;
-            input[10] = chunkType;
-            input[11] = (byte) chunkLength;
-            final ByteBuf in = channel.alloc().buffer(input.length);
-            in.writeBytes(input);
+            final ByteBuf in = channel.alloc().buffer(14 + chunkLength);
+
+            // Snappy stream identifier chunk: type 0xff, 3-byte little-endian length 6, payload "sNaPpY".
+            in.writeByte(0xff);
+            in.writeMediumLE(6);
+            in.writeByte('s');
+            in.writeByte('N');
+            in.writeByte('a');
+            in.writeByte('P');
+            in.writeByte('p');
+            in.writeByte('Y');
+
+            // Invalid data chunk header: caller-supplied type and too-short 3-byte little-endian length.
+            in.writeByte(chunkType);
+            in.writeMediumLE(chunkLength);
+            in.writeZero(chunkLength);
 
             assertThrows(DecompressionException.class, new Executable() {
                 @Override


### PR DESCRIPTION
Motivation:

Malformed Snappy framed input can declare compressed or uncompressed chunk lengths that are too short to contain the mandatory masked checksum. In the compressed case this can lead to lower-level ByteBuf index errors instead of a DecompressionException.

Modification:

Validate minimum chunk lengths in SnappyFrameDecoder before reading the checksum or Snappy preamble. Added parameterized tests that cover invalid compressed and uncompressed chunk lengths with checksum validation both enabled and disabled.

Result:

Malformed Snappy chunks with invalid lengths are rejected with DecompressionException.

Verification:

./mvnw -pl codec-compression -am -Dtest=SnappyFrameDecoderTest -Dsurefire.failIfNoSpecifiedTests=false test -DskipNativeTests -DskipAutobahnTests