### PR TITLE
Fix buddy cache evicting chunks with live buffers (#17154)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AdaptivePoolingAllocator.java
@@ -615,25 +615,14 @@ final class AdaptivePoolingAllocator implements AdaptiveByteBufAllocator.Adaptiv
 
             int size = chunks.size();
             while (size > CHUNK_REUSE_QUEUE) {
-                // Deallocate the chunk with the fewest incoming references.
                 int key = -1;
                 Chunk toDeallocate = null;
                 for (IntEntry<Chunk> entry : chunks) {
                     Chunk candidate = entry.getValue();
-                    if (candidate != null) {
-                        if (toDeallocate == null) {
-                            toDeallocate = candidate;
-                            key = entry.getKey();
-                        } else {
-                            int candidateRefCnt = candidate.refCnt();
-                            int toDeallocateRefCnt = toDeallocate.refCnt();
-                            if (candidateRefCnt < toDeallocateRefCnt ||
-                                    candidateRefCnt == toDeallocateRefCnt &&
-                                            candidate.capacity() < toDeallocate.capacity()) {
-                                toDeallocate = candidate;
-                                key = entry.getKey();
-                            }
-                        }
+                    if (candidate != null && candidate.refCnt() == 1) {
+                        toDeallocate = candidate;
+                        key = entry.getKey();
+                        break;
                     }
                 }
                 if (toDeallocate == null) {


### PR DESCRIPTION
Motivation:

The shared ConcurrentSkipListChunkCache eviction policy picked the chunk
with the lowest refCnt when the cache exceeded CHUNK_REUSE_QUEUE. Since
chunks enter the cache with refCnt = 1 + N (N live buffers), evicting
them creates zombie chunks: out of the cache, backing buffer still alive
until all N buffers release. This caused 16 GB RSS on the AG benchmark.

Modification:

Only evict chunks where refCnt == 1 (no live buffers — just the base
construction reference). If no idle chunk exists, let the cache grow
past the cap. markToDeallocate on an idle chunk decrements refCnt to 0,
triggering deallocate which frees the backing buffer cleanly.

Result:

Less memory churn under allocation pressure still allowing it to shrink
on subsequence cache requests

(cherry picked from commit https://github.com/franz1981/netty/commit/34bfcc7d04363c1290bf81fed203cd93ca1c7764)