### PR TITLE
IoUring:disable sendmsg_zc for Unix domain sockets

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
@@ -193,7 +193,7 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
 
         IoUringSocketChannelConfig config = (IoUringSocketChannelConfig) config();
         ByteBuf current = (ByteBuf) in.current();
-        if (IoUring.isSendmsgZcSupported() && current != null && config.shouldWriteZeroCopy(current.readableBytes())) {
+        if (isSendmsgZcSupported() && current != null && config.shouldWriteZeroCopy(current.readableBytes())) {
             IoUringIoHandler handler = registration().attachment();
 
             IovArray iovArray = handler.iovArray();
@@ -791,6 +791,10 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
     @Override
     public ChannelConfig config() {
         return config;
+    }
+
+    private boolean isSendmsgZcSupported() {
+        return IoUring.isSendmsgZcSupported() && socket.protocolFamily() != SocketProtocolFamily.UNIX;
     }
 
     private IoUringIoOps prepSendFdIoOps(FileDescriptor fileDescriptor, MsgHdrMemory msgHdrMemory) {

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketSendZcSendmsgZcEchoTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketSendZcSendmsgZcEchoTest.java
@@ -1,0 +1,38 @@
+package io.netty.channel.uring;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.testsuite.transport.TestsuitePermutation;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.net.SocketAddress;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IoUringDomainSocketSendZcSendmsgZcEchoTest extends IoUringSocketEchoTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IoUring.isAvailable());
+        assumeTrue(IoUring.isSendZcSupported());
+    }
+
+    @Override
+    protected SocketAddress newSocketAddress() {
+        return IoUringSocketTestPermutation.newDomainSocketAddress();
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IoUringSocketTestPermutation.INSTANCE.domainSocket();
+    }
+
+    @Override
+    protected void configure(ServerBootstrap sb, Bootstrap cb, ByteBufAllocator allocator) {
+        super.configure(sb, cb, allocator);
+        sb.childOption(IoUringChannelOption.IO_URING_WRITE_ZERO_COPY_THRESHOLD, 0);
+        cb.option(IoUringChannelOption.IO_URING_WRITE_ZERO_COPY_THRESHOLD, 0);
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketSendZcSendmsgZcEchoTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketSendZcSendmsgZcEchoTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package io.netty.channel.uring;
 
 import io.netty.bootstrap.Bootstrap;


### PR DESCRIPTION
Motivation:

IoUringSocketChannel already prevents UNIX domain sockets from using IORING_OP_SEND_ZC. However, the corresponding check was missing for IORING_OP_SENDMSG_ZC, causing batched writes to fail with EOPNOTSUPP

Modification:

Add a protocol-family check to prevent UNIX domain sockets from using IORING_OP_SENDMSG_ZC and fall back to regular writev.

Result:

UNIX domain socket writes no longer fail with EOPNOTSUPP when zero-copy writes are enabled
