### PR TITLE
fix: handle NPE in clearReadPending when channel is deregistered before task runs (#17103) [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
@@ -261,11 +261,11 @@ public abstract class AbstractNioChannel extends AbstractChannel {
         }
 
         protected final void removeReadOp() {
-            IoRegistration registration = registration();
+            IoRegistration reg = registration;
             // Check first if the key is still valid as it may be canceled as part of the deregistration
             // from the EventLoop
             // See https://github.com/netty/netty/issues/2104
-            if (!registration.isValid()) {
+            if (reg == null || !reg.isValid()) {
                 return;
             }
             removeAndSubmit(readOps);


### PR DESCRIPTION
## Motivation

Fixes #17103. When `clearReadPending()` is called from outside the event loop, it checks `isRegistered()` which returns `true`. By the time the scheduled task runs inside the event loop, the channel may have been deregistered, setting the `registration` field to `null`. The `registration()` method (which asserts non-null) returns `null` in production (assertions disabled), causing a `NullPointerException` in `removeReadOp()`.

### Before (stack trace)


## Modification

In `AbstractNioUnsafe.removeReadOp()`, read the volatile `registration` field directly instead of calling `registration()` (which asserts non-null). If null, return early — there's no registration to modify.

## Result

No more NPE when `clearReadPending` task runs after channel deregistration. The behavior is safe: if the channel was deregistered, there's no read op to remove.

## Note

This is a race condition that occurs when:
1. `clearReadPending()` is called from outside the event loop
2. `isRegistered()` returns true
3. Before the scheduled task runs, the channel is closed/deregistered
4. The task runs and `registration` is now null