### PR TITLE
Avoid redundant AsciiString UTF-8 buffer resizing

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -827,8 +827,16 @@ public final class ByteBufUtil {
      * result.
      */
     public static ByteBuf writeUtf8(ByteBufAllocator alloc, CharSequence seq) {
-        // UTF-8 uses max. 3 bytes per char, so calculate the worst case.
-        ByteBuf buf = alloc.buffer(utf8MaxBytes(seq));
+        final int reserveBytes = utf8MaxBytes(seq);
+        if (seq instanceof AsciiString && reserveBytes >= 64 &&
+                reserveBytes <= Integer.MAX_VALUE / MAX_BYTES_PER_CHAR_UTF8) {
+            // Preserve the capacity selected by the existing UTF-8 reservation while avoiding a resize.
+            ByteBuf buf = alloc.buffer(alloc.calculateNewCapacity(utf8MaxBytes(seq.length()), Integer.MAX_VALUE));
+            reserveAndWriteUtf8(buf, seq, reserveBytes);
+            return buf;
+        }
+
+        ByteBuf buf = alloc.buffer(reserveBytes);
         writeUtf8(buf, seq);
         return buf;
     }

--- a/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
@@ -91,6 +91,26 @@ public class ByteBufUtilTest {
         }
     }
 
+    private static ByteBufAllocator newAllocator(BufferType bufferType) {
+        switch (bufferType) {
+
+        case DIRECT_UNPOOLED:
+            return new UnpooledByteBufAllocator(true, true);
+        case HEAP_UNPOOLED:
+            return new UnpooledByteBufAllocator(false, true);
+        case DIRECT_POOLED:
+            return new PooledByteBufAllocator(true);
+        case HEAP_POOLED:
+            return new PooledByteBufAllocator(false);
+        case DIRECT_ADAPTIVE:
+            return new AdaptiveByteBufAllocator(true);
+        case HEAP_ADAPTIVE:
+            return new AdaptiveByteBufAllocator(false);
+        default:
+            throw new AssertionError("unexpected buffer type: " + bufferType);
+        }
+    }
+
     public static Collection<Object[]> noUnsafe() {
         return Arrays.asList(new Object[][] {
                 { BufferType.DIRECT_POOLED },
@@ -508,6 +528,59 @@ public class ByteBufUtilTest {
 
         buf.release();
         buf2.release();
+    }
+
+    @Test
+    public void testWriteUtf8AsciiStringAvoidsResize() {
+        AsciiString sequence = asciiString(1024);
+        TrackingUnpooledByteBufAllocator allocator = new TrackingUnpooledByteBufAllocator();
+        ByteBuf oldBuffer = allocator.buffer(sequence.length());
+        TrackingUnpooledHeapByteBuf oldHeapBuffer = allocator.lastBuffer;
+        ByteBuf newBuffer = ByteBufUtil.writeUtf8(allocator, sequence);
+        TrackingUnpooledHeapByteBuf newHeapBuffer = allocator.lastBuffer;
+        try {
+            ByteBufUtil.writeUtf8(oldBuffer, sequence);
+
+            assertEquals(1, oldHeapBuffer.capacityChanges);
+            assertEquals(sequence.length(), oldHeapBuffer.copiedBytes);
+            assertEquals(0, newHeapBuffer.capacityChanges);
+            assertEquals(0, newHeapBuffer.copiedBytes);
+            assertEquals(oldBuffer.capacity(), newBuffer.capacity());
+            assertEquals(oldBuffer, newBuffer);
+        } finally {
+            oldBuffer.release();
+            newBuffer.release();
+        }
+    }
+
+    @ParameterizedTest(name = PARAMETERIZED_NAME)
+    @MethodSource("noUnsafe")
+    public void testWriteUtf8AsciiStringPreservesCapacity(BufferType bufferType) {
+        AsciiString sequence = asciiString(1024);
+        ByteBufAllocator allocator = newAllocator(bufferType);
+        ByteBuf oldBuffer = allocator.buffer(sequence.length());
+        ByteBuf newBuffer = ByteBufUtil.writeUtf8(allocator, sequence);
+        try {
+            ByteBufUtil.writeUtf8(oldBuffer, sequence);
+            assertEquals(oldBuffer.capacity(), newBuffer.capacity());
+            assertEquals(oldBuffer, newBuffer);
+
+            for (int i = 0; i < 3; ++i) {
+                oldBuffer.writeBytes(sequence.array(), sequence.arrayOffset(), sequence.length());
+                newBuffer.writeBytes(sequence.array(), sequence.arrayOffset(), sequence.length());
+                assertEquals(oldBuffer.capacity(), newBuffer.capacity());
+                assertEquals(oldBuffer, newBuffer);
+            }
+        } finally {
+            oldBuffer.release();
+            newBuffer.release();
+        }
+    }
+
+    private static AsciiString asciiString(int length) {
+        byte[] bytes = new byte[length];
+        Arrays.fill(bytes, (byte) 'a');
+        return new AsciiString(bytes, false);
     }
 
     @ParameterizedTest(name = PARAMETERIZED_NAME)
@@ -1081,6 +1154,50 @@ public class ByteBufUtilTest {
             checkGetBytes(slice);
         } finally {
             buf.release();
+        }
+    }
+
+    private static final class TrackingUnpooledByteBufAllocator extends AbstractByteBufAllocator {
+        TrackingUnpooledHeapByteBuf lastBuffer;
+
+        TrackingUnpooledByteBufAllocator() {
+            super(false);
+        }
+
+        @Override
+        protected ByteBuf newHeapBuffer(int initialCapacity, int maxCapacity) {
+            lastBuffer = new TrackingUnpooledHeapByteBuf(this, initialCapacity, maxCapacity);
+            return lastBuffer;
+        }
+
+        @Override
+        protected ByteBuf newDirectBuffer(int initialCapacity, int maxCapacity) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isDirectBufferPooled() {
+            return false;
+        }
+    }
+
+    private static final class TrackingUnpooledHeapByteBuf extends UnpooledHeapByteBuf {
+        int capacityChanges;
+        int copiedBytes;
+
+        TrackingUnpooledHeapByteBuf(ByteBufAllocator allocator, int initialCapacity, int maxCapacity) {
+            super(allocator, initialCapacity, maxCapacity);
+        }
+
+        @Override
+        public ByteBuf capacity(int newCapacity) {
+            int oldCapacity = capacity();
+            if (newCapacity != oldCapacity) {
+                ++capacityChanges;
+                // UnpooledHeapByteBuf copies its full old capacity when it grows.
+                copiedBytes += oldCapacity;
+            }
+            return super.capacity(newCapacity);
         }
     }
 

--- a/microbench/src/main/java/io/netty/microbench/buffer/ByteBufUtilWriteUtf8Benchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/ByteBufUtilWriteUtf8Benchmark.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.buffer;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import io.netty.util.AsciiString;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import java.util.Arrays;
+
+@State(Scope.Thread)
+public class ByteBufUtilWriteUtf8Benchmark extends AbstractMicrobenchmark {
+
+    @Param({
+            "default",
+            "unpooledHeap",
+    })
+    public String allocatorType;
+
+    @Param({
+            "1024",
+            "4096",
+            "16384",
+            "65536",
+    })
+    public int length;
+
+    private ByteBufAllocator allocator;
+    private AsciiString sequence;
+
+    @Setup
+    public void setup() {
+        byte[] bytes = new byte[length];
+        Arrays.fill(bytes, (byte) 'a');
+        sequence = new AsciiString(bytes, false);
+
+        if ("default".equals(allocatorType)) {
+            allocator = ByteBufAllocator.DEFAULT;
+        } else if ("unpooledHeap".equals(allocatorType)) {
+            allocator = new UnpooledByteBufAllocator(false, true);
+        } else {
+            throw new IllegalArgumentException("unknown allocator type: " + allocatorType);
+        }
+    }
+
+    @Benchmark
+    public int writeUtf8() {
+        ByteBuf buffer = ByteBufUtil.writeUtf8(allocator, sequence);
+        try {
+            return buffer.getByte(buffer.writerIndex() - 1);
+        } finally {
+            buffer.release();
+        }
+    }
+
+    @Benchmark
+    public int writeUtf8AndAppend() {
+        ByteBuf buffer = ByteBufUtil.writeUtf8(allocator, sequence);
+        try {
+            buffer.writeBytes(sequence.array(), sequence.arrayOffset(), sequence.length());
+            buffer.writeBytes(sequence.array(), sequence.arrayOffset(), sequence.length());
+            buffer.writeBytes(sequence.array(), sequence.arrayOffset(), sequence.length());
+            return buffer.getByte(buffer.writerIndex() - 1);
+        } finally {
+            buffer.release();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Update the allocator-based UTF-8 write path to recognize larger AsciiString inputs. It retains the capacity that the existing maximum-UTF-8 reservation would have selected, while passing the exact ASCII byte count to the encoder so the newly allocated buffer is not immediately reallocated and copied. Other CharSequence inputs and the existing buffer-writing overload keep their current reservation behavior, preserving the returned buffer's append headroom.

## Performance

On workload `AsciiString UTF-8 write plus three equal appends, unpooled heap, 1 KiB`, median metric `ns/op` changed from 749.8 to 563.9; paired median delta -183 (-24.4% of baseline; at least 19/20 confidence interval -199.1 to -109 from 10 pairs).

On workload `AsciiString UTF-8 write plus three equal appends, unpooled heap, 1 KiB`, median metric `B/op` changed from 5216 to 4176; paired median delta -1040 (-19.9% of baseline; at least 19/20 confidence interval -1040 to -1040 from 10 pairs).

On workload `AsciiString UTF-8 write plus three equal appends, unpooled heap, 4 KiB`, median metric `B/op` changed from 20576 to 16464; paired median delta -4112 (-20% of baseline; at least 19/20 confidence interval -4112 to -4112 from 10 pairs).

On workload `AsciiString UTF-8 write plus three equal appends, unpooled heap, 16 KiB`, median metric `B/op` changed from 82016 to 65616; paired median delta -16400 (-20% of baseline; at least 19/20 confidence interval -16400 to -16400 from 10 pairs).

On workload `AsciiString UTF-8 write plus three equal appends, unpooled heap, 64 KiB`, median metric `ns/op` changed from 65776 to 51562; paired median delta -14054 (-21.4% of baseline; at least 19/20 confidence interval -16260 to -12667 from 10 pairs).

On workload `AsciiString UTF-8 write plus three equal appends, unpooled heap, 64 KiB`, median metric `B/op` changed from 327776 to 262224; paired median delta -65552 (-20% of baseline; at least 19/20 confidence interval -65552 to -65552 from 10 pairs).

On workload `AsciiString UTF-8 write, default adaptive allocator, 1 KiB`, median metric `ns/op` changed from 178.8 to 106.7; paired median delta -70.76 (-39.6% of baseline; at least 19/20 confidence interval -78.84 to -65.2 from 10 pairs).

On workload `AsciiString UTF-8 write, default adaptive allocator, 4 KiB`, median metric `ns/op` changed from 294.4 to 181.5; paired median delta -107.1 (-36.4% of baseline; at least 19/20 confidence interval -130.8 to -98.67 from 10 pairs).

On workload `AsciiString UTF-8 write, default adaptive allocator, 16 KiB`, median metric `ns/op` changed from 1018 to 517.5; paired median delta -505.7 (-49.7% of baseline; at least 19/20 confidence interval -554.7 to -484.8 from 10 pairs).

On workload `AsciiString UTF-8 write, default adaptive allocator, 64 KiB`, median metric `ns/op` changed from 3531 to 1853; paired median delta -1730 (-49% of baseline; at least 19/20 confidence interval -1912 to -1565 from 10 pairs).

## Testing

Ran the focused ByteBufUtilTest Maven suite, including encoded output, returned capacity, and append behavior across pooled, unpooled, and adaptive heap and direct allocators.

The declared correctness check passed.

Full verification record: https://app.perfloop.ai/t/oss/case_dyqr11pchm