### PR TITLE
Update the graal build to Graal CE 17

### DIFF
--- a/docker/docker-compose.centos-6.graalvm111.yaml
+++ b/docker/docker-compose.centos-6.graalvm111.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-6-1.11
     build:
       args:
-        java_version : "20.3.6.r11-grl"
+        java_version : "21.0.0.2.r11-grl"
 
   build:
     image: netty:centos-6-1.11


### PR DESCRIPTION
Motivation:
We've been using an ancient graal version 20.3.6.r11-grl.

The TLS implementation in this graal version predates RFC 9325 section 4.5 (https://www.rfc-editor.org/rfc/rfc9325.html#section-4.5) which now mandates that DH key exchange algorithms use at least 2048-bit parameters. The old graal version is still using 1024-bit parameters, which will now start to fail the TLS handshakes as we upgrade our OpenSSL versions and other alternative TLS integrations.

Modification:
Upgrade the graal build to use 17.0.9-graalce, which is much more modern and also an LTS release.

Result:
Graal builds no longer fail in TLS tests that use the DH key exchange algorithm.