### PR TITLE
Avoid classloader leak via GlobalEventExecutor terminationFuture failure

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
@@ -88,9 +88,8 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor im
         threadFactory = ThreadExecutorMap.apply(new DefaultThreadFactory(
                 DefaultThreadFactory.toPoolName(getClass()), false, Thread.NORM_PRIORITY, null), this);
 
-        UnsupportedOperationException terminationFailure = new UnsupportedOperationException();
-        ThrowableUtil.unknownStackTrace(terminationFailure, GlobalEventExecutor.class, "terminationFuture");
-        terminationFuture = new FailedFuture<Object>(this, terminationFailure);
+        terminationFuture = new FailedFuture<Object>(this,
+                StacklessUnsupportedOperationException.newInstance(GlobalEventExecutor.class, "terminationFuture"));
     }
 
     /**
@@ -325,6 +324,26 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor im
                     // -> keep this thread alive to handle the newly added entries.
                 }
             }
+        }
+    }
+
+    private static final class StacklessUnsupportedOperationException extends UnsupportedOperationException {
+
+        private static final long serialVersionUID = -8060232216137960173L;
+
+        private StacklessUnsupportedOperationException() { }
+
+        // Override fillInStackTrace() so we not populate the backtrace via a native call and so leak the
+        // Classloader. As the GlobalEventExecutor.INSTANCE is a singleton and holds on to this exception via its
+        // terminationFuture, a populated backtrace would pin the Classloader of whatever thread happened to trigger
+        // the lazy initialization of INSTANCE (see https://github.com/netty/netty/issues/17128).
+        @Override
+        public Throwable fillInStackTrace() {
+            return this;
+        }
+
+        static StacklessUnsupportedOperationException newInstance(Class<?> clazz, String method) {
+            return ThrowableUtil.unknownStackTrace(new StacklessUnsupportedOperationException(), clazz, method);
         }
     }
 }

--- a/common/src/test/java/io/netty/util/concurrent/GlobalEventExecutorTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/GlobalEventExecutorTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
@@ -154,6 +155,26 @@ public class GlobalEventExecutorTest {
         f.sync();
 
         assertTrue(t.ran.get());
+    }
+
+    @Test
+    public void testTerminationFutureFailureDoesNotFillInStackTrace() {
+        // The GlobalEventExecutor.INSTANCE is a singleton that lives for the lifetime of the Classloader that
+        // loaded it. It holds on to the failure of its terminationFuture forever, so that failure must not
+        // populate a (native) backtrace: doing so would pin the Classloader of whatever thread happened to
+        // trigger the lazy initialization of INSTANCE (see https://github.com/netty/netty/issues/17128).
+        Throwable cause = e.terminationFuture().cause();
+        assertNotNull(cause);
+        assertTrue(cause instanceof UnsupportedOperationException);
+
+        StackTraceElement[] before = cause.getStackTrace();
+        assertEquals(1, before.length);
+        assertEquals(GlobalEventExecutor.class.getName(), before[0].getClassName());
+        assertEquals("terminationFuture", before[0].getMethodName());
+
+        // fillInStackTrace() must be a no-op; otherwise it would repopulate the backtrace with native frames.
+        cause.fillInStackTrace();
+        assertArrayEquals(before, cause.getStackTrace());
     }
 
     private static final class TestRunnable implements Runnable {


### PR DESCRIPTION
### Motivation

`GlobalEventExecutor.INSTANCE` is a static singleton that lives for the lifetime of the classloader that loaded it. Its `terminationFuture` holds a `FailedFuture` whose cause was a plain `UnsupportedOperationException`.

Although `ThrowableUtil.unknownStackTrace(...)` replaces the *visible* stack trace with a single synthetic frame, the exception's internal (native) `backtrace` field is still populated at construction time by `fillInStackTrace()`. That backtrace pins the classloader of whatever thread happened to trigger the lazy initialization of `INSTANCE` (e.g. a web application's `WebAppClassLoader`), making all of that classloader's classes immortal/undeployable.

This is a follow-up to the leak fixed in #14622.

Fixes #17128

### Modification

Introduce a private `StacklessUnsupportedOperationException` whose `fillInStackTrace()` is a no-op, so the native backtrace is never captured, and use it for the `terminationFuture` failure. This mirrors the stackless-exception pattern already used throughout Netty.

### Result

The `terminationFuture` failure no longer retains a native backtrace, so it can no longer pin the triggering thread's classloader.

**Verification done:** Added `GlobalEventExecutorTest#testTerminationFutureFailureDoesNotFillInStackTrace`, which asserts that after `fillInStackTrace()` the cause's stack trace stays the single synthetic `terminationFuture` frame. It fails before the change (backtrace repopulates to 76 native frames) and passes after. Ran `mvn -pl common test -Dtest=GlobalEventExecutorTest` (6/6 pass) and `checkstyle:check@check-style` (clean) on JDK 25.