### PR TITLE
Fix typo in WebSocketServerExtension newReponseData method

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtension.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtension.java
@@ -22,11 +22,22 @@ package io.netty.handler.codec.http.websocketx.extensions;
 public interface WebSocketServerExtension extends WebSocketExtension {
 
     /**
+     * @deprecated Use {@link #newResponseData()} instead.
+     *
+     */
+    @Deprecated
+    default WebSocketExtensionData newReponseData() {
+        // Delegate to the correctly spelled method.
+        return newResponseData();
+    }
+
+    /**
      * Return an extension configuration to submit to the client as an acknowledge.
      *
      * @return the acknowledged extension configuration.
      */
-    //TODO: after migrating to JDK 8 rename this to 'newResponseData()' and mark old as deprecated with default method
-    WebSocketExtensionData newReponseData();
-
+    default WebSocketExtensionData newResponseData() {
+        // Fallback for legacy implementations overriding only the misspelled method.
+        return newReponseData();
+    }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandler.java
@@ -229,7 +229,7 @@ public class WebSocketServerExtensionHandler extends ChannelDuplexHandler {
                 List<WebSocketExtensionData> extraExtensions =
                   new ArrayList<>(extensionHandshakers.size());
                 for (WebSocketServerExtension extension : validExtensionsList) {
-                    extraExtensions.add(extension.newReponseData());
+                    extraExtensions.add(extension.newResponseData());
                 }
                 String newHeaderValue = WebSocketExtensionUtil
                   .computeMergeExtensionsHeaderValue(headerValue, extraExtensions);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateFrameServerExtensionHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/DeflateFrameServerExtensionHandshaker.java
@@ -221,7 +221,7 @@ public final class DeflateFrameServerExtensionHandshaker implements WebSocketSer
         }
 
         @Override
-        public WebSocketExtensionData newReponseData() {
+        public WebSocketExtensionData newResponseData() {
             return new WebSocketExtensionData(extensionName, Collections.<String, String>emptyMap());
         }
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateServerExtensionHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateServerExtensionHandshaker.java
@@ -406,7 +406,7 @@ public final class PerMessageDeflateServerExtensionHandshaker implements WebSock
         }
 
         @Override
-        public WebSocketExtensionData newReponseData() {
+        public WebSocketExtensionData newResponseData() {
             HashMap<String, String> parameters = new HashMap<String, String>(4);
             if (serverNoContext) {
                 parameters.put(SERVER_NO_CONTEXT, null);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandlerTest.java
@@ -69,7 +69,7 @@ public class WebSocketServerExtensionHandlerTest {
                 thenReturn(null);
 
         when(mainExtensionMock.rsv()).thenReturn(WebSocketExtension.RSV1);
-        when(mainExtensionMock.newReponseData()).thenReturn(
+        when(mainExtensionMock.newResponseData()).thenReturn(
                 new WebSocketExtensionData("main", Collections.<String, String>emptyMap()));
         when(mainExtensionMock.newExtensionEncoder()).thenReturn(new DummyEncoder());
         when(mainExtensionMock.newExtensionDecoder()).thenReturn(new DummyDecoder());
@@ -104,7 +104,7 @@ public class WebSocketServerExtensionHandlerTest {
         verify(fallbackHandshakerMock, atLeastOnce()).handshakeExtension(webSocketExtensionDataMatcher("fallback"));
 
         verify(mainExtensionMock, atLeastOnce()).rsv();
-        verify(mainExtensionMock).newReponseData();
+        verify(mainExtensionMock).newResponseData();
         verify(mainExtensionMock).newExtensionEncoder();
         verify(mainExtensionMock).newExtensionDecoder();
         verify(fallbackExtensionMock, atLeastOnce()).rsv();
@@ -124,13 +124,13 @@ public class WebSocketServerExtensionHandlerTest {
                 thenReturn(null);
 
         when(mainExtensionMock.rsv()).thenReturn(WebSocketExtension.RSV1);
-        when(mainExtensionMock.newReponseData()).thenReturn(
+        when(mainExtensionMock.newResponseData()).thenReturn(
                 new WebSocketExtensionData("main", Collections.<String, String>emptyMap()));
         when(mainExtensionMock.newExtensionEncoder()).thenReturn(new DummyEncoder());
         when(mainExtensionMock.newExtensionDecoder()).thenReturn(new DummyDecoder());
 
         when(fallbackExtensionMock.rsv()).thenReturn(WebSocketExtension.RSV2);
-        when(fallbackExtensionMock.newReponseData()).thenReturn(
+        when(fallbackExtensionMock.newResponseData()).thenReturn(
                 new WebSocketExtensionData("fallback", Collections.<String, String>emptyMap()));
         when(fallbackExtensionMock.newExtensionEncoder()).thenReturn(new Dummy2Encoder());
         when(fallbackExtensionMock.newExtensionDecoder()).thenReturn(new Dummy2Decoder());
@@ -164,13 +164,13 @@ public class WebSocketServerExtensionHandlerTest {
         verify(mainHandshakerMock).handshakeExtension(webSocketExtensionDataMatcher("fallback"));
         verify(fallbackHandshakerMock).handshakeExtension(webSocketExtensionDataMatcher("fallback"));
         verify(mainExtensionMock, times(2)).rsv();
-        verify(mainExtensionMock).newReponseData();
+        verify(mainExtensionMock).newResponseData();
         verify(mainExtensionMock).newExtensionEncoder();
         verify(mainExtensionMock).newExtensionDecoder();
 
         verify(fallbackExtensionMock, times(2)).rsv();
 
-        verify(fallbackExtensionMock).newReponseData();
+        verify(fallbackExtensionMock).newResponseData();
         verify(fallbackExtensionMock).newExtensionEncoder();
         verify(fallbackExtensionMock).newExtensionDecoder();
     }
@@ -246,7 +246,7 @@ public class WebSocketServerExtensionHandlerTest {
 
         verify(mainHandshakerMock).handshakeExtension(webSocketExtensionDataMatcher("main"));
         verify(mainExtensionMock, times(2)).rsv();
-        verify(mainExtensionMock, never()).newReponseData();
+        verify(mainExtensionMock, never()).newResponseData();
         verify(mainExtensionMock, never()).newExtensionEncoder();
         verify(mainExtensionMock, never()).newExtensionDecoder();
     }
@@ -256,7 +256,7 @@ public class WebSocketServerExtensionHandlerTest {
         // initialize
         when(mainHandshakerMock.handshakeExtension(webSocketExtensionDataMatcher("main")))
                 .thenReturn(mainExtensionMock);
-        when(mainExtensionMock.newReponseData()).thenReturn(
+        when(mainExtensionMock.newResponseData()).thenReturn(
                 new WebSocketExtensionData("main", Collections.<String, String>emptyMap()));
 
         // execute
@@ -285,7 +285,7 @@ public class WebSocketServerExtensionHandlerTest {
                 .thenReturn(mainExtensionMock);
 
         when(mainExtensionMock.rsv()).thenReturn(WebSocketExtension.RSV1);
-        when(mainExtensionMock.newReponseData()).thenReturn(
+        when(mainExtensionMock.newResponseData()).thenReturn(
                 new WebSocketExtensionData("main", Collections.<String, String>emptyMap()));
         when(mainExtensionMock.newExtensionEncoder()).thenReturn(new DummyEncoder());
         when(mainExtensionMock.newExtensionDecoder()).thenReturn(new DummyDecoder());
@@ -294,7 +294,7 @@ public class WebSocketServerExtensionHandlerTest {
                 .thenReturn(main2ExtensionMock);
 
         when(main2ExtensionMock.rsv()).thenReturn(WebSocketExtension.RSV1);
-        when(main2ExtensionMock.newReponseData()).thenReturn(
+        when(main2ExtensionMock.newResponseData()).thenReturn(
                 new WebSocketExtensionData("main2", Collections.<String, String>emptyMap()));
         when(main2ExtensionMock.newExtensionEncoder()).thenReturn(new DummyEncoder());
         when(main2ExtensionMock.newExtensionDecoder()).thenReturn(new DummyDecoder());


### PR DESCRIPTION
Fix typo in WebSocketServerExtension newReponseData method

Motivation:
There is a typo in the method name `newReponseData()` ("Reponse" instead of "Response") in the `WebSocketServerExtension` interface.

Modifications:
- Rename `newReponseData()` to `newResponseData()` in `WebSocketServerExtension`.
- Update all corresponding implementation classes to use the corrected method name.
- Update unit tests to reflect the new method name.

Result:
Correct spelling of the method name for generating WebSocket server extension response data across the codebase, ensuring clean API naming and passing tests.