### PR TITLE
Weakly reference engines from the OpenSSL engine map

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslClientSessionCache.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslClientSessionCache.java
@@ -31,7 +31,7 @@ import java.util.Set;
 final class OpenSslClientSessionCache extends OpenSslSessionCache {
     private final Map<HostPort, Set<NativeSslSession>> sessions = new HashMap<>();
 
-    OpenSslClientSessionCache(Map<Long, ReferenceCountedOpenSslEngine> engines) {
+    OpenSslClientSessionCache(OpenSslEngineMap engines) {
         super(engines);
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslEngineMap.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslEngineMap.java
@@ -16,8 +16,8 @@
 package io.netty.handler.ssl;
 
 import java.lang.ref.WeakReference;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 /**
  * Maps a native {@code SSL*} pointer to its {@link ReferenceCountedOpenSslEngine} so native OpenSSL callbacks
@@ -39,7 +39,7 @@ import java.util.concurrent.ConcurrentMap;
  */
 final class OpenSslEngineMap {
 
-    private final ConcurrentMap<Long, WeakReference<ReferenceCountedOpenSslEngine>> engines =
+    private final Map<Long, WeakReference<ReferenceCountedOpenSslEngine>> engines =
             new ConcurrentHashMap<Long, WeakReference<ReferenceCountedOpenSslEngine>>();
 
     void add(long ssl, ReferenceCountedOpenSslEngine engine) {

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslEngineMap.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslEngineMap.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import java.lang.ref.WeakReference;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Maps a native {@code SSL*} pointer to its {@link ReferenceCountedOpenSslEngine} so native OpenSSL callbacks
+ * (certificate verification, private-key operations, certificate (de)compression) can recover the engine from the
+ * raw pointer they are handed.
+ * <p>
+ * Engines are held weakly so a leaked engine is not pinned by the long-lived parent
+ * {@link ReferenceCountedOpenSslContext} (a live engine is always strongly reachable via its {@link SslHandler}, and
+ * on the stack during a callback, so weak retention never collects a usable one). For {@link SslProvider#OPENSSL}
+ * this lets {@link OpenSslEngine#finalize()} reclaim the native {@code SSL*} without waiting for the whole context to
+ * be collected; a leaked {@link SslProvider#OPENSSL_REFCNT} engine has no finalizer so its native memory still leaks,
+ * but it becomes collectable and so is reported by the {@code ResourceLeakDetector} rather than pinned silently.
+ * <p>
+ * Entries are removed in {@link ReferenceCountedOpenSslEngine#shutdown()}, so the map does not grow in steady state.
+ * A cleared {@link WeakReference} lingers only for a leaked {@code OPENSSL_REFCNT} engine (whose {@code SSL*} is never
+ * freed, hence never reused); such a husk is tiny, dwarfed by the native memory it marks, and is deliberately left as
+ * a heap-inspectable leak signal. Do not reap it (e.g. via a {@code ReferenceQueue}): {@link #get(long)} already
+ * yields {@code null} for a cleared reference, so reaping would only erase that signal.
+ */
+final class OpenSslEngineMap {
+
+    private final ConcurrentMap<Long, WeakReference<ReferenceCountedOpenSslEngine>> engines =
+            new ConcurrentHashMap<Long, WeakReference<ReferenceCountedOpenSslEngine>>();
+
+    void add(long ssl, ReferenceCountedOpenSslEngine engine) {
+        // A fresh SSL_new() pointer maps to nothing yet: an SSL* is reused only after shutdown() removed its entry
+        // (remove-before-freeSSL), and a husk survives only for a never-freed, never-reused SSL*.
+        WeakReference<ReferenceCountedOpenSslEngine> prev =
+                engines.put(ssl, new WeakReference<ReferenceCountedOpenSslEngine>(engine));
+        assert prev == null : "OpenSslEngineMap already had an entry for SSL* 0x" + Long.toHexString(ssl);
+    }
+
+    void remove(long ssl) {
+        engines.remove(ssl);
+    }
+
+    ReferenceCountedOpenSslEngine get(long ssl) {
+        WeakReference<ReferenceCountedOpenSslEngine> ref = engines.get(ssl);
+        return ref == null ? null : ref.get();
+    }
+}

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionCache.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionCache.java
@@ -49,7 +49,7 @@ class OpenSslSessionCache implements SSLSessionCache {
             DEFAULT_CACHE_SIZE = 20480;
         }
     }
-    private final Map<Long, ReferenceCountedOpenSslEngine> engines;
+    private final OpenSslEngineMap engines;
 
     private final Map<OpenSslSessionId, NativeSslSession> sessions =
             new LinkedHashMap<OpenSslSessionId, NativeSslSession>() {
@@ -74,7 +74,7 @@ class OpenSslSessionCache implements SSLSessionCache {
     private final AtomicInteger sessionTimeout = new AtomicInteger(300);
     private int sessionCounter;
 
-    OpenSslSessionCache(Map<Long, ReferenceCountedOpenSslEngine> engines) {
+    OpenSslSessionCache(OpenSslEngineMap engines) {
         this.engines = engines;
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslClientContext.java
@@ -103,7 +103,7 @@ public final class ReferenceCountedOpenSslClientContext extends ReferenceCounted
     }
 
     static OpenSslSessionContext newSessionContext(ReferenceCountedOpenSslContext thiz, long ctx,
-                                                   Map<Long, ReferenceCountedOpenSslEngine> engines,
+                                                   OpenSslEngineMap engines,
                                                    X509Certificate[] trustCertCollection,
                                                    TrustManagerFactory trustManagerFactory,
                                                    X509Certificate[] keyCertChain, PrivateKey key,
@@ -213,7 +213,7 @@ public final class ReferenceCountedOpenSslClientContext extends ReferenceCounted
     }
 
     private static void setVerifyCallback(long ctx,
-                                          Map<Long, ReferenceCountedOpenSslEngine> engines,
+                                          OpenSslEngineMap engines,
                                           X509TrustManager manager) {
         // Use this to prevent an error when running on java < 7
         if (useExtendedTrustManager(manager)) {
@@ -233,7 +233,7 @@ public final class ReferenceCountedOpenSslClientContext extends ReferenceCounted
     private static final class TrustManagerVerifyCallback extends AbstractCertificateVerifier {
         private final X509TrustManager manager;
 
-        TrustManagerVerifyCallback(Map<Long, ReferenceCountedOpenSslEngine> engines, X509TrustManager manager) {
+        TrustManagerVerifyCallback(OpenSslEngineMap engines, X509TrustManager manager) {
             super(engines);
             this.manager = manager;
         }
@@ -248,7 +248,7 @@ public final class ReferenceCountedOpenSslClientContext extends ReferenceCounted
     private static final class ExtendedTrustManagerVerifyCallback extends AbstractCertificateVerifier {
         private final X509ExtendedTrustManager manager;
 
-        ExtendedTrustManagerVerifyCallback(Map<Long, ReferenceCountedOpenSslEngine> engines,
+        ExtendedTrustManagerVerifyCallback(OpenSslEngineMap engines,
                                            X509ExtendedTrustManager manager) {
             super(engines);
             this.manager = manager;
@@ -262,10 +262,10 @@ public final class ReferenceCountedOpenSslClientContext extends ReferenceCounted
     }
 
     private static final class OpenSslClientCertificateCallback implements CertificateCallback {
-        private final Map<Long, ReferenceCountedOpenSslEngine> engines;
+        private final OpenSslEngineMap engines;
         private final OpenSslKeyMaterialManager keyManagerHolder;
 
-        OpenSslClientCertificateCallback(Map<Long, ReferenceCountedOpenSslEngine> engines,
+        OpenSslClientCertificateCallback(OpenSslEngineMap engines,
                                          OpenSslKeyMaterialManager keyManagerHolder) {
             this.engines = engines;
             this.keyManagerHolder = keyManagerHolder;

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -57,8 +57,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -170,7 +168,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
     final boolean hasTmpDhKeys;
     final String[] groups;
     final boolean enableOcsp;
-    final ConcurrentMap<Long, ReferenceCountedOpenSslEngine> engines = new ConcurrentHashMap<>();
+    final OpenSslEngineMap engines = new OpenSslEngineMap();
     final ReadWriteLock ctxLock = new ReentrantReadWriteLock();
     final List<OpenSslCredential> credentials = new ArrayList<>();
 
@@ -880,9 +878,9 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
     }
 
     abstract static class AbstractCertificateVerifier extends CertificateVerifier {
-        private final Map<Long, ReferenceCountedOpenSslEngine> engines;
+        private final OpenSslEngineMap engines;
 
-        AbstractCertificateVerifier(Map<Long, ReferenceCountedOpenSslEngine> engines) {
+        AbstractCertificateVerifier(OpenSslEngineMap engines) {
             this.engines = engines;
         }
 
@@ -1147,7 +1145,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
         }
     }
 
-    private static ReferenceCountedOpenSslEngine retrieveEngine(Map<Long, ReferenceCountedOpenSslEngine> engines,
+    private static ReferenceCountedOpenSslEngine retrieveEngine(OpenSslEngineMap engines,
                                                                 long ssl)
             throws SSLException {
         ReferenceCountedOpenSslEngine engine = engines.get(ssl);
@@ -1160,9 +1158,9 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
 
     private static final class PrivateKeyMethod implements SSLPrivateKeyMethod {
 
-        private final Map<Long, ReferenceCountedOpenSslEngine> engines;
+        private final OpenSslEngineMap engines;
         private final OpenSslPrivateKeyMethod keyMethod;
-        PrivateKeyMethod(Map<Long, ReferenceCountedOpenSslEngine> engines, OpenSslPrivateKeyMethod keyMethod) {
+        PrivateKeyMethod(OpenSslEngineMap engines, OpenSslPrivateKeyMethod keyMethod) {
             this.engines = engines;
             this.keyMethod = keyMethod;
         }
@@ -1192,10 +1190,10 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
 
     private static final class AsyncPrivateKeyMethod implements AsyncSSLPrivateKeyMethod {
 
-        private final Map<Long, ReferenceCountedOpenSslEngine> engines;
+        private final OpenSslEngineMap engines;
         private final OpenSslAsyncPrivateKeyMethod keyMethod;
 
-        AsyncPrivateKeyMethod(Map<Long, ReferenceCountedOpenSslEngine> engines,
+        AsyncPrivateKeyMethod(OpenSslEngineMap engines,
                               OpenSslAsyncPrivateKeyMethod keyMethod) {
             this.engines = engines;
             this.keyMethod = keyMethod;
@@ -1261,10 +1259,10 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
     }
 
     private static final class CompressionAlgorithm implements CertificateCompressionAlgo {
-        private final Map<Long, ReferenceCountedOpenSslEngine> engines;
+        private final OpenSslEngineMap engines;
         private final OpenSslCertificateCompressionAlgorithm compressionAlgorithm;
 
-        CompressionAlgorithm(Map<Long, ReferenceCountedOpenSslEngine> engines,
+        CompressionAlgorithm(OpenSslEngineMap engines,
                              OpenSslCertificateCompressionAlgorithm compressionAlgorithm) {
             this.engines = engines;
             this.compressionAlgorithm = compressionAlgorithm;

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -205,7 +205,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
     final boolean jdkCompatibilityMode;
     private final boolean clientMode;
     final ByteBufAllocator alloc;
-    private final Map<Long, ReferenceCountedOpenSslEngine> engines;
+    private final OpenSslEngineMap engines;
     private final OpenSslApplicationProtocolNegotiator apn;
     private final ReferenceCountedOpenSslContext parentContext;
     private final OpenSslInternalSession session;
@@ -422,8 +422,8 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
         // object so we need to retain a reference to the parent context.
         parentContext = context;
 
-        // Adding the OpenSslEngine to the OpenSslEngineMap so it can be used in the AbstractCertificateVerifier.
-        engines.put(ssl, this);
+        // Register for the SSL* -> engine reverse lookup used by native callbacks; held weakly (see OpenSslEngineMap).
+        engines.add(ssl, this);
 
         // Only create the leak after everything else was executed and so ensure we don't produce a false-positive for
         // the ResourceLeakDetector.

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslServerContext.java
@@ -98,7 +98,7 @@ public final class ReferenceCountedOpenSslServerContext extends ReferenceCounted
     }
 
     static OpenSslServerSessionContext newSessionContext(ReferenceCountedOpenSslContext thiz, long ctx,
-                                                         Map<Long, ReferenceCountedOpenSslEngine>  engines,
+                                                         OpenSslEngineMap engines,
                                                          X509Certificate[] trustCertCollection,
                                                          TrustManagerFactory trustManagerFactory,
                                                          X509Certificate[] keyCertChain, PrivateKey key,
@@ -217,7 +217,7 @@ public final class ReferenceCountedOpenSslServerContext extends ReferenceCounted
     }
 
     private static void setVerifyCallback(long ctx,
-                                          Map<Long, ReferenceCountedOpenSslEngine> engines,
+                                          OpenSslEngineMap engines,
                                           X509TrustManager manager) {
         // Use this to prevent an error when running on java < 7
         if (useExtendedTrustManager(manager)) {
@@ -229,10 +229,10 @@ public final class ReferenceCountedOpenSslServerContext extends ReferenceCounted
     }
 
     private static final class OpenSslServerCertificateCallback implements CertificateCallback {
-        private final Map<Long, ReferenceCountedOpenSslEngine> engines;
+        private final OpenSslEngineMap engines;
         private final OpenSslKeyMaterialManager keyManagerHolder;
 
-        OpenSslServerCertificateCallback(Map<Long, ReferenceCountedOpenSslEngine> engines,
+        OpenSslServerCertificateCallback(OpenSslEngineMap engines,
                                          OpenSslKeyMaterialManager keyManagerHolder) {
             this.engines = engines;
             this.keyManagerHolder = keyManagerHolder;
@@ -263,7 +263,7 @@ public final class ReferenceCountedOpenSslServerContext extends ReferenceCounted
     private static final class TrustManagerVerifyCallback extends AbstractCertificateVerifier {
         private final X509TrustManager manager;
 
-        TrustManagerVerifyCallback(Map<Long, ReferenceCountedOpenSslEngine> engines,
+        TrustManagerVerifyCallback(OpenSslEngineMap engines,
                                    X509TrustManager manager) {
             super(engines);
             this.manager = manager;
@@ -279,7 +279,7 @@ public final class ReferenceCountedOpenSslServerContext extends ReferenceCounted
     private static final class ExtendedTrustManagerVerifyCallback extends AbstractCertificateVerifier {
         private final X509ExtendedTrustManager manager;
 
-        ExtendedTrustManagerVerifyCallback(Map<Long, ReferenceCountedOpenSslEngine> engines,
+        ExtendedTrustManagerVerifyCallback(OpenSslEngineMap engines,
                                            X509ExtendedTrustManager manager) {
             super(engines);
             this.manager = manager;
@@ -293,9 +293,9 @@ public final class ReferenceCountedOpenSslServerContext extends ReferenceCounted
     }
 
     private static final class OpenSslSniHostnameMatcher implements SniHostNameMatcher {
-        private final Map<Long, ReferenceCountedOpenSslEngine> engines;
+        private final OpenSslEngineMap engines;
 
-        OpenSslSniHostnameMatcher(Map<Long, ReferenceCountedOpenSslEngine> engines) {
+        OpenSslSniHostnameMatcher(OpenSslEngineMap engines) {
             this.engines = engines;
         }
 

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -33,6 +33,7 @@ import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
@@ -55,6 +56,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
@@ -1512,6 +1514,39 @@ public class OpenSslEngineTest extends SSLEngineTest {
         } finally {
             cleanupClientSslEngine(client);
             cleanupServerSslEngine(server);
+        }
+    }
+
+    // Pins OPENSSL (not sslClientProvider()) because only the OPENSSL engine has a finalizer to drive the reclaim
+    // asserted here; the OPENSSL_REFCNT subclass overrides this to a no-op (it has no finalizer). Verifies that a
+    // leaked engine is collected and releases its parent context while the context is still alive -- only possible
+    // because OpenSslEngineMap holds engines weakly rather than pinning them for the context's lifetime.
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    public void leakedEngineIsReclaimedWhileContextAlive() throws Exception {
+        assumeTrue(OpenSsl.isAvailable());
+
+        SslContext ctx = SslContextBuilder.forClient()
+                .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                .sslProvider(OPENSSL)
+                .build();
+        try {
+            // newEngine retains the context, so its refCnt goes from 1 to 2.
+            SSLEngine engine = ctx.newEngine(UnpooledByteBufAllocator.DEFAULT);
+            assertEquals(2, ReferenceCountUtil.refCnt(ctx));
+
+            // Drop the engine without releasing it, simulating a leak (e.g. handlerRemoved0 never firing).
+            engine = null;
+
+            // Collection triggers OpenSslEngine.finalize(), which releases the context (2 -> 1).
+            while (ReferenceCountUtil.refCnt(ctx) != 1) {
+                System.gc();
+                System.runFinalization();
+                Thread.sleep(50);
+            }
+            assertEquals(1, ReferenceCountUtil.refCnt(ctx));
+        } finally {
+            ReferenceCountUtil.release(ctx);
         }
     }
 

--- a/handler/src/test/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngineTest.java
@@ -39,6 +39,13 @@ public class ReferenceCountedOpenSslEngineTest extends OpenSslEngineTest {
         return SslProvider.OPENSSL_REFCNT;
     }
 
+    // OPENSSL_REFCNT has no finalizer, so the superclass's OPENSSL-only reclaim test does not apply here.
+    // Overriding it without @Test disables it for this subclass.
+    @Override
+    public void leakedEngineIsReclaimedWhileContextAlive() {
+        // noop
+    }
+
     @MethodSource("newTestParams")
     @ParameterizedTest
     public void testNotLeakOnException(SSLEngineTestParam param) throws Exception {


### PR DESCRIPTION
Motivation:

ReferenceCountedOpenSslContext strongly references every engine through its `engines` map (the SSL* -> engine reverse lookup used by the OpenSSL callbacks). As an SslContext is typically a long-lived singleton, a leaked engine stays reachable for the context's whole lifetime, so OpenSslEngine.finalize() - the backstop meant for that case - never runs and its native memory is freed only when the context is destroyed.

Modification:

Reintroduce OpenSslEngineMap as a class holding the engines as WeakReferences. A live engine is always strongly reachable via its SslHandler, so only a leaked one becomes collectable. The abstraction removed in #15444 was a strong wrapper that rightly added no value; weak values give it a reason to exist.

Add OpenSslEngineTest.leakedEngineIsReclaimedWhileContextAlive.

Result:

A leaked OPENSSL engine is reclaimed per-engine independently of its context. For OPENSSL_REFCNT a leaked engine now also becomes collectable, so the ResourceLeakDetector reports it instead of it being pinned silently.