### PR TITLE
HTTP/2: Release compressors after failed headers writes

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
@@ -233,19 +233,26 @@ public class CompressorHttp2ConnectionEncoder extends DecoratingHttp2ConnectionE
     @Override
     public ChannelFuture writeHeaders(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int padding,
             boolean endStream, ChannelPromise promise) {
+        EmbeddedChannel compressor = null;
         try {
             // Determine if compression is required and sanitize the headers.
-            EmbeddedChannel compressor = newCompressor(ctx, headers, endStream);
+            compressor = newCompressor(ctx, headers, endStream);
 
             // Write the headers and create the stream object.
             ChannelFuture future = super.writeHeaders(ctx, streamId, headers, padding, endStream, promise);
 
             // After the stream object has been created, then attach the compressor as a property for data compression.
-            bindCompressorToStream(compressor, streamId);
+            if (bindCompressorToStream(compressor, streamId)) {
+                compressor = null;
+            }
 
             return future;
         } catch (Throwable e) {
             promise.tryFailure(e);
+        } finally {
+            if (compressor != null) {
+                compressor.finishAndReleaseAll();
+            }
         }
         return promise;
     }
@@ -254,20 +261,27 @@ public class CompressorHttp2ConnectionEncoder extends DecoratingHttp2ConnectionE
     public ChannelFuture writeHeaders(final ChannelHandlerContext ctx, final int streamId, final Http2Headers headers,
             final int streamDependency, final short weight, final boolean exclusive, final int padding,
             final boolean endOfStream, final ChannelPromise promise) {
+        EmbeddedChannel compressor = null;
         try {
             // Determine if compression is required and sanitize the headers.
-            EmbeddedChannel compressor = newCompressor(ctx, headers, endOfStream);
+            compressor = newCompressor(ctx, headers, endOfStream);
 
             // Write the headers and create the stream object.
             ChannelFuture future = super.writeHeaders(ctx, streamId, headers, streamDependency, weight, exclusive,
                                                       padding, endOfStream, promise);
 
             // After the stream object has been created, then attach the compressor as a property for data compression.
-            bindCompressorToStream(compressor, streamId);
+            if (bindCompressorToStream(compressor, streamId)) {
+                compressor = null;
+            }
 
             return future;
         } catch (Throwable e) {
             promise.tryFailure(e);
+        } finally {
+            if (compressor != null) {
+                compressor.finishAndReleaseAll();
+            }
         }
         return promise;
     }
@@ -397,17 +411,25 @@ public class CompressorHttp2ConnectionEncoder extends DecoratingHttp2ConnectionE
         }
         final EmbeddedChannel compressor = newContentCompressor(ctx, encoding);
         if (compressor != null) {
-            CharSequence targetContentEncoding = getTargetContentEncoding(encoding);
-            if (IDENTITY.contentEqualsIgnoreCase(targetContentEncoding)) {
-                headers.remove(CONTENT_ENCODING);
-            } else {
-                headers.set(CONTENT_ENCODING, targetContentEncoding);
-            }
+            boolean success = false;
+            try {
+                CharSequence targetContentEncoding = getTargetContentEncoding(encoding);
+                if (IDENTITY.contentEqualsIgnoreCase(targetContentEncoding)) {
+                    headers.remove(CONTENT_ENCODING);
+                } else {
+                    headers.set(CONTENT_ENCODING, targetContentEncoding);
+                }
 
-            // The content length will be for the decompressed data. Since we will compress the data
-            // this content-length will not be correct. Instead of queuing messages or delaying sending
-            // header frames...just remove the content-length header
-            headers.remove(CONTENT_LENGTH);
+                // The content length will be for the decompressed data. Since we will compress the data
+                // this content-length will not be correct. Instead of queuing messages or delaying sending
+                // header frames...just remove the content-length header
+                headers.remove(CONTENT_LENGTH);
+                success = true;
+            } finally {
+                if (!success) {
+                    compressor.finishAndReleaseAll();
+                }
+            }
         }
 
         return compressor;
