### PR TITLE
Fix MQTT 5 properties length decoding for multi-byte Property Length [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
@@ -854,6 +854,7 @@ public final class MqttDecoder extends ReplayingDecoder<DecoderState> {
         final long propertiesLength = decodeVariableByteInteger(buffer);
         int totalPropertiesLength = unpackA(propertiesLength);
         int numberOfBytesConsumed = unpackB(propertiesLength);
+        int propertiesEnd = totalPropertiesLength + numberOfBytesConsumed;
         if (totalPropertiesLength > 0) {
             // Force an early REPLAY when the buffer does not yet have the full properties block,
             // so we don't repeatedly parse partial properties as data arrives. A direct
@@ -865,7 +866,7 @@ public final class MqttDecoder extends ReplayingDecoder<DecoderState> {
         }
 
         MqttProperties decodedProperties = new MqttProperties();
-        while (numberOfBytesConsumed < totalPropertiesLength) {
+        while (numberOfBytesConsumed < propertiesEnd) {
             long propertyId = decodeVariableByteInteger(buffer);
             final int propertyIdValue = unpackA(propertyId);
             numberOfBytesConsumed += unpackB(propertyId);


### PR DESCRIPTION
### Motivation

Fixes #17105. When decoding an MQTT 5 PUBLISH whose Properties section is ≥ 128 bytes and ends with a single-byte-value property (e.g. Payload Format Indicator), the last property is not consumed: its 2 bytes leak into the beginning of the PUBLISH payload.

### Root cause

In `MqttDecoder.decodeProperties(ByteBuf)`, `numberOfBytesConsumed` is initialized to the number of bytes of the Property Length VBI (Variable Byte Integer), but the `while` loop condition compares it against `totalPropertiesLength`, which is the length of the property **content** only. As a result the loop reads `vbiBytes` fewer content bytes than it should.

### Modification

- Introduce a `propertiesEnd` variable that accounts for both the VBI length bytes and the content bytes.
- Change the loop condition from `numberOfBytesConsumed < totalPropertiesLength` to `numberOfBytesConsumed < propertiesEnd`.

### Result

With Property Length ≥ 128 (multi-byte VBI), the decoder correctly consumes all property bytes. Trailing single-byte-value properties (Payload Format Indicator, etc.) no longer leak into the application payload.

### Trigger conditions (both required)
1. Property Length ≥ 128 → the length VBI is ≥ 2 bytes.
2. The **last** property is a 2-byte "single-byte value" property (e.g. `PAYLOAD_FORMAT_INDICATOR`).