### PR TITLE
Add system property to disable RFC 6761 localhost resolution

### DIFF
--- a/resolver-dns/pom.xml
+++ b/resolver-dns/pom.xml
@@ -73,6 +73,10 @@
       <artifactId>apacheds-protocol-dns</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+    </dependency>
 
     <!-- Automatic native-image reflection metadata generation for handlers dependencies -->
     <dependency>

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -62,6 +62,7 @@ import io.netty.util.concurrent.PromiseNotifier;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
+import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -130,6 +131,29 @@ public class DnsNameResolver extends InetNameResolver {
         }
     };
 
+    /**
+     * System property to control RFC 6761 localhost resolution.
+     * <p>
+     * When {@code true} (the default), {@code localhost} and {@code *.localhost}
+     * are resolved to the loopback address without querying DNS servers. When
+     * {@code false}, only the pre-#16749 rules apply (Windows {@code localhost}
+     * and the Windows machine hostname). Set to {@code false} when
+     * {@code *.localhost} hostnames must resolve via DNS to non-loopback
+     * addresses.
+     *
+     * @see <a href="https://github.com/netty/netty/issues/16744">Issue 16744</a>
+     * @see <a href="https://www.rfc-editor.org/rfc/rfc6761.html#section-6.3">RFC 6761</a>
+     */
+    private static final String RESOLVE_LOCALHOST_WITHOUT_DNS_PROPERTY =
+            "io.netty.resolver.dns.resolveLocalhostWithoutDns";
+
+    /** The runtime value of {@link #RESOLVE_LOCALHOST_WITHOUT_DNS_PROPERTY}. */
+    private static boolean resolveLocalhostWithoutDns;
+
+    static void setResolveLocalhostWithoutDns(final boolean value) {
+        resolveLocalhostWithoutDns = value;
+    }
+
     static final ResolvedAddressTypes DEFAULT_RESOLVE_ADDRESS_TYPES;
     static final String[] DEFAULT_SEARCH_DOMAINS;
     private static final UnixResolverOptions DEFAULT_OPTIONS;
@@ -176,6 +200,12 @@ public class DnsNameResolver extends InetNameResolver {
         }
         DEFAULT_OPTIONS = options;
         logger.debug("Default {}", DEFAULT_OPTIONS);
+
+        resolveLocalhostWithoutDns =
+                SystemPropertyUtil.getBoolean(RESOLVE_LOCALHOST_WITHOUT_DNS_PROPERTY, true);
+        if (logger.isDebugEnabled()) {
+            logger.debug("-D{}: {}", RESOLVE_LOCALHOST_WITHOUT_DNS_PROPERTY, resolveLocalhostWithoutDns);
+        }
     }
 
     /**
@@ -738,6 +768,10 @@ public class DnsNameResolver extends InetNameResolver {
      * According to RFC 6761 Section 6.3, localhost and subdomains of localhost should be resolved to the loopback
      * address by name resolution libraries without querying DNS servers. The hostname of the local machine can usually
      * be resolved from the hosts file, but on Windows, this is no longer possible.
+     * <p>
+     * RFC 6761 behavior for {@code localhost} and {@code *.localhost} can be
+     * disabled via the {@code io.netty.resolver.dns.resolveLocalhostWithoutDns}
+     * system property.
      *
      * @param hostname the hostname that's being looked up
      * @return true if the hostname should point to the loopback adress. False otherwise.
@@ -752,10 +786,15 @@ public class DnsNameResolver extends InetNameResolver {
             return true;
         }
 
+        if (!resolveLocalhostWithoutDns) {
+            return PlatformDependent.isWindows() && LOCALHOST.equalsIgnoreCase(hostname);
+        }
+
         if (hostname.endsWith(".")) {
             hostname = hostname.substring(0, hostname.length() - 1);
         }
-        return hostname.equalsIgnoreCase(LOCALHOST) || hostname.toLowerCase(Locale.US).endsWith(DOT_LOCALHOST);
+        return hostname.equalsIgnoreCase(LOCALHOST)
+                || hostname.toLowerCase(Locale.US).endsWith(DOT_LOCALHOST);
     }
 
     private InetAddress getLocalHostAddress() {

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -65,6 +65,7 @@ import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import java.lang.reflect.Method;
 import java.net.IDN;
@@ -148,11 +149,8 @@ public class DnsNameResolver extends InetNameResolver {
             "io.netty.resolver.dns.resolveLocalhostWithoutDns";
 
     /** The runtime value of {@link #RESOLVE_LOCALHOST_WITHOUT_DNS_PROPERTY}. */
