### PR TITLE
Update compress-lzf to 1.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -950,7 +950,7 @@
       <dependency>
         <groupId>com.ning</groupId>
         <artifactId>compress-lzf</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.1</version>
       </dependency>
       <dependency>
         <groupId>at.yawk.lz4</groupId>


### PR DESCRIPTION
Motivation:

Update Netty's optional LZF compression dependency to the latest Maven Central release.

Modification:

Bump `com.ning:compress-lzf` from `1.2.0` to `1.2.1` in root dependency management.

Result:

The `codec-compression` LZF tests pass locally:

```bash
./mvnw -B -ntp -Dmaven.repo.local=/tmp/opencode/netty-maven-home/repository \
  -pl codec-compression -am test \
  -Dtest=LzfEncoderTest,LzfDecoderTest,LzfIntegrationTest,LengthAwareLzfIntegrationTest \
  -Dsurefire.failIfNoSpecifiedTests=false
```

Tests run: 36, Failures: 0, Errors: 0, Skipped: 0