### PR TITLE
Install patchelf as part of awslc docker image generation

### DIFF
--- a/docker/Dockerfile.al2023
+++ b/docker/Dockerfile.al2023
@@ -27,6 +27,7 @@ RUN dnf install -yq \
  make \
  ninja-build \
  patch \
+ patchelf \
  perl \
  perl-parent \
  perl-devel \


### PR DESCRIPTION
Motivation:

netty-tcnative needs patchelf now when building so we need to install it as part of the docker image

Modifications:

Install patchelf

Result:

awslc build job works again
