### PR TITLE
Skip JextractLocator executability tests on OSes without an execute bit

### DIFF
--- a/jextract-maven-plugin/src/test/java/io/netty/build/jextract/JextractLocatorTest.java
+++ b/jextract-maven-plugin/src/test/java/io/netty/build/jextract/JextractLocatorTest.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class JextractLocatorTest {
 
@@ -110,7 +111,8 @@ class JextractLocatorTest {
     void throwsWhenExplicitPathIsNotExecutable() throws Exception {
         final File notExec = new File(tmp, "jextract");
         assertTrue(notExec.createNewFile());
-        assertTrue(notExec.setExecutable(false));
+        assumeTrue(notExec.setExecutable(false) && !notExec.canExecute(),
+                "platform cannot represent a non-executable file (e.g. Windows NTFS)");
 
         final JextractException e = assertThrows(JextractException.class, () ->
                 JextractLocator.builder()
@@ -124,7 +126,8 @@ class JextractLocatorTest {
     void throwsWhenJextractEnvIsNotExecutable() throws Exception {
         final File notExec = new File(tmp, "jextract");
         assertTrue(notExec.createNewFile());
-        assertTrue(notExec.setExecutable(false));
+        assumeTrue(notExec.setExecutable(false) && !notExec.canExecute(),
+                "platform cannot represent a non-executable file (e.g. Windows NTFS)");
 
         final JextractException e = assertThrows(JextractException.class, () ->
                 JextractLocator.builder()


### PR DESCRIPTION
Motivation:

Two JextractLocator tests assert that the locator rejects a configured jextract path that exists but is not executable. Their setup builds that fixture with File.setExecutable(false), which returns false on operating systems that have no POSIX execute bit, so the precondition assertion fails and the tests turn red on the Windows CI job even though the scenario they cover cannot exist there.

Modification:

Both tests now guard their setup with a JUnit assumption that the platform can actually represent a non-executable file, meaning setExecutable(false) succeeds and canExecute() then reports false. Where that holds the tests run and assert the rejection behavior as before. Where it does not, such as Windows NTFS, the tests are skipped rather than failing.

Result:

The two locator tests keep full coverage on platforms where a non-executable file is meaningful and are cleanly skipped where it is not, removing the spurious Windows failure.
