### PR TITLE
Port:5.0:IoUring: Add SO_INQ support for Unix domain

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -653,10 +653,14 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         pollInId = schedulePollAdd(POLL_IN_SCHEDULED, Native.POLLIN, allowMultiShotPollIn());
     }
 
+    protected final boolean isReadMultishot() {
+        return numOutstandingReads == -1;
+    }
+
     private void readComplete(byte op, int res, int flags, short data) {
         assert numOutstandingReads > 0 || numOutstandingReads == -1 : numOutstandingReads;
 
-        boolean multishot = numOutstandingReads == -1;
+        boolean multishot = isReadMultishot();
         boolean rearm = (flags & Native.IORING_CQE_F_MORE) == 0;
         if (rearm) {
             // Reset READ_SCHEDULED if there is nothing more to handle and so we need to re-arm. This works for

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUring.java
@@ -31,6 +31,7 @@ public final class IoUring {
 
     private static final Throwable UNAVAILABILITY_CAUSE;
     private static final boolean IORING_CQE_F_SOCK_NONEMPTY_SUPPORTED;
+    private static final boolean UNIX_DOMAIN_SOCKET_INQ_SUPPORTED;
     private static final boolean IORING_SPLICE_SUPPORTED;
     private static final boolean IORING_SEND_ZC_SUPPORTED;
     private static final boolean IORING_SENDMSG_ZC_SUPPORTED;
@@ -66,6 +67,7 @@ public final class IoUring {
         logger = InternalLoggerFactory.getInstance(IoUring.class);
         Throwable cause = null;
         boolean socketNonEmptySupported = false;
+        boolean unixDomainSocketInqSupported = false;
         boolean spliceSupported = false;
         boolean sendZcSupported = false;
         boolean sendmsgZcSupported = false;
@@ -133,6 +135,7 @@ public final class IoUring {
                     registerBufferRingSupported = Native.isRegisterBufferRingSupported(ringBuffer.fd(), 0);
                     registerBufferRingIncSupported = Native.isRegisterBufferRingSupported(ringBuffer.fd(),
                             Native.IOU_PBUF_RING_INC);
+                    unixDomainSocketInqSupported = Native.isUnixDomainSocketInqSupported();
                 } finally {
                     if (ringBuffer != null) {
                         try {
@@ -149,6 +152,7 @@ public final class IoUring {
         // Assign static finals first so printFeatures() (no-arg) can read them.
         UNAVAILABILITY_CAUSE = cause;
         IORING_CQE_F_SOCK_NONEMPTY_SUPPORTED = socketNonEmptySupported;
+        UNIX_DOMAIN_SOCKET_INQ_SUPPORTED = unixDomainSocketInqSupported;
         IORING_SPLICE_SUPPORTED = spliceSupported;
         IORING_SEND_ZC_SUPPORTED = sendZcSupported;
         IORING_SENDMSG_ZC_SUPPORTED = sendmsgZcSupported;
@@ -246,6 +250,10 @@ public final class IoUring {
         return IORING_CQE_F_SOCK_NONEMPTY_SUPPORTED;
     }
 
+    static boolean isUnixDomainSocketInqSupported() {
+        return UNIX_DOMAIN_SOCKET_INQ_SUPPORTED;
+    }
+
     /**
      * Returns if SPLICE is supported or not.
      *
@@ -320,7 +328,6 @@ public final class IoUring {
     static boolean isIoringSetupNoSqarraySupported() {
         return IORING_SETUP_NO_SQARRAY_SUPPORTED;
     }
-
     /**
      * Returns if it is supported to use a buffer ring.
      *
@@ -417,6 +424,7 @@ public final class IoUring {
             return "";
         }
         return "CQE_F_SOCK_NONEMPTY_SUPPORTED=" + IORING_CQE_F_SOCK_NONEMPTY_SUPPORTED
+                + ", UNIX_DOMAIN_SOCKET_INQ_SUPPORTED=" + UNIX_DOMAIN_SOCKET_INQ_SUPPORTED
                 + ", SPLICE_SUPPORTED=" + IORING_SPLICE_SUPPORTED
                 + ", ACCEPT_NO_WAIT_SUPPORTED=" + IORING_ACCEPT_NO_WAIT_SUPPORTED
                 + ", ACCEPT_MULTISHOT_SUPPORTED=" + IORING_ACCEPT_MULTISHOT_SUPPORTED

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
@@ -537,7 +537,7 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
         short bid = (short) (flags >> Native.IORING_CQE_BUFFER_SHIFT);
         boolean more = (flags & Native.IORING_CQE_F_BUF_MORE) != 0;
 
-        boolean empty = socketIsEmpty(flags);
+        boolean completeRead = shouldCompleteReadLoop(flags, isReadMultishot());
         if (rearm) {
             // Only reset if we don't use multi-shot or we need to re-arm because the multi-shot was cancelled.
             readId = 0;
@@ -631,15 +631,26 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
             allocHandle.incMessagesRead(1);
             pipeline.fireChannelRead(byteBuf);
             byteBuf = null;
-            scheduleNextRead(pipeline, allocHandle, rearm, empty);
+            scheduleNextRead(pipeline, allocHandle, rearm, completeRead);
         } catch (Throwable t) {
             handleReadException(pipeline, byteBuf, t, allDataRead, allocHandle);
         }
     }
 
+    private boolean shouldCompleteReadLoop(int flags, boolean multishot) {
+        if (socket.protocolFamily() == SocketProtocolFamily.UNIX && !IoUring.isUnixDomainSocketInqSupported()) {
+            // Older kernels cannot report IORING_CQE_F_SOCK_NONEMPTY for UDS, so the read-loop boundary cannot be
+            // determined reliably.
+            // Multishot recv does not produce an EAGAIN completion while it remains armed, so
+            // complete the read loop for each multishot completion. A one-shot recv can continue until EAGAIN.
+            return multishot;
+        }
+        return socketIsEmpty(flags);
+    }
+
     private void scheduleNextRead(ChannelPipeline pipeline, IoUringRecvByteAllocatorHandle allocHandle,
-                                  boolean rearm, boolean empty) {
-        if (allocHandle.continueReading() && !empty) {
+                                  boolean rearm, boolean completeRead) {
+        if (allocHandle.continueReading() && !completeRead) {
             if (rearm) {
                 // We only should schedule another read if we need to rearm.
                 // See https://github.com/axboe/liburing/wiki/io_uring-and-networking-in-2023#multi-shot
@@ -775,6 +786,9 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
 
     @Override
     protected boolean socketIsEmpty(int flags) {
+        if (socket.protocolFamily() == SocketProtocolFamily.UNIX && !IoUring.isUnixDomainSocketInqSupported()) {
+            return false;
+        }
         return IoUring.isCqeFSockNonEmptySupported() && (flags & Native.IORING_CQE_F_SOCK_NONEMPTY) == 0;
     }
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -603,6 +603,7 @@ final class Native {
     }
 
     static native boolean ioUringSetupSupportsFlags(int setupFlags);
+    static native boolean isUnixDomainSocketInqSupported();
     private static native long[] ioUringSetup(int entries, int cqeSize, int setupFlags);
 
     static IoUringProbe ioUringProbe(int ringfd) {

--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -53,6 +53,11 @@
 #define UDP_SEGMENT 103
 #endif
 
+// SO_INQ was added in Linux 6.17. Define it here so we can compile with older kernel headers.
+#ifndef SO_INQ
+#define SO_INQ 84
+#endif
+
 // Add define if NETTY_IO_URING_BUILD_STATIC is defined so it is picked up in netty_jni_util.c
 #ifdef NETTY_IO_URING_BUILD_STATIC
 #define NETTY_JNI_UTIL_BUILD_STATIC
@@ -277,6 +282,18 @@ static jboolean netty_io_uring_setup_supports_flags(JNIEnv *env, jclass clazz, j
     }
     close(ring_fd);
     return JNI_TRUE;
+}
+
+static jboolean netty_io_uring_is_unix_domain_socket_inq_supported(JNIEnv *env, jclass clazz) {
+    int fd = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+    if (fd < 0) {
+        return JNI_FALSE;
+    }
+
+    int enable = 1;
+    int ret = setsockopt(fd, SOL_SOCKET, SO_INQ, &enable, sizeof(enable));
+    close(fd);
+    return ret == 0 ? JNI_TRUE : JNI_FALSE;
 }
 
 static jintArray netty_io_uring_probe0(JNIEnv *env, jclass clazz, jint ring_fd) {
@@ -848,6 +865,8 @@ static const jint statically_referenced_fixed_method_table_size = sizeof(statica
 
 static const JNINativeMethod method_table[] = {
     {"ioUringSetupSupportsFlags", "(I)Z", (void *) netty_io_uring_setup_supports_flags },
+    {"isUnixDomainSocketInqSupported", "()Z",
+        (void *) netty_io_uring_is_unix_domain_socket_inq_supported },
     {"ioUringSetup", "(III)[J", (void *) netty_io_uring_setup},
     {"ioUringRegisterIoWqMaxWorkers","(III)I", (void*) netty_io_uring_register_iowq_max_workers },
     {"ioUringRegisterEnableRings","(I)I", (void*) netty_io_uring_register_enable_rings },
@@ -974,4 +993,3 @@ JNIEXPORT void JNI_OnUnload(JavaVM* vm, void* reserved) {
     netty_jni_util_JNI_OnUnload(vm, reserved, netty_iouring_native_JNI_OnUnload);
 }
 #endif /* NETTY_IO_URING_BUILD_STATIC */
-

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketReadLoopTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDomainSocketReadLoopTest.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandler;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.FixedRecvByteBufAllocator;
+import io.netty.channel.IoEvent;
+import io.netty.channel.IoHandle;
+import io.netty.channel.IoHandler;
+import io.netty.channel.IoHandlerContext;
+import io.netty.channel.IoHandlerFactory;
+import io.netty.channel.IoRegistration;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.socket.SocketProtocolFamily;
+import io.netty.channel.unix.DomainSocketAddress;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+import io.netty.util.concurrent.Promise;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static io.netty.channel.unix.Errors.ERRNO_EAGAIN_NEGATIVE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+@Timeout(value = 1, unit = TimeUnit.MINUTES)
+public class IoUringDomainSocketReadLoopTest {
+
+    private static final int DATA_LENGTH = 4;
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IoUring.isAvailable());
+    }
+
+    @Test
+    public void testReadLoop() throws Exception {
+        List<Completion> expected = expectedCompletions();
+        CompletionRecorder recorder = new CompletionRecorder(expected.size());
+        IoHandlerFactory factory = executor -> new RecordingIoUringIoHandler(
+                IoUringIoHandler.newFactory().newHandler(executor), recorder);
+        MultiThreadIoEventLoopGroup group = new MultiThreadIoEventLoopGroup(1, factory);
+        DomainSocketAddress address = IoUringSocketTestPermutation.newDomainSocketAddress();
+        Channel server = null;
+        Channel client = null;
+        try {
+            server = new ServerBootstrap()
+                    .group(group)
+                    .channelFactory((e, c) -> new IoUringServerSocketChannel(e, c, SocketProtocolFamily.UNIX))
+                    .childOption(ChannelOption.RECVBUF_ALLOCATOR,
+                            new FixedRecvByteBufAllocator(1).maxMessagesPerRead(DATA_LENGTH + 1))
+                    .childHandler(new SimpleChannelInboundHandler<ByteBuf>() {
+                        @Override
+                        protected void channelRead0(ChannelHandlerContext ctx, ByteBuf msg) {
+                            // Discard.
+                        }
+
+                        @Override
+                        public void channelReadComplete(ChannelHandlerContext ctx) {
+                            recorder.readComplete();
+                        }
+                    })
+                    .bind(address)
+                    .sync()
+                    .getNow();
+            client = new Bootstrap()
+                    .group(group)
+                    .channelFactory(e -> new IoUringSocketChannel(e, SocketProtocolFamily.UNIX))
+                    .handler(new ChannelInboundHandler() {
+                    })
+                    .connect(address)
+                    .sync()
+                    .getNow();
+
+            client.writeAndFlush(client.alloc().buffer(DATA_LENGTH).writeZero(DATA_LENGTH)).sync();
+            recorder.await();
+
+            assertEquals(expected, recorder.completions);
+            assertEquals(1, recorder.readCompleteCount);
+        } finally {
+            if (client != null) {
+                client.close().syncUninterruptibly();
+            }
+            if (server != null) {
+                server.close().syncUninterruptibly();
+            }
+            group.shutdownGracefully().syncUninterruptibly();
+        }
+    }
+
+    private static List<Completion> expectedCompletions() {
+        List<Completion> expected = new ArrayList<Completion>();
+        expected.add(completion(Native.IORING_OP_POLL_ADD, Native.POLLIN));
+        for (int i = 0; i < DATA_LENGTH; ++i) {
+            expected.add(completion(Native.IORING_OP_RECV, 1));
+        }
+        if (!IoUring.isCqeFSockNonEmptySupported() || !IoUring.isUnixDomainSocketInqSupported()) {
+            expected.add(completion(Native.IORING_OP_RECV, ERRNO_EAGAIN_NEGATIVE));
+        }
+        return expected;
+    }
+
+    private static Completion completion(byte opcode, int res) {
+        return new Completion(opcode, res);
+    }
+
+    private static final class Completion {
+        private final byte opcode;
+        private final int res;
+
+        Completion(byte opcode, int res) {
+            this.opcode = opcode;
+            this.res = res;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (!(obj instanceof Completion)) {
+                return false;
+            }
+            Completion other = (Completion) obj;
+            return opcode == other.opcode && res == other.res;
+        }
+
+        @Override
+        public int hashCode() {
+            return 31 * opcode + res;
+        }
+
+        @Override
+        public String toString() {
+            return Native.opToStr(opcode) + '(' + res + ')';
+        }
+    }
+
+    private static final class CompletionRecorder {
+        private final Promise<Void> done = ImmediateEventExecutor.INSTANCE.newPromise();
+        private final List<Completion> completions = new ArrayList<Completion>();
+        private final int expectedCompletions;
+        private int readCompleteCount;
+
+        CompletionRecorder(int expectedCompletions) {
+            this.expectedCompletions = expectedCompletions;
+        }
+
+        void record(IoUringIoEvent event) {
+            byte opcode = event.opcode();
+            if (opcode == Native.IORING_OP_POLL_ADD || opcode == Native.IORING_OP_RECV) {
+                completions.add(completion(opcode, event.res()));
+            }
+        }
+
+        void handled() {
+            if (completions.size() >= expectedCompletions && readCompleteCount > 0) {
+                done.trySuccess(null);
+            }
+        }
+
+        void readComplete() {
+            readCompleteCount++;
+        }
+
+        void await() throws InterruptedException {
+            done.sync();
+        }
+    }
+
+    private static final class RecordingIoUringIoHandler implements IoHandler {
+        private final IoHandler delegate;
+        private final CompletionRecorder recorder;
+
+        RecordingIoUringIoHandler(IoHandler delegate, CompletionRecorder recorder) {
+            this.delegate = delegate;
+            this.recorder = recorder;
+        }
+
+        @Override
+        public void initialize() {
+            delegate.initialize();
+        }
+
+        @Override
+        public int run(IoHandlerContext context) {
+            return delegate.run(context);
+        }
+
+        @Override
+        public void prepareToDestroy() {
+            delegate.prepareToDestroy();
+        }
+
+        @Override
+        public void destroy() {
+            delegate.destroy();
+        }
+
+        @Override
+        public IoRegistration register(IoHandle handle) throws Exception {
+            IoUringIoHandle ioHandle = (IoUringIoHandle) handle;
+            return delegate.register(new IoUringIoHandle() {
+                @Override
+                public void handle(IoRegistration registration, IoEvent event) {
+                    recorder.record((IoUringIoEvent) event);
+                    ioHandle.handle(registration, event);
+                    recorder.handled();
+                }
+
+                @Override
+                public void registered() {
+                    ioHandle.registered();
+                }
+
+                @Override
+                public void unregistered() {
+                    ioHandle.unregistered();
+                }
+
+                @Override
+                public void close() throws Exception {
+                    ioHandle.close();
+                }
+            });
+        }
+
+        @Override
+        public void wakeup() {
+            delegate.wakeup();
+        }
+
+        @Override
+        public boolean isCompatible(Class<? extends IoHandle> handleType) {
+            return delegate.isCompatible(handleType);
+        }
+    }
+}


### PR DESCRIPTION
port of https://github.com/netty/netty/pull/17127 to 5.0

---

Motivation:

IoUringDomainSocketChannel inherits AbstractIoUringStreamChannel#socketIsEmpty, which uses IORING_CQE_F_SOCK_NONEMPTY to determine whether more data is available.

On Linux 5.19 through 6.16, io_uring supports this CQE flag, but Unix domain sockets do not report it. As a result, every successful UDS receive is incorrectly treated as having drained the socket. This changes the read flow into:

```
  poll -> recv -> poll -> recv
```

even when more data is already queued, introducing unnecessary poll op submissions and reducing receive performance.

Linux 6.17 added SO_INQ support for Unix domain sockets (https://github.com/torvalds/linux/commit/df30285b3670bf52e1e5512e4d4482bec5e93c16), allowing io_uring to reliably report whether unread data remains

Modification:

Add runtime detection for Unix domain socket SO_INQ support.

Use IORING_CQE_F_SOCK_NONEMPTY for UDS reads only when SO_INQ is supported. On older kernels, treat the socket state as unknown and continue receiving with MSG_DONTWAIT until EAGAIN

Result:

On older kernels without UDS SO_INQ support, IoUringDomainSocketChannel#socketIsEmpty now returns false. This prevents the absence of IORING_CQE_F_SOCK_NONEMPTY from being incorrectly interpreted as an empty socket and fixes the previous poll -> recv -> poll -> recv read pattern.
On Linux 6.17 and later, UDS reads use the kernel-provided socket state like TCP sockets and avoid unnecessary intermediate polls

cc @chrisvest 