### PR TITLE
Propagate the CI envionment variables through to the docker builds

### DIFF
--- a/docker/docker-compose.al2023.yaml
+++ b/docker/docker-compose.al2023.yaml
@@ -11,6 +11,7 @@ services:
     depends_on: [runtime-setup]
     environment:
       LD_LIBRARY_PATH: /opt/aws-lc/lib64
+      CI:
     volumes:
       # Use a separate directory for the AL2023 Maven repository
       - ~/.m2-al2023:/root/.m2

--- a/docker/docker-compose.centos-7.cross.yaml
+++ b/docker/docker-compose.centos-7.cross.yaml
@@ -19,6 +19,7 @@ services:
       - GPG_PASSPHRASE
       - GPG_PRIVATE_KEY
       - MAVEN_OPTS
+      - CI
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg

--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -16,6 +16,7 @@ services:
       - GPG_PASSPHRASE
       - GPG_PRIVATE_KEY
       - MAVEN_OPTS
+      - CI
     volumes:
       - ~/.ssh:/root/.ssh:delegated
       - ~/.gnupg:/root/.gnupg:delegated

--- a/docker/docker-compose.ubuntu-20.04.cross.yaml
+++ b/docker/docker-compose.ubuntu-20.04.cross.yaml
@@ -16,6 +16,7 @@ services:
       - GPG_PASSPHRASE
       - GPG_PRIVATE_KEY
       - MAVEN_OPTS
+      - CI
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -16,6 +16,7 @@ services:
       - GPG_PASSPHRASE
       - GPG_PRIVATE_KEY
       - MAVEN_OPTS
+      - CI
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg


### PR DESCRIPTION
Motivation:
TestLens requires this in order to activate its profile. It's possible some of our other tools, e.g. sdkman also make use of this.

Modification:
Add `CI` to the environments in our docker-compose files.

Result:
We should now get testlens results from our docker-based linux builds.