### PR TITLE
Codec-compression: Add Zstd decompressor

### DIFF
--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/ZstdDecompressor.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/ZstdDecompressor.java
@@ -18,6 +18,8 @@ package io.netty.handler.codec.compression;
 import com.github.luben.zstd.ZstdInputStreamNoFinalizer;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.Unpooled;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.UnstableApi;
 
 import java.io.IOException;
@@ -29,22 +31,29 @@ import java.io.InputStream;
  */
 @UnstableApi
 public final class ZstdDecompressor implements Decompressor {
+    /**
+     * Default upper bound on the {@code Window_Log} accepted by the decompressor.
+     * {@code 27} corresponds to a 128 MiB decompression window.
+     */
+    public static final int DEFAULT_MAX_WINDOW_LOG = 27;
+    private static final int MIN_WINDOW_LOG = 10;
+    private static final int MAX_WINDOW_LOG = 31;
+    private static final int DEFAULT_MAX_FORWARD_BYTES = CompressionUtil.DEFAULT_MAX_FORWARD_BYTES;
+
     private final ByteBufAllocator allocator;
 
     private final MutableByteBufInputStream mutableInput = new MutableByteBufInputStream();
     private final ZstdInputStreamNoFinalizer output;
 
-    {
+    ZstdDecompressor(Builder builder, ByteBufAllocator allocator) {
+        this.allocator = allocator;
         try {
             output = new ZstdInputStreamNoFinalizer(mutableInput);
+            output.setContinuous(true);
+            output.setLongMax(builder.maxWindowLog);
         } catch (IOException e) {
             throw new DecompressionException(e);
         }
-        output.setContinuous(true);
-    }
-
-    ZstdDecompressor(ByteBufAllocator allocator) {
-        this.allocator = allocator;
     }
 
     @Override
@@ -77,14 +86,18 @@ public final class ZstdDecompressor implements Decompressor {
 
     @Override
     public ByteBuf takeOutput() throws DecompressionException {
-        ByteBuf buf = allocator.buffer();
+        ByteBuf buf = allocator.buffer(DEFAULT_MAX_FORWARD_BYTES, DEFAULT_MAX_FORWARD_BYTES);
         try {
-            buf.writeBytes(output, buf.maxFastWritableBytes());
+            buf.writeBytes(output, DEFAULT_MAX_FORWARD_BYTES);
         } catch (IOException e) {
             buf.release();
             throw new DecompressionException(e);
         }
-        return buf;
+        if (buf.isReadable()) {
+            return buf;
+        }
+        buf.release();
+        return Unpooled.EMPTY_BUFFER;
     }
 
     @Override
@@ -107,12 +120,31 @@ public final class ZstdDecompressor implements Decompressor {
 
     @UnstableApi
     public static final class Builder extends AbstractDecompressorBuilder {
+        private int maxWindowLog = DEFAULT_MAX_WINDOW_LOG;
+
         Builder() {
+        }
+
+        /**
+         * Set the upper bound on the accepted {@code Window_Log}.
+         * <p>
+         * The window log size bounds the memory usage of the sliding window for ZSTD frame decompression. Frames
+         * declaring a larger window will be rejected to bound the memory the decompressor may allocate per stream.
+         *
+         * @param maxWindowLog upper bound on the {@code Window_Log} field of incoming frames; must be in
+         *                     {@code [10, 31]}
+         * @return This builder
+         */
+        @UnstableApi
+        public Builder maxWindowLog(int maxWindowLog) {
+            this.maxWindowLog = ObjectUtil.checkInRange(
+                    maxWindowLog, MIN_WINDOW_LOG, MAX_WINDOW_LOG, "maxWindowLog");
+            return this;
         }
 
         @Override
         public Decompressor build(ByteBufAllocator allocator) throws DecompressionException {
-            return new DefensiveDecompressor(new ZstdDecompressor(allocator));
+            return new DefensiveDecompressor(new ZstdDecompressor(this, allocator));
         }
     }
 

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/ZstdDecompressor.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/ZstdDecompressor.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import com.github.luben.zstd.ZstdInputStreamNoFinalizer;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.internal.UnstableApi;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Decompresses a compressed block {@link ByteBuf} using the Zstandard algorithm.
+ * See <a href="https://facebook.github.io/zstd">Zstandard</a>.
+ */
+@UnstableApi
+public final class ZstdDecompressor implements Decompressor {
+    private final ByteBufAllocator allocator;
+
+    private final MutableByteBufInputStream mutableInput = new MutableByteBufInputStream();
+    private final ZstdInputStreamNoFinalizer output;
+
+    {
+        try {
+            output = new ZstdInputStreamNoFinalizer(mutableInput);
+        } catch (IOException e) {
+            throw new DecompressionException(e);
+        }
+        output.setContinuous(true);
+    }
+
+    ZstdDecompressor(ByteBufAllocator allocator) {
+        this.allocator = allocator;
+    }
+
+    @Override
+    public Status status() throws DecompressionException {
+        try {
+            if (output.available() == 0) {
+                if (!output.getContinuous()) {
+                    return Status.COMPLETE;
+                }
+                return Status.NEED_INPUT;
+            }
+            return Status.NEED_OUTPUT;
+        } catch (IOException e) {
+            throw new DecompressionException(e);
+        }
+    }
+
+    @Override
+    public void addInput(ByteBuf buf) throws DecompressionException {
+        if (mutableInput.current != null) {
+            mutableInput.current.release();
+        }
+        mutableInput.current = buf;
+    }
+
+    @Override
+    public void endOfInput() throws DecompressionException {
+        output.setContinuous(false);
+    }
+
+    @Override
+    public ByteBuf takeOutput() throws DecompressionException {
+        ByteBuf buf = allocator.buffer();
+        try {
+            buf.writeBytes(output, buf.maxFastWritableBytes());
+        } catch (IOException e) {
+            buf.release();
+            throw new DecompressionException(e);
+        }
+        return buf;
+    }
+
+    @Override
+    public void close() {
+        if (mutableInput.current != null) {
+            mutableInput.current.release();
+            mutableInput.current = null;
+        }
+        try {
+            output.close();
+        } catch (IOException ignored) {
+            // ignore
+        }
+    }
+
+    @UnstableApi
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @UnstableApi
+    public static final class Builder extends AbstractDecompressorBuilder {
+        Builder() {
+        }
+
+        @Override
+        public Decompressor build(ByteBufAllocator allocator) throws DecompressionException {
+            return new DefensiveDecompressor(new ZstdDecompressor(allocator));
+        }
+    }
+
+    private static final class MutableByteBufInputStream extends InputStream {
+        ByteBuf current;
+
+        @Override
+        public int read() {
+            if (available() == 0) {
+                return -1;
+            }
+            return current.readByte() & 0xff;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) {
+            int available = available();
+            if (available == 0) {
+                return -1;
+            }
+
+            len = Math.min(available, len);
+            current.readBytes(b, off, len);
+            return len;
+        }
+
+        @Override
+        public int available() {
+            return current == null ? 0 : current.readableBytes();
+        }
+    }
+}

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/ZstdDecompressor.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/ZstdDecompressor.java
@@ -31,15 +31,6 @@ import java.io.InputStream;
  */
 @UnstableApi
 public final class ZstdDecompressor implements Decompressor {
-    // Don't use static here as we want to still allow to load the classes.
-    {
-        try {
-            Zstd.ensureAvailability();
-        } catch (Throwable throwable) {
-            throw new ExceptionInInitializerError(throwable);
-        }
-    }
-
     /**
      * Default upper bound on the {@code Window_Log} accepted by the decompressor.
      * {@code 27} corresponds to a 128 MiB decompression window.
@@ -55,12 +46,27 @@ public final class ZstdDecompressor implements Decompressor {
     private final ZstdInputStreamNoFinalizer output;
 
     ZstdDecompressor(Builder builder, ByteBufAllocator allocator) {
+        // Don't use static here as we want to still allow to load the classes.
+        try {
+            Zstd.ensureAvailability();
+        } catch (Throwable throwable) {
+            throw new ExceptionInInitializerError(throwable);
+        }
         this.allocator = allocator;
+        ZstdInputStreamNoFinalizer output = null;
         try {
             output = new ZstdInputStreamNoFinalizer(mutableInput);
             output.setContinuous(true);
             output.setLongMax(builder.maxWindowLog);
+            this.output = output;
         } catch (IOException e) {
+            if (output != null) {
+                try {
+                    output.close();
+                } catch (IOException closeException) {
+                    e.addSuppressed(closeException);
+                }
+            }
             throw new DecompressionException(e);
         }
     }
@@ -94,7 +100,14 @@ public final class ZstdDecompressor implements Decompressor {
 
     @Override
     public void endOfInput() throws DecompressionException {
-        output.setContinuous(false);
+        try {
+            output.setContinuous(false);
+            if (output.read() != -1) {
+                throw new DecompressionException("Unexpected output after end of input");
+            }
+        } catch (IOException e) {
+            throw new DecompressionException(e);
+        }
     }
 
     @Override

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/ZstdDecompressor.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/ZstdDecompressor.java
@@ -31,6 +31,15 @@ import java.io.InputStream;
  */
 @UnstableApi
 public final class ZstdDecompressor implements Decompressor {
+    // Don't use static here as we want to still allow to load the classes.
+    {
+        try {
+            Zstd.ensureAvailability();
+        } catch (Throwable throwable) {
+            throw new ExceptionInInitializerError(throwable);
+        }
+    }
+
     /**
      * Default upper bound on the {@code Window_Log} accepted by the decompressor.
      * {@code 27} corresponds to a 128 MiB decompression window.
@@ -73,6 +82,10 @@ public final class ZstdDecompressor implements Decompressor {
 
     @Override
     public void addInput(ByteBuf buf) throws DecompressionException {
+        if (!buf.isReadable()) {
+            buf.release();
+            return;
+        }
         if (mutableInput.current != null) {
             mutableInput.current.release();
         }

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/ZstdDecompressorTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/ZstdDecompressorTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.channel.ChannelHandler;
+
+public class ZstdDecompressorTest extends AbstractDecompressorTest {
+    @Override
+    protected ChannelHandler createCompressor() {
+        return new ZstdEncoder();
+    }
+
+    @Override
+    protected Decompressor.AbstractDecompressorBuilder createDecompressor() {
+        return ZstdDecompressor.builder();
+    }
+}

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/ZstdDecompressorTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/ZstdDecompressorTest.java
@@ -23,6 +23,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandler;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -75,6 +76,17 @@ public class ZstdDecompressorTest extends AbstractDecompressorTest {
         byte[] compressed = compressWithWindowLog(payload, 18); // 256 KiB window
 
         assertArrayEquals(payload, decompress(compressed, 20));
+    }
+
+    @Test
+    public void testTruncatedFrameIsRejectedAfterEndOfInput() {
+        byte[] payload = new byte[256 * 1024];
+        new Random(12345L).nextBytes(payload);
+
+        byte[] compressed = compressWithWindowLog(payload, 18);
+        byte[] truncated = Arrays.copyOf(compressed, compressed.length - 1);
+
+        assertThrows(DecompressionException.class, () -> decompress(truncated, 20));
     }
 
     private static byte[] decompress(byte[] compressed, int maxWindowLog) throws DecompressionException {

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/ZstdDecompressorTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/ZstdDecompressorTest.java
@@ -42,6 +42,17 @@ public class ZstdDecompressorTest extends AbstractDecompressorTest {
     }
 
     @Test
+    public void addInputReleasesEmptyBuffer() throws DecompressionException {
+        ByteBuf empty = Unpooled.buffer(0);
+        try (Decompressor decompressor = createDecompressor().build(ByteBufAllocator.DEFAULT)) {
+            assertEquals(Decompressor.Status.NEED_INPUT, decompressor.status());
+            decompressor.addInput(empty);
+            assertEquals(0, empty.refCnt());
+            assertEquals(Decompressor.Status.NEED_INPUT, decompressor.status());
+        }
+    }
+
+    @Test
     public void testFrameWithWindowLogAboveCapIsRejected() {
         // Incompressible random data so libzstd actually has to use the declared window
         // (highly compressible content lets libzstd shrink the effective window to the

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/ZstdDecompressorTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/ZstdDecompressorTest.java
@@ -15,7 +15,20 @@
  */
 package io.netty.handler.codec.compression;
 
+import com.github.luben.zstd.Zstd;
+import com.github.luben.zstd.ZstdCompressCtx;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandler;
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ZstdDecompressorTest extends AbstractDecompressorTest {
     @Override
@@ -26,5 +39,84 @@ public class ZstdDecompressorTest extends AbstractDecompressorTest {
     @Override
     protected Decompressor.AbstractDecompressorBuilder createDecompressor() {
         return ZstdDecompressor.builder();
+    }
+
+    @Test
+    public void testFrameWithWindowLogAboveCapIsRejected() {
+        // Incompressible random data so libzstd actually has to use the declared window
+        // (highly compressible content lets libzstd shrink the effective window to the
+        // content size, making setLongMax ineffective for the test).
+        byte[] payload = new byte[256 * 1024];
+        new Random(12345L).nextBytes(payload);
+
+        // Compressed with windowLog = 21 (2 MiB window).
+        byte[] compressed = compressWithWindowLog(payload, 21);
+
+        // Decompressor caps Window_Log at 15 (32 KiB) -> the frame must be rejected.
+        assertThrows(DecompressionException.class, () -> decompress(compressed, 15));
+    }
+
+    @Test
+    public void testFrameWithWindowLogWithinCapIsAccepted() throws DecompressionException {
+        byte[] payload = new byte[256 * 1024];
+        new Random(12345L).nextBytes(payload);
+
+        byte[] compressed = compressWithWindowLog(payload, 18); // 256 KiB window
+
+        assertArrayEquals(payload, decompress(compressed, 20));
+    }
+
+    private static byte[] decompress(byte[] compressed, int maxWindowLog) throws DecompressionException {
+        ByteBuf input = Unpooled.wrappedBuffer(compressed);
+        ByteBuf output = Unpooled.buffer();
+        try (Decompressor decompressor = ZstdDecompressor.builder()
+                .maxWindowLog(maxWindowLog)
+                .build(ByteBufAllocator.DEFAULT)) {
+            assertEquals(Decompressor.Status.NEED_INPUT, decompressor.status());
+            decompressor.addInput(input);
+            input = null;
+
+            boolean sentEof = false;
+            while (true) {
+                switch (decompressor.status()) {
+                    case NEED_INPUT:
+                        assertFalse(sentEof);
+                        sentEof = true;
+                        decompressor.endOfInput();
+                        break;
+                    case NEED_OUTPUT:
+                        ByteBuf b = decompressor.takeOutput();
+                        try {
+                            output.writeBytes(b);
+                        } finally {
+                            b.release();
+                        }
+                        break;
+                    case COMPLETE:
+                        byte[] bytes = new byte[output.readableBytes()];
+                        output.readBytes(bytes);
+                        return bytes;
+                    default:
+                        throw new AssertionError("Unknown status: " + decompressor.status());
+                }
+            }
+        } finally {
+            if (input != null) {
+                input.release();
+            }
+            output.release();
+        }
+    }
+
+    private static byte[] compressWithWindowLog(byte[] data, int windowLog) {
+        try (ZstdCompressCtx ctx = new ZstdCompressCtx()) {
+            ctx.setLevel(Zstd.defaultCompressionLevel());
+            ctx.setWindowLog(windowLog);
+            byte[] dst = new byte[(int) Zstd.compressBound(data.length)];
+            int written = ctx.compressByteArray(dst, 0, dst.length, data, 0, data.length);
+            byte[] out = new byte[written];
+            System.arraycopy(dst, 0, out, 0, written);
+            return out;
+        }
     }
 }


### PR DESCRIPTION
Motivation:

The decompressor API migration tracked in #16743 is being split out from #15667 into smaller, reviewable pieces. This adds the Zstd decompressor slice on top of the core decompressor API that is already present, including the ZstdDecoder window-memory guard added in #16850.

Modification:

Add `ZstdDecompressor`, backed by zstd-jni `ZstdInputStreamNoFinalizer`, and add the matching `AbstractDecompressorTest` coverage using `ZstdEncoder`.

The decompressor builder exposes `maxWindowLog(int)` and applies it through `ZstdInputStreamNoFinalizer.setLongMax(...)` so frames declaring oversized windows are rejected before zstd allocates excessive native memory. `takeOutput()` also uses the shared compression forward-size as its per-call output chunk size.

Result:

Zstd now has a decompressor implementation for the new API with focused contract coverage and bounded zstd native window memory by default.

Verification:

- `./mvnw -pl codec-compression -am -DskipRemoteStaging=true -Dcheckstyle.skip=false -DskipTests=false -Dtest=ZstdDecompressorTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl codec-compression -am -DskipRemoteStaging=true -Dcheckstyle.skip=false -DskipTests=false verify`

Part of #16743.