### PR TITLE
Codec-compression: Add backpressure decompression handlers

### DIFF
--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/AbstractBackpressureDecompressionHandler.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/AbstractBackpressureDecompressionHandler.java
@@ -1,0 +1,396 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.internal.ObjectUtil;
+import io.netty.util.internal.RecyclableArrayList;
+import io.netty.util.internal.UnstableApi;
+
+/**
+ * This is a base class for backpressure-aware decompressing handler. The purpose of this class is to share code
+ * between the "normal" decompressing handler and the HTTP/1.1 decompressor. This class can handle a single compressed
+ * stream or multiple consecutive ones (as in HTTP/1.1 connections), and it can handle framing messages.
+ */
+@UnstableApi
+public abstract class AbstractBackpressureDecompressionHandler extends ChannelDuplexHandler {
+    /**
+     * The decompressor for the current message.
+     */
+    private Decompressor decompressor;
+
+    private RecyclableArrayList heldBack;
+
+    private boolean reading;
+
+    private boolean discardRemainingContent;
+
+    private boolean anyMessageWrittenSinceReadStart;
+
+    private final BackpressureGauge backpressureGauge;
+
+    protected AbstractBackpressureDecompressionHandler(Builder builder) {
+        this.backpressureGauge = builder.backpressureGaugeBuilder.build();
+    }
+
+    private Decompressor.Status decompressorStatus(ChannelHandlerContext ctx) {
+        assert decompressor != null;
+        try {
+            return decompressor.status();
+        } catch (Exception e) {
+            handleDecompressorException(ctx, e);
+            return null;
+        }
+    }
+
+    private void handleDecompressorException(ChannelHandlerContext ctx, Exception e) {
+        Decompressor decompressor = this.decompressor;
+        this.decompressor = null;
+        try {
+            if (decompressor != null) {
+                decompressor.close();
+            }
+        } catch (Exception f) {
+            e.addSuppressed(f);
+        }
+        discardRemainingContent = true;
+        ctx.fireExceptionCaught(e);
+        fireEndOfOutput(ctx);
+    }
+
+    @Override
+    public final void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        if (!reading) {
+            reading = true;
+            anyMessageWrittenSinceReadStart = false;
+        }
+
+        if (heldBack != null) {
+            heldBack.add(msg);
+            return;
+        }
+
+        channelRead0(ctx, msg);
+    }
+
+    /**
+     * Handle an input message from {@link #channelRead(ChannelHandlerContext, Object)}. This method is only called
+     * when the decompressor is capable of accepting input ({@link #channelReadBytes} or
+     * {@link #channelReadEndOfInput}).
+     */
+    protected abstract void channelRead0(ChannelHandlerContext ctx, Object msg) throws Exception;
+
+    /**
+     * Feed some input data to the decompressor. Must be called at most once from {@link #channelRead0}, and only from
+     * there.
+     */
+    protected final void channelReadBytes(ChannelHandlerContext ctx, ByteBuf msg) {
+        if (decompressor == null) {
+            if (msg.isReadable() && !discardRemainingContent) {
+                msg.release();
+                throw new DecompressionException("Additional input after compressed data");
+            }
+            msg.release();
+        } else {
+            Decompressor.Status status = decompressorStatus(ctx);
+            if (status == null) {
+                msg.release();
+                return;
+            }
+            if (status != Decompressor.Status.NEED_INPUT) {
+                msg.release();
+                throw new IllegalStateException("Unexpected decompressor status: " + status);
+            }
+            if (msg.isReadable()) {
+                boolean failed = false;
+                try {
+                    decompressor.addInput(msg);
+                } catch (Exception e) {
+                    handleDecompressorException(ctx, e);
+                    failed = true;
+                }
+                if (!failed) {
+                    forwardOutput(ctx);
+                }
+            } else {
+                msg.release();
+            }
+        }
+    }
+
+    /**
+     * Signal end of input from {@link #channelRead0}. Must be called at most once, and only from that method. Must not
+     * be called if {@link #channelReadBytes} has been called–if you need both, please go through {@link #channelRead}
+     * twice instead, so that the message can be delayed if necessary.
+     */
+    protected final void channelReadEndOfInput(ChannelHandlerContext ctx) {
+        if (decompressor == null) {
+            // already done
+            return;
+        }
+        Decompressor.Status status = decompressorStatus(ctx);
+        if (status == null) {
+            return;
+        }
+        if (status == Decompressor.Status.NEED_INPUT) {
+            try {
+                decompressor.endOfInput();
+            } catch (Exception e) {
+                handleDecompressorException(ctx, e);
+                return;
+            }
+            forwardOutput(ctx);
+        } else {
+            throw new IllegalStateException(
+                    "Please don't call channelReadEndOfInput immediately after channelReadBytes, go through " +
+                            "channelRead again instead.");
+        }
+    }
+
+    /**
+     * Called when the end of decompressed output is reached. This can also happen as a result of a decompression
+     * exception.
+     */
+    protected abstract void fireEndOfOutput(ChannelHandlerContext ctx);
+
+    /**
+     * Start decompressing a message.
+     *
+     * @param builder The decompression format
+     */
+    protected final void beginDecompression(
+            ChannelHandlerContext ctx, Decompressor.AbstractDecompressorBuilder builder) {
+        decompressor = builder.build(ctx.alloc());
+        backpressureGauge.relieveBackpressure();
+        discardRemainingContent = false;
+        anyMessageWrittenSinceReadStart = true;
+    }
+
+    /**
+     * Send a framing message downstream, i.e. {@link BackpressureGauge#countNonByteMessage()}. You can also use this
+     * to send byte messages when processing non-compressed input.
+     */
+    protected final void fireFramingMessage(ChannelHandlerContext ctx, Object msg) {
+        backpressureGauge.countNonByteMessage();
+        anyMessageWrittenSinceReadStart = true;
+        ctx.fireChannelRead(msg);
+    }
+
+    @Override
+    public final void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+        do {
+            if (!anyMessageWrittenSinceReadStart) {
+                // we didn't forward any messages, so we need to ask upstream for more
+                reading = false;
+                if (!isAutoRead(ctx)) {
+                    ctx.read();
+                }
+                return;
+            }
+
+            // accept that we might not have hit the target.
+            backpressureGauge.increaseBackpressure();
+
+            ctx.fireChannelReadComplete();
+            reading = false;
+
+        } while (fulfillDemandOutsideRead(ctx));
+    }
+
+    /**
+     * @return {@code true} if {@link #channelReadComplete(ChannelHandlerContext)} should be called next. This is to
+     * avoid recursion
+     */
+    private boolean fulfillDemandOutsideRead(ChannelHandlerContext ctx) throws Exception {
+        assert !reading;
+
+        if (decompressor == null) {
+            return false;
+        }
+        if (downstreamMessageLimitExceeded(ctx)) {
+            return false;
+        }
+
+        RecyclableArrayList heldBack = this.heldBack;
+        if (heldBack == null) {
+            if (!isAutoRead(ctx)) {
+                ctx.read();
+            }
+            return false;
+        }
+
+        reading = true;
+        anyMessageWrittenSinceReadStart = false;
+        forwardOutput(ctx);
+        if (this.heldBack != heldBack) {
+            return false;
+        }
+        Decompressor.Status status = decompressor == null ? null : decompressorStatus(ctx);
+        if (this.heldBack != heldBack) {
+            return false;
+        }
+        if (status != Decompressor.Status.NEED_OUTPUT) {
+            this.heldBack = null;
+            if (heldBack.isEmpty() && !anyMessageWrittenSinceReadStart) {
+                heldBack.recycle();
+                return false;
+            } else {
+                // this sets reading = true
+                Object[] messages = heldBack.toArray();
+                heldBack.recycle();
+                try {
+                    for (int i = 0; i < messages.length; i++) {
+                        Object msg = messages[i];
+                        messages[i] = null;
+                        channelRead(ctx, msg);
+                    }
+                } finally {
+                    for (Object msg : messages) {
+                        ReferenceCountUtil.release(msg);
+                    }
+                }
+                return true; // channelReadComplete(ctx)
+            }
+        } else {
+            if (anyMessageWrittenSinceReadStart) {
+                return true; // channelReadComplete(ctx)
+            }
+            ctx.read();
+            return false;
+        }
+    }
+
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
+    private static boolean isAutoRead(ChannelHandlerContext ctx) {
+        return ctx.channel().config().isAutoRead();
+    }
+
+    private boolean downstreamMessageLimitExceeded(ChannelHandlerContext ctx) {
+        return backpressureGauge.backpressureLimitExceeded() && !isAutoRead(ctx);
+    }
+
+    @Override
+    public final void read(ChannelHandlerContext ctx) throws Exception {
+        if (decompressor == null) {
+            ctx.read();
+            return;
+        }
+
+        backpressureGauge.relieveBackpressure();
+        if (!reading) {
+            if (fulfillDemandOutsideRead(ctx)) {
+                channelReadComplete(ctx);
+            }
+        }
+    }
+
+    private void forwardOutput(ChannelHandlerContext ctx) {
+        while (true) {
+            Decompressor.Status status = decompressorStatus(ctx);
+            if (status == null) {
+                return;
+            }
+            switch (status) {
+                case NEED_OUTPUT:
+                    if (downstreamMessageLimitExceeded(ctx)) {
+                        if (heldBack == null) {
+                            heldBack = RecyclableArrayList.newInstance();
+                        }
+                        return;
+                    }
+                    Decompressor decompressor = this.decompressor;
+                    ByteBuf output;
+                    try {
+                        output = decompressor.takeOutput();
+                    } catch (Exception e) {
+                        handleDecompressorException(ctx, e);
+                        return;
+                    }
+                    backpressureGauge.countMessage(output.readableBytes());
+                    anyMessageWrittenSinceReadStart = true;
+                    ctx.fireChannelRead(wrapOutputBuffer(output));
+                    if (this.decompressor != decompressor) {
+                        return;
+                    }
+                    break;
+                case NEED_INPUT:
+                    return;
+                case COMPLETE:
+                    Decompressor completeDecompressor = this.decompressor;
+                    this.decompressor = null;
+                    try {
+                        completeDecompressor.close();
+                    } catch (Exception e) {
+                        ctx.fireExceptionCaught(e);
+                    }
+                    fireEndOfOutput(ctx);
+                    return;
+                default:
+                    throw new AssertionError("Unknown status: " + status);
+            }
+        }
+    }
+
+    /**
+     * Wrap an output buffer before sending it down the pipeline. This is used for HttpContent.
+     */
+    protected Object wrapOutputBuffer(ByteBuf output) {
+        return output;
+    }
+
+    @Override
+    public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+        Exception closeFailure = null;
+        if (decompressor != null) {
+            try {
+                decompressor.close();
+            } catch (Exception e) {
+                closeFailure = e;
+            }
+            decompressor = null;
+        }
+        if (heldBack != null) {
+            RecyclableArrayList heldBack = this.heldBack;
+            this.heldBack = null;
+            try {
+                for (Object o : heldBack) {
+                    ReferenceCountUtil.release(o);
+                }
+            } finally {
+                heldBack.recycle();
+            }
+        }
+        if (closeFailure != null) {
+            throw closeFailure;
+        }
+    }
+
+    @UnstableApi
+    public abstract static class Builder {
+        BackpressureGauge.Builder backpressureGaugeBuilder = BackpressureGauge.builder();
+
+        public Builder backpressureGaugeBuilder(BackpressureGauge.Builder backpressureGaugeBuilder) {
+            this.backpressureGaugeBuilder =
+                    ObjectUtil.checkNotNull(backpressureGaugeBuilder, "backpressureGaugeBuilder");
+            return this;
+        }
+
+        public abstract ChannelDuplexHandler build();
+    }
+}

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/AbstractBackpressureDecompressionHandler.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/AbstractBackpressureDecompressionHandler.java
@@ -391,6 +391,8 @@ public abstract class AbstractBackpressureDecompressionHandler extends ChannelDu
 
     @Override
     public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+        reading = false;
