### PR TITLE
codec-dns: Fix query OPCODE bit offset and mask

### DIFF
--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsQueryEncoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsQueryEncoder.java
@@ -48,7 +48,7 @@ final class DnsQueryEncoder {
     private static void encodeHeader(DnsQuery query, ByteBuf buf) {
         buf.writeShort(query.id());
         int flags = 0;
-        flags |= (query.opCode().byteValue() & 0xFF) << 14;
+        flags |= (query.opCode().byteValue() & 0xF) << 11;
         if (query.isRecursionDesired()) {
             flags |= 1 << 8;
         }

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsQueryTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsQueryTest.java
@@ -20,10 +20,14 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.util.internal.SocketUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -32,8 +36,34 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DnsQueryTest {
 
-    private static final DnsOpCode[] OP_CODES = {
-            DnsOpCode.QUERY, DnsOpCode.IQUERY, DnsOpCode.STATUS, DnsOpCode.NOTIFY, DnsOpCode.UPDATE };
+    static Stream<DnsOpCode> opCodes() {
+        return Stream.of(
+                DnsOpCode.QUERY,
+                DnsOpCode.IQUERY,
+                DnsOpCode.STATUS,
+                DnsOpCode.NOTIFY,
+                DnsOpCode.UPDATE);
+    }
+
+    static Stream<Arguments> opCodesAndExpectedFlags() {
+        return Stream.of(
+                // RFC 1035 section 4.1.1: QR(1) OPCODE(4) AA TC RD RA Z(3) RCODE(4), so the OPCODE
+                // occupies bits 14-11 and RD is bit 8.
+                Arguments.of(DnsOpCode.QUERY, false, 0x0000),
+                Arguments.of(DnsOpCode.QUERY, true, 0x0100),
+                Arguments.of(DnsOpCode.IQUERY, false, 0x0800),
+                Arguments.of(DnsOpCode.IQUERY, true, 0x0900),
+                Arguments.of(DnsOpCode.STATUS, false, 0x1000),
+                Arguments.of(DnsOpCode.STATUS, true, 0x1100),
+                Arguments.of(DnsOpCode.NOTIFY, false, 0x2000),
+                Arguments.of(DnsOpCode.NOTIFY, true, 0x2100),
+                Arguments.of(DnsOpCode.UPDATE, false, 0x2800),
+                Arguments.of(DnsOpCode.UPDATE, true, 0x2900),
+
+                // DnsOpCode does not range check, and an OPCODE that does not fit the four bits
+                // reserved for it must not reach the neighbouring QR bit.
+                Arguments.of(DnsOpCode.valueOf(16), false, 0x0000));
+    }
 
     @Test
     public void testEncodeAndDecodeQuery() {
@@ -82,76 +112,42 @@ public class DnsQueryTest {
         assertFalse(readChannel.finish());
     }
 
-    @Test
-    public void testOpCodeSurvivesEncodeAndDecode() {
+    @ParameterizedTest
+    @MethodSource("opCodes")
+    public void testOpCodeSurvivesEncodeAndDecode(DnsOpCode opCode) {
         InetSocketAddress addr = SocketUtils.socketAddress("8.8.8.8", 53);
         EmbeddedChannel writeChannel = new EmbeddedChannel(new DatagramDnsQueryEncoder());
         EmbeddedChannel readChannel = new EmbeddedChannel(new DatagramDnsQueryDecoder());
 
-        for (DnsOpCode opCode: OP_CODES) {
-            DnsQuery query = new DatagramDnsQuery(null, addr, 1, opCode).setRecord(
-                    DnsSection.QUESTION,
-                    new DefaultDnsQuestion("example.com", DnsRecordType.A));
-
-            assertTrue(writeChannel.writeOutbound(query));
-            DatagramPacket packet = writeChannel.readOutbound();
-            assertTrue(readChannel.writeInbound(packet));
-
-            DnsQuery decodedDnsQuery = readChannel.readInbound();
-            assertEquals(opCode, decodedDnsQuery.opCode());
-            assertTrue(decodedDnsQuery.release());
-        }
-
-        assertFalse(writeChannel.finish());
-        assertFalse(readChannel.finish());
-    }
-
-    @Test
-    public void testOpCodeIsEncodedIntoBits14To11() {
-        InetSocketAddress addr = SocketUtils.socketAddress("8.8.8.8", 53);
-        EmbeddedChannel writeChannel = new EmbeddedChannel(new DatagramDnsQueryEncoder());
-
-        for (DnsOpCode opCode: OP_CODES) {
-            for (boolean recursionDesired: new boolean[] { false, true }) {
-                DnsQuery query = new DatagramDnsQuery(null, addr, 1, opCode)
-                        .setRecursionDesired(recursionDesired);
-                query.setRecord(DnsSection.QUESTION,
-                        new DefaultDnsQuestion("example.com", DnsRecordType.A));
-
-                assertTrue(writeChannel.writeOutbound(query));
-                DatagramPacket packet = writeChannel.readOutbound();
-
-                // RFC 1035 section 4.1.1: the flags word is QR(1) OPCODE(4) AA TC RD RA Z(3) RCODE(4).
-                // The OPCODE and RD are the only fields this encoder writes, so the whole word is known.
-                int expectedFlags = opCode.byteValue() << 11;
-                if (recursionDesired) {
-                    expectedFlags |= 1 << 8;
-                }
-                assertEquals(expectedFlags, packet.content().getUnsignedShort(2),
-                        "unexpected flags for opCode " + opCode + " and RD " + recursionDesired);
-
-                assertTrue(packet.release());
-            }
-        }
-
-        assertFalse(writeChannel.finish());
-    }
-
-    @Test
-    public void testOutOfRangeOpCodeIsTruncatedToFourBits() {
-        InetSocketAddress addr = SocketUtils.socketAddress("8.8.8.8", 53);
-        EmbeddedChannel writeChannel = new EmbeddedChannel(new DatagramDnsQueryEncoder());
-
-        // DnsOpCode does not range check, so an OPCODE that does not fit the 4 bits reserved by
-        // RFC 1035 section 4.1.1 can reach the encoder. It must not spill into the neighbouring QR bit.
-        DnsQuery query = new DatagramDnsQuery(null, addr, 1, DnsOpCode.valueOf(16)).setRecord(
+        DnsQuery query = new DatagramDnsQuery(null, addr, 1, opCode).setRecord(
                 DnsSection.QUESTION,
                 new DefaultDnsQuestion("example.com", DnsRecordType.A));
 
         assertTrue(writeChannel.writeOutbound(query));
         DatagramPacket packet = writeChannel.readOutbound();
+        assertTrue(readChannel.writeInbound(packet));
 
-        assertEquals(0, packet.content().getUnsignedShort(2));
+        DnsQuery decodedDnsQuery = readChannel.readInbound();
+        assertEquals(opCode, decodedDnsQuery.opCode());
+        assertTrue(decodedDnsQuery.release());
+
+        assertFalse(writeChannel.finish());
+        assertFalse(readChannel.finish());
+    }
+
+    @ParameterizedTest
+    @MethodSource("opCodesAndExpectedFlags")
+    public void testOpCodeIsEncodedIntoBits14To11(DnsOpCode opCode, boolean recursionDesired, int expectedFlags) {
+        InetSocketAddress addr = SocketUtils.socketAddress("8.8.8.8", 53);
+        EmbeddedChannel writeChannel = new EmbeddedChannel(new DatagramDnsQueryEncoder());
+
+        DnsQuery query = new DatagramDnsQuery(null, addr, 1, opCode)
+                .setRecursionDesired(recursionDesired);
+        query.setRecord(DnsSection.QUESTION, new DefaultDnsQuestion("example.com", DnsRecordType.A));
+
+        assertTrue(writeChannel.writeOutbound(query));
+        DatagramPacket packet = writeChannel.readOutbound();
+        assertEquals(expectedFlags, packet.content().getUnsignedShort(2));
 
         assertTrue(packet.release());
         assertFalse(writeChannel.finish());

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsQueryTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsQueryTest.java
@@ -32,6 +32,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DnsQueryTest {
 
+    private static final DnsOpCode[] OP_CODES = {
+            DnsOpCode.QUERY, DnsOpCode.IQUERY, DnsOpCode.STATUS, DnsOpCode.NOTIFY, DnsOpCode.UPDATE };
+
     @Test
     public void testEncodeAndDecodeQuery() {
         InetSocketAddress addr = SocketUtils.socketAddress("8.8.8.8", 53);
@@ -77,5 +80,80 @@ public class DnsQueryTest {
 
         assertFalse(writeChannel.finish());
         assertFalse(readChannel.finish());
+    }
+
+    @Test
+    public void testOpCodeSurvivesEncodeAndDecode() {
+        InetSocketAddress addr = SocketUtils.socketAddress("8.8.8.8", 53);
+        EmbeddedChannel writeChannel = new EmbeddedChannel(new DatagramDnsQueryEncoder());
+        EmbeddedChannel readChannel = new EmbeddedChannel(new DatagramDnsQueryDecoder());
+
+        for (DnsOpCode opCode: OP_CODES) {
+            DnsQuery query = new DatagramDnsQuery(null, addr, 1, opCode).setRecord(
+                    DnsSection.QUESTION,
+                    new DefaultDnsQuestion("example.com", DnsRecordType.A));
+
+            assertTrue(writeChannel.writeOutbound(query));
+            DatagramPacket packet = writeChannel.readOutbound();
+            assertTrue(readChannel.writeInbound(packet));
+
+            DnsQuery decodedDnsQuery = readChannel.readInbound();
+            assertEquals(opCode, decodedDnsQuery.opCode());
+            assertTrue(decodedDnsQuery.release());
+        }
+
+        assertFalse(writeChannel.finish());
+        assertFalse(readChannel.finish());
+    }
+
+    @Test
+    public void testOpCodeIsEncodedIntoBits14To11() {
+        InetSocketAddress addr = SocketUtils.socketAddress("8.8.8.8", 53);
+        EmbeddedChannel writeChannel = new EmbeddedChannel(new DatagramDnsQueryEncoder());
+
+        for (DnsOpCode opCode: OP_CODES) {
+            for (boolean recursionDesired: new boolean[] { false, true }) {
+                DnsQuery query = new DatagramDnsQuery(null, addr, 1, opCode)
+                        .setRecursionDesired(recursionDesired);
+                query.setRecord(DnsSection.QUESTION,
+                        new DefaultDnsQuestion("example.com", DnsRecordType.A));
+
+                assertTrue(writeChannel.writeOutbound(query));
+                DatagramPacket packet = writeChannel.readOutbound();
+
+                // RFC 1035 section 4.1.1: the flags word is QR(1) OPCODE(4) AA TC RD RA Z(3) RCODE(4).
+                // The OPCODE and RD are the only fields this encoder writes, so the whole word is known.
+                int expectedFlags = opCode.byteValue() << 11;
+                if (recursionDesired) {
+                    expectedFlags |= 1 << 8;
+                }
+                assertEquals(expectedFlags, packet.content().getUnsignedShort(2),
+                        "unexpected flags for opCode " + opCode + " and RD " + recursionDesired);
+
+                assertTrue(packet.release());
+            }
+        }
+
+        assertFalse(writeChannel.finish());
+    }
+
+    @Test
+    public void testOutOfRangeOpCodeIsTruncatedToFourBits() {
+        InetSocketAddress addr = SocketUtils.socketAddress("8.8.8.8", 53);
+        EmbeddedChannel writeChannel = new EmbeddedChannel(new DatagramDnsQueryEncoder());
+
+        // DnsOpCode does not range check, so an OPCODE that does not fit the 4 bits reserved by
+        // RFC 1035 section 4.1.1 can reach the encoder. It must not spill into the neighbouring QR bit.
+        DnsQuery query = new DatagramDnsQuery(null, addr, 1, DnsOpCode.valueOf(16)).setRecord(
+                DnsSection.QUESTION,
+                new DefaultDnsQuestion("example.com", DnsRecordType.A));
+
+        assertTrue(writeChannel.writeOutbound(query));
+        DatagramPacket packet = writeChannel.readOutbound();
+
+        assertEquals(0, packet.content().getUnsignedShort(2));
+
+        assertTrue(packet.release());
+        assertFalse(writeChannel.finish());
     }
 }


### PR DESCRIPTION
Motivation:

RFC 1035 section 4.1.1 puts the OPCODE in bits 14-11. `DnsQueryEncoder` shifted by 14 and masked with `0xFF`, so every non-QUERY opcode was corrupted on the wire: NOTIFY silently became QUERY, IQUERY and UPDATE became opcode 8, and STATUS set QR, making the query a response. The response encoder and both decoders already used bits 14-11.


Modification:

Encode the OPCODE as `(opCode & 0xF) << 11`. Add tests over all five DnsOpCode constants: the round-trip, the exact flags word with and without RD, and an out of range opcode.

Result:

Non-QUERY opcodes are encoded where RFC 1035 puts them and round-trip through the decoder. This fixes the OPCODE field only; UPDATE still cannot be sent, because the prerequisite and update sections are dropped.