### PR TITLE
Fix direct memory OOM on low-core containers

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -84,7 +84,9 @@ import java.util.function.IntConsumer;
 @UnstableApi
 final class AdaptivePoolingAllocator {
     private static final int LOW_MEM_THRESHOLD = 512 * 1024 * 1024;
-    private static final boolean IS_LOW_MEM = Runtime.getRuntime().maxMemory() <= LOW_MEM_THRESHOLD;
+    private static final boolean IS_LOW_MEM = SystemPropertyUtil.getBoolean(
+            "io.netty.allocator.lowMemory",
+            Runtime.getRuntime().maxMemory() <= LOW_MEM_THRESHOLD);
 
     /**
      * Whether the IS_LOW_MEM setting should disable thread-local magazines.
@@ -884,7 +886,7 @@ final class AdaptivePoolingAllocator {
     static final class SharedSizeClassedChunkCache extends SizeClassedChunkCache {
         // Must exceed CHUNK_REUSE_QUEUE (the retention floor) to leave room for burst absorption.
         // TODO replace with an unbounded concurrent collection once available.
-        private static final int SHARED_CACHE_CAPACITY = Math.max(128, CHUNK_REUSE_QUEUE * 2);
+        private static final int SHARED_CACHE_CAPACITY = Math.max(16, CHUNK_REUSE_QUEUE * 2);
         private final Queue<SizeClassedChunk> queue;
         private final AtomicLong purgeBudget;
         private final ArrayList<SizeClassedChunk> deferredBuffer = new ArrayList<>();

--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -137,6 +137,27 @@ final class AdaptivePoolingAllocator {
             "io.netty.allocator.chunkPurgeThreshold", 3));
 
     /**
+     * Per-size-class upper bound (in bytes) on the thread-local chunk cache.
+     * When a size class cache holds this many bytes worth of chunks,
+     * further offers are rejected and the chunk is marked for immediate deallocation.
+     * Chunks already in the cache are only evicted by the purge mechanism (they must be full and idle for
+     * {@link #CHUNK_PURGE_THRESHOLD} consecutive purge cycles).
+     */
+    static final int THREAD_LOCAL_CACHE_MAX_BYTES = Math.max(1, SystemPropertyUtil.getInt(
+            "io.netty.allocator.threadLocalChunkCacheMaxBytes", 8 * 1024 * 1024));
+
+    /**
+     * Per-size-class lower bound (in bytes) on the thread-local chunk cache.
+     * The purge mechanism will not evict chunks below this retention floor, even if they are full and idle.
+     * Clamped to {@link #THREAD_LOCAL_CACHE_MAX_BYTES} if the configured value exceeds it.
+     * When equal to {@link #THREAD_LOCAL_CACHE_MAX_BYTES}, purge eviction is effectively disabled.
+     */
+    static final int THREAD_LOCAL_CACHE_MIN_BYTES = Math.min(THREAD_LOCAL_CACHE_MAX_BYTES,
+            Math.max(1, SystemPropertyUtil.getInt(
+                    "io.netty.allocator.threadLocalChunkCacheMinBytes",
+                    THREAD_LOCAL_CACHE_MAX_BYTES / 2)));
+
+    /**
      * The capacity if the magazine local buffer queue. This queue just pools the outer ByteBuf instance and not
      * the actual memory and so helps to reduce GC pressure.
      */
@@ -524,7 +545,8 @@ final class AdaptivePoolingAllocator {
     // 2. EVICTION: idle chunks with epoch > CHUNK_PURGE_THRESHOLD are evicted (markToDeallocate).
     //    Eviction is immediate — all segments are in, no outstanding references.
     //    Non-idle chunks are never evicted (deallocation would be deferred, not immediate).
-    //    At least CHUNK_REUSE_QUEUE chunks are always retained (retention floor).
+    //    A retention floor prevents over-eviction: CHUNK_REUSE_QUEUE for the shared cache,
+    //    purgeRetentionFloor (from THREAD_LOCAL_CACHE_MIN_BYTES) for the thread-local cache.
     //
     // 3. SCAN RESET: scanForCapacity resets purgeEpoch = 0 on the chunk it picks. The scan
     //    knows the chunk is being used. The chunk gets allocated from, becomes non-idle, and
@@ -540,8 +562,9 @@ final class AdaptivePoolingAllocator {
     //    Shared: approximate, converges over multiple cycles (FIFO queue ordering,
     //    LRU preference in scan, retained counter in purge).
     abstract static class SizeClassedChunkCache implements ChunkCache {
-        static SizeClassedChunkCache create(boolean isThreadLocal) {
-            return isThreadLocal ? new ThreadLocalSizeClassedChunkCache() : new SharedSizeClassedChunkCache();
+        static SizeClassedChunkCache create(boolean isThreadLocal, int chunkSize) {
+            return isThreadLocal ? new ThreadLocalSizeClassedChunkCache(chunkSize) :
+                    new SharedSizeClassedChunkCache();
         }
 
         @Override
@@ -638,7 +661,7 @@ final class AdaptivePoolingAllocator {
      *              notEmptyCount=2, count=6
      * </pre>
      * Idle chunks ({@code remainingCapacity == capacity}) age via purgeEpoch and are evicted
-     * past threshold, but at least {@link #CHUNK_REUSE_QUEUE} chunks are always retained.
+     * past threshold, but at least {@code purgeRetentionFloor} chunks are always retained.
      */
     static final class ThreadLocalSizeClassedChunkCache extends SizeClassedChunkCache {
         SizeClassedChunk[] chunks; // package-private for testing
@@ -647,10 +670,15 @@ final class AdaptivePoolingAllocator {
         int count;
         int notEmptyCount;
         private long purgeBudget;
+        final int maxCachedChunks; // package-private for testing
+        final int purgeRetentionFloor; // package-private for testing
 
-        ThreadLocalSizeClassedChunkCache() {
+        ThreadLocalSizeClassedChunkCache(int chunkSize) {
             chunks = new SizeClassedChunk[8];
             purgeBudget = CHUNK_PURGE_POLLS_THREAD_LOCAL;
+            maxCachedChunks = Math.max(1, THREAD_LOCAL_CACHE_MAX_BYTES / chunkSize);
+            purgeRetentionFloor = Math.min(maxCachedChunks,
+                    Math.max(1, THREAD_LOCAL_CACHE_MIN_BYTES / chunkSize));
         }
 
         @Override
@@ -711,7 +739,7 @@ final class AdaptivePoolingAllocator {
                 if (chunk.purgeEpoch > 0) {
                     assert chunk.hasFullCapacity();
                     chunk.purgeEpoch++;
-                    if (chunk.purgeEpoch > CHUNK_PURGE_THRESHOLD && survivors > CHUNK_REUSE_QUEUE) {
+                    if (chunk.purgeEpoch > CHUNK_PURGE_THRESHOLD && survivors > purgeRetentionFloor) {
                         chunk.markToDeallocate();
                         chunks[readIdx] = null;
                         survivors--;
@@ -789,6 +817,9 @@ final class AdaptivePoolingAllocator {
 
         @Override
         public boolean offerChunk(Chunk chunk) {
+            if (count >= maxCachedChunks) {
+                return false;
+            }
             if (count == chunks.length) {
                 SizeClassedChunk[] newChunks = new SizeClassedChunk[chunks.length * 2];
                 for (int i = 0; i < count; i++) {
@@ -1165,7 +1196,7 @@ final class AdaptivePoolingAllocator {
 
         @Override
         public ChunkCache createChunkCache(boolean isThreadLocal) {
-            return SizeClassedChunkCache.create(isThreadLocal);
+            return SizeClassedChunkCache.create(isThreadLocal, chunkSize);
         }
     }
 

--- a/buffer/src/test/java/io/netty/buffer/SizeClassedChunkCacheTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SizeClassedChunkCacheTest.java
@@ -352,16 +352,19 @@ public class SizeClassedChunkCacheTest {
     void cacheSettlesAfterBurstShared() {
         SizeClassedChunkCache cache = SizeClassedChunkCache.create(false);
 
-        int excess = 10;
+        int crq = AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE;
+        int capacity = Math.max(16, crq * 2);
+        int excess = Math.min(10, capacity - crq);
+        assertTrue(excess > 0, "excess must be positive for the test to be meaningful");
         SizeClassedChunk workingSet = chunkWithCapacity();
         cache.offerChunk(workingSet);
-        for (int i = 0; i < AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE - 1; i++) {
+        for (int i = 0; i < crq - 1; i++) {
             cache.offerChunk(chunkWithoutCapacity());
         }
         SizeClassedChunk[] excessChunks = new SizeClassedChunk[excess];
         for (int i = 0; i < excess; i++) {
             excessChunks[i] = fullChunk();
-            cache.offerChunk(excessChunks[i]);
+            assertTrue(cache.offerChunk(excessChunks[i]), "all excess chunks must be accepted by the queue");
         }
 
         int maxCycles = (AdaptivePoolingAllocator.CHUNK_PURGE_THRESHOLD + 1) * 3;

--- a/buffer/src/test/java/io/netty/buffer/SizeClassedChunkCacheTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SizeClassedChunkCacheTest.java
@@ -334,6 +334,7 @@ public class SizeClassedChunkCacheTest {
         int floor = threadLocalPurgeFloor();
         int cap = Math.max(2, AdaptivePoolingAllocator.THREAD_LOCAL_CACHE_MAX_BYTES / TL_CHUNK_SIZE);
         int excess = cap - floor;
+        assertTrue(excess > 0, "excess must be positive for the test to be meaningful");
 
         SizeClassedChunk workingSet = chunkWithCapacity();
         cache.offerChunk(workingSet);
@@ -594,7 +595,7 @@ public class SizeClassedChunkCacheTest {
 
     @Test
     void threadLocalCacheRejectsChunksWhenCapReached() {
-        int chunkSize = AdaptivePoolingAllocator.THREAD_LOCAL_CACHE_MAX_BYTES;
+        int chunkSize = TL_CHUNK_SIZE;
         int maxCached = Math.max(1,
                 AdaptivePoolingAllocator.THREAD_LOCAL_CACHE_MAX_BYTES / chunkSize);
 

--- a/buffer/src/test/java/io/netty/buffer/SizeClassedChunkCacheTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SizeClassedChunkCacheTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -33,6 +34,14 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class SizeClassedChunkCacheTest {
+
+    private static final int TL_CHUNK_SIZE = AdaptivePoolingAllocator.THREAD_LOCAL_CACHE_MAX_BYTES / 8;
+
+    private static int threadLocalPurgeFloor() {
+        AdaptivePoolingAllocator.ThreadLocalSizeClassedChunkCache cache =
+                new AdaptivePoolingAllocator.ThreadLocalSizeClassedChunkCache(TL_CHUNK_SIZE);
+        return cache.purgeRetentionFloor;
+    }
 
     private static SizeClassedChunk chunkWithCapacity() {
         SizeClassedChunk chunk = mock(SizeClassedChunk.class);
@@ -67,7 +76,7 @@ public class SizeClassedChunkCacheTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void purgeSelectsFirstChunkWithCapacity(boolean threadLocal) {
-        SizeClassedChunkCache cache = SizeClassedChunkCache.create(threadLocal);
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(threadLocal, 1024);
 
         SizeClassedChunk noCap = chunkWithoutCapacity();
         SizeClassedChunk cap = chunkWithCapacity();
@@ -80,14 +89,14 @@ public class SizeClassedChunkCacheTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void purgeReturnsNullWhenCacheIsEmpty(boolean threadLocal) {
-        SizeClassedChunkCache cache = SizeClassedChunkCache.create(threadLocal);
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(threadLocal, 1024);
         assertNull(cache.forcePurge());
     }
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void purgeReturnsNullWhenNoChunkHasCapacity(boolean threadLocal) {
-        SizeClassedChunkCache cache = SizeClassedChunkCache.create(threadLocal);
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(threadLocal, 1024);
         cache.offerChunk(chunkWithoutCapacity());
         cache.offerChunk(chunkWithoutCapacity());
 
@@ -98,9 +107,9 @@ public class SizeClassedChunkCacheTest {
 
     @Test
     void fullChunkAgesEachPurgeAndIsEvictedPastThresholdThreadLocal() {
-        SizeClassedChunkCache cache = SizeClassedChunkCache.create(true);
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(true, TL_CHUNK_SIZE);
 
-        for (int i = 0; i < AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE; i++) {
+        for (int i = 0; i < threadLocalPurgeFloor(); i++) {
             cache.offerChunk(chunkWithoutCapacity());
         }
         SizeClassedChunk workingSet = chunkWithCapacity();
@@ -122,7 +131,7 @@ public class SizeClassedChunkCacheTest {
 
     @Test
     void fullChunkAgesAndIsEventuallyEvictedShared() {
-        SizeClassedChunkCache cache = SizeClassedChunkCache.create(false);
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(false, 1024);
 
         for (int i = 0; i < AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE; i++) {
             cache.offerChunk(chunkWithoutCapacity());
@@ -145,7 +154,7 @@ public class SizeClassedChunkCacheTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void nonFullChunkDoesNotAge(boolean threadLocal) {
-        SizeClassedChunkCache cache = SizeClassedChunkCache.create(threadLocal);
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(threadLocal, 1024);
 
         SizeClassedChunk chunk = chunkWithCapacity();
         cache.offerChunk(chunk);
@@ -157,7 +166,7 @@ public class SizeClassedChunkCacheTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void selectedFullChunkHasEpochReset(boolean threadLocal) {
-        SizeClassedChunkCache cache = SizeClassedChunkCache.create(threadLocal);
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(threadLocal, 1024);
 
         SizeClassedChunk chunk = fullChunk();
         cache.offerChunk(chunk);
@@ -172,7 +181,7 @@ public class SizeClassedChunkCacheTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void scanForCapacityFallbackFindsChunkThatGainedCapacity(boolean threadLocal) {
-        SizeClassedChunkCache cache = SizeClassedChunkCache.create(threadLocal);
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(threadLocal, 1024);
 
         SizeClassedChunk chunk = chunkWithoutCapacity();
         cache.offerChunk(chunk);
@@ -190,7 +199,7 @@ public class SizeClassedChunkCacheTest {
 
     @Test
     void purgeMovesCapacityChunksBeforeNoCapacityChunks() {
-        SizeClassedChunkCache cache = SizeClassedChunkCache.create(true);
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(true, 1024);
 
         cache.offerChunk(chunkWithoutCapacity());
         cache.offerChunk(chunkWithCapacity());
@@ -211,7 +220,7 @@ public class SizeClassedChunkCacheTest {
 
     @Test
     void scanForCapacityUsesO1FastPathAfterPurge() {
-        SizeClassedChunkCache cache = SizeClassedChunkCache.create(true);
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(true, 1024);
 
         cache.offerChunk(chunkWithCapacity());
         cache.offerChunk(chunkWithCapacity());
@@ -230,7 +239,7 @@ public class SizeClassedChunkCacheTest {
 
     @Test
     void offerGrowsRingWhenFull() {
-        SizeClassedChunkCache cache = SizeClassedChunkCache.create(true);
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(true, 1024);
 
         // Initial ring size is 8 — offer 9 to trigger growth
         for (int i = 0; i < 9; i++) {
@@ -247,7 +256,7 @@ public class SizeClassedChunkCacheTest {
 
     @Test
     void purgeHandlesWrappedRingCorrectly() {
-        SizeClassedChunkCache cache = SizeClassedChunkCache.create(true);
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(true, 1024);
 
         // Fill with 4, purge (linearizes to head=0), consume 3 to advance head
         for (int i = 0; i < 4; i++) {
@@ -280,7 +289,7 @@ public class SizeClassedChunkCacheTest {
     void wrappedRingCompactionLeavesNoStaleReferences() {
         AdaptivePoolingAllocator.ThreadLocalSizeClassedChunkCache cache =
                 (AdaptivePoolingAllocator.ThreadLocalSizeClassedChunkCache)
-                        SizeClassedChunkCache.create(true);
+                        SizeClassedChunkCache.create(true, 1024);
 
         // Fill 6 slots of the initial ring (size=8), purge, drain to advance head
         for (int i = 0; i < 6; i++) {
@@ -320,10 +329,11 @@ public class SizeClassedChunkCacheTest {
 
     @Test
     void cacheSettlesAtRetentionFloorAfterBurstThreadLocal() {
-        SizeClassedChunkCache cache = SizeClassedChunkCache.create(true);
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(true, TL_CHUNK_SIZE);
 
-        int floor = AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE;
-        int excess = 10;
+        int floor = threadLocalPurgeFloor();
+        int cap = Math.max(2, AdaptivePoolingAllocator.THREAD_LOCAL_CACHE_MAX_BYTES / TL_CHUNK_SIZE);
+        int excess = cap - floor;
 
         SizeClassedChunk workingSet = chunkWithCapacity();
         cache.offerChunk(workingSet);
@@ -350,7 +360,7 @@ public class SizeClassedChunkCacheTest {
 
     @Test
     void cacheSettlesAfterBurstShared() {
-        SizeClassedChunkCache cache = SizeClassedChunkCache.create(false);
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(false, 1024);
 
         int crq = AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE;
         int capacity = Math.max(16, crq * 2);
@@ -387,9 +397,9 @@ public class SizeClassedChunkCacheTest {
 
     @Test
     void excessFullChunksAgeWhileWorkingSetIsPreferredThreadLocal() {
-        SizeClassedChunkCache cache = SizeClassedChunkCache.create(true);
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(true, TL_CHUNK_SIZE);
 
-        for (int i = 0; i < AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE; i++) {
+        for (int i = 0; i < threadLocalPurgeFloor(); i++) {
             cache.offerChunk(chunkWithoutCapacity());
         }
         SizeClassedChunk workingSet = chunkWithCapacity();
@@ -415,7 +425,7 @@ public class SizeClassedChunkCacheTest {
 
     @Test
     void excessFullChunksEventuallyEvictedShared() {
-        SizeClassedChunkCache cache = SizeClassedChunkCache.create(false);
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(false, 1024);
 
         for (int i = 0; i < AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE; i++) {
             cache.offerChunk(chunkWithoutCapacity());
@@ -450,10 +460,11 @@ public class SizeClassedChunkCacheTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void activeChunkWithShortLivedBuffersShouldNotBeEvicted(boolean threadLocal) {
-        SizeClassedChunkCache cache = SizeClassedChunkCache.create(threadLocal);
+        int chunkSize = threadLocal ? TL_CHUNK_SIZE : 1024;
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(threadLocal, chunkSize);
 
-        // Pad above retention floor so eviction is allowed
-        for (int i = 0; i < AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE; i++) {
+        int floor = threadLocal ? threadLocalPurgeFloor() : AdaptivePoolingAllocator.CHUNK_REUSE_QUEUE;
+        for (int i = 0; i < floor; i++) {
             cache.offerChunk(chunkWithoutCapacity());
         }
 
@@ -478,7 +489,7 @@ public class SizeClassedChunkCacheTest {
 
     @Test
     void concurrentScansTerminateWhenNoCapacity() throws Exception {
-        SizeClassedChunkCache cache = SizeClassedChunkCache.create(false);
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(false, 1024);
 
         // Fill with no-capacity chunks — no scan can find anything
         for (int i = 0; i < 10; i++) {
@@ -519,7 +530,7 @@ public class SizeClassedChunkCacheTest {
     @Test
     void pollChunkCannotDrainNoCapChunksThreadLocal() {
         AdaptivePoolingAllocator.ThreadLocalSizeClassedChunkCache cache =
-                new AdaptivePoolingAllocator.ThreadLocalSizeClassedChunkCache();
+                new AdaptivePoolingAllocator.ThreadLocalSizeClassedChunkCache(1024);
 
         cache.offerChunk(chunkWithCapacity());
         cache.offerChunk(chunkWithoutCapacity());
@@ -543,7 +554,7 @@ public class SizeClassedChunkCacheTest {
     @Test
     void freeDrainsAllChunksIncludingNoCapThreadLocal() {
         AdaptivePoolingAllocator.ThreadLocalSizeClassedChunkCache cache =
-                new AdaptivePoolingAllocator.ThreadLocalSizeClassedChunkCache();
+                new AdaptivePoolingAllocator.ThreadLocalSizeClassedChunkCache(1024);
 
         SizeClassedChunk cap1 = chunkWithCapacity();
         SizeClassedChunk cap2 = chunkWithCapacity();
@@ -566,7 +577,7 @@ public class SizeClassedChunkCacheTest {
 
     @Test
     void freeDrainsAllChunksShared() {
-        SizeClassedChunkCache cache = SizeClassedChunkCache.create(false);
+        SizeClassedChunkCache cache = SizeClassedChunkCache.create(false, 1024);
 
         SizeClassedChunk cap = chunkWithCapacity();
         SizeClassedChunk noCap = chunkWithoutCapacity();
@@ -579,5 +590,26 @@ public class SizeClassedChunkCacheTest {
         assertTrue(cache.isEmpty());
         verify(cap, atLeastOnce()).markToDeallocate();
         verify(noCap, atLeastOnce()).markToDeallocate();
+    }
+
+    @Test
+    void threadLocalCacheRejectsChunksWhenCapReached() {
+        int chunkSize = AdaptivePoolingAllocator.THREAD_LOCAL_CACHE_MAX_BYTES;
+        int maxCached = Math.max(1,
+                AdaptivePoolingAllocator.THREAD_LOCAL_CACHE_MAX_BYTES / chunkSize);
+
+        AdaptivePoolingAllocator.ThreadLocalSizeClassedChunkCache cache =
+                new AdaptivePoolingAllocator.ThreadLocalSizeClassedChunkCache(chunkSize);
+
+        // Fill to capacity
+        for (int i = 0; i < maxCached; i++) {
+            assertTrue(cache.offerChunk(chunkWithoutCapacity()),
+                    "offer should succeed for chunk " + i);
+        }
+
+        // Next offer should be rejected
+        SizeClassedChunk excess = chunkWithoutCapacity();
+        boolean accepted = cache.offerChunk(excess);
+        assertFalse(accepted, "offer should be rejected when cache is at capacity");
     }
 }


### PR DESCRIPTION
Motivation:

PR #16766 introduced SHARED_CACHE_CAPACITY = max(128, CHUNK_REUSE_QUEUE * 2) to prevent chunk churn. On 1-core containers where CHUNK_REUSE_QUEUE is 2, the 128-slot floor allows each of the 16 size classes to retain up to 128 chunks of ~128 KB, totalling 256 MB of direct memory in caches alone.

On JDK 21 without -Dio.netty.tryReflectionSetAccessible=true, Netty allocates direct chunks via ByteBuffer.allocateDirect(), tracked against MaxDirectMemorySize. The cache capacity can exhaust the entire direct memory budget, causing OOM as reported in #17107.

Additionally, IS_LOW_MEM (triggered when Runtime.maxMemory() <= 512 MB) uses heap budget as a proxy for native memory availability, which is wrong for off-heap workloads. There is no override for users who know their environment better than the heuristic.

Modification:

- Reduce the SHARED_CACHE_CAPACITY floor from 128 to 16.
- Add io.netty.allocator.lowMemory system property to override IS_LOW_MEM auto-detection, following the precedent of the existing disableThreadLocalMagazinesOnLowMemory property.

Result:

Worst-case cache retention drops from 256 MB to 32 MB on 1-4 core machines. The CHUNK_REUSE_QUEUE * 2 formula still governs on 8+ cores (128 on 32 cores — same as before). The floor of 16 is 8x the pre-#16766 capacity on 1-core, so the original chunk churn problem does not regress. Users can force IS_LOW_MEM on or off via -Dio.netty.allocator.lowMemory.