### PR TITLE
Add more logging to CompositeBufferGatheringWriteTest to help diagnose flaky test

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/CompositeBufferGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/CompositeBufferGatheringWriteTest.java
@@ -217,6 +217,9 @@ public class CompositeBufferGatheringWriteTest extends AbstractSocketTest {
                             if (!(cause instanceof IOException)) {
                                 clientReceived.set(cause);
                                 latch.countDown();
+                            } else if (!cause.getMessage().contains("reset")) {
+                                logger.warn("{} server got weird exception",
+                                        CompositeBufferGatheringWriteTest.this.getClass(), cause);
                             }
                         }
                     });
@@ -249,6 +252,9 @@ public class CompositeBufferGatheringWriteTest extends AbstractSocketTest {
                             if (!(cause instanceof IOException)) {
                                 clientReceived.set(cause);
                                 latch.countDown();
+                            } else if (!cause.getMessage().contains("reset")) {
+                                logger.warn("{} client got weird exception",
+                                        CompositeBufferGatheringWriteTest.this.getClass(), cause);
                             }
                         }
 


### PR DESCRIPTION
Motivation:

We sometimes observe a flaky test where we receive 0 bytes. Let's add some more logging (which we already do in other places in this class).

The test in question fails like this:

```
[ERROR] io.netty.channel.kqueue.KQueueCompositeBufferGatheringWriteTest.testCompositeBufferPartialWriteDoesNotCorruptData(TestInfo) -- Time elapsed: 0.068 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <2048> but was: <0>
	at io.netty.testsuite.transport.socket.CompositeBufferGatheringWriteTest$6$1.channelInactive(CompositeBufferGatheringWriteTest.java:259)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:251)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelInactive(DefaultChannelPipeline.java:1424)
	at io.netty.channel.DefaultChannelPipeline.fireChannelInactive(DefaultChannelPipeline.java:876)
	at io.netty.channel.AbstractChannel$AbstractUnsafe$6.run(AbstractChannel.java:676)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:148)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:141)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:535)
	at io.netty.channel.SingleThreadIoEventLoop.run(SingleThreadIoEventLoop.java:201)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:1204)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:829)

```

Modifications:

- Add more logging so we can track down the actual problem

Result:

Easier to debug why we see test failures
