### PR TITLE
Fix codec-native-quic published POM packaging

### DIFF
--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -616,6 +616,34 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <configuration>
+          <flattenDependencyMode>all</flattenDependencyMode>
+          <embedBuildProfileDependencies>true</embedBuildProfileDependencies>
+          <flattenMode>ossrh</flattenMode>
+        </configuration>
+        <executions>
+          <!-- enable flattening -->
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+          </execution>
+          <!-- ensure proper cleanup -->
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
       <!-- Also include c files in source jar -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Motivation:

The published POM for `netty-codec-native-quic` contains the unresolved `${packaging.type}` property. Some downstream dependency resolvers interpret this property as the artifact extension, resulting in attempts to resolve artifacts such as `netty-codec-native-quic-4.2.15.Final.${packaging.type}`.

Modification:

Configure the Maven Flatten Plugin for netty-codec-native-quic, following the existing Netty publication pattern. This produces a consumer POM with the packaging property resolved while preserving the profile-driven build
configuration.

Result:

The published consumer POM no longer contains an unresolved packaging property.

Fixes #17041.