### PR TITLE
Avoid classloader leak via GlobalEventExecutor terminationFuture failure [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
@@ -88,7 +88,7 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor im
         threadFactory = ThreadExecutorMap.apply(new DefaultThreadFactory(
                 DefaultThreadFactory.toPoolName(getClass()), false, Thread.NORM_PRIORITY, null), this);
 
-        UnsupportedOperationException terminationFailure = new UnsupportedOperationException();
+        UnsupportedOperationException terminationFailure = new StacklessUnsupportedOperationException();
         ThrowableUtil.unknownStackTrace(terminationFailure, GlobalEventExecutor.class, "terminationFuture");
         terminationFuture = new FailedFuture<Object>(this, terminationFailure);
     }
@@ -325,6 +325,16 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor im
                     // -> keep this thread alive to handle the newly added entries.
                 }
             }
+        }
+    }
+
+    private static final class StacklessUnsupportedOperationException extends UnsupportedOperationException {
+
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public Throwable fillInStackTrace() {
+            return this;
         }
     }
 }


### PR DESCRIPTION
### Motivation

`GlobalEventExecutor.INSTANCE` is a static singleton that lives for the lifetime of the classloader that loaded it. Its `terminationFuture` holds a `FailedFuture` whose cause was a plain `UnsupportedOperationException`.

Although `ThrowableUtil.unknownStackTrace(...)` replaces the *visible* stack trace with a single synthetic frame, the exception internal (native) `backtrace` field is still populated at construction time by `fillInStackTrace()`. That backtrace pins the classloader of whatever thread happened to trigger the lazy initialization of `INSTANCE` (e.g. a web application WebAppClassLoader), making all of that classloader classes immortal/undeployable.

This is a follow-up to the leak fixed in #14622.

Fixes #17140

### Modification

Introduce a private `StacklessUnsupportedOperationException` whose `fillInStackTrace()` is a no-op, so the native backtrace is never captured, and use it for the `terminationFuture` failure. This mirrors the stackless-exception pattern already used throughout Netty.

### Result

The `terminationFuture` failure no longer retains a native backtrace, so it can no longer pin the triggering thread classloader.