### PR TITLE
Utilize SSL.getVersionInt to avoid String allocation on SSL handshake

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ExtendedOpenSslSession.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ExtendedOpenSslSession.java
@@ -246,7 +246,7 @@ abstract class ExtendedOpenSslSession extends ExtendedSSLSession implements Open
     }
 
     @Override
-    public void handshakeFinished(byte[] id, String cipher, String protocol, byte[] peerCertificate,
+    public void handshakeFinished(byte[] id, String cipher, int protocol, byte[] peerCertificate,
                                   byte[][] peerCertificateChain, long creationTime, long timeout) throws SSLException {
         wrapped.handshakeFinished(id, cipher, protocol, peerCertificate, peerCertificateChain, creationTime, timeout);
     }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslInternalSession.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslInternalSession.java
@@ -87,6 +87,6 @@ interface OpenSslInternalSession extends OpenSslSession {
     /**
      * Called once the handshake has completed.
      */
-    void handshakeFinished(byte[] id, String cipher, String protocol, byte[] peerCertificate,
+    void handshakeFinished(byte[] id, String cipher, int protocol, byte[] peerCertificate,
                            byte[][] peerCertificateChain, long creationTime, long timeout) throws SSLException;
 }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionCache.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionCache.java
@@ -391,7 +391,7 @@ class OpenSslSessionCache implements SSLSessionCache {
         }
 
         @Override
-        public void handshakeFinished(byte[] id, String cipher, String protocol, byte[] peerCertificate,
+        public void handshakeFinished(byte[] id, String cipher, int protocol, byte[] peerCertificate,
                                       byte[][] peerCertificateChain, long creationTime, long timeout) {
             throw new UnsupportedOperationException();
         }

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -2113,7 +2113,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
      * Maps the numeric protocol version returned by {@link SSL#getVersionInt(long)} to the matching interned
      * {@link SslProtocols} constant, or {@code null} if the version is not known.
      */
-    private static String toJavaProtocolVersion(int version) {
+    private static String toJavaProtocolVersion(long ssl, int version) {
         switch (version) {
             case TLS1_3_VERSION:
                 return SslProtocols.TLS_v1_3;
@@ -2128,7 +2128,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
             case SSL2_VERSION:
                 return SslProtocols.SSL_v2;
             default:
-                return "";
+                return SSL.getVersion(ssl);
         }
     }
 
@@ -2868,7 +2868,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                     }
                 }
             }
-            return toJavaProtocolVersion(protocol);
+            return toJavaProtocolVersion(ssl, protocol);
         }
 
         @Override

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -2031,7 +2031,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
             return NEED_WRAP;
         }
         // if SSL_do_handshake returns > 0 or sslError == SSL.SSL_ERROR_NAME it means the handshake was finished.
-        session.handshakeFinished(SSL.getSessionId(ssl), SSL.getCipherForSSL(ssl), protocolVersion(),
+        session.handshakeFinished(SSL.getSessionId(ssl), SSL.getCipherForSSL(ssl), SSL.getVersionInt(ssl),
                 SSL.getPeerCertificate(ssl), SSL.getPeerCertChain(ssl),
                 SSL.getTime(ssl) * 1000L, parentContext.sessionTimeout() * 1000L);
         selectApplicationProtocol();
@@ -2109,26 +2109,6 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
         return CipherSuiteConverter.toJava(openSslCipherSuite, prefix);
     }
 
-    private String toJavaCipherSuite(String openSslCipherSuite, String version) {
-        if (openSslCipherSuite == null) {
-            return null;
-        }
-        String prefix = toJavaCipherSuitePrefix(version);
-        return CipherSuiteConverter.toJava(openSslCipherSuite, prefix);
-    }
-
-    /**
-     * Returns the negotiated protocol version as one of the {@link SslProtocols} {@code String}s.
-     * <p>
-     * This uses {@link SSL#getVersionInt(long)} and maps the returned numeric version to an interned
-     * {@link SslProtocols} constant, so no new {@code String} is allocated on the (performance sensitive)
-     * handshake path. For a version that can't be mapped it falls back to {@link SSL#getVersion(long)}.
-     */
-    private String protocolVersion() {
-        String version = toJavaProtocolVersion(SSL.getVersionInt(ssl));
-        return version != null ? version : SSL.getVersion(ssl);
-    }
-
     /**
      * Maps the numeric protocol version returned by {@link SSL#getVersionInt(long)} to the matching interned
      * {@link SslProtocols} constant, or {@code null} if the version is not known.
@@ -2148,7 +2128,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
             case SSL2_VERSION:
                 return SslProtocols.SSL_v2;
             default:
-                return null;
+                return "";
         }
     }
 
@@ -2551,7 +2531,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
         private Certificate[] peerCerts;
 
         private boolean valid = true;
-        private String protocol;
+        private int protocol;
         private String cipher;
         private OpenSslSessionId id = OpenSslSessionId.NULL_ID;
         private long creationTime;
@@ -2709,7 +2689,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
          * by the user.
          */
         @Override
