### PR TITLE
Ship native-image metadata for kqueue (macOS/BSD) (#17112)

### DIFF
--- a/transport-classes-kqueue/src/main/resources/META-INF/native-image/io.netty/netty-transport-classes-kqueue/jni-config.json
+++ b/transport-classes-kqueue/src/main/resources/META-INF/native-image/io.netty/netty-transport-classes-kqueue/jni-config.json
@@ -1,0 +1,163 @@
+[
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.kqueue.Native"
+    },
+    "name":"io.netty.channel.ChannelException"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.kqueue.Native"
+    },
+    "name":"io.netty.channel.DefaultFileRegion",
+    "allDeclaredFields": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.kqueue.Native"
+    },
+    "name":"io.netty.channel.kqueue.BsdSocket"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.kqueue.Native"
+    },
+    "name":"io.netty.channel.kqueue.Native"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.kqueue.Native"
+    },
+    "name":"io.netty.channel.kqueue.KQueueStaticallyReferencedJniMethods"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.kqueue.Native"
+    },
+    "name":"io.netty.channel.unix.Buffer"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.kqueue.Native"
+    },
+    "name":"io.netty.channel.unix.DatagramSocketAddress",
+    "methods":[{"name":"<init>","parameterTypes":["byte[]","int","int","int","io.netty.channel.unix.DatagramSocketAddress"] }]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.kqueue.Native"
+    },
+    "name":"io.netty.channel.unix.DomainDatagramSocketAddress",
+    "methods":[{"name":"<init>","parameterTypes":["byte[]","int","io.netty.channel.unix.DomainDatagramSocketAddress"] }]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.kqueue.Native"
+    },
+    "name":"io.netty.channel.unix.ErrorsStaticallyReferencedJniMethods"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.kqueue.Native"
+    },
+    "name":"io.netty.channel.unix.FileDescriptor"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.kqueue.Native"
+    },
+    "name":"io.netty.channel.unix.LimitsStaticallyReferencedJniMethods"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.kqueue.Native"
+    },
+    "name":"io.netty.channel.unix.PeerCredentials",
+    "methods":[{"name":"<init>","parameterTypes":["int","int","int[]"] }]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.kqueue.Native"
+    },
+    "name":"io.netty.channel.unix.Socket"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.kqueue.Native"
+    },
+    "name":"java.io.FileDescriptor",
+    "fields":[{"name":"fd"}]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.kqueue.Native"
+    },
+    "name":"java.io.IOException"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.kqueue.Native"
+    },
+    "name":"java.lang.Boolean",
+    "methods":[{"name":"getBoolean","parameterTypes":["java.lang.String"] }]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.kqueue.Native"
+    },
+    "name":"java.lang.OutOfMemoryError"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.kqueue.Native"
+    },
+    "name":"java.lang.RuntimeException"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.kqueue.Native"
+    },
+    "name":"java.net.InetSocketAddress",
+    "methods":[{"name":"<init>","parameterTypes":["java.lang.String","int"] }]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.kqueue.Native"
+    },
+    "name":"java.net.PortUnreachableException"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.kqueue.Native"
+    },
+    "name":"java.nio.Buffer",
+    "fields":[
+      {"name":"limit"},
+      {"name":"position"}
+    ],
+    "methods":[
+      {"name":"limit","parameterTypes":[] },
+      {"name":"position","parameterTypes":[] }
+    ]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.kqueue.Native"
+    },
+    "name":"java.nio.DirectByteBuffer"
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.kqueue.Native"
+    },
+    "name":"java.nio.channels.ClosedChannelException",
+    "methods":[{"name":"<init>","parameterTypes":[] }]
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.kqueue.Native"
+    },
+    "name":"sun.nio.ch.FileChannelImpl",
+    "fields":[{"name":"fd"}]
+  }
+]

