### PR TITLE
Fix WebSocketServerHandshaker writing response at tail of pipeline

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
@@ -228,7 +228,7 @@ public abstract class WebSocketServerHandshaker {
             encoderName = p.context(HttpResponseEncoder.class).name();
             p.addBefore(encoderName, "wsencoder", newWebSocketEncoder());
         }
-        channel.writeAndFlush(response).addListener(future -> {
+        ctx.writeAndFlush(response).addListener(future -> {
             if (future.isSuccess()) {
                 ChannelPipeline p1 = channel.pipeline();
                 p1.remove(encoderName);


### PR DESCRIPTION
### Motivation

The `WebSocketServerHandshaker.handshake()` method writes its HTTP upgrade response to the `Channel` (tail of the pipeline) rather than the `ChannelHandlerContext`. This means all handlers positioned after `WebSocketServerProtocolHandler` in the pipeline unexpectedly receive the HTTP response message, which is both surprising and can cause problems for custom handlers that queue messages until the `HandshakeComplete` event fires.

### Modification

Changed `channel.writeAndFlush(response)` to `ctx.writeAndFlush(response)` in the `handshake()` method of `WebSocketServerHandshaker`. The `ctx` variable is already resolved earlier in the same method (from the `HttpRequestDecoder` or `HttpServerCodec` in the pipeline), so this change uses the correct context that represents the handshaker's position in the pipeline.

### Result

The WebSocket upgrade response is now written at the correct pipeline position (immediately before the `wsencoder`/`wsdecoder` handlers), rather than at the tail. Handlers after `WebSocketServerProtocolHandler` will no longer see the HTTP upgrade response message.

Closes #17141
