### PR TITLE
Add option to ignore MaxDirectMemorySize JVM argument

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -249,6 +249,7 @@
                   <!-- JFR is available only in JDK9+ and is optional -->
                   jdk.jfr;resolution:=optional,
                   <!-- JVM vendor packages are optional -->
+                  com.sun.management;resolution:=optional,
                   sun.misc;resolution:=optional,
                   sun.nio.ch;resolution:=optional,
                   *

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -249,7 +249,6 @@
                   <!-- JFR is available only in JDK9+ and is optional -->
                   jdk.jfr;resolution:=optional,
                   <!-- JVM vendor packages are optional -->
-                  com.sun.management;resolution:=optional,
                   sun.misc;resolution:=optional,
                   sun.nio.ch;resolution:=optional,
                   *

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -1541,48 +1541,50 @@ public final class PlatformDependent {
             return maxDirectMemory;
         }
 
-        try {
-            // Now try to get the JVM option (-XX:MaxDirectMemorySize) and parse it.
-            // Note that we are using reflection because Android doesn't have these classes.
-            ClassLoader systemClassLoader = getSystemClassLoader();
-            Class<?> mgmtFactoryClass = Class.forName(
-                    "java.lang.management.ManagementFactory", true, systemClassLoader);
-            Class<?> runtimeClass = Class.forName(
-                    "java.lang.management.RuntimeMXBean", true, systemClassLoader);
+        if (!ignoreMaxDirectMemorySize()) {
+            try {
+                // Now try to get the JVM option (-XX:MaxDirectMemorySize) and parse it.
+                // Note that we are using reflection because Android doesn't have these classes.
+                ClassLoader systemClassLoader = getSystemClassLoader();
+                Class<?> mgmtFactoryClass = Class.forName(
+                        "java.lang.management.ManagementFactory", true, systemClassLoader);
+                Class<?> runtimeClass = Class.forName(
+                        "java.lang.management.RuntimeMXBean", true, systemClassLoader);
 
-            MethodHandles.Lookup lookup = MethodHandles.publicLookup();
-            MethodHandle getRuntime = lookup.findStatic(
-                    mgmtFactoryClass, "getRuntimeMXBean", methodType(runtimeClass));
-            MethodHandle getInputArguments = lookup.findVirtual(
-                    runtimeClass, "getInputArguments", methodType(List.class));
-            List<String> vmArgs = (List<String>) getInputArguments.invoke(getRuntime.invoke());
+                MethodHandles.Lookup lookup = MethodHandles.publicLookup();
+                MethodHandle getRuntime = lookup.findStatic(
+                        mgmtFactoryClass, "getRuntimeMXBean", methodType(runtimeClass));
+                MethodHandle getInputArguments = lookup.findVirtual(
+                        runtimeClass, "getInputArguments", methodType(List.class));
+                List<String> vmArgs = (List<String>) getInputArguments.invoke(getRuntime.invoke());
 
-            Pattern maxDirectMemorySizeArgPattern = getMaxDirectMemorySizeArgPattern();
+                Pattern maxDirectMemorySizeArgPattern = getMaxDirectMemorySizeArgPattern();
 
-            for (int i = vmArgs.size() - 1; i >= 0; i --) {
-                Matcher m = maxDirectMemorySizeArgPattern.matcher(vmArgs.get(i));
-                if (!m.matches()) {
-                    continue;
+                for (int i = vmArgs.size() - 1; i >= 0; i--) {
+                    Matcher m = maxDirectMemorySizeArgPattern.matcher(vmArgs.get(i));
+                    if (!m.matches()) {
+                        continue;
+                    }
+
+                    maxDirectMemory = Long.parseLong(m.group(1));
+                    switch (m.group(2).charAt(0)) {
+                        case 'k': case 'K':
+                            maxDirectMemory *= 1024;
+                            break;
+                        case 'm': case 'M':
+                            maxDirectMemory *= 1024 * 1024;
+                            break;
+                        case 'g': case 'G':
+                            maxDirectMemory *= 1024 * 1024 * 1024;
+                            break;
+                        default:
+                            break;
+                    }
+                    break;
                 }
-
-                maxDirectMemory = Long.parseLong(m.group(1));
-                switch (m.group(2).charAt(0)) {
-                    case 'k': case 'K':
-                        maxDirectMemory *= 1024;
-                        break;
-                    case 'm': case 'M':
-                        maxDirectMemory *= 1024 * 1024;
-                        break;
-                    case 'g': case 'G':
-                        maxDirectMemory *= 1024 * 1024 * 1024;
-                        break;
-                    default:
-                        break;
-                }
-                break;
+            } catch (Throwable ignored) {
+                // Ignore
             }
-        } catch (Throwable ignored) {
-            // Ignore
         }
 
         if (maxDirectMemory <= 0) {
@@ -1593,6 +1595,10 @@ public final class PlatformDependent {
         }
 
         return maxDirectMemory;
+    }
+
+    private static boolean ignoreMaxDirectMemorySize() {
+        return SystemPropertyUtil.getBoolean("io.netty.ignoreMaxDirectMemorySize", false);
     }
 
     private static File tmpdir0() {

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -100,6 +100,8 @@ public final class PlatformDependent {
     private static final boolean CAN_ENABLE_TCP_NODELAY_BY_DEFAULT = !isAndroid();
 
     private static final Throwable UNSAFE_UNAVAILABILITY_CAUSE = unsafeUnavailabilityCause0();
+    private static final boolean IS_J9_JVM = isJ9Jvm0();
+    private static final boolean IS_IVKVM_DOT_NET = isIkvmDotNet0();
     private static final boolean DIRECT_BUFFER_PREFERRED;
     private static final boolean EXPLICIT_NO_PREFER_DIRECT;
     private static final long MAX_DIRECT_MEMORY = estimateMaxDirectMemory();
@@ -120,8 +122,6 @@ public final class PlatformDependent {
 
     private static final boolean IS_WINDOWS = isWindows0();
     private static final boolean IS_OSX = isOsx0();
-    private static final boolean IS_J9_JVM = isJ9Jvm0();
-    private static final boolean IS_IVKVM_DOT_NET = isIkvmDotNet0();
 
     private static final int ADDRESS_SIZE = addressSize0();
     private static final AtomicLong DIRECT_MEMORY_COUNTER;
@@ -1530,8 +1530,8 @@ public final class PlatformDependent {
             return maxDirectMemory;
         }
 
-        if (!ignoreMaxDirectMemorySize()) {
-            maxDirectMemory = parseMaxDirectMemorySize(maxDirectMemory);
+        if (!isAndroid() && !ignoreMaxDirectMemorySize()) {
+            maxDirectMemory = RuntimeJvmArgs.parseMaxDirectMemorySize(maxDirectMemory);
         }
 
         if (maxDirectMemory <= 0) {
@@ -1541,54 +1541,6 @@ public final class PlatformDependent {
             logger.debug("maxDirectMemory: {} bytes", maxDirectMemory);
         }
 
-        return maxDirectMemory;
-    }
-
-    private static long parseMaxDirectMemorySize(long maxDirectMemory) {
-        try {
-            // Now try to get the JVM option (-XX:MaxDirectMemorySize) and parse it.
-            // Note that we are using reflection because Android doesn't have these classes.
-            ClassLoader systemClassLoader = getSystemClassLoader();
-            Class<?> mgmtFactoryClass = Class.forName(
-                    "java.lang.management.ManagementFactory", true, systemClassLoader);
-            Class<?> runtimeClass = Class.forName(
-                    "java.lang.management.RuntimeMXBean", true, systemClassLoader);
-
-            MethodHandles.Lookup lookup = MethodHandles.publicLookup();
-            MethodHandle getRuntime = lookup.findStatic(
-                    mgmtFactoryClass, "getRuntimeMXBean", methodType(runtimeClass));
-            MethodHandle getInputArguments = lookup.findVirtual(
-                    runtimeClass, "getInputArguments", methodType(List.class));
-            List<String> vmArgs = (List<String>) getInputArguments.invoke(getRuntime.invoke());
-
-            Pattern maxDirectMemorySizeArgPattern = Pattern
-                    .compile("\\s*-XX:MaxDirectMemorySize\\s*=\\s*([0-9]+)\\s*([kKmMgG]?)\\s*$");
-
-            for (int i = vmArgs.size() - 1; i >= 0; i--) {
-                Matcher m = maxDirectMemorySizeArgPattern.matcher(vmArgs.get(i));
-                if (!m.matches()) {
-                    continue;
-                }
-
-                maxDirectMemory = Long.parseLong(m.group(1));
-                switch (m.group(2).charAt(0)) {
-                    case 'k': case 'K':
-                        maxDirectMemory *= 1024;
-                        break;
-                    case 'm': case 'M':
-                        maxDirectMemory *= 1024 * 1024;
-                        break;
-                    case 'g': case 'G':
-                        maxDirectMemory *= 1024 * 1024 * 1024;
-                        break;
-                    default:
-                        break;
-                }
-                break;
-            }
-        } catch (Throwable ignored) {
-            // Ignore
-        }
         return maxDirectMemory;
     }
 

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -95,7 +95,6 @@ public final class PlatformDependent {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(PlatformDependent.class);
 
-    private static Pattern MAX_DIRECT_MEMORY_SIZE_ARG_PATTERN;
     private static final boolean MAYBE_SUPER_USER;
 
     private static final boolean CAN_ENABLE_TCP_NODELAY_BY_DEFAULT = !isAndroid();
@@ -1515,16 +1514,6 @@ public final class PlatformDependent {
         return vmName.equals("IKVM.NET");
     }
 
-    private static Pattern getMaxDirectMemorySizeArgPattern() {
-        // Pattern's is immutable so it's always safe published
-        Pattern pattern = MAX_DIRECT_MEMORY_SIZE_ARG_PATTERN;
-        if (pattern == null) {
-            pattern = Pattern.compile("\\s*-XX:MaxDirectMemorySize\\s*=\\s*([0-9]+)\\s*([kKmMgG]?)\\s*$");
-            MAX_DIRECT_MEMORY_SIZE_ARG_PATTERN =  pattern;
-        }
-        return pattern;
-    }
-
     /**
      * Compute an estimate of the maximum amount of direct memory available to this JVM.
      * <p>
@@ -1542,49 +1531,7 @@ public final class PlatformDependent {
         }
 
         if (!ignoreMaxDirectMemorySize()) {
-            try {
-                // Now try to get the JVM option (-XX:MaxDirectMemorySize) and parse it.
-                // Note that we are using reflection because Android doesn't have these classes.
-                ClassLoader systemClassLoader = getSystemClassLoader();
-                Class<?> mgmtFactoryClass = Class.forName(
-                        "java.lang.management.ManagementFactory", true, systemClassLoader);
-                Class<?> runtimeClass = Class.forName(
-                        "java.lang.management.RuntimeMXBean", true, systemClassLoader);
-
-                MethodHandles.Lookup lookup = MethodHandles.publicLookup();
-                MethodHandle getRuntime = lookup.findStatic(
-                        mgmtFactoryClass, "getRuntimeMXBean", methodType(runtimeClass));
-                MethodHandle getInputArguments = lookup.findVirtual(
-                        runtimeClass, "getInputArguments", methodType(List.class));
-                List<String> vmArgs = (List<String>) getInputArguments.invoke(getRuntime.invoke());
-
-                Pattern maxDirectMemorySizeArgPattern = getMaxDirectMemorySizeArgPattern();
-
-                for (int i = vmArgs.size() - 1; i >= 0; i--) {
-                    Matcher m = maxDirectMemorySizeArgPattern.matcher(vmArgs.get(i));
-                    if (!m.matches()) {
-                        continue;
-                    }
-
-                    maxDirectMemory = Long.parseLong(m.group(1));
-                    switch (m.group(2).charAt(0)) {
-                        case 'k': case 'K':
-                            maxDirectMemory *= 1024;
-                            break;
-                        case 'm': case 'M':
-                            maxDirectMemory *= 1024 * 1024;
-                            break;
-                        case 'g': case 'G':
-                            maxDirectMemory *= 1024 * 1024 * 1024;
-                            break;
-                        default:
-                            break;
-                    }
-                    break;
-                }
-            } catch (Throwable ignored) {
-                // Ignore
-            }
+            maxDirectMemory = parseMaxDirectMemorySize(maxDirectMemory);
         }
 
         if (maxDirectMemory <= 0) {
@@ -1594,6 +1541,54 @@ public final class PlatformDependent {
             logger.debug("maxDirectMemory: {} bytes", maxDirectMemory);
         }
 
+        return maxDirectMemory;
+    }
+
+    private static long parseMaxDirectMemorySize(long maxDirectMemory) {
+        try {
+            // Now try to get the JVM option (-XX:MaxDirectMemorySize) and parse it.
+            // Note that we are using reflection because Android doesn't have these classes.
+            ClassLoader systemClassLoader = getSystemClassLoader();
+            Class<?> mgmtFactoryClass = Class.forName(
+                    "java.lang.management.ManagementFactory", true, systemClassLoader);
+            Class<?> runtimeClass = Class.forName(
+                    "java.lang.management.RuntimeMXBean", true, systemClassLoader);
+
+            MethodHandles.Lookup lookup = MethodHandles.publicLookup();
+            MethodHandle getRuntime = lookup.findStatic(
+                    mgmtFactoryClass, "getRuntimeMXBean", methodType(runtimeClass));
+            MethodHandle getInputArguments = lookup.findVirtual(
+                    runtimeClass, "getInputArguments", methodType(List.class));
+            List<String> vmArgs = (List<String>) getInputArguments.invoke(getRuntime.invoke());
+
+            Pattern maxDirectMemorySizeArgPattern = Pattern
+                    .compile("\\s*-XX:MaxDirectMemorySize\\s*=\\s*([0-9]+)\\s*([kKmMgG]?)\\s*$");
+
+            for (int i = vmArgs.size() - 1; i >= 0; i--) {
+                Matcher m = maxDirectMemorySizeArgPattern.matcher(vmArgs.get(i));
+                if (!m.matches()) {
+                    continue;
+                }
+
+                maxDirectMemory = Long.parseLong(m.group(1));
+                switch (m.group(2).charAt(0)) {
+                    case 'k': case 'K':
+                        maxDirectMemory *= 1024;
+                        break;
+                    case 'm': case 'M':
+                        maxDirectMemory *= 1024 * 1024;
+                        break;
+                    case 'g': case 'G':
+                        maxDirectMemory *= 1024 * 1024 * 1024;
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            }
+        } catch (Throwable ignored) {
+            // Ignore
+        }
         return maxDirectMemory;
     }
 

--- a/common/src/main/java/io/netty/util/internal/RuntimeJvmArgs.java
+++ b/common/src/main/java/io/netty/util/internal/RuntimeJvmArgs.java
@@ -39,13 +39,10 @@ final class RuntimeJvmArgs {
                     .getInputArguments();
             for (int i = vmArgs.size() - 1; i >= 0; i--) {
                 String arg = vmArgs.get(i);
-                int idx = arg.indexOf(
-                        MAX_DIRECT_MEMORY_SIZE_ARG);
-                if (idx < 0) {
+                if (!arg.startsWith(MAX_DIRECT_MEMORY_SIZE_ARG)) {
                     continue;
                 }
-                return parseSize(arg, idx
-                        + MAX_DIRECT_MEMORY_SIZE_ARG.length());
+                return parseSize(arg, MAX_DIRECT_MEMORY_SIZE_ARG.length());
             }
         } catch (Throwable ignored) {
             // Ignore

--- a/common/src/main/java/io/netty/util/internal/RuntimeJvmArgs.java
+++ b/common/src/main/java/io/netty/util/internal/RuntimeJvmArgs.java
@@ -32,8 +32,7 @@ final class RuntimeJvmArgs {
     private RuntimeJvmArgs() {
     }
 
-    static long parseMaxDirectMemorySize(
-            final long maxDirectMemory) {
+    static long parseMaxDirectMemorySize(final long maxDirectMemory) {
         try {
             List<String> vmArgs = ManagementFactory
                     .getRuntimeMXBean()

--- a/common/src/main/java/io/netty/util/internal/RuntimeJvmArgs.java
+++ b/common/src/main/java/io/netty/util/internal/RuntimeJvmArgs.java
@@ -2,95 +2,83 @@
  * Copyright 2026 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
- * version 2.0 (the "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at:
+ * version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at:
  *
  *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
  */
 package io.netty.util.internal;
 
-import com.sun.management.HotSpotDiagnosticMXBean;
-
 import java.lang.management.ManagementFactory;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
- * This allows avoiding class verification failures on older Android runtimes.
- * Android does not have {@link java.lang.management.ManagementFactory}, so loading this class
- * on Android will fail with {@link NoClassDefFoundError} — callers must catch {@link Throwable}.
+ * Avoid class verification failures on Android.
+ * Android does not have {@link ManagementFactory},
+ * so loading this class on Android will fail with
+ * {@link NoClassDefFoundError}.
  */
 final class RuntimeJvmArgs {
+
+    private static final String MAX_DIRECT_MEMORY_SIZE_ARG =
+            "-XX:MaxDirectMemorySize=";
 
     private RuntimeJvmArgs() {
     }
 
-    public static long parseMaxDirectMemorySize(long maxDirectMemory) {
-        if (PlatformDependent.isAndroid()) {
-            return maxDirectMemory;
-        }
-        if (PlatformDependent.isJ9Jvm()) {
-            return parseMaxDirectMemorySizeVmArgs(maxDirectMemory);
-        }
-        return parseMaxDirectMemorySizeVmOption(maxDirectMemory);
-    }
-
-    private static long parseMaxDirectMemorySizeVmOption(long maxDirectMemory) {
+    static long parseMaxDirectMemorySize(
+            final long maxDirectMemory) {
         try {
-            HotSpotDiagnosticMXBean bean = ManagementFactory.getPlatformMXBean(HotSpotDiagnosticMXBean.class);
-            if (bean != null) {
-                long value = Long.parseLong(bean.getVMOption("MaxDirectMemorySize").getValue());
-                if (value > 0) {
-                    return value;
-                }
-            }
-        } catch (Throwable ignored) {
-            // Ignore
-        }
-        return maxDirectMemory;
-    }
-
-    private static long parseMaxDirectMemorySizeVmArgs(long maxDirectMemory) {
-        try {
-            List<String> vmArgs = ManagementFactory.getRuntimeMXBean().getInputArguments();
-            Pattern maxDirectMemorySizeArgPattern = Pattern
-                    .compile("\\s*-XX:MaxDirectMemorySize\\s*=\\s*([0-9]+)\\s*([kKmMgG]?)\\s*$");
-
+            List<String> vmArgs = ManagementFactory
+                    .getRuntimeMXBean()
+                    .getInputArguments();
             for (int i = vmArgs.size() - 1; i >= 0; i--) {
-                Matcher m = maxDirectMemorySizeArgPattern.matcher(vmArgs.get(i));
-                if (!m.matches()) {
+                String arg = vmArgs.get(i);
+                int idx = arg.indexOf(
+                        MAX_DIRECT_MEMORY_SIZE_ARG);
+                if (idx < 0) {
                     continue;
                 }
-
-                maxDirectMemory = Long.parseLong(m.group(1));
-                switch (m.group(2).charAt(0)) {
-                    case 'k':
-                    case 'K':
-                        maxDirectMemory *= 1024;
-                        break;
-                    case 'm':
-                    case 'M':
-                        maxDirectMemory *= 1024 * 1024;
-                        break;
-                    case 'g':
-                    case 'G':
-                        maxDirectMemory *= 1024 * 1024 * 1024;
-                        break;
-                    default:
-                        break;
-                }
-                break;
+                return parseSize(arg, idx
+                        + MAX_DIRECT_MEMORY_SIZE_ARG.length());
             }
         } catch (Throwable ignored) {
             // Ignore
         }
         return maxDirectMemory;
+    }
+
+    private static long parseSize(
+            final String arg, final int offset) {
+        String val = arg.substring(offset).trim();
+        if (val.isEmpty()) {
+            return -1;
+        }
+        char lastChar = val.charAt(val.length() - 1);
+        long multiplier;
+        switch (lastChar) {
+            case 'k':
+            case 'K':
+                multiplier = 1024;
+                break;
+            case 'm':
+            case 'M':
+                multiplier = 1024 * 1024;
+                break;
+            case 'g':
+            case 'G':
+                multiplier = 1024L * 1024 * 1024;
+                break;
+            default:
+                return Long.parseLong(val);
+        }
+        String numStr = val.substring(0, val.length() - 1);
+        return Long.parseLong(numStr) * multiplier;
     }
 }

--- a/common/src/main/java/io/netty/util/internal/RuntimeJvmArgs.java
+++ b/common/src/main/java/io/netty/util/internal/RuntimeJvmArgs.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal;
+
+import com.sun.management.HotSpotDiagnosticMXBean;
+
+import java.lang.management.ManagementFactory;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * This allows avoiding class verification failures on older Android runtimes.
+ * Android does not have {@link java.lang.management.ManagementFactory}, so loading this class
+ * on Android will fail with {@link NoClassDefFoundError} — callers must catch {@link Throwable}.
+ */
+final class RuntimeJvmArgs {
+
+    private RuntimeJvmArgs() {
+    }
+
+    public static long parseMaxDirectMemorySize(long maxDirectMemory) {
+        if (PlatformDependent.isAndroid()) {
+            return maxDirectMemory;
+        }
+        if (PlatformDependent.isJ9Jvm()) {
+            return parseMaxDirectMemorySizeVmArgs(maxDirectMemory);
+        }
+        return parseMaxDirectMemorySizeVmOption(maxDirectMemory);
+    }
+
+    private static long parseMaxDirectMemorySizeVmOption(long maxDirectMemory) {
+        try {
+            HotSpotDiagnosticMXBean bean = ManagementFactory.getPlatformMXBean(HotSpotDiagnosticMXBean.class);
+            if (bean != null) {
+                long value = Long.parseLong(bean.getVMOption("MaxDirectMemorySize").getValue());
+                if (value > 0) {
+                    return value;
+                }
+            }
+        } catch (Throwable ignored) {
+            // Ignore
+        }
+        return maxDirectMemory;
+    }
+
+    private static long parseMaxDirectMemorySizeVmArgs(long maxDirectMemory) {
+        try {
+            List<String> vmArgs = ManagementFactory.getRuntimeMXBean().getInputArguments();
+            Pattern maxDirectMemorySizeArgPattern = Pattern
+                    .compile("\\s*-XX:MaxDirectMemorySize\\s*=\\s*([0-9]+)\\s*([kKmMgG]?)\\s*$");
+
+            for (int i = vmArgs.size() - 1; i >= 0; i--) {
+                Matcher m = maxDirectMemorySizeArgPattern.matcher(vmArgs.get(i));
+                if (!m.matches()) {
+                    continue;
+                }
+
+                maxDirectMemory = Long.parseLong(m.group(1));
+                switch (m.group(2).charAt(0)) {
+                    case 'k':
+                    case 'K':
+                        maxDirectMemory *= 1024;
+                        break;
+                    case 'm':
+                    case 'M':
+                        maxDirectMemory *= 1024 * 1024;
+                        break;
+                    case 'g':
+                    case 'G':
+                        maxDirectMemory *= 1024 * 1024 * 1024;
+                        break;
+                    default:
+                        break;
+                }
+                break;
+            }
+        } catch (Throwable ignored) {
+            // Ignore
+        }
+        return maxDirectMemory;
+    }
+}

--- a/common/src/main/java/io/netty/util/internal/RuntimeJvmArgs.java
+++ b/common/src/main/java/io/netty/util/internal/RuntimeJvmArgs.java
@@ -54,8 +54,7 @@ final class RuntimeJvmArgs {
         return maxDirectMemory;
     }
 
-    private static long parseSize(
-            final String arg, final int offset) {
+    private static long parseSize(final String arg, final int offset) {
         String val = arg.substring(offset).trim();
         if (val.isEmpty()) {
             return -1;


### PR DESCRIPTION
Motivation:
DirectCleaner, CleanerJava24Linker and CleanerJava25 allocations are not naturally bound to JVM off-heap limits (on OpenJDK) and there's little value into reflectively retrieve via MXBean the value of MaxDirectMemory, if not getting a startup hit.

Modification:
Introduces an option to ignore the value of MaxDirectMemory

Results:
Faster startup