### PR TITLE
Fix maxAllocation for brotli-encoded content in HttpContentDecompress…

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentDecompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentDecompressor.java
@@ -104,7 +104,7 @@ public class HttpContentDecompressor extends HttpContentDecoder {
         }
         if (Brotli.isAvailable() && BR.contentEqualsIgnoreCase(contentEncoding)) {
             return new EmbeddedChannel(ctx.channel().id(), ctx.channel().metadata().hasDisconnect(),
-              ctx.channel().config(), new BrotliDecoder(maxAllocation));
+              ctx.channel().config(), BrotliDecoder.newDecoderWithMaxAllocation(maxAllocation));
         }
 
         if (SNAPPY.contentEqualsIgnoreCase(contentEncoding)) {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentDecompressorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentDecompressorTest.java
@@ -26,14 +26,19 @@ import io.netty.handler.codec.compression.Brotli;
 import io.netty.handler.codec.compression.Zstd;
 import io.netty.handler.flow.FlowControlHandler;
 import io.netty.util.ReferenceCountUtil;
+import com.aayushatharva.brotli4j.encoder.BrotliOutputStream;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -194,6 +199,74 @@ public class HttpContentDecompressorTest {
         decompressChannel.writeInbound(new DefaultLastHttpContent(compressed));
 
         assertEquals((long) chunkSize * numberOfChunks, incomingHandler.total);
+    }
+
+    @Test
+    public void testBrotliDecodingHonorsMaxAllocationAsOutputCap() throws Exception {
+        Assumptions.assumeTrue(Brotli.isAvailable(),
+                "brotli4j native library not available on this platform");
+
+        // 128KB of moderately compressible bytes so the decompressed size
+        // definitely exceeds BrotliDecoder's 64KB default output cap and any
+        // small maxAllocation we might set below.
+        byte[] payload = new byte[128 * 1024];
+        for (int i = 0; i < payload.length; i++) {
+            payload[i] = (byte) (i % 251);
+        }
+        ByteArrayOutputStream compressedOut = new ByteArrayOutputStream();
+        BrotliOutputStream brotliOs = new BrotliOutputStream(compressedOut);
+        brotliOs.write(payload);
+        brotliOs.close();
+        byte[] compressed = compressedOut.toByteArray();
+
+        // Deliberately use a tiny maxAllocation. Before the fix this configured
+        // BrotliDecoder.inputBufferSize = 64, effectively breaking the decoder
+        // for realistic payloads; after the fix it configures outputBufferSize.
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpContentDecompressor(64));
+        try {
+            HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+            response.headers().set(HttpHeaderNames.CONTENT_ENCODING, HttpHeaderValues.BR);
+            response.headers().set(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
+            assertTrue(channel.writeInbound(response));
+            assertTrue(channel.writeInbound(new DefaultHttpContent(Unpooled.wrappedBuffer(compressed))));
+            assertTrue(channel.writeInbound(LastHttpContent.EMPTY_LAST_CONTENT));
+
+            // Drain and concatenate every decompressed HttpContent chunk.
+            byte[] decompressed = new byte[0];
+            int contentChunks = 0;
+            Object msg;
+            while ((msg = channel.readInbound()) != null) {
+                try {
+                    if (msg instanceof HttpContent) {
+                        ByteBuf buf = ((HttpContent) msg).content();
+                        if (buf.readableBytes() > 0) {
+                            contentChunks++;
+                            int len = decompressed.length;
+                            decompressed = Arrays.copyOf(decompressed, len + buf.readableBytes());
+                            buf.readBytes(decompressed, len, buf.readableBytes());
+                        }
+                    }
+                } finally {
+                    ReferenceCountUtil.release(msg);
+                }
+            }
+
+            assertThat(decompressed)
+                    .as("decompressed bytes must match original payload")
+                    .isEqualTo(payload);
+
+            // Regression signal: with maxAllocation=64 correctly routed to
+            // BrotliDecoder.outputBufferSize, a 128KB payload must be forwarded
+            // in many small chunks. Under the previous (buggy) wiring the same
+            // maxAllocation would be applied to inputBufferSize while
+            // outputBufferSize stayed at BrotliDecoder's 64KB default, so only
+            // a handful of large chunks would be emitted.
+            assertThat(contentChunks)
+                    .as("expected many small chunks when maxAllocation=64 caps output size")
+                    .isGreaterThan(100);
+        } finally {
+            channel.finishAndReleaseAll();
+        }
     }
 
     private static final class ZipBombIncomingHandler extends ChannelInboundHandlerAdapter {

--- a/codec/src/main/java/io/netty/handler/codec/compression/BrotliDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/BrotliDecoder.java
@@ -80,6 +80,22 @@ public final class BrotliDecoder extends ByteToMessageDecoder {
         this.outputBufferSize = ObjectUtil.checkPositive(outputBufferSize, "outputBufferSize");
     }
 
+    /**
+     * Creates a new {@link BrotliDecoder} that use the {@code maxAllocation}
+     * semantics: the supplied value bounds the size of the emitted decompressed chunks.
+     * The input buffer size stays at the decoder's default.
+     *
+     * @param maxAllocation maximum size, in bytes, of each decompressed output
+     *                      buffer forwarded downstream; if {@code 0}, the
+     *                      decoder's default output cap is used.
+     */
+    public static BrotliDecoder newDecoderWithMaxAllocation(int maxAllocation) {
+        ObjectUtil.checkPositiveOrZero(maxAllocation, "maxAllocation");
+        return maxAllocation > 0 ?
+                new BrotliDecoder(DEFAULT_INPUT_BUFFER_SIZE, maxAllocation) :
+                new BrotliDecoder();
+    }
+
     private void forwardOutput(ChannelHandlerContext ctx) {
         ByteBuffer nativeBuffer = decoder.pull(outputBufferSize);
         // nativeBuffer actually wraps brotli's internal buffer so we need to copy its content


### PR DESCRIPTION
…or (#17037)

Motivation
HttpContentDecompressor documents maxAllocation as the maximum decompression buffer size. For gzip / deflate / zstd it is routed to each decoder's output-cap parameter. For brotli it was passed to new BrotliDecoder(maxAllocation), whose single argument is inputBufferSize, not the output cap. So a large maxAllocation enlarged brotli's input buffer while the output cap stayed at the 64 KiB default; a small maxAllocation did not tighten the output cap for brotli at all. Modifications
Add BrotliDecoder.newDecoderWithMaxAllocation(int): routes maxAllocation to outputBufferSize, 0 falls back to new BrotliDecoder(). `HttpContentDecompressor`: brotli branch uses the new factory instead of new BrotliDecoder(maxAllocation).
Add
HttpContentDecompressorTest#testBrotliDecodingHonorsMaxAllocationAsOutputCap: brotli-compress 128 KiB, decode with HttpContentDecompressor(64), assert lossless decode and >100 chunks.
Result
Fixes #17034.
maxAllocation now has consistent semantics across gzip / deflate / zstd / brotli. No API removed, one new public factory added on BrotliDecoder.

---------

Co-authored-by: Norman Maurer <norman_maurer@apple.com>

(cherry picked from commit 0332676fd1d7b65a8a8b249a5bf96b30e2c998a3)