### PR TITLE
HTTP/2: Drain queued frames stranded by a writability change during flush

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -80,6 +80,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
     private BaseDecoder byteDecoder;
     private long gracefulShutdownTimeoutMillis;
     private boolean inFlush;
+    private boolean flushAgain;
 
     protected Http2ConnectionHandler(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder,
                                      Http2Settings initialSettings) {
@@ -190,17 +191,40 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
 
     @Override
     public void flush(ChannelHandlerContext ctx) {
+        if (inFlush) {
+            // Reentrant flush (e.g. from a synchronous writability change) must not recurse — that livelocks
+            // (#17256); the in-progress flush loop picks it up.
+            flushAgain = true;
+            return;
+        }
         inFlush = true;
         try {
-            // Trigger pending writes in the remote flow controller.
-            encoder.flowController().writePendingBytes();
-            ctx.flush();
+            do {
+                flushAgain = false;
+                // Trigger pending writes in the remote flow controller.
+                encoder.flowController().writePendingBytes();
+                ctx.flush();
+                // Honor any flush re-requested while we were flushing (a resumed write, or a direct flush from
+                // elsewhere in the pipeline) regardless of writability — flushing already-written data doesn't
+                // need a writable channel.
+            } while (flushAgain);
         } catch (Http2Exception e) {
             onError(ctx, true, e);
         } catch (Throwable cause) {
             onError(ctx, true, connectionError(INTERNAL_ERROR, cause, "Error flushing"));
         } finally {
             inFlush = false;
+        }
+    }
+
+    private boolean hasPendingData() {
+        final Http2RemoteFlowController flowController = encoder.flowController();
+        try {
+            // Stop at the first stream that still has a flow-controlled frame queued. Frame-based, so it counts
+            // zero-length frames (e.g. trailing headers) that carry no flow-control bytes.
+            return connection().forEachActiveStream(stream -> !flowController.hasFlowControlled(stream)) != null;
+        } catch (Http2Exception e) {
+            return false;
         }
     }
 
@@ -460,10 +484,11 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
 
     @Override
     public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
-        // Writability is expected to change while we are writing. We cannot allow this event to trigger reentering
-        // the allocation and write loop. Reentering the event loop will lead to over or illegal allocation.
         try {
-            if (ctx.channel().isWritable() && !inFlush) {
+            // Only flush on a writability change if the flow controller has frames queued. A toggle with
+            // nothing to write (e.g. SslHandler during setup) must not flush, or the flush -> writability ->
+            // flush cycle livelocks (#17256).
+            if (ctx.channel().isWritable() && hasPendingData()) {
                 flush(ctx);
             }
             encoder.flowController().channelWritabilityChanged();

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -26,6 +26,8 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.DefaultChannelPromise;
+import io.netty.channel.WriteBufferWaterMark;
+import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http2.Http2CodecUtil.SimpleChannelPromiseAggregator;
 import io.netty.handler.codec.http2.Http2Exception.ShutdownHint;
@@ -47,6 +49,7 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -361,6 +364,48 @@ public class Http2ConnectionHandlerTest {
         verify(remoteFlow).writePendingBytes();
         verify(ctx).flush();
         verify(remoteFlow).channelWritabilityChanged();
+    }
+
+    /**
+     * A large body must fully drain even when the channel briefly becomes unwritable while it is being written
+     * and then flips back to writable synchronously during {@code flush()}. That writable transition re-enters
+     * {@link Http2ConnectionHandler#channelWritabilityChanged(ChannelHandlerContext)} while the flush is still in
+     * progress; the handler must not recurse (which livelocks), but it must still write the frames that were
+     * queued in the remote flow controller. Dropping the reentrant flush strands the tail of the body forever.
+     */
+    @Test
+    public void largeWriteDrainsFullyWhenWritabilityTogglesDuringFlush() throws Exception {
+        // Small watermarks so writing ~1 KiB flips the channel unwritable, and EmbeddedChannel draining the
+        // outbound buffer during flush() flips it back to writable synchronously (ChannelOutboundBuffer.remove
+        // fires the event inline), re-entering flush().
+        EmbeddedChannel channel = new EmbeddedChannel();
+        channel.config().setWriteBufferWaterMark(new WriteBufferWaterMark(512, 1024));
+
+        Http2ConnectionHandler handler = new Http2ConnectionHandlerBuilder()
+                .server(false)
+                .frameListener(new Http2FrameAdapter())
+                .validateHeaders(false)
+                .gracefulShutdownTimeoutMillis(0)
+                .build();
+
+        channel.connect(new InetSocketAddress(0));
+        channel.pipeline().addLast(handler);
+        channel.pipeline().fireChannelActive();
+        // Discard the connection preface + SETTINGS the handler wrote on activation.
+        channel.releaseOutbound();
+
+        ChannelHandlerContext ctx = channel.pipeline().context(handler);
+        handler.encoder().writeHeaders(ctx, 3, new DefaultHttp2Headers(), 0, false, ctx.newPromise());
+
+        // Larger than the write high-watermark but within the default 65535-byte flow-control window, so only
+        // channel writability (not flow control) gates the write.
+        final int size = 60 * 1024;
+        ByteBuf data = Unpooled.buffer(size).writeZero(size);
+        ChannelPromise dataPromise = ctx.newPromise();
+        handler.encoder().writeData(ctx, 3, data, 0, false, dataPromise);
+        handler.flush(ctx);
+        assertTrue(dataPromise.isSuccess());
+        channel.finishAndReleaseAll();
     }
 
     @Test


### PR DESCRIPTION
Motivation:

The `inFlush` guard added in #17266 (fixing livelock #17256) drops a flush that
re-enters via a synchronous writability change. But when writePendingBytes()
leaves frames queued and the following ctx.flush() drains the transport and
flips the channel writable mid-flush, that dropped flush was the only signal to
write the rest — so large writes (e.g. a multi-MiB gRPC body) hang.

Modification:

- Gate the writability-driven flush: channelWritabilityChanged only flushes when
  the remote flow controller still has frames queued, so a writability toggle
  with nothing to write (e.g. SslHandler during setup) can't drive the
  flush -> writability -> flush livelock (#17256).
- flush() re-runs while a flush was requested reentrantly while it was running,
  honoring it regardless of writability; the inFlush guard turns that reentrancy
  into iteration rather than recursion.

Result:

Large HTTP/2 writes no longer stall on a mid-flush writability flip, and #17256
stays fixed.