### PR TITLE
Use VarHandle JCTools queues without Unsafe

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -58,6 +58,13 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.jctools</groupId>
+      <artifactId>jctools-core-jdk11</artifactId>
+      <!-- Need compile scope to be taken into account by shade plugin -->
+      <scope>compile</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.jetbrains</groupId>
       <artifactId>annotations</artifactId>
       <scope>provided</scope>

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -30,6 +30,12 @@ import org.jctools.queues.atomic.MpscUnboundedAtomicArrayQueue;
 import org.jctools.queues.atomic.SpscLinkedAtomicQueue;
 import org.jctools.queues.atomic.unpadded.MpscAtomicUnpaddedArrayQueue;
 import org.jctools.queues.unpadded.MpscUnpaddedArrayQueue;
+import org.jctools.queues.varhandle.MpmcVarHandleArrayQueue;
+import org.jctools.queues.varhandle.MpscChunkedVarHandleArrayQueue;
+import org.jctools.queues.varhandle.MpscUnboundedVarHandleArrayQueue;
+import org.jctools.queues.varhandle.MpscVarHandleArrayQueue;
+import org.jctools.queues.varhandle.SpscLinkedVarHandleQueue;
+import org.jctools.queues.varhandle.unpadded.MpscVarHandleUnpaddedArrayQueue;
 import org.jctools.util.Pow2;
 import org.jctools.util.UnsafeAccess;
 
@@ -688,6 +694,10 @@ public final class PlatformDependent {
         return VAR_HANDLE;
     }
 
