### PR TITLE
Configure TestLens for the PR builds

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -109,6 +109,9 @@ jobs:
             cache-windows-maven-${{ hashFiles('**/pom.xml') }}
             cache-windows-maven-
 
+      - name: Set up TestLens
+        uses: testlens-app/setup-testlens@3f82d2dc6cd5c03f02ce5f7885a21195d85f8d14 # Pin 1.9.3
+
       - name: Build project
         run: ./mvnw.cmd -B -ntp --file pom.xml clean package -Pboringssl -DskipHttp2Testsuite=true -DskipAutobahnTestsuite=true
 
@@ -270,6 +273,9 @@ jobs:
             cache-maven-al2023-${{ hashFiles('**/pom.xml') }}
             cache-maven-al2023-
 
+      - name: Set up TestLens
+        uses: testlens-app/setup-testlens@3f82d2dc6cd5c03f02ce5f7885a21195d85f8d14 # Pin 1.9.3
+
       - name: Build docker image
         run: docker compose ${{ matrix.docker-compose-build }}
 
@@ -347,6 +353,9 @@ jobs:
 
       - name: Install tools via brew
         run: brew bundle
+
+      - name: Set up TestLens
+        uses: testlens-app/setup-testlens@3f82d2dc6cd5c03f02ce5f7885a21195d85f8d14 # Pin 1.9.3
 
       - name: Build project
         run: ./mvnw -B -ntp --file pom.xml clean install -Pboringssl -DskipHttp2Testsuite=true -DskipAutobahnTestsuite=true -DskipTests=true && ./mvnw -B -ntp --file pom.xml package -Pboringssl -pl transport-native-kqueue


### PR DESCRIPTION
Motivation:
TestLens is a new tool by the JUnit maintainers that helps to get flaky tests under control. It is free for open source projects.

Modification:
TestLens needs to instrument the maven POM files, so this adds a github action invocation to the PR builds that do that before running our maven builds.

Result:
TestLens is now enabled in our PR builds.
