### PR TITLE
Use X509ExtendedTrustManager in SSLErrorTest

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
@@ -40,11 +40,13 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.net.ssl.ManagerFactoryParameters;
+import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
+import javax.net.ssl.X509ExtendedTrustManager;
 import javax.security.auth.x500.X500Principal;
 import java.io.File;
+import java.net.Socket;
 import java.security.KeyStore;
 import java.security.cert.CRLReason;
 import java.security.cert.CertPathValidatorException;
@@ -215,7 +217,31 @@ public class SslErrorTest {
 
         @Override
         protected TrustManager[] engineGetTrustManagers() {
-            return new TrustManager[] { new X509TrustManager() {
+            return new TrustManager[] { new X509ExtendedTrustManager() {
+
+                @Override
+                public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket)
+                        throws CertificateException {
+                    throw exception;
+                }
+
+                @Override
+                public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket)
+                        throws CertificateException {
+                    throw exception;
+                }
+
+                @Override
+                public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine engine)
+                        throws CertificateException {
+                    throw exception;
+                }
+
+                @Override
+                public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine)
+                        throws CertificateException {
+                    throw exception;
+                }
 
                 @Override
                 public void checkClientTrusted(X509Certificate[] x509Certificates, String s)


### PR DESCRIPTION
Motivation:

When sun.misc.Unsafe is not usable we can't wrap TrustManager with the JDK included X509ExtendedTrustManager implementation that does extra validations. Because of this we fail to setup the SslContext.

Modifications:

Explicit use X509ExtendedTrustManager in test

Result:

Test passes again when sun.misc.Unsafe is not usable
