### PR TITLE
Update flatten plugin and use flattenDependecyMode direct

### DIFF
--- a/codec-http3/pom.xml
+++ b/codec-http3/pom.xml
@@ -201,8 +201,7 @@
         <configuration>
           <!-- We need to also merge the dependencies defined by our profile. -->
           <embedBuildProfileDependencies>true</embedBuildProfileDependencies>
-          <!-- Ensure excludes are set correctly -->
-          <flattenDependencyMode>all</flattenDependencyMode>
+          <flattenDependencyMode>direct</flattenDependencyMode>
           <flattenMode>ossrh</flattenMode>
         </configuration>
         <executions>

--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -620,7 +620,7 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
         <configuration>
-          <flattenDependencyMode>all</flattenDependencyMode>
+          <flattenDependencyMode>direct</flattenDependencyMode>
           <embedBuildProfileDependencies>true</embedBuildProfileDependencies>
           <flattenMode>ossrh</flattenMode>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -2229,7 +2229,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>flatten-maven-plugin</artifactId>
-          <version>1.2.2</version>
+          <version>1.8.0</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
Motivation:

Our used flatten plugin version was really old. Beside this our configuration caused the http3 and quic codec to haven direct dependencies on jctools which is not correct as we shade it.

Modifications:

- Update plugin version
- Use flattenDependencyMode direct

Result:

Generate the correct dependencies in the flattened pom
