### PR TITLE
Codec-compression: Add Lz4FrameDecompressor

### DIFF
--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/Lz4FrameDecompressor.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/Lz4FrameDecompressor.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.compression;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.UnstableApi;
 import net.jpountz.lz4.LZ4Exception;
 import net.jpountz.lz4.LZ4Factory;
@@ -194,7 +195,10 @@ public final class Lz4FrameDecompressor extends InputBufferingDecompressor {
                     ByteBuffer outBuffer = uncompressed.internalNioBuffer(
                             uncompressed.writerIndex(), decompressedLength);
                     if (inBuffer.remaining() < compressedLength || outBuffer.remaining() < decompressedLength) {
-                        throw new DecompressionException("Weird compressedLength");
+                        throw new DecompressionException(String.format(
+                                "buffer lengths too small: compressed(%d/%d), decompressed(%d/%d)",
+                                inBuffer.remaining(), compressedLength,
+                                outBuffer.remaining(), decompressedLength));
                     }
                     final int actualDecompressedLength;
                     try {
@@ -254,7 +258,7 @@ public final class Lz4FrameDecompressor extends InputBufferingDecompressor {
          * @return This builder
          */
         public Builder factory(LZ4Factory factory) {
-            this.factory = factory;
+            this.factory = ObjectUtil.checkNotNull(factory, "factory");
             return this;
         }
 

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/Lz4FrameDecompressor.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/Lz4FrameDecompressor.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.internal.UnstableApi;
+import net.jpountz.lz4.LZ4Exception;
+import net.jpountz.lz4.LZ4Factory;
+import net.jpountz.lz4.LZ4SafeDecompressor;
+
+import java.nio.ByteBuffer;
+import java.util.zip.Checksum;
+
+import static io.netty.handler.codec.compression.Lz4Constants.BLOCK_TYPE_COMPRESSED;
+import static io.netty.handler.codec.compression.Lz4Constants.BLOCK_TYPE_NON_COMPRESSED;
+import static io.netty.handler.codec.compression.Lz4Constants.COMPRESSION_LEVEL_BASE;
+import static io.netty.handler.codec.compression.Lz4Constants.DEFAULT_SEED;
+import static io.netty.handler.codec.compression.Lz4Constants.HEADER_LENGTH;
+import static io.netty.handler.codec.compression.Lz4Constants.MAGIC_NUMBER;
+import static io.netty.handler.codec.compression.Lz4Constants.MAX_BLOCK_SIZE;
+
+/**
+ * Uncompresses a {@link ByteBuf} encoded with the LZ4 format.
+ *
+ * See original <a href="https://github.com/Cyan4973/lz4">LZ4 Github project</a>
+ * and <a href="https://fastcompression.blogspot.ru/2011/05/lz4-explained.html">LZ4 block format</a>
+ * for full description.
+ *
+ * Since the original LZ4 block format does not contains size of compressed block and size of original data
+ * this encoder uses format like <a href="https://github.com/idelpivnitskiy/lz4-java">LZ4 Java</a> library
+ * written by Adrien Grand and approved by Yann Collet (author of original LZ4 library).
+ *
+ *  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *     * * * * * * * * * *
+ *  * Magic * Token *  Compressed *  Decompressed *  Checksum *  +  *  LZ4 compressed *
+ *  *       *       *    length   *     length    *           *     *      block      *
+ *  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *     * * * * * * * * * *
+ */
+@UnstableApi
+public final class Lz4FrameDecompressor extends InputBufferingDecompressor {
+    /**
+     * Current state of stream.
+     */
+    private enum State {
+        INIT_BLOCK,
+        DECOMPRESS_DATA,
+        FINISHED,
+    }
+
+    private State currentState = State.INIT_BLOCK;
+
+    /**
+     * Underlying decompressor in use.
+     */
+    private LZ4SafeDecompressor decompressor;
+
+    /**
+     * Underlying checksum calculator in use.
+     */
+    private ByteBufChecksum checksum;
+
+    /**
+     * Type of current block.
+     */
+    private int blockType;
+
+    /**
+     * Compressed length of current incoming block.
+     */
+    private int compressedLength;
+
+    /**
+     * Decompressed length of current incoming block.
+     */
+    private int decompressedLength;
+
+    /**
+     * Checksum value of current incoming block.
+     */
+    private int currentChecksum;
+
+    Lz4FrameDecompressor(Builder builder, ByteBufAllocator allocator) {
+        super(allocator);
+        this.decompressor = builder.factory.safeDecompressor();
+        this.checksum = builder.checksum == null ? null : ByteBufChecksum.wrapChecksum(builder.checksum);
+    }
+
+    @Override
+    void processInput(ByteBuf buf) throws DecompressionException {
+        if (currentState != State.INIT_BLOCK) {
+            return;
+        }
+
+        if (buf.readableBytes() < HEADER_LENGTH) {
+            return;
+        }
+        final long magic = buf.readLong();
+        if (magic != MAGIC_NUMBER) {
+            throw new DecompressionException("unexpected block identifier");
+        }
+
+        final int token = buf.readByte();
+        final int compressionLevel = (token & 0x0F) + COMPRESSION_LEVEL_BASE;
+        int blockType = token & 0xF0;
+
+        int compressedLength = Integer.reverseBytes(buf.readInt());
+        if (compressedLength < 0 || compressedLength > MAX_BLOCK_SIZE) {
+            throw new DecompressionException(String.format(
+                    "invalid compressedLength: %d (expected: 0-%d)",
+                    compressedLength, MAX_BLOCK_SIZE));
+        }
+
+        int decompressedLength = Integer.reverseBytes(buf.readInt());
+        final int maxDecompressedLength = 1 << compressionLevel;
+        if (decompressedLength < 0 || decompressedLength > maxDecompressedLength) {
+            throw new DecompressionException(String.format(
+                    "invalid decompressedLength: %d (expected: 0-%d)",
+                    decompressedLength, maxDecompressedLength));
+        }
+        if (decompressedLength == 0 && compressedLength != 0
+                || decompressedLength != 0 && compressedLength == 0
+                || blockType == BLOCK_TYPE_NON_COMPRESSED && decompressedLength != compressedLength) {
+            throw new DecompressionException(String.format(
+                    "stream corrupted: compressedLength(%d) and decompressedLength(%d) mismatch",
+                    compressedLength, decompressedLength));
+        }
+
+        int currentChecksum = Integer.reverseBytes(buf.readInt());
+        if (decompressedLength == 0 && compressedLength == 0) {
+            if (currentChecksum != 0) {
+                throw new DecompressionException("stream corrupted: checksum error");
+            }
+            currentState = State.FINISHED;
+            decompressor = null;
+            checksum = null;
+            return;
+        }
+
+        this.blockType = blockType;
+        this.compressedLength = compressedLength;
+        this.decompressedLength = decompressedLength;
+        this.currentChecksum = currentChecksum;
+
+        currentState = State.DECOMPRESS_DATA;
+    }
+
+    @Override
+    public Status status() throws DecompressionException {
+        switch (currentState) {
+            case INIT_BLOCK:
+                return Status.NEED_INPUT;
+            case DECOMPRESS_DATA:
+                return available() < compressedLength ? Status.NEED_INPUT : Status.NEED_OUTPUT;
+            case FINISHED:
+                return Status.COMPLETE;
+            default:
+                throw new AssertionError("Unexpected state: " + currentState);
+        }
+    }
+
+    @Override
+    public void endOfInput() throws DecompressionException {
+        throw new DecompressionException("Unexpected end of input");
+    }
+
+    @Override
+    ByteBuf processOutput(ByteBuf in) throws DecompressionException {
+        ByteBuf uncompressed = null;
+        try {
+            switch (blockType) {
+                case BLOCK_TYPE_NON_COMPRESSED:
+                    // Just pass through, we not update the readerIndex yet as we do this outside of the
+                    // switch statement.
+                    uncompressed = in.retainedSlice(in.readerIndex(), decompressedLength);
+                    break;
+                case BLOCK_TYPE_COMPRESSED:
+                    uncompressed = allocator.buffer(decompressedLength, decompressedLength);
+
+                    ByteBuffer inBuffer = CompressionUtil.safeReadableNioBuffer(in);
+                    ByteBuffer outBuffer = uncompressed.internalNioBuffer(
+                            uncompressed.writerIndex(), decompressedLength);
+                    if (inBuffer.remaining() < compressedLength || outBuffer.remaining() < decompressedLength) {
+                        throw new DecompressionException("Weird compressedLength");
+                    }
+                    final int actualDecompressedLength;
+                    try {
+                        actualDecompressedLength = decompressor.decompress(
+                                inBuffer, inBuffer.position(), compressedLength,
+                                outBuffer, outBuffer.position(), decompressedLength);
+                    } catch (LZ4Exception e) {
+                        throw new DecompressionException(e);
+                    }
+                    if (actualDecompressedLength != decompressedLength) {
+                        throw new DecompressionException(String.format(
+                                "stream corrupted: decompressedLength(%d) and actual length(%d) mismatch",
+                                decompressedLength, actualDecompressedLength));
+                    }
+                    // Update the writerIndex now to reflect what we decompressed.
+                    uncompressed.writerIndex(uncompressed.writerIndex() + actualDecompressedLength);
+                    break;
+                default:
+                    throw new DecompressionException(String.format(
+                            "unexpected blockType: %d (expected: %d or %d)",
+                            blockType, BLOCK_TYPE_NON_COMPRESSED, BLOCK_TYPE_COMPRESSED));
+            }
+            // Skip inbound bytes after we processed them.
+            in.skipBytes(compressedLength);
+            if (checksum != null) {
+                CompressionUtil.checkChecksum(checksum, uncompressed, currentChecksum);
+            }
+            currentState = State.INIT_BLOCK;
+            return uncompressed;
+        } catch (Throwable t) {
+            if (uncompressed != null) {
+                uncompressed.release();
+            }
+            throw t;
+        }
+    }
+
+    @UnstableApi
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @UnstableApi
+    public static final class Builder extends AbstractDecompressorBuilder {
+        private LZ4Factory factory = LZ4Factory.fastestInstance();
+        private Checksum checksum;
+
+        Builder() {
+        }
+
+        /**
+         * User customizable {@link LZ4Factory} instance
+         * which may be JNI bindings to the original C implementation, a pure Java implementation
+         * or a Java implementation that uses the {@link sun.misc.Unsafe}.
+         *
+         * @param factory The factory to use
+         * @return This builder
+         */
+        public Builder factory(LZ4Factory factory) {
+            this.factory = factory;
+            return this;
+        }
+
+        /**
+         * The {@link Checksum} instance to use to check data for integrity. By default, no checksum validation is
+         * performed.
+         *
+         * @param checksum The checksum to use
+         * @return This builder
+         */
+        public Builder checksum(Checksum checksum) {
+            this.checksum = checksum;
+            return this;
+        }
+
+        /**
+         * Enable checksum validation using the default checksum, xxhash.
+         *
+         * @return This builder
+         */
+        public Builder defaultChecksum() {
+            return checksum(new Lz4XXHash32(DEFAULT_SEED));
+        }
+
+        @Override
+        public Decompressor build(ByteBufAllocator allocator) throws DecompressionException {
+            return new DefensiveDecompressor(new Lz4FrameDecompressor(this, allocator));
+        }
+    }
+}

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/Lz4FrameDecompressor.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/Lz4FrameDecompressor.java
@@ -52,6 +52,8 @@ import static io.netty.handler.codec.compression.Lz4Constants.MAX_BLOCK_SIZE;
  */
 @UnstableApi
 public final class Lz4FrameDecompressor extends InputBufferingDecompressor {
+    private static final int DEFAULT_MAX_DECOMPRESSED_LENGTH = 256 * 1024;
+
     /**
      * Current state of stream.
      */
@@ -72,6 +74,8 @@ public final class Lz4FrameDecompressor extends InputBufferingDecompressor {
      * Underlying checksum calculator in use.
      */
     private ByteBufChecksum checksum;
+
+    private final int maxDecompressedLength;
 
     /**
      * Type of current block.
@@ -97,6 +101,7 @@ public final class Lz4FrameDecompressor extends InputBufferingDecompressor {
         super(allocator);
         this.decompressor = builder.factory.safeDecompressor();
         this.checksum = builder.checksum == null ? null : ByteBufChecksum.wrapChecksum(builder.checksum);
+        this.maxDecompressedLength = builder.maxDecompressedLength;
     }
 
     @Override
@@ -125,11 +130,17 @@ public final class Lz4FrameDecompressor extends InputBufferingDecompressor {
         }
 
         int decompressedLength = Integer.reverseBytes(buf.readInt());
-        final int maxDecompressedLength = 1 << compressionLevel;
-        if (decompressedLength < 0 || decompressedLength > maxDecompressedLength) {
+        if (decompressedLength > maxDecompressedLength) {
+            throw new DecompressionException(String.format(
+                    "decompressedLength too large: %d (expected: 0-%d)",
+                    decompressedLength, maxDecompressedLength));
+        }
+
+        final int maxLocalDecompressedLength = 1 << compressionLevel;
+        if (decompressedLength < 0 || decompressedLength > maxLocalDecompressedLength) {
             throw new DecompressionException(String.format(
                     "invalid decompressedLength: %d (expected: 0-%d)",
-                    decompressedLength, maxDecompressedLength));
+                    decompressedLength, maxLocalDecompressedLength));
         }
         if (decompressedLength == 0 && compressedLength != 0
                 || decompressedLength != 0 && compressedLength == 0
@@ -245,6 +256,7 @@ public final class Lz4FrameDecompressor extends InputBufferingDecompressor {
     public static final class Builder extends AbstractDecompressorBuilder {
         private LZ4Factory factory = LZ4Factory.fastestInstance();
         private Checksum checksum;
+        private int maxDecompressedLength = DEFAULT_MAX_DECOMPRESSED_LENGTH;
 
         Builder() {
         }
@@ -281,6 +293,19 @@ public final class Lz4FrameDecompressor extends InputBufferingDecompressor {
          */
         public Builder defaultChecksum() {
             return checksum(new Lz4XXHash32(DEFAULT_SEED));
+        }
+
+        /**
+         * Set the maximum allowed decompressed block length. The default is 256 KiB. Use {@code 0} to allow the
+         * LZ4 format maximum of 32 MiB.
+         *
+         * @param maxDecompressedLength maximum decompressed block length
+         * @return This builder
+         */
+        public Builder maxDecompressedLength(int maxDecompressedLength) {
+            this.maxDecompressedLength = maxDecompressedLength == 0 ? MAX_BLOCK_SIZE :
+                    ObjectUtil.checkInRange(maxDecompressedLength, 0, MAX_BLOCK_SIZE, "maxDecompressedLength");
+            return this;
         }
 
         @Override

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/Lz4FrameDecompressor.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/Lz4FrameDecompressor.java
@@ -189,7 +189,8 @@ public final class Lz4FrameDecompressor extends InputBufferingDecompressor {
                 case BLOCK_TYPE_COMPRESSED:
                     uncompressed = allocator.buffer(decompressedLength, decompressedLength);
 
-                    ByteBuffer inBuffer = CompressionUtil.safeReadableNioBuffer(in);
+                    ByteBuffer inBuffer = CompressionUtil.safeNioBuffer(
+                            in, in.readerIndex(), compressedLength);
                     ByteBuffer outBuffer = uncompressed.internalNioBuffer(
                             uncompressed.writerIndex(), decompressedLength);
                     if (inBuffer.remaining() < compressedLength || outBuffer.remaining() < decompressedLength) {

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/Lz4DecompressorTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/Lz4DecompressorTest.java
@@ -25,10 +25,13 @@ import static io.netty.handler.codec.compression.Decompressor.Status.NEED_INPUT;
 import static io.netty.handler.codec.compression.Decompressor.Status.NEED_OUTPUT;
 import static io.netty.handler.codec.compression.Lz4Constants.BLOCK_TYPE_COMPRESSED;
 import static io.netty.handler.codec.compression.Lz4Constants.MAGIC_NUMBER;
+import static io.netty.handler.codec.compression.Lz4Constants.MAX_BLOCK_SIZE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class Lz4DecompressorTest extends AbstractDecompressorTest {
+    private static final int DEFAULT_MAX_DECOMPRESSED_LENGTH = 256 * 1024;
+
     @Override
     protected ChannelHandler createCompressor() {
         return new Lz4FrameEncoder();
@@ -42,6 +45,33 @@ public class Lz4DecompressorTest extends AbstractDecompressorTest {
     @Test
     public void testFactoryRejectsNull() {
         assertThrows(NullPointerException.class, () -> Lz4FrameDecompressor.builder().factory(null));
+    }
+
+    @Test
+    public void testDefaultMaxDecompressedLength() throws Exception {
+        assertRejectsDecompressedLength(
+                Lz4FrameDecompressor.builder(), DEFAULT_MAX_DECOMPRESSED_LENGTH + 1);
+    }
+
+    @Test
+    public void testCustomMaxDecompressedLength() throws Exception {
+        assertAcceptsDecompressedLength(
+                Lz4FrameDecompressor.builder().maxDecompressedLength(DEFAULT_MAX_DECOMPRESSED_LENGTH + 1),
+                DEFAULT_MAX_DECOMPRESSED_LENGTH + 1);
+    }
+
+    @Test
+    public void testZeroMaxDecompressedLengthAllowsFormatMaximum() throws Exception {
+        assertAcceptsDecompressedLength(
+                Lz4FrameDecompressor.builder().maxDecompressedLength(0), MAX_BLOCK_SIZE);
+    }
+
+    @Test
+    public void testInvalidMaxDecompressedLength() {
+        assertThrows(IllegalArgumentException.class,
+                () -> Lz4FrameDecompressor.builder().maxDecompressedLength(-1));
+        assertThrows(IllegalArgumentException.class,
+                () -> Lz4FrameDecompressor.builder().maxDecompressedLength(MAX_BLOCK_SIZE + 1));
     }
 
     @Test
@@ -114,5 +144,34 @@ public class Lz4DecompressorTest extends AbstractDecompressorTest {
             assertEquals(NEED_INPUT, decompressor.status());
             assertThrows(DecompressionException.class, decompressor::endOfInput);
         }
+    }
+
+    private static void assertRejectsDecompressedLength(Decompressor.AbstractDecompressorBuilder builder,
+                                                        int decompressedLength) throws Exception {
+        try (Decompressor decompressor = builder.build(ByteBufAllocator.DEFAULT)) {
+            assertEquals(NEED_INPUT, decompressor.status());
+            assertThrows(DecompressionException.class,
+                    () -> decompressor.addInput(compressedBlockHeader(decompressedLength)));
+        }
+    }
+
+    private static void assertAcceptsDecompressedLength(Decompressor.AbstractDecompressorBuilder builder,
+                                                        int decompressedLength) throws Exception {
+        try (Decompressor decompressor = builder.build(ByteBufAllocator.DEFAULT)) {
+            assertEquals(NEED_INPUT, decompressor.status());
+            decompressor.addInput(compressedBlockHeader(decompressedLength));
+            assertEquals(NEED_INPUT, decompressor.status());
+        }
+    }
+
+    private static ByteBuf compressedBlockHeader(int decompressedLength) {
+        int compressionLevel = 32 - Integer.numberOfLeadingZeros(decompressedLength - 1);
+        ByteBuf input = Unpooled.buffer();
+        input.writeLong(MAGIC_NUMBER);
+        input.writeByte(BLOCK_TYPE_COMPRESSED | compressionLevel - Lz4Constants.COMPRESSION_LEVEL_BASE);
+        input.writeIntLE(1);
+        input.writeIntLE(decompressedLength);
+        input.writeIntLE(0);
+        return input;
     }
 }

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/Lz4DecompressorTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/Lz4DecompressorTest.java
@@ -40,6 +40,28 @@ public class Lz4DecompressorTest extends AbstractDecompressorTest {
     }
 
     @Test
+    public void testRejectsCompressedDataBeyondDeclaredLength() throws Exception {
+        ByteBuf input = Unpooled.buffer();
+        input.writeLong(MAGIC_NUMBER);
+        input.writeByte(BLOCK_TYPE_COMPRESSED);
+        input.writeIntLE(1);
+        input.writeIntLE(8);
+        input.writeIntLE(0);
+        input.writeByte(0x80);
+        input.writeZero(8);
+
+        try (Decompressor decompressor = createDecompressor().build(ByteBufAllocator.DEFAULT)) {
+            assertEquals(NEED_INPUT, decompressor.status());
+            decompressor.addInput(input);
+            assertEquals(NEED_OUTPUT, decompressor.status());
+            assertThrows(DecompressionException.class, () -> {
+                ByteBuf output = decompressor.takeOutput();
+                output.release();
+            });
+        }
+    }
+
+    @Test
     public void testRejectsDecompressedLengthMismatch() throws Exception {
         ByteBuf input = Unpooled.buffer();
         input.writeLong(MAGIC_NUMBER);

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/Lz4DecompressorTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/Lz4DecompressorTest.java
@@ -40,6 +40,11 @@ public class Lz4DecompressorTest extends AbstractDecompressorTest {
     }
 
     @Test
+    public void testFactoryRejectsNull() {
+        assertThrows(NullPointerException.class, () -> Lz4FrameDecompressor.builder().factory(null));
+    }
+
+    @Test
     public void testRejectsCompressedDataBeyondDeclaredLength() throws Exception {
         ByteBuf input = Unpooled.buffer();
         input.writeLong(MAGIC_NUMBER);

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/Lz4DecompressorTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/Lz4DecompressorTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandler;
+import org.junit.jupiter.api.Test;
+
+import static io.netty.handler.codec.compression.Decompressor.Status.NEED_INPUT;
+import static io.netty.handler.codec.compression.Decompressor.Status.NEED_OUTPUT;
+import static io.netty.handler.codec.compression.Lz4Constants.BLOCK_TYPE_COMPRESSED;
+import static io.netty.handler.codec.compression.Lz4Constants.MAGIC_NUMBER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class Lz4DecompressorTest extends AbstractDecompressorTest {
+    @Override
+    protected ChannelHandler createCompressor() {
+        return new Lz4FrameEncoder();
+    }
+
+    @Override
+    protected Decompressor.AbstractDecompressorBuilder createDecompressor() {
+        return Lz4FrameDecompressor.builder();
+    }
+
+    @Test
+    public void testRejectsDecompressedLengthMismatch() throws Exception {
+        ByteBuf input = Unpooled.buffer();
+        input.writeLong(MAGIC_NUMBER);
+        input.writeByte(BLOCK_TYPE_COMPRESSED);
+        input.writeIntLE(2);
+        input.writeIntLE(8);
+        input.writeIntLE(0);
+        input.writeByte(0x10);
+        input.writeByte(0);
+
+        try (Decompressor decompressor = createDecompressor().build(ByteBufAllocator.DEFAULT)) {
+            assertEquals(NEED_INPUT, decompressor.status());
+            decompressor.addInput(input);
+            assertEquals(NEED_OUTPUT, decompressor.status());
+            assertThrows(DecompressionException.class, () -> {
+                ByteBuf output = decompressor.takeOutput();
+                output.release();
+            });
+        }
+    }
+
+    @Test
+    public void testRejectsTruncatedHeader() throws Exception {
+        ByteBuf input = Unpooled.buffer();
+        input.writeLong(MAGIC_NUMBER);
+        assertRejectsTruncatedInput(input);
+    }
+
+    @Test
+    public void testRejectsTruncatedBlock() throws Exception {
+        ByteBuf input = Unpooled.buffer();
+        input.writeLong(MAGIC_NUMBER);
+        input.writeByte(BLOCK_TYPE_COMPRESSED);
+        input.writeIntLE(2);
+        input.writeIntLE(8);
+        input.writeIntLE(0);
+        input.writeByte(0x10);
+        assertRejectsTruncatedInput(input);
+    }
+
+    private void assertRejectsTruncatedInput(ByteBuf input) throws Exception {
+        try (Decompressor decompressor = createDecompressor().build(ByteBufAllocator.DEFAULT)) {
+            assertEquals(NEED_INPUT, decompressor.status());
+            decompressor.addInput(input);
+            assertEquals(NEED_INPUT, decompressor.status());
+            assertThrows(DecompressionException.class, decompressor::endOfInput);
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

The decompressor API migration tracked by #16743 calls for the remaining per-format implementations from #15667 to be split into small, independently reviewable pull requests. LZ4 is one of the remaining formats.

Modification:

Add `Lz4FrameDecompressor` using the new `Decompressor` API and builder pattern. Reject truncated streams, limit compressed input to the declared block, and validate the actual decompressed size before publishing output. Add a configurable per-block decompressed length limit that defaults to 256 KiB, with `0` allowing the LZ4 format maximum of 32 MiB. Add shared contract coverage and LZ4-specific malformed-input and limit tests.

Result:

LZ4 frame decompression is available through the new API. `./mvnw -pl codec-compression -am verify` passes with 394 codec-compression tests, including checkstyle and XML formatting checks.

Part of #16743.