### PR TITLE
Use safe decompressor in Lz4FrameDecoder

### DIFF
--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/Lz4FrameDecoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/Lz4FrameDecoder.java
@@ -21,8 +21,9 @@ import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.util.internal.ObjectUtil;
 import net.jpountz.lz4.LZ4Exception;
 import net.jpountz.lz4.LZ4Factory;
-import net.jpountz.lz4.LZ4FastDecompressor;
+import net.jpountz.lz4.LZ4SafeDecompressor;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.zip.Checksum;
 
@@ -67,7 +68,7 @@ public class Lz4FrameDecoder extends ByteToMessageDecoder {
     /**
      * Underlying decompressor in use.
      */
-    private LZ4FastDecompressor decompressor;
+    private LZ4SafeDecompressor decompressor;
 
     /**
      * Underlying checksum calculator in use.
@@ -174,7 +175,7 @@ public class Lz4FrameDecoder extends ByteToMessageDecoder {
      *                  maximum length of the decompressed block. If {@code 0} is given it uses {@code 32MB} by default.
      */
     public Lz4FrameDecoder(LZ4Factory factory, Checksum checksum, int maxDecompressedLength) {
-        decompressor = ObjectUtil.checkNotNull(factory, "factory").fastDecompressor();
+        decompressor = ObjectUtil.checkNotNull(factory, "factory").safeDecompressor();
         this.checksum = checksum == null ? null : ByteBufChecksum.wrapChecksum(checksum);
         this.maxDecompressedLength = maxDecompressedLength == 0 ? MAX_BLOCK_SIZE :
                 ObjectUtil.checkInRange(maxDecompressedLength, 0, MAX_BLOCK_SIZE, "maxDecompressedLength");
@@ -266,8 +267,19 @@ public class Lz4FrameDecoder extends ByteToMessageDecoder {
                         case BLOCK_TYPE_COMPRESSED:
                             uncompressed = ctx.alloc().buffer(decompressedLength, decompressedLength);
 
-                            decompressor.decompress(CompressionUtil.safeReadableNioBuffer(in),
-                                    uncompressed.internalNioBuffer(uncompressed.writerIndex(), decompressedLength));
+                            ByteBuffer source = CompressionUtil.safeNioBuffer(
+                                    in, in.readerIndex(), compressedLength);
+                            ByteBuffer destination = uncompressed.internalNioBuffer(
+                                    uncompressed.writerIndex(), decompressedLength);
+                            int actualDecompressedLength = decompressor.decompress(
+                                    source, source.position(), compressedLength,
+                                    destination, destination.position(), decompressedLength);
+                            if (actualDecompressedLength != decompressedLength) {
+                                throw new DecompressionException(String.format(
+                                        "stream corrupted: decompressedLength(%d) and " +
+                                                "actualDecompressedLength(%d) mismatch",
+                                        decompressedLength, actualDecompressedLength));
+                            }
                             // Update the writerIndex now to reflect what we decompressed.
                             uncompressed.writerIndex(uncompressed.writerIndex() + decompressedLength);
                             break;

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/Lz4FrameDecoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/Lz4FrameDecoderTest.java
@@ -50,6 +50,44 @@ public class Lz4FrameDecoderTest extends AbstractDecoderTest {
     }
 
     @Test
+    public void testRejectsCompressedDataBeyondDeclaredLength() {
+        EmbeddedChannel decoder = new EmbeddedChannel(new Lz4FrameDecoder(false));
+        ByteBuf input = decoder.alloc().buffer();
+        input.writeLong(MAGIC_NUMBER);
+        input.writeByte(BLOCK_TYPE_COMPRESSED);
+        input.writeIntLE(1);
+        input.writeIntLE(8);
+        input.writeIntLE(0);
+        input.writeByte(0x80);
+        input.writeZero(8);
+
+        try {
+            assertThrows(DecompressionException.class, () -> decoder.writeInbound(input));
+        } finally {
+            decoder.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    public void testRejectsDecompressedLengthMismatch() {
+        EmbeddedChannel decoder = new EmbeddedChannel(new Lz4FrameDecoder(false));
+        ByteBuf input = decoder.alloc().buffer();
+        input.writeLong(MAGIC_NUMBER);
+        input.writeByte(BLOCK_TYPE_COMPRESSED);
+        input.writeIntLE(2);
+        input.writeIntLE(8);
+        input.writeIntLE(0);
+        input.writeByte(0x10);
+        input.writeByte(0);
+
+        try {
+            assertThrows(DecompressionException.class, () -> decoder.writeInbound(input));
+        } finally {
+            decoder.finishAndReleaseAll();
+        }
+    }
+
+    @Test
     public void testUnexpectedBlockIdentifier() {
         final byte[] data = Arrays.copyOf(DATA, DATA.length);
         data[1] = 0x00;


### PR DESCRIPTION
Motivation:

`Lz4FrameDecoder` currently uses `LZ4FastDecompressor`. Recent lz4-java security hardening has degraded the performance of this path, while the decoder already knows the exact compressed block length required by `LZ4SafeDecompressor`. The fast API also does not accept the compressed source length, allowing malformed blocks to consume trailing readable bytes.

Modification:

- Use `LZ4SafeDecompressor` from the configured `LZ4Factory`.
- Pass the exact declared compressed and decompressed lengths to the bounded decompression API.
- Reject output whose actual decompressed length differs from the frame header.
- Add regression coverage for reading beyond the declared compressed length and for decompressed-length mismatches.

Result:

Valid LZ4 frames continue to decode normally, while malformed blocks are constrained to their declared input and output bounds. The `codec-compression` test suite passes with 359 tests, and the focused `Lz4FrameDecoderTest` passes after allocating test inputs through the channel allocator.