### PR TITLE
Add HttpContentCompressor constructor with ability to specify desired…

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
@@ -185,6 +185,26 @@ public class HttpContentCompressor extends HttpContentEncoder {
      *        if the default should be used.
      */
     public HttpContentCompressor(int contentSizeThreshold, CompressionOptions... compressionOptions) {
+        this(contentSizeThreshold, DEFAULT_MAX_PIPELINE_DEPTH, compressionOptions);
+    }
+
+    /**
+     * Create a new {@link HttpContentCompressor} instance with specified
+     * {@link CompressionOptions}s
+     *
+     * @param contentSizeThreshold
+     *        The response body is compressed when the size of the response
+     *        body exceeds the threshold. The value should be a non negative
+     *        number. {@code 0} will enable compression for all responses.
+     * @param maxPipelineDepth
+     *        The maximum allowed depth of the encoding pipeline queue, the default
+     *        value is set to {@link DEFAULT_MAX_PIPELINE_DEPTH}
+     * @param compressionOptions {@link CompressionOptions} or {@code null}
+     *        if the default should be used.
+     */
+    public HttpContentCompressor(int contentSizeThreshold, int maxPipelineDepth,
+            CompressionOptions... compressionOptions) {
+        super(maxPipelineDepth);
         this.contentSizeThreshold = ObjectUtil.checkPositiveOrZero(contentSizeThreshold, "contentSizeThreshold");
         BrotliOptions brotliOptions = null;
         GzipOptions gzipOptions = null;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentEncoder.java
@@ -55,6 +55,7 @@ import static io.netty.handler.codec.http.HttpHeaderNames.*;
  * converts them into {@link ByteBuf}s.
  */
 public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpRequest, HttpObject> {
+    public static final int DEFAULT_MAX_PIPELINE_DEPTH = 128;
 
     private enum State {
         PASS_THROUGH,
@@ -65,12 +66,18 @@ public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpReque
     private static final CharSequence ZERO_LENGTH_HEAD = "HEAD";
     private static final CharSequence ZERO_LENGTH_CONNECT = "CONNECT";
 
+    private final int maxPipelineDepth;
     private final Queue<CharSequence> acceptEncodingQueue = new ArrayDeque<CharSequence>();
     private EmbeddedChannel encoder;
     private State state = State.AWAIT_HEADERS;
 
     public HttpContentEncoder() {
+        this(DEFAULT_MAX_PIPELINE_DEPTH);
+    }
+
+    public HttpContentEncoder(int maxPipelineDepth) {
         super(HttpRequest.class, HttpObject.class);
+        this.maxPipelineDepth = ObjectUtil.checkPositive(maxPipelineDepth, "maxPipelineDepth");
     }
 
     @Override
@@ -80,6 +87,9 @@ public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpReque
 
     @Override
     protected void decode(ChannelHandlerContext ctx, HttpRequest msg, List<Object> out) throws Exception {
+        if (maxPipelineDepth <= acceptEncodingQueue.size()) {
+            throw new IllegalStateException("maxPipelineDepth exceeded: " + maxPipelineDepth);
+        }
         CharSequence acceptEncoding;
         List<String> acceptEncodingHeaders = msg.headers().getAll(ACCEPT_ENCODING);
         switch (acceptEncodingHeaders.size()) {


### PR DESCRIPTION
… maxPipelineDepth (#17068)

Motivation:

In scope of https://github.com/netty/netty/pull/17063, the `HttpContentEncoder` got a new property `maxPipelineDepth` and the respective constructor variant. However, the subclasses, notably `HttpContentCompressor` have not been updated to allow changing `maxPipelineDepth` and always use the default `128`.

Modification:

Add `HttpContentCompressor` constructor variant with ability to specify desired `maxPipelineDepth`. It would help us to absorb the change through configuration setting.

@chrisvest would appreciate your feedback, thank you.

Signed-off-by: Andriy Redko <drreta@gmail.com>

(cherry picked from commit 61aca07bf4b803286c4a6f349acffda167b7f93d)