### PR TITLE
Fix NPE in AbstractNioChannel.removeReadOp() after concurrent deregistration (#17104)

### DIFF
--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
@@ -277,7 +277,11 @@ public abstract class AbstractNioChannel extends AbstractChannel {
     }
 
     protected final void removeReadOp() {
-        IoRegistration registration = registration();
+        // Read the field directly as the channel may have been deregistered concurrently (setting
+        // registration to null) after the isRegistered() check in clearReadPending() but before the
+        // clearReadPendingRunnable is executed on the EventLoop. See https://github.com/netty/netty/issues/17103
+        IoRegistration registration = AbstractNioChannel.this.registration;
+
         // Check first if the key is still valid as it may be canceled as part of the deregistration
         // from the EventLoop
         // See https://github.com/netty/netty/issues/2104

--- a/transport/src/test/java/io/netty/channel/nio/AbstractNioChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/nio/AbstractNioChannelTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.nio;
+
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class AbstractNioChannelTest {
+
+    // https://github.com/netty/netty/issues/17103
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    public void testRemoveReadOpDoesNotThrowAfterDeregister() throws Exception {
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        try {
+            EventLoop loop = group.next();
+            AbstractNioChannel channel = new NioSocketChannel(loop);
+            channel.register().syncUninterruptibly();
+
+            // Deregistering runs doDeregister() which sets the IoRegistration field to null. This mimics
+            // a deregistration that races with clearReadPending(): the isRegistered() check there reads the
+            // separate "registered" boolean and may pass, after which the scheduled clearReadPendingRunnable
+            // ends up calling removeReadOp() on the EventLoop once the registration has already been cleared.
+            channel.deregister().syncUninterruptibly();
+            assertFalse(channel.isRegistered());
+
+            // Before the fix this threw a NullPointerException (or AssertionError with -ea) because
+            // removeReadOp() dereferenced the now-null registration via registration().
+            assertDoesNotThrow(channel::removeReadOp);
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #17103

`clearReadPending()` guards scheduling of `clearReadPendingRunnable`
with an `isRegistered()` check, which reads the `registered` boolean of
`AbstractChannel`. That boolean and the `IoRegistration registration`
field of `AbstractNioChannel` are not updated atomically. When a channel
is deregistered from another thread *after* the `isRegistered()` check
passed but *before* the runnable runs on the `EventLoop`,
`doDeregister()` has already set `registration` to `null`.
`removeReadOp()` then obtained the field via `registration()` (which
only `assert`s non-null) and dereferenced it, producing the reported
`NullPointerException` in production (or an `AssertionError` when
assertions are enabled):

```
java.lang.NullPointerException
    at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.removeReadOp(AbstractNioChannel.java:268)
    at io.netty.channel.nio.AbstractNioChannel.clearReadPending0(AbstractNioChannel.java:223)
    at io.netty.channel.nio.AbstractNioChannel$1.run(AbstractNioChannel.java:66)
    ...
```

Make `removeReadOp()` read the `registration` field directly and
null-check it before use, mirroring the null-safe idiom already used by
`doBeginRead()` in the same class. Behaviour is unchanged when the
channel is still registered.

`removeReadOp()` no longer throws when the channel has been deregistered
concurrently.

Added
`AbstractNioChannelTest#testRemoveReadOpDoesNotThrowAfterDeregister`,
which registers a `NioSocketChannel`, deregisters it (clearing the
registration), then invokes `removeReadOp()`. The test fails on the
current code (NPE / AssertionError at `AbstractNioChannel.java:264` →
`registration()` at `:156`) and passes with this change.

Verification done: built `transport` (+ deps) and ran the new regression
test (fails before / passes after the fix); ran the existing
`NioEventLoopTest` (13 tests, all green); ran the project checkstyle
execution (`checkstyle:check@check-style`, no violations).

Co-authored-by: Norman Maurer <norman_maurer@apple.com>
