### PR TITLE
FileRegion: Remove outdated JDK upgrade warning

### DIFF
--- a/transport/src/main/java/io/netty/channel/FileRegion.java
+++ b/transport/src/main/java/io/netty/channel/FileRegion.java
@@ -25,23 +25,6 @@ import java.nio.channels.WritableByteChannel;
  * A region of a file that is sent via a {@link Channel} which supports
  * <a href="https://en.wikipedia.org/wiki/Zero-copy">zero-copy file transfer</a>.
  *
- * <h3>Upgrade your JDK / JRE</h3>
- *
- * {@link FileChannel#transferTo(long, long, WritableByteChannel)} has at least
- * four known bugs in the old versions of Sun JDK and perhaps its derived ones.
- * Please upgrade your JDK to 1.6.0_18 or later version if you are going to use
- * zero-copy file transfer.
- * <ul>
- * <li><a href="https://bugs.java.com/bugdatabase/view_bug.do?bug_id=5103988">5103988</a>
- *   - FileChannel.transferTo() should return -1 for EAGAIN instead throws IOException</li>
- * <li><a href="https://bugs.java.com/bugdatabase/view_bug.do?bug_id=6253145">6253145</a>
- *   - FileChannel.transferTo() on Linux fails when going beyond 2GB boundary</li>
- * <li><a href="https://bugs.java.com/bugdatabase/view_bug.do?bug_id=6427312">6427312</a>
- *   - FileChannel.transferTo() throws IOException "system call interrupted"</li>
- * <li><a href="https://bugs.java.com/bugdatabase/view_bug.do?bug_id=6524172">6470086</a>
- *   - FileChannel.transferTo(2147483647, 1, channel) causes "Value too large" exception</li>
- * </ul>
- *
  * <h3>Check your operating system and JDK / JRE</h3>
  *
  * If your operating system (or JDK / JRE) does not support zero-copy file


### PR DESCRIPTION
Motivation:

The FileRegion Javadoc contains an outdated warning about FileChannel.transferTo() bugs in old JDK versions and recommends upgrading to JDK 1.6.0_18 or later. Netty 4.2 requires Java 8 or newer, so this guidance is no longer relevant and may confuse users.

Modification:

Remove the obsolete JDK upgrade warning and its list of historical FileChannel.transferTo() bugs from the FileRegion Javadoc.

Result: 

Fixes #17305.