### PR TITLE
Add a script that can download GHSA vulnerability reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 # Report directories
 /reports
 */reports
+.github/ghsa
 
 # Mac-specific directory that no other operating system needs.
 .DS_Store
@@ -37,7 +38,6 @@ replay_pid*.log
 *.threads
 
 dependency-reduced-pom.xml
-
 */.unison.*
 
 # exclude mainframer files

--- a/pom.xml
+++ b/pom.xml
@@ -1609,7 +1609,7 @@
               <encoding>UTF-8</encoding>
               <sourceDirectories>${basedir}</sourceDirectories>
               <includes>**/*</includes>
-              <excludes>nohttp-checkstyle-suppressions.xml,**/.git/**/*,**/.idea/**/*,**/target/**/,**/.flattened-pom.xml,**/*.class</excludes>
+              <excludes>nohttp-checkstyle-suppressions.xml,**/.git/**/*,**/.idea/**/*,**/target/**/,**/.flattened-pom.xml,**/*.class,**/.github/ghsa/**</excludes>
             </configuration>
             <goals>
               <goal>check</goal>

--- a/scripts/collect-ghsa-reports.sh
+++ b/scripts/collect-ghsa-reports.sh
@@ -1,4 +1,19 @@
 #!/usr/bin/env bash
+# ----------------------------------------------------------------------------
+# Copyright 2026 The Netty Project
+#
+# The Netty Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
 set -euo pipefail
 
 GHSA_DIR="$PWD/.github/ghsa"

--- a/scripts/collect-ghsa-reports.sh
+++ b/scripts/collect-ghsa-reports.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GHSA_DIR="$PWD/.github/ghsa"
+if [ ! -d "$GHSA_DIR" ]; then
+    echo "Error: $GHSA_DIR is not a directory -- this script must be run from the project root directory"
+    exit 1
+fi
+if ! command -v "jq" &> /dev/null; then
+    echo "Error: jq is not installed"
+    exit 1
+fi
+if ! command -v "gh" &> /dev/null; then
+    echo "Error: gh is not installed"
+    exit 1
+fi
+
+find "$GHSA_DIR" -name '*.json' -delete
+
+gh api repos/netty/netty/security-advisories --paginate | jq -rc '.[]' | while read -r report ; do
+    ghsa=$(jq -r '.ghsa_id' <<< "$report")
+    state=$(jq -r '.state' <<< "$report")
+
+    if [[ ! "$ghsa" =~ ^GHSA-[a-zA-Z0-9_-]+$ ]]; then
+        echo "Warning: skipping entry, unexpected ghsa_id value '$ghsa'" >&2
+        continue
+    fi
+    if [[ ! "$state" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+        echo "Warning: skipping $ghsa, unexpected state value '$state'" >&2
+        continue
+    fi
+
+    echo "==== $ghsa ===="
+    mkdir -p "$GHSA_DIR/$state"
+    jq <<< "$report" > "$GHSA_DIR/$state/$ghsa.json"
+done
+echo "Done."


### PR DESCRIPTION
Motivation:
It is useful to download the vulnerability reports in order to deduplicate them, or otherwise process them in bulk.

Modification:
Add a script that uses `gh` and `jq` to download all GHSA reports as json blobs.
Ensure the download directory is ignored by Git and the HTTPS checkstyle check.

Result:
We can download GHSA reports for bulk processing.