### PR TITLE
Do not write WebSocket handshake response to the tail of the pipeline (#17192)

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
@@ -166,6 +166,9 @@ public abstract class WebSocketServerHandshaker {
      * Performs the opening handshake. When call this method you <strong>MUST NOT</strong> retain the
      * {@link FullHttpRequest} which is passed in.
      *
+     * When called from within a {@link ChannelHandler} you most likely want to use
+     * {@link #handshake(ChannelHandlerContext, FullHttpRequest)}.
+     *
      * @param channel
      *              Channel
      * @param req
@@ -182,6 +185,9 @@ public abstract class WebSocketServerHandshaker {
      *
      * When call this method you <strong>MUST NOT</strong> retain the {@link FullHttpRequest} which is passed in.
      *
+     * When called from within a {@link ChannelHandler} you most likely want to use
+     * {@link #handshake(ChannelHandlerContext, FullHttpRequest, HttpHeaders, Promise)}.
+     *
      * @param channel
      *            Channel
      * @param req
@@ -195,6 +201,57 @@ public abstract class WebSocketServerHandshaker {
      */
     public final Future<Void> handshake(Channel channel, FullHttpRequest req,
                                             HttpHeaders responseHeaders, final Promise<Void> promise) {
+        return handshake0(channel, channel, req, responseHeaders, promise);
+    }
+
+    /**
+     * Performs the opening handshake. When call this method you <strong>MUST NOT</strong> retain the
+     * {@link FullHttpRequest} which is passed in.
+     *
+     * The handshake response is written to the given {@link ChannelHandlerContext}, so handlers placed
+     * after the {@link ChannelHandler} the context belongs to will not see the response. The handler the
+     * context belongs to must be placed after the HTTP encoder as the response still needs to be encoded.
+     *
+     * @param ctx
+     *              the {@link ChannelHandlerContext} to use.
+     * @param req
+     *              HTTP Request
+     * @return future
+     *              The {@link Future} which is notified once the opening handshake completes
+     */
+    public Future<Void> handshake(ChannelHandlerContext ctx, FullHttpRequest req) {
+        ObjectUtil.checkNotNull(ctx, "ctx");
+        return handshake(ctx, req, null, ctx.newPromise());
+    }
+
+    /**
+     * Performs the opening handshake
+     *
+     * When call this method you <strong>MUST NOT</strong> retain the {@link FullHttpRequest} which is passed in.
+     *
+     * The handshake response is written to the given {@link ChannelHandlerContext}, so handlers placed
+     * after the {@link ChannelHandler} the context belongs to will not see the response. The handler the
+     * context belongs to must be placed after the HTTP encoder as the response still needs to be encoded.
+     *
+     * @param ctx
+     *            the {@link ChannelHandlerContext} to use.
+     * @param req
+     *            HTTP Request
+     * @param responseHeaders
+     *            Extra headers to add to the handshake response or {@code null} if no extra headers should be added
+     * @param promise
+     *            the {@link Promise} to be notified when the opening handshake is done
+     * @return future
+     *            the {@link Future} which is notified when the opening handshake is done
+     */
+    public Future<Void> handshake(ChannelHandlerContext ctx, FullHttpRequest req,
+                                            HttpHeaders responseHeaders, final Promise<Void> promise) {
+        ObjectUtil.checkNotNull(ctx, "ctx");
+        return handshake0(ctx, ctx.channel(), req, responseHeaders, promise);
+    }
+
+    private Future<Void> handshake0(final ChannelOutboundInvoker invoker, final Channel channel, FullHttpRequest req,
+                                     HttpHeaders responseHeaders, final Promise<Void> promise) {
 
         if (logger.isDebugEnabled()) {
             logger.debug("{} WebSocket version {} server handshake", channel, version());
@@ -227,7 +284,7 @@ public abstract class WebSocketServerHandshaker {
             encoderName = p.context(HttpResponseEncoder.class).name();
             p.addBefore(encoderName, "wsencoder", newWebSocketEncoder());
         }
-        channel.writeAndFlush(response).addListener(future -> {
+        invoker.writeAndFlush(response).addListener(future -> {
             if (future.isSuccess()) {
                 ChannelPipeline p1 = channel.pipeline();
                 p1.remove(encoderName);
@@ -242,6 +299,9 @@ public abstract class WebSocketServerHandshaker {
     /**
      * Performs the opening handshake. When call this method you <strong>MUST NOT</strong> retain the
      * {@link FullHttpRequest} which is passed in.
+     *
+     * When called from within a {@link ChannelHandler} you most likely want to use
+     * {@link #handshake(ChannelHandlerContext, HttpRequest)}.
      *
      * @param channel
      *              Channel
@@ -259,6 +319,9 @@ public abstract class WebSocketServerHandshaker {
      *
      * When call this method you <strong>MUST NOT</strong> retain the {@link HttpRequest} which is passed in.
      *
+     * When called from within a {@link ChannelHandler} you most likely want to use
+     * {@link #handshake(ChannelHandlerContext, HttpRequest, HttpHeaders, Promise)}.
+     *
      * @param channel
      *            Channel
      * @param req
@@ -272,8 +335,59 @@ public abstract class WebSocketServerHandshaker {
      */
     public final Future<Void> handshake(final Channel channel, HttpRequest req,
                                          final HttpHeaders responseHeaders, final Promise<Void> promise) {
+        return handshake0(channel, channel, req, responseHeaders, promise);
+    }
+
+    /**
+     * Performs the opening handshake. When call this method you <strong>MUST NOT</strong> retain the
+     * {@link HttpRequest} which is passed in.
+     *
+     * The handshake response is written to the given {@link ChannelHandlerContext}, so handlers placed
+     * after the {@link ChannelHandler} the context belongs to will not see the response. The handler the
+     * context belongs to must be placed after the HTTP encoder as the response still needs to be encoded.
+     *
+     * @param ctx
+     *              the {@link ChannelHandlerContext} to use.
+     * @param req
+     *              HTTP Request
+     * @return future
+     *              The {@link Future} which is notified once the opening handshake completes
+     */
+    public Future<Void> handshake(ChannelHandlerContext ctx, HttpRequest req) {
+        ObjectUtil.checkNotNull(ctx, "ctx");
+        return handshake(ctx, req, null, ctx.newPromise());
+    }
+
+    /**
+     * Performs the opening handshake
+     *
+     * When call this method you <strong>MUST NOT</strong> retain the {@link HttpRequest} which is passed in.
+     *
+     * The handshake response is written to the given {@link ChannelHandlerContext}, so handlers placed
+     * after the {@link ChannelHandler} the context belongs to will not see the response. The handler the
+     * context belongs to must be placed after the HTTP encoder as the response still needs to be encoded.
+     *
+     * @param ctx
+     *            the {@link ChannelHandlerContext} to use.
+     * @param req
+     *            HTTP Request
+     * @param responseHeaders
+     *            Extra headers to add to the handshake response or {@code null} if no extra headers should be added
+     * @param promise
+     *            the {@link Promise} to be notified when the opening handshake is done
+     * @return future
+     *            the {@link Future} which is notified when the opening handshake is done
+     */
+    public Future<Void> handshake(ChannelHandlerContext ctx, HttpRequest req,
+                                         final HttpHeaders responseHeaders, final Promise<Void> promise) {
+        ObjectUtil.checkNotNull(ctx, "ctx");
+        return handshake0(ctx, ctx.channel(), req, responseHeaders, promise);
+    }
+
+    private Future<Void> handshake0(final ChannelOutboundInvoker invoker, final Channel channel, HttpRequest req,
+                                     final HttpHeaders responseHeaders, final Promise<Void> promise) {
         if (req instanceof FullHttpRequest) {
-            return handshake(channel, (FullHttpRequest) req, responseHeaders, promise);
+            return handshake0(invoker, channel, (FullHttpRequest) req, responseHeaders, promise);
         }
 
         if (logger.isDebugEnabled()) {
@@ -347,7 +461,7 @@ public abstract class WebSocketServerHandshaker {
             private void handleHandshakeRequest(ChannelHandlerContext ctx, HttpObject httpObject) {
                 if (httpObject instanceof FullHttpRequest) {
                     ctx.pipeline().remove(this);
-                    handshake(channel, (FullHttpRequest) httpObject, responseHeaders, promise);
+                    handshake0(invoker, channel, (FullHttpRequest) httpObject, responseHeaders, promise);
                     return;
                 }
 
@@ -357,7 +471,7 @@ public abstract class WebSocketServerHandshaker {
                     fullHttpRequest = null;
                     try {
                         ctx.pipeline().remove(this);
-                        handshake(channel, handshakeRequest, responseHeaders, promise);
+                        handshake0(invoker, channel, handshakeRequest, responseHeaders, promise);
                     } finally {
                         handshakeRequest.release();
                     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
@@ -80,7 +80,8 @@ class WebSocketServerProtocolHandshakeHandler implements ChannelInboundHandler {
                     WebSocketServerProtocolHandler.setHandshaker(ctx.channel(), handshaker);
                     ctx.pipeline().remove(this);
 
-                    final Future<Void> handshakeFuture = handshaker.handshake(ctx.channel(), req);
+                    // The write via the removed handler's ctx still starts at this handler's former position.
+                    final Future<Void> handshakeFuture = handshaker.handshake(ctx, req);
                     handshakeFuture.addListener(future -> {
                         if (!future.isSuccess()) {
                             localHandshakePromise.tryFailure(future.cause());

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13Test.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13Test.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.http.websocketx;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
@@ -109,7 +110,7 @@ public class WebSocketServerHandshaker13Test extends WebSocketServerHandshakerTe
         Throwable exception = assertThrows(WebSocketServerHandshakeException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
-                serverHandshaker.handshake(null, request, null, null);
+                serverHandshaker.handshake((Channel) null, request, null, null);
             }
         });
 
@@ -135,7 +136,7 @@ public class WebSocketServerHandshaker13Test extends WebSocketServerHandshakerTe
         Throwable exception = assertThrows(WebSocketServerHandshakeException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
-                serverHandshaker.handshake(null, request, null, null);
+                serverHandshaker.handshake((Channel) null, request, null, null);
             }
         });
 
@@ -161,7 +162,7 @@ public class WebSocketServerHandshaker13Test extends WebSocketServerHandshakerTe
         Throwable exception = assertThrows(WebSocketServerHandshakeException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
-                serverHandshaker.handshake(null, request, null, null);
+                serverHandshaker.handshake((Channel)  null, request, null, null);
             }
         });
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshakerTest.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.http.websocketx;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
@@ -112,7 +113,7 @@ public abstract class WebSocketServerHandshakerTest {
                                                              "ws://example.com/chat");
         request.headers().set("x-client-header", "value");
         try {
-            serverHandshaker.handshake(null, request, null, null);
+            serverHandshaker.handshake((Channel) null, request, null, null);
         } catch (WebSocketServerHandshakeException exception) {
             assertNotNull(exception.getMessage());
             assertEquals(request.headers(), exception.request().headers());
@@ -195,7 +196,7 @@ public abstract class WebSocketServerHandshakerTest {
         Throwable exception = assertThrows(WebSocketServerHandshakeException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
-                serverHandshaker.handshake(null, request, null, null);
+                serverHandshaker.handshake((Channel) null, request, null, null);
             }
         });
 
@@ -221,7 +222,7 @@ public abstract class WebSocketServerHandshakerTest {
         Throwable exception = assertThrows(WebSocketServerHandshakeException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
-                serverHandshaker.handshake(null, request, null, null);
+                serverHandshaker.handshake((Channel) null, request, null, null);
             }
         });
 
@@ -247,7 +248,7 @@ public abstract class WebSocketServerHandshakerTest {
         Throwable exception = assertThrows(WebSocketServerHandshakeException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
-                serverHandshaker.handshake(null, request, null, null);
+                serverHandshaker.handshake((Channel) null, request, null, null);
             }
         });
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandlerTest.java
@@ -77,7 +77,7 @@ public class WebSocketServerProtocolHandlerTest {
         ChannelHandlerContext handshakerCtx = ch.pipeline().context(WebSocketServerProtocolHandshakeHandler.class);
         writeUpgradeRequest(ch, full);
 
-        FullHttpResponse response = responses.remove();
+        FullHttpResponse response = ch.readOutbound();
         assertEquals(SWITCHING_PROTOCOLS, response.status());
         response.release();
         assertNotNull(WebSocketServerProtocolHandler.getHandshaker(handshakerCtx.channel()));
@@ -99,7 +99,7 @@ public class WebSocketServerProtocolHandlerTest {
         });
         writeUpgradeRequest(ch);
 
-        FullHttpResponse response = responses.remove();
+        FullHttpResponse response = ch.readOutbound();
         assertEquals(SWITCHING_PROTOCOLS, response.status());
         response.release();
         assertNotNull(WebSocketServerProtocolHandler.getHandshaker(handshakerCtx.channel()));
@@ -161,7 +161,7 @@ public class WebSocketServerProtocolHandlerTest {
                 new MockOutboundHandler());
         writeUpgradeRequest(ch);
 
-        FullHttpResponse response = responses.remove();
+        FullHttpResponse response = ch.readOutbound();
         assertEquals(SWITCHING_PROTOCOLS, response.status());
         response.release();
 
@@ -182,7 +182,7 @@ public class WebSocketServerProtocolHandlerTest {
                 new MockOutboundHandler());
         writeUpgradeRequest(ch);
 
-        FullHttpResponse response = responses.remove();
+        FullHttpResponse response = ch.readOutbound();
         assertEquals(SWITCHING_PROTOCOLS, response.status());
         response.release();
 
@@ -195,7 +195,7 @@ public class WebSocketServerProtocolHandlerTest {
         EmbeddedChannel ch = createChannel(customTextFrameHandler);
         writeUpgradeRequest(ch);
 
-        FullHttpResponse response = responses.remove();
+        FullHttpResponse response = ch.readOutbound();
         assertEquals(SWITCHING_PROTOCOLS, response.status());
         response.release();
 
@@ -227,18 +227,21 @@ public class WebSocketServerProtocolHandlerTest {
 
         FullHttpResponse response;
 
-        createChannel(config, null).writeInbound(builder.uri("/test").build());
-        response = responses.remove();
+        EmbeddedChannel ch = createChannel(config, null);
+        ch.writeInbound(builder.uri("/test").build());
+        response = ch.readOutbound();
         assertEquals(SWITCHING_PROTOCOLS, response.status());
         response.release();
 
-        createChannel(config, null).writeInbound(builder.uri("/?q=v").build());
-        response = responses.remove();
+        ch = createChannel(config, null);
+        ch.writeInbound(builder.uri("/?q=v").build());
+        response = ch.readOutbound();
         assertEquals(SWITCHING_PROTOCOLS, response.status());
         response.release();
 
-        createChannel(config, null).writeInbound(builder.uri("/").build());
-        response = responses.remove();
+        ch = createChannel(config, null);
+        ch.writeInbound(builder.uri("/").build());
+        response = ch.readOutbound();
         assertEquals(SWITCHING_PROTOCOLS, response.status());
         response.release();
     }
@@ -266,7 +269,7 @@ public class WebSocketServerProtocolHandlerTest {
                 new MockOutboundHandler());
         ch.writeInbound(httpRequest);
 
-        FullHttpResponse response = responses.remove();
+        FullHttpResponse response = ch.readOutbound();
         assertEquals(SWITCHING_PROTOCOLS, response.status());
         response.release();
     }
@@ -397,6 +400,59 @@ public class WebSocketServerProtocolHandlerTest {
         assertEquals(expectedFrame, closeMessage);
         closeMessage.release();
         expectedFrame.release();
+
+        assertFalse(client.finishAndReleaseAll());
+        assertFalse(server.finishAndReleaseAll());
+    }
+
+    @Test
+    public void testHandshakeResponseNotSeenByHandlersAfterProtocolHandlerFull() throws Exception {
+        testHandshakeResponseNotSeenByHandlersAfterProtocolHandler0(true);
+    }
+
+    @Test
+    public void testHandshakeResponseNotSeenByHandlersAfterProtocolHandlerNonFull() throws Exception {
+        testHandshakeResponseNotSeenByHandlersAfterProtocolHandler0(false);
+    }
+
+    private void testHandshakeResponseNotSeenByHandlersAfterProtocolHandler0(boolean full) throws Exception {
+        final Queue<Object> writtenAfterProtocolHandler = new ArrayDeque<Object>();
+        EmbeddedChannel client = createClient();
+        final EmbeddedChannel server;
+        if (full) {
+            server = createServer();
+        } else {
+            // No HttpObjectAggregator so that the handshake handler receives a plain HttpRequest.
+            server = new EmbeddedChannel(
+                new HttpServerCodec(),
+                new WebSocketServerProtocolHandler(WebSocketServerProtocolConfig.newBuilder()
+                    .websocketPath("/test")
+                    .dropPongFrames(false)
+                    .build()));
+        }
+        // Added after register() so the recorder really sits behind the WebSocketServerProtocolHandler.
+        server.pipeline().addLast(new ChannelOutboundHandler() {
+            @Override
+            public void write(ChannelHandlerContext ctx, Object msg, CompletionHandler<Void> handler) {
+                writtenAfterProtocolHandler.add(msg);
+                ctx.write(msg, handler);
+            }
+        });
+
+        assertFalse(server.writeInbound(client.<ByteBuf>readOutbound()));
+        assertFalse(client.writeInbound(server.<ByteBuf>readOutbound()));
+
+        // The handshake response must not pass through handlers placed after the protocol handler.
+        assertTrue(writtenAfterProtocolHandler.isEmpty());
+
+        client.close();
+        assertFalse(server.writeInbound(client.<ByteBuf>readOutbound()));
+        assertFalse(client.isOpen());
+        assertFalse(server.isOpen());
+
+        CloseWebSocketFrame closeMessage = decode(server.<ByteBuf>readOutbound(), CloseWebSocketFrame.class);
+        assertEquals(closeMessage.statusCode(), WebSocketCloseStatus.NORMAL_CLOSURE.code());
+        closeMessage.release();
 
         assertFalse(client.finishAndReleaseAll());
         assertFalse(server.finishAndReleaseAll());

--- a/example/src/main/java/io/netty/example/http/websocketx/benchmarkserver/WebSocketServerHandler.java
+++ b/example/src/main/java/io/netty/example/http/websocketx/benchmarkserver/WebSocketServerHandler.java
@@ -102,7 +102,7 @@ public class WebSocketServerHandler extends SimpleChannelInboundHandler<Object> 
         if (handshaker == null) {
             WebSocketServerHandshakerFactory.sendUnsupportedVersionResponse(ctx.channel());
         } else {
-            handshaker.handshake(ctx.channel(), req);
+            handshaker.handshake(ctx, req);
         }
     }
 


### PR DESCRIPTION
`WebSocketServerHandshaker` writes the 101 Switching Protocols response
via
`Channel.writeAndFlush()`. The write starts at the tail of the pipeline,
so every
`ChannelOutboundHandler` placed after `WebSocketServerProtocolHandler`
sees the
raw HTTP upgrade response, even though handlers there operate on
WebSocket
frames. In #17141 a handler that queues outbound messages until
`HandshakeComplete` captured the response itself, so the handshake could
never
complete.

`WebSocketServerHandshaker` already provides `ChannelHandlerContext`
overloads
for `close()` for the same reason; this change applies the same pattern
to the
handshake response.

- Add `handshake(ChannelHandlerContext, ...)` overloads to
  `WebSocketServerHandshaker`, following the existing
`close(ChannelHandlerContext, ...)` overloads in the same class, and
route both
variants through a shared `handshake0(ChannelOutboundInvoker, Channel,
...)`.
- `WebSocketServerProtocolHandshakeHandler` now passes its ctx, so the
response
  is written from the handshake handler's former position.
- Update the benchmarkserver example to use the new overload.
- Tests: a regression test asserts a handler behind the protocol handler
observes no write during the handshake, for both full and non-full
upgrade
requests. Existing tests that captured the response behind the protocol
handler now read it via `readOutbound()`. Four `handshake(null, ...)`
calls
  needed a `(Channel)` cast to stay unambiguous.

Notes:

- With the documented pipeline ordering (extension/compression handler
before
the protocol handler, as in `WebSocketServerInitializer`) nothing
changes: the
write still traverses `WebSocketServerExtensionHandler` and the HTTP
encoder.
Only handlers behind the protocol handler stop seeing the 101, which is
the
  bug being fixed.
- The tail-write behavior of the `Channel` overloads is unchanged and
still
  covered by `WebSocketServerHandshaker00/08/13Test` and
  `WebSocketServerHandshakerTest`.

Fixes #17141.

---------

Co-authored-by: el-psy-kongroo-d <307969302+el-psy-kongroo-d@users.noreply.github.com>
Co-authored-by: Norman Maurer <norman_maurer@apple.com>
