### PR TITLE
POOL: Close active unhealthy channels on release

### DIFF
--- a/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
@@ -328,6 +328,7 @@ public class SimpleChannelPool implements ChannelPool {
                 releaseAndOffer(channel, promise);
             } else { //channel not healthy, just releasing it.
                 handler.channelReleased(channel);
+                closeChannel(channel);
                 promise.setSuccess(null);
             }
         } catch (Throwable cause) {

--- a/transport/src/test/java/io/netty/channel/pool/SimpleChannelPoolTest.java
+++ b/transport/src/test/java/io/netty/channel/pool/SimpleChannelPoolTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.function.Executable;
 import java.util.Queue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.netty.channel.pool.ChannelPoolTestUtils.getLocalAddrId;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -198,6 +199,62 @@ public class SimpleChannelPoolTest {
         channel3.close().syncUninterruptibly();
         pool.close();
         group.shutdownGracefully();
+    }
+
+    @Test
+    public void testActiveUnhealthyChannelIsClosedOnRelease() throws Exception {
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(LocalIoHandler.newFactory());
+        LocalAddress addr = new LocalAddress(getLocalAddrId());
+        ServerBootstrap sb = new ServerBootstrap()
+                .group(group)
+                .channel(LocalServerChannel.class)
+                .childHandler(new ChannelInboundHandlerAdapter());
+        Channel sc = sb.bind(addr).syncUninterruptibly().channel();
+
+        AtomicBoolean channelReleased = new AtomicBoolean();
+        ChannelPoolHandler handler = new ChannelPoolHandler() {
+            @Override
+            public void channelReleased(Channel ch) {
+                assertTrue(ch.isActive());
+                channelReleased.set(true);
+            }
+
+            @Override
+            public void channelAcquired(Channel ch) {
+                // NOOP
+            }
+
+            @Override
+            public void channelCreated(Channel ch) {
+                // NOOP
+            }
+        };
+        Bootstrap cb = new Bootstrap()
+                .group(group)
+                .channel(LocalChannel.class)
+                .remoteAddress(addr);
+        ChannelHealthChecker healthChecker = channel ->
+                channel.eventLoop().newSucceededFuture(Boolean.FALSE);
+        SimpleChannelPool pool = new SimpleChannelPool(cb, handler, healthChecker);
+        Channel channel = null;
+        try {
+            channel = pool.acquire().syncUninterruptibly().getNow();
+            assertTrue(channel.isActive());
+
+            Future<Void> releaseFuture = pool.release(channel).syncUninterruptibly();
+
+            assertTrue(releaseFuture.isSuccess());
+            assertTrue(channelReleased.get());
+            assertTrue(channel.closeFuture().awaitUninterruptibly(1, TimeUnit.SECONDS));
+            assertFalse(channel.isActive());
+        } finally {
+            if (channel != null) {
+                channel.close().syncUninterruptibly();
+            }
+            pool.close();
+            sc.close().syncUninterruptibly();
+            group.shutdownGracefully();
+        }
     }
 
     /**


### PR DESCRIPTION
Motivation:

When a custom `ChannelHealthChecker` reports an active channel as unhealthy during release, `SimpleChannelPool` removes the channel from pool ownership and does not return it to storage, but leaves it open. The release future still succeeds, so the active channel is no longer owned by either the caller or the pool.

Modification:

- Close channels rejected by the release health check after invoking `channelReleased()`.
- Add a regression test with a custom health checker that rejects an active channel and verifies callback ordering, release success, and channel closure.

Result:

Active unhealthy channels are successfully discarded without changing the `channelReleased()` callback ordering or release promise semantics.

Tests:

`./mvnw -pl transport -Dtest=SimpleChannelPoolTest,FixedChannelPoolTest test`