### PR TITLE
Codec-compression: Add Snappy frame decompressor

### DIFF
--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/SnappyFrameDecompressor.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/SnappyFrameDecompressor.java
@@ -27,7 +27,7 @@ import static io.netty.handler.codec.compression.Snappy.validateChecksum;
  * See <a href="https://github.com/google/snappy/blob/master/framing_format.txt">Snappy framing format</a>.
  */
 @UnstableApi
-public class SnappyFrameDecompressor extends InputBufferingDecompressor {
+public final class SnappyFrameDecompressor extends InputBufferingDecompressor {
 
     private enum ChunkType {
         STREAM_IDENTIFIER,

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/SnappyFrameDecompressor.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/SnappyFrameDecompressor.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.internal.UnstableApi;
+
+import static io.netty.handler.codec.compression.Snappy.validateChecksum;
+
+/**
+ * Uncompresses a {@link ByteBuf} encoded with the Snappy framing format.
+ *
+ * See <a href="https://github.com/google/snappy/blob/master/framing_format.txt">Snappy framing format</a>.
+ */
+@UnstableApi
+public class SnappyFrameDecompressor extends InputBufferingDecompressor {
+
+    private enum ChunkType {
+        STREAM_IDENTIFIER,
+        COMPRESSED_DATA,
+        UNCOMPRESSED_DATA,
+        RESERVED_UNSKIPPABLE,
+        RESERVED_SKIPPABLE
+    }
+
+    private static final int SNAPPY_IDENTIFIER_LEN = 6;
+    // See https://github.com/google/snappy/blob/1.1.9/framing_format.txt#L95
+    private static final int MAX_UNCOMPRESSED_DATA_SIZE = 65536 + 4;
+    // An uncompressed chunk contains a 4-byte masked checksum followed by the data.
+    private static final int MIN_UNCOMPRESSED_DATA_SIZE = 4;
+    // See https://github.com/google/snappy/blob/1.1.9/framing_format.txt#L82
+    private static final int MAX_DECOMPRESSED_DATA_SIZE = 65536;
+    // See https://github.com/google/snappy/blob/1.1.9/framing_format.txt#L82
+    private static final int MAX_COMPRESSED_CHUNK_SIZE = 16777216 - 1;
+    // A compressed chunk contains a 4-byte masked checksum followed by a Snappy stream.
+    private static final int MIN_COMPRESSED_CHUNK_SIZE = 5;
+
+    private final Snappy snappy = new Snappy();
+    private final boolean validateChecksums;
+
+    private boolean started;
+    private int numBytesToSkip;
+
+    private ByteBuf pendingOutput;
+    private boolean eof;
+
+    SnappyFrameDecompressor(Builder builder, ByteBufAllocator allocator) {
+        super(allocator);
+        this.validateChecksums = builder.validateChecksums;
+    }
+
+    @Override
+    public void close() {
+        super.close();
+        if (pendingOutput != null) {
+            pendingOutput.release();
+            pendingOutput = null;
+        }
+    }
+
+    @Override
+    public Status status() throws DecompressionException {
+        if (pendingOutput != null) {
+            return Status.NEED_OUTPUT;
+        }
+        if (eof) {
+            return Status.COMPLETE;
+        }
+        return Status.NEED_INPUT;
+    }
+
+    @Override
+    public void endOfInput() throws DecompressionException {
+        if (available() != 0 || numBytesToSkip != 0) {
+            throw new DecompressionException("Unexpected end of input");
+        }
+        eof = true;
+    }
+
+    @Override
+    void processInput(ByteBuf in) throws DecompressionException {
+        while (in.isReadable()) {
+            if (numBytesToSkip != 0) {
+                // The last chunkType we detected was RESERVED_SKIPPABLE and we still have some bytes to skip.
+                int skipBytes = Math.min(numBytesToSkip, in.readableBytes());
+                in.skipBytes(skipBytes);
+                numBytesToSkip -= skipBytes;
+
+                // Let's return and try again.
+                continue;
+            }
+
+            int idx = in.readerIndex();
+            final int inSize = in.readableBytes();
+            if (inSize < 4) {
+                // We need to be at least able to read the chunk type identifier (one byte),
+                // and the length of the chunk (3 bytes) in order to proceed
+                return;
+            }
+
+            final int chunkTypeVal = in.getUnsignedByte(idx);
+            final ChunkType chunkType = mapChunkType((byte) chunkTypeVal);
+            final int chunkLength = in.getUnsignedMediumLE(idx + 1);
+
+            switch (chunkType) {
+                case STREAM_IDENTIFIER:
+                    if (chunkLength != SNAPPY_IDENTIFIER_LEN) {
+                        throw new DecompressionException("Unexpected length of stream identifier: " + chunkLength);
+                    }
+
+                    if (inSize < 4 + SNAPPY_IDENTIFIER_LEN) {
+                        return;
+                    }
+
+                    in.skipBytes(4);
+                    int offset = in.readerIndex();
+                    in.skipBytes(SNAPPY_IDENTIFIER_LEN);
+
+                    checkByte(in.getByte(offset++), (byte) 's');
+                    checkByte(in.getByte(offset++), (byte) 'N');
+                    checkByte(in.getByte(offset++), (byte) 'a');
+                    checkByte(in.getByte(offset++), (byte) 'P');
+                    checkByte(in.getByte(offset++), (byte) 'p');
+                    checkByte(in.getByte(offset), (byte) 'Y');
+
+                    started = true;
+                    break;
+                case RESERVED_SKIPPABLE:
+                    if (!started) {
+                        throw new DecompressionException("Received RESERVED_SKIPPABLE tag before STREAM_IDENTIFIER");
+                    }
+
+                    in.skipBytes(4);
+
+                    int skipBytes = Math.min(chunkLength, in.readableBytes());
+                    in.skipBytes(skipBytes);
+                    if (skipBytes != chunkLength) {
+                        // We could skip all bytes, let's store the remaining so we can do so once we receive more
+                        // data.
+                        numBytesToSkip = chunkLength - skipBytes;
+                    }
+                    break;
+                case RESERVED_UNSKIPPABLE:
+                    // The spec mandates that reserved unskippable chunks must immediately
+                    // return an error, as we must assume that we cannot decode the stream
+                    // correctly
+                    throw new DecompressionException(
+                            "Found reserved unskippable chunk type: 0x" + Integer.toHexString(chunkTypeVal));
+                case UNCOMPRESSED_DATA:
+                    if (!started) {
+                        throw new DecompressionException("Received UNCOMPRESSED_DATA tag before STREAM_IDENTIFIER");
+                    }
+                    if (chunkLength > MAX_UNCOMPRESSED_DATA_SIZE) {
+                        throw new DecompressionException("Received UNCOMPRESSED_DATA larger than " +
+                                MAX_UNCOMPRESSED_DATA_SIZE + " bytes");
+                    }
+                    if (chunkLength < MIN_UNCOMPRESSED_DATA_SIZE) {
+                        throw new DecompressionException("Received UNCOMPRESSED_DATA with invalid chunk length: " +
+                                chunkLength);
+                    }
+
+                    if (inSize < 4 + chunkLength) {
+                        return;
+                    }
+
+                    in.skipBytes(4);
+                    if (validateChecksums) {
+                        int checksum = in.readIntLE();
+                        validateChecksum(checksum, in, in.readerIndex(), chunkLength - 4);
+                    } else {
+                        in.skipBytes(4);
+                    }
+                    pendingOutput = in.readRetainedSlice(chunkLength - 4);
+                    return;
+                case COMPRESSED_DATA:
+                    if (!started) {
+                        throw new DecompressionException("Received COMPRESSED_DATA tag before STREAM_IDENTIFIER");
+                    }
+
+                    if (chunkLength > MAX_COMPRESSED_CHUNK_SIZE) {
+                        throw new DecompressionException("Received COMPRESSED_DATA that contains" +
+                                " chunk that exceeds " + MAX_COMPRESSED_CHUNK_SIZE + " bytes");
+                    }
+                    if (chunkLength < MIN_COMPRESSED_CHUNK_SIZE) {
+                        throw new DecompressionException("Received COMPRESSED_DATA with invalid chunk length: " +
+                                chunkLength);
+                    }
+
+                    if (inSize < 4 + chunkLength) {
+                        return;
+                    }
+
+                    in.skipBytes(4);
+                    int checksum = in.readIntLE();
+
+                    int uncompressedSize = snappy.getPreamble(in);
+                    if (uncompressedSize > MAX_DECOMPRESSED_DATA_SIZE) {
+                        throw new DecompressionException("Received COMPRESSED_DATA that contains" +
+                                " uncompressed data that exceeds " + MAX_DECOMPRESSED_DATA_SIZE + " bytes");
+                    }
+
+                    ByteBuf uncompressed = allocator.buffer(uncompressedSize, MAX_DECOMPRESSED_DATA_SIZE);
+                    try {
+                        if (validateChecksums) {
+                            int oldWriterIndex = in.writerIndex();
+                            try {
+                                in.writerIndex(in.readerIndex() + chunkLength - 4);
+                                snappy.decode(in, uncompressed);
+                            } finally {
+                                in.writerIndex(oldWriterIndex);
+                            }
+                            validateChecksum(checksum, uncompressed, 0, uncompressed.writerIndex());
+                        } else {
+                            snappy.decode(in.readSlice(chunkLength - 4), uncompressed);
+                        }
+                        pendingOutput = uncompressed;
+                        uncompressed = null;
+                    } finally {
+                        if (uncompressed != null) {
+                            uncompressed.release();
+                        }
+                    }
+                    snappy.reset();
+                    return;
+            }
+        }
+    }
+
+    @Override
+    ByteBuf processOutput(ByteBuf buf) throws DecompressionException {
+        ByteBuf p = pendingOutput;
+        pendingOutput = null;
+        return p;
+    }
+
+    private static void checkByte(byte actual, byte expect) {
+        if (actual != expect) {
+            throw new DecompressionException("Unexpected stream identifier contents. Mismatched snappy " +
+                    "protocol version?");
+        }
+    }
+
+    /**
+     * Decodes the chunk type from the type tag byte.
+     *
+     * @param type The tag byte extracted from the stream
+     * @return The appropriate {@link ChunkType}, defaulting to {@link ChunkType#RESERVED_UNSKIPPABLE}
+     */
+    private static ChunkType mapChunkType(byte type) {
+        if (type == 0) {
+            return ChunkType.COMPRESSED_DATA;
+        } else if (type == 1) {
+            return ChunkType.UNCOMPRESSED_DATA;
+        } else if (type == (byte) 0xff) {
+            return ChunkType.STREAM_IDENTIFIER;
+        } else if ((type & 0x80) == 0x80) {
+            return ChunkType.RESERVED_SKIPPABLE;
+        } else {
+            return ChunkType.RESERVED_UNSKIPPABLE;
+        }
+    }
+
+    @UnstableApi
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @UnstableApi
+    public static final class Builder extends AbstractDecompressorBuilder {
+        boolean validateChecksums;
+
+        Builder() {
+        }
+
+        /**
+         * If true, the checksum field will be validated against the actual
+         * uncompressed data, and if the checksums do not match, a suitable
+         * {@link DecompressionException} will be thrown. Off by default.
+         *
+         * @param validateChecksums Whether to validate the checksums
+         * @return This builder
+         */
+        public Builder validateChecksums(boolean validateChecksums) {
+            this.validateChecksums = validateChecksums;
+            return this;
+        }
+
+        @Override
+        public Decompressor build(ByteBufAllocator allocator) throws DecompressionException {
+            return new DefensiveDecompressor(new SnappyFrameDecompressor(this, allocator));
+        }
+    }
+}

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/SnappyDecompressorTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/SnappyDecompressorTest.java
@@ -58,6 +58,42 @@ public class SnappyDecompressorTest extends AbstractDecompressorTest {
     }
 
     @Test
+    public void testInvalidChecksumThrowsException() throws Exception {
+        try (Decompressor decompressor = SnappyFrameDecompressor.builder()
+                .validateChecksums(true).build(ByteBufAllocator.DEFAULT)) {
+            ByteBuf in = uncompressedDataWithChecksum(0, 0, 0, 0);
+
+            assertEquals(Decompressor.Status.NEED_INPUT, decompressor.status());
+            assertThrows(DecompressionException.class, () -> decompressor.addInput(in));
+        }
+    }
+
+    @Test
+    public void testValidChecksumProducesOutput() throws Exception {
+        try (Decompressor decompressor = SnappyFrameDecompressor.builder()
+                .validateChecksums(true).build(ByteBufAllocator.DEFAULT)) {
+            ByteBuf in = uncompressedDataWithChecksum(0x6f, -0x68, 0x2e, -0x47);
+
+            assertEquals(Decompressor.Status.NEED_INPUT, decompressor.status());
+            decompressor.addInput(in);
+            assertEquals(Decompressor.Status.NEED_OUTPUT, decompressor.status());
+
+            ByteBuf expected = Unpooled.wrappedBuffer(new byte[] { 'n', 'e', 't', 't', 'y' });
+            ByteBuf actual = decompressor.takeOutput();
+            try {
+                assertEquals(expected, actual);
+            } finally {
+                expected.release();
+                actual.release();
+            }
+
+            assertEquals(Decompressor.Status.NEED_INPUT, decompressor.status());
+            decompressor.endOfInput();
+            assertEquals(Decompressor.Status.COMPLETE, decompressor.status());
+        }
+    }
+
+    @Test
     public void testEndOfInputWithPartialFrameHeaderThrowsException() throws Exception {
         assertTruncated(Unpooled.wrappedBuffer(new byte[] { (byte) 0xff, 0x06 }));
     }
@@ -107,6 +143,31 @@ public class SnappyDecompressorTest extends AbstractDecompressorTest {
             assertEquals(Decompressor.Status.NEED_INPUT, decompressor.status());
             assertThrows(DecompressionException.class, () -> decompressor.addInput(in));
         }
+    }
+
+    private static ByteBuf uncompressedDataWithChecksum(int checksumByte1, int checksumByte2,
+            int checksumByte3, int checksumByte4) {
+        ByteBuf in = ByteBufAllocator.DEFAULT.buffer(23);
+        in.writeByte(0xff);
+        in.writeMediumLE(6);
+        in.writeByte('s');
+        in.writeByte('N');
+        in.writeByte('a');
+        in.writeByte('P');
+        in.writeByte('p');
+        in.writeByte('Y');
+        in.writeByte(0x01);
+        in.writeMediumLE(9);
+        in.writeByte(checksumByte1);
+        in.writeByte(checksumByte2);
+        in.writeByte(checksumByte3);
+        in.writeByte(checksumByte4);
+        in.writeByte('n');
+        in.writeByte('e');
+        in.writeByte('t');
+        in.writeByte('t');
+        in.writeByte('y');
+        return in;
     }
 
     private static void assertTruncated(ByteBuf in) throws Exception {

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/SnappyDecompressorTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/SnappyDecompressorTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandler;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class SnappyDecompressorTest extends AbstractDecompressorTest {
+    @Override
+    protected ChannelHandler createCompressor() {
+        return new SnappyFrameEncoder();
+    }
+
+    @Override
+    protected Decompressor.AbstractDecompressorBuilder createDecompressor() {
+        return SnappyFrameDecompressor.builder();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "false, 0", "false, 1", "false, 2", "false, 3", "false, 4",
+            "true, 0", "true, 1", "true, 2", "true, 3", "true, 4"
+    })
+    public void testCompressedDataWithTooShortChunkLengthThrowsException(
+            boolean validateChecksums, int chunkLength) throws Exception {
+        assertInvalidChunkLength(validateChecksums, (byte) 0x00, chunkLength);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "false, 0", "false, 1", "false, 2", "false, 3",
+            "true, 0", "true, 1", "true, 2", "true, 3"
+    })
+    public void testUncompressedDataWithTooShortChunkLengthThrowsException(
+            boolean validateChecksums, int chunkLength) throws Exception {
+        assertInvalidChunkLength(validateChecksums, (byte) 0x01, chunkLength);
+    }
+
+    @Test
+    public void testEndOfInputWithPartialFrameHeaderThrowsException() throws Exception {
+        assertTruncated(Unpooled.wrappedBuffer(new byte[] { (byte) 0xff, 0x06 }));
+    }
+
+    @Test
+    public void testEndOfInputWithPartialStreamIdentifierThrowsException() throws Exception {
+        assertTruncated(Unpooled.wrappedBuffer(new byte[] { (byte) 0xff, 0x06, 0x00, 0x00, 's', 'N' }));
+    }
+
+    @Test
+    public void testEndOfInputWithPartialUncompressedDataThrowsException() throws Exception {
+        assertTruncated(Unpooled.wrappedBuffer(new byte[] {
+                (byte) 0xff, 0x06, 0x00, 0x00, 's', 'N', 'a', 'P', 'p', 'Y',
+                0x01, 0x09, 0x00, 0x00, 0x00, 0x00
+        }));
+    }
+
+    @Test
+    public void testEndOfInputWithPartialSkippableChunkThrowsException() throws Exception {
+        assertTruncated(Unpooled.wrappedBuffer(new byte[] {
+                (byte) 0xff, 0x06, 0x00, 0x00, 's', 'N', 'a', 'P', 'p', 'Y',
+                (byte) 0x81, 0x05, 0x00, 0x00, 'n', 'e'
+        }));
+    }
+
+    private static void assertInvalidChunkLength(boolean validateChecksums, byte chunkType, int chunkLength)
+            throws Exception {
+        try (Decompressor decompressor = SnappyFrameDecompressor.builder()
+                .validateChecksums(validateChecksums).build(ByteBufAllocator.DEFAULT)) {
+            final ByteBuf in = ByteBufAllocator.DEFAULT.buffer(14 + chunkLength);
+
+            // Snappy stream identifier chunk: type 0xff, 3-byte little-endian length 6, payload "sNaPpY".
+            in.writeByte(0xff);
+            in.writeMediumLE(6);
+            in.writeByte('s');
+            in.writeByte('N');
+            in.writeByte('a');
+            in.writeByte('P');
+            in.writeByte('p');
+            in.writeByte('Y');
+
+            // Invalid data chunk header: caller-supplied type and too-short 3-byte little-endian length.
+            in.writeByte(chunkType);
+            in.writeMediumLE(chunkLength);
+            in.writeZero(chunkLength);
+
+            assertEquals(Decompressor.Status.NEED_INPUT, decompressor.status());
+            assertThrows(DecompressionException.class, () -> decompressor.addInput(in));
+        }
+    }
+
+    private static void assertTruncated(ByteBuf in) throws Exception {
+        try (Decompressor decompressor = SnappyFrameDecompressor.builder().build(ByteBufAllocator.DEFAULT)) {
+            assertEquals(Decompressor.Status.NEED_INPUT, decompressor.status());
+            decompressor.addInput(in);
+            assertEquals(Decompressor.Status.NEED_INPUT, decompressor.status());
+            assertThrows(DecompressionException.class, decompressor::endOfInput);
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

The decompressor API migration tracked in #16743 is being split into small, reviewable PRs. Snappy is one of the remaining per-format decompressor implementations.

Modification:

- Add `SnappyFrameDecompressor` based on the existing Snappy frame decoder behavior.
- Add `SnappyDecompressorTest` using the shared decompressor contract test suite.
- Cover Snappy-specific malformed frame cases for too-short chunks and truncated input at EOF.

Result:

Snappy can be decompressed through the new `Decompressor` API while preserving frame-decoder validation behavior.

Verification:

- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk MAVEN_USER_HOME=/tmp/opencode/m2-compress-snappy ./mvnw -pl codec-compression -am -Dtest=SnappyDecompressorTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `JAVA_HOME=/usr/lib/jvm/java-21-openjdk MAVEN_USER_HOME=/tmp/opencode/m2-compress-snappy ./mvnw -pl codec-compression -am verify`

Part of #16743.