### PR TITLE
Fix OCSP Tests

### DIFF
--- a/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/NoOcspResponderException.java
+++ b/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/NoOcspResponderException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl.ocsp;
+
+/**
+ * Thrown internally by {@link OcspClient} if the certificate being checked does not specify any OCSP Responder.
+ * <p>
+ * This exception extends {@link NullPointerException} for backwards compatibility reasons.
+ */
+public final class NoOcspResponderException extends NullPointerException {
+    /**
+     * Create a new instance with the given message.
+     * @param message The error message.
+     */
+    public NoOcspResponderException(String message) {
+        super(message);
+    }
+}

--- a/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspClient.java
+++ b/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspClient.java
@@ -104,7 +104,7 @@ final class OcspClient {
      * @param issuer                {@link X509Certificate} issuer of client certificate
      * @param validateResponseNonce Set to {@code true} to enable OCSP response validation
      * @param ioTransport           {@link IoTransport} to use
-     * @return                      {@link Promise} of {@link BasicOCSPResp}
+     * @param responsePromise      {@link Promise} of {@link BasicOCSPResp}
      */
     static void query(final X509Certificate x509Certificate,
                                         final X509Certificate issuer, final boolean validateResponseNonce,
@@ -401,13 +401,15 @@ final class OcspClient {
         AuthorityInformationAccess aiaExtension = AuthorityInformationAccess.fromExtensions(holder.getExtensions());
 
         // Lookup for OCSP responder url
-        for (AccessDescription accessDescription : aiaExtension.getAccessDescriptions()) {
-            if (accessDescription.getAccessMethod().equals(id_ad_ocsp)) {
-                return accessDescription.getAccessLocation().getName().toASN1Primitive().toString();
+        if (aiaExtension != null) {
+            for (AccessDescription accessDescription : aiaExtension.getAccessDescriptions()) {
+                if (accessDescription.getAccessMethod().equals(id_ad_ocsp)) {
+                    return accessDescription.getAccessLocation().getName().toASN1Primitive().toString();
+                }
             }
         }
 
-        throw new NullPointerException("Unable to find OCSP responder URL in Certificate");
+        throw new NoOcspResponderException("Unable to find OCSP responder URL in Certificate");
     }
 
     static final class Initializer extends ChannelInitializer<SocketChannel> {

--- a/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspServerCertificateValidator.java
+++ b/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspServerCertificateValidator.java
@@ -168,8 +168,8 @@ public class OcspServerCertificateValidator extends ByteToMessageDecoder impleme
 
                             Date current = new Date();
                             Date thisUpdate = response.getThisUpdate();
-                        Date nextUpdate = response.getNextUpdate();
-                        if (thisUpdate == null || !current.after(thisUpdate) ||
+                            Date nextUpdate = response.getNextUpdate();
+                            if (thisUpdate == null || !current.after(thisUpdate) ||
                                     (nextUpdate != null && !current.before(nextUpdate))) {
                                 ctx.fireExceptionCaught(new IllegalStateException("OCSP Response is out-of-date"));
                                 return;

--- a/handler-ssl-ocsp/src/test/java/io/netty/handler/ssl/ocsp/OcspClientTest.java
+++ b/handler-ssl-ocsp/src/test/java/io/netty/handler/ssl/ocsp/OcspClientTest.java
@@ -73,7 +73,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class OcspClientTest extends AbstractOcspTest {
 
     @ParameterizedTest
-    @ValueSource(strings = {"https://netty.io", "https://apple.com"})
+    @ValueSource(strings = {"https://apple.com"})
     void simpleOcspQueryTest(String urlString) throws IOException, ExecutionException, InterruptedException {
         HttpsURLConnection httpsConnection = null;
         try {

--- a/handler-ssl-ocsp/src/test/java/io/netty/handler/ssl/ocsp/OcspServerCertificateValidatorTest.java
+++ b/handler-ssl-ocsp/src/test/java/io/netty/handler/ssl/ocsp/OcspServerCertificateValidatorTest.java
@@ -59,7 +59,7 @@ class OcspServerCertificateValidatorTest extends AbstractOcspTest {
                         @Override
                         protected void initChannel(SocketChannel ch) {
                             ChannelPipeline pipeline = ch.pipeline();
-                            pipeline.addLast(sslContext.newHandler(ch.alloc(), "netty.io", 443));
+                            pipeline.addLast(sslContext.newHandler(ch.alloc(), "apple.com", 443));
                             pipeline.addLast(new OcspServerCertificateValidator(false, createDefaultTransport()));
                             pipeline.addLast(new SimpleChannelInboundHandler<Object>() {
                                 @Override
@@ -81,7 +81,7 @@ class OcspServerCertificateValidatorTest extends AbstractOcspTest {
                         }
                     });
 
-            ChannelFuture channelFuture = bootstrap.connect("netty.io", 443);
+            ChannelFuture channelFuture = bootstrap.connect("apple.com", 443);
             channelFuture.sync();
 
             // Wait for maximum of 1 minute for Ocsp validation to happen

--- a/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/OCSPTest.java
+++ b/testsuite-jpms/src/test/java/io/netty/testsuite_jpms/test/OCSPTest.java
@@ -62,7 +62,7 @@ public class OCSPTest {
                         @Override
                         protected void initChannel(SocketChannel ch) {
                             ChannelPipeline pipeline = ch.pipeline();
-                            pipeline.addLast(sslContext.newHandler(ch.alloc(), "netty.io", 443));
+                            pipeline.addLast(sslContext.newHandler(ch.alloc(), "apple.com", 443));
                             pipeline.addLast(new OcspServerCertificateValidator(false));
                             pipeline.addLast(new SimpleChannelInboundHandler<>() {
                                 @Override
@@ -84,7 +84,7 @@ public class OCSPTest {
                         }
                     });
 
-            ChannelFuture channelFuture = bootstrap.connect("netty.io", 443);
+            ChannelFuture channelFuture = bootstrap.connect("apple.com", 443);
             channelFuture.sync();
 
             // Wait for maximum of 1 minute for Ocsp validation to happen


### PR DESCRIPTION
Motivation:
Google Trust Services, which supply the SSL certificate for `netty.io`, recently stopped adding OCSP entries to the certificates they create.

This broke some of our OCSP tests, which were relying on reaching out to netty.io and checking the certificate.

Modification:
Change the test domain to instead use `apple.com`, which still adds OCSP entries to their certificates.

Result:
This makes the tests pass again as a temporary measure. The real fix is to add OCSP support to our netty-pkitesting module, and instead rely entirely on local connections with certificates fully controlled by the test setup.