### PR TITLE
Port to 4.1: Add clock skew tolerance to OcspServerCertificateValidator 

### DIFF
--- a/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspServerCertificateValidator.java
+++ b/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspServerCertificateValidator.java
@@ -37,7 +37,6 @@ import org.bouncycastle.cert.ocsp.SingleResp;
 import java.net.SocketAddress;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
-import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -190,13 +189,13 @@ public class OcspServerCertificateValidator extends ByteToMessageDecoder impleme
 
                                 Date thisUpdateDate = response.getThisUpdate();
                                 Date nextUpdateDate = response.getNextUpdate();
-                                Instant thisUpdate = thisUpdateDate == null ? null :
-                                    thisUpdateDate.toInstant().minusMillis(CLOCK_SKEW_TOLERANCE_MILLIS);
-                                Instant nextUpdate = nextUpdateDate == null ? null :
-                                    nextUpdateDate.toInstant().plusMillis(CLOCK_SKEW_TOLERANCE_MILLIS);
-                                Instant now = Instant.now();
-                                if (thisUpdate == null || !now.isAfter(thisUpdate) ||
-                                    (nextUpdate != null && !now.isBefore(nextUpdate))) {
+                                Date thisUpdate = thisUpdateDate == null ? null :
+                                    new Date(thisUpdateDate.getTime() - CLOCK_SKEW_TOLERANCE_MILLIS);
+                                Date nextUpdate = nextUpdateDate == null ? null :
+                                    new Date(nextUpdateDate.getTime() + CLOCK_SKEW_TOLERANCE_MILLIS);
+                                Date now = new Date();
+                                if (thisUpdate == null || !now.after(thisUpdate) ||
+                                    (nextUpdate != null && !now.before(nextUpdate))) {
                                     ctx.fireExceptionCaught(new IllegalStateException("OCSP Response is out-of-date"));
                                     return;
                                 }

--- a/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspServerCertificateValidator.java
+++ b/handler-ssl-ocsp/src/main/java/io/netty/handler/ssl/ocsp/OcspServerCertificateValidator.java
@@ -28,6 +28,7 @@ import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.SystemPropertyUtil;
 import org.bouncycastle.cert.ocsp.BasicOCSPResp;
 import org.bouncycastle.cert.ocsp.OCSPException;
 import org.bouncycastle.cert.ocsp.RevokedStatus;
@@ -36,8 +37,10 @@ import org.bouncycastle.cert.ocsp.SingleResp;
 import java.net.SocketAddress;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
+import java.time.Instant;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
@@ -52,6 +55,23 @@ public class OcspServerCertificateValidator extends ByteToMessageDecoder impleme
      */
     public static final AttributeKey<Boolean> OCSP_PIPELINE_ATTRIBUTE =
             AttributeKey.newInstance("io.netty.handler.ssl.ocsp.pipeline");
+
+    /**
+     * Tolerate some clock skew in the OCSP validity time. Default to 15 minutes, which is the same as the JDK.
+     */
+    private static final long CLOCK_SKEW_TOLERANCE_MILLIS = getClockSkewTolerance();
+
+    private static long getClockSkewTolerance() {
+        long defaultToleranceSeconds = TimeUnit.MINUTES.toSeconds(15);
+        long maxToleranceSeconds = TimeUnit.DAYS.toSeconds(2);
+        long configuredToleranceSeconds = SystemPropertyUtil.getLong("io.netty.handler.ssl.ocsp.clockSkew",
+            SystemPropertyUtil.getLong("com.sun.security.ocsp.clockSkew", defaultToleranceSeconds));
+        if (configuredToleranceSeconds < 0 || configuredToleranceSeconds > maxToleranceSeconds) {
+            // Ignore negative and extremely large values.
+            configuredToleranceSeconds = defaultToleranceSeconds;
+        }
+        return TimeUnit.SECONDS.toMillis(configuredToleranceSeconds);
+    }
 
     private final boolean closeAndThrowIfNotValid;
     private final boolean validateNonce;
@@ -168,11 +188,15 @@ public class OcspServerCertificateValidator extends ByteToMessageDecoder impleme
                             if (future.isSuccess()) {
                                 SingleResp response = future.getNow().getResponses()[0];
 
-                                Date current = new Date();
-                                Date thisUpdate = response.getThisUpdate();
-                                Date nextUpdate = response.getNextUpdate();
-                                if (thisUpdate == null || !current.after(thisUpdate) ||
-                                        (nextUpdate != null && !current.before(nextUpdate))) {
+                                Date thisUpdateDate = response.getThisUpdate();
+                                Date nextUpdateDate = response.getNextUpdate();
+                                Instant thisUpdate = thisUpdateDate == null ? null :
+                                    thisUpdateDate.toInstant().minusMillis(CLOCK_SKEW_TOLERANCE_MILLIS);
+                                Instant nextUpdate = nextUpdateDate == null ? null :
+                                    nextUpdateDate.toInstant().plusMillis(CLOCK_SKEW_TOLERANCE_MILLIS);
+                                Instant now = Instant.now();
+                                if (thisUpdate == null || !now.isAfter(thisUpdate) ||
+                                    (nextUpdate != null && !now.isBefore(nextUpdate))) {
                                     ctx.fireExceptionCaught(new IllegalStateException("OCSP Response is out-of-date"));
                                     return;
                                 }
@@ -188,14 +212,14 @@ public class OcspServerCertificateValidator extends ByteToMessageDecoder impleme
                                 }
 
                                 ctx.fireUserEventTriggered(new OcspValidationEvent(
-                                        new OcspResponse(status, response.getThisUpdate(), response.getNextUpdate())));
+                                    new OcspResponse(status, thisUpdateDate, nextUpdateDate)));
 
                                 // If Certificate is not VALID and 'closeAndThrowIfNotValid' is set
                                 // to 'true' then close the channel and throw an exception.
                                 if (status != OcspResponse.Status.VALID && closeAndThrowIfNotValid) {
                                     // Certificate is not valid. Throw
                                     ctx.fireExceptionCaught(new OCSPException(
-                                            "Certificate not valid. Status: " + status));
+                                        "Certificate not valid. Status: " + status));
                                     ctx.close();
                                 }
                             } else {


### PR DESCRIPTION
Motivation:
Clock skew, or even just response time over the network, can turn a valid OCSP response into an invalid one if we require that the validation time must fall exactly within the validity period of the response.

Modification:
Add a clock skew tolerance to widen the validity period by default 15 minutes in both directions. The JDK also uses 15 minutes as their clock skew tolerance, and we inspect their system property in addition to our own.

Result:
Reasonable clock skew no longer cause otherwise valid OCSP responses to be rejected.