-        public void handshakeFinished(byte[] id, String cipher, String protocol, byte[] peerCertificate,
+        public void handshakeFinished(byte[] id, String cipher, int protocol, byte[] peerCertificate,
                                       byte[][] peerCertificateChain, long creationTime, long timeout)
                 throws SSLException {
             synchronized (ReferenceCountedOpenSslEngine.this) {
@@ -2880,17 +2860,15 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
 
         @Override
         public String getProtocol() {
-            String protocol = this.protocol;
-            if (protocol == null) {
+            int protocol = this.protocol;
+            if (protocol == 0) {
                 synchronized (ReferenceCountedOpenSslEngine.this) {
                     if (!destroyed) {
-                        protocol = protocolVersion();
-                    } else {
-                        protocol = StringUtil.EMPTY_STRING;
+                        protocol = SSL.getVersionInt(ssl);
                     }
                 }
             }
-            return protocol;
+            return toJavaProtocolVersion(protocol);
         }
 
         @Override

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -2109,6 +2109,14 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
         return CipherSuiteConverter.toJava(openSslCipherSuite, prefix);
     }
 
+    private String toJavaCipherSuite(String openSslCipherSuite, String version) {
+        if (openSslCipherSuite == null) {
+            return null;
+        }
+        String prefix = toJavaCipherSuitePrefix(version);
+        return CipherSuiteConverter.toJava(openSslCipherSuite, prefix);
+    }
+
     /**
      * Returns the negotiated protocol version as one of the {@link SslProtocols} {@code String}s.
      * <p>
@@ -2141,6 +2149,27 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                 return SslProtocols.SSL_v2;
             default:
                 return null;
+        }
+    }
+
+    /**
+     * Converts the protocol version string returned by {@link SSL#getVersion(long)} to protocol family string.
+     */
+    private static String toJavaCipherSuitePrefix(String protocolVersion) {
+        final char c;
+        if (protocolVersion == null || protocolVersion.isEmpty()) {
+            c = 0;
+        } else {
+            c = protocolVersion.charAt(0);
+        }
+
+        switch (c) {
+            case 'T':
+                return "TLS";
+            case 'S':
+                return "SSL";
+            default:
+                return "UNKNOWN";
         }
     }
 
@@ -2693,7 +2722,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                         // did not set it earlier via setSessionDetails(...)
                         this.creationTime = lastAccessed = creationTime;
                     }
-                    this.cipher = toJavaCipherSuite(cipher, SSL.getVersionInt(ssl));
+                    this.cipher = toJavaCipherSuite(cipher, protocol);
                     this.protocol = protocol;
                     try {
                         String groupName = SSL.getGroupName(ssl);

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -115,6 +115,15 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
             SSL.SSL_OP_NO_TLSv1_3
     };
 
+    // Numeric protocol versions as returned by SSL_version() (see SSL#getVersionInt(long)). These are not the
+    // SSL.SSL_PROTOCOL_* bitmask flags but the raw values OpenSSL uses to identify the negotiated protocol.
+    private static final int SSL2_VERSION = 0x0002;
+    private static final int SSL3_VERSION = 0x0300;
+    private static final int TLS1_VERSION = 0x0301;
+    private static final int TLS1_1_VERSION = 0x0302;
+    private static final int TLS1_2_VERSION = 0x0303;
+    private static final int TLS1_3_VERSION = 0x0304;
+
     /**
      * Depends upon tcnative ... only use if tcnative is available!
      */
@@ -2022,7 +2031,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
             return NEED_WRAP;
         }
         // if SSL_do_handshake returns > 0 or sslError == SSL.SSL_ERROR_NAME it means the handshake was finished.
-        session.handshakeFinished(SSL.getSessionId(ssl), SSL.getCipherForSSL(ssl), SSL.getVersion(ssl),
+        session.handshakeFinished(SSL.getSessionId(ssl), SSL.getCipherForSSL(ssl), protocolVersion(),
                 SSL.getPeerCertificate(ssl), SSL.getPeerCertChain(ssl),
                 SSL.getTime(ssl) * 1000L, parentContext.sessionTimeout() * 1000L);
         selectApplicationProtocol();
@@ -2089,11 +2098,10 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
             return null;
         }
 
-        String version = SSL.getVersion(ssl);
-        return toJavaCipherSuite(openSslCipherSuite, version);
+        return toJavaCipherSuite(openSslCipherSuite, SSL.getVersionInt(ssl));
     }
 
