### PR TITLE
BrotliEncoder: Prevent duplicate close scheduling (#17175)

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/BrotliEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/BrotliEncoder.java
@@ -187,6 +187,7 @@ public final class BrotliEncoder extends MessageToByteEncoder<ByteBuf> {
         private ByteBuf writableBuffer;
         private final BrotliEncoderChannel brotliEncoderChannel;
         private final ChannelHandlerContext ctx;
+        private boolean closeInitiated;
         private boolean isClosed;
 
         private Writer(Encoder.Parameters parameters, ChannelHandlerContext ctx) throws IOException {
@@ -240,8 +241,11 @@ public final class BrotliEncoder extends MessageToByteEncoder<ByteBuf> {
 
         @Override
         public void close() {
+            if (closeInitiated) {
+                return;
+            }
+            closeInitiated = true;
             final ChannelPromise promise = ctx.newPromise();
-
             ctx.executor().execute(new Runnable() {
                 @Override
                 public void run() {


### PR DESCRIPTION
Motivation:

`BrotliEncoderChannel.close()` closes its destination, which re-enters `BrotliEncoder.Writer.close()`. The re-entrant call schedules another finish task before `isClosed` is set. If the first finish fails, the second task can retry with an already-failed close promise.

Modification:

Track whether writer close has already been initiated and ignore subsequent close calls before scheduling another finish task.

Result:

Brotli encoder close is idempotent while a finish is pending, and exceptional finalization no longer retries with an already-completed promise.