+        readPending = false;
         Exception closeFailure = null;
         if (decompressor != null) {
             try {

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/AbstractBackpressureDecompressionHandler.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/AbstractBackpressureDecompressionHandler.java
@@ -252,18 +252,17 @@ public abstract class AbstractBackpressureDecompressionHandler extends ChannelDu
                 return false;
             } else {
                 // this sets reading = true
-                Object[] messages = heldBack.toArray();
-                heldBack.recycle();
+                int messageIndex = 0;
                 try {
-                    for (int i = 0; i < messages.length; i++) {
-                        Object msg = messages[i];
-                        messages[i] = null;
+                    while (messageIndex < heldBack.size()) {
+                        Object msg = heldBack.get(messageIndex++);
                         channelRead(ctx, msg);
                     }
                 } finally {
-                    for (Object msg : messages) {
-                        ReferenceCountUtil.release(msg);
+                    while (messageIndex < heldBack.size()) {
+                        ReferenceCountUtil.release(heldBack.get(messageIndex++));
                     }
+                    heldBack.recycle();
                 }
                 return true; // channelReadComplete(ctx)
             }

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/AbstractBackpressureDecompressionHandler.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/AbstractBackpressureDecompressionHandler.java
@@ -120,6 +120,7 @@ public abstract class AbstractBackpressureDecompressionHandler extends ChannelDu
                 throw new IllegalStateException("Unexpected decompressor status: " + status);
             }
             if (msg.isReadable()) {
+                int readableBytes = msg.readableBytes();
                 boolean failed = false;
                 try {
                     decompressor.addInput(msg);
@@ -130,8 +131,14 @@ public abstract class AbstractBackpressureDecompressionHandler extends ChannelDu
                 if (!failed) {
                     forwardOutput(ctx);
                 }
+                if (!isAutoRead(ctx) && !anyMessageWrittenSinceReadStart) {
+                    backpressureGauge.countMessage(readableBytes);
+                }
             } else {
                 msg.release();
+                if (!isAutoRead(ctx) && !anyMessageWrittenSinceReadStart) {
+                    backpressureGauge.countMessage(0);
+                }
             }
         }
     }
@@ -200,9 +207,19 @@ public abstract class AbstractBackpressureDecompressionHandler extends ChannelDu
             if (!anyMessageWrittenSinceReadStart) {
                 // we didn't forward any messages, so we need to ask upstream for more
                 reading = false;
-                readPending = false;
-                if (!isAutoRead(ctx)) {
+                boolean readPending = this.readPending;
+                this.readPending = false;
+                if (readPending) {
+                    backpressureGauge.relieveBackpressure();
+                }
+                if (!isAutoRead(ctx) && decompressor != null && !backpressureGauge.backpressureLimitExceeded()) {
                     ctx.read();
+                } else {
+                    backpressureGauge.increaseBackpressure();
+                    ctx.fireChannelReadComplete();
+                    if (readPending && decompressor == null && !isAutoRead(ctx)) {
+                        ctx.read();
+                    }
                 }
                 return;
             }

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/AbstractBackpressureDecompressionHandler.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/AbstractBackpressureDecompressionHandler.java
@@ -39,6 +39,8 @@ public abstract class AbstractBackpressureDecompressionHandler extends ChannelDu
 
     private boolean reading;
 
+    private boolean readPending;
+
     private boolean discardRemainingContent;
 
     private boolean anyMessageWrittenSinceReadStart;
@@ -198,6 +200,7 @@ public abstract class AbstractBackpressureDecompressionHandler extends ChannelDu
             if (!anyMessageWrittenSinceReadStart) {
                 // we didn't forward any messages, so we need to ask upstream for more
                 reading = false;
+                readPending = false;
                 if (!isAutoRead(ctx)) {
                     ctx.read();
                 }
@@ -209,6 +212,16 @@ public abstract class AbstractBackpressureDecompressionHandler extends ChannelDu
 
             ctx.fireChannelReadComplete();
             reading = false;
+            if (readPending) {
+                readPending = false;
+                backpressureGauge.relieveBackpressure();
+                if (decompressor == null) {
+                    if (!isAutoRead(ctx)) {
+                        ctx.read();
+                    }
+                    return;
+                }
+            }
 
         } while (fulfillDemandOutsideRead(ctx));
     }
@@ -291,11 +304,14 @@ public abstract class AbstractBackpressureDecompressionHandler extends ChannelDu
             return;
         }
 
