### PR TITLE
Merge changes from forks (#17213)

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsHandler.java
@@ -193,7 +193,9 @@ public class CorsHandler extends ChannelDuplexHandler {
     }
 
     private static void setVaryHeader(final HttpResponse response) {
-        response.headers().set(HttpHeaderNames.VARY, HttpHeaderNames.ORIGIN);
+        if (!response.headers().containsValue(HttpHeaderNames.VARY, HttpHeaderNames.ORIGIN, true)) {
+            response.headers().add(HttpHeaderNames.VARY, HttpHeaderNames.ORIGIN);
+        }
     }
 
     private static void setAnyOrigin(final HttpResponse response) {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cors/CorsHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cors/CorsHandlerTest.java
@@ -25,6 +25,7 @@ import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.DefaultHttpHeadersFactory;
 import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http.HttpMethod;
@@ -682,6 +683,32 @@ public class CorsHandlerTest {
         assertEquals("null", response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN));
         assertTrue(ReferenceCountUtil.release(response));
     }
+
+   @Test
+   public void varyHeaderIsAppended() {
+       CorsConfig config = forAnyOrigin().allowCredentials().build();
+       EmbeddedChannel channel = new EmbeddedChannel(new CorsHandler(config),
+               new SimpleChannelInboundHandler<Object>() {
+                   @Override
+                   protected void channelRead0(ChannelHandlerContext ctx, Object msg) {
+                       HttpResponse response = new DefaultFullHttpResponse(HTTP_1_1, OK, Unpooled.buffer(0));
+                       response.headers().set(VARY, ACCEPT_ENCODING);
+                       ctx.writeAndFlush(response);
+                   }
+               });
+       FullHttpRequest request = createHttpRequest(GET);
+       request.headers().set(ORIGIN, "http://localhost:7777");
+       assertFalse(channel.writeInbound(request));
+
+       FullHttpResponse response = channel.readOutbound();
+
+       List<String> varyHeaders = response.headers().getAll(VARY);
+       assertThat(varyHeaders).contains(ACCEPT_ENCODING.toString());
+       assertThat(varyHeaders).contains(ORIGIN.toString());
+
+       response.release();
+       assertFalse(channel.finish());
+   }
 
     private static HttpResponse simpleRequest(final CorsConfig config, final String origin) {
         return simpleRequest(config, origin, null);

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttCodecUtil.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttCodecUtil.java
@@ -44,9 +44,13 @@ final class MqttCodecUtil {
     }
 
     static boolean isValidPublishTopicName(String topicName) {
+        if (topicName == null) {
+            return false;
+        }
         // publish topic name must not contain any wildcard
-        for (char c : TOPIC_WILDCARDS) {
-            if (topicName.indexOf(c) >= 0) {
+        for (int i = 0; i < topicName.length(); i++) {
+            char c = topicName.charAt(i);
+            if (c == '#' || c == '+' || c == '\0') {
                 return false;
             }
         }
@@ -57,15 +61,31 @@ final class MqttCodecUtil {
         return messageId != 0;
     }
 
-    static boolean isValidClientId(MqttVersion mqttVersion, int maxClientIdLength, String clientId) {
+    static boolean isValidUserName(String userName) {
+        return userName == null || userName.indexOf('\0') == -1;
+    }
+
+    /**
+     * Determine if a client identifier is valid.
+     * @param mqttVersion The MQTT version semantics to use.
+     * @param maxClientIdLength The max client id length.
+     * @param clientId The client id value.
+     * @param acceptNulBytes MQTT normally does not allow NUL bytes in client identifiers.
+     * Set this to {@code true} to enable "legacy"/"lenient" mode, otherwise {@code false} for strict spec compliance.
+     * @return {@code true} if the client id is valid, otherwise {@code false}.
+     */
+    static boolean isValidClientId(MqttVersion mqttVersion, int maxClientIdLength, String clientId,
+                                   boolean acceptNulBytes) {
+        if (clientId == null || (!acceptNulBytes && clientId.indexOf('\0') != -1)) {
+            return false;
+        }
         if (mqttVersion == MqttVersion.MQTT_3_1) {
-            return clientId != null && clientId.length() >= MIN_CLIENT_ID_LENGTH &&
-                clientId.length() <= maxClientIdLength;
+            return clientId.length() >= MIN_CLIENT_ID_LENGTH && clientId.length() <= maxClientIdLength;
         }
         if (mqttVersion == MqttVersion.MQTT_3_1_1 || mqttVersion == MqttVersion.MQTT_5) {
             // In 3.1.3.1 Client Identifier of MQTT 3.1.1 and 5.0 specifications, The Server MAY allow ClientId’s
             // that contain more than 23 encoded bytes. And, The Server MAY allow zero-length ClientId.
-            return clientId != null;
+            return true;
         }
         throw new IllegalArgumentException(mqttVersion + " is unknown mqtt version");
     }

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
@@ -552,8 +552,8 @@ public final class MqttDecoder extends ReplayingDecoder<DecoderState> {
         final String decodedClientIdValue = decodedClientId.value;
         final MqttVersion mqttVersion = MqttVersion.fromProtocolNameAndLevel(mqttConnectVariableHeader.name(),
                 (byte) mqttConnectVariableHeader.version());
-        if (!isValidClientId(mqttVersion, maxClientIdLength, decodedClientIdValue)) {
-            throw new MqttIdentifierRejectedException("invalid clientIdentifier: " + decodedClientIdValue);
+        if (!isValidClientId(mqttVersion, maxClientIdLength, decodedClientIdValue, !strictUtf8Validation)) {
+            throw new MqttIdentifierRejectedException("invalid clientIdentifier");
         }
         int numberOfBytesConsumed = decodedClientId.numberOfBytesConsumed;
 

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttEncoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttEncoder.java
@@ -30,6 +30,8 @@ import java.util.List;
 import static io.netty.buffer.ByteBufUtil.*;
 import static io.netty.handler.codec.mqtt.MqttCodecUtil.getMqttVersion;
 import static io.netty.handler.codec.mqtt.MqttCodecUtil.isValidClientId;
+import static io.netty.handler.codec.mqtt.MqttCodecUtil.isValidPublishTopicName;
+import static io.netty.handler.codec.mqtt.MqttCodecUtil.isValidUserName;
 import static io.netty.handler.codec.mqtt.MqttCodecUtil.setMqttVersion;
 import static io.netty.handler.codec.mqtt.MqttConstant.DEFAULT_MAX_CLIENT_ID_LENGTH;
 
@@ -126,8 +128,8 @@ public final class MqttEncoder extends MessageToMessageEncoder<MqttMessage> {
 
         // Client id
         String clientIdentifier = payload.clientIdentifier();
-        if (!isValidClientId(mqttVersion, DEFAULT_MAX_CLIENT_ID_LENGTH, clientIdentifier)) {
-            throw new MqttIdentifierRejectedException("invalid clientIdentifier: " + clientIdentifier);
+        if (!isValidClientId(mqttVersion, DEFAULT_MAX_CLIENT_ID_LENGTH, clientIdentifier, false)) {
+            throw new MqttIdentifierRejectedException("invalid clientIdentifier");
         }
         int clientIdentifierBytes = utf8Bytes(clientIdentifier);
         payloadBufferSize += 2 + clientIdentifierBytes;
@@ -138,6 +140,9 @@ public final class MqttEncoder extends MessageToMessageEncoder<MqttMessage> {
         byte[] willMessage = payload.willMessageInBytes();
         byte[] willMessageBytes = willMessage != null ? willMessage : EmptyArrays.EMPTY_BYTES;
         if (variableHeader.isWillFlag()) {
+            if (!isValidPublishTopicName(willTopic)) {
+                throw new MqttIdentifierRejectedException("invalid willTopic");
+            }
             payloadBufferSize += 2 + willTopicBytes;
             payloadBufferSize += 2 + willMessageBytes.length;
         }
@@ -145,6 +150,9 @@ public final class MqttEncoder extends MessageToMessageEncoder<MqttMessage> {
         String userName = payload.userName();
         int userNameBytes = nullableUtf8Bytes(userName);
         if (variableHeader.hasUserName()) {
+            if (!isValidUserName(userName)) {
+                throw new MqttIdentifierRejectedException("invalid userName");
+            }
             payloadBufferSize += 2 + userNameBytes;
         }
 
@@ -433,6 +441,9 @@ public final class MqttEncoder extends MessageToMessageEncoder<MqttMessage> {
         ByteBuf payload = message.payload().duplicate();
 
         String topicName = variableHeader.topicName();
+        if (!isValidPublishTopicName(topicName)) {
+            throw new MqttIdentifierRejectedException("invalid topicName");
+        }
         int topicNameBytes = utf8Bytes(topicName);
 
         ByteBuf propertiesBuf = encodePropertiesIfNeeded(mqttVersion,

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttIdentifierRejectedException.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttIdentifierRejectedException.java
@@ -18,7 +18,8 @@ package io.netty.handler.codec.mqtt;
 import io.netty.handler.codec.DecoderException;
 
 /**
- * A {@link MqttIdentifierRejectedException} which is thrown when a CONNECT request contains invalid client identifier.
+ * A {@link MqttIdentifierRejectedException} which is thrown when a CONNECT request contains invalid client identifier,
+ * will topic name, or username, or when a PUBLISH message contains an invalid topic name.
  */
 public final class MqttIdentifierRejectedException extends DecoderException {
 

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
@@ -34,6 +34,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
@@ -1515,6 +1517,83 @@ public class MqttCodecTest {
             assertEquals("a\u0000b", ((MqttConnectMessage) msg).payload().clientIdentifier());
         } finally {
             ReferenceCountUtil.release(msg);
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(MqttVersion.class)
+    public void encodeConnectMessageWithNulInClientIdIsRejected(MqttVersion version) {
+        final MqttConnectMessage message = MqttMessageBuilders.connect()
+                .clientId("client\u0000id")
+                .protocolVersion(version)
+                .cleanSession(true)
+                .keepAlive(KEEP_ALIVE_SECONDS)
+                .build();
+        assertThrows(MqttIdentifierRejectedException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                MqttEncoder.doEncode(ctx, message);
+            }
+        });
+    }
+
+    @ParameterizedTest
+    @EnumSource(MqttVersion.class)
+    public void encodeConnectMessageWithNulInWillTopicIsRejected(MqttVersion version) {
+        final MqttConnectMessage message = MqttMessageBuilders.connect()
+                .clientId(CLIENT_ID)
+                .protocolVersion(version)
+                .willFlag(true)
+                .willQoS(MqttQoS.AT_LEAST_ONCE)
+                .willTopic("will\u0000topic")
+                .willMessage(WILL_MESSAGE.getBytes(CharsetUtil.UTF_8))
+                .cleanSession(true)
+                .keepAlive(KEEP_ALIVE_SECONDS)
+                .build();
+        assertThrows(MqttIdentifierRejectedException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                MqttEncoder.doEncode(ctx, message);
+            }
+        });
+    }
+
+    @ParameterizedTest
+    @EnumSource(MqttVersion.class)
+    public void encodeConnectMessageWithNulInUserNameIsRejected(MqttVersion version) {
+        final MqttConnectMessage message = MqttMessageBuilders.connect()
+                .clientId(CLIENT_ID)
+                .protocolVersion(version)
+                .username("user\u0000name")
+                .password(PASSWORD_BYTES)
+                .cleanSession(true)
+                .keepAlive(KEEP_ALIVE_SECONDS)
+                .build();
+        assertThrows(MqttIdentifierRejectedException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                MqttEncoder.doEncode(ctx, message);
+            }
+        });
+    }
+
+    @Test
+    public void encodePublishMessageWithNulInTopicIsRejected() {
+        MqttFixedHeader fixedHeader =
+                new MqttFixedHeader(MqttMessageType.PUBLISH, false, MqttQoS.AT_LEAST_ONCE, false, 0);
+        MqttPublishVariableHeader variableHeader = new MqttPublishVariableHeader("home/\u0000/sensor", 1);
+        ByteBuf payload = ALLOCATOR.buffer();
+        payload.writeBytes("data".getBytes(CharsetUtil.UTF_8));
+        final MqttPublishMessage message = new MqttPublishMessage(fixedHeader, variableHeader, payload);
+        try {
+            assertThrows(MqttIdentifierRejectedException.class, new Executable() {
+                @Override
+                public void execute() throws Throwable {
+                    MqttEncoder.doEncode(ctx, message);
+                }
+            });
+        } finally {
+            payload.release();
         }
     }
 }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/Socks4ClientEncoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/Socks4ClientEncoder.java
@@ -20,7 +20,9 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.EncoderException;
 import io.netty.handler.codec.MessageToByteEncoder;
+import io.netty.util.AsciiString;
 import io.netty.util.NetUtil;
 
 /**
@@ -45,14 +47,25 @@ public final class Socks4ClientEncoder extends MessageToByteEncoder<Socks4Comman
         ByteBufUtil.writeShortBE(out, msg.dstPort());
         if (NetUtil.isValidIpV4Address(msg.dstAddr())) {
             out.writeBytes(NetUtil.createByteArrayFromIpAddressString(msg.dstAddr()));
-            ByteBufUtil.writeAscii(out, msg.userId());
+            ByteBufUtil.writeAscii(out, sanitize("userId", msg.userId()));
             out.writeByte(0);
         } else {
             out.writeBytes(IPv4_DOMAIN_MARKER);
-            ByteBufUtil.writeAscii(out, msg.userId());
+            ByteBufUtil.writeAscii(out, sanitize("userId", msg.userId()));
             out.writeByte(0);
-            ByteBufUtil.writeAscii(out, msg.dstAddr());
+            ByteBufUtil.writeAscii(out, sanitize("dstAddr", msg.dstAddr()));
             out.writeByte(0);
         }
+    }
+
+    private CharSequence sanitize(String fieldName, String strValue) {
+        for (int i = 0, len = strValue.length(); i < len; i++) {
+            char c = strValue.charAt(i);
+            // SOCKS4 uses NUL-bytes as field delimiters.
+            if (AsciiString.c2b(c) == 0) {
+                throw new EncoderException("Illegal character in " + fieldName + " field.");
+            }
+        }
+        return strValue;
     }
 }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5ClientEncoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5ClientEncoder.java
@@ -77,7 +77,7 @@ public class Socks5ClientEncoder extends MessageToByteEncoder<Socks5Message> {
 
         final List<Socks5AuthMethod> authMethods = msg.authMethods();
         final int numAuthMethods = authMethods.size();
-        out.writeByte(numAuthMethods);
+        writeFieldLength(out, numAuthMethods);
 
         if (authMethods instanceof RandomAccess) {
             for (int i = 0; i < numAuthMethods; i ++) {
@@ -94,11 +94,11 @@ public class Socks5ClientEncoder extends MessageToByteEncoder<Socks5Message> {
         out.writeByte(0x01);
 
         final String username = msg.username();
-        out.writeByte(username.length());
+        writeFieldLength(out, username.length());
         ByteBufUtil.writeAscii(out, username);
 
         final String password = msg.password();
-        out.writeByte(password.length());
+        writeFieldLength(out, password.length());
         ByteBufUtil.writeAscii(out, password);
     }
 
@@ -109,7 +109,22 @@ public class Socks5ClientEncoder extends MessageToByteEncoder<Socks5Message> {
 
         final Socks5AddressType dstAddrType = msg.dstAddrType();
         out.writeByte(dstAddrType.byteValue());
-        addressEncoder.encodeAddress(dstAddrType, msg.dstAddr(), out);
+        String addrValue = msg.dstAddr();
+        if (addrValue != null && dstAddrType == Socks5AddressType.DOMAIN) {
+            checkFieldLength(addrValue.length());
+        }
+        addressEncoder.encodeAddress(dstAddrType, addrValue, out);
         ByteBufUtil.writeShortBE(out, msg.dstPort());
+    }
+
+    private static void writeFieldLength(ByteBuf out, int length) {
+        checkFieldLength(length);
+        out.writeByte(length);
+    }
+
+    private static void checkFieldLength(int length) {
+        if (length > 255 || length < 0) {
+            throw new EncoderException("Invalid field length value: " + length);
+        }
     }
 }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5ServerEncoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5ServerEncoder.java
@@ -86,8 +86,18 @@ public class Socks5ServerEncoder extends MessageToByteEncoder<Socks5Message> {
 
         final Socks5AddressType bndAddrType = msg.bndAddrType();
         out.writeByte(bndAddrType.byteValue());
-        addressEncoder.encodeAddress(bndAddrType, msg.bndAddr(), out);
+        String addrValue = msg.bndAddr();
+        if (addrValue != null && bndAddrType == Socks5AddressType.DOMAIN) {
+            checkFieldLength(addrValue.length());
+        }
+        addressEncoder.encodeAddress(bndAddrType, addrValue, out);
 
         ByteBufUtil.writeShortBE(out, msg.bndPort());
+    }
+
+    private static void checkFieldLength(int length) {
+        if (length > 255 || length < 0) {
+            throw new EncoderException("Invalid field length value: " + length);
+        }
     }
 }

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v4/Socks4ClientEncoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v4/Socks4ClientEncoderTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.socksx.v4;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.EncoderException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class Socks4ClientEncoderTest {
+    @Test
+    public void mustEncodeCommandRequestToIPv4() {
+        EmbeddedChannel encoder = new EmbeddedChannel(Socks4ClientEncoder.INSTANCE);
+        DefaultSocks4CommandRequest request = new DefaultSocks4CommandRequest(
+                Socks4CommandType.CONNECT, "127.0.0.1", 8008, "user");
+        assertTrue(encoder.writeOutbound(request));
+        ByteBuf buf = encoder.readOutbound();
+        assertNotNull(buf);
+        buf.release();
+        assertFalse(encoder.finish());
+    }
+    @Test
+    public void mustEncodeCommandRequestToDomain() {
+        EmbeddedChannel encoder = new EmbeddedChannel(Socks4ClientEncoder.INSTANCE);
+        DefaultSocks4CommandRequest request = new DefaultSocks4CommandRequest(
+                Socks4CommandType.CONNECT, "unix://uds.sock", 8008, "user");
+        assertTrue(encoder.writeOutbound(request));
+        ByteBuf buf = encoder.readOutbound();
+        assertNotNull(buf);
+        buf.release();
+        assertFalse(encoder.finish());
+    }
+
+    @Test
+    public void mustRejectNulByteInUserIdWithIPv4Destination() {
+        EmbeddedChannel encoder = new EmbeddedChannel(Socks4ClientEncoder.INSTANCE);
+        DefaultSocks4CommandRequest request = new DefaultSocks4CommandRequest(
+                Socks4CommandType.CONNECT, "127.0.0.1", 8008, "use\0r");
+        assertThatThrownBy(() -> encoder.writeOutbound(request))
+                .isInstanceOf(EncoderException.class)
+                .hasMessageContaining("Illegal character");
+        assertFalse(encoder.finish());
+    }
+
+    @Test
+    public void mustRejectNulByteInUserIdWithDomainDestination() {
+        EmbeddedChannel encoder = new EmbeddedChannel(Socks4ClientEncoder.INSTANCE);
+        DefaultSocks4CommandRequest request = new DefaultSocks4CommandRequest(
+                Socks4CommandType.CONNECT, "unix://uds.sock", 8008, "use\0r");
+        assertThatThrownBy(() -> encoder.writeOutbound(request))
+                .isInstanceOf(EncoderException.class)
+                .hasMessageContaining("Illegal character");
+        assertFalse(encoder.finish());
+    }
+
+    @Test
+    public void mustRejectNulByteInDstAddr() {
+        EmbeddedChannel encoder = new EmbeddedChannel(Socks4ClientEncoder.INSTANCE);
+        DefaultSocks4CommandRequest request = new DefaultSocks4CommandRequest(
+                Socks4CommandType.CONNECT, "unix://uds\0.sock", 8008, "user");
+        assertThatThrownBy(() -> encoder.writeOutbound(request))
+                .isInstanceOf(EncoderException.class)
+                .hasMessageContaining("Illegal character");
+        assertFalse(encoder.finish());
+    }
+}

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v4/Socks4ClientEncoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v4/Socks4ClientEncoderTest.java
@@ -18,6 +18,7 @@ package io.netty.handler.codec.socksx.v4;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.EncoderException;
+import org.assertj.core.api.ThrowableAssert;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -51,10 +52,15 @@ class Socks4ClientEncoderTest {
 
     @Test
     public void mustRejectNulByteInUserIdWithIPv4Destination() {
-        EmbeddedChannel encoder = new EmbeddedChannel(Socks4ClientEncoder.INSTANCE);
-        DefaultSocks4CommandRequest request = new DefaultSocks4CommandRequest(
+        final EmbeddedChannel encoder = new EmbeddedChannel(Socks4ClientEncoder.INSTANCE);
+        final DefaultSocks4CommandRequest request = new DefaultSocks4CommandRequest(
                 Socks4CommandType.CONNECT, "127.0.0.1", 8008, "use\0r");
-        assertThatThrownBy(() -> encoder.writeOutbound(request))
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            @Override
+            public void call() throws Throwable {
+                encoder.writeOutbound(request);
+            }
+        })
                 .isInstanceOf(EncoderException.class)
                 .hasMessageContaining("Illegal character");
         assertFalse(encoder.finish());
@@ -62,21 +68,30 @@ class Socks4ClientEncoderTest {
 
     @Test
     public void mustRejectNulByteInUserIdWithDomainDestination() {
-        EmbeddedChannel encoder = new EmbeddedChannel(Socks4ClientEncoder.INSTANCE);
-        DefaultSocks4CommandRequest request = new DefaultSocks4CommandRequest(
+        final EmbeddedChannel encoder = new EmbeddedChannel(Socks4ClientEncoder.INSTANCE);
+        final DefaultSocks4CommandRequest request = new DefaultSocks4CommandRequest(
                 Socks4CommandType.CONNECT, "unix://uds.sock", 8008, "use\0r");
-        assertThatThrownBy(() -> encoder.writeOutbound(request))
-                .isInstanceOf(EncoderException.class)
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            @Override
+            public void call() throws Throwable {
+                encoder.writeOutbound(request);
+            }
+        }).isInstanceOf(EncoderException.class)
                 .hasMessageContaining("Illegal character");
         assertFalse(encoder.finish());
     }
 
     @Test
     public void mustRejectNulByteInDstAddr() {
-        EmbeddedChannel encoder = new EmbeddedChannel(Socks4ClientEncoder.INSTANCE);
-        DefaultSocks4CommandRequest request = new DefaultSocks4CommandRequest(
+        final EmbeddedChannel encoder = new EmbeddedChannel(Socks4ClientEncoder.INSTANCE);
+        final DefaultSocks4CommandRequest request = new DefaultSocks4CommandRequest(
                 Socks4CommandType.CONNECT, "unix://uds\0.sock", 8008, "user");
-        assertThatThrownBy(() -> encoder.writeOutbound(request))
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            @Override
+            public void call() throws Throwable {
+                encoder.writeOutbound(request);
+            }
+        })
                 .isInstanceOf(EncoderException.class)
                 .hasMessageContaining("Illegal character");
         assertFalse(encoder.finish());

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5ClientEncoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5ClientEncoderTest.java
@@ -20,8 +20,10 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.EncoderException;
 import io.netty.handler.codec.socksx.SocksVersion;
+import org.assertj.core.api.ThrowableAssert;
 import org.junit.jupiter.api.Test;
 
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -36,8 +38,12 @@ class Socks5ClientEncoderTest {
     public void initialRequestEncodingMustAcceptMaxNumberOfAuthMethods() {
         EmbeddedChannel encoder = new EmbeddedChannel(Socks5ClientEncoder.DEFAULT);
         assertTrue(encoder.writeOutbound(new DefaultSocks5InitialRequest(
-                Stream.generate(() -> Socks5AuthMethod.PASSWORD).limit(255).collect(Collectors.toList())
-        )));
+                Stream.generate(new Supplier<Socks5AuthMethod>() {
+                    @Override
+                    public Socks5AuthMethod get() {
+                        return Socks5AuthMethod.PASSWORD;
+                    }
+                }).limit(255).collect(Collectors.toList()))));
         ByteBuf buf = encoder.readOutbound();
         assertNotNull(buf);
         buf.release();
@@ -47,10 +53,15 @@ class Socks5ClientEncoderTest {
     @Test
     public void initialRequestEncodingMustRejectTooManyAuthMethods() {
         EmbeddedChannel encoder = new EmbeddedChannel(Socks5ClientEncoder.DEFAULT);
-        assertThatThrownBy(() -> encoder.writeOutbound(new DefaultSocks5InitialRequest(
-                Stream.generate(() -> Socks5AuthMethod.PASSWORD).limit(256).collect(Collectors.toList())
-        )))
-                .isInstanceOf(EncoderException.class)
+        assertThatThrownBy(
+            new ThrowableAssert.ThrowingCallable() {
+                @Override
+                public void call() throws Throwable {
+                    encoder.writeOutbound(new DefaultSocks5InitialRequest(
+                        Stream.generate(() -> Socks5AuthMethod.PASSWORD).limit(256).collect(Collectors.toList())));
+                }
+            }
+        ).isInstanceOf(EncoderException.class)
                 .hasMessageContaining("Invalid field length");
         assertFalse(encoder.finish());
     }
@@ -77,7 +88,11 @@ class Socks5ClientEncoderTest {
                 new DefaultSocks5PasswordAuthRequest("user", "pass") {
                     @Override
                     public String password() {
-                        return Stream.generate(() -> "a").limit(255).collect(Collectors.joining());
+                        StringBuilder sb = new StringBuilder(255);
+                        for (int i = 0; i < 255; i++) {
+                            sb.append("a");
+                        }
+                        return sb.toString();
                     }
                 }
         ));
@@ -97,7 +112,11 @@ class Socks5ClientEncoderTest {
                 new DefaultSocks5PasswordAuthRequest("user", "pass") {
                     @Override
                     public String username() {
-                        return Stream.generate(() -> "a").limit(256).collect(Collectors.joining());
+                        StringBuilder sb = new StringBuilder(256);
+                        for (int i = 0; i < 256; i++) {
+                            sb.append("a");
+                        }
+                        return sb.toString();
                     }
                 }
         ))
@@ -109,7 +128,11 @@ class Socks5ClientEncoderTest {
                 new DefaultSocks5PasswordAuthRequest("user", "pass") {
                     @Override
                     public String password() {
-                        return Stream.generate(() -> "a").limit(256).collect(Collectors.joining());
+                        StringBuilder sb = new StringBuilder(256);
+                        for (int i = 0; i < 256; i++) {
+                            sb.append("a");
+                        }
+                        return sb.toString();
                     }
                 }
         ))
@@ -180,41 +203,46 @@ class Socks5ClientEncoderTest {
     @Test
     public void commandRequestEncodingMustRejectTooLongDstAddr() {
         EmbeddedChannel encoder = new EmbeddedChannel(Socks5ClientEncoder.DEFAULT);
-        assertThatThrownBy(() -> encoder.writeOutbound(new Socks5CommandRequest() {
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
             @Override
-            public DecoderResult decoderResult() {
-                return DecoderResult.SUCCESS;
-            }
+            public void call() throws Throwable {
+                encoder.writeOutbound(new Socks5CommandRequest() {
+                    @Override
+                    public DecoderResult decoderResult() {
+                        return DecoderResult.SUCCESS;
+                    }
 
-            @Override
-            public void setDecoderResult(DecoderResult result) {
-            }
+                    @Override
+                    public void setDecoderResult(DecoderResult result) {
+                    }
 
-            @Override
-            public SocksVersion version() {
-                return SocksVersion.SOCKS5;
-            }
+                    @Override
+                    public SocksVersion version() {
+                        return SocksVersion.SOCKS5;
+                    }
 
-            @Override
-            public Socks5CommandType type() {
-                return Socks5CommandType.CONNECT;
-            }
+                    @Override
+                    public Socks5CommandType type() {
+                        return Socks5CommandType.CONNECT;
+                    }
 
-            @Override
-            public Socks5AddressType dstAddrType() {
-                return Socks5AddressType.DOMAIN;
-            }
+                    @Override
+                    public Socks5AddressType dstAddrType() {
+                        return Socks5AddressType.DOMAIN;
+                    }
 
-            @Override
-            public String dstAddr() {
-                return Stream.generate(() -> "a").limit(256).collect(Collectors.joining());
-            }
+                    @Override
+                    public String dstAddr() {
+                        return Stream.generate(() -> "a").limit(256).collect(Collectors.joining());
+                    }
 
-            @Override
-            public int dstPort() {
-                return 8080;
+                    @Override
+                    public int dstPort() {
+                        return 8080;
+                    }
+                });
             }
-        }))
+        })
                 .isInstanceOf(EncoderException.class)
                 .hasMessageContaining("Invalid field length");
         assertFalse(encoder.finish());

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5ClientEncoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5ClientEncoderTest.java
@@ -80,7 +80,12 @@ class Socks5ClientEncoderTest {
                 new DefaultSocks5PasswordAuthRequest("user", "pass") {
                     @Override
                     public String username() {
-                        return Stream.generate(() -> "a").limit(255).collect(Collectors.joining());
+                        return Stream.generate(new Supplier<String>() {
+                            @Override
+                            public String get() {
+                                return "a";
+                            }
+                        }).limit(255).collect(Collectors.joining());
                     }
                 }
         ));

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5ClientEncoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5ClientEncoderTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.socksx.v5;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.DecoderResult;
+import io.netty.handler.codec.EncoderException;
+import io.netty.handler.codec.socksx.SocksVersion;
+import org.junit.jupiter.api.Test;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class Socks5ClientEncoderTest {
+    @Test
+    public void initialRequestEncodingMustAcceptMaxNumberOfAuthMethods() {
+        EmbeddedChannel encoder = new EmbeddedChannel(Socks5ClientEncoder.DEFAULT);
+        assertTrue(encoder.writeOutbound(new DefaultSocks5InitialRequest(
+                Stream.generate(() -> Socks5AuthMethod.PASSWORD).limit(255).collect(Collectors.toList())
+        )));
+        ByteBuf buf = encoder.readOutbound();
+        assertNotNull(buf);
+        buf.release();
+        assertFalse(encoder.finish());
+    }
+
+    @Test
+    public void initialRequestEncodingMustRejectTooManyAuthMethods() {
+        EmbeddedChannel encoder = new EmbeddedChannel(Socks5ClientEncoder.DEFAULT);
+        assertThatThrownBy(() -> encoder.writeOutbound(new DefaultSocks5InitialRequest(
+                Stream.generate(() -> Socks5AuthMethod.PASSWORD).limit(256).collect(Collectors.toList())
+        )))
+                .isInstanceOf(EncoderException.class)
+                .hasMessageContaining("Invalid field length");
+        assertFalse(encoder.finish());
+    }
+
+    @Test
+    public void passwordAuthRequestEncodingMustAcceptMaxLengthUsername() {
+        EmbeddedChannel encoder = new EmbeddedChannel(Socks5ClientEncoder.DEFAULT);
+
+        // max length username
+        assertTrue(encoder.writeOutbound(
+                new DefaultSocks5PasswordAuthRequest("user", "pass") {
+                    @Override
+                    public String username() {
+                        return Stream.generate(() -> "a").limit(255).collect(Collectors.joining());
+                    }
+                }
+        ));
+        ByteBuf buf = encoder.readOutbound();
+        assertNotNull(buf);
+        buf.release();
+
+        // max length password
+        assertTrue(encoder.writeOutbound(
+                new DefaultSocks5PasswordAuthRequest("user", "pass") {
+                    @Override
+                    public String password() {
+                        return Stream.generate(() -> "a").limit(255).collect(Collectors.joining());
+                    }
+                }
+        ));
+        buf = encoder.readOutbound();
+        assertNotNull(buf);
+        buf.release();
+
+        assertFalse(encoder.finish());
+    }
+
+    @Test
+    public void passwordAuthRequestEncodingMustRejectTooLongUsernameOrPassword() {
+        EmbeddedChannel encoder = new EmbeddedChannel(Socks5ClientEncoder.DEFAULT);
+
+        // too long username
+        assertThatThrownBy(() -> encoder.writeOutbound(
+                new DefaultSocks5PasswordAuthRequest("user", "pass") {
+                    @Override
+                    public String username() {
+                        return Stream.generate(() -> "a").limit(256).collect(Collectors.joining());
+                    }
+                }
+        ))
+                .isInstanceOf(EncoderException.class)
+                .hasMessageContaining("Invalid field length");
+
+        // too long password
+        assertThatThrownBy(() -> encoder.writeOutbound(
+                new DefaultSocks5PasswordAuthRequest("user", "pass") {
+                    @Override
+                    public String password() {
+                        return Stream.generate(() -> "a").limit(256).collect(Collectors.joining());
+                    }
+                }
+        ))
+                .isInstanceOf(EncoderException.class)
+                .hasMessageContaining("Invalid field length");
+
+        assertFalse(encoder.finish());
+    }
+
+    @Test
+    public void commandRequestEncodingMustAcceptMaxLengthDstAddr() {
+        EmbeddedChannel encoder = new EmbeddedChannel(Socks5ClientEncoder.DEFAULT);
+        String dstAddr = Stream.generate(() -> "aaa").limit(64).collect(Collectors.joining("."));
+        assertThat(dstAddr).hasSize(255);
+        assertTrue(encoder.writeOutbound(new DefaultSocks5CommandRequest(
+                Socks5CommandType.CONNECT, Socks5AddressType.DOMAIN,
+                dstAddr, 8080)));
+        ByteBuf buf = encoder.readOutbound();
+        assertNotNull(buf);
+        buf.release();
+        assertFalse(encoder.finish());
+    }
+
+    @Test
+    public void commandRequestEncodingMustAcceptNullDstAddr() {
+        EmbeddedChannel encoder = new EmbeddedChannel(Socks5ClientEncoder.DEFAULT);
+        assertTrue(encoder.writeOutbound(new Socks5CommandRequest() {
+            @Override
+            public DecoderResult decoderResult() {
+                return DecoderResult.SUCCESS;
+            }
+
+            @Override
+            public void setDecoderResult(DecoderResult result) {
+            }
+
+            @Override
+            public SocksVersion version() {
+                return SocksVersion.SOCKS5;
+            }
+
+            @Override
+            public Socks5CommandType type() {
+                return Socks5CommandType.CONNECT;
+            }
+
+            @Override
+            public Socks5AddressType dstAddrType() {
+                return Socks5AddressType.DOMAIN;
+            }
+
+            @Override
+            public String dstAddr() {
+                return null;
+            }
+
+            @Override
+            public int dstPort() {
+                return 8080;
+            }
+        }));
+        ByteBuf buf = encoder.readOutbound();
+        assertNotNull(buf);
+        buf.release();
+        assertFalse(encoder.finish());
+    }
+
+    @Test
+    public void commandRequestEncodingMustRejectTooLongDstAddr() {
+        EmbeddedChannel encoder = new EmbeddedChannel(Socks5ClientEncoder.DEFAULT);
+        assertThatThrownBy(() -> encoder.writeOutbound(new Socks5CommandRequest() {
+            @Override
+            public DecoderResult decoderResult() {
+                return DecoderResult.SUCCESS;
+            }
+
+            @Override
+            public void setDecoderResult(DecoderResult result) {
+            }
+
+            @Override
+            public SocksVersion version() {
+                return SocksVersion.SOCKS5;
+            }
+
+            @Override
+            public Socks5CommandType type() {
+                return Socks5CommandType.CONNECT;
+            }
+
+            @Override
+            public Socks5AddressType dstAddrType() {
+                return Socks5AddressType.DOMAIN;
+            }
+
+            @Override
+            public String dstAddr() {
+                return Stream.generate(() -> "a").limit(256).collect(Collectors.joining());
+            }
+
+            @Override
+            public int dstPort() {
+                return 8080;
+            }
+        }))
+                .isInstanceOf(EncoderException.class)
+                .hasMessageContaining("Invalid field length");
+        assertFalse(encoder.finish());
+    }
+}

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5ClientEncoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5ClientEncoderTest.java
@@ -23,10 +23,6 @@ import io.netty.handler.codec.socksx.SocksVersion;
 import org.assertj.core.api.ThrowableAssert;
 import org.junit.jupiter.api.Test;
 
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -34,16 +30,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class Socks5ClientEncoderTest {
+
     @Test
     public void initialRequestEncodingMustAcceptMaxNumberOfAuthMethods() {
         EmbeddedChannel encoder = new EmbeddedChannel(Socks5ClientEncoder.DEFAULT);
-        assertTrue(encoder.writeOutbound(new DefaultSocks5InitialRequest(
-                Stream.generate(new Supplier<Socks5AuthMethod>() {
-                    @Override
-                    public Socks5AuthMethod get() {
-                        return Socks5AuthMethod.PASSWORD;
-                    }
-                }).limit(255).collect(Collectors.toList()))));
+        assertTrue(encoder.writeOutbound(
+            new DefaultSocks5InitialRequest(Socks5CommonTestUtils.generateList(Socks5AuthMethod.PASSWORD, 255))));
         ByteBuf buf = encoder.readOutbound();
         assertNotNull(buf);
         buf.release();
@@ -57,13 +49,9 @@ class Socks5ClientEncoderTest {
             new ThrowableAssert.ThrowingCallable() {
                 @Override
                 public void call() throws Throwable {
-                    encoder.writeOutbound(new DefaultSocks5InitialRequest(
-                        Stream.generate(new Supplier<Socks5AuthMethod>() {
-                            @Override
-                            public Socks5AuthMethod get() {
-                                return Socks5AuthMethod.PASSWORD;
-                            }
-                        }).limit(256).collect(Collectors.toList())));
+                    encoder.writeOutbound(
+                        new DefaultSocks5InitialRequest(Socks5CommonTestUtils.generateList(
+                            Socks5AuthMethod.PASSWORD, 256)));
                 }
             }
         ).isInstanceOf(EncoderException.class)
@@ -80,12 +68,7 @@ class Socks5ClientEncoderTest {
                 new DefaultSocks5PasswordAuthRequest("user", "pass") {
                     @Override
                     public String username() {
-                        return Stream.generate(new Supplier<String>() {
-                            @Override
-                            public String get() {
-                                return "a";
-                            }
-                        }).limit(255).collect(Collectors.joining());
+                        return Socks5CommonTestUtils.generateString("a", 255);
                     }
                 }
         ));
@@ -98,11 +81,7 @@ class Socks5ClientEncoderTest {
                 new DefaultSocks5PasswordAuthRequest("user", "pass") {
                     @Override
                     public String password() {
-                        StringBuilder sb = new StringBuilder(255);
-                        for (int i = 0; i < 255; i++) {
-                            sb.append("a");
-                        }
-                        return sb.toString();
+                        return Socks5CommonTestUtils.generateString("a", 255);
                     }
                 }
         ));
@@ -125,11 +104,7 @@ class Socks5ClientEncoderTest {
                     new DefaultSocks5PasswordAuthRequest("user", "pass") {
                         @Override
                         public String username() {
-                            StringBuilder sb = new StringBuilder(256);
-                            for (int i = 0; i < 256; i++) {
-                                sb.append("a");
-                            }
-                            return sb.toString();
+                            return Socks5CommonTestUtils.generateString("a", 256);
                         }
                     }
                 );
@@ -146,11 +121,7 @@ class Socks5ClientEncoderTest {
                     new DefaultSocks5PasswordAuthRequest("user", "pass") {
                         @Override
                         public String password() {
-                            StringBuilder sb = new StringBuilder(256);
-                            for (int i = 0; i < 256; i++) {
-                                sb.append("a");
-                            }
-                            return sb.toString();
+                            return Socks5CommonTestUtils.generateString("a", 256);
                         }
                     }
                 );
@@ -165,12 +136,9 @@ class Socks5ClientEncoderTest {
     @Test
     public void commandRequestEncodingMustAcceptMaxLengthDstAddr() {
         EmbeddedChannel encoder = new EmbeddedChannel(Socks5ClientEncoder.DEFAULT);
-        String dstAddr = Stream.generate(new Supplier<String>() {
-            @Override
-            public String get() {
-                return "aaa";
-            }
-        }).limit(64).collect(Collectors.joining("."));
+        String dstAddr = "aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa" +
+            ".aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa" +
+            ".aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa";
         assertThat(dstAddr).hasSize(255);
         assertTrue(encoder.writeOutbound(new DefaultSocks5CommandRequest(
                 Socks5CommandType.CONNECT, Socks5AddressType.DOMAIN,
@@ -258,12 +226,7 @@ class Socks5ClientEncoderTest {
 
                     @Override
                     public String dstAddr() {
-                        return Stream.generate(new Supplier<String>() {
-                            @Override
-                            public String get() {
-                                return "a";
-                            }
-                        }).limit(256).collect(Collectors.joining());
+                        return Socks5CommonTestUtils.generateString("a", 256);
                     }
 
                     @Override

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5ClientEncoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5ClientEncoderTest.java
@@ -58,7 +58,12 @@ class Socks5ClientEncoderTest {
                 @Override
                 public void call() throws Throwable {
                     encoder.writeOutbound(new DefaultSocks5InitialRequest(
-                        Stream.generate(() -> Socks5AuthMethod.PASSWORD).limit(256).collect(Collectors.toList())));
+                        Stream.generate(new Supplier<Socks5AuthMethod>() {
+                            @Override
+                            public Socks5AuthMethod get() {
+                                return Socks5AuthMethod.PASSWORD;
+                            }
+                        }).limit(256).collect(Collectors.toList())));
                 }
             }
         ).isInstanceOf(EncoderException.class)

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5ClientEncoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5ClientEncoderTest.java
@@ -115,37 +115,47 @@ class Socks5ClientEncoderTest {
 
     @Test
     public void passwordAuthRequestEncodingMustRejectTooLongUsernameOrPassword() {
-        EmbeddedChannel encoder = new EmbeddedChannel(Socks5ClientEncoder.DEFAULT);
+        final EmbeddedChannel encoder = new EmbeddedChannel(Socks5ClientEncoder.DEFAULT);
 
         // too long username
-        assertThatThrownBy(() -> encoder.writeOutbound(
-                new DefaultSocks5PasswordAuthRequest("user", "pass") {
-                    @Override
-                    public String username() {
-                        StringBuilder sb = new StringBuilder(256);
-                        for (int i = 0; i < 256; i++) {
-                            sb.append("a");
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            @Override
+            public void call() throws Throwable {
+                encoder.writeOutbound(
+                    new DefaultSocks5PasswordAuthRequest("user", "pass") {
+                        @Override
+                        public String username() {
+                            StringBuilder sb = new StringBuilder(256);
+                            for (int i = 0; i < 256; i++) {
+                                sb.append("a");
+                            }
+                            return sb.toString();
                         }
-                        return sb.toString();
                     }
-                }
-        ))
+                );
+            }
+        })
                 .isInstanceOf(EncoderException.class)
                 .hasMessageContaining("Invalid field length");
 
         // too long password
-        assertThatThrownBy(() -> encoder.writeOutbound(
-                new DefaultSocks5PasswordAuthRequest("user", "pass") {
-                    @Override
-                    public String password() {
-                        StringBuilder sb = new StringBuilder(256);
-                        for (int i = 0; i < 256; i++) {
-                            sb.append("a");
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            @Override
+            public void call() throws Throwable {
+                encoder.writeOutbound(
+                    new DefaultSocks5PasswordAuthRequest("user", "pass") {
+                        @Override
+                        public String password() {
+                            StringBuilder sb = new StringBuilder(256);
+                            for (int i = 0; i < 256; i++) {
+                                sb.append("a");
+                            }
+                            return sb.toString();
                         }
-                        return sb.toString();
                     }
-                }
-        ))
+                );
+            }
+        })
                 .isInstanceOf(EncoderException.class)
                 .hasMessageContaining("Invalid field length");
 
@@ -155,7 +165,12 @@ class Socks5ClientEncoderTest {
     @Test
     public void commandRequestEncodingMustAcceptMaxLengthDstAddr() {
         EmbeddedChannel encoder = new EmbeddedChannel(Socks5ClientEncoder.DEFAULT);
-        String dstAddr = Stream.generate(() -> "aaa").limit(64).collect(Collectors.joining("."));
+        String dstAddr = Stream.generate(new Supplier<String>() {
+            @Override
+            public String get() {
+                return "aaa";
+            }
+        }).limit(64).collect(Collectors.joining("."));
         assertThat(dstAddr).hasSize(255);
         assertTrue(encoder.writeOutbound(new DefaultSocks5CommandRequest(
                 Socks5CommandType.CONNECT, Socks5AddressType.DOMAIN,
@@ -243,7 +258,12 @@ class Socks5ClientEncoderTest {
 
                     @Override
                     public String dstAddr() {
-                        return Stream.generate(() -> "a").limit(256).collect(Collectors.joining());
+                        return Stream.generate(new Supplier<String>() {
+                            @Override
+                            public String get() {
+                                return "a";
+                            }
+                        }).limit(256).collect(Collectors.joining());
                     }
 
                     @Override

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5ClientEncoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5ClientEncoderTest.java
@@ -44,7 +44,7 @@ class Socks5ClientEncoderTest {
 
     @Test
     public void initialRequestEncodingMustRejectTooManyAuthMethods() {
-        EmbeddedChannel encoder = new EmbeddedChannel(Socks5ClientEncoder.DEFAULT);
+        final EmbeddedChannel encoder = new EmbeddedChannel(Socks5ClientEncoder.DEFAULT);
         assertThatThrownBy(
             new ThrowableAssert.ThrowingCallable() {
                 @Override
@@ -195,7 +195,7 @@ class Socks5ClientEncoderTest {
 
     @Test
     public void commandRequestEncodingMustRejectTooLongDstAddr() {
-        EmbeddedChannel encoder = new EmbeddedChannel(Socks5ClientEncoder.DEFAULT);
+        final EmbeddedChannel encoder = new EmbeddedChannel(Socks5ClientEncoder.DEFAULT);
         assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
             @Override
             public void call() throws Throwable {

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5CommonTestUtils.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5CommonTestUtils.java
@@ -18,6 +18,9 @@ package io.netty.handler.codec.socksx.v5;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.embedded.EmbeddedChannel;
 
+import java.util.ArrayList;
+import java.util.List;
+
 final class Socks5CommonTestUtils {
     /**
      * A constructor to stop this class being constructed.
@@ -52,5 +55,21 @@ final class Socks5CommonTestUtils {
         out.finish();
 
         return encoded;
+    }
+
+    static <T> List<T> generateList(T obj, int count) {
+        List<T> list = new ArrayList<T>(count);
+        for (int i = 0; i < count; i++) {
+            list.add(obj);
+        }
+        return list;
+    }
+
+    static String generateString(String str, int count) {
+        StringBuilder sb = new StringBuilder(str.length() * count);
+        for (int i = 0; i < count; i++) {
+            sb.append(str);
+        }
+        return sb.toString();
     }
 }

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5ServerEncoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5ServerEncoderTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.socksx.v5;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.DecoderResult;
+import io.netty.handler.codec.EncoderException;
+import io.netty.handler.codec.socksx.SocksVersion;
+import org.junit.jupiter.api.Test;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class Socks5ServerEncoderTest {
+    @Test
+    public void commandResponseEncodingMustAcceptMaxLengthDstAddr() {
+        EmbeddedChannel encoder = new EmbeddedChannel(Socks5ServerEncoder.DEFAULT);
+        String dstAddr = Stream.generate(() -> "aaa").limit(64).collect(Collectors.joining("."));
+        assertThat(dstAddr).hasSize(255);
+        assertTrue(encoder.writeOutbound(new DefaultSocks5CommandResponse(
+                Socks5CommandStatus.SUCCESS, Socks5AddressType.DOMAIN,
+                dstAddr, 8080)));
+        ByteBuf buf = encoder.readOutbound();
+        assertNotNull(buf);
+        buf.release();
+        assertFalse(encoder.finish());
+    }
+
+    @Test
+    public void commandResponseEncodingMustAcceptNullDstAddr() {
+        EmbeddedChannel encoder = new EmbeddedChannel(Socks5ServerEncoder.DEFAULT);
+        assertTrue(encoder.writeOutbound(new Socks5CommandResponse() {
+            @Override
+            public DecoderResult decoderResult() {
+                return DecoderResult.SUCCESS;
+            }
+
+            @Override
+            public void setDecoderResult(DecoderResult result) {
+            }
+
+            @Override
+            public SocksVersion version() {
+                return SocksVersion.SOCKS5;
+            }
+
+            @Override
+            public Socks5CommandStatus status() {
+                return Socks5CommandStatus.SUCCESS;
+            }
+
+            @Override
+            public Socks5AddressType bndAddrType() {
+                return Socks5AddressType.DOMAIN;
+            }
+
+            @Override
+            public String bndAddr() {
+                return null;
+            }
+
+            @Override
+            public int bndPort() {
+                return 8080;
+            }
+        }));
+        ByteBuf buf = encoder.readOutbound();
+        assertNotNull(buf);
+        buf.release();
+        assertFalse(encoder.finish());
+    }
+
+    @Test
+    public void commandResponseEncodingMustRejectTooLongDstAddr() {
+        EmbeddedChannel encoder = new EmbeddedChannel(Socks5ServerEncoder.DEFAULT);
+        assertThatThrownBy(() -> encoder.writeOutbound(new Socks5CommandResponse() {
+            @Override
+            public DecoderResult decoderResult() {
+                return DecoderResult.SUCCESS;
+            }
+
+            @Override
+            public void setDecoderResult(DecoderResult result) {
+            }
+
+            @Override
+            public SocksVersion version() {
+                return SocksVersion.SOCKS5;
+            }
+
+            @Override
+            public Socks5CommandStatus status() {
+                return Socks5CommandStatus.SUCCESS;
+            }
+
+            @Override
+            public Socks5AddressType bndAddrType() {
+                return Socks5AddressType.DOMAIN;
+            }
+
+            @Override
+            public String bndAddr() {
+                return Stream.generate(() -> "a").limit(256).collect(Collectors.joining());
+            }
+
+            @Override
+            public int bndPort() {
+                return 8080;
+            }
+        }))
+                .isInstanceOf(EncoderException.class)
+                .hasMessageContaining("Invalid field length");
+        assertFalse(encoder.finish());
+    }
+}

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5ServerEncoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5ServerEncoderTest.java
@@ -22,6 +22,7 @@ import io.netty.handler.codec.EncoderException;
 import io.netty.handler.codec.socksx.SocksVersion;
 import org.junit.jupiter.api.Test;
 
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -35,7 +36,12 @@ class Socks5ServerEncoderTest {
     @Test
     public void commandResponseEncodingMustAcceptMaxLengthDstAddr() {
         EmbeddedChannel encoder = new EmbeddedChannel(Socks5ServerEncoder.DEFAULT);
-        String dstAddr = Stream.generate(() -> "aaa").limit(64).collect(Collectors.joining("."));
+        String dstAddr = Stream.generate(new Supplier<String>() {
+            @Override
+            public String get() {
+                return "aaa";
+            }
+        }).limit(64).collect(Collectors.joining("."));
         assertThat(dstAddr).hasSize(255);
         assertTrue(encoder.writeOutbound(new DefaultSocks5CommandResponse(
                 Socks5CommandStatus.SUCCESS, Socks5AddressType.DOMAIN,

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5ServerEncoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5ServerEncoderTest.java
@@ -20,6 +20,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.EncoderException;
 import io.netty.handler.codec.socksx.SocksVersion;
+import org.assertj.core.api.ThrowableAssert;
 import org.junit.jupiter.api.Test;
 
 import java.util.function.Supplier;
@@ -98,42 +99,52 @@ class Socks5ServerEncoderTest {
 
     @Test
     public void commandResponseEncodingMustRejectTooLongDstAddr() {
-        EmbeddedChannel encoder = new EmbeddedChannel(Socks5ServerEncoder.DEFAULT);
-        assertThatThrownBy(() -> encoder.writeOutbound(new Socks5CommandResponse() {
+        final EmbeddedChannel encoder = new EmbeddedChannel(Socks5ServerEncoder.DEFAULT);
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
             @Override
-            public DecoderResult decoderResult() {
-                return DecoderResult.SUCCESS;
-            }
+            public void call() throws Throwable {
+                encoder.writeOutbound(new Socks5CommandResponse() {
+                    @Override
+                    public DecoderResult decoderResult() {
+                        return DecoderResult.SUCCESS;
+                    }
 
-            @Override
-            public void setDecoderResult(DecoderResult result) {
-            }
+                    @Override
+                    public void setDecoderResult(DecoderResult result) {
+                    }
 
-            @Override
-            public SocksVersion version() {
-                return SocksVersion.SOCKS5;
-            }
+                    @Override
+                    public SocksVersion version() {
+                        return SocksVersion.SOCKS5;
+                    }
 
-            @Override
-            public Socks5CommandStatus status() {
-                return Socks5CommandStatus.SUCCESS;
-            }
+                    @Override
+                    public Socks5CommandStatus status() {
+                        return Socks5CommandStatus.SUCCESS;
+                    }
 
-            @Override
-            public Socks5AddressType bndAddrType() {
-                return Socks5AddressType.DOMAIN;
-            }
+                    @Override
+                    public Socks5AddressType bndAddrType() {
+                        return Socks5AddressType.DOMAIN;
+                    }
 
-            @Override
-            public String bndAddr() {
-                return Stream.generate(() -> "a").limit(256).collect(Collectors.joining());
-            }
+                    @Override
+                    public String bndAddr() {
+                        return Stream.generate(new Supplier<String>() {
+                            @Override
+                            public String get() {
+                                return "a";
+                            }
+                        }).limit(256).collect(Collectors.joining());
+                    }
 
-            @Override
-            public int bndPort() {
-                return 8080;
+                    @Override
+                    public int bndPort() {
+                        return 8080;
+                    }
+                });
             }
-        }))
+        })
                 .isInstanceOf(EncoderException.class)
                 .hasMessageContaining("Invalid field length");
         assertFalse(encoder.finish());

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5ServerEncoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5ServerEncoderTest.java
@@ -37,12 +37,9 @@ class Socks5ServerEncoderTest {
     @Test
     public void commandResponseEncodingMustAcceptMaxLengthDstAddr() {
         EmbeddedChannel encoder = new EmbeddedChannel(Socks5ServerEncoder.DEFAULT);
-        String dstAddr = Stream.generate(new Supplier<String>() {
-            @Override
-            public String get() {
-                return "aaa";
-            }
-        }).limit(64).collect(Collectors.joining("."));
+        String dstAddr = "aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa" +
+            ".aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa" +
+            ".aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa.aaa";
         assertThat(dstAddr).hasSize(255);
         assertTrue(encoder.writeOutbound(new DefaultSocks5CommandResponse(
                 Socks5CommandStatus.SUCCESS, Socks5AddressType.DOMAIN,
@@ -130,12 +127,7 @@ class Socks5ServerEncoderTest {
 
                     @Override
                     public String bndAddr() {
-                        return Stream.generate(new Supplier<String>() {
-                            @Override
-                            public String get() {
-                                return "a";
-                            }
-                        }).limit(256).collect(Collectors.joining());
+                        return Socks5CommonTestUtils.generateString("a", 256);
                     }
 
                     @Override

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslClientContext.java
@@ -178,6 +178,14 @@ public final class ReferenceCountedOpenSslClientContext extends ReferenceCounted
                 //
                 //            See https://github.com/netty/netty/issues/5372
 
+                if (thiz.endpointIdentificationAlgorithm != null && !thiz.endpointIdentificationAlgorithm.isEmpty() &&
+                        !useExtendedTrustManager(manager)) {
+                    throw new UnsupportedOperationException(
+                            "Endpoint identification algorithm '" + thiz.endpointIdentificationAlgorithm + "' is " +
+                            "configured but the trust manager does not support extended trust manager verification. " +
+                            "Please provide an X509ExtendedTrustManager or use the SslProvider.JDK.");
+                }
+
                 setVerifyCallback(ctx, engines, manager);
             } catch (Exception e) {
                 if (keyMaterialProvider != null) {

--- a/handler/src/main/java/io/netty/handler/ssl/SslClientHelloHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslClientHelloHandler.java
@@ -56,6 +56,8 @@ public abstract class SslClientHelloHandler<T> extends ByteToMessageDecoder impl
     private boolean suppressRead;
     private boolean readPending;
     private ByteBuf handshakeBuffer;
+    private int aggregatedBytes;
+    private int handshakeLength = -1;
 
     public SslClientHelloHandler() {
         this(DEFAULT_MAX_CLIENT_HELLO_LENGTH);
@@ -72,9 +74,8 @@ public abstract class SslClientHelloHandler<T> extends ByteToMessageDecoder impl
     protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
         if (!suppressRead && !handshakeFailed) {
             try {
-                int readerIndex = in.readerIndex();
-                int readableBytes = in.readableBytes();
-                int handshakeLength = -1;
+                int readerIndex = in.readerIndex() + aggregatedBytes;
+                int readableBytes = in.readableBytes() - aggregatedBytes;
 
                 // Check if we have enough data to determine the record type and length.
                 while (readableBytes >= SslUtils.SSL_RECORD_HEADER_LENGTH) {
@@ -121,13 +122,62 @@ public abstract class SslClientHelloHandler<T> extends ByteToMessageDecoder impl
 
                                 // Let's check if we already parsed the handshake length or not.
                                 if (handshakeLength == -1) {
-                                    if (readerIndex + 4 > endOffset) {
-                                        // Need more data to read HandshakeType and handshakeLength (4 bytes)
-                                        return;
+                                    if (handshakeBuffer == null &&
+                                            readerIndex + SslUtils.SSL_RECORD_HEADER_LENGTH + 4 <= endOffset) {
+                                        final int handshakeType = in.getUnsignedByte(readerIndex +
+                                                SslUtils.SSL_RECORD_HEADER_LENGTH);
+
+                                        // Check if this is a clientHello(1)
+                                        // See https://tools.ietf.org/html/rfc5246#section-7.4
+                                        if (handshakeType != 1) {
+                                            select(ctx, null);
+                                            return;
+                                        }
+
+                                        // Read the length of the handshake as it may arrive in fragments
+                                        // See https://tools.ietf.org/html/rfc5246#section-7.4
+                                        handshakeLength = in.getUnsignedMedium(readerIndex +
+                                                SslUtils.SSL_RECORD_HEADER_LENGTH + 1);
+
+                                        if (handshakeLength > maxClientHelloLength && maxClientHelloLength != 0) {
+                                            TooLongFrameException e = new TooLongFrameException(
+                                                    "ClientHello length exceeds " + maxClientHelloLength +
+                                                            ": " + handshakeLength);
+                                            in.skipBytes(in.readableBytes());
+                                            ctx.fireUserEventTriggered(new SniCompletionEvent(e));
+                                            SslUtils.handleHandshakeFailure(ctx, e, true);
+                                            throw e;
+                                        }
+
+                                        if (handshakeLength + 4 + SslUtils.SSL_RECORD_HEADER_LENGTH <= packetLength) {
+                                            // We have everything we need in one packet.
+                                            // Skip the record header and handshake header (this sums up as 4 bytes)
+                                            readerIndex += SslUtils.SSL_RECORD_HEADER_LENGTH + 4;
+                                            final int clientHelloLength = handshakeLength;
+                                            handshakeLength = -1;
+                                            select(ctx, in.retainedSlice(readerIndex, clientHelloLength));
+                                            return;
+                                        }
+                                    }
+                                }
+
+                                if (handshakeBuffer == null) {
+                                    handshakeBuffer = ctx.alloc().buffer();
+                                }
+
+                                // Combine the encapsulated data in one buffer but not include the SSL_RECORD_HEADER
+                                handshakeBuffer.writeBytes(in, readerIndex + SslUtils.SSL_RECORD_HEADER_LENGTH,
+                                        packetLength - SslUtils.SSL_RECORD_HEADER_LENGTH);
+                                readerIndex += packetLength;
+                                readableBytes -= packetLength;
+                                aggregatedBytes += packetLength;
+                                if (handshakeLength == -1) {
+                                    if (handshakeBuffer.readableBytes() < 4) {
+                                        continue;
                                     }
 
-                                    final int handshakeType = in.getUnsignedByte(readerIndex +
-                                            SslUtils.SSL_RECORD_HEADER_LENGTH);
+                                    final int handshakeType = handshakeBuffer.getUnsignedByte(0);
+                                    handshakeLength = handshakeBuffer.getUnsignedMedium(1);
 
                                     // Check if this is a clientHello(1)
                                     // See https://tools.ietf.org/html/rfc5246#section-7.4
@@ -135,11 +185,6 @@ public abstract class SslClientHelloHandler<T> extends ByteToMessageDecoder impl
                                         select(ctx, null);
                                         return;
                                     }
-
-                                    // Read the length of the handshake as it may arrive in fragments
-                                    // See https://tools.ietf.org/html/rfc5246#section-7.4
-                                    handshakeLength = in.getUnsignedMedium(readerIndex +
-                                            SslUtils.SSL_RECORD_HEADER_LENGTH + 1);
 
                                     if (handshakeLength > maxClientHelloLength && maxClientHelloLength != 0) {
                                         TooLongFrameException e = new TooLongFrameException(
@@ -150,34 +195,12 @@ public abstract class SslClientHelloHandler<T> extends ByteToMessageDecoder impl
                                         SslUtils.handleHandshakeFailure(ctx, e, true);
                                         throw e;
                                     }
-                                    // Consume handshakeType and handshakeLength (this sums up as 4 bytes)
-                                    readerIndex += 4;
-                                    packetLength -= 4;
-
-                                    if (handshakeLength + 4 + SslUtils.SSL_RECORD_HEADER_LENGTH <= packetLength) {
-                                        // We have everything we need in one packet.
-                                        // Skip the record header
-                                        readerIndex += SslUtils.SSL_RECORD_HEADER_LENGTH;
-                                        select(ctx, in.retainedSlice(readerIndex, handshakeLength));
-                                        return;
-                                    } else {
-                                        if (handshakeBuffer == null) {
-                                            handshakeBuffer = ctx.alloc().buffer(handshakeLength);
-                                        } else {
-                                            // Clear the buffer so we can aggregate into it again.
-                                            handshakeBuffer.clear();
-                                        }
-                                    }
                                 }
 
-                                // Combine the encapsulated data in one buffer but not include the SSL_RECORD_HEADER
-                                handshakeBuffer.writeBytes(in, readerIndex + SslUtils.SSL_RECORD_HEADER_LENGTH,
-                                        packetLength - SslUtils.SSL_RECORD_HEADER_LENGTH);
-                                readerIndex += packetLength;
-                                readableBytes -= packetLength;
-                                if (handshakeLength <= handshakeBuffer.readableBytes()) {
-                                    ByteBuf clientHello = handshakeBuffer.setIndex(0, handshakeLength);
+                                if (handshakeBuffer.readableBytes() >= handshakeLength + 4) {
+                                    ByteBuf clientHello = handshakeBuffer.setIndex(4, handshakeLength + 4).slice();
                                     handshakeBuffer = null;
+                                    handshakeLength = -1;
 
                                     select(ctx, clientHello);
                                     return;
@@ -210,6 +233,7 @@ public abstract class SslClientHelloHandler<T> extends ByteToMessageDecoder impl
     private void releaseHandshakeBuffer() {
         releaseIfNotNull(handshakeBuffer);
         handshakeBuffer = null;
+        handshakeLength = -1;
     }
 
     private static void releaseIfNotNull(ByteBuf buffer) {

--- a/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
@@ -679,7 +679,7 @@ public class SniHandlerTest {
     @MethodSource("data")
     @SuppressWarnings("unchecked")
     public void testTinyFragmentsAreAggregatedOnlyOnce(SslProvider provider) throws Exception {
-        AtomicLong copiedBytes = new AtomicLong();
+        final AtomicLong copiedBytes = new AtomicLong();
         EmbeddedChannel server = new EmbeddedChannel(new SniHandler(mock(DomainNameMapping.class)));
         server.config().setAllocator(new AbstractByteBufAllocator() {
             @Override
@@ -712,7 +712,7 @@ public class SniHandlerTest {
         }
     }
 
-    private static ByteBuf countingBuffer(ByteBuf buffer, AtomicLong copiedBytes) {
+    private static ByteBuf countingBuffer(ByteBuf buffer, final AtomicLong copiedBytes) {
         return new DuplicatedByteBuf(buffer) {
             @Override
             public ByteBuf writeBytes(ByteBuf src, int srcIndex, int length) {

--- a/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
@@ -25,7 +25,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Stream;
 
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
@@ -71,7 +70,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -659,16 +657,16 @@ public class SniHandlerTest {
         testWithFragmentSize(provider, 50);
     }
 
-    static Stream<Arguments> tinyFragmentData() {
-        List<Arguments> args = new ArrayList<Arguments>();
+    static List<Object[]> tinyFragmentData() {
+        List<Object[]> args = new ArrayList<Object[]>();
         for (Object provider : data()) {
             // Fragment sizes smaller than the 4-byte handshake header, so the header itself is
             // split across multiple TLS records.
             for (int size = 1; size <= 4; size++) {
-                args.add(Arguments.of(provider, size));
+                args.add(new Object[] { provider, size });
             }
         }
-        return args.stream();
+        return args;
     }
 
     @ParameterizedTest(name = "{index}: sslProvider={0}, fragmentSize={1}")

--- a/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
@@ -23,16 +23,20 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
 
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 
+import io.netty.buffer.DuplicatedByteBuf;
 import io.netty.handler.codec.TooLongFrameException;
 import io.netty.handler.ssl.util.CachedSelfSignedCertificate;
 import io.netty.util.concurrent.Future;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.AbstractByteBufAllocator;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
@@ -67,6 +71,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -654,7 +659,83 @@ public class SniHandlerTest {
         testWithFragmentSize(provider, 50);
     }
 
+    static Stream<Arguments> tinyFragmentData() {
+        List<Arguments> args = new ArrayList<Arguments>();
+        for (Object provider : data()) {
+            // Fragment sizes smaller than the 4-byte handshake header, so the header itself is
+            // split across multiple TLS records.
+            for (int size = 1; size <= 4; size++) {
+                args.add(Arguments.of(provider, size));
+            }
+        }
+        return args.stream();
+    }
+
+    @ParameterizedTest(name = "{index}: sslProvider={0}, fragmentSize={1}")
+    @MethodSource("tinyFragmentData")
+    public void testTinyFragments(SslProvider provider, int fragmentSize) throws Exception {
+        testWithFragmentSize(provider, fragmentSize);
+    }
+
+    @ParameterizedTest(name = "{index}: sslProvider={0}")
+    @MethodSource("data")
+    @SuppressWarnings("unchecked")
+    public void testTinyFragmentsAreAggregatedOnlyOnce(SslProvider provider) throws Exception {
+        AtomicLong copiedBytes = new AtomicLong();
+        EmbeddedChannel server = new EmbeddedChannel(new SniHandler(mock(DomainNameMapping.class)));
+        server.config().setAllocator(new AbstractByteBufAllocator() {
+            @Override
+            public boolean isDirectBufferPooled() {
+                return false;
+            }
+
+            @Override
+            protected ByteBuf newHeapBuffer(int initialCapacity, int maxCapacity) {
+                return countingBuffer(Unpooled.buffer(initialCapacity, maxCapacity), copiedBytes);
+            }
+
+            @Override
+            protected ByteBuf newDirectBuffer(int initialCapacity, int maxCapacity) {
+                return countingBuffer(Unpooled.directBuffer(initialCapacity, maxCapacity), copiedBytes);
+            }
+        });
+
+        try {
+            List<ByteBuf> fragments = clientHelloInMultipleFragments(provider, "netty.io", 1, 1);
+            // Hold back the last fragment on purpose, so the handler keeps aggregating the ClientHello.
+            ReferenceCountUtil.release(fragments.remove(fragments.size() - 1));
+            for (ByteBuf fragment : fragments) {
+                assertFalse(server.writeInbound(fragment));
+            }
+
+            assertEquals(fragments.size(), copiedBytes.get());
+        } finally {
+            server.finishAndReleaseAll();
+        }
+    }
+
+    private static ByteBuf countingBuffer(ByteBuf buffer, AtomicLong copiedBytes) {
+        return new DuplicatedByteBuf(buffer) {
+            @Override
+            public ByteBuf writeBytes(ByteBuf src, int srcIndex, int length) {
+                copiedBytes.addAndGet(length);
+                return super.writeBytes(src, srcIndex, length);
+            }
+        };
+    }
+
+    @ParameterizedTest(name = "{index}: sslProvider={0}")
+    @MethodSource("data")
+    public void testTinyFirstFragment(SslProvider provider) throws Exception {
+        testWithFragmentSize(provider, 1, Integer.MAX_VALUE);
+    }
+
     private void testWithFragmentSize(SslProvider provider, final int maxFragmentSize) throws Exception {
+        testWithFragmentSize(provider, maxFragmentSize, maxFragmentSize);
+    }
+
+    private void testWithFragmentSize(SslProvider provider, final int firstFragmentSize, final int maxFragmentSize)
+            throws Exception {
         final String sni = "netty.io";
         SelfSignedCertificate cert = CachedSelfSignedCertificate.getCachedCertificate();
         final SslContext context = SslContextBuilder.forServer(cert.key(), cert.cert())
@@ -670,7 +751,8 @@ public class SniHandlerTest {
                 }
             });
 
-            final List<ByteBuf> buffers = clientHelloInMultipleFragments(provider, sni, maxFragmentSize);
+            final List<ByteBuf> buffers =
+                    clientHelloInMultipleFragments(provider, sni, firstFragmentSize, maxFragmentSize);
             for (ByteBuf buffer : buffers) {
                 server.writeInbound(buffer);
             }
@@ -681,7 +763,8 @@ public class SniHandlerTest {
     }
 
     private static List<ByteBuf> clientHelloInMultipleFragments(
-            SslProvider provider, String hostname, int maxTlsPlaintextSize) throws SSLException {
+            SslProvider provider, String hostname, int firstTlsPlaintextSize, int maxTlsPlaintextSize)
+            throws SSLException {
         final EmbeddedChannel client = new EmbeddedChannel();
         final SslContext ctx = SslContextBuilder.forClient()
                 .sslProvider(provider)
@@ -691,7 +774,7 @@ public class SniHandlerTest {
             final SslHandler sslHandler = ctx.newHandler(client.alloc(), hostname, -1);
             client.pipeline().addLast(sslHandler);
             final ByteBuf clientHello = client.readOutbound();
-            List<ByteBuf> buffers = split(clientHello, maxTlsPlaintextSize);
+            List<ByteBuf> buffers = split(clientHello, firstTlsPlaintextSize, maxTlsPlaintextSize);
             assertTrue(client.finishAndReleaseAll());
             return buffers;
         } finally {
@@ -699,7 +782,7 @@ public class SniHandlerTest {
         }
     }
 
-    private static List<ByteBuf> split(ByteBuf clientHello, int maxSize) {
+    private static List<ByteBuf> split(ByteBuf clientHello, int firstSize, int maxSize) {
         final int type = clientHello.readUnsignedByte();
         final int version = clientHello.readUnsignedShort();
         final int length = clientHello.readUnsignedShort();
@@ -707,7 +790,7 @@ public class SniHandlerTest {
 
         final List<ByteBuf> result = new ArrayList<ByteBuf>();
         while (clientHello.readableBytes() > 0) {
-            final int toRead = Math.min(maxSize, clientHello.readableBytes());
+            final int toRead = Math.min(result.isEmpty() ? firstSize : maxSize, clientHello.readableBytes());
             final ByteBuf bb = clientHello.alloc().buffer(SslUtils.SSL_RECORD_HEADER_LENGTH + toRead);
             bb.writeByte(type);
             bb.writeShort(version);

--- a/transport-sctp/src/main/java/io/netty/handler/codec/sctp/SctpMessageCompletionHandler.java
+++ b/transport-sctp/src/main/java/io/netty/handler/codec/sctp/SctpMessageCompletionHandler.java
@@ -37,9 +37,13 @@ import static io.netty.util.internal.ObjectUtil.checkPositive;
  * {@link ChannelInboundHandler}.
  */
 public class SctpMessageCompletionHandler extends MessageToMessageDecoder<SctpMessage> {
+    private static final int DEFAULT_MAX_BUFFERED_BYTES = 16 * 1024 * 1024;
+
     private final IntObjectMap<List<ByteBuf>> incompleteSctpMessages = new IntObjectHashMap<List<ByteBuf>>();
     private final int maxIncompleteSctpMessages;
     private final int maxFragments;
+    private final int maxBufferedBytes;
+    private long bufferedBytes;
 
     public SctpMessageCompletionHandler() {
         this(128, 128);
@@ -52,9 +56,21 @@ public class SctpMessageCompletionHandler extends MessageToMessageDecoder<SctpMe
      * @param maxFragments              the maximum number of fragments per sctp message.
      */
     public SctpMessageCompletionHandler(int maxIncompleteSctpMessages, int maxFragments) {
+        this(maxIncompleteSctpMessages, maxFragments, DEFAULT_MAX_BUFFERED_BYTES);
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param maxIncompleteSctpMessages the maximum number of incomplete sctp message inflight.
+     * @param maxFragments              the maximum number of fragments per sctp message.
+     * @param maxBufferedBytes          the maximum number of bytes buffered by incomplete sctp messages.
+     */
+    public SctpMessageCompletionHandler(int maxIncompleteSctpMessages, int maxFragments, int maxBufferedBytes) {
         super(SctpMessage.class);
         this.maxIncompleteSctpMessages = checkPositive(maxIncompleteSctpMessages, "maxIncompleteSctpMessages");
         this.maxFragments = checkPositive(maxFragments, "maxFragments");
+        this.maxBufferedBytes = checkPositive(maxBufferedBytes, "maxBufferedBytes");
     }
 
     @Override
@@ -75,16 +91,20 @@ public class SctpMessageCompletionHandler extends MessageToMessageDecoder<SctpMe
                     throw new CodecException(
                             "Too many incomplete sctp messages in flight: " + maxIncompleteSctpMessages);
                 }
+                checkBufferedBytes(byteBuf);
                 //first incomplete message
                 frag = new ArrayList<ByteBuf>();
                 frag.add(byteBuf.retain());
+                bufferedBytes += byteBuf.readableBytes();
                 incompleteSctpMessages.put(streamIdentifier, frag);
             }
         } else {
             if (maxFragments <= frag.size()) {
                 throw new CodecException("Too many fragments for sctp message: " + maxFragments);
             }
+            checkBufferedBytes(byteBuf);
             frag.add(byteBuf.retain());
+            bufferedBytes += byteBuf.readableBytes();
             if (isComplete) {
                 // Is complete so remove it.
                 incompleteSctpMessages.remove(streamIdentifier);
@@ -100,7 +120,21 @@ public class SctpMessageCompletionHandler extends MessageToMessageDecoder<SctpMe
                         isUnordered,
                         composite);
                 out.add(assembledMsg);
+                removeBufferedBytes(frag);
             }
+        }
+    }
+
+    private void checkBufferedBytes(ByteBuf byteBuf) {
+        int readableBytes = byteBuf.readableBytes();
+        if (readableBytes > maxBufferedBytes - bufferedBytes) {
+            throw new CodecException("Too many buffered bytes for incomplete sctp messages: " + maxBufferedBytes);
+        }
+    }
+
+    private void removeBufferedBytes(List<ByteBuf> buffers) {
+        for (ByteBuf buffer : buffers) {
+            bufferedBytes -= buffer.readableBytes();
         }
     }
 
@@ -112,6 +146,7 @@ public class SctpMessageCompletionHandler extends MessageToMessageDecoder<SctpMe
             }
         }
         incompleteSctpMessages.clear();
+        bufferedBytes = 0;
         super.handlerRemoved(ctx);
     }
 

--- a/transport-sctp/src/test/java/io/netty/handler/codec/sctp/SctpMessageCompletionHandlerTest.java
+++ b/transport-sctp/src/test/java/io/netty/handler/codec/sctp/SctpMessageCompletionHandlerTest.java
@@ -101,10 +101,10 @@ public class SctpMessageCompletionHandlerTest {
 
     @Test
     public void testBufferedBytesLimited() {
-        EmbeddedChannel channel = new EmbeddedChannel(new SctpMessageCompletionHandler(2, 2, 8));
+        final EmbeddedChannel channel = new EmbeddedChannel(new SctpMessageCompletionHandler(2, 2, 8));
         ByteBuf buffer = Unpooled.wrappedBuffer(new byte[] { 1, 2, 3, 4 });
         ByteBuf buffer2 = Unpooled.wrappedBuffer(new byte[] { 1, 2, 3, 4 });
-        ByteBuf buffer3 = Unpooled.wrappedBuffer(new byte[] { 1 });
+        final ByteBuf buffer3 = Unpooled.wrappedBuffer(new byte[] { 1 });
 
         assertFalse(channel.writeInbound(new SctpMessage(new TestMessageInfo(false, 1), buffer)));
         assertEquals(1, buffer.refCnt());
@@ -112,8 +112,12 @@ public class SctpMessageCompletionHandlerTest {
         assertFalse(channel.writeInbound(new SctpMessage(new TestMessageInfo(false, 2), buffer2)));
         assertEquals(1, buffer2.refCnt());
 
-        assertThrows(CodecException.class, () ->
-                channel.writeInbound(new SctpMessage(new TestMessageInfo(false, 1), buffer3)));
+        assertThrows(CodecException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                channel.writeInbound(new SctpMessage(new TestMessageInfo(false, 1), buffer3));
+            }
+        });
         assertEquals(0, buffer.refCnt());
         assertEquals(0, buffer2.refCnt());
         assertEquals(0, buffer3.refCnt());
@@ -143,7 +147,12 @@ public class SctpMessageCompletionHandlerTest {
 
     @Test
     public void testBufferedBytesLimitMustBePositive() {
-        assertThrows(IllegalArgumentException.class, () -> new SctpMessageCompletionHandler(1, 1, 0));
+        assertThrows(IllegalArgumentException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                new SctpMessageCompletionHandler(1, 1, 0);
+            }
+        });
     }
 
     @Test

--- a/transport-sctp/src/test/java/io/netty/handler/codec/sctp/SctpMessageCompletionHandlerTest.java
+++ b/transport-sctp/src/test/java/io/netty/handler/codec/sctp/SctpMessageCompletionHandlerTest.java
@@ -100,6 +100,53 @@ public class SctpMessageCompletionHandlerTest {
     }
 
     @Test
+    public void testBufferedBytesLimited() {
+        EmbeddedChannel channel = new EmbeddedChannel(new SctpMessageCompletionHandler(2, 2, 8));
+        ByteBuf buffer = Unpooled.wrappedBuffer(new byte[] { 1, 2, 3, 4 });
+        ByteBuf buffer2 = Unpooled.wrappedBuffer(new byte[] { 1, 2, 3, 4 });
+        ByteBuf buffer3 = Unpooled.wrappedBuffer(new byte[] { 1 });
+
+        assertFalse(channel.writeInbound(new SctpMessage(new TestMessageInfo(false, 1), buffer)));
+        assertEquals(1, buffer.refCnt());
+
+        assertFalse(channel.writeInbound(new SctpMessage(new TestMessageInfo(false, 2), buffer2)));
+        assertEquals(1, buffer2.refCnt());
+
+        assertThrows(CodecException.class, () ->
+                channel.writeInbound(new SctpMessage(new TestMessageInfo(false, 1), buffer3)));
+        assertEquals(0, buffer.refCnt());
+        assertEquals(0, buffer2.refCnt());
+        assertEquals(0, buffer3.refCnt());
+
+        assertFalse(channel.finish());
+    }
+
+    @Test
+    public void testBufferedBytesReleasedAfterCompletion() {
+        EmbeddedChannel channel = new EmbeddedChannel(new SctpMessageCompletionHandler(2, 2, 8));
+        ByteBuf buffer = Unpooled.wrappedBuffer(new byte[] { 1, 2, 3, 4 });
+        ByteBuf buffer2 = Unpooled.wrappedBuffer(new byte[] { 5, 6, 7, 8 });
+        ByteBuf buffer3 = Unpooled.wrappedBuffer(new byte[] { 9, 10, 11, 12, 13, 14, 15, 16 });
+
+        assertFalse(channel.writeInbound(new SctpMessage(new TestMessageInfo(false, 1), buffer)));
+        assertTrue(channel.writeInbound(new SctpMessage(new TestMessageInfo(true, 1), buffer2)));
+        SctpMessage read = channel.readInbound();
+        assertEquals(8, read.content().readableBytes());
+        read.release();
+
+        assertFalse(channel.writeInbound(new SctpMessage(new TestMessageInfo(false, 2), buffer3)));
+        assertEquals(1, buffer3.refCnt());
+
+        assertFalse(channel.finish());
+        assertEquals(0, buffer3.refCnt());
+    }
+
+    @Test
+    public void testBufferedBytesLimitMustBePositive() {
+        assertThrows(IllegalArgumentException.class, () -> new SctpMessageCompletionHandler(1, 1, 0));
+    }
+
+    @Test
     public void testNotFragmented() {
         EmbeddedChannel channel = new EmbeddedChannel(new SctpMessageCompletionHandler());
         ByteBuf buffer = Unpooled.wrappedBuffer(new byte[] { 1, 2, 3, 4 });


### PR DESCRIPTION
[CORS: Don't override vary header if it already
exists](https://github.com/netty/netty/commit/1a896ebe1eeeda8408e026b8059347eb65fc9157)
Motivation:

Netty's CorsHandler silently overwrites existing Vary headers, enabling
cache poisoning and sensitive information disclosure.

Modifications:

- Only set vary header if it not already exists
- Add unit test

Result:

No more cache poisoning possible

---

[Encoding-side validation of MQTT
fields](https://github.com/netty/netty/commit/99755538744cee063b4e4dc18aa2e4eaa002c860)
Motivation:
The MqttEncoder should not produce malformed messages if client id,
topics, or usernames contain illegal characters.

Modification:
Add validation of client identifier, will topic, and username to the
encoding path of CONNECT messages, and also to the topic name when
encoding PUBLISH messages.

Result:
The encoder will now throw an exception if any of these fields contain a
NUL byte.

---

[Bound SCTP fragmented message
buffering](https://github.com/netty/netty/commit/c07b97c693674d720b2b881a2b0052bc916f0b5d)

---

[Correctly handle ClientHello with a handshake header split across
TLS…](https://github.com/netty/netty/commit/a8f53f2a1486b8eb16862a818a606e9f3c308045)
… records

Motivation:

The handshake header (HandshakeType + 3-byte length = 4 bytes) may be
delivered across multiple TLS records. SslClientHelloHandler assumed
these
4 bytes were always contained in the first record and read them directly
from it, which is incorrect when the header spans records.

Modification:

- Read the handshake header directly from the record only when the full
4 bytes are contained in it.
- Otherwise aggregate the record payloads into handshakeBuffer and read
the
handshakeType and handshakeLength from the buffer once at least 4 bytes
are available.
- Aggregate the handshake header together with the body and slice past
the
4-byte header once the full ClientHello has been buffered.
- Add SniHandlerTest cases for fragment sizes 1-4.

Result:

ClientHello messages whose handshake header is fragmented across
multiple
TLS records are parsed correctly.

---

[Harden the SOCKS4/5 input validation at encoding
time](https://github.com/netty/netty/commit/46254065878fed061d8619b90cc871593cfc6bcf)
Motivation:
SOCKS4 is a delimiter-based protocol, and does not support NUL bytes in
string or byte-sequence fields.
SOCKS5 is a Tag-Length-Value protocol, and does not support lengths
greater than 255.

Modification:
Add validations for NUL bytes and lengths for SOCKS4 and 5,
respectively, and ensure both client- and server-side encoders behave
correctly.
Add tests to verify the correct handling of boundary conditions.

Result:
Correct delimiter and length handling in the SOCKS4/5 encoders, even
when integrators use custom implementations of the message types.

---

[Do not re-aggregate the ClientHello on every received TLS
record](https://github.com/netty/netty/commit/bb741549f31c878cdd492eda6c0eccb3e02a978c)

---

[Validate trust manager
configuration](https://github.com/netty/netty/commit/5f1888e6384ddcdd95ecae4f921e3c8fd61612fa)
Motivation:

Certain trust manager configurations were not being validated
against the configured endpoint identification algorithm.

Modification:

Add a check that fails fast when the configured trust manager
does not support the required verification mode.

Result:

Misconfigured trust manager setups are now rejected explicitly
instead of failing silently.

---------

Co-authored-by: Norman Maurer <norman_maurer@apple.com>
Co-authored-by: yawkat <jonas.konrad@oracle.com>
Co-authored-by: multicode <multicode@yawk.at>
Co-authored-by: Violeta Georgieva <696661+violetagg@users.noreply.github.com>