-    private String toJavaCipherSuite(String openSslCipherSuite, String version) {
+    private String toJavaCipherSuite(String openSslCipherSuite, int version) {
         if (openSslCipherSuite == null) {
             return null;
         }
@@ -2102,20 +2110,53 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
     }
 
     /**
-     * Converts the protocol version string returned by {@link SSL#getVersion(long)} to protocol family string.
+     * Returns the negotiated protocol version as one of the {@link SslProtocols} {@code String}s.
+     * <p>
+     * This uses {@link SSL#getVersionInt(long)} and maps the returned numeric version to an interned
+     * {@link SslProtocols} constant, so no new {@code String} is allocated on the (performance sensitive)
+     * handshake path. For a version that can't be mapped it falls back to {@link SSL#getVersion(long)}.
      */
-    private static String toJavaCipherSuitePrefix(String protocolVersion) {
-        final char c;
-        if (protocolVersion == null || protocolVersion.isEmpty()) {
-            c = 0;
-        } else {
-            c = protocolVersion.charAt(0);
-        }
+    private String protocolVersion() {
+        String version = toJavaProtocolVersion(SSL.getVersionInt(ssl));
+        return version != null ? version : SSL.getVersion(ssl);
+    }
 
-        switch (c) {
-            case 'T':
+    /**
+     * Maps the numeric protocol version returned by {@link SSL#getVersionInt(long)} to the matching interned
+     * {@link SslProtocols} constant, or {@code null} if the version is not known.
+     */
+    private static String toJavaProtocolVersion(int version) {
+        switch (version) {
+            case TLS1_3_VERSION:
+                return SslProtocols.TLS_v1_3;
+            case TLS1_2_VERSION:
+                return SslProtocols.TLS_v1_2;
+            case TLS1_1_VERSION:
+                return SslProtocols.TLS_v1_1;
+            case TLS1_VERSION:
+                return SslProtocols.TLS_v1;
+            case SSL3_VERSION:
+                return SslProtocols.SSL_v3;
+            case SSL2_VERSION:
+                return SslProtocols.SSL_v2;
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * Converts the numeric protocol version returned by {@link SSL#getVersionInt(long)} to the cipher suite
+     * protocol family prefix.
+     */
+    private static String toJavaCipherSuitePrefix(int protocolVersion) {
+        switch (protocolVersion) {
+            case TLS1_VERSION:
+            case TLS1_1_VERSION:
+            case TLS1_2_VERSION:
+            case TLS1_3_VERSION:
                 return "TLS";
-            case 'S':
+            case SSL2_VERSION:
+            case SSL3_VERSION:
                 return "SSL";
             default:
                 return "UNKNOWN";
@@ -2652,7 +2693,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                         // did not set it earlier via setSessionDetails(...)
                         this.creationTime = lastAccessed = creationTime;
                     }
-                    this.cipher = toJavaCipherSuite(cipher, protocol);
+                    this.cipher = toJavaCipherSuite(cipher, SSL.getVersionInt(ssl));
                     this.protocol = protocol;
                     try {
                         String groupName = SSL.getGroupName(ssl);
@@ -2814,7 +2855,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
             if (protocol == null) {
                 synchronized (ReferenceCountedOpenSslEngine.this) {
                     if (!destroyed) {
-                        protocol = SSL.getVersion(ssl);
+                        protocol = protocolVersion();
                     } else {
                         protocol = StringUtil.EMPTY_STRING;
                     }

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -2133,27 +2133,6 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
     }
 
     /**
-     * Converts the protocol version string returned by {@link SSL#getVersion(long)} to protocol family string.
-     */
-    private static String toJavaCipherSuitePrefix(String protocolVersion) {
-        final char c;
-        if (protocolVersion == null || protocolVersion.isEmpty()) {
-            c = 0;
-        } else {
-            c = protocolVersion.charAt(0);
-        }
-
-        switch (c) {
-            case 'T':
-                return "TLS";
-            case 'S':
-                return "SSL";
-            default:
-                return "UNKNOWN";
-        }
-    }
-
-    /**
      * Converts the numeric protocol version returned by {@link SSL#getVersionInt(long)} to the cipher suite
      * protocol family prefix.
      */
@@ -2863,9 +2842,10 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
             int protocol = this.protocol;
             if (protocol == 0) {
                 synchronized (ReferenceCountedOpenSslEngine.this) {
-                    if (!destroyed) {
-                        protocol = SSL.getVersionInt(ssl);
+                    if (destroyed) {
+                        return StringUtil.EMPTY_STRING;
                     }
+                    protocol = SSL.getVersionInt(ssl);
                 }
             }
             return toJavaProtocolVersion(ssl, protocol);


### PR DESCRIPTION
Motivation:

netty-tcnative added `SSL.getVersionInt(long)` which returns the negotiated protocol version as an int instead of allocating a new String on every call like `SSL.getVersion(long)` does.

Modifications:

Add a protocolVersion() helper to ReferenceCountedOpenSslEngine that calls SSL.getVersionInt(long) and maps the returned numeric version to the matching interned SslProtocols constant (TLSv1.3, TLSv1.2, ...), falling back to SSL.getVersion(long) for versions that can't be mapped. Use it for the session protocol String (handshakeFinished and OpenSslSession#getProtocol()).

Carry the numeric version through the cipher suite conversion as well: toJavaCipherSuite(...) and toJavaCipherSuitePrefix(...) now take the int version returned by SSL.getVersionInt(long) and switch on it directly, instead of inspecting the first char of the version String. This drops the String entirely from the cipher suite prefix computation and is more robust than the previous charAt(0) heuristic.

Result:

No String is allocated when retrieving the negotiated protocol version on the SSL handshake path.

Follow-up of https://github.com/netty/netty/pull/16278 and https://github.com/netty/netty-tcnative/commit/5f9becb3e3d1d3a7f19d2f647b431abf64952d40 