### PR TITLE
Adjust failsafe plugin version to be in sync with surefire plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2017,7 +2017,7 @@
         <!-- keep surefire and failsafe in sync -->
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>3.5.3</version>
+          <version>3.5.6</version>
         </plugin>
         <plugin>
           <artifactId>maven-clean-plugin</artifactId>


### PR DESCRIPTION
Motivation:

We recently update the surefire plugin version but did miss to also update the failsafe plugin version so both stay in sync

Modifications:

Update failsafe version

Result:

failsafe and surefire plugin versions are the same again