+        if (reading) {
+            readPending = true;
+            return;
+        }
+
         backpressureGauge.relieveBackpressure();
-        if (!reading) {
-            if (fulfillDemandOutsideRead(ctx)) {
-                channelReadComplete(ctx);
-            }
+        if (fulfillDemandOutsideRead(ctx)) {
+            channelReadComplete(ctx);
         }
     }
 
@@ -323,6 +339,9 @@ public abstract class AbstractBackpressureDecompressionHandler extends ChannelDu
                     }
                     backpressureGauge.countMessage(output.readableBytes());
                     anyMessageWrittenSinceReadStart = true;
+                    if (readPending) {
+                        readPending = false;
+                    }
                     ctx.fireChannelRead(wrapOutputBuffer(output));
                     if (this.decompressor != decompressor) {
                         return;

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/BackpressureDecompressionHandler.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/BackpressureDecompressionHandler.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.internal.ObjectUtil;
+import io.netty.util.internal.UnstableApi;
+
+/**
+ * A channel handler that decompresses incoming {@link ByteBuf}s using a {@link Decompressor}. This is designed as a
+ * drop-in replacement for the various decompression decoders (e.g. {@link BrotliDecoder}), but properly handles
+ * downstream backpressure.
+ * <p>
+ * Disable auto-read on the channel to enforce the configured backpressure limits.
+ */
+@UnstableApi
+public final class BackpressureDecompressionHandler extends AbstractBackpressureDecompressionHandler {
+    private final Decompressor.AbstractDecompressorBuilder decompressorBuilder;
+
+    BackpressureDecompressionHandler(Builder builder) {
+        super(builder);
+        this.decompressorBuilder = builder.decompressorBuilder;
+    }
+
+    /**
+     * Create a new handler builder.
+     *
+     * @param decompressorBuilder The decompressor builder to use. This builder is invoked lazily when the handler
+     *                            is added to the pipeline.
+     * @return The builder for the decompression handler
+     */
+    public static Builder builder(Decompressor.AbstractDecompressorBuilder decompressorBuilder) {
+        return new Builder(decompressorBuilder);
+    }
+
+    /**
+     * Create a new decompression handler with default settings. Equivalent to
+     * {@code builder(decompressorBuilder).build()}.
+     *
+     * @param decompressorBuilder The decompressor builder to use. This builder is invoked lazily when the handler
+     *                            is added to the pipeline.
+     * @return The decompression handler
+     */
+    public static BackpressureDecompressionHandler create(
+            Decompressor.AbstractDecompressorBuilder decompressorBuilder) {
+        return builder(decompressorBuilder).build();
+    }
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        if (evt == EndOfContentEvent.INSTANCE) {
+            channelRead(ctx, evt);
+            channelReadComplete(ctx);
+            return;
+        }
+        super.userEventTriggered(ctx, evt);
+    }
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, Object msg) throws Exception {
+        if (msg == EndOfContentEvent.INSTANCE) {
+            channelReadEndOfInput(ctx);
+        } else {
+            channelReadBytes(ctx, (ByteBuf) msg);
+        }
+    }
+
+    @Override
+    protected void fireEndOfOutput(ChannelHandlerContext ctx) {
+        ctx.fireUserEventTriggered(EndOfContentEvent.INSTANCE);
+    }
+
+    @Override
+    public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+        beginDecompression(ctx, decompressorBuilder);
+    }
+
+    @UnstableApi
+    public static final class Builder extends AbstractBackpressureDecompressionHandler.Builder {
+        private final Decompressor.AbstractDecompressorBuilder decompressorBuilder;
+
+        Builder(Decompressor.AbstractDecompressorBuilder decompressorBuilder) {
+            this.decompressorBuilder = ObjectUtil.checkNotNull(decompressorBuilder, "decompressorBuilder");
+        }
+
+        /**
+         * Create a new decompression handler. Note that the actual decompressor is only created when the handler is
+         * added to a pipeline, to avoid memory leaks if the handler is never used.
+         *
+         * @return The handler
+         */
+        public BackpressureDecompressionHandler build() {
+            return new BackpressureDecompressionHandler(this);
+        }
+    }
+
+    /**
+     * Special {@link #userEventTriggered(ChannelHandlerContext, Object) user event} that is used to signify that no
+     * more {@link #channelRead(ChannelHandlerContext, Object)} events are forthcoming.
+     * {@link BackpressureDecompressionHandler} will handle this event and
+     * {@link Decompressor#endOfInput() forward it to the decompressor}. When the decompressor signals no more output
+     * is available, the handler will also fire this event.
+     */
+    @UnstableApi
+    public static final class EndOfContentEvent {
+        @SuppressWarnings("InstantiationOfUtilityClass")
+        public static final EndOfContentEvent INSTANCE = new EndOfContentEvent();
+
+        private EndOfContentEvent() {
+        }
+    }
+}

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/BackpressureGauge.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/BackpressureGauge.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.internal.ObjectUtil;
+import io.netty.util.internal.UnstableApi;
+
+/**
+ * This class centralizes backpressure accounting and, more importantly, configuration for decompression
+ * {@link io.netty.channel.ChannelHandler}s.
+ * <p>
+ * The configured limits are enforced when auto-read is disabled on the channel.
+ */
+@UnstableApi
+public final class BackpressureGauge {
+    private final int messagesPerRead;
+    private int downstreamMessageBudget;
+
+    private final long bytesPerRead;
+    private long downstreamBytesBudget;
+
+    BackpressureGauge(Builder builder) {
+        this.messagesPerRead = builder.messagesPerRead;
+        this.bytesPerRead = builder.bytesPerRead;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Count a framing message that does not have a clearly defined byte count.
+     */
+    public void countNonByteMessage() {
+        countMessage(1);
+    }
+
+    /**
+     * Count a message.
+     *
+     * @param bytes The number of bytes
+     */
+    public void countMessage(long bytes) {
+        ObjectUtil.checkPositiveOrZero(bytes, "bytes");
+        downstreamMessageBudget--;
+        downstreamBytesBudget -= bytes;
+    }
+
+    /**
+     * Relieve backpressure on this gauge, resetting the limits back to their configured maximum.
+     */
+    public void relieveBackpressure() {
+        downstreamMessageBudget = messagesPerRead;
+        downstreamBytesBudget = bytesPerRead;
+    }
+
+    /**
+     * Increase backpressure so that future {@link #backpressureLimitExceeded()} calls will return {@code true} until
+     * backpressure is relieved again.
+     */
+    public void increaseBackpressure() {
+        downstreamMessageBudget = 0;
+    }
+
+    /**
+     * Check whether the backpressure limit has been exceeded and we should stop sending messages until
+     * {@link #relieveBackpressure()} is called.
+     *
+     * @return {@code true} if we should stop sending messages
+     */
+    public boolean backpressureLimitExceeded() {
+        return downstreamMessageBudget <= 0 || downstreamBytesBudget <= 0;
+    }
+
+    @UnstableApi
+    public static final class Builder {
+        int messagesPerRead = 64;
+        long bytesPerRead = 1024 * 1024;
+
+        Builder() {
+        }
+
+        /**
+         * Configure the maximum message target per {@link ChannelHandlerContext#read() read operation}. Note that this
+         * is a rough guideline, and unlike {@code FlowControlHandler}, this limit can sometimes be exceeded.
+         * <p>
+         * The default value is 64. The purpose of this limit is to prevent uncontrolled decompression ("zip bombs")
+         * when auto-read is disabled.
+         *
+         * @param messagesPerRead The maximum number of messages per read operation
+         * @return This builder
+         */
+        public Builder messagesPerRead(int messagesPerRead) {
+            this.messagesPerRead = ObjectUtil.checkPositive(messagesPerRead, "messagesPerRead");
+            return this;
+        }
+
+        /**
+         * Configure the maximum number of bytes per {@link ChannelHandlerContext#read() read operation}. Note that
+         * this is a rough guideline, and this limit can sometimes be exceeded.
+         * <p>
+         * The default value is 1MiB. The purpose of this limit is to prevent uncontrolled decompression ("zip bombs")
+         * when auto-read is disabled.
+         *
+         * @param bytesPerRead The maximum number of bytes per read operation
+         * @return This builder
+         */
+        public Builder bytesPerRead(long bytesPerRead) {
+            this.bytesPerRead = ObjectUtil.checkPositive(bytesPerRead, "bytesPerRead");
+            return this;
+        }
+
+        public BackpressureGauge build() {
+            return new BackpressureGauge(this);
+        }
+    }
+}

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/Bzip2Decompressor.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/Bzip2Decompressor.java
@@ -132,6 +132,9 @@ public final class Bzip2Decompressor extends InputBufferingDecompressor {
                     if (storedCombinedCRC != streamCRC) {
                         throw new DecompressionException("stream CRC error");
                     }
+                    if (reader.hasReadableBits(8)) {
+                        throw new DecompressionException("Unexpected data after end of stream");
+                    }
                     currentState = State.EOF;
                     break;
                 }

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/BackpressureDecompressionHandlerTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/BackpressureDecompressionHandlerTest.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.compression;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
@@ -141,6 +142,89 @@ class BackpressureDecompressionHandlerTest {
     }
 
     @Test
+    public void preservesReadFromChannelRead() {
+        ReadCounter readCounter = new ReadCounter();
+        EmbeddedChannel channel = new EmbeddedChannel(
+                readCounter,
+                new NumberToBuffer(),
+                BackpressureDecompressionHandler.builder(new MockDecompressor.Builder()
+                                .needInput()
+                                .needOutput(1)
+                                .needInput())
+                        .backpressureGaugeBuilder(BackpressureGauge.builder().messagesPerRead(1))
+                        .build(),
+                new BufferToNumber(),
+                new ReadOnOne()
+        );
+        channel.config().setAutoRead(false);
+
+        channel.writeInbound(0);
+
+        assertEquals(1, channel.<Integer>readInbound());
+        assertEquals(READ_COMPLETE, channel.readInbound());
+        assertNull(channel.readInbound());
+        assertEquals(1, readCounter.reads);
+
+        channel.finish();
+    }
+
+    @Test
+    public void preservesReadAfterCompletion() {
+        ReadCounter readCounter = new ReadCounter();
+        EmbeddedChannel channel = new EmbeddedChannel(
+                readCounter,
+                new NumberToBuffer(),
+                BackpressureDecompressionHandler.builder(new MockDecompressor.Builder()
+                                .needInput()
+                                .needOutput(1)
+                                .complete())
+                        .backpressureGaugeBuilder(BackpressureGauge.builder().messagesPerRead(1))
+                        .build(),
+                new BufferToNumber(),
+                new ReadOnOne()
+        );
+        channel.config().setAutoRead(false);
+
+        channel.writeInbound(0);
+
+        assertEquals(1, channel.<Integer>readInbound());
+        assertEquals(BackpressureDecompressionHandler.EndOfContentEvent.INSTANCE, channel.readInbound());
+        assertEquals(READ_COMPLETE, channel.readInbound());
+        assertNull(channel.readInbound());
+        assertEquals(1, readCounter.reads);
+
+        channel.finish();
+    }
+
+    @Test
+    public void reentrantReadIsSatisfiedByOutput() {
+        ReadCounter readCounter = new ReadCounter();
+        EmbeddedChannel channel = new EmbeddedChannel(
+                readCounter,
+                new NumberToBuffer(),
+                BackpressureDecompressionHandler.builder(new MockDecompressor.Builder()
+                                .needInput()
+                                .needOutput(2)
+                                .needInput())
+                        .backpressureGaugeBuilder(BackpressureGauge.builder().messagesPerRead(2))
+                        .build(),
+                new BufferToNumber(),
+                new ReadOnOne()
+        );
+        channel.config().setAutoRead(false);
+
+        channel.writeInbound(0);
+
+        assertEquals(1, channel.<Integer>readInbound());
+        assertEquals(2, channel.<Integer>readInbound());
+        assertEquals(READ_COMPLETE, channel.readInbound());
+        assertNull(channel.readInbound());
+        assertEquals(0, readCounter.reads);
+
+        channel.finish();
+    }
+
+    @Test
     public void handlerRemovalWhileResumingOutput() {
         BackpressureDecompressionHandler.Builder builder = BackpressureDecompressionHandler.builder(
                 new MockDecompressor.Builder().needInput().needOutput(2).complete());
@@ -237,6 +321,25 @@ class BackpressureDecompressionHandlerTest {
                 ctx.pipeline().remove(handler);
             }
             ctx.fireChannelRead(msg);
+        }
+    }
+
+    private static final class ReadOnOne extends ChannelInboundHandlerAdapter {
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+            if (Integer.valueOf(1).equals(msg)) {
+                ctx.read();
+            }
+            ctx.fireChannelRead(msg);
+        }
+    }
+
+    private static final class ReadCounter extends ChannelDuplexHandler {
+        private int reads;
+
+        @Override
+        public void read(ChannelHandlerContext ctx) throws Exception {
+            reads++;
         }
     }
 

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/BackpressureDecompressionHandlerTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/BackpressureDecompressionHandlerTest.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.compression;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -225,6 +226,89 @@ class BackpressureDecompressionHandlerTest {
     }
 
     @Test
