### PR TITLE
Port: Codec-compression: Add BrotliDecompressor

### DIFF
--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/BrotliDecompressor.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/BrotliDecompressor.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import com.aayushatharva.brotli4j.decoder.DecoderJNI;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.internal.ObjectUtil;
+import io.netty.util.internal.UnstableApi;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * Decompresses a {@link ByteBuf} encoded with the brotli format.
+ *
+ * See <a href="https://github.com/google/brotli">brotli</a>.
+ */
+@UnstableApi
+public final class BrotliDecompressor implements Decompressor {
+    private final ByteBufAllocator allocator;
+    private DecoderJNI.Wrapper decoder;
+    private ByteBuf unusedInput;
+
+    static {
+        try {
+            Brotli.ensureAvailability();
+        } catch (Throwable throwable) {
+            throw new ExceptionInInitializerError(throwable);
+        }
+    }
+
+    BrotliDecompressor(Builder builder, ByteBufAllocator allocator) throws DecompressionException {
+        this.allocator = allocator;
+        try {
+            this.decoder = new DecoderJNI.Wrapper(builder.inputBufferSize, builder.maxOutputChunkSize);
+        } catch (IOException ioe) {
+            throw new DecompressionException(ioe);
+        }
+    }
+
+    @Override
+    public Status status() throws DecompressionException {
+        while (true) {
+            switch (decoder.getStatus()) {
+                case ERROR:
+                    throw new DecompressionException("Brotli error status");
+                case DONE:
+                    return Status.COMPLETE;
+                case NEEDS_MORE_INPUT:
+                    if (decoder.hasOutput()) {
+                        return Status.NEED_OUTPUT;
+                    }
+                    if (unusedInput == null) {
+                        return Status.NEED_INPUT;
+                    }
+                    addSomeInput(unusedInput);
+                    if (!unusedInput.isReadable()) {
+                        unusedInput.release();
+                        unusedInput = null;
+                    }
+                    break;
+                case OK:
+                    decoder.push(0);
+                    break;
+                case NEEDS_MORE_OUTPUT:
+                    return Status.NEED_OUTPUT;
+                default:
+                    throw new AssertionError("Unknown status: " + decoder.getStatus());
+            }
+        }
+    }
+
+    @Override
+    public void addInput(ByteBuf buf) throws DecompressionException {
+        try {
+            if (unusedInput != null) {
+                throw new IllegalStateException("Not in state NEED_INPUT");
+            }
+            addSomeInput(buf);
+        } catch (Throwable t) {
+            buf.release();
+            throw t;
+        }
+        if (buf.isReadable()) {
+            this.unusedInput = buf;
+        } else {
+            buf.release();
+        }
+    }
+
+    private void addSomeInput(ByteBuf buf) {
+        ByteBuffer decoderInputBuffer = decoder.getInputBuffer();
+        decoderInputBuffer.clear();
+        int readBytes = readBytes(buf, decoderInputBuffer);
+        decoder.push(readBytes);
+    }
+
+    @Override
+    public void endOfInput() throws DecompressionException {
+        if (decoder.getStatus() == DecoderJNI.Status.NEEDS_MORE_INPUT) {
+            assert unusedInput == null : "Expected to be in NEED_INPUT state";
+            decoder.push(0);
+            if (decoder.getStatus() == DecoderJNI.Status.NEEDS_MORE_INPUT) {
+                throw new DecompressionException("Truncated brotli stream");
+            }
+        }
+    }
+
+    @Override
+    public ByteBuf takeOutput() throws DecompressionException {
+        ByteBuffer nativeBuffer = decoder.pull();
+        // nativeBuffer actually wraps brotli's internal buffer so we need to copy its content
+        // size limited by maxOutputChunkSize
+        ByteBuf copy = allocator.buffer(nativeBuffer.remaining());
+        copy.writeBytes(nativeBuffer);
+        return copy;
+    }
+
+    @Override
+    public void close() {
+        if (decoder != null) {
+            decoder.destroy();
+            decoder = null;
+        }
+        if (unusedInput != null) {
+            unusedInput.release();
+            unusedInput = null;
+        }
+    }
+
+    private static int readBytes(ByteBuf in, ByteBuffer dest) {
+        int limit = Math.min(in.readableBytes(), dest.remaining());
+        ByteBuffer slice = dest.slice();
+        slice.limit(limit);
+        in.readBytes(slice);
+        dest.position(dest.position() + limit);
+        return limit;
+    }
+
+    @UnstableApi
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @UnstableApi
+    public static final class Builder extends AbstractDecompressorBuilder {
+        private int inputBufferSize = 8 * 1024;
+        private int maxOutputChunkSize = 64 * 1024;
+
+        Builder() {
+        }
+
+        /**
+         * Desired size of the input buffer in bytes. Default 8K.
+         *
+         * @param inputBufferSize desired size of the input buffer in bytes
+         * @return This builder
+         */
+        public Builder inputBufferSize(int inputBufferSize) {
+            this.inputBufferSize = ObjectUtil.checkPositive(inputBufferSize, "inputBufferSize");
+            return this;
+        }
+
+        /**
+         * Number of bytes of output to consume at a time. Default 64K.
+         *
+         * @param maxOutputChunkSize Maximum output chunk size
+         * @return This builder
+         */
+        public Builder maxOutputChunkSize(int maxOutputChunkSize) {
+            this.maxOutputChunkSize = ObjectUtil.checkPositive(maxOutputChunkSize, "maxOutputChunkSize");
+            return this;
+        }
+
+        @Override
+        public Decompressor build(ByteBufAllocator allocator) throws DecompressionException {
+            return new DefensiveDecompressor(new BrotliDecompressor(this, allocator));
+        }
+    }
+}

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/BrotliEncoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/BrotliEncoder.java
@@ -249,14 +249,13 @@ public final class BrotliEncoder extends MessageToByteEncoder<ByteBuf> {
                 return;
             }
             closeInitiated = true;
