### PR TITLE
Update graal version

### DIFF
--- a/docker/docker-compose.centos-6.graalvm111.yaml
+++ b/docker/docker-compose.centos-6.graalvm111.yaml
@@ -6,7 +6,7 @@ services:
     image: netty:centos-6-1.11
     build:
       args:
-        java_version : "20.3.6.r11-grl"
+        java_version : "17.0.9-graalce"
 
   build:
     image: netty:centos-6-1.11


### PR DESCRIPTION
Motivation:

The used graal version is not on sdkman anymore

Modifications:

Update to 17.0.9-graalce

Result:

Build pass again
