### PR TITLE
IoUring: Fix the recvmmsg emulation

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -757,13 +757,12 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
 
             boolean multishot = isReadMultishot();
             boolean rearm = (flags & Native.IORING_CQE_F_MORE) == 0;
-            if (rearm) {
-                // Reset READ_SCHEDULED if there is nothing more to handle and so we need to re-arm. This works for
-                // multi-shot and non multi-shot variants.
-                ioState &= ~READ_SCHEDULED;
-            }
             boolean pending = readPending;
             if (multishot) {
+                if (rearm) {
+                    // Reset READ_SCHEDULED if there is nothing more to handle and so we need to re-arm.
+                    ioState &= ~READ_SCHEDULED;
+                }
                 // Reset readPending so we can still keep track if we might need to cancel the multi-shot read or
                 // not.
                 readPending = false;

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
@@ -471,6 +471,8 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
         @Override
         protected int scheduleRead0(boolean first, boolean socketIsEmpty) {
             final IoUringRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
+            IoUringIoHandler ioUringIoHandler = registration().attachment();
+            int submissionQueueRemaining = ioUringIoHandler.submitIfFullAndGetRemaining();
             ByteBuf byteBuf = allocHandle.allocate(alloc());
             assert readBuffer == null;
             readBuffer = byteBuf;
@@ -480,7 +482,7 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
             int datagramSize = ((IoUringDatagramChannelConfig) config()).getMaxDatagramPayloadSize();
 
             int numDatagram = datagramSize == 0 ? 1 : Math.max(1, byteBuf.writableBytes() / datagramSize);
-
+            numDatagram = Math.min(Math.min(submissionQueueRemaining, recvmsgHdrs.capacity()), numDatagram);
             int scheduled = scheduleRecvmsg(byteBuf, numDatagram, datagramSize);
             if (scheduled == 0) {
                 // We could not schedule any recvmmsg so we need to release the buffer as there will be no
@@ -495,12 +497,12 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
             int writable = byteBuf.writableBytes();
             long bufferAddress = IoUring.memoryAddress(byteBuf) + byteBuf.writerIndex();
             if (numDatagram <= 1) {
-                return scheduleRecvmsg0(bufferAddress, writable, true) ? 1 : 0;
+                return scheduleRecvmsg0(bufferAddress, writable, true, false) ? 1 : 0;
             }
             int i = 0;
             // Add multiple IORING_OP_RECVMSG to the submission queue. This basically emulates recvmmsg(...)
             for (; i < numDatagram && writable >= datagramSize; i++) {
-                if (!scheduleRecvmsg0(bufferAddress, datagramSize, i == 0)) {
+                if (!scheduleRecvmsg0(bufferAddress, datagramSize, i == 0, i + 1 < numDatagram)) {
                     break;
                 }
                 bufferAddress += datagramSize;
@@ -509,7 +511,7 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
             return i;
         }
 
-        private boolean scheduleRecvmsg0(long bufferAddress, int bufferLength, boolean first) {
+        private boolean scheduleRecvmsg0(long bufferAddress, int bufferLength, boolean first, boolean more) {
             MsgHdrMemory msgHdrMemory = recvmsgHdrs.nextHdr();
             if (msgHdrMemory == null) {
                 // We can not continue reading before we did not submit the recvmsg(s) and received the results.
@@ -519,11 +521,12 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
 
             int fd = fd().intValue();
             int msgFlags = first ? 0 : Native.MSG_DONTWAIT;
+            int sqeFlags = more ? Native.IOSQE_HARDLINK : 0;
             IoRegistration registration = registration();
             // We always use idx here so we can detect if no idx was used by checking if data < 0 in
             // readComplete0(...)
             IoUringIoOps ops = IoUringIoOps.newRecvmsg(
-                    fd, (byte) 0, msgFlags, msgHdrMemory.address(), msgHdrMemory.idx());
+                    fd, (byte) sqeFlags, msgFlags, msgHdrMemory.address(), msgHdrMemory.idx());
             long id = registration.submit(ops);
             if (id == 0) {
                 // Submission failed we don't used the MsgHdrMemory and so should give it back.

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -190,6 +190,16 @@ public final class IoUringIoHandler implements IoHandler {
         return ioCompletions;
     }
 
+    int submitIfFullAndGetRemaining() {
+        SubmissionQueue submissionQueue = ringBuffer.ioUringSubmissionQueue();
+        if (submissionQueue.remaining() == 0) {
+            if (submitAndClearNow(submissionQueue) == 0) {
+                throw new IllegalStateException("Submission queue is full and no submissions were accepted");
+            }
+        }
+        return submissionQueue.remaining();
+    }
+
     private boolean needSubmit(int sqFlags) {
         SubmissionQueue submissionQueue = ringBuffer.ioUringSubmissionQueue();
         return submissionQueue.count() > 0

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -320,6 +320,7 @@ final class Native {
     static final int IORING_ENTER_NO_IOWAIT = 1 << 7;
     static final int IOSQE_ASYNC = NativeStaticallyReferencedJniMethods.iosqeAsync();
     static final int IOSQE_LINK = NativeStaticallyReferencedJniMethods.iosqeLink();
+    static final int IOSQE_HARDLINK = NativeStaticallyReferencedJniMethods.iosqeHardlink();
     static final int IOSQE_IO_DRAIN = NativeStaticallyReferencedJniMethods.iosqeDrain();
     static final int IOSQE_BUFFER_SELECT = NativeStaticallyReferencedJniMethods.iosqeBufferSelect();
     static final int IOSQE_CQE_SKIP_SUCCESS = 1 << 6;

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/NativeStaticallyReferencedJniMethods.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/NativeStaticallyReferencedJniMethods.java
@@ -74,6 +74,7 @@ final class NativeStaticallyReferencedJniMethods {
     static native int ioringEnterGetevents();
     static native int iosqeAsync();
     static native int iosqeLink();
+    static native int iosqeHardlink();
     static native int iosqeDrain();
     static native int msgDontwait();
     static native int iosqeBufferSelect();

--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -738,6 +738,10 @@ static jint netty_io_uring_iosqeLink(JNIEnv* env, jclass clazz) {
     return IOSQE_IO_LINK;
 }
 
+static jint netty_io_uring_iosqeHardlink(JNIEnv* env, jclass clazz) {
+    return IOSQE_IO_HARDLINK;
+}
+
 static jint netty_io_uring_iosqeDrain(JNIEnv* env, jclass clazz) {
     return IOSQE_IO_DRAIN;
 }
@@ -842,6 +846,7 @@ static const JNINativeMethod statically_referenced_fixed_method_table[] = {
   { "ioringEnterGetevents", "()I", (void *) netty_io_uring_ioringEnterGetevents },
   { "iosqeAsync", "()I", (void *) netty_io_uring_iosqeAsync },
   { "iosqeLink", "()I", (void *) netty_io_uring_iosqeLink },
+  { "iosqeHardlink", "()I", (void *) netty_io_uring_iosqeHardlink },
   { "iosqeDrain", "()I", (void *) netty_io_uring_iosqeDrain },
   { "iosqeBufferSelect", "()I", (void *) netty_io_uring_BufferSelect },
   { "msgDontwait", "()I", (void *) netty_io_uring_msgDontwait },

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDatagramHardlinkTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDatagramHardlinkTest.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.FixedRecvByteBufAllocator;
+import io.netty.channel.IoEvent;
+import io.netty.channel.IoHandle;
+import io.netty.channel.IoHandler;
+import io.netty.channel.IoHandlerContext;
+import io.netty.channel.IoHandlerFactory;
+import io.netty.channel.IoRegistration;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.socket.DatagramPacket;
+import io.netty.channel.socket.SocketProtocolFamily;
+import io.netty.util.NetUtil;
+import io.netty.util.concurrent.ThreadAwareExecutor;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static io.netty.channel.unix.Errors.ERRNO_EAGAIN_NEGATIVE;
+import static io.netty.channel.unix.Errors.ERRNO_EBADF_NEGATIVE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+@Timeout(value = 1, unit = TimeUnit.MINUTES)
+public class IoUringDatagramHardlinkTest {
+
+    private static final int DATAGRAM_SIZE = 512;
+    private static final int BATCH_SIZE = 4;
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IoUring.isAvailable());
+    }
+
+    @Test
+    public void testRecvmmsgHardlinkOrder() throws Exception {
+        CompletionRecorder recorder = new CompletionRecorder();
+        IoHandlerFactory factory = executor -> new RecordingIoUringIoHandler(
+                IoUringIoHandler.newFactory().newHandler(executor), recorder);
+        MultiThreadIoEventLoopGroup group = new MultiThreadIoEventLoopGroup(1, factory);
+        Channel receiver = null;
+        Channel sender = null;
+        try {
+            receiver = newBootstrap(group)
+                    .handler(new ChannelInboundHandlerAdapter())
+                    .bind(new InetSocketAddress(NetUtil.LOCALHOST4, 0))
+                    .sync()
+                    .channel();
+
+            sender = new Bootstrap()
+                    .group(group)
+                    .channelFactory(() -> new IoUringDatagramChannel(SocketProtocolFamily.INET))
+                    .handler(new ChannelInboundHandlerAdapter())
+                    .bind(new InetSocketAddress(NetUtil.LOCALHOST4, 0))
+                    .sync()
+                    .channel();
+
+            // The hard linked recvmsg chain must park as a whole. Without hard linking the
+            // MSG_DONTWAIT recvmsg ops would already have completed with EAGAIN here.
+            Thread.sleep(100);
+            assertEquals(0, recorder.size());
+
+            sender.writeAndFlush(new DatagramPacket(
+                    sender.alloc().buffer(DATAGRAM_SIZE).writeZero(DATAGRAM_SIZE),
+                    (InetSocketAddress) receiver.localAddress())).sync();
+            recorder.await(BATCH_SIZE);
+
+            assertEquals(Arrays.asList(
+                    DATAGRAM_SIZE,
+                    ERRNO_EAGAIN_NEGATIVE,
+                    ERRNO_EAGAIN_NEGATIVE,
+                    ERRNO_EAGAIN_NEGATIVE), recorder.completions());
+        } finally {
+            if (sender != null) {
+                sender.close().syncUninterruptibly();
+            }
+            if (receiver != null) {
+                receiver.close().syncUninterruptibly();
+            }
+            group.shutdownGracefully().syncUninterruptibly();
+        }
+    }
+
+    @Test
+    public void testClosePendingRecvmmsgHardlink() throws Exception {
+        CompletionRecorder recorder = new CompletionRecorder();
+        IoHandlerFactory factory = executor -> new RecordingIoUringIoHandler(
+                IoUringIoHandler.newFactory().newHandler(executor), recorder);
+        MultiThreadIoEventLoopGroup group = new MultiThreadIoEventLoopGroup(1, factory);
+        Channel receiver = null;
+        Channel sender = null;
+        try {
+            receiver = newBootstrap(group)
+                    .handler(new ChannelInboundHandlerAdapter())
+                    .bind(new InetSocketAddress(NetUtil.LOCALHOST4, 0))
+                    .sync()
+                    .channel();
+
+            sender = new Bootstrap()
+                    .group(group)
+                    .channelFactory(() -> new IoUringDatagramChannel(SocketProtocolFamily.INET))
+                    .handler(new ChannelInboundHandlerAdapter())
+                    .bind(new InetSocketAddress(NetUtil.LOCALHOST4, 0))
+                    .sync()
+                    .channel();
+
+            // Let the read loop schedule the first batch and the AUTO_READ re-scheduled batch.
+            Thread.sleep(100);
+            assertEquals(0, recorder.size());
+
+            sender.writeAndFlush(new DatagramPacket(
+                    sender.alloc().buffer(DATAGRAM_SIZE).writeZero(DATAGRAM_SIZE),
+                    (InetSocketAddress) receiver.localAddress())).sync();
+            recorder.await(BATCH_SIZE);
+
+            // Close while the re-scheduled (hard linked) batch is still pending. Without the fix in
+            // readComplete(...) the fd would be closed before all recvmsg ops completed and so some
+            // of them would complete with EBADF.
+            receiver.close().syncUninterruptibly();
+            recorder.await(BATCH_SIZE * 2);
+
+            assertFalse(recorder.completions().contains(ERRNO_EBADF_NEGATIVE), recorder.completions().toString());
+        } finally {
+            if (sender != null) {
+                sender.close().syncUninterruptibly();
+            }
+            if (receiver != null) {
+                receiver.close().syncUninterruptibly();
+            }
+            group.shutdownGracefully().syncUninterruptibly();
+        }
+    }
+
+    private static Bootstrap newBootstrap(MultiThreadIoEventLoopGroup group) {
+        return new Bootstrap()
+                .group(group)
+                .channelFactory(() -> new IoUringDatagramChannel(SocketProtocolFamily.INET))
+                .option(ChannelOption.RECVBUF_ALLOCATOR,
+                        new FixedRecvByteBufAllocator(BATCH_SIZE * DATAGRAM_SIZE))
+                .option(IoUringChannelOption.MAX_DATAGRAM_PAYLOAD_SIZE, DATAGRAM_SIZE);
+    }
+
+    private static final class CompletionRecorder {
+        private final List<Integer> completions = new ArrayList<Integer>();
+
+        synchronized void record(IoUringIoEvent event) {
+            if (event.opcode() == Native.IORING_OP_RECVMSG) {
+                completions.add(event.res());
+                notifyAll();
+            }
+        }
+
+        synchronized int size() {
+            return completions.size();
+        }
+
+        synchronized List<Integer> completions() {
+            return new ArrayList<Integer>(completions);
+        }
+
+        synchronized void await(int count) throws InterruptedException {
+            while (completions.size() < count) {
+                wait();
+            }
+        }
+    }
+
+    private static final class RecordingIoUringIoHandler implements IoHandler {
+        private final IoHandler delegate;
+        private final CompletionRecorder recorder;
+
+        RecordingIoUringIoHandler(IoHandler delegate, CompletionRecorder recorder) {
+            this.delegate = delegate;
+            this.recorder = recorder;
+        }
+
+        @Override
+        public void initialize() {
+            delegate.initialize();
+        }
+
+        @Override
+        public int run(IoHandlerContext context) {
+            return delegate.run(context);
+        }
+
+        @Override
+        public void prepareToDestroy() {
+            delegate.prepareToDestroy();
+        }
+
+        @Override
+        public void destroy() {
+            delegate.destroy();
+        }
+
+        @Override
+        public IoRegistration register(IoHandle handle) throws Exception {
+            IoUringIoHandle ioHandle = (IoUringIoHandle) handle;
+            return delegate.register(new IoUringIoHandle() {
+                @Override
+                public void handle(IoRegistration registration, IoEvent event) {
+                    recorder.record((IoUringIoEvent) event);
+                    ioHandle.handle(registration, event);
+                }
+
+                @Override
+                public void registered() {
+                    ioHandle.registered();
+                }
+
+                @Override
+                public void unregistered() {
+                    ioHandle.unregistered();
+                }
+
+                @Override
+                public void close() throws Exception {
+                    ioHandle.close();
+                }
+            });
+        }
+
+        @Override
+        public void wakeup() {
+            delegate.wakeup();
+        }
+
+        @Override
+        public boolean isCompatible(Class<? extends IoHandle> handleType) {
+            return delegate.isCompatible(handleType);
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

The previous implementation submitted multiple recvmsg SQEs concurrently. The first request waited for data, while the following MSG_DONTWAIT requests immediately returned -EAGAIN. This violated the semantics of recvmmsg(MSG_WAITFORONE): wait for the first receive to complete, then try the remaining receives without blocking.

Netty only supports active cancellation and cannot handle passive -ECANCELED completions produced when an IOSQE_IO_LINK predecessor fails.  IOSQE_IO_HARDLINK is therefore used to serialize the SQEs without propagating failures to the remaining requests.

The SQEs are constructed internally by Netty and are not expected to fail during kernel prep. Linux io_init_req() / io_submit_fail_init()  https://github.com/torvalds/linux/blame/v7.0/io_uring/io_uring.c#L1610-L1750

The relevant short-submission case is request-allocation failure. Linux io_submit_sqes()  (https://github.com/torvalds/linux/blame/v7.0/io_uring/io_uring.c#L1883-L1922) The kernel correctly submits the already assembled chain even when its last accepted SQE still carries a link. Only a split at k = N - 1, before the final unlinked SQE, may allow that SQE to execute independently and return -EAGAIN early, without affecting data or Channel state.


Modification:

1. Use IOSQE_IO_HARDLINK to implement recvmmsg semantics and limit the batch using the available SQ and MsgHdrMemoryArray capacity.
2. Update AbstractUringUnsafe#readComplete. The previous rearm logic unexpectedly cleared READ_SCHEDULED after the first normal CQE, so it could not correctly wait for multiple in-flight SQEs and could close the fd too early:
      - Normal TCP reads are already serialized, and if (--numOutstandingReads == 0) correctly clears the state for non-multishot reads.
      - In the previous UDP implementation, the non-blocking SQEs completed immediately, leaving only the first SQE genuinely pending.
      - With IOSQE_IO_HARDLINK, multiple SQEs remain in flight, so READ_SCHEDULED must remain set until all of them complete.


Result:

UDP now follows the intended recvmmsg semantics.