-            final Promise<Void> promise = ctx.newPromise();
             ctx.executor().execute(new Runnable() {
                 @Override
                 public void run() {
                     try {
-                        finish(promise);
+                        finish(closeFuture);
                     } catch (IOException ex) {
-                        promise.setFailure(new IllegalStateException("Failed to finish encoding", ex));
+                        closeFuture.setFailure(new IllegalStateException("Failed to finish encoding", ex));
                     }
                 }
             });

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/BrotliEncoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/BrotliEncoder.java
@@ -186,6 +186,7 @@ public final class BrotliEncoder extends MessageToByteEncoder<ByteBuf> {
      */
     private static final class Writer implements WritableByteChannel {
 
+        private final Promise<Void> closeFuture;
         private ByteBuf writableBuffer;
         private final BrotliEncoderChannel brotliEncoderChannel;
         private final ChannelHandlerContext ctx;

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/BrotliEncoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/BrotliEncoder.java
@@ -165,8 +165,11 @@ public final class BrotliEncoder extends MessageToByteEncoder<ByteBuf> {
         }
 
         if (writer != null) {
+            writer.closeFuture.addHandler(promise);
             writer.close();
             this.writer = null;
+        } else {
+            promise.setSuccess(null);
         }
     }
 
@@ -186,11 +189,13 @@ public final class BrotliEncoder extends MessageToByteEncoder<ByteBuf> {
         private ByteBuf writableBuffer;
         private final BrotliEncoderChannel brotliEncoderChannel;
         private final ChannelHandlerContext ctx;
+        private final Promise<Void> closeFuture;
         private boolean isClosed;
 
         private Writer(Encoder.Parameters parameters, ChannelHandlerContext ctx) throws IOException {
             brotliEncoderChannel = new BrotliEncoderChannel(this, parameters);
             this.ctx = ctx;
+            this.closeFuture = ctx.newPromise();
         }
 
         private void encode(ByteBuf msg, boolean preferDirect) throws Exception {
@@ -239,16 +244,11 @@ public final class BrotliEncoder extends MessageToByteEncoder<ByteBuf> {
 
         @Override
         public void close() {
-            final Promise<Void> promise = ctx.newPromise();
-
-            ctx.executor().execute(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        finish(promise);
-                    } catch (IOException ex) {
-                        promise.setFailure(new IllegalStateException("Failed to finish encoding", ex));
-                    }
+            ctx.executor().execute(() -> {
+                try {
+                    finish(closeFuture);
+                } catch (IOException ex) {
+                    closeFuture.setFailure(new IllegalStateException("Failed to finish encoding", ex));
                 }
             });
         }

--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/BrotliEncoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/BrotliEncoder.java
@@ -190,6 +190,7 @@ public final class BrotliEncoder extends MessageToByteEncoder<ByteBuf> {
         private final BrotliEncoderChannel brotliEncoderChannel;
         private final ChannelHandlerContext ctx;
         private final Promise<Void> closeFuture;
+        private boolean closeInitiated;
         private boolean isClosed;
 
         private Writer(Encoder.Parameters parameters, ChannelHandlerContext ctx) throws IOException {
@@ -244,6 +245,10 @@ public final class BrotliEncoder extends MessageToByteEncoder<ByteBuf> {
 
         @Override
         public void close() {
+            if (closeInitiated) {
+                return;
+            }
+            closeInitiated = true;
             ctx.executor().execute(() -> {
                 try {
                     finish(closeFuture);

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/BrotliDecompressorTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/BrotliDecompressorTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2025 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelHandler;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class BrotliDecompressorTest extends AbstractDecompressorTest {
+    @Override
+    protected ChannelHandler createCompressor() {
+        return new BrotliEncoder();
+    }
+
+    @Override
+    protected Decompressor.AbstractDecompressorBuilder createDecompressor() {
+        return BrotliDecompressor.builder();
+    }
+
+    @Test
+    public void reportsOutputBeforeMoreInput() throws Exception {
+        ByteBuf[] data = largeData();
+
+        try (Decompressor decompressor = createDecompressor().build(ByteBufAllocator.DEFAULT)) {
+            assertEquals(Decompressor.Status.NEED_INPUT, decompressor.status());
+            decompressor.addInput(data[0]);
+            data[0] = null;
+
+            assertEquals(Decompressor.Status.NEED_OUTPUT, decompressor.status());
+            decompressor.takeOutput().release();
+        } finally {
+            for (ByteBuf buffer : data) {
+                if (buffer != null) {
+                    buffer.release();
+                }
+            }
+        }
+    }
+
+    @Test
+    public void endOfInputRejectsTruncatedStream() throws Exception {
+        ByteBuf[] data = smallData();
+        ByteBuf truncated = data[0].readRetainedSlice(data[0].readableBytes() - 1);
+
+        try (Decompressor decompressor = createDecompressor().build(ByteBufAllocator.DEFAULT)) {
+            assertEquals(Decompressor.Status.NEED_INPUT, decompressor.status());
+            decompressor.addInput(truncated);
+            truncated = null;
+
+            while (decompressor.status() == Decompressor.Status.NEED_OUTPUT) {
+                decompressor.takeOutput().release();
+            }
+
+            assertEquals(Decompressor.Status.NEED_INPUT, decompressor.status());
+            assertThrows(DecompressionException.class, decompressor::endOfInput);
+        } finally {
+            if (truncated != null) {
+                truncated.release();
+            }
+            for (ByteBuf buffer : data) {
+                buffer.release();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

The decompressor API migration tracked in https://github.com/netty/netty/issues/16743 needs per-format
implementations split into independently reviewable changes. Brotli
support is one of the remaining formats after the core decompressor API
landed in https://github.com/netty/netty/pull/16745.

Modification:

- Add `BrotliDecompressor` using the new `Decompressor` API.
- Add `BrotliDecompressorTest` using the shared decompressor contract
tests.
- Fix `BrotliEncoder` close handling so the finish future returned
during close is completed by the writer.

Result:

Brotli now has a reusable decompressor implementation that can be used
without a channel-based decoder, and the codec-compression module
verifies successfully.

Part of https://github.com/netty/netty/issues/16743.

---------

Co-authored-by: multicode <multicode@yawk.at>

(cherry picked from commit https://github.com/netty/netty/commit/b8fb58f596a62e7993c86bd98f1e26a8bb64b9b1)