### PR TITLE
Codec-compression: Add LZF decompressor

### DIFF
--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/LzfDecompressor.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/LzfDecompressor.java
@@ -36,7 +36,7 @@ import static com.ning.compress.lzf.LZFChunk.HEADER_LEN_NOT_COMPRESSED;
  * and <a href="https://github.com/ning/compress/wiki/LZFFormat">LZF format</a> for full description.
  */
 @UnstableApi
-public class LzfDecompressor extends InputBufferingDecompressor {
+public final class LzfDecompressor extends InputBufferingDecompressor {
     /**
      * Current state of decompression.
      */
@@ -188,24 +188,24 @@ public class LzfDecompressor extends InputBufferingDecompressor {
             final byte[] inputArray = arrayView.array();
             final int inPos = arrayView.arrayOffset() + arrayView.readerIndex();
 
-            ByteBuf uncompressed = allocator.heapBuffer(originalLength, originalLength);
-            final byte[] outputArray = uncompressed.array();
-            final int outPos = uncompressed.arrayOffset() + uncompressed.writerIndex();
-
-            boolean success = false;
+            ByteBuf uncompressed = null;
             try {
+                uncompressed = allocator.heapBuffer(originalLength, originalLength);
+                final byte[] outputArray = uncompressed.array();
+                final int outPos = uncompressed.arrayOffset() + uncompressed.writerIndex();
                 decoder.decodeChunk(
                         inputArray, inPos, inPos + chunkLength,
                         outputArray, outPos, outPos + originalLength);
                 uncompressed.writerIndex(uncompressed.writerIndex() + originalLength);
                 in.skipBytes(chunkLength);
                 currentState = State.INIT_BLOCK;
-                success = true;
-                return uncompressed;
+                ByteBuf output = uncompressed;
+                uncompressed = null;
+                return output;
             } catch (LZFException e) {
                 throw new DecompressionException(e);
             } finally {
-                if (!success) {
+                if (uncompressed != null) {
                     uncompressed.release();
                 }
                 if (arrayView != in) {

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/LzfDecompressor.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/LzfDecompressor.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import com.ning.compress.lzf.ChunkDecoder;
+import com.ning.compress.lzf.LZFChunk;
+import com.ning.compress.lzf.LZFException;
+import com.ning.compress.lzf.util.ChunkDecoderFactory;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.internal.UnstableApi;
+
+import static com.ning.compress.lzf.LZFChunk.BLOCK_TYPE_COMPRESSED;
+import static com.ning.compress.lzf.LZFChunk.BLOCK_TYPE_NON_COMPRESSED;
+import static com.ning.compress.lzf.LZFChunk.BYTE_V;
+import static com.ning.compress.lzf.LZFChunk.BYTE_Z;
+import static com.ning.compress.lzf.LZFChunk.HEADER_LEN_NOT_COMPRESSED;
+
+/**
+ * Uncompresses a {@link ByteBuf} encoded with the LZF format.
+ * <p>
+ * See original <a href="http://oldhome.schmorp.de/marc/liblzf.html">LZF package</a>
+ * and <a href="https://github.com/ning/compress/wiki/LZFFormat">LZF format</a> for full description.
+ */
+@UnstableApi
+public class LzfDecompressor extends InputBufferingDecompressor {
+    /**
+     * Current state of decompression.
+     */
+    private enum State {
+        INIT_BLOCK,
+        INIT_ORIGINAL_LENGTH,
+        DECOMPRESS_DATA,
+        END,
+    }
+
+    private State currentState = State.INIT_BLOCK;
+
+    /**
+     * Magic number of LZF chunk.
+     */
+    private static final short MAGIC_NUMBER = BYTE_Z << 8 | BYTE_V;
+
+    private final ChunkDecoder decoder;
+
+    /**
+     * Length of current received chunk of data.
+     */
+    private int chunkLength;
+
+    /**
+     * Original length of current received chunk of data.
+     * It is equal to {@link #chunkLength} for non compressed chunks.
+     */
+    private int originalLength;
+
+    /**
+     * Indicates is this chunk compressed or not.
+     */
+    private boolean isCompressed;
+
+    LzfDecompressor(Builder builder, ByteBufAllocator allocator) {
+        super(allocator);
+        decoder = builder.safeInstance ?
+                ChunkDecoderFactory.safeInstance()
+                : ChunkDecoderFactory.optimalInstance();
+    }
+
+    @Override
+    void processInput(ByteBuf buf) throws DecompressionException {
+        switch (currentState) {
+            case INIT_BLOCK:
+                if (buf.readableBytes() < HEADER_LEN_NOT_COMPRESSED) {
+                    break;
+                }
+                final int magic = buf.readUnsignedShort();
+                if (magic != MAGIC_NUMBER) {
+                    throw new DecompressionException("unexpected block identifier");
+                }
+
+                final int type = buf.readByte();
+                switch (type) {
+                    case BLOCK_TYPE_NON_COMPRESSED:
+                        isCompressed = false;
+                        currentState = State.DECOMPRESS_DATA;
+                        break;
+                    case BLOCK_TYPE_COMPRESSED:
+                        isCompressed = true;
+                        currentState = State.INIT_ORIGINAL_LENGTH;
+                        break;
+                    default:
+                        throw new DecompressionException(String.format(
+                                "unknown type of chunk: %d (expected: %d or %d)",
+                                type, BLOCK_TYPE_NON_COMPRESSED, BLOCK_TYPE_COMPRESSED));
+                }
+                chunkLength = buf.readUnsignedShort();
+
+                // chunkLength can never exceed MAX_CHUNK_LEN as MAX_CHUNK_LEN is 64kb and readUnsignedShort can
+                // never return anything bigger as well. Let's add some check any way to make things easier in terms
+                // of debugging if we ever hit this because of an bug.
+                if (chunkLength > LZFChunk.MAX_CHUNK_LEN) {
+                    throw new DecompressionException(String.format(
+                            "chunk length exceeds maximum: %d (expected: =< %d)",
+                            chunkLength, LZFChunk.MAX_CHUNK_LEN));
+                }
+
+                if (type != BLOCK_TYPE_COMPRESSED) {
+                    break;
+                }
+                // fall through
+            case INIT_ORIGINAL_LENGTH:
+                if (buf.readableBytes() < 2) {
+                    break;
+                }
+                originalLength = buf.readUnsignedShort();
+
+                // originalLength can never exceed MAX_CHUNK_LEN as MAX_CHUNK_LEN is 64kb and readUnsignedShort can
+                // never return anything bigger as well. Let's add some check any way to make things easier in terms
+                // of debugging if we ever hit this because of an bug.
+                if (originalLength > LZFChunk.MAX_CHUNK_LEN) {
+                    throw new DecompressionException(String.format(
+                            "original length exceeds maximum: %d (expected: =< %d)",
+                            originalLength, LZFChunk.MAX_CHUNK_LEN));
+                }
+
+                currentState = State.DECOMPRESS_DATA;
+                // fall through
+            case DECOMPRESS_DATA:
+
+                break;
+            default:
+                throw new IllegalStateException();
+        }
+    }
+
+    @Override
+    public Status status() throws DecompressionException {
+        switch (currentState) {
+            case INIT_BLOCK:
+            case INIT_ORIGINAL_LENGTH:
+                return Status.NEED_INPUT;
+            case DECOMPRESS_DATA:
+                return available() < chunkLength ? Status.NEED_INPUT : Status.NEED_OUTPUT;
+            case END:
+                return Status.COMPLETE;
+            default:
+                throw new AssertionError("Unknown state: " + currentState);
+        }
+    }
+
+    @Override
+    public void endOfInput() throws DecompressionException {
+        if (currentState != State.INIT_BLOCK) {
+            throw new DecompressionException("Incomplete block");
+        }
+        currentState = State.END;
+    }
+
+    @Override
+    ByteBuf processOutput(ByteBuf in) throws DecompressionException {
+        final int chunkLength = this.chunkLength;
+        if (in.readableBytes() < chunkLength) {
+            throw new IllegalStateException("Not in state NEED_OUTPUT");
+        }
+        final int originalLength = this.originalLength;
+
+        if (isCompressed) {
+            ByteBuf arrayView;
+            if (!in.hasArray()) {
+                arrayView = allocator.heapBuffer(in.readableBytes());
+                arrayView.writeBytes(in, in.readerIndex(), in.readableBytes());
+            } else {
+                arrayView = in;
+            }
+            final byte[] inputArray = arrayView.array();
+            final int inPos = arrayView.arrayOffset() + arrayView.readerIndex();
+
+            ByteBuf uncompressed = allocator.heapBuffer(originalLength, originalLength);
+            final byte[] outputArray = uncompressed.array();
+            final int outPos = uncompressed.arrayOffset() + uncompressed.writerIndex();
+
+            try {
+                decoder.decodeChunk(
+                        inputArray, inPos, inPos + chunkLength,
+                        outputArray, outPos, outPos + originalLength);
+                uncompressed.writerIndex(uncompressed.writerIndex() + originalLength);
+            } catch (LZFException e) {
+                uncompressed.release();
+                throw new DecompressionException(e);
+            } finally {
+                in.skipBytes(chunkLength);
+                if (arrayView != in) {
+                    arrayView.release();
+                }
+            }
+
+            currentState = State.INIT_BLOCK;
+            return uncompressed;
+        } else {
+            currentState = State.INIT_BLOCK;
+            return in.readRetainedSlice(chunkLength);
+        }
+    }
+
+    @UnstableApi
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @UnstableApi
+    public static final class Builder extends AbstractDecompressorBuilder {
+        private boolean safeInstance;
+
+        Builder() {
+        }
+
+        /**
+         * If {@code true} decoder will use {@link ChunkDecoder} that only uses standard JDK access methods,
+         * and should work on all Java platforms and JVMs.
+         * Otherwise decoder will try to use highly optimized {@link ChunkDecoder} implementation that uses
+         * Sun JDK's {@link sun.misc.Unsafe} class (which may be included by other JDK's as well).
+         *
+         * @param safeInstance Whether to use the safe instance only
+         * @return This builder
+         */
+        public Builder safeInstance(boolean safeInstance) {
+            this.safeInstance = safeInstance;
+            return this;
+        }
+
+        @Override
+        public Decompressor build(ByteBufAllocator allocator) throws DecompressionException {
+            return new DefensiveDecompressor(new LzfDecompressor(this, allocator));
+        }
+    }
+}

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/LzfDecompressor.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/LzfDecompressor.java
@@ -68,7 +68,7 @@ public class LzfDecompressor extends InputBufferingDecompressor {
     private int originalLength;
 
     /**
-     * Indicates is this chunk compressed or not.
+     * Indicates whether this chunk is compressed.
      */
     private boolean isCompressed;
 
@@ -109,8 +109,8 @@ public class LzfDecompressor extends InputBufferingDecompressor {
                 chunkLength = buf.readUnsignedShort();
 
                 // chunkLength can never exceed MAX_CHUNK_LEN as MAX_CHUNK_LEN is 64kb and readUnsignedShort can
-                // never return anything bigger as well. Let's add some check any way to make things easier in terms
-                // of debugging if we ever hit this because of an bug.
+                // never return anything bigger as well. Let's add a check anyway to make things easier in terms
+                // of debugging if we ever hit this because of a bug.
                 if (chunkLength > LZFChunk.MAX_CHUNK_LEN) {
                     throw new DecompressionException(String.format(
                             "chunk length exceeds maximum: %d (expected: =< %d)",
@@ -128,8 +128,8 @@ public class LzfDecompressor extends InputBufferingDecompressor {
                 originalLength = buf.readUnsignedShort();
 
                 // originalLength can never exceed MAX_CHUNK_LEN as MAX_CHUNK_LEN is 64kb and readUnsignedShort can
-                // never return anything bigger as well. Let's add some check any way to make things easier in terms
-                // of debugging if we ever hit this because of an bug.
+                // never return anything bigger as well. Let's add a check anyway to make things easier in terms
+                // of debugging if we ever hit this because of a bug.
                 if (originalLength > LZFChunk.MAX_CHUNK_LEN) {
                     throw new DecompressionException(String.format(
                             "original length exceeds maximum: %d (expected: =< %d)",
@@ -163,7 +163,7 @@ public class LzfDecompressor extends InputBufferingDecompressor {
 
     @Override
     public void endOfInput() throws DecompressionException {
-        if (currentState != State.INIT_BLOCK) {
+        if (currentState != State.INIT_BLOCK || available() != 0) {
             throw new DecompressionException("Incomplete block");
         }
         currentState = State.END;
@@ -180,8 +180,8 @@ public class LzfDecompressor extends InputBufferingDecompressor {
         if (isCompressed) {
             ByteBuf arrayView;
             if (!in.hasArray()) {
-                arrayView = allocator.heapBuffer(in.readableBytes());
-                arrayView.writeBytes(in, in.readerIndex(), in.readableBytes());
+                arrayView = allocator.heapBuffer(chunkLength, chunkLength);
+                arrayView.writeBytes(in, in.readerIndex(), chunkLength);
             } else {
                 arrayView = in;
             }
@@ -192,23 +192,26 @@ public class LzfDecompressor extends InputBufferingDecompressor {
             final byte[] outputArray = uncompressed.array();
             final int outPos = uncompressed.arrayOffset() + uncompressed.writerIndex();
 
+            boolean success = false;
             try {
                 decoder.decodeChunk(
                         inputArray, inPos, inPos + chunkLength,
                         outputArray, outPos, outPos + originalLength);
                 uncompressed.writerIndex(uncompressed.writerIndex() + originalLength);
+                in.skipBytes(chunkLength);
+                currentState = State.INIT_BLOCK;
+                success = true;
+                return uncompressed;
             } catch (LZFException e) {
-                uncompressed.release();
                 throw new DecompressionException(e);
             } finally {
-                in.skipBytes(chunkLength);
+                if (!success) {
+                    uncompressed.release();
+                }
                 if (arrayView != in) {
                     arrayView.release();
                 }
             }
-
-            currentState = State.INIT_BLOCK;
-            return uncompressed;
         } else {
             currentState = State.INIT_BLOCK;
             return in.readRetainedSlice(chunkLength);
@@ -236,12 +239,14 @@ public class LzfDecompressor extends InputBufferingDecompressor {
          * @param safeInstance Whether to use the safe instance only
          * @return This builder
          */
+        @UnstableApi
         public Builder safeInstance(boolean safeInstance) {
             this.safeInstance = safeInstance;
             return this;
         }
 
         @Override
+        @UnstableApi
         public Decompressor build(ByteBufAllocator allocator) throws DecompressionException {
             return new DefensiveDecompressor(new LzfDecompressor(this, allocator));
         }

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/LzfDecompressorTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/LzfDecompressorTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.channel.ChannelHandler;
+
+public class LzfDecompressorTest extends AbstractDecompressorTest {
+    @Override
+    protected ChannelHandler createCompressor() {
+        return new LzfEncoder();
+    }
+
+    @Override
+    protected Decompressor.AbstractDecompressorBuilder createDecompressor() {
+        return LzfDecompressor.builder();
+    }
+}

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/LzfDecompressorTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/LzfDecompressorTest.java
@@ -15,7 +15,17 @@
  */
 package io.netty.handler.codec.compression;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandler;
+import org.junit.jupiter.api.Test;
+
+import static com.ning.compress.lzf.LZFChunk.BLOCK_TYPE_NON_COMPRESSED;
+import static com.ning.compress.lzf.LZFChunk.BYTE_V;
+import static com.ning.compress.lzf.LZFChunk.BYTE_Z;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class LzfDecompressorTest extends AbstractDecompressorTest {
     @Override
@@ -26,5 +36,46 @@ public class LzfDecompressorTest extends AbstractDecompressorTest {
     @Override
     protected Decompressor.AbstractDecompressorBuilder createDecompressor() {
         return LzfDecompressor.builder();
+    }
+
+    @Test
+    public void testUnexpectedBlockIdentifier() throws DecompressionException {
+        ByteBuf in = Unpooled.buffer();
+        in.writeShort(0x1234);  // random value
+        in.writeByte(BLOCK_TYPE_NON_COMPRESSED);
+        in.writeShort(0);
+
+        try (Decompressor decompressor = createDecompressor().build(ByteBufAllocator.DEFAULT)) {
+            assertEquals(Decompressor.Status.NEED_INPUT, decompressor.status());
+            assertThrows(DecompressionException.class, () -> decompressor.addInput(in));
+        }
+    }
+
+    @Test
+    public void testUnknownTypeOfChunk() throws DecompressionException {
+        ByteBuf in = Unpooled.buffer();
+        in.writeByte(BYTE_Z);
+        in.writeByte(BYTE_V);
+        in.writeByte(0xFF);   // random value
+        in.writeInt(0);
+
+        try (Decompressor decompressor = createDecompressor().build(ByteBufAllocator.DEFAULT)) {
+            assertEquals(Decompressor.Status.NEED_INPUT, decompressor.status());
+            assertThrows(DecompressionException.class, () -> decompressor.addInput(in));
+        }
+    }
+
+    @Test
+    public void testIncompleteHeader() throws DecompressionException {
+        ByteBuf in = Unpooled.buffer();
+        in.writeByte(BYTE_Z);
+        in.writeByte(BYTE_V);
+
+        try (Decompressor decompressor = createDecompressor().build(ByteBufAllocator.DEFAULT)) {
+            assertEquals(Decompressor.Status.NEED_INPUT, decompressor.status());
+            decompressor.addInput(in);
+            assertEquals(Decompressor.Status.NEED_INPUT, decompressor.status());
+            assertThrows(DecompressionException.class, decompressor::endOfInput);
+        }
     }
 }


### PR DESCRIPTION
Motivation:

The decompressor API migration tracked by #16743 is being split into small per-format PRs. LZF still needs a standalone implementation for the new pull-based `Decompressor` API.

Modification:

Add `LzfDecompressor`, extracted from the LZF decoder logic in #15667 and adapted to `InputBufferingDecompressor` / `DefensiveDecompressor`.

Add `LzfDecompressorTest` using the shared `AbstractDecompressorTest` harness.

This intentionally does not add the backpressure handler tests from #15667 because that handler infrastructure is tracked separately.

Result:

LZF can be decompressed through the new `Decompressor` API.

Verification:

- `./mvnw -Dmaven.user.home=/tmp/opencode/m2-wrapper -pl codec-compression -am -Dtest=LzfDecompressorTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -Dmaven.user.home=/tmp/opencode/m2-wrapper -pl codec-compression -am verify`

Related to #16743.