### PR TITLE
HTTP/2: Test writability change during close

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -78,6 +78,7 @@ import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
@@ -364,6 +365,27 @@ public class Http2ConnectionHandlerTest {
         verify(remoteFlow).writePendingBytes();
         verify(ctx).flush();
         verify(remoteFlow).channelWritabilityChanged();
+    }
+
+    @Test
+    public void closeShouldNotFlushOnWritabilityChangeWithoutPendingData() throws Exception {
+        when(channel.isWritable()).thenReturn(true);
+        handler = new Http2ConnectionHandlerBuilder().codec(decoder, encoder)
+                .decoupleCloseAndGoAway(true).build();
+        handler.handlerAdded(ctx);
+        clearInvocations(ctx);
+        doAnswer(new Answer<ChannelFuture>() {
+            @Override
+            public ChannelFuture answer(InvocationOnMock invocation) throws Throwable {
+                handler.channelWritabilityChanged(ctx);
+                return future;
+            }
+        }).when(ctx).close(any(ChannelPromise.class));
+
+        handler.close(ctx, promise);
+
+        verify(ctx).close(promise);
+        verify(ctx, never()).flush();
     }
 
     /**


### PR DESCRIPTION
Motivation:

A synchronous writability change can occur while `Http2ConnectionHandler.close()` is forwarding a close through the pipeline. This previously allowed `channelWritabilityChanged()` to trigger an unnecessary flush and contribute to a flush/writability feedback loop.

Modification:

Add a regression test covering the `decoupleCloseAndGoAway` close path. The test simulates a synchronous writability change during `ctx.close()` and verifies that no flush occurs when the HTTP/2 flow controller has no pending data.

Result:

Fixes #17276.