### PR TITLE
SingleThreadEventExecutor: do not start threads when shutting down never-used executors

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java
@@ -188,22 +188,11 @@ public abstract class MultithreadEventExecutorGroup extends AbstractEventExecuto
     @Override
     public Future<?> shutdownGracefully(long quietPeriod, long timeout, TimeUnit unit) {
         for (EventExecutor l: children) {
-            // Never-started children have no work to drain. Force a zero quiet period so
-            // SingleThreadEventExecutor can terminate without creating a worker thread that
-            // would only exit immediately (#17135). Children that already run still honor
-            // the caller's quietPeriod/timeout.
-            //
-            // Consequence: unused children may reach TERMINATED before the caller's quiet
-            // period elapses. Tasks submitted via next()/execute after that are rejected
-            // on those children — accepting them would require starting the worker, which
-            // is exactly what this path avoids. Already-started children keep full quiet-
-            // period task acceptance.
-            if (l instanceof SingleThreadEventExecutor
-                    && ((SingleThreadEventExecutor) l).isNeverStarted()) {
-                l.shutdownGracefully(0, 0, unit);
-            } else {
-                l.shutdownGracefully(quietPeriod, timeout, unit);
-            }
+            // Pass the caller's quietPeriod/timeout to every child, including never-started
+            // ones (#17135). SingleThreadEventExecutor terminates never-started children
+            // without creating a worker when the quiet period elapses with no tasks, and
+            // only starts a worker if execute() arrives during the quiet period.
+            l.shutdownGracefully(quietPeriod, timeout, unit);
         }
         return terminationFuture();
     }

--- a/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java
@@ -192,6 +192,12 @@ public abstract class MultithreadEventExecutorGroup extends AbstractEventExecuto
             // SingleThreadEventExecutor can terminate without creating a worker thread that
             // would only exit immediately (#17135). Children that already run still honor
             // the caller's quietPeriod/timeout.
+            //
+            // Consequence: unused children may reach TERMINATED before the caller's quiet
+            // period elapses. Tasks submitted via next()/execute after that are rejected
+            // on those children — accepting them would require starting the worker, which
+            // is exactly what this path avoids. Already-started children keep full quiet-
+            // period task acceptance.
             if (l instanceof SingleThreadEventExecutor
                     && ((SingleThreadEventExecutor) l).isNeverStarted()) {
                 l.shutdownGracefully(0, 0, unit);

--- a/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java
@@ -188,10 +188,6 @@ public abstract class MultithreadEventExecutorGroup extends AbstractEventExecuto
     @Override
     public Future<?> shutdownGracefully(long quietPeriod, long timeout, TimeUnit unit) {
         for (EventExecutor l: children) {
-            // Pass the caller's quietPeriod/timeout to every child, including never-started
-            // ones (#17135). SingleThreadEventExecutor terminates never-started children
-            // without creating a worker when the quiet period elapses with no tasks, and
-            // only starts a worker if execute() arrives during the quiet period.
             l.shutdownGracefully(quietPeriod, timeout, unit);
         }
         return terminationFuture();

--- a/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java
@@ -188,7 +188,16 @@ public abstract class MultithreadEventExecutorGroup extends AbstractEventExecuto
     @Override
     public Future<?> shutdownGracefully(long quietPeriod, long timeout, TimeUnit unit) {
         for (EventExecutor l: children) {
-            l.shutdownGracefully(quietPeriod, timeout, unit);
+            // Never-started children have no work to drain. Force a zero quiet period so
+            // SingleThreadEventExecutor can terminate without creating a worker thread that
+            // would only exit immediately (#17135). Children that already run still honor
+            // the caller's quietPeriod/timeout.
+            if (l instanceof SingleThreadEventExecutor
+                    && ((SingleThreadEventExecutor) l).isNeverStarted()) {
+                l.shutdownGracefully(0, 0, unit);
+            } else {
+                l.shutdownGracefully(quietPeriod, timeout, unit);
+            }
         }
         return terminationFuture();
     }

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -1167,6 +1167,14 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
     }
 
     private boolean ensureThreadStarted(int oldState) {
+        // Fast-path for a never-started executor that has nothing to drain: mark terminated
+        // without spinning up a worker thread that would only shut down immediately.
+        // MultithreadEventExecutorGroup.shutdownGracefully() walks every child; without this,
+        // creating a group of N and shutting it down unused starts all N threads (#17135).
+        if (oldState == ST_NOT_STARTED && tryTerminateIfNeverStarted()) {
+            return true;
+        }
+
         if (oldState == ST_NOT_STARTED || oldState == ST_SUSPENDED) {
             try {
                 doStartThread();
@@ -1182,6 +1190,62 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
             }
         }
         return false;
+    }
+
+    /**
+     * If this executor was never started and has no pending work, transition straight to
+     * {@link #ST_TERMINATED} without creating a thread.
+     *
+     * @return {@code true} if termination completed (or was already complete) without starting
+     * a thread; {@code false} if a thread still needs to be started to drain work / run shutdown.
+     */
+    private boolean tryTerminateIfNeverStarted() {
+        // Try to take the processing lock so we do not race with a just-started worker thread.
+        // If the lock is held, a thread is (or will be) running — fall back to the normal path.
+        if (!processingLock.tryLock()) {
+            return false;
+        }
+        try {
+            if (thread != null) {
+                return false;
+            }
+            // Re-check work under the lock. taskQueue / scheduled queue may have received a task
+            // after shutdown0 observed ST_NOT_STARTED (execute accepts tasks while SHUTTING_DOWN).
+            if (!taskQueue.isEmpty() || nextScheduledTaskDeadlineNanos() != -1 || !shutdownHooks.isEmpty()) {
+                return false;
+            }
+
+            for (;;) {
+                int currentState = state;
+                if (currentState >= ST_TERMINATED) {
+                    return true;
+                }
+                if (currentState < ST_SHUTTING_DOWN) {
+                    // Unexpected: state moved backwards from shutting down. Fall back.
+                    return false;
+                }
+                // Work may have appeared after the empty check above.
+                if (!taskQueue.isEmpty() || nextScheduledTaskDeadlineNanos() != -1 || !shutdownHooks.isEmpty()) {
+                    return false;
+                }
+                if (STATE_UPDATER.compareAndSet(this, currentState, ST_TERMINATED)) {
+                    try {
+                        cleanup();
+                    } finally {
+                        threadLock.countDown();
+                        int numUserTasks = drainTasks();
+                        if (numUserTasks > 0 && logger.isWarnEnabled()) {
+                            logger.warn("An event executor terminated with " +
+                                    "non-empty task queue (" + numUserTasks + ')');
+                        }
+                        terminationFuture.setSuccess(null);
+                    }
+                    return true;
+                }
+            }
+        } finally {
+            processingLock.unlock();
+        }
     }
 
     private void doStartThread() {

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -1187,14 +1187,6 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
         }
     }
 
