### PR TITLE
Respect max messages per read in LocalServerChannel (#17255)

### DIFF
--- a/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
@@ -156,6 +156,7 @@ public class LocalServerChannel extends AbstractServerChannel {
             if (m == null) {
                 break;
             }
+            handle.incMessagesRead(1);
             pipeline.fireChannelRead(m);
         } while (handle.continueReading());
         handle.readComplete();

--- a/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
@@ -48,8 +48,12 @@ import org.junit.jupiter.api.function.Executable;
 import java.net.ConnectException;
 import java.nio.channels.AlreadyConnectedException;
 import java.nio.channels.ClosedChannelException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -1213,6 +1217,85 @@ public class LocalChannelTest {
 
             countDownLatch.await();
         } finally {
+            closeChannel(sc);
+        }
+    }
+
+    @Test
+    @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+    public void testServerMaxMessagesPerReadRespectedWithQueuedConnections() throws Exception {
+        final int maxMessagesPerRead = 2;
+        final int connections = 5;
+        final CountDownLatch queuedConnections = new CountDownLatch(connections);
+        final BlockingQueue<Integer> messagesPerReadComplete = new LinkedBlockingQueue<Integer>();
+        final List<ChannelFuture> connectFutures = new ArrayList<ChannelFuture>();
+
+        Bootstrap cb = new Bootstrap();
+        ServerBootstrap sb = new ServerBootstrap();
+
+        cb.group(sharedGroup)
+                .channel(LocalChannel.class)
+                .handler(new ChannelInitializer<Channel>() {
+                    @Override
+                    protected void initChannel(Channel ch) {
+                        // NOOP
+                    }
+                });
+
+        sb.group(sharedGroup)
+                .channelFactory(() -> new LocalServerChannel() {
+                    @Override
+                    protected LocalChannel newLocalChannel(LocalChannel peer) {
+                        LocalChannel child = super.newLocalChannel(peer);
+                        queuedConnections.countDown();
+                        return child;
+                    }
+                })
+                .option(ChannelOption.AUTO_READ, false)
+                .option(ChannelOption.MAX_MESSAGES_PER_READ, maxMessagesPerRead)
+                .handler(new ChannelInboundHandlerAdapter() {
+                    private int messagesRead;
+
+                    @Override
+                    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                        messagesRead++;
+                        ctx.fireChannelRead(msg);
+                    }
+
+                    @Override
+                    public void channelReadComplete(ChannelHandlerContext ctx) {
+                        messagesPerReadComplete.add(messagesRead);
+                        messagesRead = 0;
+                        ctx.fireChannelReadComplete();
+                    }
+                })
+                .childHandler(new ChannelInitializer<Channel>() {
+                    @Override
+                    protected void initChannel(Channel ch) {
+                        // NOOP
+                    }
+                });
+
+        Channel sc = null;
+        try {
+            sc = sb.bind(TEST_ADDRESS).sync().channel();
+            for (int i = 0; i < connections; i++) {
+                connectFutures.add(cb.connect(TEST_ADDRESS));
+            }
+
+            assertTrue(queuedConnections.await(5, SECONDS));
+
+            sc.config().setAutoRead(true);
+            assertEquals(maxMessagesPerRead, messagesPerReadComplete.take());
+            assertEquals(maxMessagesPerRead, messagesPerReadComplete.take());
+            assertEquals(connections - 2 * maxMessagesPerRead, messagesPerReadComplete.take());
+            for (ChannelFuture connectFuture : connectFutures) {
+                connectFuture.sync();
+            }
+        } finally {
+            for (ChannelFuture connectFuture : connectFutures) {
+                closeChannel(connectFuture.channel());
+            }
             closeChannel(sc);
         }
     }

--- a/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
@@ -21,6 +21,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.AbstractChannel;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFactory;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
@@ -32,6 +33,7 @@ import io.netty.channel.DefaultEventLoopGroup;
 import io.netty.channel.DefaultMaxMessagesRecvByteBufAllocator;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.ServerChannel;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.SingleThreadEventLoop;
 import io.netty.util.ReferenceCountUtil;
@@ -1243,12 +1245,17 @@ public class LocalChannelTest {
                 });
 
         sb.group(sharedGroup)
-                .channelFactory(() -> new LocalServerChannel() {
+                .channelFactory(new ChannelFactory<ServerChannel>() {
                     @Override
-                    protected LocalChannel newLocalChannel(LocalChannel peer) {
-                        LocalChannel child = super.newLocalChannel(peer);
-                        queuedConnections.countDown();
-                        return child;
+                    public ServerChannel newChannel() {
+                        return new LocalServerChannel() {
+                            @Override
+                            protected LocalChannel newLocalChannel(LocalChannel peer) {
+                                LocalChannel child = super.newLocalChannel(peer);
+                                queuedConnections.countDown();
+                                return child;
+                            }
+                        };
                     }
                 })
                 .option(ChannelOption.AUTO_READ, false)


### PR DESCRIPTION
Motivation:

`LocalServerChannel` resets a `RecvByteBufAllocator.Handle` and consults
`continueReading()` in its accept loop, but it never increments the
handle's message count. Since `ServerChannelRecvByteBufAllocator`
ignores byte counts, `totalMessages` remains zero and queued connections
are drained in one read cycle regardless of `maxMessagesPerRead`.

This restores the read-limit behavior originally addressed by #7885,
which became observable again after #11729 introduced the server-channel
allocator.

Modification:

- Increment the receive handle's message count for every accepted local
connection.
- Add a regression test that queues five connections with auto-read
disabled, enables auto-read with a limit of two, and verifies read-cycle
sizes of 2, 2, and 1.

Result:

`LocalServerChannel` now respects the configured maximum messages per
read while continuing to deliver remaining queued connections in
subsequent read cycles.

Validation:

- `./mvnw -pl transport
-Dtest=io.netty.channel.local.LocalChannelTest#testServerMaxMessagesPerReadRespectedWithQueuedConnections
test`
- `./mvnw -pl transport -Dtest=io.netty.channel.local.LocalChannelTest
test` — 27 tests passed
- `./mvnw -pl transport test` — 391 tests passed, 9 skipped
