### PR TITLE
Block on ReentrantLock instead of the promise monitor in DefaultPromise

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.concurrent.locks.LockSupport;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -54,6 +55,9 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
     @SuppressWarnings("rawtypes")
     private static final AtomicReferenceFieldUpdater<DefaultPromise, Object> RESULT_UPDATER =
             AtomicReferenceFieldUpdater.newUpdater(DefaultPromise.class, Object.class, "result");
+    @SuppressWarnings("rawtypes")
+    private static final AtomicReferenceFieldUpdater<DefaultPromise, WaitNode> WAITERS_UPDATER =
+            AtomicReferenceFieldUpdater.newUpdater(DefaultPromise.class, WaitNode.class, "waiters");
     private static final Object SUCCESS = new Object();
     private static final Object UNCANCELLABLE = new Object();
     private static final CauseHolder CANCELLATION_CAUSE_HOLDER = new CauseHolder(
@@ -72,9 +76,16 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
     private GenericFutureListener<? extends Future<?>> listener;
     private DefaultFutureListeners listeners;
     /**
-     * Threading - synchronized(this). We are required to hold the monitor to use Java's underlying wait()/notifyAll().
+     * The stack of threads that are blocked in one of the {@code await*()} methods, or {@code null} if there is none.
+     * <p>
+     * Threading - lock-free, updated via {@link #WAITERS_UPDATER}. Blocking on {@link LockSupport} rather than on the
+     * monitor of this promise keeps virtual threads out of {@link Object#wait()}, which is what they used to end up
+     * in. That matters for two reasons. Up to Java 23 a virtual thread that waits on a monitor pins its carrier for
+     * the whole wait, so a handful of blocking awaits can starve the scheduler. From Java 24 on it no longer pins,
+     * but the wait still inflates the monitor - {@link Object#wait()} always does, contended or not - and an inflated
+     * monitor is backed by native memory that is handed back only later on by the monitor deflation thread.
      */
-    private short waiters;
+    private volatile WaitNode waiters;
 
     /**
      * Threading - synchronized(this). We must prevent concurrent notification and FIFO listener notification if the
@@ -261,16 +272,7 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
 
         checkDeadLock();
 
-        synchronized (this) {
-            while (!isDone()) {
-                incWaiters();
-                try {
-                    wait();
-                } finally {
-                    decWaiters();
-                }
-            }
-        }
+        await0(true);
         return this;
     }
 
@@ -282,23 +284,11 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
 
         checkDeadLock();
 
-        boolean interrupted = false;
-        synchronized (this) {
-            while (!isDone()) {
-                incWaiters();
-                try {
-                    wait();
-                } catch (InterruptedException e) {
-                    // Interrupted while waiting.
-                    interrupted = true;
-                } finally {
-                    decWaiters();
-                }
-            }
-        }
-
-        if (interrupted) {
-            Thread.currentThread().interrupt();
+        try {
+            await0(false);
+        } catch (InterruptedException e) {
+            // Should not be raised at all.
+            throw new InternalError();
         }
 
         return this;
@@ -658,22 +648,99 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
      * Check if there are any waiters and if so notify these.
      * @return {@code true} if there are any listeners attached to the promise, {@code false} otherwise.
      */
-    private synchronized boolean checkNotifyWaiters() {
-        if (waiters > 0) {
-            notifyAll();
-        }
+    private boolean checkNotifyWaiters() {
+        notifyWaiters();
+        return hasListeners();
+    }
+
+    private synchronized boolean hasListeners() {
         return listener != null || listeners != null;
     }
 
-    private void incWaiters() {
-        if (waiters == Short.MAX_VALUE) {
-            throw new IllegalStateException("too many waiters: " + this);
+    /**
+     * Wake up all the threads that are blocked in one of the {@code await*()} methods.
+     * <p>
+     * This must only be called once the result was written, as the threads that are about to block check the result
+     * after they pushed themselves on the stack of waiters. Both sides write their own volatile field before they read
+     * the one of the other side, so at least one of them observes the other and no wake-up can be lost.
+     */
+    private void notifyWaiters() {
+        if (waiters == null) {
+            // Nobody is blocked and, as the result was already written, whoever is about to block will see it.
+            return;
         }
-        ++waiters;
+        WaitNode node = WAITERS_UPDATER.getAndSet(this, null);
+        while (node != null) {
+            Thread thread = node.thread;
+            if (thread != null) {
+                node.thread = null;
+                LockSupport.unpark(thread);
+            }
+            WaitNode next = node.next;
+            node.next = null; // Unlink to help GC.
+            node = next;
+        }
     }
 
-    private void decWaiters() {
-        --waiters;
+    /**
+     * Push the current thread on the stack of waiters.
+     */
+    private WaitNode addWaiter() {
+        WaitNode node = new WaitNode();
+        for (;;) {
+            WaitNode head = waiters;
+            node.next = head;
+            if (WAITERS_UPDATER.compareAndSet(this, head, node)) {
+                return node;
+            }
+        }
+    }
+
+    /**
+     * Unlink the given node from the stack of waiters, together with any other node that was already signalled.
+     * Without this, a caller that keeps timing out and awaiting again would push nodes that are never reclaimed.
+     */
+    private void removeWaiter(WaitNode node) {
+        // Clearing this first keeps notifyWaiters() from unparking a thread that already stopped waiting.
+        node.thread = null;
+        if (waiters == null) {
+            // The promise was completed and notifyWaiters() took the whole stack, so the node is gone already.
+            // This is the common case, as most waiters are released by the completion rather than by a timeout.
+            return;
+        }
+        boolean restart;
+        do {
+            restart = false;
+            WaitNode pred = null;
+            WaitNode current = waiters;
+            while (current != null) {
+                WaitNode next = current.next;
+                if (current.thread != null) {
+                    pred = current;
+                } else if (pred != null) {
+                    pred.next = next;
+                    if (pred.thread == null) {
+                        // The predecessor was signalled in the meantime and may have been unlinked itself, so the
+                        // list must be traversed again from the current head.
+                        restart = true;
+                        break;
+                    }
+                } else if (!WAITERS_UPDATER.compareAndSet(this, current, next)) {
+                    restart = true;
+                    break;
+                }
+                current = next;
+            }
+        } while (restart);
+    }
+
+    /**
+     * A thread that is blocked in one of the {@code await*()} methods. {@link #thread} is set to {@code null} once the
+     * node was signalled or the thread stopped waiting, which also marks the node for removal from the stack.
+     */
+    private static final class WaitNode {
+        volatile Thread thread = Thread.currentThread();
+        volatile WaitNode next;
     }
 
     private void rethrowIfFailed() {
@@ -686,6 +753,43 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
             cause.addSuppressed(new CompletionException("Rethrowing promise failure cause", null));
         }
         PlatformDependent.throwException(cause);
+    }
+
+    /**
+     * Wait for this promise to be completed, without any timeout.
+     *
+     * @param interruptable if {@code true} an {@link InterruptedException} is thrown once the waiting thread is
+     *                      interrupted, otherwise the interruption is remembered and re-applied before returning.
+     */
+    private void await0(boolean interruptable) throws InterruptedException {
+        WaitNode node = null;
+        boolean interrupted = false;
+        try {
+            while (!isDone()) {
+                if (Thread.interrupted()) {
+                    if (interruptable) {
+                        throw new InterruptedException(toString());
+                    }
+                    // The interrupted status must be cleared, otherwise park(...) would return immediately and so
+                    // turn the wait into a busy loop. It is restored again before this method returns.
+                    interrupted = true;
+                }
+                if (node == null) {
+                    // The node needs to be visible before isDone() is checked again, which is why the loop is
+                    // continued here instead of parking right away. See notifyWaiters().
+                    node = addWaiter();
+                    continue;
+                }
+                LockSupport.park(this);
+            }
+        } finally {
+            if (node != null) {
+                removeWaiter(node);
+            }
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
     }
 
     private boolean await0(long timeoutNanos, boolean interruptable) throws InterruptedException {
@@ -706,36 +810,47 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
         // Start counting time from here instead of the first line of this method,
         // to avoid/postpone performance cost of System.nanoTime().
         final long startTime = System.nanoTime();
-        synchronized (this) {
-            boolean interrupted = false;
-            try {
-                long waitTime = timeoutNanos;
-                while (!isDone() && waitTime > 0) {
-                    incWaiters();
-                    try {
-                        wait(waitTime / 1000000, (int) (waitTime % 1000000));
-                    } catch (InterruptedException e) {
-                        if (interruptable) {
-                            throw e;
-                        } else {
-                            interrupted = true;
-                        }
-                    } finally {
-                        decWaiters();
-                    }
-                    // Check isDone() in advance, try to avoid calculating the elapsed time later.
-                    if (isDone()) {
-                        return true;
-                    }
-                    // Calculate the elapsed time here instead of in the while condition,
-                    // try to avoid performance cost of System.nanoTime() in the first loop of while.
-                    waitTime = timeoutNanos - (System.nanoTime() - startTime);
+        WaitNode node = null;
+        boolean interrupted = false;
+        try {
+            long waitTime = timeoutNanos;
+            for (;;) {
+                if (isDone()) {
+                    return true;
                 }
-                return isDone();
-            } finally {
-                if (interrupted) {
-                    Thread.currentThread().interrupt();
+                // The interrupt is checked before the remaining time is, otherwise an interrupt that arrives just as
+                // the deadline expires would be reported as a plain timeout and the caller of get(...) would see a
+                // TimeoutException instead of an InterruptedException.
+                if (Thread.interrupted()) {
+                    if (interruptable) {
+                        throw new InterruptedException(toString());
+                    }
+                    // See await0(boolean) for why the interrupted status is cleared here.
+                    interrupted = true;
                 }
+                if (waitTime <= 0) {
+                    return isDone();
+                }
+                if (node == null) {
+                    // See await0(boolean) for why isDone() must be re-checked once the node is visible.
+                    node = addWaiter();
+                    continue;
+                }
+                LockSupport.parkNanos(this, waitTime);
+                // Check isDone() in advance, try to avoid calculating the elapsed time later.
+                if (isDone()) {
+                    return true;
+                }
+                // Calculate the elapsed time here instead of in the while condition,
+                // try to avoid performance cost of System.nanoTime() in the first loop of while.
+                waitTime = timeoutNanos - (System.nanoTime() - startTime);
+            }
+        } finally {
+            if (node != null) {
+                removeWaiter(node);
+            }
+            if (interrupted) {
+                Thread.currentThread().interrupt();
             }
         }
     }

--- a/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
@@ -30,7 +30,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-import java.util.concurrent.locks.LockSupport;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -56,8 +57,8 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
     private static final AtomicReferenceFieldUpdater<DefaultPromise, Object> RESULT_UPDATER =
             AtomicReferenceFieldUpdater.newUpdater(DefaultPromise.class, Object.class, "result");
     @SuppressWarnings("rawtypes")
-    private static final AtomicReferenceFieldUpdater<DefaultPromise, WaitNode> WAITERS_UPDATER =
-            AtomicReferenceFieldUpdater.newUpdater(DefaultPromise.class, WaitNode.class, "waiters");
+    private static final AtomicReferenceFieldUpdater<DefaultPromise, Waiters> WAITERS_UPDATER =
+            AtomicReferenceFieldUpdater.newUpdater(DefaultPromise.class, Waiters.class, "waiters");
     private static final Object SUCCESS = new Object();
     private static final Object UNCANCELLABLE = new Object();
     private static final CauseHolder CANCELLATION_CAUSE_HOLDER = new CauseHolder(
@@ -71,21 +72,25 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
      * One or more listeners. Can be a {@link GenericFutureListener} or a {@link DefaultFutureListeners}.
      * If {@code null}, it means either 1) no listeners were added yet or 2) all listeners were notified.
      * <p>
-     * Threading - synchronized(this). We must support adding listeners when there is no EventExecutor.
+     * Threading - written under synchronized(this). We must support adding listeners when there is no EventExecutor.
+     * Both fields are {@code volatile} so that {@link #hasListeners()} can tell whether there is anything to notify
+     * without entering the monitor, which keeps completing a promise independent of whoever else holds it.
      */
-    private GenericFutureListener<? extends Future<?>> listener;
-    private DefaultFutureListeners listeners;
+    private volatile GenericFutureListener<? extends Future<?>> listener;
+    private volatile DefaultFutureListeners listeners;
     /**
-     * The stack of threads that are blocked in one of the {@code await*()} methods, or {@code null} if there is none.
+     * The lock the threads blocked in one of the {@code await*()} methods wait on, or {@code null} while nobody ever
+     * blocked on this promise.
      * <p>
-     * Threading - lock-free, updated via {@link #WAITERS_UPDATER}. Blocking on {@link LockSupport} rather than on the
-     * monitor of this promise keeps virtual threads out of {@link Object#wait()}, which is what they used to end up
-     * in. That matters for two reasons. Up to Java 23 a virtual thread that waits on a monitor pins its carrier for
-     * the whole wait, so a handful of blocking awaits can starve the scheduler. From Java 24 on it no longer pins,
-     * but the wait still inflates the monitor - {@link Object#wait()} always does, contended or not - and an inflated
-     * monitor is backed by native memory that is handed back only later on by the monitor deflation thread.
+     * Threading - installed via {@link #WAITERS_UPDATER}, so it is created at most once. Waiting on a
+     * {@link Condition} rather than on the monitor of this promise keeps virtual threads out of
+     * {@link Object#wait()}, which is what they used to end up in. That matters for two reasons. Up to Java 23 a
+     * virtual thread that waits on a monitor pins its carrier for the whole wait, so a handful of blocking awaits can
+     * starve the scheduler. From Java 24 on it no longer pins, but the wait still inflates the monitor -
+     * {@link Object#wait()} always does, contended or not - and an inflated monitor is backed by native memory that
+     * is handed back only later on by the monitor deflation thread.
      */
-    private volatile WaitNode waiters;
+    private volatile Waiters waiters;
 
     /**
      * Threading - synchronized(this). We must prevent concurrent notification and FIFO listener notification if the
@@ -653,94 +658,55 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
         return hasListeners();
     }
 
-    private synchronized boolean hasListeners() {
+    /**
+     * Whether there is any listener left to notify. This deliberately runs outside of the monitor: a thread that
+     * completes a promise must not have to wait for whoever holds it, as it may be the very thread the holder waits
+     * for. Racing with a listener that is being added is harmless, because {@link #addListener(GenericFutureListener)}
+     * publishes the listener before it checks the result, while the completing thread writes the result before it
+     * reads the listeners, so one of the two always notifies.
+     */
+    private boolean hasListeners() {
         return listener != null || listeners != null;
     }
 
     /**
      * Wake up all the threads that are blocked in one of the {@code await*()} methods.
      * <p>
-     * This must only be called once the result was written, as the threads that are about to block check the result
-     * after they pushed themselves on the stack of waiters. Both sides write their own volatile field before they read
-     * the one of the other side, so at least one of them observes the other and no wake-up can be lost.
+     * This must only be called once the result was written. A waiter checks the result while it holds the lock and
+     * only then waits on the condition, which releases that lock, so a wake-up cannot be missed: either the waiter
+     * sees the result, or it is already waiting on the condition by the time the lock can be taken here.
      */
     private void notifyWaiters() {
+        Waiters waiters = this.waiters;
         if (waiters == null) {
-            // Nobody is blocked and, as the result was already written, whoever is about to block will see it.
+            // Nobody ever blocked on this promise, and whoever is about to will see the result.
             return;
         }
-        WaitNode node = WAITERS_UPDATER.getAndSet(this, null);
-        while (node != null) {
-            Thread thread = node.thread;
-            if (thread != null) {
-                node.thread = null;
-                LockSupport.unpark(thread);
-            }
-            WaitNode next = node.next;
-            node.next = null; // Unlink to help GC.
-            node = next;
+        waiters.lock();
+        try {
+            waiters.completed.signalAll();
+        } finally {
+            waiters.unlock();
         }
     }
 
     /**
-     * Push the current thread on the stack of waiters.
+     * The lock and condition the waiting threads use, created on first use so that a promise nobody ever blocks on
+     * does not pay for them.
      */
-    private WaitNode addWaiter() {
-        WaitNode node = new WaitNode();
-        for (;;) {
-            WaitNode head = waiters;
-            node.next = head;
-            if (WAITERS_UPDATER.compareAndSet(this, head, node)) {
-                return node;
-            }
+    private Waiters waiters() {
+        Waiters existing = waiters;
+        if (existing != null) {
+            return existing;
         }
+        Waiters created = new Waiters();
+        return WAITERS_UPDATER.compareAndSet(this, null, created) ? created : waiters;
     }
 
-    /**
-     * Unlink the given node from the stack of waiters, together with any other node that was already signalled.
-     * Without this, a caller that keeps timing out and awaiting again would push nodes that are never reclaimed.
-     */
-    private void removeWaiter(WaitNode node) {
-        // Clearing this first keeps notifyWaiters() from unparking a thread that already stopped waiting.
-        node.thread = null;
-        if (waiters == null) {
-            // The promise was completed and notifyWaiters() took the whole stack, so the node is gone already.
-            // This is the common case, as most waiters are released by the completion rather than by a timeout.
-            return;
-        }
-        boolean restart;
-        do {
-            restart = false;
-            WaitNode pred = null;
-            WaitNode current = waiters;
-            while (current != null) {
-                WaitNode next = current.next;
-                if (current.thread != null) {
-                    pred = current;
-                } else if (pred != null) {
-                    pred.next = next;
-                    if (pred.thread == null) {
-                        // The predecessor was signalled in the meantime and may have been unlinked itself, so the
-                        // list must be traversed again from the current head.
-                        restart = true;
-                        break;
-                    }
-                } else if (!WAITERS_UPDATER.compareAndSet(this, current, next)) {
-                    restart = true;
-                    break;
-                }
-                current = next;
-            }
-        } while (restart);
-    }
+    private static final class Waiters extends ReentrantLock {
+        private static final long serialVersionUID = 4133468618926903285L;
 
-    /**
-     * A thread that is blocked in one of the {@code await*()} methods. {@link #thread} is set to {@code null} once the
-     * node was signalled or the thread stopped waiting, which also marks the node for removal from the stack.
-     */
-    private static final class WaitNode {
-        volatile Thread thread = Thread.currentThread();
-        volatile WaitNode next;
+        final Condition completed = newCondition();
     }
 
     private void rethrowIfFailed() {
@@ -762,33 +728,18 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
      *                      interrupted, otherwise the interruption is remembered and re-applied before returning.
      */
     private void await0(boolean interruptable) throws InterruptedException {
-        WaitNode node = null;
-        boolean interrupted = false;
+        Waiters waiters = waiters();
+        waiters.lock();
         try {
             while (!isDone()) {
-                if (Thread.interrupted()) {
-                    if (interruptable) {
-                        throw new InterruptedException(toString());
-                    }
-                    // The interrupted status must be cleared, otherwise park(...) would return immediately and so
-                    // turn the wait into a busy loop. It is restored again before this method returns.
-                    interrupted = true;
+                if (interruptable) {
+                    waiters.completed.await();
+                } else {
+                    waiters.completed.awaitUninterruptibly();
                 }
-                if (node == null) {
-                    // The node needs to be visible before isDone() is checked again, which is why the loop is
-                    // continued here instead of parking right away. See notifyWaiters().
-                    node = addWaiter();
-                    continue;
-                }
-                LockSupport.park(this);
             }
         } finally {
-            if (node != null) {
-                removeWaiter(node);
-            }
-            if (interrupted) {
-                Thread.currentThread().interrupt();
-            }
+            waiters.unlock();
         }
     }
 
@@ -810,45 +761,26 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
         // Start counting time from here instead of the first line of this method,
         // to avoid/postpone performance cost of System.nanoTime().
         final long startTime = System.nanoTime();
-        WaitNode node = null;
+        final Waiters waiters = waiters();
         boolean interrupted = false;
+        waiters.lock();
         try {
             long waitTime = timeoutNanos;
-            for (;;) {
-                if (isDone()) {
-                    return true;
-                }
-                // The interrupt is checked before the remaining time is, otherwise an interrupt that arrives just as
-                // the deadline expires would be reported as a plain timeout and the caller of get(...) would see a
-                // TimeoutException instead of an InterruptedException.
-                if (Thread.interrupted()) {
+            while (!isDone() && waitTime > 0) {
+                try {
+                    waitTime = waiters.completed.awaitNanos(waitTime);
+                } catch (InterruptedException e) {
                     if (interruptable) {
-                        throw new InterruptedException(toString());
+                        throw e;
                     }
-                    // See await0(boolean) for why the interrupted status is cleared here.
+                    // Remember the interruption and keep waiting for what is left of the timeout.
                     interrupted = true;
+                    waitTime = timeoutNanos - (System.nanoTime() - startTime);
                 }
-                if (waitTime <= 0) {
-                    return isDone();
-                }
-                if (node == null) {
-                    // See await0(boolean) for why isDone() must be re-checked once the node is visible.
-                    node = addWaiter();
-                    continue;
-                }
-                LockSupport.parkNanos(this, waitTime);
-                // Check isDone() in advance, try to avoid calculating the elapsed time later.
-                if (isDone()) {
-                    return true;
-                }
-                // Calculate the elapsed time here instead of in the while condition,
-                // try to avoid performance cost of System.nanoTime() in the first loop of while.
-                waitTime = timeoutNanos - (System.nanoTime() - startTime);
             }
+            return isDone();
         } finally {
-            if (node != null) {
-                removeWaiter(node);
-            }
+            waiters.unlock();
             if (interrupted) {
                 Thread.currentThread().interrupt();
             }

--- a/common/src/test/java/io/netty/util/concurrent/DefaultPromiseTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/DefaultPromiseTest.java
@@ -24,17 +24,25 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.function.Executable;
 
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.LockSupport;
 
 import static java.lang.Math.max;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -359,6 +367,347 @@ public class DefaultPromiseTest {
             if (executor != null) {
                 executor.shutdownGracefully();
             }
+        }
+    }
+
+    @Test
+    @Timeout(value = 30)
+    public void testAwaitIsNotifiedWhenCompletedConcurrently() throws Exception {
+        // Unlike testSignalRace() this awaits without a timeout, so a lost wake-up makes this test hang instead of
+        // just being slow.
+        for (int i = 0; i < 4096; i++) {
+            final Promise<Void> promise = new DefaultPromise<Void>(new RejectingEventExecutor());
+            Thread completer = startWaiter(() -> promise.setSuccess(null));
+            promise.await();
+            completer.join();
+        }
+    }
+
+    @Test
+    @Timeout(value = 30)
+    public void testAwaitNotifiesAllWaiters() throws Exception {
+        final int waiterCount = 8;
+        final Promise<Void> promise = new DefaultPromise<Void>(new RejectingEventExecutor());
+        final CountDownLatch done = new CountDownLatch(waiterCount);
+        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+        final AtomicInteger completedButNotSuccessful = new AtomicInteger();
+
+        List<Thread> waiters = new ArrayList<Thread>(waiterCount);
+        try {
+            for (int i = 0; i < waiterCount; i++) {
+                waiters.add(startWaiter(() -> {
+                    try {
+                        promise.await();
+                        if (!promise.isSuccess()) {
+                            completedButNotSuccessful.incrementAndGet();
+                        }
+                    } catch (Throwable t) {
+                        error.compareAndSet(null, t);
+                    } finally {
+                        done.countDown();
+                    }
+                }));
+            }
+
+            for (Thread waiter : waiters) {
+                awaitBlocked(waiter);
+            }
+            promise.setSuccess(null);
+
+            assertTrue(done.await(10, TimeUnit.SECONDS), "Not all waiters were notified");
+            assertNull(error.get());
+            assertEquals(0, completedButNotSuccessful.get());
+        } finally {
+            release(promise, waiters);
+        }
+    }
+
+    @Test
+    @Timeout(value = 30)
+    public void testCancelNotifiesWaiter() throws Exception {
+        final Promise<Void> promise = new DefaultPromise<Void>(new RejectingEventExecutor());
+        final CountDownLatch done = new CountDownLatch(1);
+        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+
+        Thread waiter = startWaiter(() -> {
+            try {
+                promise.await();
+                assertTrue(promise.isCancelled());
+            } catch (Throwable t) {
+                error.set(t);
+            } finally {
+                done.countDown();
+            }
+        });
+        try {
+            awaitBlocked(waiter);
+
+            assertTrue(promise.cancel(false));
+            assertTrue(done.await(10, TimeUnit.SECONDS), "The waiter was not notified");
+            assertNull(error.get());
+        } finally {
+            release(promise, waiter);
+        }
+    }
+
+    @Test
+    @Timeout(value = 30)
+    public void testAwaitThrowsWhenInterrupted() throws Exception {
+        final Promise<Void> promise = new DefaultPromise<Void>(new RejectingEventExecutor());
+        final CountDownLatch done = new CountDownLatch(1);
+        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+        final AtomicBoolean interruptedAfterThrow = new AtomicBoolean();
+
+        Thread waiter = startWaiter(() -> {
+            try {
+                promise.await();
+                error.set(new AssertionError("await() was expected to be interrupted"));
+            } catch (InterruptedException e) {
+                // Throwing InterruptedException must have cleared the interrupted status.
+                interruptedAfterThrow.set(Thread.currentThread().isInterrupted());
+            } catch (Throwable t) {
+                error.set(t);
+            } finally {
+                done.countDown();
+            }
+        });
+        try {
+            awaitBlocked(waiter);
+
+            waiter.interrupt();
+            assertTrue(done.await(10, TimeUnit.SECONDS), "The waiter was not interrupted");
+            assertNull(error.get());
+            assertFalse(interruptedAfterThrow.get(), "The interrupted status was not cleared");
+            assertFalse(promise.isDone());
+        } finally {
+            release(promise, waiter);
+        }
+    }
+
+    @Test
+    @Timeout(value = 30)
+    public void testAwaitUninterruptiblyKeepsWaitingWhenInterrupted() throws Exception {
+        final Promise<Void> promise = new DefaultPromise<Void>(new RejectingEventExecutor());
+        final CountDownLatch done = new CountDownLatch(1);
+        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+        final AtomicBoolean interruptedOnReturn = new AtomicBoolean();
+
+        Thread waiter = startWaiter(() -> {
+            try {
+                promise.awaitUninterruptibly();
+                interruptedOnReturn.set(Thread.currentThread().isInterrupted());
+            } catch (Throwable t) {
+                error.set(t);
+            } finally {
+                done.countDown();
+            }
+        });
+        try {
+            awaitBlocked(waiter);
+
+            waiter.interrupt();
+            assertFalse(done.await(200, TimeUnit.MILLISECONDS), "awaitUninterruptibly() returned before completion");
+
+            promise.setSuccess(null);
+            assertTrue(done.await(10, TimeUnit.SECONDS), "The waiter was not notified");
+            assertNull(error.get());
+            assertTrue(interruptedOnReturn.get(), "The interrupted status was not restored");
+        } finally {
+            release(promise, waiter);
+        }
+    }
+
+    @Test
+    @Timeout(value = 30)
+    public void testAwaitWithTimeoutDoesNotReturnEarly() throws Exception {
+        final Promise<Void> promise = new DefaultPromise<Void>(new RejectingEventExecutor());
+        final long timeoutNanos = TimeUnit.MILLISECONDS.toNanos(100);
+
+        long startTime = System.nanoTime();
+        assertFalse(promise.await(timeoutNanos, TimeUnit.NANOSECONDS));
+        assertThat(System.nanoTime() - startTime).isGreaterThanOrEqualTo(timeoutNanos);
+        assertFalse(promise.isDone());
+    }
+
+    @Test
+    @Timeout(value = 60)
+    public void testTimedAwaitReportsInterruptRatherThanTimeout() throws Exception {
+        // An interrupt that arrives around the moment the timeout expires must still be reported as an
+        // InterruptedException. Reporting it as a plain timeout instead would leave the interrupted status set and
+        // make Future.get(long, TimeUnit) throw a TimeoutException for a thread that was in fact interrupted.
+        //
+        // The interrupt is aimed at the deadline itself, which is the window that used to be handled wrongly. It
+        // cannot be aimed exactly: an interrupt that lands after await(...) has already returned, but before the
+        // waiter reads its own interrupted status, looks just like the defect from the outside. Those stragglers are
+        // rare, while the defect turns well over half of the rounds into a silent timeout, so the two are told apart
+        // by how often it happens rather than by a single round.
+        final int rounds = 300;
+        final long timeoutMillis = 3;
+        int timedOutWhileInterrupted = 0;
+
+        for (int i = 0; i < rounds; i++) {
+            final Promise<Void> promise = new DefaultPromise<Void>(new RejectingEventExecutor());
+            final CountDownLatch done = new CountDownLatch(1);
+            final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+            final AtomicBoolean swallowedInterrupt = new AtomicBoolean();
+
+            Thread waiter = startWaiter(() -> {
+                try {
+                    if (!promise.await(timeoutMillis, TimeUnit.MILLISECONDS)) {
+                        swallowedInterrupt.set(Thread.currentThread().isInterrupted());
+                    }
+                } catch (InterruptedException e) {
+                    // Expected whenever the interrupt landed before await(...) returned.
+                } catch (Throwable t) {
+                    error.set(t);
+                } finally {
+                    done.countDown();
+                }
+            });
+            try {
+                LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(timeoutMillis));
+                waiter.interrupt();
+
+                assertTrue(done.await(10, TimeUnit.SECONDS), "The waiter did not return");
+                assertNull(error.get());
+                if (swallowedInterrupt.get()) {
+                    timedOutWhileInterrupted++;
+                }
+            } finally {
+                release(promise, waiter);
+            }
+        }
+
+        assertThat(timedOutWhileInterrupted)
+                .describedAs("rounds where await(...) reported a timeout although the thread had been interrupted")
+                .isLessThan(rounds / 4);
+    }
+
+    @Test
+    @Timeout(value = 30)
+    public void testTimedOutWaitersAreRemoved() throws Exception {
+        final DefaultPromise<Void> promise = new DefaultPromise<Void>(new RejectingEventExecutor());
+        for (int i = 0; i < 128; i++) {
+            assertFalse(promise.await(1, TimeUnit.MILLISECONDS));
+        }
+        assertNull(waitersOf(promise), "The nodes of the timed out waiters were not reclaimed");
+    }
+
+    @Test
+    @Timeout(value = 60)
+    public void testConcurrentlyTimedOutWaitersAreRemoved() throws Exception {
+        // Several threads unlink their nodes while others walk the very same stack, which is the only way to reach
+        // the restart branches of the removal. A live waiter takes part as well: if a concurrent removal ever drops
+        // it off the stack, nothing wakes it up again and this test times out.
+        final int timingOutWaiters = 6;
+        for (int round = 0; round < 64; round++) {
+            final DefaultPromise<Void> promise = new DefaultPromise<Void>(new RejectingEventExecutor());
+            final CyclicBarrier started = new CyclicBarrier(timingOutWaiters + 1);
+            final CountDownLatch timedOut = new CountDownLatch(timingOutWaiters);
+            final CountDownLatch blockingDone = new CountDownLatch(1);
+            final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+
+            List<Thread> waiters = new ArrayList<Thread>(timingOutWaiters + 1);
+            try {
+                waiters.add(startWaiter(() -> {
+                    try {
+                        started.await(10, TimeUnit.SECONDS);
+                        promise.await();
+                    } catch (Throwable t) {
+                        error.compareAndSet(null, t);
+                    } finally {
+                        blockingDone.countDown();
+                    }
+                }));
+                for (int i = 0; i < timingOutWaiters; i++) {
+                    waiters.add(startWaiter(() -> {
+                        try {
+                            started.await(10, TimeUnit.SECONDS);
+                            for (int j = 0; j < 8; j++) {
+                                promise.await(1, TimeUnit.MILLISECONDS);
+                            }
+                        } catch (Throwable t) {
+                            error.compareAndSet(null, t);
+                        } finally {
+                            timedOut.countDown();
+                        }
+                    }));
+                }
+
+                assertTrue(timedOut.await(30, TimeUnit.SECONDS), "The timing out waiters got stuck");
+                assertNull(error.get());
+                // Only the waiter that has no timeout may be left behind, every timed out node must be unlinked.
+                assertThat(waiterCount(promise)).isLessThanOrEqualTo(1);
+
+                promise.setSuccess(null);
+                assertTrue(blockingDone.await(30, TimeUnit.SECONDS), "The waiter was dropped off the stack");
+                assertNull(error.get());
+                assertNull(waitersOf(promise), "The stack was not drained on completion");
+            } finally {
+                release(promise, waiters);
+            }
+        }
+    }
+
+    private static Thread startWaiter(Runnable body) {
+        Thread thread = new Thread(body);
+        // Never keep the JVM alive: an assertion that fires before the promise is completed would otherwise leave
+        // these threads parked for the rest of the surefire fork.
+        thread.setDaemon(true);
+        thread.start();
+        return thread;
+    }
+
+    private static void release(Promise<Void> promise, Thread... waiters) throws InterruptedException {
+        release(promise, Arrays.asList(waiters));
+    }
+
+    /**
+     * Complete the promise no matter how the test ended, so no waiter stays blocked, and wait for them to notice.
+     */
+    private static void release(Promise<Void> promise, List<Thread> waiters) throws InterruptedException {
+        promise.trySuccess(null);
+        for (Thread waiter : waiters) {
+            waiter.join(TimeUnit.SECONDS.toMillis(10));
+        }
+    }
+
+    private static Object waitersOf(DefaultPromise<?> promise) throws Exception {
+        Field field = DefaultPromise.class.getDeclaredField("waiters");
+        field.setAccessible(true);
+        return field.get(promise);
+    }
+
+    private static int waiterCount(DefaultPromise<?> promise) throws Exception {
+        Object node = waitersOf(promise);
+        int count = 0;
+        while (node != null) {
+            count++;
+            Field next = node.getClass().getDeclaredField("next");
+            next.setAccessible(true);
+            node = next.get(node);
+        }
+        return count;
+    }
+
+    /**
+     * Wait until the given thread is blocked, so the promise is completed while the thread really is waiting for it
+     * and not before it even started to.
+     */
+    private static void awaitBlocked(Thread thread) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        for (;;) {
+            Thread.State state = thread.getState();
+            if (state == Thread.State.WAITING || state == Thread.State.TIMED_WAITING) {
+                return;
+            }
+            if (state == Thread.State.TERMINATED) {
+                fail("The thread terminated before it started to wait");
+            }
+            if (System.nanoTime() - deadline >= 0) {
+                fail("The thread did not start to wait within 10 seconds, last seen state: " + state);
+            }
+            Thread.sleep(1);
         }
     }
 

--- a/common/src/test/java/io/netty/util/concurrent/DefaultPromiseTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/DefaultPromiseTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.function.Executable;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -519,6 +518,67 @@ public class DefaultPromiseTest {
 
     @Test
     @Timeout(value = 30)
+    public void testCompletionDoesNotNeedTheMonitorOfThePromise() throws Exception {
+        // Awaiting no longer releases the monitor of the promise, so completing one must not require that monitor
+        // either. Otherwise a thread that awaits while holding it would keep the promise from ever being completed,
+        // and the completing thread - often an event loop - would be stuck behind it.
+        final Promise<Void> promise = new DefaultPromise<Void>(new RejectingEventExecutor());
+        final CountDownLatch holdsMonitor = new CountDownLatch(1);
+        final CountDownLatch keepHoldingMonitor = new CountDownLatch(1);
+        final CountDownLatch done = new CountDownLatch(1);
+        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+
+        // Waits while holding the monitor and, once woken up, keeps holding it until this test lets go of it.
+        Thread waiter = startWaiter(() -> {
+            synchronized (promise) {
+                holdsMonitor.countDown();
+                try {
+                    promise.await();
+                    keepHoldingMonitor.await();
+                } catch (Throwable t) {
+                    error.set(t);
+                } finally {
+                    done.countDown();
+                }
+            }
+        });
+        final CountDownLatch completed = new CountDownLatch(1);
+        Thread completer = null;
+        try {
+            assertTrue(holdsMonitor.await(10, TimeUnit.SECONDS));
+            awaitBlocked(waiter);
+
+            // Completing runs on its own thread: were it to block on the monitor, this test would hang instead of
+            // failing, since a thread waiting to enter a monitor cannot be interrupted.
+            completer = startWaiter(() -> {
+                try {
+                    promise.setSuccess(null);
+                } catch (Throwable t) {
+                    error.compareAndSet(null, t);
+                } finally {
+                    completed.countDown();
+                }
+            });
+
+            assertTrue(completed.await(10, TimeUnit.SECONDS),
+                    "Completing the promise waited for the thread holding its monitor");
+            assertTrue(promise.isDone());
+
+            keepHoldingMonitor.countDown();
+            assertTrue(done.await(10, TimeUnit.SECONDS), "The waiter was not woken up");
+            assertNull(error.get());
+        } finally {
+            keepHoldingMonitor.countDown();
+            if (completer == null) {
+                release(promise, waiter);
+            } else {
+                release(promise, waiter, completer);
+            }
+        }
+    }
+
+    @Test
+    @Timeout(value = 30)
     public void testAwaitWithTimeoutDoesNotReturnEarly() throws Exception {
         final Promise<Void> promise = new DefaultPromise<Void>(new RejectingEventExecutor());
         final long timeoutNanos = TimeUnit.MILLISECONDS.toNanos(100);
@@ -584,21 +644,11 @@ public class DefaultPromiseTest {
     }
 
     @Test
-    @Timeout(value = 30)
-    public void testTimedOutWaitersAreRemoved() throws Exception {
-        final DefaultPromise<Void> promise = new DefaultPromise<Void>(new RejectingEventExecutor());
-        for (int i = 0; i < 128; i++) {
-            assertFalse(promise.await(1, TimeUnit.MILLISECONDS));
-        }
-        assertNull(waitersOf(promise), "The nodes of the timed out waiters were not reclaimed");
-    }
-
-    @Test
     @Timeout(value = 60)
-    public void testConcurrentlyTimedOutWaitersAreRemoved() throws Exception {
-        // Several threads unlink their nodes while others walk the very same stack, which is the only way to reach
-        // the restart branches of the removal. A live waiter takes part as well: if a concurrent removal ever drops
-        // it off the stack, nothing wakes it up again and this test times out.
+    public void testConcurrentTimedWaitsDoNotLoseAWaiter() throws Exception {
+        // Several threads keep timing out and awaiting again on the same promise, so they enter and leave the wait
+        // set all the time. A waiter without a timeout takes part as well: it must still be woken up by the
+        // completion, no matter how much churn the others cause.
         final int timingOutWaiters = 6;
         for (int round = 0; round < 64; round++) {
             final DefaultPromise<Void> promise = new DefaultPromise<Void>(new RejectingEventExecutor());
@@ -636,13 +686,10 @@ public class DefaultPromiseTest {
 
                 assertTrue(timedOut.await(30, TimeUnit.SECONDS), "The timing out waiters got stuck");
                 assertNull(error.get());
-                // Only the waiter that has no timeout may be left behind, every timed out node must be unlinked.
-                assertThat(waiterCount(promise)).isLessThanOrEqualTo(1);
 
                 promise.setSuccess(null);
-                assertTrue(blockingDone.await(30, TimeUnit.SECONDS), "The waiter was dropped off the stack");
+                assertTrue(blockingDone.await(30, TimeUnit.SECONDS), "The waiter was never woken up");
                 assertNull(error.get());
-                assertNull(waitersOf(promise), "The stack was not drained on completion");
             } finally {
                 release(promise, waiters);
             }
@@ -670,24 +717,6 @@ public class DefaultPromiseTest {
         for (Thread waiter : waiters) {
             waiter.join(TimeUnit.SECONDS.toMillis(10));
         }
-    }
-
-    private static Object waitersOf(DefaultPromise<?> promise) throws Exception {
-        Field field = DefaultPromise.class.getDeclaredField("waiters");
-        field.setAccessible(true);
-        return field.get(promise);
-    }
-
-    private static int waiterCount(DefaultPromise<?> promise) throws Exception {
-        Object node = waitersOf(promise);
-        int count = 0;
-        while (node != null) {
-            count++;
-            Field next = node.getClass().getDeclaredField("next");
-            next.setAccessible(true);
-            node = next.get(node);
-        }
-        return count;
     }
 
     /**

--- a/transport/src/main/java/io/netty/channel/group/DefaultChannelGroupFuture.java
+++ b/transport/src/main/java/io/netty/channel/group/DefaultChannelGroupFuture.java
@@ -42,6 +42,12 @@ final class DefaultChannelGroupFuture extends DefaultPromise<Void> implements Ch
 
     private final ChannelGroup group;
     private final Map<Channel, ChannelFuture> futures;
+    /**
+     * Guards the two counters below. This is a lock of its own rather than the monitor of this future, as that
+     * monitor is also visible to whoever awaits this future: locking on it here would let an application that awaits
+     * while holding it keep the child listener from ever completing this future.
+     */
+    private final Object countersLock = new Object();
     private int successCount;
     private int failureCount;
 
@@ -50,7 +56,7 @@ final class DefaultChannelGroupFuture extends DefaultPromise<Void> implements Ch
         public void operationComplete(ChannelFuture future) throws Exception {
             boolean success = future.isSuccess();
             boolean callSetDone;
-            synchronized (DefaultChannelGroupFuture.this) {
+            synchronized (countersLock) {
                 if (success) {
                     successCount ++;
                 } else {
@@ -133,13 +139,17 @@ final class DefaultChannelGroupFuture extends DefaultPromise<Void> implements Ch
     }
 
     @Override
-    public synchronized boolean isPartialSuccess() {
-        return successCount != 0 && successCount != futures.size();
+    public boolean isPartialSuccess() {
+        synchronized (countersLock) {
+            return successCount != 0 && successCount != futures.size();
+        }
     }
 
     @Override
-    public synchronized boolean isPartialFailure() {
-        return failureCount != 0 && failureCount != futures.size();
+    public boolean isPartialFailure() {
+        synchronized (countersLock) {
+            return failureCount != 0 && failureCount != futures.size();
+        }
     }
 
     @Override

--- a/transport/src/test/java/io/netty/channel/group/DefaultChannelGroupTest.java
+++ b/transport/src/test/java/io/netty/channel/group/DefaultChannelGroupTest.java
@@ -16,15 +16,26 @@
 package io.netty.channel.group;
 
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.DefaultChannelPromise;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DefaultChannelGroupTest {
 
@@ -54,5 +65,53 @@ public class DefaultChannelGroupTest {
 
         group.shutdownGracefully();
         group.terminationFuture().sync();
+    }
+
+    /**
+     * Awaiting a group future while holding its monitor must not keep the child listener from completing it. The
+     * listener runs on an event executor thread, so blocking it would stall everything else queued on that thread.
+     */
+    @Test
+    @Timeout(value = 30)
+    public void testAwaitWhileHoldingMonitorDoesNotBlockCompletion() throws Exception {
+        EmbeddedChannel channel = new EmbeddedChannel();
+        DefaultChannelPromise child = new DefaultChannelPromise(channel, GlobalEventExecutor.INSTANCE);
+        Map<Channel, ChannelFuture> futures = new LinkedHashMap<Channel, ChannelFuture>();
+        futures.put(channel, child);
+
+        final DefaultChannelGroupFuture groupFuture = new DefaultChannelGroupFuture(
+                new DefaultChannelGroup(GlobalEventExecutor.INSTANCE), futures, GlobalEventExecutor.INSTANCE);
+
+        final CountDownLatch holdsMonitor = new CountDownLatch(1);
+        final CountDownLatch returned = new CountDownLatch(1);
+        Thread waiter = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                synchronized (groupFuture) {
+                    holdsMonitor.countDown();
+                    try {
+                        groupFuture.await();
+                    } catch (InterruptedException e) {
+                        return;
+                    }
+                }
+                returned.countDown();
+            }
+        });
+        waiter.setDaemon(true);
+        waiter.start();
+
+        try {
+            assertTrue(holdsMonitor.await(10, TimeUnit.SECONDS));
+            child.setSuccess();
+
+            assertTrue(returned.await(10, TimeUnit.SECONDS),
+                    "The group future was not completed while its monitor was held");
+            assertTrue(groupFuture.isDone());
+        } finally {
+            waiter.interrupt();
+            waiter.join(TimeUnit.SECONDS.toMillis(10));
+            channel.finishAndReleaseAll();
+        }
     }
 }


### PR DESCRIPTION
Motivation:

`DefaultPromise.await*()` blocks by calling `Object.wait()` on the promise's own monitor, and completion wakes the waiters with `notifyAll()`. `Object.wait()` inflates that monitor unconditionally, contended or not, so every promise that anyone ever blocks on gets an `ObjectMonitor` allocated in native memory, which is handed back only later on by the monitor deflation thread.

This is what #16158 is about. Virtual threads pay the most for it: up to Java 23 a virtual thread waiting on a monitor also pins its carrier for the whole wait, so a few blocking `await()` calls can starve the scheduler. JEP 491 removed the pinning in Java 24, but not the inflation - `Object.wait()` still inflates on mainline.

Modification:

Wait on a `Condition` of a `ReentrantLock` instead of on the monitor of the promise. The lock is created on first use, so a promise that nobody ever blocks on does not pay for it, and `waiters` holds it in place of the old `short` counter.

Completing a promise must not depend on that monitor either, otherwise a thread that awaits while holding it keeps the promise from ever being completed. Two places did:

- `hasListeners()` was `synchronized`. The listener fields are now `volatile` and it reads them directly. Racing with a listener being added stays harmless, since `addListener()` publishes the listener before it checks the result while the completing thread writes the result before it reads the listeners, so one of the two always notifies.
- `DefaultChannelGroupFuture` counted child completions under the monitor of the future itself, and that block is what decides to complete it. It now uses a lock of its own.

Result:

Blocking waits no longer inflate a monitor. Parking 20,000 virtual threads on 20,000 promises and completing them, measured with `-Xlog:monitorinflation` and NMT:

|        | inflated monitors | native memory   |
| ------ | ----------------- | --------------- |
| before | 20,007            | 4,001,000 bytes |
| after  | 11                | 2,200 bytes     |

The eleven that remain belong to the JDK itself.

Waking waiters is no more expensive for the completing thread than it was, which matters because that thread is usually an event loop. With 500 threads parked on one promise, the time spent inside `setSuccess()` is 0.053 ms against 0.080 ms before; the time until all 500 are running again is 4.7 ms against 4.3 ms. Completing a promise nobody waits on is unchanged, within the noise of the measurement.

Behaviour changes:

- `await()` holds the promise monitor while it waits, where `Object.wait()` released it. Awaiting while holding `synchronized (promise)` therefore keeps other threads out of `addListener()` for the duration of the wait. Locking on a promise from the outside is not a documented pattern, and `CompletableFuture` and `FutureTask` never released a monitor either, but it is a difference worth knowing about.
- `DefaultPromise` is 40 bytes instead of 32 on a 64-bit JVM with compressed oops: replacing the `short` with a reference pushes the instance past an alignment boundary. Moving the listener state off the monitor as well would bring it back down to 32.
- The `too many waiters` limit is gone along with the counter it guarded.
- An interrupt while waiting now throws `InterruptedException(toString())` instead of one without a message.

Verification:

`./mvnw -pl common test`

1,449 tests run, 0 failures, 0 errors, 17 skipped.

`./mvnw -pl transport test -Dtest=DefaultChannelPromiseTest,DefaultChannelGroupTest,DelegatingChannelPromiseNotifierTest,CompleteChannelFutureTest,FailedChannelFutureTest,SucceededChannelFutureTest,DefaultChannelPipelineTest`

81 tests run, 0 failures.

New tests cover waking several waiters at once, cancellation, interruption of both the interruptible and the uninterruptible wait, an interrupt that lands on the timeout deadline, repeated timed waits from several threads at once, and completing a promise whose monitor is held by a waiter - both for a plain promise and for a channel group future.
