### PR TITLE
Update setup-testlens to v1.9.4 (#17223)

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -91,7 +91,7 @@ jobs:
             cache-windows-maven-
 
       - name: Set up TestLens
-        uses: testlens-app/setup-testlens@3f82d2dc6cd5c03f02ce5f7885a21195d85f8d14 # Pin 1.9.3
+        uses: testlens-app/setup-testlens@d29a2be31512b3aeda3adcef09fbe0d55af90c51 # Pin 1.9.4
 
       - name: Build project
         run: ./mvnw.cmd -B -ntp --file pom.xml clean package -Pboringssl -DskipHttp2Testsuite=true -DskipAutobahnTestsuite=true
@@ -252,7 +252,9 @@ jobs:
             cache-maven-al2023-
 
       - name: Set up TestLens
-        uses: testlens-app/setup-testlens@3f82d2dc6cd5c03f02ce5f7885a21195d85f8d14 # Pin 1.9.3
+        uses: testlens-app/setup-testlens@d29a2be31512b3aeda3adcef09fbe0d55af90c51 # Pin 1.9.4
+        with:
+          working-directory: netty
 
       - name: Build docker image
         run: docker compose ${{ matrix.docker-compose-build }}
@@ -333,7 +335,7 @@ jobs:
         run: brew bundle
 
       - name: Set up TestLens
-        uses: testlens-app/setup-testlens@3f82d2dc6cd5c03f02ce5f7885a21195d85f8d14 # Pin 1.9.3
+        uses: testlens-app/setup-testlens@d29a2be31512b3aeda3adcef09fbe0d55af90c51 # Pin 1.9.4
 
       - name: Build project
         run: ./mvnw -B -ntp --file pom.xml clean package -Pboringssl -DskipHttp2Testsuite=true -DskipAutobahnTestsuite=true -DskipTests=true

--- a/docker/docker-compose.al2023.yaml
+++ b/docker/docker-compose.al2023.yaml
@@ -11,7 +11,6 @@ services:
     depends_on: [runtime-setup]
     environment:
       LD_LIBRARY_PATH: /opt/aws-lc/lib64
-      CI:
     volumes:
       # Use a separate directory for the AL2023 Maven repository
       - ~/.m2-al2023:/root/.m2

--- a/docker/docker-compose.centos-7.yaml
+++ b/docker/docker-compose.centos-7.yaml
@@ -19,7 +19,6 @@ services:
       - GPG_PASSPHRASE
       - GPG_PRIVATE_KEY
       - MAVEN_OPTS
-      - CI
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg

--- a/docker/docker-compose.ubuntu-20.04.yaml
+++ b/docker/docker-compose.ubuntu-20.04.yaml
@@ -16,7 +16,6 @@ services:
       - GPG_PASSPHRASE
       - GPG_PRIVATE_KEY
       - MAVEN_OPTS
-      - CI
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -16,7 +16,6 @@ services:
       - GPG_PASSPHRASE
       - GPG_PRIVATE_KEY
       - MAVEN_OPTS
-      - CI
     volumes:
       - ~/.ssh:/root/.ssh
       - ~/.gnupg:/root/.gnupg


### PR DESCRIPTION
Motivation:

Fix reporting of test results via TestLens.

Modification:

Update to the latest version of the `setup-testlens` action which no longer requires propagating the `CI` env var and includes a fix that captures other required GitHub context env vars (e.g., `GITHUB_SHA`) early so they don't have to propagated to the Docker container, either.

Result:

Test results and failures are now reported by TestLens for Docker-based Linux builds as well.

(cherry picked from commit a43881461408edd14492e8c5985ddd0a1f505d7f)
