### PR TITLE
Correctly mark org.jctools:jctools-core-jdk11 as non optional

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -62,7 +62,6 @@
       <artifactId>jctools-core-jdk11</artifactId>
       <!-- Need compile scope to be taken into account by shade plugin -->
       <scope>compile</scope>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jetbrains</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -765,7 +765,7 @@
     <junit.version>5.14.3</junit.version>
     <junit.platform.version>1.14.0</junit.platform.version>
     <jazzer.version>0.30.0</jazzer.version>
-    <jctools.version>4.0.6</jctools.version>
+    <jctools.version>4.0.7</jctools.version>
     <skipTests>false</skipTests>
     <testJavaHome>${java.home}</testJavaHome>
     <testJvm>${testJavaHome}/bin/java</testJvm>


### PR DESCRIPTION
Motivation:

95012caf2c3c615bb6d8b7a084bc36a2064b17c8 introduced the use of jctools-core-jdk11 but did mark it as optional while it needs to be non-optional as otherwise intellij will not be able to load and run tests

Modifications:

Remove optional declaration

Result:

Be able to run tests via intellij again
