### PR TITLE
Add exportKeyingMaterial() to QuicSslEngine (RFC 5705 TLS exporter)

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/BoringSSL.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/BoringSSL.java
@@ -130,6 +130,9 @@ final class BoringSSL {
 
     static native void SSL_cleanup(long ssl);
 
+    static native byte @Nullable [] SSL_export_keying_material(
+            long ssl, byte[] label, byte @Nullable [] context, int length);
+
     static native long EVP_PKEY_parse(byte[] bytes, String pass);
     static native void EVP_PKEY_free(long key);
 

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicSslEngine.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicSslEngine.java
@@ -15,9 +15,38 @@
  */
 package io.netty.handler.codec.quic;
 
+import org.jetbrains.annotations.Nullable;
+
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLException;
 
 /**
  * An {@link SSLEngine} that can be used for QUIC.
  */
-public abstract class QuicSslEngine extends SSLEngine { }
+public abstract class QuicSslEngine extends SSLEngine {
+
+    /**
+     * Export keying material as described in <a href="https://datatracker.ietf.org/doc/html/rfc5705">RFC 5705</a>
+     * (also known as a TLS <em>exporter</em>). The returned bytes are derived from the secrets of the current
+     * TLS session and so are guaranteed to be identical on both peers of the connection, while being unique to
+     * this session. This makes them useful for channel binding, e.g. to bind an application level proof of
+     * possession to the underlying QUIC connection.
+     *
+     * @param label     the exporter label, encoded as US-ASCII. To avoid collisions applications should use a
+     *                  label that is unique to them.
+     * @param context   the application provided context value or {@code null} if no context should be used.
+     *                  As QUIC always uses TLS 1.3, passing {@code null} and passing an empty array produce
+     *                  the same keying material.
+     * @param length    the number of bytes of keying material to generate. Must be non-negative.
+     * @return          the exported keying material of the requested {@code length}.
+     * @throws SSLException                  if the keying material could not be exported, for example because the
+     *                                       handshake did not complete yet or the connection was already closed.
+     * @throws IllegalArgumentException      if {@code length} is negative.
+     * @throws NullPointerException          if {@code label} is {@code null}.
+     * @throws UnsupportedOperationException if the underlying implementation does not support exporting keying
+     *                                       material.
+     */
+    public byte[] exportKeyingMaterial(String label, byte @Nullable [] context, int length) throws SSLException {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicConnection.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicConnection.java
@@ -140,6 +140,15 @@ final class QuicheQuicConnection {
         };
     }
 
+    byte @Nullable [] exportKeyingMaterial(byte[] label, byte @Nullable [] context, int length) {
+        synchronized (this) {
+            if (connection == -1) {
+                return null;
+            }
+            return BoringSSL.SSL_export_keying_material(ssl, label, context, length);
+        }
+    }
+
     @Nullable
     QuicConnectionAddress sourceId() {
         return connectionId(() -> Quiche.quiche_conn_source_id(connection));

--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicSslEngine.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicSslEngine.java
@@ -26,6 +26,7 @@ import org.jetbrains.annotations.Nullable;
 import javax.net.ssl.SNIHostName;
 import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLEngineResult;
+import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
@@ -34,6 +35,7 @@ import javax.net.ssl.SSLSessionBindingListener;
 import javax.net.ssl.SSLSessionContext;
 import javax.security.cert.X509Certificate;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.security.cert.Certificate;
 import java.util.Arrays;
@@ -200,6 +202,29 @@ final class QuicheQuicSslEngine extends QuicSslEngine {
     @Override
     public SSLSession getSession() {
         return session;
+    }
+
+    @Override
+    public byte[] exportKeyingMaterial(String label, byte @Nullable [] context, int length) throws SSLException {
+        ObjectUtil.checkNotNull(label, "label");
+        ObjectUtil.checkPositiveOrZero(length, "length");
+
+        final byte[] keyingMaterial;
+        synchronized (this) {
+            if (!handshakeFinished) {
+                throw new SSLException("Handshake did not complete yet, unable to export keying material");
+            }
+            QuicheQuicConnection connection = this.connection;
+            if (connection == null) {
+                throw new SSLException("No connection available, unable to export keying material");
+            }
+            keyingMaterial = connection.exportKeyingMaterial(
+                    label.getBytes(StandardCharsets.US_ASCII), context, length);
+        }
+        if (keyingMaterial == null) {
+            throw new SSLException("Unable to export keying material");
+        }
+        return keyingMaterial;
     }
 
     @Override

--- a/codec-native-quic/src/main/c/netty_quic_boringssl.c
+++ b/codec-native-quic/src/main/c/netty_quic_boringssl.c
@@ -1297,6 +1297,55 @@ void netty_boringssl_SSL_cleanup(JNIEnv* env, jclass clazz, jlong ssl) {
     }
 }
 
+// Export keying material as defined in https://datatracker.ietf.org/doc/html/rfc5705 (aka a TLS exporter).
+// Returns null (and does not throw) when the exporter secret is not (yet) available or the export fails,
+// the caller is responsible for translating this into an exception.
+jbyteArray netty_boringssl_SSL_export_keying_material(JNIEnv* env, jclass clazz, jlong ssl,
+        jbyteArray labelArray, jbyteArray contextArray, jint length) {
+    uint8_t* label = (uint8_t*) (*env)->GetByteArrayElements(env, labelArray, 0);
+    if (label == NULL) {
+        return NULL;
+    }
+    int label_len = (*env)->GetArrayLength(env, labelArray);
+
+    // The context is optional. When it is not present at all (contextArray == NULL) we must set use_context to 0
+    // so BoringSSL does not mix an empty context into the derivation, which differs from "no context".
+    uint8_t* context = NULL;
+    int context_len = 0;
+    int use_context = 0;
+    if (contextArray != NULL) {
+        context = (uint8_t*) (*env)->GetByteArrayElements(env, contextArray, 0);
+        if (context == NULL) {
+            (*env)->ReleaseByteArrayElements(env, labelArray, (jbyte*) label, JNI_ABORT);
+            return NULL;
+        }
+        context_len = (*env)->GetArrayLength(env, contextArray);
+        use_context = 1;
+    }
+
+    jbyteArray result = NULL;
+    // OPENSSL_malloc(0) may return NULL, so ensure we always request at least one byte.
+    uint8_t* out = (uint8_t*) OPENSSL_malloc(length == 0 ? 1 : (size_t) length);
+    if (out != NULL &&
+            SSL_export_keying_material((SSL*) ssl, out, (size_t) length,
+                                       (const char*) label, (size_t) label_len,
+                                       context, (size_t) context_len, use_context) == 1) {
+        result = (*env)->NewByteArray(env, length);
+        if (result != NULL) {
+            (*env)->SetByteArrayRegion(env, result, 0, length, (jbyte*) out);
+        }
+    }
+
+    if (out != NULL) {
+        OPENSSL_free(out);
+    }
+    (*env)->ReleaseByteArrayElements(env, labelArray, (jbyte*) label, JNI_ABORT);
+    if (context != NULL) {
+        (*env)->ReleaseByteArrayElements(env, contextArray, (jbyte*) context, JNI_ABORT);
+    }
+    return result;
+}
+
 int netty_boringssl_password_callback(char *buf, int bufsiz, int verify, void *cb) {
     char *password = (char *) cb;
     if (password == NULL) {
@@ -1509,6 +1558,7 @@ static const JNINativeMethod fixed_method_table[] = {
   { "SSL_free", "(J)V", (void *) netty_boringssl_SSL_free },
   { "SSL_getTask", "(J)Ljava/lang/Runnable;", (void *) netty_boringssl_SSL_getTask },
   { "SSL_cleanup", "(J)V", (void *) netty_boringssl_SSL_cleanup },
+  { "SSL_export_keying_material", "(J[B[BI)[B", (void *) netty_boringssl_SSL_export_keying_material },
   { "EVP_PKEY_parse", "([BLjava/lang/String;)J", (void *) netty_boringssl_EVP_PKEY_parse },
   { "EVP_PKEY_free", "(J)V", (void *) netty_boringssl_EVP_PKEY_free },
   { "CRYPTO_BUFFER_stack_new", "(J[[B)J", (void *) netty_boringssl_CRYPTO_BUFFER_stack_new },

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicSslEngineExportKeyingMaterialTest.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicSslEngineExportKeyingMaterialTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.quic;
+
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.net.ssl.SSLException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class QuicSslEngineExportKeyingMaterialTest extends AbstractQuicTest {
+
+    private static final String LABEL = "EXPORTER-netty-quic-test";
+
+    @ParameterizedTest
+    @MethodSource("newSslTaskExecutors")
+    @Timeout(30)
+    public void testExportKeyingMaterialMatchesOnBothPeers(Executor executor) throws Throwable {
+        CountDownLatch serverActiveLatch = new CountDownLatch(1);
+        AtomicReference<QuicChannel> serverChannelRef = new AtomicReference<>();
+
+        Channel server = QuicTestUtils.newServer(executor,
+                new CaptureChannelHandler(serverChannelRef, serverActiveLatch),
+                new ChannelInboundHandlerAdapter());
+        InetSocketAddress address = (InetSocketAddress) server.localAddress();
+        Channel channel = QuicTestUtils.newClient(executor);
+        try {
+            QuicChannel quicChannel = QuicTestUtils.newQuicChannelBootstrap(channel)
+                    .handler(new ChannelInboundHandlerAdapter())
+                    .streamHandler(new ChannelInboundHandlerAdapter())
+                    .remoteAddress(address)
+                    .connect()
+                    .get();
+
+            assertTrue(serverActiveLatch.await(30, TimeUnit.SECONDS));
+
+            QuicSslEngine clientEngine = (QuicSslEngine) quicChannel.sslEngine();
+            QuicChannel serverChannel = serverChannelRef.get();
+            assertNotNull(serverChannel);
+            QuicSslEngine serverEngine = (QuicSslEngine) serverChannel.sslEngine();
+            assertNotNull(clientEngine);
+            assertNotNull(serverEngine);
+
+            // Same label + context (null) must produce identical keying material on both peers.
+            byte[] clientMaterial = clientEngine.exportKeyingMaterial(LABEL, null, 32);
+            byte[] serverMaterial = serverEngine.exportKeyingMaterial(LABEL, null, 32);
+            assertEquals(32, clientMaterial.length);
+            assertArrayEquals(clientMaterial, serverMaterial);
+
+            // A context value is also mixed in identically on both peers.
+            byte[] context = "some-context".getBytes(StandardCharsets.US_ASCII);
+            byte[] clientWithContext = clientEngine.exportKeyingMaterial(LABEL, context, 32);
+            byte[] serverWithContext = serverEngine.exportKeyingMaterial(LABEL, context, 32);
+            assertArrayEquals(clientWithContext, serverWithContext);
+
+            // As QUIC always uses TLS 1.3, an empty context produces the same keying material as no context
+            // (in TLS 1.3 the exporter does not distinguish between the two, unlike TLS 1.2 / RFC 5705).
+            byte[] clientWithEmptyContext = clientEngine.exportKeyingMaterial(LABEL, new byte[0], 32);
+            assertArrayEquals(clientMaterial, clientWithEmptyContext);
+
+            // Different context => different keying material.
+            assertFalse(Arrays.equals(clientMaterial, clientWithContext));
+
+            // Different label => different keying material.
+            byte[] clientOtherLabel = clientEngine.exportKeyingMaterial("EXPORTER-netty-quic-other", null, 32);
+            assertFalse(Arrays.equals(clientMaterial, clientOtherLabel));
+
+            // A zero length request is allowed and returns an empty array.
+            assertEquals(0, clientEngine.exportKeyingMaterial(LABEL, null, 0).length);
+
+            // Negative length is rejected.
+            assertThrows(IllegalArgumentException.class, () -> clientEngine.exportKeyingMaterial(LABEL, null, -1));
+
+            quicChannel.close().sync();
+            quicChannel.closeFuture().sync();
+            serverChannel.close().sync();
+        } finally {
+            server.close().sync();
+            channel.close().sync();
+            shutdown(executor);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("newSslTaskExecutors")
+    @Timeout(30)
+    public void testExportKeyingMaterialBeforeHandshakeThrows(Executor executor) throws Throwable {
+        QuicSslContext context = QuicSslContextBuilder.forClient()
+                .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                .applicationProtocols(QuicTestUtils.PROTOS)
+                .build();
+        try {
+            QuicSslEngine engine = context.newEngine(UnpooledByteBufAllocator.DEFAULT);
+            assertThrows(SSLException.class, () -> engine.exportKeyingMaterial(LABEL, null, 32));
+        } finally {
+            shutdown(executor);
+        }
+    }
+
+    private static final class CaptureChannelHandler extends ChannelInboundHandlerAdapter {
+        private final AtomicReference<QuicChannel> channelRef;
+        private final CountDownLatch activeLatch;
+
+        CaptureChannelHandler(AtomicReference<QuicChannel> channelRef, CountDownLatch activeLatch) {
+            this.channelRef = channelRef;
+            this.activeLatch = activeLatch;
+        }
+
+        @Override
+        public void channelActive(ChannelHandlerContext ctx) {
+            channelRef.set((QuicChannel) ctx.channel());
+            activeLatch.countDown();
+            ctx.fireChannelActive();
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

There is currently no way to obtain exported keying material (RFC 5705,
also known as a TLS exporter) from a QUIC connection. Exported keying
material is useful for channel binding: an application can bind a proof
(e.g. a signature made with a client private key) to the underlying
QUIC connection, so the proof cannot be replayed on a different
connection.

Modifications:

- Add QuicSslEngine.exportKeyingMaterial(String label, byte[] context,
  int length). The base implementation throws
  UnsupportedOperationException so existing sub-classes are not broken.
- Implement it in QuicheQuicSslEngine on top of BoringSSLs
  SSL_export_keying_material via a new JNI binding.
- Map a null context to use_context = 0 and an empty array to
  use_context = 1 with zero length. As QUIC always uses TLS 1.3, both
  produce the same keying material (unlike TLS 1.2 / RFC 5705); this is
  documented on the method.
- Throw SSLException if the handshake did not complete yet or the
  connection is not available anymore.
- Add tests that verify both peers derive identical keying material for
  the same label / context, that different labels and contexts produce
  different output, that an empty and null context produce the same
  output, that a zero length request returns an empty array, that a
  negative length is rejected and that exporting before the handshake
  completed throws.

Result:

Keying material can be exported from a QUIC connection, enabling
channel binding and similar use cases.