+    public void boundsInputBytesWithoutOutput() {
+        InputOnRead input = new InputOnRead();
+        EmbeddedChannel channel = new EmbeddedChannel(
+                input,
+                BackpressureDecompressionHandler.builder(new MockDecompressor.Builder()
+                                .needInput()
+                                .needInput()
+                                .needInput())
+                        .backpressureGaugeBuilder(BackpressureGauge.builder()
+                                .messagesPerRead(64)
+                                .bytesPerRead(8))
+                        .build(),
+                new BufferToNumber()
+        );
+        channel.config().setAutoRead(false);
+
+        channel.read();
+
+        assertEquals(2, input.reads);
+        assertEquals(READ_COMPLETE, channel.readInbound());
+        assertNull(channel.readInbound());
+
+        channel.finish();
+    }
+
+    @Test
+    public void boundsEmptyInputWithoutOutput() {
+        EmptyInputOnRead input = new EmptyInputOnRead();
+        EmbeddedChannel channel = new EmbeddedChannel(
+                input,
+                BackpressureDecompressionHandler.builder(new MockDecompressor.Builder().needInput())
+                        .backpressureGaugeBuilder(BackpressureGauge.builder().messagesPerRead(2))
+                        .build(),
+                new BufferToNumber()
+        );
+        channel.config().setAutoRead(false);
+
+        channel.read();
+
+        assertEquals(2, input.reads);
+        assertEquals(READ_COMPLETE, channel.readInbound());
+        assertNull(channel.readInbound());
+
+        channel.finish();
+    }
+
+    @Test
+    public void forwardsReadCompleteWithoutOutputWithAutoRead() {
+        EmbeddedChannel channel = new EmbeddedChannel(
+                new NumberToBuffer(),
+                BackpressureDecompressionHandler.create(new MockDecompressor.Builder().needInput().needInput()),
+                new BufferToNumber()
+        );
+
+        channel.writeInbound(0);
+
+        assertEquals(READ_COMPLETE, channel.readInbound());
+        assertNull(channel.readInbound());
+
+        channel.finish();
+    }
+
+    @Test
+    public void preservesReadAfterEndOfInputWithoutOutput() {
+        ReadCounter readCounter = new ReadCounter();
+        EmbeddedChannel channel = new EmbeddedChannel(
+                readCounter,
+                BackpressureDecompressionHandler.create(new MockDecompressor.Builder()
+                        .needInput()
+                        .complete()),
+                new ReadOnEndOfContent()
+        );
+        channel.config().setAutoRead(false);
+
+        channel.pipeline().firstContext()
+                .fireUserEventTriggered(BackpressureDecompressionHandler.EndOfContentEvent.INSTANCE);
+
+        assertEquals(1, readCounter.reads);
+
+        channel.finish();
+    }
+
+    @Test
     public void handlerRemovalWhileResumingOutput() {
         BackpressureDecompressionHandler.Builder builder = BackpressureDecompressionHandler.builder(
                 new MockDecompressor.Builder().needInput().needOutput(2).complete());
@@ -340,6 +424,37 @@ class BackpressureDecompressionHandlerTest {
         @Override
         public void read(ChannelHandlerContext ctx) throws Exception {
             reads++;
+        }
+    }
+
+    private static final class ReadOnEndOfContent extends ChannelInboundHandlerAdapter {
+        @Override
+        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            if (evt == BackpressureDecompressionHandler.EndOfContentEvent.INSTANCE) {
+                ctx.read();
+            }
+            ctx.fireUserEventTriggered(evt);
+        }
+    }
+
+    private static final class InputOnRead extends ChannelDuplexHandler {
+        private int reads;
+
+        @Override
+        public void read(ChannelHandlerContext ctx) throws Exception {
+            ctx.fireChannelRead(numberedBuffer(reads++));
+            ctx.fireChannelReadComplete();
+        }
+    }
+
+    private static final class EmptyInputOnRead extends ChannelDuplexHandler {
+        private int reads;
+
+        @Override
+        public void read(ChannelHandlerContext ctx) throws Exception {
+            reads++;
+            ctx.fireChannelRead(Unpooled.EMPTY_BUFFER);
+            ctx.fireChannelReadComplete();
         }
     }
 

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/BackpressureDecompressionHandlerTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/BackpressureDecompressionHandlerTest.java
@@ -1,0 +1,330 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.netty.handler.codec.compression.Decompressor.Status.COMPLETE;
+import static io.netty.handler.codec.compression.Decompressor.Status.NEED_INPUT;
+import static io.netty.handler.codec.compression.Decompressor.Status.NEED_OUTPUT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class BackpressureDecompressionHandlerTest {
+    private static final String READ_COMPLETE = "readComplete";
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void maxMessages(boolean autoRead) {
+        EmbeddedChannel channel = new EmbeddedChannel(
+                new NumberToBuffer(),
+                BackpressureDecompressionHandler.builder(new MockDecompressor.Builder()
+                                .needInput()
+                                .needOutput(4)
+                                .complete())
+                        .backpressureGaugeBuilder(BackpressureGauge.builder().messagesPerRead(2))
+                        .build(),
+                new BufferToNumber()
+        );
+        channel.config().setAutoRead(autoRead);
+
+        channel.writeInbound(0);
+
+        assertEquals(1, channel.<Integer>readInbound());
+        assertEquals(2, channel.<Integer>readInbound());
+
+        if (!autoRead) {
+            assertEquals(READ_COMPLETE, channel.readInbound());
+
+            assertNull(channel.readInbound());
+            channel.read();
+        }
+
+        assertEquals(3, channel.<Integer>readInbound());
+        assertEquals(4, channel.<Integer>readInbound());
+        assertEquals(BackpressureDecompressionHandler.EndOfContentEvent.INSTANCE, channel.readInbound());
+        assertEquals(READ_COMPLETE, channel.readInbound());
+        assertNull(channel.readInbound());
+
+        channel.finish();
+    }
+
+    @Test
+    public void endOfInput() {
+        EmbeddedChannel channel = new EmbeddedChannel(
+                new NumberToBuffer(),
+                BackpressureDecompressionHandler.builder(new MockDecompressor.Builder()
+                                .needInput()
+                                .needOutput(1)
+                                .needInput()
+                                .needOutput(1)
+                                .complete())
+                        .backpressureGaugeBuilder(BackpressureGauge.builder().messagesPerRead(2))
+                        .build(),
+                new BufferToNumber()
+        );
+
+        channel.writeInbound(0);
+        assertEquals(1, channel.<Integer>readInbound());
+        assertEquals(READ_COMPLETE, channel.readInbound());
+
+        channel.pipeline().firstContext()
+                .fireUserEventTriggered(BackpressureDecompressionHandler.EndOfContentEvent.INSTANCE);
+
+        assertEquals(3, channel.<Integer>readInbound());
+        assertEquals(BackpressureDecompressionHandler.EndOfContentEvent.INSTANCE, channel.readInbound());
+        assertEquals(READ_COMPLETE, channel.readInbound());
+        assertNull(channel.readInbound());
+
+        channel.finish();
+    }
+
+    @Test
+    public void replaysHeldMessages() {
+        EmbeddedChannel channel = new EmbeddedChannel(
+                new NumberToBuffer(),
+                BackpressureDecompressionHandler.builder(new MockDecompressor.Builder()
+                                .needInput()
+                                .needOutput(2)
+                                .needInput()
+                                .needOutput(1)
+                                .complete())
+                        .backpressureGaugeBuilder(BackpressureGauge.builder().messagesPerRead(1))
+                        .build(),
+                new BufferToNumber()
+        );
+        channel.config().setAutoRead(false);
+
+        channel.writeInbound(0, 3);
+
+        assertEquals(1, channel.<Integer>readInbound());
+        assertEquals(READ_COMPLETE, channel.readInbound());
+        assertNull(channel.readInbound());
+
+        channel.read();
+
+        assertEquals(2, channel.<Integer>readInbound());
+        assertEquals(READ_COMPLETE, channel.readInbound());
+        assertNull(channel.readInbound());
+
+        channel.read();
+
+        assertEquals(4, channel.<Integer>readInbound());
+        assertEquals(BackpressureDecompressionHandler.EndOfContentEvent.INSTANCE, channel.readInbound());
+        assertEquals(READ_COMPLETE, channel.readInbound());
+        assertNull(channel.readInbound());
+
+        channel.finish();
+    }
+
+    @Test
+    public void handlerRemovalWhileResumingOutput() {
+        BackpressureDecompressionHandler.Builder builder = BackpressureDecompressionHandler.builder(
+                new MockDecompressor.Builder().needInput().needOutput(2).complete());
+        builder.backpressureGaugeBuilder(BackpressureGauge.builder().messagesPerRead(1));
+        BackpressureDecompressionHandler handler = builder.build();
+        EmbeddedChannel channel = new EmbeddedChannel(
+                new NumberToBuffer(), handler, new BufferToNumber(), new RemoveHandlerOnTwo(handler));
+        channel.config().setAutoRead(false);
+
+        channel.writeInbound(0);
+        assertEquals(1, channel.<Integer>readInbound());
+        assertEquals(READ_COMPLETE, channel.readInbound());
+
+        channel.read();
+
+        assertEquals(2, channel.<Integer>readInbound());
+        assertNull(channel.readInbound());
+        assertNull(channel.pipeline().context(handler));
+
+        channel.finish();
+    }
+
+    @Test
+    public void handlerRemovalOnStatusFailureWhileResumingOutput() {
+        BackpressureDecompressionHandler.Builder builder = BackpressureDecompressionHandler.builder(
+                new MockDecompressor.Builder()
+                        .needInput().needOutput(2).needInput().failStatusCall(9));
+        builder.backpressureGaugeBuilder(BackpressureGauge.builder().messagesPerRead(1));
+        BackpressureDecompressionHandler handler = builder.build();
+        EmbeddedChannel channel = new EmbeddedChannel(
+                new NumberToBuffer(), handler, new BufferToNumber(), new RemoveHandlerOnException(handler));
+        channel.config().setAutoRead(false);
+
+        channel.writeInbound(0);
+        assertEquals(1, channel.<Integer>readInbound());
+        assertEquals(READ_COMPLETE, channel.readInbound());
+
+        channel.read();
+
+        assertEquals(2, channel.<Integer>readInbound());
+        assertEquals(BackpressureDecompressionHandler.EndOfContentEvent.INSTANCE, channel.readInbound());
+        assertNull(channel.readInbound());
+        assertNull(channel.pipeline().context(handler));
+
+        channel.finish();
+    }
+
+    private static ByteBuf numberedBuffer(int index) {
+        ByteBuf buf = ByteBufAllocator.DEFAULT.buffer(4);
+        buf.writeInt(index);
+        return buf;
+    }
+
+    private static final class NumberToBuffer extends ChannelInboundHandlerAdapter {
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+            ctx.fireChannelRead(numberedBuffer((Integer) msg));
+        }
+    }
+
+    private static final class BufferToNumber extends ChannelInboundHandlerAdapter {
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+            ByteBuf buf = (ByteBuf) msg;
+            ctx.fireChannelRead(buf.readInt());
+            buf.release();
+        }
+
+        @Override
+        public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+            ctx.fireChannelRead(READ_COMPLETE);
+            ctx.fireChannelReadComplete();
+        }
+
+        @Override
+        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            if (evt == BackpressureDecompressionHandler.EndOfContentEvent.INSTANCE) {
+                ctx.fireChannelRead(BackpressureDecompressionHandler.EndOfContentEvent.INSTANCE);
+                ctx.fireChannelReadComplete();
+            }
+        }
+    }
+
+    private static final class RemoveHandlerOnTwo extends ChannelInboundHandlerAdapter {
+        private final BackpressureDecompressionHandler handler;
+
+        RemoveHandlerOnTwo(BackpressureDecompressionHandler handler) {
+            this.handler = handler;
+        }
+
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+            if (Integer.valueOf(2).equals(msg)) {
+                ctx.pipeline().remove(handler);
+            }
+            ctx.fireChannelRead(msg);
+        }
+    }
+
+    private static final class RemoveHandlerOnException extends ChannelInboundHandlerAdapter {
+        private final BackpressureDecompressionHandler handler;
+
+        RemoveHandlerOnException(BackpressureDecompressionHandler handler) {
+            this.handler = handler;
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+            ctx.pipeline().remove(handler);
+        }
+    }
+
+    private static final class MockDecompressor implements Decompressor {
+        private final List<Status> events;
+        private final int failStatusCall;
+        private int index;
+        private int statusCalls;
+
+        MockDecompressor(List<Status> events, int failStatusCall) {
+            this.events = events;
+            this.failStatusCall = failStatusCall;
+        }
+
+        @Override
+        public Status status() throws DecompressionException {
+            if (++statusCalls == failStatusCall) {
+                throw new DecompressionException("status failure");
+            }
+            return events.get(index);
+        }
+
+        @Override
+        public void addInput(ByteBuf buf) throws DecompressionException {
+            assertEquals(NEED_INPUT, status());
+            assertEquals(index++, buf.readInt());
+            buf.release();
+        }
+
+        @Override
+        public void endOfInput() throws DecompressionException {
+            assertEquals(NEED_INPUT, status());
+            index++;
+        }
+
+        @Override
+        public ByteBuf takeOutput() throws DecompressionException {
+            assertEquals(NEED_OUTPUT, status());
+            return numberedBuffer(index++);
+        }
+
+        @Override
+        public void close() throws DecompressionException {
+        }
+
+        static final class Builder extends AbstractDecompressorBuilder {
+            private final List<Status> events = new ArrayList<>();
+            private int failStatusCall = -1;
+
+            Builder needInput() {
+                events.add(NEED_INPUT);
+                return this;
+            }
+
+            Builder needOutput(int count) {
+                for (int i = 0; i < count; i++) {
+                    events.add(NEED_OUTPUT);
+                }
+                return this;
+            }
+
+            Builder complete() {
+                events.add(COMPLETE);
+                return this;
+            }
+
+            Builder failStatusCall(int failStatusCall) {
+                this.failStatusCall = failStatusCall;
+                return this;
+            }
+
+            @Override
+            public Decompressor build(ByteBufAllocator allocator) throws DecompressionException {
+                return new DefensiveDecompressor(new MockDecompressor(events, failStatusCall));
+            }
+        }
+    }
+}

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/BrotliDecoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/BrotliDecoderTest.java
@@ -20,6 +20,7 @@ import com.aayushatharva.brotli4j.encoder.BrotliOutputStream;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -82,7 +83,11 @@ public class BrotliDecoderTest {
 
     @BeforeEach
     public void initChannel() {
-        channel = new EmbeddedChannel(new BrotliDecoder());
+        channel = new EmbeddedChannel(createDecoder());
+    }
+
+    protected ChannelHandler createDecoder() {
+        return new BrotliDecoder();
     }
 
     @AfterEach

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/BrotliDecompressorHandlerIntegrationTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/BrotliDecompressorHandlerIntegrationTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+
+public class BrotliDecompressorHandlerIntegrationTest extends BrotliIntegrationTest {
+    @Override
+    protected EmbeddedChannel createDecoder() {
+        return new EmbeddedChannel(BackpressureDecompressionHandler.create(BrotliDecompressor.builder()));
+    }
+}

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/BrotliDecompressorHandlerTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/BrotliDecompressorHandlerTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.channel.ChannelHandler;
+
+public class BrotliDecompressorHandlerTest extends BrotliDecoderTest {
+    @Override
+    protected ChannelHandler createDecoder() {
+        return BackpressureDecompressionHandler.create(BrotliDecompressor.builder());
+    }
+}

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/Bzip2DecoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/Bzip2DecoderTest.java
@@ -31,7 +31,6 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class Bzip2DecoderTest extends AbstractDecoderTest {
 
@@ -51,14 +50,20 @@ public class Bzip2DecoderTest extends AbstractDecoderTest {
     }
 
     private void writeInboundDestroyAndExpectDecompressionException(ByteBuf in) {
+        RuntimeException writeFailure = null;
         try {
             channel.writeInbound(in);
+        } catch (RuntimeException e) {
+            writeFailure = e;
+            throw e;
         } finally {
             try {
                 destroyChannel();
-                fail();
-            } catch (DecompressionException ignored) {
-                // expected
+            } catch (RuntimeException e) {
+                if (writeFailure == null) {
+                    throw e;
+                }
+                writeFailure.addSuppressed(e);
             }
         }
     }

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/Bzip2DecompressorHandlerIntegrationTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/Bzip2DecompressorHandlerIntegrationTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+
+public class Bzip2DecompressorHandlerIntegrationTest extends Bzip2IntegrationTest {
+    @Override
+    protected EmbeddedChannel createDecoder() {
+        return new EmbeddedChannel(BackpressureDecompressionHandler.create(Bzip2Decompressor.builder()));
+    }
+}

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/Bzip2DecompressorHandlerTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/Bzip2DecompressorHandlerTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+
+public class Bzip2DecompressorHandlerTest extends Bzip2DecoderTest {
+
+    public Bzip2DecompressorHandlerTest() throws Exception {
+    }
+
+    @Override
+    protected EmbeddedChannel createChannel() {
+        return new EmbeddedChannel(BackpressureDecompressionHandler.create(Bzip2Decompressor.builder()));
+    }
+}

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/Bzip2DecompressorTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/Bzip2DecompressorTest.java
@@ -15,9 +15,11 @@
  */
 package io.netty.handler.codec.compression;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandler;
+import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -42,6 +44,35 @@ public class Bzip2DecompressorTest extends AbstractDecompressorTest {
 
             assertEquals(Decompressor.Status.NEED_INPUT, decompressor.status());
             assertThrows(DecompressionException.class, decompressor::endOfInput);
+        }
+    }
+
+    @Test
+    public void rejectsTrailingData() throws DecompressionException {
+        EmbeddedChannel encoder = new EmbeddedChannel(createCompressor());
+        ByteBuf compressed = Unpooled.buffer();
+        try {
+            encoder.writeOutbound(Unpooled.wrappedBuffer(new byte[] { 1 }));
+            encoder.finish();
+
+            ByteBuf encoded;
+            while ((encoded = encoder.readOutbound()) != null) {
+                compressed.writeBytes(encoded);
+                encoded.release();
+            }
+        } finally {
+            encoder.finishAndReleaseAll();
+        }
+        compressed.writeByte(0);
+
+        try (Decompressor decompressor = createDecompressor().build(ByteBufAllocator.DEFAULT)) {
+            assertEquals(Decompressor.Status.NEED_INPUT, decompressor.status());
+            decompressor.addInput(compressed);
+            assertThrows(DecompressionException.class, () -> {
+                while (decompressor.status() == Decompressor.Status.NEED_OUTPUT) {
+                    decompressor.takeOutput().release();
+                }
+            });
         }
     }
 }

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/FastLzDecompressorHandlerIntegrationTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/FastLzDecompressorHandlerIntegrationTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+
+public class FastLzDecompressorHandlerIntegrationTest extends FastLzIntegrationTest {
+    @Override
+    protected EmbeddedChannel createDecoder() {
+        return new EmbeddedChannel(BackpressureDecompressionHandler.create(
+                FastLzFrameDecompressor.builder().defaultChecksum()));
+    }
+}

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/JdkZlibDecompressorHandlerIntegrationTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/JdkZlibDecompressorHandlerIntegrationTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+
+public class JdkZlibDecompressorHandlerIntegrationTest extends JdkZlibIntegrationTest {
+    @Override
+    protected EmbeddedChannel createDecoder() {
+        return new EmbeddedChannel(BackpressureDecompressionHandler.create(JdkZlibDecompressor.builder()));
+    }
+}

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/Lz4FrameDecompressorHandlerIntegrationTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/Lz4FrameDecompressorHandlerIntegrationTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+
+public class Lz4FrameDecompressorHandlerIntegrationTest extends Lz4FrameIntegrationTest {
+    @Override
+    protected EmbeddedChannel createDecoder() {
+        return new EmbeddedChannel(BackpressureDecompressionHandler.create(
+                Lz4FrameDecompressor.builder().defaultChecksum()));
+    }
+}

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/Lz4FrameDecompressorHandlerTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/Lz4FrameDecompressorHandlerTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+
+public class Lz4FrameDecompressorHandlerTest extends Lz4FrameDecoderTest {
+
+    public Lz4FrameDecompressorHandlerTest() throws Exception {
+    }
+
+    @Override
+    protected EmbeddedChannel createChannel() {
+        return new EmbeddedChannel(BackpressureDecompressionHandler.create(
+                Lz4FrameDecompressor.builder().defaultChecksum()));
+    }
+}

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/LzfDecompressorHandlerIntegrationTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/LzfDecompressorHandlerIntegrationTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+
+public class LzfDecompressorHandlerIntegrationTest extends LzfIntegrationTest {
+    @Override
+    protected EmbeddedChannel createDecoder() {
+        return new EmbeddedChannel(BackpressureDecompressionHandler.create(LzfDecompressor.builder()));
+    }
+}

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/LzfDecompressorHandlerTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/LzfDecompressorHandlerTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+
+public class LzfDecompressorHandlerTest extends LzfDecoderTest {
+
+    public LzfDecompressorHandlerTest() throws Exception {
+    }
+
+    @Override
+    protected EmbeddedChannel createChannel() {
+        return new EmbeddedChannel(BackpressureDecompressionHandler.create(
+                LzfDecompressor.builder()));
+    }
+}

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/SnappyDecompressorHandlerIntegrationTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/SnappyDecompressorHandlerIntegrationTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+
+public class SnappyDecompressorHandlerIntegrationTest extends SnappyIntegrationTest {
+    @Override
+    protected EmbeddedChannel createDecoder() {
+        return new EmbeddedChannel(BackpressureDecompressionHandler.create(SnappyFrameDecompressor.builder()));
+    }
+}

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/SnappyDecompressorHandlerJumboSizeIntegrationTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/SnappyDecompressorHandlerJumboSizeIntegrationTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+
+public class SnappyDecompressorHandlerJumboSizeIntegrationTest extends SnappyJumboSizeIntegrationTest {
+    @Override
+    protected EmbeddedChannel createDecoder() {
+        return new EmbeddedChannel(BackpressureDecompressionHandler.create(SnappyFrameDecompressor.builder()));
+    }
+}

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/SnappyFrameDecoderTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/SnappyFrameDecoderTest.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.compression;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,7 +37,11 @@ public class SnappyFrameDecoderTest {
 
     @BeforeEach
     public void initChannel() {
-        channel = new EmbeddedChannel(new SnappyFrameDecoder());
+        channel = new EmbeddedChannel(createDecoder());
+    }
+
+    protected ChannelHandler createDecoder() {
+        return new SnappyFrameDecoder();
     }
 
     @AfterEach

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/SnappyFrameDecompressorHandlerTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/SnappyFrameDecompressorHandlerTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.channel.ChannelHandler;
+
+public class SnappyFrameDecompressorHandlerTest extends SnappyFrameDecoderTest {
+    @Override
+    protected ChannelHandler createDecoder() {
+        return BackpressureDecompressionHandler.create(SnappyFrameDecompressor.builder());
+    }
+}

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/ZstdDecompressorHandlerIntegrationTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/ZstdDecompressorHandlerIntegrationTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+
+public class ZstdDecompressorHandlerIntegrationTest extends ZstdIntegrationTest {
+    @Override
+    protected EmbeddedChannel createDecoder() {
+        return new EmbeddedChannel(BackpressureDecompressionHandler.create(ZstdDecompressor.builder()));
+    }
+}

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/ZstdDecompressorHandlerTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/ZstdDecompressorHandlerTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+
+public class ZstdDecompressorHandlerTest extends ZstdDecoderTest {
+
+    public ZstdDecompressorHandlerTest() throws Exception {
+    }
+
+    @Override
+    public EmbeddedChannel createChannel() {
+        return new EmbeddedChannel(BackpressureDecompressionHandler.create(ZstdDecompressor.builder()));
+    }
+}


### PR DESCRIPTION
Motivation:

The decompressor API migration in #15667 is being split into smaller, independently reviewable changes as tracked by #16743. The core API and decompressor implementations are available on 4.2, but the generic backpressure-aware handler infrastructure is not.

Modification:

* Add `BackpressureGauge`, `AbstractBackpressureDecompressionHandler`, and `BackpressureDecompressionHandler` from #15667.
* Preserve decompressor state and buffer ownership across manual reads, failures, end-of-input, and reentrant handler removal.
* Bound manual reads that consume compressed input without producing output.
* Add focused backpressure and read-complete tests.
* Run the existing FastLZ, Bzip2, Snappy, Brotli, JDK zlib, LZ4, LZF, and Zstd decoder/integration suites through the new handler.
* Keep the new APIs marked unstable while the migration is in progress.

Result:

Pull-based decompressors can be installed as channel handlers with bounded manual-read output and read-complete propagation. Existing 4.2 decompressor implementations are covered through the handler without adding HTTP/1.1, HTTP/2, or additional format work.

Verification:

`./mvnw -B -ntp -pl codec-compression -am verify -Dcheckstyle.skip=false`

All 11 reactor projects passed. `codec-compression` ran 700 tests with no failures or errors, and Checkstyle completed successfully. The nine newly added algorithm handler classes ran 93 focused tests with no failures, errors, or skips.

Part of #16743.