### PR TITLE
Ensure OCSP is also tested with out native implementation

### DIFF
--- a/handler-ssl-ocsp/pom.xml
+++ b/handler-ssl-ocsp/pom.xml
@@ -45,6 +45,11 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
+      <artifactId>netty-handler</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
       <artifactId>netty-transport</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -83,6 +88,14 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-testsuite-common</artifactId>
       <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- ensure tests are run with tcnative as well -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>${tcnative.artifactId}</artifactId>
+      <classifier>${tcnative.classifier}</classifier>
+      <optional>true</optional>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -560,7 +560,7 @@ public final class OpenSsl {
 
     private static boolean doesSupportOcsp() {
         boolean supportsOcsp = false;
-        if (version() >= 0x10002000L) {
+        if (isBoringSSL() || isAWSLC()) {
             long sslCtx = -1;
             try {
                 sslCtx = SSLContext.make(SSL.SSL_PROTOCOL_TLSV1_2, SSL.SSL_MODE_SERVER);


### PR DESCRIPTION
Motivation:

We need to have the native tcnative libs on the classpath so the tests are also run against it

Modifications:

- Explicit depend on netty-handler
- Add tcnative as test dependency

Result:

Tests are also run against native impl
