### PR TITLE
Release unsent LastHttpContent in HttpChunkedInput (#17240)

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpChunkedInput.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpChunkedInput.java
@@ -60,7 +60,7 @@ public class HttpChunkedInput implements ChunkedInput<HttpContent> {
      * chunk.
      * @param input {@link ChunkedInput} containing data to write
      * @param lastHttpContent {@link LastHttpContent} that will be written as the terminating chunk. Use this for
-     *            training headers.
+     *            trailing headers. Ownership is transferred to this {@link HttpChunkedInput}.
      */
     public HttpChunkedInput(ChunkedInput<ByteBuf> input, LastHttpContent lastHttpContent) {
         this.input = input;
@@ -79,7 +79,14 @@ public class HttpChunkedInput implements ChunkedInput<HttpContent> {
 
     @Override
     public void close() throws Exception {
-        input.close();
+        try {
+            input.close();
+        } finally {
+            if (!sentLastChunk) {
+                sentLastChunk = true;
+                lastHttpContent.release();
+            }
+        }
     }
 
     @Deprecated

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpChunkedInputTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpChunkedInputTest.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.http;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.stream.ChunkedFile;
@@ -25,6 +26,7 @@ import io.netty.handler.stream.ChunkedNioFile;
 import io.netty.handler.stream.ChunkedNioStream;
 import io.netty.handler.stream.ChunkedStream;
 import io.netty.handler.stream.ChunkedWriteHandler;
+import io.netty.util.concurrent.Future;
 import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
 
@@ -35,8 +37,10 @@ import java.io.IOException;
 import java.nio.channels.Channels;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HttpChunkedInputTest {
@@ -116,6 +120,61 @@ public class HttpChunkedInputTest {
         assertNull(input.readChunk(ByteBufAllocator.DEFAULT));
     }
 
+    @Test
+    public void testCloseReleasesUnsentLastHttpContent() throws Exception {
+        TestChunkedInput chunkedInput = new TestChunkedInput(false, false);
+        LastHttpContent lastHttpContent = new DefaultLastHttpContent(Unpooled.buffer(1).writeByte(1));
+        HttpChunkedInput input = new HttpChunkedInput(chunkedInput, lastHttpContent);
+        EmbeddedChannel channel = new EmbeddedChannel(new ChunkedWriteHandler());
+
+        try {
+            Future<Void> writeFuture = channel.writeAndFlush(input);
+            assertFalse(writeFuture.isDone());
+
+            assertFalse(channel.finish());
+            assertTrue(chunkedInput.closed);
+            assertFalse(writeFuture.isSuccess());
+            assertEquals(0, lastHttpContent.refCnt());
+
+            input.close();
+            assertEquals(0, lastHttpContent.refCnt());
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    public void testCloseDoesNotReleaseSentLastHttpContent() throws Exception {
+        LastHttpContent lastHttpContent = new DefaultLastHttpContent(Unpooled.buffer(1).writeByte(1));
+        HttpChunkedInput input = new HttpChunkedInput(new TestChunkedInput(true, false), lastHttpContent);
+        EmbeddedChannel channel = new EmbeddedChannel(new ChunkedWriteHandler());
+
+        try {
+            assertTrue(channel.writeOutbound(input));
+            assertSame(lastHttpContent, channel.readOutbound());
+            assertNull(channel.readOutbound());
+            assertEquals(1, lastHttpContent.refCnt());
+
+            input.close();
+            input.close();
+            assertEquals(1, lastHttpContent.refCnt());
+        } finally {
+            lastHttpContent.release();
+            channel.finishAndReleaseAll();
+        }
+    }
+
+    @Test
+    public void testCloseReleasesUnsentLastHttpContentWhenInputCloseThrows() throws Exception {
+        LastHttpContent lastHttpContent = new DefaultLastHttpContent(Unpooled.buffer(1).writeByte(1));
+        HttpChunkedInput input = new HttpChunkedInput(new TestChunkedInput(false, true), lastHttpContent);
+
+        assertThrows(IOException.class, input::close);
+        assertEquals(0, lastHttpContent.refCnt());
+        assertThrows(IOException.class, input::close);
+        assertEquals(0, lastHttpContent.refCnt());
+    }
+
     private static void check(ChunkedInput<?>... inputs) throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new ChunkedWriteHandler());
 
@@ -154,5 +213,50 @@ public class HttpChunkedInputTest {
         assertEquals(BYTES.length * inputs.length, read);
         assertSame(LastHttpContent.EMPTY_LAST_CONTENT, lastHttpContent,
                 "Last chunk must be LastHttpContent.EMPTY_LAST_CONTENT");
+    }
+
+    private static final class TestChunkedInput implements ChunkedInput<ByteBuf> {
+        private final boolean endOfInput;
+        private final boolean failOnClose;
+        private boolean closed;
+
+        TestChunkedInput(boolean endOfInput, boolean failOnClose) {
+            this.endOfInput = endOfInput;
+            this.failOnClose = failOnClose;
+        }
+
+        @Override
+        public boolean isEndOfInput() {
+            return endOfInput;
+        }
+
+        @Override
+        public void close() throws Exception {
+            closed = true;
+            if (failOnClose) {
+                throw new IOException("close failed");
+            }
+        }
+
+        @Deprecated
+        @Override
+        public ByteBuf readChunk(ChannelHandlerContext ctx) {
+            return null;
+        }
+
+        @Override
+        public ByteBuf readChunk(ByteBufAllocator allocator) {
+            return null;
+        }
+
+        @Override
+        public long length() {
+            return 0;
+        }
+
+        @Override
+        public long progress() {
+            return 0;
+        }
     }
 }


### PR DESCRIPTION
Motivation:

`HttpChunkedInput` retains a custom `LastHttpContent` until
`readChunk(...)`
returns it. If `ChunkedWriteHandler` discards a suspended or otherwise
incomplete write, it closes the `HttpChunkedInput`, but the previous
implementation only closed the wrapped input. The unsent terminating
content
therefore remained at `refCnt == 1`.

Modification:

- Release the terminating content from `HttpChunkedInput.close()` when
it has
  not been handed off by `readChunk(...)`.
- Perform that release in a `finally` block so a wrapped input close
failure
  cannot leak the content.
- Mark the terminal state before releasing so repeated `close()` calls
cannot
  double-release it.
- Document ownership of a custom terminating content.
- Add tests for an aborted `ChunkedWriteHandler` write, the successful
handoff
  path, a wrapped input close failure, and repeated close calls.

Result:

Custom terminating content is released when a chunked HTTP write is
closed
before completion, while successfully handed-off content remains owned
by the
outbound pipeline.

Testing:

- `./mvnw -q -pl codec-http -Dtest=HttpChunkedInputTest test`
- `./mvnw -q -Pleak -pl codec-http -Dtest=HttpChunkedInputTest test`
- `./mvnw -q -pl codec-http -am -DskipTests install`