+    static boolean hasJctoolsVarHandle() {
+        return javaVersion() >= 11;
+    }
+
     /**
      * {@code true} if {@code VarHandle} should be used for multi-byte access.
      *
@@ -1279,13 +1289,19 @@ public final class PlatformDependent {
         }
 
         static <T> Queue<T> newChunkedMpscQueue(final int chunkSize, final int capacity) {
-            return USE_MPSC_CHUNKED_ARRAY_QUEUE ? new MpscChunkedArrayQueue<T>(chunkSize, capacity)
+            if (USE_MPSC_CHUNKED_ARRAY_QUEUE) {
+                return new MpscChunkedArrayQueue<T>(chunkSize, capacity);
+            }
+            return hasJctoolsVarHandle() ? new MpscChunkedVarHandleArrayQueue<T>(chunkSize, capacity)
                     : new MpscChunkedAtomicArrayQueue<T>(chunkSize, capacity);
         }
 
         static <T> Queue<T> newMpscQueue() {
-            return USE_MPSC_CHUNKED_ARRAY_QUEUE ? new MpscUnboundedArrayQueue<T>(MPSC_CHUNK_SIZE)
-                                                : new MpscUnboundedAtomicArrayQueue<T>(MPSC_CHUNK_SIZE);
+            if (USE_MPSC_CHUNKED_ARRAY_QUEUE) {
+                return new MpscUnboundedArrayQueue<T>(MPSC_CHUNK_SIZE);
+            }
+            return hasJctoolsVarHandle() ? new MpscUnboundedVarHandleArrayQueue<T>(MPSC_CHUNK_SIZE)
+                    : new MpscUnboundedAtomicArrayQueue<T>(MPSC_CHUNK_SIZE);
         }
     }
 
@@ -1320,7 +1336,10 @@ public final class PlatformDependent {
      * consumer (one thread!).
      */
     public static <T> Queue<T> newSpscQueue() {
-        return hasUnsafe() ? new SpscLinkedQueue<T>() : new SpscLinkedAtomicQueue<T>();
+        if (hasUnsafe()) {
+            return new SpscLinkedQueue<T>();
+        }
+        return hasJctoolsVarHandle() ? new SpscLinkedVarHandleQueue<T>() : new SpscLinkedAtomicQueue<T>();
     }
 
     /**
@@ -1328,7 +1347,10 @@ public final class PlatformDependent {
      * consumer (one thread!) with the given fixes {@code capacity}.
      */
     public static <T> Queue<T> newFixedMpscQueue(int capacity) {
-        return hasUnsafe() ? new MpscArrayQueue<T>(capacity) : new MpscAtomicArrayQueue<T>(capacity);
+        if (hasUnsafe()) {
+            return new MpscArrayQueue<T>(capacity);
+        }
+        return hasJctoolsVarHandle() ? new MpscVarHandleArrayQueue<T>(capacity) : new MpscAtomicArrayQueue<T>(capacity);
     }
 
     /**
@@ -1337,7 +1359,11 @@ public final class PlatformDependent {
      * This should be preferred to {@link #newFixedMpscQueue(int)} when the queue is not to be heavily contended.
      */
     public static <T> Queue<T> newFixedMpscUnpaddedQueue(int capacity) {
-        return hasUnsafe() ? new MpscUnpaddedArrayQueue<T>(capacity) : new MpscAtomicUnpaddedArrayQueue<T>(capacity);
+        if (hasUnsafe()) {
+            return new MpscUnpaddedArrayQueue<T>(capacity);
+        }
+        return hasJctoolsVarHandle() ? new MpscVarHandleUnpaddedArrayQueue<T>(capacity)
+                : new MpscAtomicUnpaddedArrayQueue<T>(capacity);
     }
 
     /**
@@ -1345,7 +1371,10 @@ public final class PlatformDependent {
      * consumers with the given fixes {@code capacity}.
      */
     public static <T> Queue<T> newFixedMpmcQueue(int capacity) {
-        return hasUnsafe() ? new MpmcArrayQueue<T>(capacity) : new MpmcAtomicArrayQueue<T>(capacity);
+        if (hasUnsafe()) {
+            return new MpmcArrayQueue<T>(capacity);
+        }
+        return hasJctoolsVarHandle() ? new MpmcVarHandleArrayQueue<T>(capacity) : new MpmcAtomicArrayQueue<T>(capacity);
     }
 
     /**

--- a/common/src/main/java/io/netty/util/internal/shaded/org/jctools/queues/varhandle/DoNotRemove.java
+++ b/common/src/main/java/io/netty/util/internal/shaded/org/jctools/queues/varhandle/DoNotRemove.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal.shaded.org.jctools.queues.varhandle;
+
+// Placeholder for module-info maven plugin to add the package to the module-info descriptor
+class DoNotRemove {
+}

--- a/common/src/main/java/io/netty/util/internal/shaded/org/jctools/queues/varhandle/DoNotRemove.java
+++ b/common/src/main/java/io/netty/util/internal/shaded/org/jctools/queues/varhandle/DoNotRemove.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Netty Project
+ * Copyright 2026 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/common/src/main/java/io/netty/util/internal/shaded/org/jctools/queues/varhandle/package-info.java
+++ b/common/src/main/java/io/netty/util/internal/shaded/org/jctools/queues/varhandle/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The Netty Project
+ * Copyright 2026 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/common/src/main/java/io/netty/util/internal/shaded/org/jctools/queues/varhandle/package-info.java
+++ b/common/src/main/java/io/netty/util/internal/shaded/org/jctools/queues/varhandle/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Placeholder package.
+ */
+package io.netty.util.internal.shaded.org.jctools.queues.varhandle;

--- a/common/src/main/java/io/netty/util/internal/shaded/org/jctools/queues/varhandle/unpadded/DoNotRemove.java
+++ b/common/src/main/java/io/netty/util/internal/shaded/org/jctools/queues/varhandle/unpadded/DoNotRemove.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Netty Project
+ * Copyright 2026 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/common/src/main/java/io/netty/util/internal/shaded/org/jctools/queues/varhandle/unpadded/DoNotRemove.java
+++ b/common/src/main/java/io/netty/util/internal/shaded/org/jctools/queues/varhandle/unpadded/DoNotRemove.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2024 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal.shaded.org.jctools.queues.varhandle.unpadded;
+
+// Placeholder for module-info maven plugin to add the package to the module-info descriptor
+class DoNotRemove {
+}

