### PR TITLE
`HttpServerCodec`: do not consume the method queue for 1xx interim responses (#17182)

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerCodec.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerCodec.java
@@ -28,7 +28,6 @@ import java.util.Queue;
 import static io.netty.handler.codec.http.HttpObjectDecoder.DEFAULT_MAX_CHUNK_SIZE;
 import static io.netty.handler.codec.http.HttpObjectDecoder.DEFAULT_MAX_HEADER_SIZE;
 import static io.netty.handler.codec.http.HttpObjectDecoder.DEFAULT_MAX_INITIAL_LINE_LENGTH;
-import static io.netty.handler.codec.http.HttpObjectDecoder.DEFAULT_VALIDATE_HEADERS;
 
 /**
  * A combination of {@link HttpRequestDecoder} and {@link HttpResponseEncoder}
@@ -216,6 +215,12 @@ public final class HttpServerCodec extends CombinedChannelDuplexHandler<HttpRequ
 
         @Override
         protected boolean isContentAlwaysEmpty(@SuppressWarnings("unused") HttpResponse msg) {
+            if (msg.status().codeClass() == HttpStatusClass.INFORMATIONAL) {
+                // An informational response should be excluded from paired comparison. This covers 101 as well:
+                // once the protocol is switched this handler is removed from the pipeline, so the entry that is
+                // left behind goes away with it. Just delegate to super method which has all the needed handling.
+                return super.isContentAlwaysEmpty(msg);
+            }
             method = queue.poll();
             return HttpMethod.HEAD.equals(method) || super.isContentAlwaysEmpty(msg);
         }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerCodecTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerCodecTest.java
@@ -227,6 +227,354 @@ public class HttpServerCodecTest {
         assertFalse(ch.finishAndReleaseAll());
     }
 
+    @Test
+    public void testInterleavedRequestResponseAcrossOverflow() {
+        // Test interleaved enqueue/dequeue that crosses the inline-to-overflow boundary.
+        // Send some requests, process some responses, then send more requests to trigger overflow.
+        EmbeddedChannel ch = new EmbeddedChannel(new HttpServerCodec());
+
+        // Send 30 GET requests (not yet filling the 32-slot inline queue).
+        StringBuilder requests = new StringBuilder();
+        for (int i = 0; i < 30; i++) {
+            requests.append("GET /").append(i).append(" HTTP/1.1\r\nHost: a\r\n\r\n");
+        }
+        assertTrue(ch.writeInbound(Unpooled.copiedBuffer(requests.toString(), CharsetUtil.UTF_8)));
+
+        // Drain inbound.
+        for (;;) {
+            Object msg = ch.readInbound();
+            if (msg == null) {
+                break;
+            }
+            if (msg instanceof HttpContent) {
+                ((HttpContent) msg).release();
+            }
+        }
+
+        // Respond to 10 of them (draining 10 from the queue, leaving 20).
+        for (int i = 0; i < 10; i++) {
+            FullHttpResponse resp = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
+                    Unpooled.copiedBuffer("ok", CharsetUtil.UTF_8));
+            resp.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, 2);
+            assertTrue(ch.writeOutbound(resp));
+            ByteBuf buf = ch.readOutbound();
+            buf.release();
+        }
+
+        // Now send 15 more requests (20 remaining + 15 = 35 total, exceeding inline capacity of 32).
+        // Put a HEAD request as the last one to verify overflow ordering.
+        requests = new StringBuilder();
+        for (int i = 30; i < 44; i++) {
+            requests.append("GET /").append(i).append(" HTTP/1.1\r\nHost: a\r\n\r\n");
+        }
+        requests.append("HEAD /44 HTTP/1.1\r\nHost: a\r\n\r\n");
+        assertTrue(ch.writeInbound(Unpooled.copiedBuffer(requests.toString(), CharsetUtil.UTF_8)));
+
+        // Drain inbound.
+        for (;;) {
+            Object msg = ch.readInbound();
+            if (msg == null) {
+                break;
+            }
+            if (msg instanceof HttpContent) {
+                ((HttpContent) msg).release();
+            }
+        }
+
+        // Respond to remaining 20 GET requests (inline queue).
+        for (int i = 10; i < 30; i++) {
+            FullHttpResponse resp = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
+                    Unpooled.copiedBuffer("ok", CharsetUtil.UTF_8));
+            resp.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, 2);
+            assertTrue(ch.writeOutbound(resp));
+            ByteBuf buf = ch.readOutbound();
+            buf.release();
+        }
+
+        // Respond to the 14 GET requests that were added.
+        for (int i = 30; i < 44; i++) {
+            FullHttpResponse resp = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
+                    Unpooled.copiedBuffer("ok", CharsetUtil.UTF_8));
+            resp.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, 2);
+            assertTrue(ch.writeOutbound(resp));
+            ByteBuf buf = ch.readOutbound();
+            String encoded = buf.toString(CharsetUtil.US_ASCII);
+            assertTrue(encoded.contains("ok"), "GET response at position " + i + " should contain body");
+            buf.release();
+        }
+
+        // Respond to the HEAD request at position 44 — must be content-always-empty.
+        HttpResponse headResp = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        headResp.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, 999);
+        assertTrue(ch.writeOutbound(headResp));
+        assertTrue(ch.writeOutbound(LastHttpContent.EMPTY_LAST_CONTENT));
+
+        ByteBuf buf = ch.readOutbound();
+        String encoded = buf.toString(CharsetUtil.US_ASCII);
+        assertTrue(encoded.contains("HTTP/1.1 200 OK"), "HEAD response should be 200 OK");
+        buf.release();
+
+        buf = ch.readOutbound();
+        assertFalse(buf.isReadable(), "HEAD response body should be empty in overflow scenario");
+        buf.release();
+
+        assertFalse(ch.finishAndReleaseAll());
+    }
+
+    @Test
+    public void testGetMethodHasNormalBody() {
+        // Verify a simple GET request is treated as METHOD_FLAG_NONE and body is included.
+        EmbeddedChannel ch = new EmbeddedChannel(new HttpServerCodec());
+
+        assertTrue(ch.writeInbound(Unpooled.copiedBuffer(
+                "GET / HTTP/1.1\r\nHost: a\r\n\r\n", CharsetUtil.UTF_8)));
+
+        HttpRequest request = ch.readInbound();
+        assertEquals(HttpMethod.GET, request.method());
+        LastHttpContent content = ch.readInbound();
+        content.release();
+
+        FullHttpResponse resp = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
+                Unpooled.copiedBuffer("hello", CharsetUtil.UTF_8));
+        resp.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, 5);
+        assertTrue(ch.writeOutbound(resp));
+
+        ByteBuf buf = ch.readOutbound();
+        String encoded = buf.toString(CharsetUtil.US_ASCII);
+        assertTrue(encoded.contains("hello"), "GET response should contain body");
+        assertTrue(encoded.contains("content-length: 5"));
+        buf.release();
+
+        assertFalse(ch.finishAndReleaseAll());
+    }
+
+    @Test
+    public void testPostMethodHasNormalBody() {
+        // POST should also be METHOD_FLAG_NONE.
+        EmbeddedChannel ch = new EmbeddedChannel(new HttpServerCodec());
+
+        assertTrue(ch.writeInbound(Unpooled.copiedBuffer(
+                "POST / HTTP/1.1\r\nHost: a\r\nContent-Length: 0\r\n\r\n", CharsetUtil.UTF_8)));
+
+        for (;;) {
+            Object msg = ch.readInbound();
+            if (msg == null) {
+                break;
+            }
+            if (msg instanceof HttpContent) {
+                ((HttpContent) msg).release();
+            }
+        }
+
+        FullHttpResponse resp = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
+                Unpooled.copiedBuffer("result", CharsetUtil.UTF_8));
+        resp.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, 6);
+        assertTrue(ch.writeOutbound(resp));
+
+        ByteBuf buf = ch.readOutbound();
+        String encoded = buf.toString(CharsetUtil.US_ASCII);
+        assertTrue(encoded.contains("result"), "POST response should contain body");
+        buf.release();
+
+        assertFalse(ch.finishAndReleaseAll());
+    }
+
+    @Test
+    public void testOverflowDrainsBeforeInlineRefill() {
+        // Verify that once overflow is activated, subsequent enqueues also go to overflow
+        // until the overflow drains, keeping FIFO order correct.
+        EmbeddedChannel ch = new EmbeddedChannel(new HttpServerCodec());
+
+        int totalRequests = 34; // 32 inline + 2 overflow
+
+        // Send 34 pipelined requests: position 33 (overflow) is HEAD.
+        StringBuilder requests = new StringBuilder();
+        for (int i = 0; i < totalRequests; i++) {
+            if (i == 33) {
+                requests.append("HEAD /").append(i).append(" HTTP/1.1\r\nHost: a\r\n\r\n");
+            } else {
+                requests.append("GET /").append(i).append(" HTTP/1.1\r\nHost: a\r\n\r\n");
+            }
+        }
+        assertTrue(ch.writeInbound(Unpooled.copiedBuffer(requests.toString(), CharsetUtil.UTF_8)));
+
+        // Drain inbound.
+        for (;;) {
+            Object msg = ch.readInbound();
+            if (msg == null) {
+                break;
+            }
+            if (msg instanceof HttpContent) {
+                ((HttpContent) msg).release();
+            }
+        }
+
+        // Send responses for first 33 (all GET).
+        for (int i = 0; i < 33; i++) {
+            FullHttpResponse resp = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
+                    Unpooled.copiedBuffer("ok", CharsetUtil.UTF_8));
+            resp.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, 2);
+            assertTrue(ch.writeOutbound(resp));
+            ByteBuf buf = ch.readOutbound();
+            String encoded = buf.toString(CharsetUtil.US_ASCII);
+            assertTrue(encoded.contains("ok"), "GET response at position " + i + " should contain body");
+            buf.release();
+        }
+
+        // Response for position 33 — HEAD from overflow queue.
+        HttpResponse headResp = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        headResp.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, 42);
+        assertTrue(ch.writeOutbound(headResp));
+        assertTrue(ch.writeOutbound(LastHttpContent.EMPTY_LAST_CONTENT));
+
+        ByteBuf buf = ch.readOutbound();
+        buf.release();
+
+        buf = ch.readOutbound();
+        assertFalse(buf.isReadable(), "HEAD response from overflow queue body should be empty");
+        buf.release();
+
+        assertFalse(ch.finishAndReleaseAll());
+    }
+
+    @Test
+    public void testPollFromEmptyQueueReturnsNone() {
+        // If a response is written without a matching request (unusual but defensive),
+        // pollMethod should return METHOD_FLAG_NONE, so body is treated normally.
+        EmbeddedChannel ch = new EmbeddedChannel(new HttpServerCodec());
+
+        // Write a response without any prior request.
+        FullHttpResponse resp = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
+                Unpooled.copiedBuffer("data", CharsetUtil.UTF_8));
+        resp.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, 4);
+        assertDoesNotThrow(() -> ch.writeOutbound(resp));
+
+        ByteBuf buf = ch.readOutbound();
+        assertNotNull(buf);
+        String encoded = buf.toString(CharsetUtil.US_ASCII);
+        assertTrue(encoded.contains("data"), "Response body should be present even without prior request");
+        buf.release();
+
+        ch.finishAndReleaseAll();
+    }
+
+    @Test
+    public void testHeadResponseHasNoContentAfterInterimResponse() {
+        // A 1xx interim response must not consume an entry of the method queue, as it is not the
+        // final response for the queued request.
+        EmbeddedChannel ch = new EmbeddedChannel(new HttpServerCodec());
+
+        // Send a single HEAD request. Method queue = [HEAD].
+        assertTrue(ch.writeInbound(Unpooled.copiedBuffer(
+                "HEAD /a HTTP/1.1\r\nHost: a\r\n\r\n", CharsetUtil.UTF_8)));
+        HttpRequest request = ch.readInbound();
+        assertEquals(HttpMethod.HEAD, request.method());
+        LastHttpContent requestContent = ch.readInbound();
+        assertFalse(requestContent.content().isReadable());
+        requestContent.release();
+
+        // Write a 103 Early Hints interim response. The HEAD entry must stay in the queue.
+        FullHttpResponse earlyHints = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.EARLY_HINTS);
+        assertTrue(ch.writeOutbound(earlyHints));
+        ByteBuf earlyHintsBuf = ch.readOutbound();
+        assertEquals("HTTP/1.1 103 Early Hints\r\n\r\n", earlyHintsBuf.toString(CharsetUtil.US_ASCII));
+        earlyHintsBuf.release();
+
+        // Now write the final response for the HEAD request, with content attached.
+        FullHttpResponse finalResponse = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
+                Unpooled.copiedBuffer("body", CharsetUtil.UTF_8));
+        finalResponse.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, 4);
+        assertTrue(ch.writeOutbound(finalResponse));
+
+        // A HEAD response must never carry a body per RFC 9110 section 9.3.2, regardless of
+        // any interim responses sent before it.
+        ByteBuf buf = ch.readOutbound();
+        assertEquals("HTTP/1.1 200 OK\r\ncontent-length: 4\r\n\r\n", buf.toString(CharsetUtil.US_ASCII));
+        buf.release();
+
+        assertFalse(ch.finishAndReleaseAll());
+    }
+
+    @Test
+    public void testPipelinedResponseContentPreservedAfterInterimResponse() {
+        // A 1xx interim response for one pipelined request must not consume a method queue entry,
+        // so the queue order is preserved for the remaining pipelined requests.
+        EmbeddedChannel ch = new EmbeddedChannel(new HttpServerCodec());
+
+        // Pipeline two requests: GET /a then HEAD /b. Method queue = [OTHER, HEAD].
+        assertTrue(ch.writeInbound(Unpooled.copiedBuffer(
+                "GET /a HTTP/1.1\r\nHost: a\r\n\r\n" +
+                "HEAD /b HTTP/1.1\r\nHost: a\r\n\r\n", CharsetUtil.UTF_8)));
+
+        HttpRequest requestA = ch.readInbound();
+        assertEquals(HttpMethod.GET, requestA.method());
+        LastHttpContent requestAContent = ch.readInbound();
+        assertFalse(requestAContent.content().isReadable());
+        requestAContent.release();
+
+        HttpRequest requestB = ch.readInbound();
+        assertEquals(HttpMethod.HEAD, requestB.method());
+        LastHttpContent requestBContent = ch.readInbound();
+        assertFalse(requestBContent.content().isReadable());
+        requestBContent.release();
+
+        // Send a 1xx interim response for /a. The queue must stay at [OTHER, HEAD].
+        FullHttpResponse earlyHints = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.EARLY_HINTS);
+        assertTrue(ch.writeOutbound(earlyHints));
+        ByteBuf earlyHintsBuf = ch.readOutbound();
+        assertEquals("HTTP/1.1 103 Early Hints\r\n\r\n", earlyHintsBuf.toString(CharsetUtil.US_ASCII));
+        earlyHintsBuf.release();
+
+        // Now send the final response to /a, with content attached.
+        FullHttpResponse finalResponseA = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
+                Unpooled.copiedBuffer("body-a", CharsetUtil.UTF_8));
+        finalResponseA.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, 6);
+        assertTrue(ch.writeOutbound(finalResponseA));
+
+        // The GET /a response body must be preserved.
+        ByteBuf buf = ch.readOutbound();
+        assertEquals("HTTP/1.1 200 OK\r\ncontent-length: 6\r\n\r\nbody-a", buf.toString(CharsetUtil.US_ASCII));
+        buf.release();
+
+        assertFalse(ch.finishAndReleaseAll());
+    }
+
+    @Test
+    public void testSwitchingProtocolsResponseHasNoContent() {
+        // A 101 Switching Protocols response must never carry a body.
+        EmbeddedChannel ch = new EmbeddedChannel(new HttpServerCodec());
+
+        // Send a HEAD request that asks to switch protocols. Method queue = [HEAD].
+        assertTrue(ch.writeInbound(Unpooled.copiedBuffer(
+                "HEAD / HTTP/1.1\r\n" +
+                "Host: a\r\n" +
+                "Connection: upgrade\r\n" +
+                "Upgrade: websocket\r\n\r\n", CharsetUtil.UTF_8)));
+        HttpRequest request = ch.readInbound();
+        assertEquals(HttpMethod.HEAD, request.method());
+        LastHttpContent requestContent = ch.readInbound();
+        assertFalse(requestContent.content().isReadable());
+        requestContent.release();
+
+        HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.SWITCHING_PROTOCOLS);
+        response.headers().set(HttpHeaderNames.CONNECTION, "upgrade");
+        response.headers().set(HttpHeaderNames.UPGRADE, "websocket");
+        assertTrue(ch.writeOutbound(response));
+        assertTrue(ch.writeOutbound(LastHttpContent.EMPTY_LAST_CONTENT));
+
+        ByteBuf buf = ch.readOutbound();
+        assertEquals("HTTP/1.1 101 Switching Protocols\r\n" +
+                "connection: upgrade\r\n" +
+                "upgrade: websocket\r\n\r\n", buf.toString(CharsetUtil.US_ASCII));
+        buf.release();
+
+        buf = ch.readOutbound();
+        assertFalse(buf.isReadable());
+        buf.release();
+
+        assertFalse(ch.finishAndReleaseAll());
+    }
+
     private static ByteBuf prepareDataChunk(int size) {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < size; ++i) {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerCodecTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerCodecTest.java
@@ -21,6 +21,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -441,13 +442,18 @@ public class HttpServerCodecTest {
     public void testPollFromEmptyQueueReturnsNone() {
         // If a response is written without a matching request (unusual but defensive),
         // pollMethod should return METHOD_FLAG_NONE, so body is treated normally.
-        EmbeddedChannel ch = new EmbeddedChannel(new HttpServerCodec());
+        final EmbeddedChannel ch = new EmbeddedChannel(new HttpServerCodec());
 
         // Write a response without any prior request.
-        FullHttpResponse resp = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
+        final FullHttpResponse resp = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
                 Unpooled.copiedBuffer("data", CharsetUtil.UTF_8));
         resp.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, 4);
-        assertDoesNotThrow(() -> ch.writeOutbound(resp));
+        assertDoesNotThrow(new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                ch.writeOutbound(resp);
+            }
+        });
 
         ByteBuf buf = ch.readOutbound();
         assertNotNull(buf);


### PR DESCRIPTION
Resolves #17181.

`HttpClientCodec` and `HttpContentEncoder`, but `HttpServerCodec` was
left out.

`isContentAlwaysEmpty(HttpResponse)` in `HttpServerCodec` polls the
request method queue for every response it encodes:

```java
@Override
protected boolean isContentAlwaysEmpty(HttpResponse msg) {
    methodFlag = pollMethod();
    return methodFlag == METHOD_FLAG_HEAD || super.isContentAlwaysEmpty(msg);
}
```

It is invoked for every `HttpResponse` on both encoder paths —
`encodeFullHttpMessage()` and `encodeInitHttpMessage()` in
`HttpObjectEncoder`. An interim response is not the final response to
the queued request, so consuming an entry shifts the queue by one and
the wrong method gets paired with the final response.

Both failure modes are reachable from first-party handlers:
`HttpServerExpectContinueHandler` and `HttpObjectAggregator` write `100
Continue` through this encoder.

Skip `pollMethod()` when the response status class is `INFORMATIONAL`
and delegate to the super method, mirroring the guard already present in
`isContentAlwaysEmpty(HttpMessage)` in `HttpClientCodec`.

`methodFlag` is intentionally left untouched on the interim path.
`sanitizeHeadersBeforeEncode()` reads it for the CONNECT check, but that
branch also requires `codeClass() == SUCCESS`, which a 1xx response
never satisfies.

Interim responses no longer shift the method queue, so HEAD and CONNECT
are paired with their own final response.

Encoder output for the two broken cases, measured with the tests added
here:

| scenario | before | after |
|---|---|---|
| `HEAD /a`, then `103`, then final `200 OK` with content | `HTTP/1.1
200 OK\r\ncontent-length: 4\r\n\r\nbody` | `HTTP/1.1 200
OK\r\ncontent-length: 4\r\n\r\n` |
| pipelined `GET /a` + `HEAD /b`, then `103`, then `/a`'s `200 OK` with
content | `HTTP/1.1 200 OK\r\ncontent-length: 6\r\n\r\n` | `HTTP/1.1 200
OK\r\ncontent-length: 6\r\n\r\nbody-a` |
| `HEAD /` with `Upgrade`, then `101` | `HTTP/1.1 101 Switching
Protocols\r\nconnection: upgrade\r\nupgrade: websocket\r\n\r\n` |
unchanged |

The first row is a HEAD response carrying a body, which per RFC 9110
section 9.3.2 must never happen — on a keep-alive connection the peer
reads those bytes as the start of the next response. The second is a
non-HEAD response losing its body while keeping `Content-Length`,
leaving the peer waiting for six bytes that never arrive.

Sequential request/response traffic recovers on its own, since an empty
queue falls back to `METHOD_FLAG_OTHER`. Corruption needs either a 1xx
preceding a HEAD response, or pipelining combined with a 1xx.

101 is included in `INFORMATIONAL` and is therefore covered by the
guard, with no change on the wire. After switching protocols the codec
is removed from the pipeline — by `upgradeFrom()` in `HttpServerCodec`
for h2c, and by `WebSocketServerHandshaker` for WebSocket — so the entry
left behind is discarded together with the handler. The third row above
pins this.

This also corrects CONNECT: previously a 1xx could consume the CONNECT
entry, so the final 2xx response missed the `Transfer-Encoding`
stripping in `sanitizeHeadersBeforeEncode()`.

`codec-http` passes in full: 8973 tests, 0 failures.

Co-authored-by: Norman Maurer <norman_maurer@apple.com>
