### PR TITLE
HTTP/2: Prevent reentrant flush on writability change

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -79,6 +79,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
     private ChannelFutureListener closeListener;
     private BaseDecoder byteDecoder;
     private long gracefulShutdownTimeoutMillis;
+    private boolean inFlush;
 
     protected Http2ConnectionHandler(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder,
                                      Http2Settings initialSettings) {
@@ -189,6 +190,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
 
     @Override
     public void flush(ChannelHandlerContext ctx) {
+        inFlush = true;
         try {
             // Trigger pending writes in the remote flow controller.
             encoder.flowController().writePendingBytes();
@@ -197,6 +199,8 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
             onError(ctx, true, e);
         } catch (Throwable cause) {
             onError(ctx, true, connectionError(INTERNAL_ERROR, cause, "Error flushing"));
+        } finally {
+            inFlush = false;
         }
     }
 
@@ -459,7 +463,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         // Writability is expected to change while we are writing. We cannot allow this event to trigger reentering
         // the allocation and write loop. Reentering the event loop will lead to over or illegal allocation.
         try {
-            if (ctx.channel().isWritable()) {
+            if (ctx.channel().isWritable() && !inFlush) {
                 flush(ctx);
             }
             encoder.flowController().channelWritabilityChanged();

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -344,6 +344,26 @@ public class Http2ConnectionHandlerTest {
     }
 
     @Test
+    public void channelWritabilityChangedShouldNotReenterFlush() throws Exception {
+        when(channel.isActive()).thenReturn(false);
+        when(channel.isWritable()).thenReturn(true);
+        handler = newHandler();
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                handler.channelWritabilityChanged(ctx);
+                return null;
+            }
+        }).when(ctx).flush();
+
+        handler.flush(ctx);
+
+        verify(remoteFlow).writePendingBytes();
+        verify(ctx).flush();
+        verify(remoteFlow).channelWritabilityChanged();
+    }
+
+    @Test
     public void serverReceivingInvalidClientPrefaceStringShouldHandleException() throws Exception {
         when(connection.isServer()).thenReturn(true);
         handler = newHandler();


### PR DESCRIPTION
Motivation:

An HTTP/2 connection can enter a livelock when a flush synchronously triggers a channel writability change. `channelWritabilityChanged` then re-enters `Http2ConnectionHandler.flush()` while the original flush is still in progress, causing the event-loop thread to spin indefinitely.

Modification:

Track when `Http2ConnectionHandler` is performing a flush and prevent `channelWritabilityChanged` from initiating a nested flush during that operation.

Add a regression test that simulates a synchronous writability change during `ChannelHandlerContext.flush()` and verifies that the flush is not re-entered.

Result:

Fixes #17256.