--- a/common/src/main/java/io/netty/util/internal/shaded/org/jctools/queues/varhandle/unpadded/package-info.java
+++ b/common/src/main/java/io/netty/util/internal/shaded/org/jctools/queues/varhandle/unpadded/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The Netty Project
+ * Copyright 2026 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/common/src/main/java/io/netty/util/internal/shaded/org/jctools/queues/varhandle/unpadded/package-info.java
+++ b/common/src/main/java/io/netty/util/internal/shaded/org/jctools/queues/varhandle/unpadded/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Placeholder package.
+ */
+package io.netty.util.internal.shaded.org.jctools.queues.varhandle.unpadded;

--- a/common/src/test/java/io/netty/util/internal/PlatformDependentTest.java
+++ b/common/src/test/java/io/netty/util/internal/PlatformDependentTest.java
@@ -33,6 +33,25 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class PlatformDependentTest {
     private static final Random r = new Random();
+
+    @Test
+    public void testVarHandleQueuesWhenUnsafeIsUnavailable() {
+        assumeTrue(!PlatformDependent.hasUnsafe() && PlatformDependent.hasJctoolsVarHandle());
+
+        assertEquals("org.jctools.queues.varhandle.MpscUnboundedVarHandleArrayQueue",
+                PlatformDependent.newMpscQueue().getClass().getName());
+        assertEquals("org.jctools.queues.varhandle.MpscChunkedVarHandleArrayQueue",
+                PlatformDependent.newMpscQueue(16).getClass().getName());
+        assertEquals("org.jctools.queues.varhandle.SpscLinkedVarHandleQueue",
+                PlatformDependent.newSpscQueue().getClass().getName());
+        assertEquals("org.jctools.queues.varhandle.MpscVarHandleArrayQueue",
+                PlatformDependent.newFixedMpscQueue(16).getClass().getName());
+        assertEquals("org.jctools.queues.varhandle.unpadded.MpscVarHandleUnpaddedArrayQueue",
+                PlatformDependent.newFixedMpscUnpaddedQueue(16).getClass().getName());
+        assertEquals("org.jctools.queues.varhandle.MpmcVarHandleArrayQueue",
+                PlatformDependent.newFixedMpmcQueue(16).getClass().getName());
+    }
+
     @Test
     public void testEqualsConsistentTime() {
         testEquals(new EqualityChecker() {

--- a/pom.xml
+++ b/pom.xml
@@ -765,6 +765,7 @@
     <junit.version>5.14.3</junit.version>
     <junit.platform.version>1.14.0</junit.platform.version>
     <jazzer.version>0.30.0</jazzer.version>
+    <jctools.version>4.0.6</jctools.version>
     <skipTests>false</skipTests>
     <testJavaHome>${java.home}</testJavaHome>
     <testJvm>${testJavaHome}/bin/java</testJvm>
@@ -1023,7 +1024,12 @@
       <dependency>
         <groupId>org.jctools</groupId>
         <artifactId>jctools-core</artifactId>
-        <version>4.0.6</version>
+        <version>${jctools.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jctools</groupId>
+        <artifactId>jctools-core-jdk11</artifactId>
+        <version>${jctools.version}</version>
       </dependency>
 
       <!-- Annotations for IDE integration and analysis -->


### PR DESCRIPTION
Motivation:

Netty currently falls back to JCTools atomic queues when `Unsafe` is unavailable. JCTools 4.0.6 provides VarHandle-based queues that avoid `Unsafe` while offering a more efficient alternative to the atomic implementations.

Modification:

Added and shaded the `jctools-core-jdk11` dependency. Updated the queue factories in `PlatformDependent` to prefer implementations in this order:

1. Unsafe-based queues when `Unsafe` is available.
2. VarHandle-based queues when `Unsafe` is unavailable but VarHandle is supported.
3. Atomic queues as the fallback.

Added test coverage for the VarHandle queue selection when `Unsafe` is disabled.

Result:

Fixes #17157.