### PR TITLE
HTTP: Preserve encoder state after header encoding failures

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectEncoder.java
@@ -532,16 +532,17 @@ public abstract class HttpObjectEncoder<H extends HttpMessage> extends MessageTo
         try {
             // Encode the message.
             encodeInitialLine(buf, m);
-            state = isContentAlwaysEmpty(m) ? ST_CONTENT_ALWAYS_EMPTY :
+            final int nextState = isContentAlwaysEmpty(m) ? ST_CONTENT_ALWAYS_EMPTY :
                     HttpUtil.isTransferEncodingChunked(m) ? ST_CONTENT_CHUNK : ST_CONTENT_NON_CHUNK;
 
-            sanitizeHeadersBeforeEncode(m, state == ST_CONTENT_ALWAYS_EMPTY);
+            sanitizeHeadersBeforeEncode(m, nextState == ST_CONTENT_ALWAYS_EMPTY);
 
             encodeHeaders(m.headers(), buf);
             ByteBufUtil.writeShortBE(buf, CRLF_SHORT);
 
             headersEncodedSizeAccumulator = HEADERS_WEIGHT_NEW * padSizeForAccumulation(buf.readableBytes()) +
                     HEADERS_WEIGHT_HISTORICAL * headersEncodedSizeAccumulator;
+            state = nextState;
             success = true;
             return buf;
         } finally {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseEncoderTest.java
@@ -413,7 +413,33 @@ public class HttpResponseEncoderTest {
     }
 
     @Test
-    public void testInitHttpMessageHeaderEncodingFailureReleasesBuffer() throws Exception {
+    public void testInitHttpMessageHeaderSanitizationFailureDoesNotCorruptState() {
+        final EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseEncoder());
+        final DefaultHttpResponse invalidResponse = new DefaultHttpResponse(
+                HttpVersion.HTTP_1_1, HttpResponseStatus.NO_CONTENT, new ReadOnlyHttpHeaders(false));
+
+        EncoderException e = assertThrows(EncoderException.class, new Executable() {
+            @Override
+            public void execute() {
+                channel.writeOutbound(invalidResponse);
+            }
+        });
+        assertInstanceOf(UnsupportedOperationException.class, e.getCause());
+
+        assertEncoderStillUsable(channel);
+        assertFalse(channel.finish());
+    }
+
+    private static void assertEncoderStillUsable(EmbeddedChannel channel) {
+        assertTrue(channel.writeOutbound(
+                new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK)));
+        ByteBuf buffer = channel.readOutbound();
+        assertEquals("HTTP/1.1 200 OK\r\n\r\n", buffer.toString(CharsetUtil.US_ASCII));
+        buffer.release();
+    }
+
+    @Test
+    public void testInitHttpMessageHeaderEncodingFailureReleasesBufferAndPreservesState() throws Exception {
         final TrackingFailingAllocator allocator = new TrackingFailingAllocator();
         final EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseEncoder());
         channel.config().setAllocator(allocator);
@@ -431,6 +457,7 @@ public class HttpResponseEncoderTest {
         assertInstanceOf(OutOfMemoryError.class, e.getCause().getCause());
 
         assertAllTrackedBuffersReleased(allocator);
+        assertEncoderStillUsable(channel);
         channel.finishAndReleaseAll();
     }
 


### PR DESCRIPTION
Motivation:

`encodeInitHttpMessage()` updated the encoder state before running header sanitization and encoding. If either step threw, the allocated buffer was released but the encoder remained in a content state even though no output had been produced. A subsequent valid response was then rejected with `unexpected message type`.

This can be reproduced without a fatal error by encoding a `204 No Content` response backed by `ReadOnlyHttpHeaders`. Sanitization fails with `UnsupportedOperationException`, and the next response fails because the encoder is still in state 3.

#17089 made the header buffer exception-safe, but its regression test ended the channel immediately after the failure and did not exercise another response.

Modification:

- Compute the next content state in a local variable.
- Commit it to the encoder only after header sanitization and encoding complete successfully.
- Add a regression test for a sanitization failure and extend the existing header encoding failure test to verify that a valid response can still be encoded afterward.

Result:

An initial-message header failure no longer leaves the encoder unusable. Successful encoding and wire output are unchanged.

Verification:

`./mvnw -pl codec-http test`

8,982 tests run, 0 failures, 0 errors, 4 skipped.
