### PR TITLE
fix(mqtt): drop UNSUBACK reason codes for MQTT 3.x encoding

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttEncoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttEncoder.java
@@ -418,13 +418,18 @@ public final class MqttEncoder extends MessageToMessageEncoder<MqttMessage> {
             MqttUnsubAckMessage message) {
         if (message.variableHeader() instanceof  MqttMessageIdAndPropertiesVariableHeader) {
             MqttVersion mqttVersion = getMqttVersion(ctx);
+            // Reason Codes were introduced in MQTT 5.0 only. MQTT 3.1.1 (and 3.1) UNSUBACK packets
+            // have no payload, so reason codes must be suppressed for older protocol versions
+            // even when the caller populated them via MqttMessageBuilders.
+            final boolean writeReasonCodes = mqttVersion == MqttVersion.MQTT_5;
             ByteBuf propertiesBuf = encodePropertiesIfNeeded(mqttVersion,
                     ctx.alloc(),
                     message.idAndPropertiesVariableHeader().properties());
             try {
                 int variableHeaderBufferSize = 2 + propertiesBuf.readableBytes();
                 MqttUnsubAckPayload payload = message.payload();
-                int payloadBufferSize = payload == null ? 0 : payload.unsubscribeReasonCodes().size();
+                int payloadBufferSize = writeReasonCodes && payload != null
+                        ? payload.unsubscribeReasonCodes().size() : 0;
                 int variablePartSize = variableHeaderBufferSize + payloadBufferSize;
                 int fixedHeaderBufferSize = 1 + getVariableLengthInt(variablePartSize);
                 ByteBuf buf = ctx.alloc().buffer(fixedHeaderBufferSize + variablePartSize);
@@ -433,7 +438,7 @@ public final class MqttEncoder extends MessageToMessageEncoder<MqttMessage> {
                 buf.writeShort(message.variableHeader().messageId());
                 buf.writeBytes(propertiesBuf);
 
-                if (payload != null) {
+                if (writeReasonCodes && payload != null) {
                     for (Short reasonCode : payload.unsubscribeReasonCodes()) {
                         buf.writeByte(reasonCode);
                     }

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
@@ -936,6 +936,41 @@ public class MqttCodecTest {
     }
 
     @Test
+    public void testUnsubAckMessageForMqtt311DropsReasonCodes() throws Exception {
+        // MQTT 3.1.1 UNSUBACK has no properties and no payload. Even when a caller populates
+        // properties / reason codes (for example via MqttMessageBuilders), the encoder must
+        // strip them so the wire format remains valid for 3.1.1 (Remaining Length must be 2).
+        when(versionAttrMock.get()).thenReturn(MqttVersion.MQTT_3_1_1);
+
+        MqttProperties props = new MqttProperties();
+        props.add(new MqttProperties.IntegerProperty(PAYLOAD_FORMAT_INDICATOR, 6));
+        final MqttUnsubAckMessage message = MqttMessageBuilders.unsubAck()
+                .packetId((short) 1)
+                .properties(props)
+                .addReasonCode((short) 0x83)
+                .build();
+        ByteBuf byteBuf = MqttEncoder.doEncode(ctx, message);
+
+        // Fixed header (1 byte) + Remaining Length (0x02) + Packet Identifier (2 bytes) = 4 bytes.
+        assertEquals(4, byteBuf.readableBytes());
+        assertEquals(MqttMessageType.UNSUBACK.value() << 4, byteBuf.getByte(0) & 0xF0);
+        assertEquals(2, byteBuf.getByte(1));
+        assertEquals(1, byteBuf.getUnsignedShort(2));
+
+        mqttDecoder.channelRead(ctx, byteBuf);
+
+        assertEquals(1, out.size());
+
+        final MqttUnsubAckMessage decodedMessage = (MqttUnsubAckMessage) out.get(0);
+        validateFixedHeaders(message.fixedHeader(), decodedMessage.fixedHeader());
+        validateMessageIdVariableHeader(
+                message.variableHeader(),
+                decodedMessage.variableHeader());
+        assertTrue(decodedMessage.payload() == null
+                || decodedMessage.payload().unsubscribeReasonCodes().isEmpty());
+    }
+
+    @Test
     public void testDisconnectMessageForMqtt5() throws Exception {
         when(versionAttrMock.get()).thenReturn(MqttVersion.MQTT_5);
 


### PR DESCRIPTION
Motivation:

MQTT 3.x UNSUBACK only includes the Packet Identifier, while the reason code payload is a new addition in MQTT 5.0.

Modification:

drop UNSUBACK reason codes for MQTT 3.x encoding
