### PR TITLE
Update lz4-java to 1.11.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -955,7 +955,7 @@
       <dependency>
         <groupId>at.yawk.lz4</groupId>
         <artifactId>lz4-java</artifactId>
-        <version>1.11.1</version>
+        <version>1.11.2</version>
       </dependency>
       <dependency>
         <groupId>com.github.jponge</groupId>


### PR DESCRIPTION
Motivation:

lz4-java 1.11.2 is the latest security release and addresses GHSA-6cx8-rjf8-pr8g and GHSA-4v53-57pg-c464.

Modification:

Update the managed `at.yawk.lz4:lz4-java` dependency from 1.11.1 to 1.11.2.

Result:

Netty uses the latest lz4-java release. The codec-compression LZ4 test suite passes with 56 tests and no failures or errors.