--- a/transport-classes-kqueue/src/main/resources/META-INF/native-image/io.netty/netty-transport-classes-kqueue/native-image.properties
+++ b/transport-classes-kqueue/src/main/resources/META-INF/native-image/io.netty/netty-transport-classes-kqueue/native-image.properties
@@ -1,0 +1,15 @@
+# Copyright 2026 The Netty Project
+#
+# The Netty Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+Args = --initialize-at-run-time=io.netty.channel.kqueue,io.netty.channel.unix.Limits,io.netty.channel.unix.IovArray,io.netty.channel.unix.Errors

--- a/transport-classes-kqueue/src/main/resources/META-INF/native-image/io.netty/netty-transport-classes-kqueue/reflect-config.json
+++ b/transport-classes-kqueue/src/main/resources/META-INF/native-image/io.netty/netty-transport-classes-kqueue/reflect-config.json
@@ -1,0 +1,51 @@
+[
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.kqueue.Native"
+    },
+    "name":"io.netty.channel.kqueue.KQueueServerSocketChannel",
+    "allDeclaredConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.kqueue.Native"
+    },
+    "name":"io.netty.channel.kqueue.KQueueServerDomainSocketChannel",
+    "allDeclaredConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.kqueue.Native"
+    },
+    "name":"io.netty.channel.kqueue.KQueueDomainSocketChannel",
+    "allDeclaredConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.kqueue.Native"
+    },
+    "name":"io.netty.channel.kqueue.KQueueSocketChannel",
+    "allDeclaredConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.kqueue.Native"
+    },
+    "name":"io.netty.channel.kqueue.KQueueDatagramChannel",
+    "allDeclaredConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.kqueue.Native"
+    },
+    "name":"io.netty.channel.kqueue.KQueueDomainDatagramChannel",
+    "allDeclaredConstructors": true
+  },
+  {
+    "condition": {
+      "typeReachable": "io.netty.channel.kqueue.Native"
+    },
+    "name": "io.netty.util.internal.NativeLibraryUtil",
+    "allDeclaredMethods": true
+  }
+]

--- a/transport-classes-kqueue/src/main/resources/META-INF/native-image/io.netty/netty-transport-classes-kqueue/resource-config.json
+++ b/transport-classes-kqueue/src/main/resources/META-INF/native-image/io.netty/netty-transport-classes-kqueue/resource-config.json
@@ -1,0 +1,12 @@
+{
+  "resources":{
+    "includes":[
+      {
+        "condition": {
+          "typeReachable": "io.netty.channel.kqueue.Native"
+        },
+        "pattern":".*libnetty_transport_native_kqueue_.*\\.jnilib"
+      }
+    ]},
+  "bundles":[]
+}


### PR DESCRIPTION
## Motivation

The `netty-transport-classes-kqueue` (macOS) module doesn't include GraalVM native-image metadata in META-INF/native-image, while its Linux counterpart `netty-transport-classes-epoll` does.

Because of this the kqueue classes default to build-time class initialization under native-image, meaning `KQueue.isAvailable() == true` is baked into the image heap at build-time, which crashes applications at runtime with an `UnsatisfiedLinkError` when the package isn't available.

## Modifications

Added a META-INF/native-image directory for kqueue, similar to epoll:

- `native-image.properties`: added `--initialize-at-run-time=io.netty.channel.kqueue,io.netty.channel.unix.Limits,io.netty.channel.unix.IovArray,io.netty.channel.unix.Errors` (so `KQueue.isAvailable()` is evaluated at runtime)
- `resource-config.json`: added the kqueue native library (.*libnetty_transport_native_kqueue_.*\.jnilib).
- `reflect-config.json` / `jni-config.json`: added reflection/JNI registrations, guarded by typeReachable: io.netty.channel.kqueue.Native.

The metadata mirrors epoll's but is adjusted where the two transports differ:

- kqueue has an extra channel `KQueueDomainDatagramChannel` registered in this PR.
- epoll registers `NativeDatagramPacketArray$NativeDatagramPacket` for JNI, but kqueue
  has no such class (it receives datagrams via `DatagramSocketAddress` and
  `DomainDatagramSocketAddress`, which are both registered, so nothing's needed here)

## Result

Fixes #17112 
