### PR TITLE
Fix TSAN data race in Netty 4.2 Recycler

### DIFF
--- a/common/src/main/java/io/netty/util/Recycler.java
+++ b/common/src/main/java/io/netty/util/Recycler.java
@@ -503,8 +503,8 @@ public abstract class Recycler<T> {
         private final int ratioInterval;
         private final H[] batch;
         private int batchSize;
-        private Thread owner;
-        private MessagePassingQueue<H> pooledHandles;
+        private volatile Thread owner;
+        private volatile MessagePassingQueue<H> pooledHandles;
         private int ratioCounter;
 
         LocalPool(int maxCapacity) {


### PR DESCRIPTION
Restore the `volatile` modifier to the `owner` and `pooledHandles` fields in `Recycler$LocalPool`. These fields were volatile in Netty 4.1, but the modifier was lost during the refactoring of `Recycler` for Netty 4.2.

This fixes TSAN data races observed when a thread-local pool is being removed during thread termination (in `onRemoval`) while concurrent threads are still attempting to recycle objects back to it (in `release`).
