### PR TITLE
Fix JdkZlibDecompressor losing the tail of highly compressible streams

### DIFF
--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/JdkZlibDecompressor.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/JdkZlibDecompressor.java
@@ -38,6 +38,14 @@ public final class JdkZlibDecompressor extends InputBufferingDecompressor {
     private static final int FCOMMENT = 0x10;
     private static final int FRESERVED = 0xE0;
 
+    /**
+     * Smallest output buffer we hand to {@link Inflater#inflate(byte[], int, int)}. The number of remaining input
+     * bytes is only a hint for how much output to expect: the inflater may still hold decoded data that did not fit
+     * into the previous output buffer, and by then it may have consumed all input bytes already
+     * ({@link Inflater#getRemaining()} == 0). Inflating into a zero-sized buffer can never make progress.
+     */
+    private static final int MIN_OUTPUT_BUFFER_SIZE = 512;
+
     private Inflater inflater;
     private final int maxAllocation;
     private final byte[] dictionary;
@@ -69,6 +77,12 @@ public final class JdkZlibDecompressor extends InputBufferingDecompressor {
      * buffer too much (e.g. compact it).
      */
     private boolean inputBufferInInflater;
+    /**
+     * If this is true, the last {@link Inflater#inflate(byte[], int, int)} filled the output buffer completely, so
+     * the inflater may still hold decoded data even if {@link Inflater#needsInput()} reports that all input was
+     * consumed.
+     */
+    private boolean inflaterHasPendingOutput;
 
     JdkZlibDecompressor(Builder builder, ByteBufAllocator allocator) {
         super(allocator);
@@ -102,6 +116,8 @@ public final class JdkZlibDecompressor extends InputBufferingDecompressor {
     public Status status() throws DecompressionException {
         if (finished) {
             return Status.COMPLETE;
+        } else if (inflaterHasPendingOutput) {
+            return Status.NEED_OUTPUT;
         } else if (inflater == null || inflater.needsInput() || gzipState == GzipState.FOOTER_START) {
             return Status.NEED_INPUT;
         } else {
@@ -187,7 +203,7 @@ public final class JdkZlibDecompressor extends InputBufferingDecompressor {
 
     @Override
     ByteBuf processOutput(ByteBuf buf) throws DecompressionException {
-        int proposedCapacity = inflater.getRemaining() << 1;
+        int proposedCapacity = Math.max(inflater.getRemaining() << 1, MIN_OUTPUT_BUFFER_SIZE);
         int targetCapacity = maxAllocation == 0
                 ? proposedCapacity : Math.min(maxAllocation, proposedCapacity);
         ByteBuf decompressed = allocator.heapBuffer(targetCapacity);
@@ -196,9 +212,10 @@ public final class JdkZlibDecompressor extends InputBufferingDecompressor {
             byte[] outArray = decompressed.array();
             int writerIndex = decompressed.writerIndex();
             int outIndex = decompressed.arrayOffset() + writerIndex;
+            int writableBytes = decompressed.writableBytes();
             int outputLength;
             try {
-                outputLength = inflater.inflate(outArray, outIndex, decompressed.writableBytes());
+                outputLength = inflater.inflate(outArray, outIndex, writableBytes);
             } catch (DataFormatException e) {
                 throw new DecompressionException("decompression failure", e);
             }
@@ -226,6 +243,10 @@ public final class JdkZlibDecompressor extends InputBufferingDecompressor {
                     processInput(buf);
                 }
             }
+            // If we filled the whole buffer the inflater may still have decoded data left that it could not write.
+            // In that case we must ask for another output buffer, as needsInput() only tells us that all input
+            // bytes were consumed, not that all output was produced.
+            inflaterHasPendingOutput = outputLength == writableBytes && !inflater.finished();
             success = true;
             return decompressed;
         } finally {

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/JdkZlibDecompressorTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/JdkZlibDecompressorTest.java
@@ -277,6 +277,7 @@ public class JdkZlibDecompressorTest extends AbstractDecompressorTest {
                 output.write(buffer, 0, read);
             }
             input.close();
+            output.close();
             return output.toByteArray();
         } finally {
             inflater.end();

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/JdkZlibDecompressorTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/JdkZlibDecompressorTest.java
@@ -30,9 +30,12 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
+import java.util.zip.Inflater;
+import java.util.zip.InflaterInputStream;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -159,6 +162,18 @@ public class JdkZlibDecompressorTest extends AbstractDecompressorTest {
     }
 
     @Test
+    public void testHighlyCompressibleStreamIsFullyDecompressed() throws Exception {
+        // The tail of such a stream expands far beyond the number of remaining input bytes: the inflater pulls the
+        // last input bytes into its internal state while it still has to emit data. getRemaining() is 0 by then,
+        // so sizing the output buffer by it alone leaves the inflater without room to write the rest.
+        byte[] expected = new byte[100000];
+        Arrays.fill(expected, (byte) 'a');
+        byte[] compressed = compress(expected);
+        assertArrayEquals(expected, jdkDecompress(compressed));
+        assertArrayEquals(expected, decompress(createDecompressor().build(ByteBufAllocator.DEFAULT), compressed));
+    }
+
+    @Test
     public void testBadSecondGzipMagicRejected() throws Exception {
         assumeTrue(wrapper == ZlibWrapper.GZIP);
         byte[] compressed = gzip("bad magic".getBytes(CharsetUtil.UTF_8));
@@ -227,6 +242,57 @@ public class JdkZlibDecompressorTest extends AbstractDecompressorTest {
             }
         } finally {
             output.release();
+        }
+    }
+
+    /**
+     * Compress with the wrapper this test instance runs with, using the JDK so that the input is known-good
+     * independently of netty's own encoders.
+     */
+    private byte[] compress(byte[] data) throws IOException {
+        switch (wrapper) {
+            case GZIP:
+                return gzip(data);
+            case ZLIB:
+                return deflate(data);
+            case NONE:
+                return rawDeflate(data);
+            default:
+                throw new AssertionError("Unexpected wrapper: " + wrapper);
+        }
+    }
+
+    /** Decompress with the JDK, to prove the compressed input is valid. */
+    private byte[] jdkDecompress(byte[] compressed) throws IOException {
+        if (wrapper == ZlibWrapper.GZIP) {
+            return jdkGunzip(compressed);
+        }
+        Inflater inflater = new Inflater(wrapper == ZlibWrapper.NONE);
+        try {
+            InflaterInputStream input = new InflaterInputStream(new ByteArrayInputStream(compressed), inflater);
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            byte[] buffer = new byte[256];
+            int read;
+            while ((read = input.read(buffer)) != -1) {
+                output.write(buffer, 0, read);
+            }
+            input.close();
+            return output.toByteArray();
+        } finally {
+            inflater.end();
+        }
+    }
+
+    private static byte[] rawDeflate(byte[] data) throws IOException {
+        Deflater deflater = new Deflater(Deflater.DEFAULT_COMPRESSION, true);
+        try {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            DeflaterOutputStream stream = new DeflaterOutputStream(output, deflater);
+            stream.write(data);
+            stream.close();
+            return output.toByteArray();
+        } finally {
+            deflater.end();
         }
     }
 


### PR DESCRIPTION
### Motivation

`JdkZlibDecompressor#processOutput` sizes every output buffer as
`inflater.getRemaining() << 1`. The number of remaining input bytes is only a hint: the inflater
may still hold decoded data that did not fit into the previous output buffer, and by then it may
have pulled the last input bytes into its internal state, so `getRemaining()` is `0` and the
proposed buffer has zero capacity. `inflate(...)` cannot make progress with it, and because
`status()` maps `inflater.needsInput()` straight to `NEED_INPUT`, the caller is asked for more
input instead of draining the pending output. At the end of the stream `endOfInput()` then fails
with `Compressed stream ended before the end-of-stream marker`, even though the stream was
complete and valid.

Measured with 100000 bytes of `'a'` deflated raw (115 bytes, ratio ~870:1), driving the
decompressor exactly as its own tests do:

```
new JdkZlibDecompressor (ZlibWrapper.NONE): 99848 of 100000 bytes, then
    DecompressionException: Compressed stream ended before the end-of-stream marker
legacy JdkZlibDecoder  (ZlibWrapper.NONE): 100000 bytes
java.util.zip.Inflater                   : 100000 bytes
```

Replaying the same buffer sizing against a bare `Inflater` shows the state that is mis-read:

```
iteration 2148: inflate returned 0 cap=0 getRemaining=0 needsInput=true finished=false producedSoFar=99848
drained with a 64K buffer afterwards: 152B, finished=true
```

So the tail is inside the `Inflater` the whole time and only the buffer sizing keeps it there.
The legacy `JdkZlibDecoder` is not affected because it inflates into a single buffer that it keeps
expanding, so `inflate(...)` always has room. `ZlibWrapper.ZLIB` and `ZlibWrapper.GZIP` hide the
problem as well, because their trailer keeps `getRemaining()` above zero until the inflater is
finished; raw deflate has no trailer, which is what `permessage-deflate` and
`Content-Encoding: deflate` payloads look like.

### Modification

- Never propose a zero-sized output buffer: `processOutput` floors the proposed capacity at
  `MIN_OUTPUT_BUFFER_SIZE` (512 bytes). `maxAllocation` still caps it exactly as before, so a
  configured limit keeps its meaning.
- Remember whether the last `inflate(...)` filled the output buffer completely and, if it did,
  report `NEED_OUTPUT` from `status()` so the pending output is drained before more input is
  requested. `needsInput()` only says that all input bytes were consumed, not that all output was
  produced. The flag is cleared once a call does not fill the buffer or the inflater is finished,
  so this cannot loop.

### Result

A valid deflate stream is fully decompressed regardless of its compression ratio.

**Verification done:** added `JdkZlibDecompressorTest#testHighlyCompressibleStreamIsFullyDecompressed`.
It runs for all three wrappers, cross-checks the compressed input with the JDK inflater first so a
failure cannot be blamed on the fixture, and then asserts the decompressor returns the same bytes.
It fails on unpatched `4.2` for `ZlibWrapper.NONE` with the exception above and passes with this
change. `./mvnw -pl codec-compression clean install` is green on JDK 21 (499 tests, checkstyle,
forbidden-apis and revapi included).

I also ran the other `Decompressor` implementations through the same battery (round trip at chunk
sizes 1..64K, `addInput` ownership on malformed input, `close()` idempotency, concatenated frames,
and hand-crafted gzip headers covering every `FLG` combination against `GZIPInputStream`) and found
no other divergence, so this change is limited to the zlib one.
