### PR TITLE
Weakly reference engines from the OpenSSL engine map (#17199)

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslClientContext.java
@@ -208,7 +208,7 @@ public final class OpenSslClientContext extends OpenSslContext {
         boolean success = false;
         try {
             OpenSslKeyMaterialProvider.validateKeyMaterialSupported(keyCertChain, key, keyPassword);
-            sessionContext = newSessionContext(this, ctx, engineMap, trustCertCollection, trustManagerFactory,
+            sessionContext = newSessionContext(this, ctx, engines, trustCertCollection, trustManagerFactory,
                                                keyCertChain, key, keyPassword, keyManagerFactory, keyStore,
                                                sessionCacheSize, sessionTimeout, resumptionController);
             success = true;

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslClientSessionCache.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslClientSessionCache.java
@@ -31,8 +31,8 @@ import java.util.Set;
 final class OpenSslClientSessionCache extends OpenSslSessionCache {
     private final Map<HostPort, Set<NativeSslSession>> sessions = new HashMap<HostPort, Set<NativeSslSession>>();
 
-    OpenSslClientSessionCache(OpenSslEngineMap engineMap) {
-        super(engineMap);
+    OpenSslClientSessionCache(OpenSslEngineMap engines) {
+        super(engines);
     }
 
     @Override

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslEngineMap.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslEngineMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Netty Project
+ * Copyright 2026 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -15,21 +15,47 @@
  */
 package io.netty.handler.ssl;
 
-interface OpenSslEngineMap {
+import java.lang.ref.WeakReference;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
-    /**
-     * Remove the {@link OpenSslEngine} with the given {@code ssl} address and
-     * return it.
-     */
-    ReferenceCountedOpenSslEngine remove(long ssl);
+/**
+ * Maps a native {@code SSL*} pointer to its {@link ReferenceCountedOpenSslEngine} so native OpenSSL callbacks
+ * (certificate verification, private-key operations, certificate (de)compression) can recover the engine from the
+ * raw pointer they are handed.
+ * <p>
+ * Engines are held weakly so a leaked engine is not pinned by the long-lived parent
+ * {@link ReferenceCountedOpenSslContext} (a live engine is always strongly reachable via its {@link SslHandler}, and
+ * on the stack during a callback, so weak retention never collects a usable one). For {@link SslProvider#OPENSSL}
+ * this lets {@link OpenSslEngine#finalize()} reclaim the native {@code SSL*} without waiting for the whole context to
+ * be collected; a leaked {@link SslProvider#OPENSSL_REFCNT} engine has no finalizer so its native memory still leaks,
+ * but it becomes collectable and so is reported by the {@code ResourceLeakDetector} rather than pinned silently.
+ * <p>
+ * Entries are removed in {@link ReferenceCountedOpenSslEngine#shutdown()}, so the map does not grow in steady state.
+ * A cleared {@link WeakReference} lingers only for a leaked {@code OPENSSL_REFCNT} engine (whose {@code SSL*} is never
+ * freed, hence never reused); such a husk is tiny, dwarfed by the native memory it marks, and is deliberately left as
+ * a heap-inspectable leak signal. Do not reap it (e.g. via a {@code ReferenceQueue}): {@link #get(long)} already
+ * yields {@code null} for a cleared reference, so reaping would only erase that signal.
+ */
+final class OpenSslEngineMap {
 
-    /**
-     * Add a {@link OpenSslEngine} to this {@link OpenSslEngineMap}.
-     */
-    void add(ReferenceCountedOpenSslEngine engine);
+    private final Map<Long, WeakReference<ReferenceCountedOpenSslEngine>> engines =
+            new ConcurrentHashMap<Long, WeakReference<ReferenceCountedOpenSslEngine>>();
 
-    /**
-     * Get the {@link OpenSslEngine} for the given {@code ssl} address.
-     */
-    ReferenceCountedOpenSslEngine get(long ssl);
+    void add(long ssl, ReferenceCountedOpenSslEngine engine) {
+        // A fresh SSL_new() pointer maps to nothing yet: an SSL* is reused only after shutdown() removed its entry
+        // (remove-before-freeSSL), and a husk survives only for a never-freed, never-reused SSL*.
+        WeakReference<ReferenceCountedOpenSslEngine> prev =
+                engines.put(ssl, new WeakReference<ReferenceCountedOpenSslEngine>(engine));
+        assert prev == null : "OpenSslEngineMap already had an entry for SSL* 0x" + Long.toHexString(ssl);
+    }
+
+    void remove(long ssl) {
+        engines.remove(ssl);
+    }
+
+    ReferenceCountedOpenSslEngine get(long ssl) {
+        WeakReference<ReferenceCountedOpenSslEngine> ref = engines.get(ssl);
+        return ref == null ? null : ref.get();
+    }
 }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
@@ -356,7 +356,7 @@ public final class OpenSslServerContext extends OpenSslContext {
         boolean success = false;
         try {
             OpenSslKeyMaterialProvider.validateKeyMaterialSupported(keyCertChain, key, keyPassword);
-            sessionContext = newSessionContext(this, ctx, engineMap, trustCertCollection, trustManagerFactory,
+            sessionContext = newSessionContext(this, ctx, engines, trustCertCollection, trustManagerFactory,
                                                keyCertChain, key, keyPassword, keyManagerFactory, keyStore,
                                                sessionCacheSize, sessionTimeout, resumptionController);
             success = true;

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslServerSessionContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslServerSessionContext.java
@@ -26,7 +26,7 @@ import java.util.concurrent.locks.Lock;
  */
 public final class OpenSslServerSessionContext extends OpenSslSessionContext {
     OpenSslServerSessionContext(ReferenceCountedOpenSslContext context, OpenSslKeyMaterialProvider provider) {
-        super(context, provider, SSL.SSL_SESS_CACHE_SERVER, new OpenSslSessionCache(context.engineMap));
+        super(context, provider, SSL.SSL_SESS_CACHE_SERVER, new OpenSslSessionCache(context.engines));
     }
 
     /**

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionCache.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionCache.java
@@ -49,7 +49,7 @@ class OpenSslSessionCache implements SSLSessionCache {
             DEFAULT_CACHE_SIZE = 20480;
         }
     }
-    private final OpenSslEngineMap engineMap;
+    private final OpenSslEngineMap engines;
 
     private final Map<OpenSslSessionId, NativeSslSession> sessions =
             new LinkedHashMap<OpenSslSessionId, NativeSslSession>() {
@@ -74,8 +74,8 @@ class OpenSslSessionCache implements SSLSessionCache {
     private final AtomicInteger sessionTimeout = new AtomicInteger(300);
     private int sessionCounter;
 
-    OpenSslSessionCache(OpenSslEngineMap engineMap) {
-        this.engineMap = engineMap;
+    OpenSslSessionCache(OpenSslEngineMap engines) {
+        this.engines = engines;
     }
 
     final void setSessionTimeout(int seconds) {
@@ -142,7 +142,7 @@ class OpenSslSessionCache implements SSLSessionCache {
 
     @Override
     public boolean sessionCreated(long ssl, long sslSession) {
-        ReferenceCountedOpenSslEngine engine = engineMap.get(ssl);
+        ReferenceCountedOpenSslEngine engine = engines.get(ssl);
         if (engine == null) {
             // We couldn't find the engine itself.
             return false;
@@ -208,7 +208,7 @@ class OpenSslSessionCache implements SSLSessionCache {
             }
         }
         session.setLastAccessedTime(System.currentTimeMillis());
-        ReferenceCountedOpenSslEngine engine = engineMap.get(ssl);
+        ReferenceCountedOpenSslEngine engine = engines.get(ssl);
         if (engine != null) {
             OpenSslInternalSession sslSession = (OpenSslInternalSession) engine.getSession();
             sslSession.setSessionDetails(session.getCreationTime(),

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslClientContext.java
@@ -85,7 +85,7 @@ public final class ReferenceCountedOpenSslClientContext extends ReferenceCounted
                 resumptionController, options);
         boolean success = false;
         try {
-            sessionContext = newSessionContext(this, ctx, engineMap, trustCertCollection, trustManagerFactory,
+            sessionContext = newSessionContext(this, ctx, engines, trustCertCollection, trustManagerFactory,
                                                keyCertChain, key, keyPassword, keyManagerFactory, keyStore,
                                                sessionCacheSize, sessionTimeout, resumptionController);
             success = true;
@@ -102,7 +102,7 @@ public final class ReferenceCountedOpenSslClientContext extends ReferenceCounted
     }
 
     static OpenSslSessionContext newSessionContext(ReferenceCountedOpenSslContext thiz, long ctx,
-                                                   OpenSslEngineMap engineMap,
+                                                   OpenSslEngineMap engines,
                                                    X509Certificate[] trustCertCollection,
                                                    TrustManagerFactory trustManagerFactory,
                                                    X509Certificate[] keyCertChain, PrivateKey key,
@@ -146,7 +146,7 @@ public final class ReferenceCountedOpenSslClientContext extends ReferenceCounted
                         OpenSslKeyMaterialManager materialManager =
                                 new OpenSslKeyMaterialManager(keyMaterialProvider, thiz.hasTmpDhKeys);
                         SSLContext.setCertificateCallback(ctx, new OpenSslClientCertificateCallback(
-                                engineMap, materialManager));
+                                engines, materialManager));
                     }
                 }
             } catch (Exception e) {
@@ -178,7 +178,7 @@ public final class ReferenceCountedOpenSslClientContext extends ReferenceCounted
                 //
                 //            See https://github.com/netty/netty/issues/5372
 
-                setVerifyCallback(ctx, engineMap, manager);
+                setVerifyCallback(ctx, engines, manager);
             } catch (Exception e) {
                 if (keyMaterialProvider != null) {
                     keyMaterialProvider.destroy();
@@ -208,27 +208,29 @@ public final class ReferenceCountedOpenSslClientContext extends ReferenceCounted
     }
 
     @SuppressJava6Requirement(reason = "Guarded by java version check")
-    private static void setVerifyCallback(long ctx, OpenSslEngineMap engineMap, X509TrustManager manager) {
+    private static void setVerifyCallback(long ctx,
+                                          OpenSslEngineMap engines,
+                                          X509TrustManager manager) {
         // Use this to prevent an error when running on java < 7
         if (useExtendedTrustManager(manager)) {
             SSLContext.setCertVerifyCallback(ctx,
-                    new ExtendedTrustManagerVerifyCallback(engineMap, (X509ExtendedTrustManager) manager));
+                    new ExtendedTrustManagerVerifyCallback(engines, (X509ExtendedTrustManager) manager));
         } else {
-            SSLContext.setCertVerifyCallback(ctx, new TrustManagerVerifyCallback(engineMap, manager));
+            SSLContext.setCertVerifyCallback(ctx, new TrustManagerVerifyCallback(engines, manager));
         }
     }
 
     static final class OpenSslClientSessionContext extends OpenSslSessionContext {
         OpenSslClientSessionContext(ReferenceCountedOpenSslContext context, OpenSslKeyMaterialProvider provider) {
-            super(context, provider, SSL.SSL_SESS_CACHE_CLIENT, new OpenSslClientSessionCache(context.engineMap));
+            super(context, provider, SSL.SSL_SESS_CACHE_CLIENT, new OpenSslClientSessionCache(context.engines));
         }
     }
 
     private static final class TrustManagerVerifyCallback extends AbstractCertificateVerifier {
         private final X509TrustManager manager;
 
-        TrustManagerVerifyCallback(OpenSslEngineMap engineMap, X509TrustManager manager) {
-            super(engineMap);
+        TrustManagerVerifyCallback(OpenSslEngineMap engines, X509TrustManager manager) {
+            super(engines);
             this.manager = manager;
         }
 
@@ -243,8 +245,9 @@ public final class ReferenceCountedOpenSslClientContext extends ReferenceCounted
     private static final class ExtendedTrustManagerVerifyCallback extends AbstractCertificateVerifier {
         private final X509ExtendedTrustManager manager;
 
-        ExtendedTrustManagerVerifyCallback(OpenSslEngineMap engineMap, X509ExtendedTrustManager manager) {
-            super(engineMap);
+        ExtendedTrustManagerVerifyCallback(OpenSslEngineMap engines,
+                                           X509ExtendedTrustManager manager) {
+            super(engines);
             this.manager = manager;
         }
 
@@ -256,17 +259,18 @@ public final class ReferenceCountedOpenSslClientContext extends ReferenceCounted
     }
 
     private static final class OpenSslClientCertificateCallback implements CertificateCallback {
-        private final OpenSslEngineMap engineMap;
+        private final OpenSslEngineMap engines;
         private final OpenSslKeyMaterialManager keyManagerHolder;
 
-        OpenSslClientCertificateCallback(OpenSslEngineMap engineMap, OpenSslKeyMaterialManager keyManagerHolder) {
-            this.engineMap = engineMap;
+        OpenSslClientCertificateCallback(OpenSslEngineMap engines,
+                                         OpenSslKeyMaterialManager keyManagerHolder) {
+            this.engines = engines;
             this.keyManagerHolder = keyManagerHolder;
         }
 
         @Override
         public void handle(long ssl, byte[] keyTypeBytes, byte[][] asn1DerEncodedPrincipals) throws Exception {
-            final ReferenceCountedOpenSslEngine engine = engineMap.get(ssl);
+            final ReferenceCountedOpenSslEngine engine = engines.get(ssl);
             // May be null if it was destroyed in the meantime.
             if (engine == null) {
                 return;

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -165,7 +165,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
     final boolean hasTmpDhKeys;
 
     final boolean enableOcsp;
-    final OpenSslEngineMap engineMap = new DefaultOpenSslEngineMap();
+    final OpenSslEngineMap engines = new OpenSslEngineMap();
     final ReadWriteLock ctxLock = new ReentrantReadWriteLock();
 
     private volatile int bioNonApplicationBufferSize = DEFAULT_BIO_NON_APPLICATION_BUFFER_SIZE;
@@ -428,14 +428,14 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
 
             SSLContext.setUseTasks(ctx, useTasks);
             if (privateKeyMethod != null) {
-                SSLContext.setPrivateKeyMethod(ctx, new PrivateKeyMethod(engineMap, privateKeyMethod));
+                SSLContext.setPrivateKeyMethod(ctx, new PrivateKeyMethod(engines, privateKeyMethod));
             }
             if (asyncPrivateKeyMethod != null) {
-                SSLContext.setPrivateKeyMethod(ctx, new AsyncPrivateKeyMethod(engineMap, asyncPrivateKeyMethod));
+                SSLContext.setPrivateKeyMethod(ctx, new AsyncPrivateKeyMethod(engines, asyncPrivateKeyMethod));
             }
             if (certCompressionConfig != null) {
                 for (OpenSslCertificateCompressionConfig.AlgorithmConfig configPair : certCompressionConfig) {
-                    final CertificateCompressionAlgo algo = new CompressionAlgorithm(engineMap, configPair.algorithm());
+                    final CertificateCompressionAlgo algo = new CompressionAlgorithm(engines, configPair.algorithm());
                     switch (configPair.mode()) {
                         case Decompress:
                             SSLContext.addCertificateCompressionAlgorithm(
@@ -650,7 +650,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
         Lock writerLock = ctxLock.writeLock();
         writerLock.lock();
         try {
-            SSLContext.setPrivateKeyMethod(ctx, new PrivateKeyMethod(engineMap, method));
+            SSLContext.setPrivateKeyMethod(ctx, new PrivateKeyMethod(engines, method));
         } finally {
             writerLock.unlock();
         }
@@ -832,15 +832,15 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
     }
 
     abstract static class AbstractCertificateVerifier extends CertificateVerifier {
-        private final OpenSslEngineMap engineMap;
+        private final OpenSslEngineMap engines;
 
-        AbstractCertificateVerifier(OpenSslEngineMap engineMap) {
-            this.engineMap = engineMap;
+        AbstractCertificateVerifier(OpenSslEngineMap engines) {
+            this.engines = engines;
         }
 
         @Override
         public final int verify(long ssl, byte[][] chain, String auth) {
-            final ReferenceCountedOpenSslEngine engine = engineMap.get(ssl);
+            final ReferenceCountedOpenSslEngine engine = engines.get(ssl);
             if (engine == null) {
                 // May be null if it was destroyed in the meantime.
                 return CertificateVerifier.X509_V_ERR_UNSPECIFIED;
@@ -905,25 +905,6 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
 
         abstract void verify(ReferenceCountedOpenSslEngine engine, X509Certificate[] peerCerts,
                              String auth) throws Exception;
-    }
-
-    private static final class DefaultOpenSslEngineMap implements OpenSslEngineMap {
-        private final Map<Long, ReferenceCountedOpenSslEngine> engines = PlatformDependent.newConcurrentHashMap();
-
-        @Override
-        public ReferenceCountedOpenSslEngine remove(long ssl) {
-            return engines.remove(ssl);
-        }
-
-        @Override
-        public void add(ReferenceCountedOpenSslEngine engine) {
-            engines.put(engine.sslPointer(), engine);
-        }
-
-        @Override
-        public ReferenceCountedOpenSslEngine get(long ssl) {
-            return engines.get(ssl);
-        }
     }
 
     static void setKeyMaterial(long ctx, X509Certificate[] keyCertChain, PrivateKey key, String keyPassword)
@@ -1078,16 +1059,16 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
 
     private static final class PrivateKeyMethod implements SSLPrivateKeyMethod {
 
-        private final OpenSslEngineMap engineMap;
+        private final OpenSslEngineMap engines;
         private final OpenSslPrivateKeyMethod keyMethod;
-        PrivateKeyMethod(OpenSslEngineMap engineMap, OpenSslPrivateKeyMethod keyMethod) {
-            this.engineMap = engineMap;
+        PrivateKeyMethod(OpenSslEngineMap engines, OpenSslPrivateKeyMethod keyMethod) {
+            this.engines = engines;
             this.keyMethod = keyMethod;
         }
 
         @Override
         public byte[] sign(long ssl, int signatureAlgorithm, byte[] digest) throws Exception {
-            ReferenceCountedOpenSslEngine engine = retrieveEngine(engineMap, ssl);
+            ReferenceCountedOpenSslEngine engine = retrieveEngine(engines, ssl);
             try {
                 return verifyResult(keyMethod.sign(engine, signatureAlgorithm, digest));
             } catch (Exception e) {
@@ -1098,7 +1079,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
 
         @Override
         public byte[] decrypt(long ssl, byte[] input) throws Exception {
-            ReferenceCountedOpenSslEngine engine = retrieveEngine(engineMap, ssl);
+            ReferenceCountedOpenSslEngine engine = retrieveEngine(engines, ssl);
             try {
                 return verifyResult(keyMethod.decrypt(engine, input));
             } catch (Exception e) {
@@ -1110,18 +1091,19 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
 
     private static final class AsyncPrivateKeyMethod implements AsyncSSLPrivateKeyMethod {
 
-        private final OpenSslEngineMap engineMap;
+        private final OpenSslEngineMap engines;
         private final OpenSslAsyncPrivateKeyMethod keyMethod;
 
-        AsyncPrivateKeyMethod(OpenSslEngineMap engineMap, OpenSslAsyncPrivateKeyMethod keyMethod) {
-            this.engineMap = engineMap;
+        AsyncPrivateKeyMethod(OpenSslEngineMap engines,
+                              OpenSslAsyncPrivateKeyMethod keyMethod) {
+            this.engines = engines;
             this.keyMethod = keyMethod;
         }
 
         @Override
         public void sign(long ssl, int signatureAlgorithm, byte[] bytes, ResultCallback<byte[]> resultCallback) {
             try {
-                ReferenceCountedOpenSslEngine engine = retrieveEngine(engineMap, ssl);
+                ReferenceCountedOpenSslEngine engine = retrieveEngine(engines, ssl);
                 keyMethod.sign(engine, signatureAlgorithm, bytes)
                         .addListener(new ResultCallbackListener(engine, ssl, resultCallback));
             } catch (SSLException e) {
@@ -1132,7 +1114,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
         @Override
         public void decrypt(long ssl, byte[] bytes, ResultCallback<byte[]> resultCallback) {
             try {
-                ReferenceCountedOpenSslEngine engine = retrieveEngine(engineMap, ssl);
+                ReferenceCountedOpenSslEngine engine = retrieveEngine(engines, ssl);
                 keyMethod.decrypt(engine, bytes)
                         .addListener(new ResultCallbackListener(engine, ssl, resultCallback));
             } catch (SSLException e) {
@@ -1178,23 +1160,24 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
     }
 
     private static final class CompressionAlgorithm implements CertificateCompressionAlgo {
-        private final OpenSslEngineMap engineMap;
+        private final OpenSslEngineMap engines;
         private final OpenSslCertificateCompressionAlgorithm compressionAlgorithm;
 
-        CompressionAlgorithm(OpenSslEngineMap engineMap, OpenSslCertificateCompressionAlgorithm compressionAlgorithm) {
-            this.engineMap = engineMap;
+        CompressionAlgorithm(OpenSslEngineMap engines,
+                             OpenSslCertificateCompressionAlgorithm compressionAlgorithm) {
+            this.engines = engines;
             this.compressionAlgorithm = compressionAlgorithm;
         }
 
         @Override
         public byte[] compress(long ssl, byte[] bytes) throws Exception {
-            ReferenceCountedOpenSslEngine engine = retrieveEngine(engineMap, ssl);
+            ReferenceCountedOpenSslEngine engine = retrieveEngine(engines, ssl);
             return compressionAlgorithm.compress(engine, bytes);
         }
 
         @Override
         public byte[] decompress(long ssl, int len, byte[] bytes) throws Exception {
-            ReferenceCountedOpenSslEngine engine = retrieveEngine(engineMap, ssl);
+            ReferenceCountedOpenSslEngine engine = retrieveEngine(engines, ssl);
             return compressionAlgorithm.decompress(engine, len, bytes);
         }
 

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -1977,9 +1977,6 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
             return handshakeException();
         }
 
-        // Adding the OpenSslEngine to the OpenSslEngineMap so it can be used in the AbstractCertificateVerifier.
-        engines.add(ssl, this);
-
         if (!sessionSet) {
             if (!parentContext.sessionContext().setSessionFromCache(ssl, session, getPeerHost(), getPeerPort())) {
                 // The session was not reused via the cache. Call prepareHandshake() to ensure we remove all previous

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -201,7 +201,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
     final boolean jdkCompatibilityMode;
     private final boolean clientMode;
     final ByteBufAllocator alloc;
-    private final OpenSslEngineMap engineMap;
+    private final OpenSslEngineMap engines;
     private final OpenSslApplicationProtocolNegotiator apn;
     private final ReferenceCountedOpenSslContext parentContext;
     private final OpenSslInternalSession session;
@@ -229,7 +229,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                                   String endpointIdentificationAlgorithm) {
         super(peerHost, peerPort);
         OpenSsl.ensureAvailability();
-        engineMap = context.engineMap;
+        engines = context.engines;
         enableOcsp = context.enableOcsp;
         this.jdkCompatibilityMode = jdkCompatibilityMode;
         this.alloc = checkNotNull(alloc, "alloc");
@@ -415,6 +415,9 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
         }
         parentContext = context;
 
+        // Register for the SSL* -> engine reverse lookup used by native callbacks; held weakly (see OpenSslEngineMap).
+        engines.add(ssl, this);
+
         // Only create the leak after everything else was executed and so ensure we don't produce a false-positive for
         // the ResourceLeakDetector.
         leak = leakDetection ? leakDetector.track(this) : null;
@@ -574,11 +577,11 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
     public final synchronized void shutdown() {
         if (!destroyed) {
             destroyed = true;
-            // Let's check if engineMap is null as it could be in theory if we throw an OOME during the construction of
+            // Let's check if engines is null as it could be in theory if we throw an OOME during the construction of
             // ReferenceCountedOpenSslEngine (before we assign the field). This is needed as shutdown() is called from
             // the finalizer as well.
-            if (engineMap != null) {
-                engineMap.remove(ssl);
+            if (engines != null) {
+                engines.remove(ssl);
             }
             SSL.freeSSL(ssl);
             ssl = networkBIO = 0;
@@ -1975,7 +1978,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
         }
 
         // Adding the OpenSslEngine to the OpenSslEngineMap so it can be used in the AbstractCertificateVerifier.
-        engineMap.add(this);
+        engines.add(ssl, this);
 
         if (!sessionSet) {
             if (!parentContext.sessionContext().setSessionFromCache(ssl, session, getPeerHost(), getPeerPort())) {

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslServerContext.java
@@ -78,7 +78,7 @@ public final class ReferenceCountedOpenSslServerContext extends ReferenceCounted
         // Create a new SSL_CTX and configure it.
         boolean success = false;
         try {
-            sessionContext = newSessionContext(this, ctx, engineMap, trustCertCollection, trustManagerFactory,
+            sessionContext = newSessionContext(this, ctx, engines, trustCertCollection, trustManagerFactory,
                     keyCertChain, key, keyPassword, keyManagerFactory, keyStore,
                     sessionCacheSize, sessionTimeout, resumptionController);
             if (SERVER_ENABLE_SESSION_TICKET) {
@@ -98,7 +98,7 @@ public final class ReferenceCountedOpenSslServerContext extends ReferenceCounted
     }
 
     static OpenSslServerSessionContext newSessionContext(ReferenceCountedOpenSslContext thiz, long ctx,
-                                                         OpenSslEngineMap engineMap,
+                                                         OpenSslEngineMap engines,
                                                          X509Certificate[] trustCertCollection,
                                                          TrustManagerFactory trustManagerFactory,
                                                          X509Certificate[] keyCertChain, PrivateKey key,
@@ -135,7 +135,7 @@ public final class ReferenceCountedOpenSslServerContext extends ReferenceCounted
                     keyMaterialProvider = providerFor(keyManagerFactory, keyPassword);
 
                     SSLContext.setCertificateCallback(ctx, new OpenSslServerCertificateCallback(
-                            engineMap, new OpenSslKeyMaterialManager(keyMaterialProvider, thiz.hasTmpDhKeys)));
+                            engines, new OpenSslKeyMaterialManager(keyMaterialProvider, thiz.hasTmpDhKeys)));
                 }
             } catch (Exception e) {
                 throw new SSLException("failed to set certificate and key", e);
@@ -159,7 +159,7 @@ public final class ReferenceCountedOpenSslServerContext extends ReferenceCounted
                 //
                 //            See https://github.com/netty/netty/issues/5372
 
-                setVerifyCallback(ctx, engineMap, manager);
+                setVerifyCallback(ctx, engines, manager);
 
                 X509Certificate[] issuers = manager.getAcceptedIssuers();
                 if (issuers != null && issuers.length > 0) {
@@ -184,7 +184,7 @@ public final class ReferenceCountedOpenSslServerContext extends ReferenceCounted
                     // IMPORTANT: The callbacks set for hostname matching must be static to prevent memory leak as
                     //            otherwise the context can never be collected. This is because the JNI code holds
                     //            a global reference to the matcher.
-                    SSLContext.setSniHostnameMatcher(ctx, new OpenSslSniHostnameMatcher(engineMap));
+                    SSLContext.setSniHostnameMatcher(ctx, new OpenSslSniHostnameMatcher(engines));
                 }
             } catch (SSLException e) {
                 throw e;
@@ -214,28 +214,29 @@ public final class ReferenceCountedOpenSslServerContext extends ReferenceCounted
     }
 
     @SuppressJava6Requirement(reason = "Guarded by java version check")
-    private static void setVerifyCallback(long ctx, OpenSslEngineMap engineMap, X509TrustManager manager) {
+    private static void setVerifyCallback(long ctx, OpenSslEngineMap engines, X509TrustManager manager) {
         // Use this to prevent an error when running on java < 7
         if (useExtendedTrustManager(manager)) {
             SSLContext.setCertVerifyCallback(ctx, new ExtendedTrustManagerVerifyCallback(
-                    engineMap, (X509ExtendedTrustManager) manager));
+                    engines, (X509ExtendedTrustManager) manager));
         } else {
-            SSLContext.setCertVerifyCallback(ctx, new TrustManagerVerifyCallback(engineMap, manager));
+            SSLContext.setCertVerifyCallback(ctx, new TrustManagerVerifyCallback(engines, manager));
         }
     }
 
     private static final class OpenSslServerCertificateCallback implements CertificateCallback {
-        private final OpenSslEngineMap engineMap;
+        private final OpenSslEngineMap engines;
         private final OpenSslKeyMaterialManager keyManagerHolder;
 
-        OpenSslServerCertificateCallback(OpenSslEngineMap engineMap, OpenSslKeyMaterialManager keyManagerHolder) {
-            this.engineMap = engineMap;
+        OpenSslServerCertificateCallback(OpenSslEngineMap engines,
+                                         OpenSslKeyMaterialManager keyManagerHolder) {
+            this.engines = engines;
             this.keyManagerHolder = keyManagerHolder;
         }
 
         @Override
         public void handle(long ssl, byte[] keyTypeBytes, byte[][] asn1DerEncodedPrincipals) throws Exception {
-            final ReferenceCountedOpenSslEngine engine = engineMap.get(ssl);
+            final ReferenceCountedOpenSslEngine engine = engines.get(ssl);
             if (engine == null) {
                 // Maybe null if destroyed in the meantime.
                 return;
@@ -258,8 +259,9 @@ public final class ReferenceCountedOpenSslServerContext extends ReferenceCounted
     private static final class TrustManagerVerifyCallback extends AbstractCertificateVerifier {
         private final X509TrustManager manager;
 
-        TrustManagerVerifyCallback(OpenSslEngineMap engineMap, X509TrustManager manager) {
-            super(engineMap);
+        TrustManagerVerifyCallback(OpenSslEngineMap engines,
+                                   X509TrustManager manager) {
+            super(engines);
             this.manager = manager;
         }
 
@@ -274,8 +276,9 @@ public final class ReferenceCountedOpenSslServerContext extends ReferenceCounted
     private static final class ExtendedTrustManagerVerifyCallback extends AbstractCertificateVerifier {
         private final X509ExtendedTrustManager manager;
 
-        ExtendedTrustManagerVerifyCallback(OpenSslEngineMap engineMap, X509ExtendedTrustManager manager) {
-            super(engineMap);
+        ExtendedTrustManagerVerifyCallback(OpenSslEngineMap engines,
+                                           X509ExtendedTrustManager manager) {
+            super(engines);
             this.manager = manager;
         }
 
@@ -287,15 +290,15 @@ public final class ReferenceCountedOpenSslServerContext extends ReferenceCounted
     }
 
     private static final class OpenSslSniHostnameMatcher implements SniHostNameMatcher {
-        private final OpenSslEngineMap engineMap;
+        private final OpenSslEngineMap engines;
 
-        OpenSslSniHostnameMatcher(OpenSslEngineMap engineMap) {
-            this.engineMap = engineMap;
+        OpenSslSniHostnameMatcher(OpenSslEngineMap engines) {
+            this.engines = engines;
         }
 
         @Override
         public boolean match(long ssl, String hostname) {
-            ReferenceCountedOpenSslEngine engine = engineMap.get(ssl);
+            ReferenceCountedOpenSslEngine engine = engines.get(ssl);
             if (engine != null) {
                 // TODO: In the next release of tcnative we should pass the byte[] directly in and not use a String.
                 return engine.checkSniHostnameMatch(hostname.getBytes(CharsetUtil.UTF_8));

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -24,12 +24,14 @@ import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.internal.tcnative.SSL;
 import io.netty.util.CharsetUtil;
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.function.Executable;
@@ -50,6 +52,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
@@ -1481,6 +1484,39 @@ public class OpenSslEngineTest extends SSLEngineTest {
         } finally {
             cleanupClientSslEngine(client);
             cleanupServerSslEngine(server);
+        }
+    }
+
+    // Pins OPENSSL (not sslClientProvider()) because only the OPENSSL engine has a finalizer to drive the reclaim
+    // asserted here; the OPENSSL_REFCNT subclass overrides this to a no-op (it has no finalizer). Verifies that a
+    // leaked engine is collected and releases its parent context while the context is still alive -- only possible
+    // because OpenSslEngineMap holds engines weakly rather than pinning them for the context's lifetime.
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    public void leakedEngineIsReclaimedWhileContextAlive() throws Exception {
+        assumeTrue(OpenSsl.isAvailable());
+
+        SslContext ctx = SslContextBuilder.forClient()
+                .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                .sslProvider(OPENSSL)
+                .build();
+        try {
+            // newEngine retains the context, so its refCnt goes from 1 to 2.
+            SSLEngine engine = ctx.newEngine(UnpooledByteBufAllocator.DEFAULT);
+            assertEquals(2, ReferenceCountUtil.refCnt(ctx));
+
+            // Drop the engine without releasing it, simulating a leak (e.g. handlerRemoved0 never firing).
+            engine = null;
+
+            // Collection triggers OpenSslEngine.finalize(), which releases the context (2 -> 1).
+            while (ReferenceCountUtil.refCnt(ctx) != 1) {
+                System.gc();
+                System.runFinalization();
+                Thread.sleep(50);
+            }
+            assertEquals(1, ReferenceCountUtil.refCnt(ctx));
+        } finally {
+            ReferenceCountUtil.release(ctx);
         }
     }
 

--- a/handler/src/test/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngineTest.java
@@ -59,6 +59,13 @@ public class ReferenceCountedOpenSslEngineTest extends OpenSslEngineTest {
         ReferenceCountUtil.release(unwrapEngine(engine));
     }
 
+    // OPENSSL_REFCNT has no finalizer, so the superclass's OPENSSL-only reclaim test does not apply here.
+    // Overriding it without @Test disables it for this subclass.
+    @Override
+    public void leakedEngineIsReclaimedWhileContextAlive() {
+        // noop
+    }
+
     @MethodSource("newTestParams")
     @ParameterizedTest
     public void testNotLeakOnException(SSLEngineTestParam param) throws Exception {


### PR DESCRIPTION
Motivation:

ReferenceCountedOpenSslContext strongly references every engine through its `engines` map (the SSL* -> engine reverse lookup used by the OpenSSL callbacks). As an SslContext is typically a long-lived singleton, a leaked engine stays reachable for the context's whole lifetime, so OpenSslEngine.finalize() - the backstop meant for that case - never runs and its native memory is freed only when the context is destroyed.

Modification:

Reintroduce OpenSslEngineMap as a class holding the engines as WeakReferences. A live engine is always strongly reachable via its SslHandler, so only a leaked one becomes collectable. The abstraction removed in #15444 was a strong wrapper that rightly added no value; weak values give it a reason to exist.

Add OpenSslEngineTest.leakedEngineIsReclaimedWhileContextAlive.

Result:

A leaked OPENSSL engine is reclaimed per-engine independently of its context. For OPENSSL_REFCNT a leaked engine now also becomes collectable, so the ResourceLeakDetector reports it instead of it being pinned silently.

(cherry picked from commit 26255b123f7c699cd88cbdb42f6ecc6ed5cb7843)

This also backports https://github.com/netty/netty/pull/15444 which is harmless because neither of those types are  public.
