### PR TITLE
Fix silent failures and optimize error short-circuit in multi-threaded tests

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
@@ -2791,6 +2791,10 @@ public abstract class AbstractByteBufTest {
                     }
                 } catch (Throwable e) {
                     innerThrowable.compareAndSet(null, e);
+                    // Short-circuit: wake up the main thread immediately
+                    while (latch.getCount() > 0) {
+                        latch.countDown();
+                    }
                 } finally {
                     try {
                         barrier.await();
@@ -2809,6 +2813,11 @@ public abstract class AbstractByteBufTest {
                 e.addSuppressed(inner);
             }
             throw e;
+        }
+        // Ensure failures in worker threads are propagated to the test thread.
+        Throwable failedThreadException = innerThrowable.get();
+        if (failedThreadException != null) {
+            throw new AssertionError("Worker thread failed", failedThreadException);
         }
     }
 
@@ -2872,6 +2881,10 @@ public abstract class AbstractByteBufTest {
                     }
                 } catch (Throwable e) {
                     innerThrowable.compareAndSet(null, e);
+                    // Short-circuit: wake up the main thread immediately
+                    while (latch.getCount() > 0) {
+                        latch.countDown();
+                    }
                 } finally {
                     try {
                         barrier.await();
@@ -2890,6 +2903,11 @@ public abstract class AbstractByteBufTest {
                 e.addSuppressed(inner);
             }
             throw e;
+        }
+        // Ensure failures in worker threads are propagated to the test thread.
+        Throwable failedThreadException = innerThrowable.get();
+        if (failedThreadException != null) {
+            throw new AssertionError("Worker thread failed", failedThreadException);
         }
     }
 


### PR DESCRIPTION
**Motivation**:
While `testReadOutputStreamMultipleThreads` and `testReadGatheringByteChannelMultipleThreads` captured worker thread errors inside an `AtomicReference`, they only checked it if `latch.await()` or `barrier.await()` threw an exception. If the latch successfully hit zero, any recorded worker thread failures were silently ignored, causing failing tests to pass. Furthermore, when a thread failed, other worker threads would keep spinning needlessly instead of short-circuiting.

**Modifications**:
- Added a short-circuit loop inside the catch block of the worker threads to instantly count down the remaining latch items upon encountering a failure.
- Added an explicit post-await check to look for captured exceptions and cleanly rethrow them out of the main thread using `AssertionError`.

**Result**:
Multi-threaded test failures are now instantly short-circuited and correctly reported back to the test runner instead of failing silently.