### PR TITLE
HTTP: Release content encoder after header mutation failure

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentEncoder.java
@@ -184,35 +184,47 @@ public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpReque
                     break;
                 }
 
-                encoder = result.contentEncoder();
+                EmbeddedChannel contentEncoder = result.contentEncoder();
+                try {
+                    // Encode the content and remove or replace the existing headers
+                    // so that the message looks like a decoded message.
+                    res.headers().set(HttpHeaderNames.CONTENT_ENCODING, result.targetContentEncoding());
 
-                // Encode the content and remove or replace the existing headers
-                // so that the message looks like a decoded message.
-                res.headers().set(HttpHeaderNames.CONTENT_ENCODING, result.targetContentEncoding());
+                    // Output the rewritten response.
+                    if (isFull) {
+                        // Convert full message into unfull one.
+                        HttpResponse newRes = new DefaultHttpResponse(res.protocolVersion(), res.status());
+                        newRes.headers().set(res.headers());
+                        out.add(newRes);
 
-                // Output the rewritten response.
-                if (isFull) {
-                    // Convert full message into unfull one.
-                    HttpResponse newRes = new DefaultHttpResponse(res.protocolVersion(), res.status());
-                    newRes.headers().set(res.headers());
-                    out.add(newRes);
-
-                    ensureContent(res);
-                    encodeFullResponse(newRes, (HttpContent) res, out);
-                    break;
-                } else {
-                    // Make the response chunked to simplify content transformation.
-                    res.headers().remove(HttpHeaderNames.CONTENT_LENGTH);
-                    res.headers().set(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
-
-                    out.add(ReferenceCountUtil.retain(res));
-                    state = State.AWAIT_CONTENT;
-                    if (!(msg instanceof HttpContent)) {
-                        // only break out the switch statement if we have not content to process
-                        // See https://github.com/netty/netty/issues/2006
+                        ensureContent(res);
+                        encoder = contentEncoder;
+                        encodeFullResponse(newRes, (HttpContent) res, out);
+                        contentEncoder = null;
                         break;
+                    } else {
+                        // Make the response chunked to simplify content transformation.
+                        res.headers().remove(HttpHeaderNames.CONTENT_LENGTH);
+                        res.headers().set(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
+
+                        out.add(ReferenceCountUtil.retain(res));
+                        state = State.AWAIT_CONTENT;
+                        encoder = contentEncoder;
+                        contentEncoder = null;
+                        if (!(msg instanceof HttpContent)) {
+                            // only break out the switch statement if we have not content to process
+                            // See https://github.com/netty/netty/issues/2006
+                            break;
+                        }
+                        // Fall through to encode the content
                     }
-                    // Fall through to encode the content
+                } finally {
+                    if (contentEncoder != null) {
+                        if (encoder == contentEncoder) {
+                            encoder = null;
+                        }
+                        contentEncoder.finishAndReleaseAll();
+                    }
                 }
             }
             case AWAIT_CONTENT: {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentEncoderTest.java
@@ -46,6 +46,8 @@ public class HttpContentEncoderTest {
 
     private static final class TestEncoder extends HttpContentEncoder {
 
+        private EmbeddedChannel contentEncoder;
+
         TestEncoder() {
         }
 
@@ -55,13 +57,18 @@ public class HttpContentEncoderTest {
 
         @Override
         protected Result beginEncode(HttpResponse httpResponse, String acceptEncoding) {
-            return new Result("test", new EmbeddedChannel(new MessageToByteEncoder<ByteBuf>() {
+            contentEncoder = new EmbeddedChannel(new MessageToByteEncoder<ByteBuf>() {
                 @Override
                 protected void encode(ChannelHandlerContext ctx, ByteBuf in, ByteBuf out) throws Exception {
                     out.writeBytes(String.valueOf(in.readableBytes()).getBytes(CharsetUtil.US_ASCII));
                     in.skipBytes(in.readableBytes());
                 }
-            }));
+            });
+            return new Result("test", contentEncoder);
+        }
+
+        EmbeddedChannel contentEncoder() {
+            return contentEncoder;
         }
     }
 
@@ -454,6 +461,29 @@ public class HttpContentEncoderTest {
                 new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/")));
 
         ch.finishAndReleaseAll();
+    }
+
+    @Test
+    public void testHeaderMutationFailureReleasesContentEncoder() {
+        TestEncoder encoder = new TestEncoder();
+        EmbeddedChannel channel = new EmbeddedChannel(encoder);
+        try {
+            assertTrue(channel.writeInbound(new DefaultFullHttpRequest(
+                    HttpVersion.HTTP_1_1, HttpMethod.GET, "/first")));
+
+            EncoderException exception = assertThrows(EncoderException.class, () -> channel.writeOutbound(
+                    new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
+                            new ReadOnlyHttpHeaders(false))));
+            assertInstanceOf(UnsupportedOperationException.class, exception.getCause());
+            assertFalse(encoder.contentEncoder().isOpen());
+
+            assertTrue(channel.writeInbound(new DefaultFullHttpRequest(
+                    HttpVersion.HTTP_1_1, HttpMethod.GET, "/second")));
+            assertTrue(channel.writeOutbound(new DefaultFullHttpResponse(
+                    HttpVersion.HTTP_1_1, HttpResponseStatus.OK, Unpooled.wrappedBuffer(new byte[1]))));
+        } finally {
+            channel.finishAndReleaseAll();
+        }
     }
 
     private static void assertEmptyResponse(EmbeddedChannel ch) {


### PR DESCRIPTION
### Motivation

`HttpContentEncoder` stored the `EmbeddedChannel` returned by `beginEncode()` in its `encoder` field before mutating the response headers. If a mutation failed, for example because the response used `ReadOnlyHttpHeaders`, the newly created content encoder remained open.

With assertions disabled, a subsequent response could overwrite the field. Handler removal or channel shutdown would then release only the replacement encoder, leaving the first encoder without deterministic cleanup.

### Modification

- Keep a newly created content encoder locally owned while response headers and streaming state are prepared.
- Transfer ownership to the handler field only when encoding can proceed.
- Call `finishAndReleaseAll()` when preparation or synchronous full-response encoding fails before ownership is retained.
- Add a regression test that verifies the failed encoder is closed and the handler remains usable for the next response.

### Result

Header mutation failures no longer leave a content encoder open or allow it to be lost on a later response. Successful full and streaming response encoding remains unchanged.

### Testing

- `./mvnw -pl codec-http -Dtest=HttpContentEncoderTest#testHeaderMutationFailureReleasesContentEncoder test`
- `./mvnw -pl codec-http -Dtest=HttpContentEncoderTest#testHeaderMutationFailureReleasesContentEncoder -DargLine.common=-da test`
- `./mvnw -pl codec-http test` — 8,983 tests, 0 failures, 0 errors, 4 skipped