-    private static boolean resolveLocalhostWithoutDns;
-
-    static void setResolveLocalhostWithoutDns(final boolean value) {
-        resolveLocalhostWithoutDns = value;
-    }
+    @VisibleForTesting
+    static boolean resolveLocalhostWithoutDns;
 
     static final ResolvedAddressTypes DEFAULT_RESOLVE_ADDRESS_TYPES;
     static final String[] DEFAULT_SEARCH_DOMAINS;

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -261,7 +261,7 @@ public class DnsNameResolverTest {
         DOMAINS_PUNYCODE.put("müller.de", "xn--mller-kva.de");
     }
 
-    private static final Set<String> DOMAINS_ALL;
+    static final Set<String> DOMAINS_ALL;
 
     static {
         Set<String> all = new HashSet<String>(DOMAINS.size() + DOMAINS_PUNYCODE.size());

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -907,6 +907,100 @@ public class DnsNameResolverTest {
 
     @ParameterizedTest
     @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveDotLocalhostViaDnsWhenDisabled(DnsNameResolverChannelStrategy strategy) throws Exception {
+        final String hostname = "myservice.localhost";
+        final String expectedIp = "10.0.0.1";
+        final TestDnsServer customDnsServer = new TestDnsServer(new RecordStore() {
+            @Override
+            public Set<ResourceRecord> getRecords(QuestionRecord question) {
+                if (question.getRecordType() == RecordType.A) {
+                    String domainName = question.getDomainName();
+                    if (domainName.equalsIgnoreCase(hostname) || domainName.equalsIgnoreCase(hostname + '.')) {
+                        return Collections.singleton(newARecord(hostname, expectedIp));
+                    }
+                }
+                return Collections.emptySet();
+            }
+        });
+        customDnsServer.start();
+        DnsNameResolver.setResolveLocalhostWithoutDns(false);
+        try {
+            DnsNameResolver resolver = newResolver(strategy, false, null, customDnsServer)
+                    .resolvedAddressTypes(ResolvedAddressTypes.IPV4_ONLY)
+                    .hostsFileEntriesResolver(new HostsFileEntriesResolver() {
+                        @Override
+                        public InetAddress address(String inetHost, ResolvedAddressTypes resolvedAddressTypes) {
+                            return null;
+                        }
+                    })
+                    .build();
+            try {
+                InetAddress address = resolver.resolve(hostname).syncUninterruptibly().getNow();
+                assertEquals(expectedIp, address.getHostAddress());
+
+                TestRecursiveCacheDnsQueryLifecycleObserverFactory lifecycleObserverFactory =
+                        (TestRecursiveCacheDnsQueryLifecycleObserverFactory)
+                                resolver.dnsQueryLifecycleObserverFactory();
+                assertFalse(lifecycleObserverFactory.observers.isEmpty());
+            } finally {
+                resolver.close();
+            }
+        } finally {
+            DnsNameResolver.setResolveLocalhostWithoutDns(true);
+            customDnsServer.stop();
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveLocalhostViaDnsWhenDisabledOnNonWindows(DnsNameResolverChannelStrategy strategy)
+            throws Exception {
+        assumeThat(PlatformDependent.isWindows()).isFalse();
+
+        final String expectedIp = "10.0.0.2";
+        final TestDnsServer customDnsServer = new TestDnsServer(new RecordStore() {
+            @Override
+            public Set<ResourceRecord> getRecords(QuestionRecord question) {
+                if (question.getRecordType() == RecordType.A) {
+                    String domainName = question.getDomainName();
+                    if (domainName.equalsIgnoreCase("localhost") || domainName.equalsIgnoreCase("localhost.")) {
+                        return Collections.singleton(newARecord("localhost", expectedIp));
+                    }
+                }
+                return Collections.emptySet();
+            }
+        });
+        customDnsServer.start();
+        DnsNameResolver.setResolveLocalhostWithoutDns(false);
+        try {
+            DnsNameResolver resolver = newResolver(strategy, false, null, customDnsServer)
+                    .resolvedAddressTypes(ResolvedAddressTypes.IPV4_ONLY)
+                    .hostsFileEntriesResolver(new HostsFileEntriesResolver() {
+                        @Override
+                        public InetAddress address(String inetHost, ResolvedAddressTypes resolvedAddressTypes) {
+                            return null;
+                        }
+                    })
+                    .build();
+            try {
+                InetAddress address = resolver.resolve("localhost").syncUninterruptibly().getNow();
+                assertEquals(expectedIp, address.getHostAddress());
+
+                TestRecursiveCacheDnsQueryLifecycleObserverFactory lifecycleObserverFactory =
+                        (TestRecursiveCacheDnsQueryLifecycleObserverFactory)
+                                resolver.dnsQueryLifecycleObserverFactory();
+                assertFalse(lifecycleObserverFactory.observers.isEmpty());
+            } finally {
+                resolver.close();
+            }
+        } finally {
+            DnsNameResolver.setResolveLocalhostWithoutDns(true);
+            customDnsServer.stop();
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
     public void testResolveNullIpv4(DnsNameResolverChannelStrategy strategy) {
         testResolve0(strategy, ResolvedAddressTypes.IPV4_ONLY, NetUtil.LOCALHOST4, null);
     }

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -380,20 +380,26 @@ public class DnsNameResolverTest {
     private static final TestDnsServer dnsServer = new TestDnsServer(DOMAINS_ALL);
     private static final EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
 
-    static DnsNameResolverBuilder newResolver(DnsNameResolverChannelStrategy strategy,
+    private static DnsNameResolverBuilder newResolver(DnsNameResolverChannelStrategy strategy,
                                                       boolean decodeToUnicode) {
         return newResolver(strategy, decodeToUnicode, null);
     }
 
-    static DnsNameResolverBuilder newResolver(DnsNameResolverChannelStrategy strategy, boolean decodeToUnicode,
+    private static DnsNameResolverBuilder newResolver(DnsNameResolverChannelStrategy strategy, boolean decodeToUnicode,
                                                       DnsServerAddressStreamProvider dnsServerAddressStreamProvider) {
         return newResolver(strategy, decodeToUnicode, dnsServerAddressStreamProvider, dnsServer);
     }
 
-    static DnsNameResolverBuilder newResolver(DnsNameResolverChannelStrategy strategy, boolean decodeToUnicode,
+    private static DnsNameResolverBuilder newResolver(DnsNameResolverChannelStrategy strategy, boolean decodeToUnicode,
                                                       DnsServerAddressStreamProvider dnsServerAddressStreamProvider,
                                                       TestDnsServer dnsServer) {
-        DnsNameResolverBuilder builder = new DnsNameResolverBuilder(group.next())
+        return newResolver(strategy, decodeToUnicode, dnsServerAddressStreamProvider, dnsServer, group.next());
+    }
+
+    static DnsNameResolverBuilder newResolver(DnsNameResolverChannelStrategy strategy, boolean decodeToUnicode,
+                                                      DnsServerAddressStreamProvider dnsServerAddressStreamProvider,
+                                                      TestDnsServer dnsServer, EventLoop eventLoop) {
+        DnsNameResolverBuilder builder = new DnsNameResolverBuilder(eventLoop)
                 .dnsQueryLifecycleObserverFactory(new TestRecursiveCacheDnsQueryLifecycleObserverFactory())
                 .datagramChannelType(NioDatagramChannel.class)
                 .maxQueriesPerResolve(1)

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -380,17 +380,17 @@ public class DnsNameResolverTest {
     private static final TestDnsServer dnsServer = new TestDnsServer(DOMAINS_ALL);
     private static final EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
 
-    private static DnsNameResolverBuilder newResolver(DnsNameResolverChannelStrategy strategy,
+    static DnsNameResolverBuilder newResolver(DnsNameResolverChannelStrategy strategy,
                                                       boolean decodeToUnicode) {
         return newResolver(strategy, decodeToUnicode, null);
     }
 
-    private static DnsNameResolverBuilder newResolver(DnsNameResolverChannelStrategy strategy, boolean decodeToUnicode,
+    static DnsNameResolverBuilder newResolver(DnsNameResolverChannelStrategy strategy, boolean decodeToUnicode,
                                                       DnsServerAddressStreamProvider dnsServerAddressStreamProvider) {
         return newResolver(strategy, decodeToUnicode, dnsServerAddressStreamProvider, dnsServer);
     }
 
-    private static DnsNameResolverBuilder newResolver(DnsNameResolverChannelStrategy strategy, boolean decodeToUnicode,
+    static DnsNameResolverBuilder newResolver(DnsNameResolverChannelStrategy strategy, boolean decodeToUnicode,
                                                       DnsServerAddressStreamProvider dnsServerAddressStreamProvider,
                                                       TestDnsServer dnsServer) {
         DnsNameResolverBuilder builder = new DnsNameResolverBuilder(group.next())
@@ -902,100 +902,6 @@ public class DnsNameResolverTest {
             assertNoQueriesMade(resolver);
         } finally {
             resolver.close();
-        }
-    }
-
-    @ParameterizedTest
-    @EnumSource(DnsNameResolverChannelStrategy.class)
-    public void testResolveDotLocalhostViaDnsWhenDisabled(DnsNameResolverChannelStrategy strategy) throws Exception {
-        final String hostname = "myservice.localhost";
-        final String expectedIp = "10.0.0.1";
-        final TestDnsServer customDnsServer = new TestDnsServer(new RecordStore() {
-            @Override
-            public Set<ResourceRecord> getRecords(QuestionRecord question) {
-                if (question.getRecordType() == RecordType.A) {
-                    String domainName = question.getDomainName();
-                    if (domainName.equalsIgnoreCase(hostname) || domainName.equalsIgnoreCase(hostname + '.')) {
-                        return Collections.singleton(newARecord(hostname, expectedIp));
-                    }
-                }
-                return Collections.emptySet();
-            }
-        });
-        customDnsServer.start();
-        DnsNameResolver.setResolveLocalhostWithoutDns(false);
-        try {
-            DnsNameResolver resolver = newResolver(strategy, false, null, customDnsServer)
-                    .resolvedAddressTypes(ResolvedAddressTypes.IPV4_ONLY)
-                    .hostsFileEntriesResolver(new HostsFileEntriesResolver() {
-                        @Override
-                        public InetAddress address(String inetHost, ResolvedAddressTypes resolvedAddressTypes) {
-                            return null;
-                        }
-                    })
-                    .build();
-            try {
-                InetAddress address = resolver.resolve(hostname).syncUninterruptibly().getNow();
-                assertEquals(expectedIp, address.getHostAddress());
-
-                TestRecursiveCacheDnsQueryLifecycleObserverFactory lifecycleObserverFactory =
-                        (TestRecursiveCacheDnsQueryLifecycleObserverFactory)
-                                resolver.dnsQueryLifecycleObserverFactory();
-                assertFalse(lifecycleObserverFactory.observers.isEmpty());
-            } finally {
-                resolver.close();
-            }
-        } finally {
-            DnsNameResolver.setResolveLocalhostWithoutDns(true);
-            customDnsServer.stop();
-        }
-    }
-
-    @ParameterizedTest
-    @EnumSource(DnsNameResolverChannelStrategy.class)
-    public void testResolveLocalhostViaDnsWhenDisabledOnNonWindows(DnsNameResolverChannelStrategy strategy)
-            throws Exception {
-        assumeThat(PlatformDependent.isWindows()).isFalse();
-
-        final String expectedIp = "10.0.0.2";
-        final TestDnsServer customDnsServer = new TestDnsServer(new RecordStore() {
-            @Override
-            public Set<ResourceRecord> getRecords(QuestionRecord question) {
-                if (question.getRecordType() == RecordType.A) {
-                    String domainName = question.getDomainName();
-                    if (domainName.equalsIgnoreCase("localhost") || domainName.equalsIgnoreCase("localhost.")) {
-                        return Collections.singleton(newARecord("localhost", expectedIp));
-                    }
-                }
-                return Collections.emptySet();
-            }
-        });
-        customDnsServer.start();
-        DnsNameResolver.setResolveLocalhostWithoutDns(false);
-        try {
-            DnsNameResolver resolver = newResolver(strategy, false, null, customDnsServer)
-                    .resolvedAddressTypes(ResolvedAddressTypes.IPV4_ONLY)
-                    .hostsFileEntriesResolver(new HostsFileEntriesResolver() {
-                        @Override
-                        public InetAddress address(String inetHost, ResolvedAddressTypes resolvedAddressTypes) {
-                            return null;
-                        }
-                    })
-                    .build();
-            try {
-                InetAddress address = resolver.resolve("localhost").syncUninterruptibly().getNow();
-                assertEquals(expectedIp, address.getHostAddress());
-
-                TestRecursiveCacheDnsQueryLifecycleObserverFactory lifecycleObserverFactory =
-                        (TestRecursiveCacheDnsQueryLifecycleObserverFactory)
-                                resolver.dnsQueryLifecycleObserverFactory();
-                assertFalse(lifecycleObserverFactory.observers.isEmpty());
-            } finally {
-                resolver.close();
-            }
-        } finally {
-            DnsNameResolver.setResolveLocalhostWithoutDns(true);
-            customDnsServer.stop();
         }
     }
 
@@ -2269,7 +2175,7 @@ public class DnsNameResolverTest {
         }
     }
 
-    private static final class TestRecursiveCacheDnsQueryLifecycleObserverFactory
+    static final class TestRecursiveCacheDnsQueryLifecycleObserverFactory
             implements DnsQueryLifecycleObserverFactory {
         final Queue<TestDnsQueryLifecycleObserver> observers =
                 new ConcurrentLinkedQueue<TestDnsQueryLifecycleObserver>();

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/IsolatedDnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/IsolatedDnsNameResolverTest.java
@@ -85,7 +85,7 @@ public class IsolatedDnsNameResolverTest {
         customDnsServer.start();
         DnsNameResolver.resolveLocalhostWithoutDns = false;
         try {
-            DnsNameResolver resolver = newResolver(strategy, false, null, customDnsServer)
+            DnsNameResolver resolver = newResolver(strategy, false, null, customDnsServer, group.next())
                     .resolvedAddressTypes(ResolvedAddressTypes.IPV4_ONLY)
                     .hostsFileEntriesResolver(new HostsFileEntriesResolver() {
                         @Override
@@ -132,7 +132,7 @@ public class IsolatedDnsNameResolverTest {
         customDnsServer.start();
         DnsNameResolver.resolveLocalhostWithoutDns = false;
         try {
-            DnsNameResolver resolver = newResolver(strategy, false, null, customDnsServer)
+            DnsNameResolver resolver = newResolver(strategy, false, null, customDnsServer, group.next())
                     .resolvedAddressTypes(ResolvedAddressTypes.IPV4_ONLY)
                     .hostsFileEntriesResolver(new HostsFileEntriesResolver() {
                         @Override

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/IsolatedDnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/IsolatedDnsNameResolverTest.java
@@ -65,7 +65,6 @@ public class IsolatedDnsNameResolverTest {
         }
     }
 
-
     @ParameterizedTest
     @EnumSource(DnsNameResolverChannelStrategy.class)
     public void testResolveDotLocalhostViaDnsWhenDisabled(DnsNameResolverChannelStrategy strategy) throws Exception {

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/IsolatedDnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/IsolatedDnsNameResolverTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.resolver.HostsFileEntriesResolver;
+import io.netty.resolver.ResolvedAddressTypes;
+import io.netty.resolver.dns.DnsNameResolverTest.TestRecursiveCacheDnsQueryLifecycleObserverFactory;
+import io.netty.util.internal.PlatformDependent;
+import org.apache.directory.server.dns.messages.QuestionRecord;
+import org.apache.directory.server.dns.messages.RecordType;
+import org.apache.directory.server.dns.messages.ResourceRecord;
+import org.apache.directory.server.dns.store.RecordStore;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.parallel.Isolated;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.net.InetAddress;
+import java.util.Collections;
+import java.util.Set;
+
+import static io.netty.resolver.dns.DnsNameResolverTest.newResolver;
+import static io.netty.resolver.dns.TestDnsServer.newARecord;
+import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+@Isolated
+public class IsolatedDnsNameResolverTest {
+    private static boolean existingLocalhostSetting;
+
+    @BeforeAll
+    public static void captureSetting() throws Exception {
+        existingLocalhostSetting = DnsNameResolver.resolveLocalhostWithoutDns;
+    }
+
+    @AfterAll
+    public static void restoreSetting() {
+        DnsNameResolver.resolveLocalhostWithoutDns = existingLocalhostSetting;
+    }
+
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveDotLocalhostViaDnsWhenDisabled(DnsNameResolverChannelStrategy strategy) throws Exception {
+        final String hostname = "myservice.localhost";
+        final String expectedIp = "10.0.0.1";
+        final TestDnsServer customDnsServer = new TestDnsServer(new RecordStore() {
+            @Override
+            public Set<ResourceRecord> getRecords(QuestionRecord question) {
+                if (question.getRecordType() == RecordType.A) {
+                    String domainName = question.getDomainName();
+                    if (domainName.equalsIgnoreCase(hostname) || domainName.equalsIgnoreCase(hostname + '.')) {
+                        return Collections.singleton(newARecord(hostname, expectedIp));
+                    }
+                }
+                return Collections.emptySet();
+            }
+        });
+        customDnsServer.start();
+        DnsNameResolver.resolveLocalhostWithoutDns = false;
+        try {
+            DnsNameResolver resolver = newResolver(strategy, false, null, customDnsServer)
+                    .resolvedAddressTypes(ResolvedAddressTypes.IPV4_ONLY)
+                    .hostsFileEntriesResolver(new HostsFileEntriesResolver() {
+                        @Override
+                        public InetAddress address(String inetHost, ResolvedAddressTypes resolvedAddressTypes) {
+                            return null;
+                        }
+                    })
+                    .build();
+            try {
+                InetAddress address = resolver.resolve(hostname).syncUninterruptibly().getNow();
+                assertEquals(expectedIp, address.getHostAddress());
+
+                TestRecursiveCacheDnsQueryLifecycleObserverFactory lifecycleObserverFactory =
+                        (TestRecursiveCacheDnsQueryLifecycleObserverFactory)
+                                resolver.dnsQueryLifecycleObserverFactory();
+                assertFalse(lifecycleObserverFactory.observers.isEmpty());
+            } finally {
+                resolver.close();
+            }
+        } finally {
+            customDnsServer.stop();
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(DnsNameResolverChannelStrategy.class)
+    public void testResolveLocalhostViaDnsWhenDisabledOnNonWindows(DnsNameResolverChannelStrategy strategy)
+            throws Exception {
+        assumeThat(PlatformDependent.isWindows()).isFalse();
+
+        final String expectedIp = "10.0.0.2";
+        final TestDnsServer customDnsServer = new TestDnsServer(new RecordStore() {
+            @Override
+            public Set<ResourceRecord> getRecords(QuestionRecord question) {
+                if (question.getRecordType() == RecordType.A) {
+                    String domainName = question.getDomainName();
+                    if (domainName.equalsIgnoreCase("localhost") || domainName.equalsIgnoreCase("localhost.")) {
+                        return Collections.singleton(newARecord("localhost", expectedIp));
+                    }
+                }
+                return Collections.emptySet();
+            }
+        });
+        customDnsServer.start();
+        DnsNameResolver.resolveLocalhostWithoutDns = false;
+        try {
+            DnsNameResolver resolver = newResolver(strategy, false, null, customDnsServer)
+                    .resolvedAddressTypes(ResolvedAddressTypes.IPV4_ONLY)
+                    .hostsFileEntriesResolver(new HostsFileEntriesResolver() {
+                        @Override
+                        public InetAddress address(String inetHost, ResolvedAddressTypes resolvedAddressTypes) {
+                            return null;
+                        }
+                    })
+                    .build();
+            try {
+                InetAddress address = resolver.resolve("localhost").syncUninterruptibly().getNow();
+                assertEquals(expectedIp, address.getHostAddress());
+
+                TestRecursiveCacheDnsQueryLifecycleObserverFactory lifecycleObserverFactory =
+                        (TestRecursiveCacheDnsQueryLifecycleObserverFactory)
+                                resolver.dnsQueryLifecycleObserverFactory();
+                assertFalse(lifecycleObserverFactory.observers.isEmpty());
+            } finally {
+                resolver.close();
+            }
+        } finally {
+            customDnsServer.stop();
+        }
+    }
+}

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/IsolatedDnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/IsolatedDnsNameResolverTest.java
@@ -15,6 +15,9 @@
  */
 package io.netty.resolver.dns;
 
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
 import io.netty.resolver.HostsFileEntriesResolver;
 import io.netty.resolver.ResolvedAddressTypes;
 import io.netty.resolver.dns.DnsNameResolverTest.TestRecursiveCacheDnsQueryLifecycleObserverFactory;
@@ -33,6 +36,7 @@ import java.net.InetAddress;
 import java.util.Collections;
 import java.util.Set;
 
+import static io.netty.resolver.dns.DnsNameResolverTest.DOMAINS_ALL;
 import static io.netty.resolver.dns.DnsNameResolverTest.newResolver;
 import static io.netty.resolver.dns.TestDnsServer.newARecord;
 import static org.assertj.core.api.Assumptions.assumeThat;
@@ -41,17 +45,26 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @Isolated
 public class IsolatedDnsNameResolverTest {
+    private static final TestDnsServer dnsServer = new TestDnsServer(DOMAINS_ALL);
+    private static final EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
     private static boolean existingLocalhostSetting;
 
     @BeforeAll
     public static void captureSetting() throws Exception {
         existingLocalhostSetting = DnsNameResolver.resolveLocalhostWithoutDns;
+        dnsServer.start();
     }
 
     @AfterAll
     public static void restoreSetting() {
-        DnsNameResolver.resolveLocalhostWithoutDns = existingLocalhostSetting;
+        try {
+            dnsServer.stop();
+            group.shutdownGracefully();
+        } finally {
+            DnsNameResolver.resolveLocalhostWithoutDns = existingLocalhostSetting;
+        }
     }
+
 
     @ParameterizedTest
     @EnumSource(DnsNameResolverChannelStrategy.class)


### PR DESCRIPTION
Motivation:
Commit a6aeb6de (#16749) resolves localhost and *.localhost to loopback without querying DNS per RFC 6761. Some deployment environments use *.localhost hostnames that should resolve via DNS to non-loopback addresses.

Modifications:
- Add -Dio.netty.resolver.dns.resolveLocalhostWithoutDns (default true)
- When false, restore pre-#16749 behavior where only Windows localhost and the Windows machine hostname are short-circuited to loopback
- Add tests verifying *.localhost falls through to DNS when disabled

Result:
Applications can opt out of automatic loopback resolution for .localhost hostnames by setting the system property to false.

Fixes 
This fixes the scenario where *.localhost is used for non-loopback addresses, e.g. as an entrypoint into a service mesh.