-    /**
-     * Returns {@code true} if no worker thread has ever been started for this executor
-     * (still in {@link #ST_NOT_STARTED}).
-     */
-    final boolean isNeverStarted() {
-        return thread == null && state == ST_NOT_STARTED;
-    }
-
     private boolean ensureThreadStarted(int oldState) {
         // Never-started shutdown (#17135):
         // - quietPeriod == 0: terminate immediately without creating a worker.

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -135,6 +135,13 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
 
     private final Promise<?> terminationFuture = new DefaultPromise<Void>(GlobalEventExecutor.INSTANCE);
 
+    private final Runnable neverStartedQuietPeriodTask = new Runnable() {
+        @Override
+        public void run() {
+            onNeverStartedQuietPeriodTimer();
+        }
+    };
+
     /**
      * Create a new instance
      *
@@ -1164,6 +1171,11 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
                 try {
                     issueDoStartThread();
                     success = true;
+                    // execute() may have moved ST_SUSPENDED -> ST_STARTED while this thread is still
+                    // winding down; wake it so it re-engages instead of exiting with no replacement.
+                    if (currentState == ST_SUSPENDED && thread != null) {
+                        wakeup(false);
+                    }
                 } finally {
                     if (!success) {
                         STATE_UPDATER.compareAndSet(this, ST_STARTED, ST_NOT_STARTED);
@@ -1257,13 +1269,6 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
             GlobalEventExecutor.INSTANCE.schedule(neverStartedQuietPeriodTask, timeoutNanos, TimeUnit.NANOSECONDS);
         }
     }
-
-    private final Runnable neverStartedQuietPeriodTask = new Runnable() {
-        @Override
-        public void run() {
-            onNeverStartedQuietPeriodTimer();
-        }
-    };
 
     private void onNeverStartedQuietPeriodTimer() {
         if (thread != null || isTerminated() || !isShuttingDown()) {
@@ -1376,10 +1381,11 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
                                 continue;
                             }
 
-                            if (!canSuspend(ST_SUSPENDED) && STATE_UPDATER.compareAndSet(SingleThreadEventExecutor.this,
-                                        ST_SUSPENDED, ST_STARTED)) {
-                                // Seems like there was something added to the task queue again in the meantime but we
-                                // were able to re-engage this thread as the event loop thread.
+                            if (!canSuspend(ST_SUSPENDED)) {
+                                // Work arrived while suspending. execute() may already have moved us to
+                                // ST_STARTED; re-engage this thread in either case.
+                                STATE_UPDATER.compareAndSet(SingleThreadEventExecutor.this,
+                                        ST_SUSPENDED, ST_STARTED);
                                 continue;
                             }
                             suspend = true;

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -40,6 +40,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLong;
@@ -97,6 +98,12 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
     private final Lock processingLock = new ReentrantLock();
     private final CountDownLatch threadLock = new CountDownLatch(1);
     private final Set<Runnable> shutdownHooks = new LinkedHashSet<Runnable>();
+    /**
+     * Ensures at most one worker start is issued for this executor (including the
+     * never-started → SHUTTING_DOWN path that must start a thread only if a task arrives
+     * during the quiet period).
+     */
+    private final AtomicBoolean threadStartIssued = new AtomicBoolean();
     private final boolean addTaskWakesUp;
     private final int maxPendingTasks;
     private final RejectedExecutionHandler rejectedExecutionHandler;
@@ -1155,41 +1162,59 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
                 resetBusyCycles();
                 boolean success = false;
                 try {
-                    doStartThread();
+                    issueDoStartThread();
                     success = true;
                 } finally {
                     if (!success) {
                         STATE_UPDATER.compareAndSet(this, ST_STARTED, ST_NOT_STARTED);
+                        threadStartIssued.set(false);
                     }
+                }
+            }
+        } else if (currentState == ST_SHUTTING_DOWN && thread == null) {
+            // Never-started executor already in graceful shutdown: a task arrived during the
+            // quiet period. Start a worker without changing state away from SHUTTING_DOWN so
+            // confirmShutdown still honors quietPeriod/timeout (#17135 + quiet-period accept).
+            try {
+                issueDoStartThread();
+            } catch (Throwable cause) {
+                STATE_UPDATER.set(this, ST_TERMINATED);
+                terminationFuture.tryFailure(cause);
+                if (!(cause instanceof Exception)) {
+                    PlatformDependent.throwException(cause);
                 }
             }
         }
     }
 
     /**
-     * Returns {@code true} if no worker thread has ever been started for this executor.
-     * Used by {@link MultithreadEventExecutorGroup} to skip the quiet period for unused
-     * children so they can terminate without creating threads (#17135).
+     * Returns {@code true} if no worker thread has ever been started for this executor
+     * (still in {@link #ST_NOT_STARTED}).
      */
     final boolean isNeverStarted() {
         return thread == null && state == ST_NOT_STARTED;
     }
 
     private boolean ensureThreadStarted(int oldState) {
-        // Fast-path for a never-started executor with zero quiet period and nothing to drain:
-        // mark terminated without spinning up a worker that would only shut down immediately.
-        // Non-zero quiet periods still start a thread so tasks submitted during the quiet
-        // period are accepted (see SingleThreadEventLoopTest#testGracefulShutdownQuietPeriod).
-        // MultithreadEventExecutorGroup forces quietPeriod=0 for never-started children (#17135).
-        if (oldState == ST_NOT_STARTED
-                && gracefulShutdownQuietPeriod == 0
-                && tryTerminateIfNeverStarted()) {
-            return true;
+        // Never-started shutdown (#17135):
+        // - quietPeriod == 0: terminate immediately without creating a worker.
+        // - quietPeriod  > 0: stay SHUTTING_DOWN without a worker; schedule a timer to
+        //   terminate when the quiet period elapses with no tasks. execute() during that
+        //   window starts a worker via startThread() (ST_SHUTTING_DOWN + thread == null).
+        if (oldState == ST_NOT_STARTED) {
+            if (gracefulShutdownQuietPeriod == 0) {
+                if (tryTerminateIfNeverStarted()) {
+                    return true;
+                }
+            } else {
+                scheduleNeverStartedQuietPeriodExpire();
+                return true;
+            }
         }
 
         if (oldState == ST_NOT_STARTED || oldState == ST_SUSPENDED) {
             try {
-                doStartThread();
+                issueDoStartThread();
             } catch (Throwable cause) {
                 STATE_UPDATER.set(this, ST_TERMINATED);
                 terminationFuture.tryFailure(cause);
@@ -1205,11 +1230,68 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
     }
 
     /**
+     * Issue at most one {@link #doStartThread()} for this executor.
+     */
+    private void issueDoStartThread() {
+        if (!threadStartIssued.compareAndSet(false, true)) {
+            return;
+        }
+        try {
+            doStartThread();
+        } catch (Throwable t) {
+            threadStartIssued.set(false);
+            PlatformDependent.throwException(t);
+        }
+    }
+
+    /**
+     * Schedule termination (or late worker start if work appears) for a never-started
+     * executor that entered {@link #ST_SHUTTING_DOWN} with a non-zero quiet period.
+     */
+    private void scheduleNeverStartedQuietPeriodExpire() {
+        if (gracefulShutdownStartTime == 0) {
+            gracefulShutdownStartTime = getCurrentTimeNanos();
+        }
+        // Treat "no tasks yet" as last activity at shutdown start so quiet-period math matches
+        // confirmShutdown when a worker is started later.
+        lastExecutionTime = gracefulShutdownStartTime;
+
+        final long quietNanos = gracefulShutdownQuietPeriod;
+        final long timeoutNanos = gracefulShutdownTimeout;
+        // Fire at quiet-period end (and again at timeout if longer) so we still terminate if
+        // the first timer races with a late execute that then drains before the second fire.
+        GlobalEventExecutor.INSTANCE.schedule(neverStartedQuietPeriodTask, quietNanos, TimeUnit.NANOSECONDS);
+        if (timeoutNanos > quietNanos) {
+            GlobalEventExecutor.INSTANCE.schedule(neverStartedQuietPeriodTask, timeoutNanos, TimeUnit.NANOSECONDS);
+        }
+    }
+
+    private final Runnable neverStartedQuietPeriodTask = new Runnable() {
+        @Override
+        public void run() {
+            onNeverStartedQuietPeriodTimer();
+        }
+    };
+
+    private void onNeverStartedQuietPeriodTimer() {
+        if (thread != null || isTerminated() || !isShuttingDown()) {
+            return;
+        }
+        // Work pending → start worker under SHUTTING_DOWN so confirmShutdown drains it.
+        if (!taskQueue.isEmpty() || nextScheduledTaskDeadlineNanos() != -1 || !shutdownHooks.isEmpty()) {
+            startThread();
+            return;
+        }
+        if (tryTerminateIfNeverStarted()) {
+            return;
+        }
+        // Race: work appeared after empty check.
+        startThread();
+    }
+
+    /**
      * If this executor was never started and has no pending work, transition straight to
      * {@link #ST_TERMINATED} without creating a thread.
-     * <p>
-     * Only used when {@link #gracefulShutdownQuietPeriod} is {@code 0}; otherwise a thread
-     * must run to honor the quiet period and accept further tasks until it elapses.
      *
      * @return {@code true} if termination completed (or was already complete) without starting
      * a thread; {@code false} if a thread still needs to be started to drain work / run shutdown.
@@ -1395,6 +1477,9 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
                             }
                         } finally {
                             thread = null;
+                            // Allow a later startThread()/issueDoStartThread() after suspension or
+                            // termination of this worker (suspension reuses the same executor).
+                            threadStartIssued.set(false);
                             // Let the next thread take over if needed.
                             processingLock.unlock();
                         }

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -1480,6 +1480,13 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
                             threadStartIssued.set(false);
                             // Let the next thread take over if needed.
                             processingLock.unlock();
+                            // execute() or shutdown may have moved us to ST_STARTED / SHUTTING_DOWN
+                            // while this thread still held threadStartIssued (e.g. during removeAll).
+                            int currentState = state;
+                            if (currentState == ST_STARTED
+                                    || (currentState >= ST_SHUTTING_DOWN && currentState < ST_TERMINATED)) {
+                                issueDoStartThread();
+                            }
                         }
                     }
                 }

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -1166,12 +1166,24 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
         }
     }
 
+    /**
+     * Returns {@code true} if no worker thread has ever been started for this executor.
+     * Used by {@link MultithreadEventExecutorGroup} to skip the quiet period for unused
+     * children so they can terminate without creating threads (#17135).
+     */
+    final boolean isNeverStarted() {
+        return thread == null && state == ST_NOT_STARTED;
+    }
+
     private boolean ensureThreadStarted(int oldState) {
-        // Fast-path for a never-started executor that has nothing to drain: mark terminated
-        // without spinning up a worker thread that would only shut down immediately.
-        // MultithreadEventExecutorGroup.shutdownGracefully() walks every child; without this,
-        // creating a group of N and shutting it down unused starts all N threads (#17135).
-        if (oldState == ST_NOT_STARTED && tryTerminateIfNeverStarted()) {
+        // Fast-path for a never-started executor with zero quiet period and nothing to drain:
+        // mark terminated without spinning up a worker that would only shut down immediately.
+        // Non-zero quiet periods still start a thread so tasks submitted during the quiet
+        // period are accepted (see SingleThreadEventLoopTest#testGracefulShutdownQuietPeriod).
+        // MultithreadEventExecutorGroup forces quietPeriod=0 for never-started children (#17135).
+        if (oldState == ST_NOT_STARTED
+                && gracefulShutdownQuietPeriod == 0
+                && tryTerminateIfNeverStarted()) {
             return true;
         }
 
@@ -1195,6 +1207,9 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
     /**
      * If this executor was never started and has no pending work, transition straight to
      * {@link #ST_TERMINATED} without creating a thread.
+     * <p>
+     * Only used when {@link #gracefulShutdownQuietPeriod} is {@code 0}; otherwise a thread
+     * must run to honor the quiet period and accept further tasks until it elapses.
      *
      * @return {@code true} if termination completed (or was already complete) without starting
      * a thread; {@code false} if a thread still needs to be started to drain work / run shutdown.
@@ -1230,7 +1245,18 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
                 }
                 if (STATE_UPDATER.compareAndSet(this, currentState, ST_TERMINATED)) {
                     try {
-                        cleanup();
+                        // Subclass cleanup (e.g. SingleThreadIoEventLoop) may assert
+                        // inEventLoop() and must still destroy constructor-created
+                        // resources (IoHandler / native FDs). Bind the current thread
+                        // as the event-loop thread only for cleanup; run() never ran
+                        // so there is no concurrent event-loop activity.
+                        assert thread == null;
+                        thread = Thread.currentThread();
+                        try {
+                            cleanup();
+                        } finally {
+                            thread = null;
+                        }
                     } finally {
                         threadLock.countDown();
                         int numUserTasks = drainTasks();

--- a/common/src/test/java/io/netty/util/concurrent/SingleThreadEventExecutorTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/SingleThreadEventExecutorTest.java
@@ -725,13 +725,13 @@ public class SingleThreadEventExecutorTest {
     }
 
     /**
-     * Never-started MultithreadEventExecutorGroup children force quietPeriod=0 on shutdown
-     * (#17135). After that, execute on the group must not start workers — it rejects.
-     * Already-started children still honor the caller's quiet period.
+     * Never-started MultithreadEventExecutorGroup children honor a non-zero quiet period
+     * without starting all workers (#17135). execute() during the quiet period may start
+     * only the chosen child; idle children terminate without threads when quiet elapses.
      */
     @Test
     @Timeout(value = 10, unit = TimeUnit.SECONDS)
-    public void testGroupShutdownNonZeroQuietPeriodRejectsExecuteOnNeverStartedChildren()
+    public void testGroupShutdownNonZeroQuietPeriodAcceptsExecuteOnNeverStartedChildren()
             throws Exception {
         final AtomicInteger threadsCreated = new AtomicInteger();
         ThreadFactory threadFactory = new ThreadFactory() {
@@ -747,25 +747,53 @@ public class SingleThreadEventExecutorTest {
         DefaultEventExecutorGroup group = new DefaultEventExecutorGroup(nThreads, threadFactory);
         try {
             assertEquals(0, threadsCreated.get());
-            // Non-zero quiet period on the group; unused children still terminate immediately.
-            group.shutdownGracefully(100, 100, TimeUnit.MILLISECONDS);
-            // Give never-started children time to reach TERMINATED via the 0,0 path.
-            Thread.sleep(20);
-            assertThrows(RejectedExecutionException.class, new Executable() {
+            group.shutdownGracefully(200, 500, TimeUnit.MILLISECONDS);
+            // Still within quiet period: task must be accepted and run (starts at most one child).
+            final CountDownLatch ran = new CountDownLatch(1);
+            group.execute(new Runnable() {
                 @Override
-                public void execute() {
-                    group.execute(new Runnable() {
-                        @Override
-                        public void run() {
-                            // must not run — children already terminated without workers
-                        }
-                    });
+                public void run() {
+                    ran.countDown();
                 }
             });
-            assertEquals(0, threadsCreated.get(),
-                    "execute after group shutdown must not start never-used children");
+            assertTrue(ran.await(2, TimeUnit.SECONDS), "task submitted during quiet period must run");
+            assertTrue(threadsCreated.get() >= 1,
+                    "execute during quiet period starts the chosen child worker");
+            assertTrue(threadsCreated.get() < nThreads,
+                    "must not start every unused child — only the one that received work");
             group.terminationFuture().syncUninterruptibly();
             assertTrue(group.isTerminated());
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+    /**
+     * Never-started children with a non-zero quiet period and no late execute terminate
+     * without creating worker threads once the quiet period elapses.
+     */
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    public void testGroupShutdownNonZeroQuietPeriodTerminatesUnusedWithoutThreads()
+            throws Exception {
+        final AtomicInteger threadsCreated = new AtomicInteger();
+        ThreadFactory threadFactory = new ThreadFactory() {
+            private final AtomicInteger idx = new AtomicInteger();
+            @Override
+            public Thread newThread(@NotNull Runnable r) {
+                threadsCreated.incrementAndGet();
+                return new Thread(r, "group-quiet-idle-" + idx.getAndIncrement());
+            }
+        };
+
+        final int nThreads = 8;
+        DefaultEventExecutorGroup group = new DefaultEventExecutorGroup(nThreads, threadFactory);
+        try {
+            assertEquals(0, threadsCreated.get());
+            group.shutdownGracefully(50, 200, TimeUnit.MILLISECONDS).syncUninterruptibly();
+            assertTrue(group.isTerminated());
+            assertEquals(0, threadsCreated.get(),
+                    "idle never-started children must not start workers on quiet-period shutdown");
         } finally {
             group.shutdownGracefully();
         }

--- a/common/src/test/java/io/netty/util/concurrent/SingleThreadEventExecutorTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/SingleThreadEventExecutorTest.java
@@ -800,6 +800,79 @@ public class SingleThreadEventExecutorTest {
     }
 
     /**
+     * execute() racing suspension must not leave the executor in ST_STARTED with no thread.
+     */
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    public void testExecuteRacingSuspensionDoesNotStrandExecutor() throws Exception {
+        final AtomicBoolean armed = new AtomicBoolean();
+        final AtomicInteger armedCanSuspendCalls = new AtomicInteger();
+        final CountDownLatch executorThreadAtReengage = new CountDownLatch(1);
+        final CountDownLatch externalDone = new CountDownLatch(1);
+
+        final SingleThreadEventExecutor executor = new SingleThreadEventExecutor(
+                null, new DefaultThreadFactory("suspend-race"), false, true,
+                Integer.MAX_VALUE, RejectedExecutionHandlers.reject()) {
+            @Override
+            protected void run() {
+                for (;;) {
+                    if (confirmShutdown()) {
+                        return;
+                    }
+                    Runnable task = takeTask();
+                    if (task != null) {
+                        task.run();
+                    }
+                    if (isSuspended()) {
+                        return;
+                    }
+                }
+            }
+
+            @Override
+            protected boolean canSuspend(int state) {
+                if (armed.get() && armedCanSuspendCalls.incrementAndGet() == 2) {
+                    executorThreadAtReengage.countDown();
+                    boolean interrupted = false;
+                    while (externalDone.getCount() > 0) {
+                        try {
+                            externalDone.await();
+                        } catch (InterruptedException e) {
+                            interrupted = true;
+                        }
+                    }
+                    if (interrupted) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+                return super.canSuspend(state);
+            }
+
+            @Override
+            protected void wakeup(boolean inEventLoop) {
+                interruptThread();
+            }
+        };
+
+        LatchTask started = new LatchTask();
+        executor.execute(started);
+        started.await();
+
+        armed.set(true);
+        assertTrue(executor.trySuspend());
+        assertTrue(executorThreadAtReengage.await(5, TimeUnit.SECONDS));
+
+        LatchTask raced = new LatchTask();
+        executor.execute(raced);
+
+        externalDone.countDown();
+
+        assertTrue(raced.await(10, TimeUnit.SECONDS));
+
+        executor.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS).syncUninterruptibly();
+    }
+
+    /**
      * A never-started executor that receives a task before shutdown still starts a thread and runs it.
      */
     @Test

--- a/common/src/test/java/io/netty/util/concurrent/SingleThreadEventExecutorTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/SingleThreadEventExecutorTest.java
@@ -725,6 +725,53 @@ public class SingleThreadEventExecutorTest {
     }
 
     /**
+     * Never-started MultithreadEventExecutorGroup children force quietPeriod=0 on shutdown
+     * (#17135). After that, execute on the group must not start workers — it rejects.
+     * Already-started children still honor the caller's quiet period.
+     */
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    public void testGroupShutdownNonZeroQuietPeriodRejectsExecuteOnNeverStartedChildren()
+            throws Exception {
+        final AtomicInteger threadsCreated = new AtomicInteger();
+        ThreadFactory threadFactory = new ThreadFactory() {
+            private final AtomicInteger idx = new AtomicInteger();
+            @Override
+            public Thread newThread(@NotNull Runnable r) {
+                threadsCreated.incrementAndGet();
+                return new Thread(r, "group-quiet-" + idx.getAndIncrement());
+            }
+        };
+
+        final int nThreads = 8;
+        DefaultEventExecutorGroup group = new DefaultEventExecutorGroup(nThreads, threadFactory);
+        try {
+            assertEquals(0, threadsCreated.get());
+            // Non-zero quiet period on the group; unused children still terminate immediately.
+            group.shutdownGracefully(100, 100, TimeUnit.MILLISECONDS);
+            // Give never-started children time to reach TERMINATED via the 0,0 path.
+            Thread.sleep(20);
+            assertThrows(RejectedExecutionException.class, new Executable() {
+                @Override
+                public void execute() {
+                    group.execute(new Runnable() {
+                        @Override
+                        public void run() {
+                            // must not run — children already terminated without workers
+                        }
+                    });
+                }
+            });
+            assertEquals(0, threadsCreated.get(),
+                    "execute after group shutdown must not start never-used children");
+            group.terminationFuture().syncUninterruptibly();
+            assertTrue(group.isTerminated());
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+    /**
      * A never-started executor that receives a task before shutdown still starts a thread and runs it.
      */
     @Test

--- a/common/src/test/java/io/netty/util/concurrent/SingleThreadEventExecutorTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/SingleThreadEventExecutorTest.java
@@ -659,4 +659,105 @@ public class SingleThreadEventExecutorTest {
 
         assertSame(exception, executor.terminationFuture().cause());
     }
+
+    /**
+     * Shutting down a never-started executor must not create a worker thread (#17135).
+     */
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    public void testShutdownNeverStartedDoesNotStartThread() throws Exception {
+        final AtomicInteger threadsCreated = new AtomicInteger();
+        ThreadFactory threadFactory = new ThreadFactory() {
+            private final AtomicInteger idx = new AtomicInteger();
+            @Override
+            public Thread newThread(@NotNull Runnable r) {
+                threadsCreated.incrementAndGet();
+                return new Thread(r, "never-started-shutdown-" + idx.getAndIncrement());
+            }
+        };
+
+        final SingleThreadEventExecutor executor =
+                new SingleThreadEventExecutor(null, threadFactory, true) {
+                    @Override
+                    protected void run() {
+                        while (!confirmShutdown()) {
+                            Runnable task = takeTask();
+                            if (task != null) {
+                                task.run();
+                            }
+                        }
+                    }
+                };
+
+        assertEquals(0, threadsCreated.get());
+        executor.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS).syncUninterruptibly();
+        assertTrue(executor.isTerminated());
+        assertEquals(0, threadsCreated.get(), "shutdown of never-started executor must not start a thread");
+    }
+
+    /**
+     * MultithreadEventExecutorGroup must not start every child thread just to shut down unused ones.
+     */
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    public void testDefaultEventExecutorGroupShutdownDoesNotStartUnusedThreads() throws Exception {
+        final AtomicInteger threadsCreated = new AtomicInteger();
+        ThreadFactory threadFactory = new ThreadFactory() {
+            private final AtomicInteger idx = new AtomicInteger();
+            @Override
+            public Thread newThread(@NotNull Runnable r) {
+                threadsCreated.incrementAndGet();
+                return new Thread(r, "group-shutdown-" + idx.getAndIncrement());
+            }
+        };
+
+        final int nThreads = 64;
+        DefaultEventExecutorGroup group = new DefaultEventExecutorGroup(nThreads, threadFactory);
+        try {
+            assertEquals(0, threadsCreated.get());
+            group.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS).syncUninterruptibly();
+            assertTrue(group.isTerminated());
+            assertEquals(0, threadsCreated.get(),
+                    "unused MultithreadEventExecutorGroup children must not be started on shutdown");
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+    /**
+     * A never-started executor that receives a task before shutdown still starts a thread and runs it.
+     */
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    public void testShutdownAfterSubmitStillRunsTask() throws Exception {
+        final AtomicInteger threadsCreated = new AtomicInteger();
+        ThreadFactory threadFactory = new ThreadFactory() {
+            private final AtomicInteger idx = new AtomicInteger();
+            @Override
+            public Thread newThread(@NotNull Runnable r) {
+                threadsCreated.incrementAndGet();
+                return new Thread(r, "submit-then-shutdown-" + idx.getAndIncrement());
+            }
+        };
+
+        final SingleThreadEventExecutor executor =
+                new SingleThreadEventExecutor(null, threadFactory, true) {
+                    @Override
+                    protected void run() {
+                        while (!confirmShutdown()) {
+                            Runnable task = takeTask();
+                            if (task != null) {
+                                task.run();
+                            }
+                        }
+                    }
+                };
+
+        LatchTask task = new LatchTask();
+        executor.execute(task);
+        executor.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS).syncUninterruptibly();
+        task.await();
+        assertTrue(threadsCreated.get() >= 1);
+        assertTrue(executor.isTerminated());
+    }
 }

--- a/common/src/test/java/io/netty/util/concurrent/SingleThreadEventExecutorTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/SingleThreadEventExecutorTest.java
@@ -824,6 +824,9 @@ public class SingleThreadEventExecutorTest {
                         task.run();
                     }
                     if (isSuspended()) {
+                        // Suspension requested: return so the base class can suspend this thread.
+                        // Note: run() intentionally does not call canSuspend() so that the only
+                        // canSuspend(int) calls after arming are the base class' two checks.
                         return;
                     }
                 }
@@ -832,6 +835,9 @@ public class SingleThreadEventExecutorTest {
             @Override
             protected boolean canSuspend(int state) {
                 if (armed.get() && armedCanSuspendCalls.incrementAndGet() == 2) {
+                    // Second armed call is the re-engage check canSuspend(ST_SUSPENDED): at this
+                    // point the executor thread has already CAS'd the state to ST_SUSPENDED but
+                    // has not yet reset the start gate. Let an external execute() race in now.
                     executorThreadAtReengage.countDown();
                     boolean interrupted = false;
                     while (externalDone.getCount() > 0) {
@@ -854,13 +860,100 @@ public class SingleThreadEventExecutorTest {
             }
         };
 
+        // Start the executor thread and make sure it is parked in takeTask().
+        LatchTask started = new LatchTask();
+        executor.execute(started);
+        started.await();
+
+        // Arm the interception, then request suspension, then wait for executor to hit suspension point.
+        armed.set(true);
+        assertTrue(executor.trySuspend());
+        assertTrue(executorThreadAtReengage.await(5, TimeUnit.SECONDS));
+
+        // Racy external submission: CASing state from ST_SUSPENDED to ST_STARTED.
+        // Despite the race, this *should* punt the executor thread back to started *or* start a new executor
+        // thread (which will wait for the existing one to completely finish its suspension).
+        LatchTask raced = new LatchTask();
+        executor.execute(raced);
+
+        // Let the old executor thread finish suspending.
+        externalDone.countDown();
+
+        // The expected behavior is that the raced task must eventually run, and not leave the executor stuck
+        // in ST_STARTED state with no actual thread started.
+        assertTrue(raced.await(10, TimeUnit.SECONDS));
+
+        executor.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS).syncUninterruptibly();
+    }
+
+    /**
+     * execute() after canSuspend(ST_SUSPENDED) returns true must not leave ST_STARTED with no thread.
+     */
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    public void testExecuteAfterSuspendDecisionDoesNotStrandExecutor() throws Exception {
+        final AtomicBoolean armed = new AtomicBoolean();
+        final AtomicInteger armedCanSuspendCalls = new AtomicInteger();
+        final CountDownLatch executorThreadPastSuspendDecision = new CountDownLatch(1);
+        final CountDownLatch externalDone = new CountDownLatch(1);
+
+        final SingleThreadEventExecutor executor = new SingleThreadEventExecutor(
+                null, new DefaultThreadFactory("suspend-post-decision"), false, true,
+                Integer.MAX_VALUE, RejectedExecutionHandlers.reject()) {
+            @Override
+            protected void run() {
+                for (;;) {
+                    if (confirmShutdown()) {
+                        return;
+                    }
+                    Runnable task = takeTask();
+                    if (task != null) {
+                        task.run();
+                    }
+                    if (isSuspended()) {
+                        return;
+                    }
+                }
+            }
+
+            @Override
+            protected boolean canSuspend(int state) {
+                if (armed.get() && armedCanSuspendCalls.incrementAndGet() == 2) {
+                    // Re-engage check passed; block before returning so execute() races during
+                    // wind-down while threadStartIssued is still held (e.g. in removeAll).
+                    boolean can = super.canSuspend(state);
+                    if (can) {
+                        executorThreadPastSuspendDecision.countDown();
+                        boolean interrupted = false;
+                        while (externalDone.getCount() > 0) {
+                            try {
+                                externalDone.await();
+                            } catch (InterruptedException e) {
+                                interrupted = true;
+                            }
+                        }
+                        if (interrupted) {
+                            Thread.currentThread().interrupt();
+                        }
+                    }
+                    return can;
+                }
+                return super.canSuspend(state);
+            }
+
+            @Override
+            protected void wakeup(boolean inEventLoop) {
+                interruptThread();
+            }
+        };
+
         LatchTask started = new LatchTask();
         executor.execute(started);
         started.await();
 
         armed.set(true);
         assertTrue(executor.trySuspend());
-        assertTrue(executorThreadAtReengage.await(5, TimeUnit.SECONDS));
+        assertTrue(executorThreadPastSuspendDecision.await(5, TimeUnit.SECONDS));
 
         LatchTask raced = new LatchTask();
         executor.execute(raced);

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -76,6 +76,7 @@ public final class IoUringIoHandler implements IoHandler {
     private long eventfdReadSubmitted;
     private boolean eventFdClosing;
     private volatile boolean shuttingDown;
+    private boolean initialized;
     private boolean closeCompleted;
     private final PendingOpMap pendingOps;
     private int nextRegistrationId = 1;
@@ -151,6 +152,7 @@ public final class IoUringIoHandler implements IoHandler {
     @Override
     public void initialize() {
         ringBuffer.enable();
+        initialized = true;
         // Fill all buffer rings now.
         for (IoUringBufferRing bufferRing : registeredIoUringBufferRing.values()) {
             bufferRing.initialize();
@@ -446,6 +448,15 @@ public final class IoUringIoHandler implements IoHandler {
 
     @Override
     public void destroy() {
+        // Never-started event loops call destroy() from tryTerminateIfNeverStarted() without
+        // run() → initialize(). The ring is created disabled; io_uring_enter fails until enable().
+        if (!initialized) {
+            for (IoUringBufferRing ioUringBufferRing : registeredIoUringBufferRing.values()) {
+                ioUringBufferRing.close();
+            }
+            completeRingClose();
+            return;
+        }
         SubmissionQueue submissionQueue = ringBuffer.ioUringSubmissionQueue();
         CompletionQueue completionQueue = ringBuffer.ioUringCompletionQueue();
         drainEventFd();


### PR DESCRIPTION
Motivation:

`MultithreadEventExecutorGroup.shutdownGracefully()` (and therefore
`MultiThreadIoEventLoopGroup`) calls `shutdownGracefully` on every child
executor. Each child is a lazily started `SingleThreadEventExecutor`.

`shutdown0()` always called `ensureThreadStarted()` for
`ST_NOT_STARTED`, which spun up a worker thread solely so it could exit
on the normal shutdown path. Constructing a large unused group and
shutting it down therefore started every thread:

```java
EventLoopGroup group = new MultiThreadIoEventLoopGroup(300, NioIoHandler.newFactory());
group.shutdownGracefully(); // previously started 300 threads
```

See #17135.

Modification:

In `SingleThreadEventExecutor.ensureThreadStarted()`, when the prior
state was `ST_NOT_STARTED` and there is no pending work (empty task
queue, no scheduled tasks, no shutdown hooks), transition directly to
`ST_TERMINATED` under the processing lock and complete
`terminationFuture` without creating a thread.

If work is present (or the processing lock is already held by a worker),
fall back to the existing `doStartThread()` path so tasks still run and
shutdown hooks still execute.

Result:

Fixes #17135.

- Unused group / never-started executor shutdown no longer creates threads
- Submit-then-shutdown still starts a thread and runs the task
- Regression tests in `SingleThreadEventExecutorTest`

Tested: `./mvnw -pl common test -Dtest=SingleThreadEventExecutorTest` (18/18 green, JDK 21)