@@ -417,14 +439,17 @@ public class CompressorHttp2ConnectionEncoder extends DecoratingHttp2ConnectionE
      * Called after the super class has written the headers and created any associated stream objects.
      * @param compressor The compressor associated with the stream identified by {@code streamId}.
      * @param streamId The stream id for which the headers were written.
+     * @return {@code true} if ownership of {@code compressor} was transferred to the stream.
      */
-    private void bindCompressorToStream(EmbeddedChannel compressor, int streamId) {
+    private boolean bindCompressorToStream(EmbeddedChannel compressor, int streamId) {
         if (compressor != null) {
             Http2Stream stream = connection().stream(streamId);
             if (stream != null) {
                 stream.setProperty(propertyKey, compressor);
+                return true;
             }
         }
+        return false;
     }
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
@@ -409,10 +409,9 @@ public class CompressorHttp2ConnectionEncoder extends DecoratingHttp2ConnectionE
         if (encoding == null) {
             encoding = IDENTITY;
         }
-        final EmbeddedChannel compressor = newContentCompressor(ctx, encoding);
-        if (compressor != null) {
-            boolean success = false;
-            try {
+        EmbeddedChannel compressor = newContentCompressor(ctx, encoding);
+        try {
+            if (compressor != null) {
                 CharSequence targetContentEncoding = getTargetContentEncoding(encoding);
                 if (IDENTITY.contentEqualsIgnoreCase(targetContentEncoding)) {
                     headers.remove(CONTENT_ENCODING);
@@ -424,15 +423,16 @@ public class CompressorHttp2ConnectionEncoder extends DecoratingHttp2ConnectionE
                 // this content-length will not be correct. Instead of queuing messages or delaying sending
                 // header frames...just remove the content-length header
                 headers.remove(CONTENT_LENGTH);
-                success = true;
-            } finally {
-                if (!success) {
-                    compressor.finishAndReleaseAll();
-                }
+            }
+
+            EmbeddedChannel result = compressor;
+            compressor = null;
+            return result;
+        } finally {
+            if (compressor != null) {
+                compressor.finishAndReleaseAll();
             }
         }
-
-        return compressor;
     }
 
     /**

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoderTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
+ * the specific language governing permissions and limitations under the License.
+ */
+package io.netty.handler.codec.http2;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.DefaultChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_ENCODING;
+import static io.netty.handler.codec.http.HttpHeaderValues.GZIP;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CompressorHttp2ConnectionEncoderTest {
+    private static final int STREAM_ID = 3;
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void compressorIsClosedWhenHeadersWriteDoesNotCreateStream(boolean hasPriority) {
+        Http2Connection connection = new DefaultHttp2Connection(false);
+        DefaultHttp2ConnectionEncoder delegate = newDelegate(connection, mock(Http2FrameWriter.class));
+        TestCompressorHttp2ConnectionEncoder encoder = new TestCompressorHttp2ConnectionEncoder(delegate);
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        ChannelPromise promise = newPromise();
+
+        writeHeaders(encoder, ctx, 2, promise, hasPriority);
+
+        assertTrue(promise.isDone());
+        assertFalse(promise.isSuccess());
+        assertNull(connection.stream(2));
+        assertClosed(encoder.compressor);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void compressorIsClosedWhenDelegateThrows(boolean hasPriority) {
+        RuntimeException cause = new RuntimeException("write failed");
+        Http2Connection connection = new DefaultHttp2Connection(false);
+        Http2ConnectionEncoder delegate = mock(Http2ConnectionEncoder.class);
+        when(delegate.connection()).thenReturn(connection);
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        ChannelPromise promise = newPromise();
+        failHeadersWrite(delegate, ctx, promise, hasPriority, cause);
+        TestCompressorHttp2ConnectionEncoder encoder = new TestCompressorHttp2ConnectionEncoder(delegate);
+
+        writeHeaders(encoder, ctx, STREAM_ID, promise, hasPriority);
+
+        assertSame(cause, promise.cause());
+        assertClosed(encoder.compressor);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void streamOwnsCompressorWhenHeadersWriteFailsAsynchronously(boolean hasPriority) throws Exception {
+        RuntimeException cause = new RuntimeException("write failed");
+        Http2Connection connection = new DefaultHttp2Connection(false);
+        Http2FrameWriter writer = mock(Http2FrameWriter.class);
+        DefaultHttp2ConnectionEncoder delegate = newDelegate(connection, writer);
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        ChannelPromise promise = newPromise();
+        returnHeadersPromise(writer, ctx, promise, hasPriority);
+        TestCompressorHttp2ConnectionEncoder encoder = new TestCompressorHttp2ConnectionEncoder(delegate);
+
+        writeHeaders(encoder, ctx, STREAM_ID, promise, hasPriority);
+
+        Http2Stream stream = connection.stream(STREAM_ID);
+        assertFalse(promise.isDone());
+        assertTrue(encoder.compressor.isOpen());
+
+        promise.setFailure(cause);
+        assertTrue(encoder.compressor.isOpen());
+
+        stream.close();
+        assertClosed(encoder.compressor);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    public void existingStreamOwnsCompressorWhenHeadersWriteFails(boolean hasPriority) throws Exception {
+        Http2Connection connection = new DefaultHttp2Connection(false);
+        Http2Stream stream = connection.local().createStream(STREAM_ID, true);
+        DefaultHttp2ConnectionEncoder delegate = newDelegate(connection, mock(Http2FrameWriter.class));
+        TestCompressorHttp2ConnectionEncoder encoder = new TestCompressorHttp2ConnectionEncoder(delegate);
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        ChannelPromise promise = newPromise();
+
+        writeHeaders(encoder, ctx, STREAM_ID, promise, hasPriority);
+
+        assertTrue(promise.isDone());
+        assertFalse(promise.isSuccess());
+        assertTrue(encoder.compressor.isOpen());
+
+        stream.close();
+        assertClosed(encoder.compressor);
+    }
+
+    @Test
+    public void compressorIsClosedWhenTargetContentEncodingFails() {
+        RuntimeException cause = new RuntimeException("encoding failed");
+        Http2ConnectionEncoder delegate = mock(Http2ConnectionEncoder.class);
+        when(delegate.connection()).thenReturn(new DefaultHttp2Connection(false));
+        TestCompressorHttp2ConnectionEncoder encoder = new TestCompressorHttp2ConnectionEncoder(delegate);
+        encoder.targetContentEncodingFailure = cause;
+        ChannelPromise promise = newPromise();
+
+        writeHeaders(encoder, mock(ChannelHandlerContext.class), STREAM_ID, promise, false);
+
+        assertSame(cause, promise.cause());
+        assertClosed(encoder.compressor);
+    }
+
+    private static void writeHeaders(Http2ConnectionEncoder encoder, ChannelHandlerContext ctx, int streamId,
+                                     ChannelPromise promise, boolean hasPriority) {
+        Http2Headers headers = new DefaultHttp2Headers().set(CONTENT_ENCODING, GZIP);
+        if (hasPriority) {
+            encoder.writeHeaders(ctx, streamId, headers, 0, (short) 16, false, 0, false, promise);
+        } else {
+            encoder.writeHeaders(ctx, streamId, headers, 0, false, promise);
+        }
+    }
+
+    private static void failHeadersWrite(Http2ConnectionEncoder delegate, ChannelHandlerContext ctx,
+                                         ChannelPromise promise, boolean hasPriority, RuntimeException cause) {
+        if (hasPriority) {
+            doThrow(cause).when(delegate).writeHeaders(eq(ctx), eq(STREAM_ID), any(Http2Headers.class), eq(0),
+                    eq((short) 16), eq(false), eq(0), eq(false), eq(promise));
+        } else {
+            doThrow(cause).when(delegate).writeHeaders(eq(ctx), eq(STREAM_ID), any(Http2Headers.class), eq(0),
+                    eq(false), eq(promise));
+        }
+    }
+
+    private static void returnHeadersPromise(Http2FrameWriter writer, ChannelHandlerContext ctx,
+                                             ChannelPromise promise, boolean hasPriority) {
+        if (hasPriority) {
+            when(writer.writeHeaders(eq(ctx), eq(STREAM_ID), any(Http2Headers.class), eq(0), eq((short) 16),
+                    eq(false), eq(0), eq(false), eq(promise))).thenReturn(promise);
+        } else {
+            when(writer.writeHeaders(eq(ctx), eq(STREAM_ID), any(Http2Headers.class), eq(0), eq(false), eq(promise)))
+                    .thenReturn(promise);
+        }
+    }
+
+    private static ChannelPromise newPromise() {
+        return new DefaultChannelPromise(mock(Channel.class), ImmediateEventExecutor.INSTANCE);
+    }
+
+    private static DefaultHttp2ConnectionEncoder newDelegate(Http2Connection connection, Http2FrameWriter writer) {
+        connection.remote().flowController(mock(Http2RemoteFlowController.class));
+        DefaultHttp2ConnectionEncoder delegate = new DefaultHttp2ConnectionEncoder(connection, writer);
+        delegate.lifecycleManager(mock(Http2LifecycleManager.class));
+        return delegate;
+    }
+
+    private static void assertClosed(TestEmbeddedChannel compressor) {
+        assertFalse(compressor.isOpen());
+        assertEquals(1, compressor.cleanupCalls);
+    }
+
+    private static final class TestCompressorHttp2ConnectionEncoder extends CompressorHttp2ConnectionEncoder {
+        TestEmbeddedChannel compressor;
+        RuntimeException targetContentEncodingFailure;
+
+        TestCompressorHttp2ConnectionEncoder(Http2ConnectionEncoder delegate) {
+            super(delegate);
+        }
+
+        @Override
+        protected EmbeddedChannel newContentCompressor(ChannelHandlerContext ctx, CharSequence contentEncoding) {
+            compressor = new TestEmbeddedChannel();
+            return compressor;
+        }
+
+        @Override
+        protected CharSequence getTargetContentEncoding(CharSequence contentEncoding) throws Http2Exception {
+            if (targetContentEncodingFailure != null) {
+                throw targetContentEncodingFailure;
+            }
+            return contentEncoding;
+        }
+    }
+
+    private static final class TestEmbeddedChannel extends EmbeddedChannel {
+        int cleanupCalls;
+
+        @Override
+        public boolean finishAndReleaseAll() {
+            ++cleanupCalls;
+            return super.finishAndReleaseAll();
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

`CompressorHttp2ConnectionEncoder` creates an `EmbeddedChannel` before delegating a HEADERS write. A delegate may fail the promise without throwing and without creating a stream, for example when a client writes headers with an invalid even stream ID. In that case, the compressor is never attached to a stream and is not released by `onStreamRemoved`.

A compressor can also be left open if the delegate throws after compressor creation, or if target content encoding preparation fails.

### Modification

- Keep ownership of newly created compressors until they are attached to a stream.
- Release compressors that are not attached after either `writeHeaders` overload returns or throws.
- Release partially initialized compressors if header preparation fails.
- Add regression tests for both overloads covering missing streams, synchronous and asynchronous failures, and existing streams in invalid states.

### Result

Failed HEADERS writes no longer leave compression `EmbeddedChannel`s open, while compressors attached to streams continue to be released by the existing stream-removal path.

### Testing

- `./mvnw -pl codec-http2 -Dtest=CompressorHttp2ConnectionEncoderTest test`
- `./mvnw -pl codec-http2 -Dtest=CompressorHttp2ConnectionEncoderTest,DataCompressionHttp2Test test`
- `./mvnw -pl codec-http2 test`
