### PR TITLE
Close Channel when connect is cancelled during resolution

### DIFF
--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -240,13 +240,11 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
 
             // Wait until the name resolution is finished.
             resolveFuture.addListener((FutureListener<SocketAddress>) future -> {
-                if (promise.isDone()) {
-                    return;
-                }
-                if (future.cause() != null) {
+                Throwable cause = future.cause();
+                if (cause != null) {
                     channel.close();
-                    promise.tryFailure(future.cause());
-                } else {
+                    promise.tryFailure(cause);
+                } else if (!promise.isDone()) {
                     doConnect(future.getNow(), localAddress, promise);
                 }
             });

--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -193,11 +193,10 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
 
     private ChannelFuture doResolveAndConnect0(final Channel channel, SocketAddress remoteAddress,
                                                final SocketAddress localAddress, final ChannelPromise promise) {
-        // The Channel was created and registered before the address resolution started. If cancellation won the
-        // registration race, close the Channel and skip resolution. Once resolution starts, don't allow cancellation
-        // to race with resolver completion.
+        // The Channel was created and registered before the address resolution started. Close it if the connect
+        // attempt fails or is cancelled while resolution is still in progress.
         promise.addListener(ChannelFutureListener.CLOSE_ON_FAILURE);
-        if (!promise.setUncancellable()) {
+        if (promise.isDone()) {
             return promise;
         }
 
@@ -213,7 +212,8 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
                 resolver = ExternalAddressResolver.getOrDefault(externalResolver).getResolver(eventLoop);
             } catch (Throwable cause) {
                 channel.close();
-                return promise.setFailure(cause);
+                promise.tryFailure(cause);
+                return promise;
             }
 
             if (!resolver.isSupported(remoteAddress) || resolver.isResolved(remoteAddress)) {
@@ -230,7 +230,7 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
                 if (resolveFailureCause != null) {
                     // Failed to resolve immediately
                     channel.close();
-                    promise.setFailure(resolveFailureCause);
+                    promise.tryFailure(resolveFailureCause);
                 } else {
                     // Succeeded to resolve immediately; cached? (or did a blocking lookup)
                     doConnect(resolveFuture.getNow(), localAddress, promise);
@@ -240,9 +240,12 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
 
             // Wait until the name resolution is finished.
             resolveFuture.addListener((FutureListener<SocketAddress>) future -> {
+                if (promise.isDone()) {
+                    return;
+                }
                 if (future.cause() != null) {
                     channel.close();
-                    promise.setFailure(future.cause());
+                    promise.tryFailure(future.cause());
                 } else {
                     doConnect(future.getNow(), localAddress, promise);
                 }

--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -213,8 +213,7 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
                 resolver = ExternalAddressResolver.getOrDefault(externalResolver).getResolver(eventLoop);
             } catch (Throwable cause) {
                 channel.close();
-                promise.setFailure(cause);
-                return promise;
+                return promise.setFailure(cause);
             }
 
             if (!resolver.isSupported(remoteAddress) || resolver.isResolved(remoteAddress)) {
@@ -249,7 +248,7 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
                 }
             });
         } catch (Throwable cause) {
-            promise.setFailure(cause);
+            promise.tryFailure(cause);
         }
         return promise;
     }

--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -193,6 +193,13 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
 
     private ChannelFuture doResolveAndConnect0(final Channel channel, SocketAddress remoteAddress,
                                                final SocketAddress localAddress, final ChannelPromise promise) {
+        // The Channel was created and registered before the address resolution started. Close it if the connect
+        // attempt fails or is cancelled while resolution is still in progress.
+        promise.addListener(ChannelFutureListener.CLOSE_ON_FAILURE);
+        if (promise.isDone()) {
+            return promise;
+        }
+
         try {
             if (disableResolver) {
                 doConnect(remoteAddress, localAddress, promise);
@@ -205,7 +212,8 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
                 resolver = ExternalAddressResolver.getOrDefault(externalResolver).getResolver(eventLoop);
             } catch (Throwable cause) {
                 channel.close();
-                return promise.setFailure(cause);
+                promise.tryFailure(cause);
+                return promise;
             }
 
             if (!resolver.isSupported(remoteAddress) || resolver.isResolved(remoteAddress)) {
@@ -222,7 +230,7 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
                 if (resolveFailureCause != null) {
                     // Failed to resolve immediately
                     channel.close();
-                    promise.setFailure(resolveFailureCause);
+                    promise.tryFailure(resolveFailureCause);
                 } else {
                     // Succeeded to resolve immediately; cached? (or did a blocking lookup)
                     doConnect(resolveFuture.getNow(), localAddress, promise);
@@ -232,9 +240,12 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
 
             // Wait until the name resolution is finished.
             resolveFuture.addListener((FutureListener<SocketAddress>) future -> {
+                if (promise.isDone()) {
+                    return;
+                }
                 if (future.cause() != null) {
                     channel.close();
-                    promise.setFailure(future.cause());
+                    promise.tryFailure(future.cause());
                 } else {
                     doConnect(future.getNow(), localAddress, promise);
                 }
@@ -259,7 +270,6 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
                 } else {
                     channel.connect(remoteAddress, localAddress, connectPromise);
                 }
-                connectPromise.addListener(ChannelFutureListener.CLOSE_ON_FAILURE);
             }
         });
     }

--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -193,10 +193,11 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
 
     private ChannelFuture doResolveAndConnect0(final Channel channel, SocketAddress remoteAddress,
                                                final SocketAddress localAddress, final ChannelPromise promise) {
-        // The Channel was created and registered before the address resolution started. Close it if the connect
-        // attempt fails or is cancelled while resolution is still in progress.
+        // The Channel was created and registered before the address resolution started. If cancellation won the
+        // registration race, close the Channel and skip resolution. Once resolution starts, don't allow cancellation
+        // to race with resolver completion.
         promise.addListener(ChannelFutureListener.CLOSE_ON_FAILURE);
-        if (promise.isDone()) {
+        if (!promise.setUncancellable()) {
             return promise;
         }
 
@@ -212,7 +213,7 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
                 resolver = ExternalAddressResolver.getOrDefault(externalResolver).getResolver(eventLoop);
             } catch (Throwable cause) {
                 channel.close();
-                promise.tryFailure(cause);
+                promise.setFailure(cause);
                 return promise;
             }
 
@@ -230,7 +231,7 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
                 if (resolveFailureCause != null) {
                     // Failed to resolve immediately
                     channel.close();
-                    promise.tryFailure(resolveFailureCause);
+                    promise.setFailure(resolveFailureCause);
                 } else {
                     // Succeeded to resolve immediately; cached? (or did a blocking lookup)
                     doConnect(resolveFuture.getNow(), localAddress, promise);
@@ -240,18 +241,15 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
 
             // Wait until the name resolution is finished.
             resolveFuture.addListener((FutureListener<SocketAddress>) future -> {
-                if (promise.isDone()) {
-                    return;
-                }
                 if (future.cause() != null) {
                     channel.close();
-                    promise.tryFailure(future.cause());
+                    promise.setFailure(future.cause());
                 } else {
                     doConnect(future.getNow(), localAddress, promise);
                 }
             });
         } catch (Throwable cause) {
-            promise.tryFailure(cause);
+            promise.setFailure(cause);
         }
         return promise;
     }

--- a/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
@@ -396,7 +396,7 @@ public class BootstrapTest {
 
     @Test
     @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-    public void testCancelDuringAddressResolutionClosesChannel() throws Exception {
+    public void testConnectIsUncancellableDuringAddressResolution() throws Exception {
         EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
         PendingAddressResolverGroup resolverGroup = new PendingAddressResolverGroup();
         ChannelFuture connectFuture = null;
@@ -409,19 +409,20 @@ public class BootstrapTest {
 
             connectFuture = bootstrap.connect(InetSocketAddress.createUnresolved("netty.io", 443));
             assertTrue(resolverGroup.resolveStarted.await(5, TimeUnit.SECONDS));
-            assertTrue(connectFuture.cancel(false));
-            assertTrue(connectFuture.channel().closeFuture().await(5, TimeUnit.SECONDS));
-            assertFalse(connectFuture.channel().isOpen());
+            assertFalse(connectFuture.cancel(false));
+            assertFalse(connectFuture.isDone());
+            assertTrue(connectFuture.channel().isOpen());
 
             Promise<SocketAddress> resolvePromise = resolverGroup.resolvePromise.get();
             assertNotNull(resolvePromise);
             assertFalse(resolvePromise.isDone());
-            assertTrue(resolvePromise.tryFailure(new UnknownHostException("late resolver failure")));
-            connectFuture.channel().eventLoop().submit(new Runnable() {
-                @Override
-                public void run() { }
-            }).sync();
-            assertTrue(connectFuture.isCancelled());
+            UnknownHostException cause = new UnknownHostException("resolver failure");
+            resolvePromise.setFailure(cause);
+
+            assertTrue(connectFuture.await(5, TimeUnit.SECONDS));
+            assertSame(cause, connectFuture.cause());
+            assertTrue(connectFuture.channel().closeFuture().await(5, TimeUnit.SECONDS));
+            assertFalse(connectFuture.channel().isOpen());
         } finally {
             if (connectFuture != null) {
                 connectFuture.channel().close().syncUninterruptibly();

--- a/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
@@ -396,7 +396,7 @@ public class BootstrapTest {
 
     @Test
     @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-    public void testConnectIsUncancellableDuringAddressResolution() throws Exception {
+    public void testCancelDuringAddressResolutionClosesChannel() throws Exception {
         EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
         PendingAddressResolverGroup resolverGroup = new PendingAddressResolverGroup();
         ChannelFuture connectFuture = null;
@@ -409,20 +409,19 @@ public class BootstrapTest {
 
             connectFuture = bootstrap.connect(InetSocketAddress.createUnresolved("netty.io", 443));
             assertTrue(resolverGroup.resolveStarted.await(5, TimeUnit.SECONDS));
-            assertFalse(connectFuture.cancel(false));
-            assertFalse(connectFuture.isDone());
-            assertTrue(connectFuture.channel().isOpen());
+            assertTrue(connectFuture.cancel(false));
+            assertTrue(connectFuture.channel().closeFuture().await(5, TimeUnit.SECONDS));
+            assertFalse(connectFuture.channel().isOpen());
 
             Promise<SocketAddress> resolvePromise = resolverGroup.resolvePromise.get();
             assertNotNull(resolvePromise);
             assertFalse(resolvePromise.isDone());
-            UnknownHostException cause = new UnknownHostException("resolver failure");
-            resolvePromise.setFailure(cause);
-
-            assertTrue(connectFuture.await(5, TimeUnit.SECONDS));
-            assertSame(cause, connectFuture.cause());
-            assertTrue(connectFuture.channel().closeFuture().await(5, TimeUnit.SECONDS));
-            assertFalse(connectFuture.channel().isOpen());
+            assertTrue(resolvePromise.tryFailure(new UnknownHostException("late resolver failure")));
+            connectFuture.channel().eventLoop().submit(new Runnable() {
+                @Override
+                public void run() { }
+            }).sync();
+            assertTrue(connectFuture.isCancelled());
         } finally {
             if (connectFuture != null) {
                 connectFuture.channel().close().syncUninterruptibly();

--- a/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
@@ -38,6 +38,8 @@ import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalChannel;
 import io.netty.channel.local.LocalIoHandler;
 import io.netty.channel.local.LocalServerChannel;
+import io.netty.channel.nio.NioIoHandler;
+import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.resolver.AbstractAddressResolver;
 import io.netty.resolver.AddressResolver;
 import io.netty.resolver.AddressResolverGroup;
@@ -52,6 +54,7 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.function.Executable;
 
 import java.net.ConnectException;
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
@@ -66,6 +69,8 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -390,6 +395,88 @@ public class BootstrapTest {
     }
 
     @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+    public void testCancelDuringAddressResolutionClosesChannel() throws Exception {
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        PendingAddressResolverGroup resolverGroup = new PendingAddressResolverGroup();
+        ChannelFuture connectFuture = null;
+        try {
+            Bootstrap bootstrap = new Bootstrap()
+                    .group(group)
+                    .channel(NioSocketChannel.class)
+                    .resolver(resolverGroup)
+                    .handler(dummyHandler);
+
+            connectFuture = bootstrap.connect(InetSocketAddress.createUnresolved("netty.io", 443));
+            assertTrue(resolverGroup.resolveStarted.await(5, TimeUnit.SECONDS));
+            assertTrue(connectFuture.cancel(false));
+            assertTrue(connectFuture.channel().closeFuture().await(5, TimeUnit.SECONDS));
+            assertFalse(connectFuture.channel().isOpen());
+
+            Promise<SocketAddress> resolvePromise = resolverGroup.resolvePromise.get();
+            assertNotNull(resolvePromise);
+            assertFalse(resolvePromise.isDone());
+            assertTrue(resolvePromise.tryFailure(new UnknownHostException("late resolver failure")));
+            connectFuture.channel().eventLoop().submit(new Runnable() {
+                @Override
+                public void run() { }
+            }).sync();
+            assertTrue(connectFuture.isCancelled());
+        } finally {
+            if (connectFuture != null) {
+                connectFuture.channel().close().syncUninterruptibly();
+            }
+            resolverGroup.close();
+            group.shutdownGracefully().syncUninterruptibly();
+        }
+    }
+
+    @Test
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+    public void testCancelBeforeRegistrationDoesNotResolveAddress() throws Exception {
+        DefaultEventLoop group = new DefaultEventLoop();
+        PendingAddressResolverGroup resolverGroup = new PendingAddressResolverGroup();
+        CountDownLatch eventLoopBlocked = new CountDownLatch(1);
+        CountDownLatch releaseEventLoop = new CountDownLatch(1);
+        ChannelFuture connectFuture = null;
+        try {
+            group.execute(new Runnable() {
+                @Override
+                public void run() {
+                    eventLoopBlocked.countDown();
+                    try {
+                        releaseEventLoop.await();
+                    } catch (InterruptedException ignore) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+            });
+            assertTrue(eventLoopBlocked.await(5, TimeUnit.SECONDS));
+
+            Bootstrap bootstrap = new Bootstrap()
+                    .group(group)
+                    .channel(LocalChannel.class)
+                    .resolver(resolverGroup)
+                    .handler(dummyHandler);
+
+            connectFuture = bootstrap.connect(LocalAddress.ANY);
+            assertTrue(connectFuture.cancel(false));
+            releaseEventLoop.countDown();
+
+            assertTrue(connectFuture.channel().closeFuture().await(5, TimeUnit.SECONDS));
+            assertFalse(connectFuture.channel().isOpen());
+            assertEquals(0, resolverGroup.resolveCount.get());
+        } finally {
+            releaseEventLoop.countDown();
+            if (connectFuture != null) {
+                connectFuture.channel().close().syncUninterruptibly();
+            }
+            resolverGroup.close();
+            group.shutdownGracefully().syncUninterruptibly();
+        }
+    }
+
+    @Test
     public void testGetResolverFailed() throws Exception {
         class TestException extends RuntimeException { }
 
@@ -607,6 +694,39 @@ public class BootstrapTest {
                             }
                         }
                     });
+                }
+            };
+        }
+    }
+
+    private static final class PendingAddressResolverGroup extends AddressResolverGroup<SocketAddress> {
+
+        final CountDownLatch resolveStarted = new CountDownLatch(1);
+        final AtomicInteger resolveCount = new AtomicInteger();
+        final AtomicReference<Promise<SocketAddress>> resolvePromise =
+                new AtomicReference<Promise<SocketAddress>>();
+
+        @Override
+        protected AddressResolver<SocketAddress> newResolver(EventExecutor executor) throws Exception {
+            return new AbstractAddressResolver<SocketAddress>(executor) {
+                @Override
+                protected boolean doIsResolved(SocketAddress address) {
+                    return false;
+                }
+
+                @Override
+                protected void doResolve(SocketAddress address, Promise<SocketAddress> promise) throws Exception {
+                    resolveCount.incrementAndGet();
+                    if (!resolvePromise.compareAndSet(null, promise)) {
+                        throw new IllegalStateException("resolve already started");
+                    }
+                    resolveStarted.countDown();
+                }
+
+                @Override
+                protected void doResolveAll(SocketAddress address, Promise<List<SocketAddress>> promise)
+                        throws Exception {
+                    throw new UnsupportedOperationException();
                 }
             };
         }


### PR DESCRIPTION
Motivation:

`Bootstrap.connect(...)` creates and registers a Channel before asynchronous address resolution. If the connect future is cancelled while resolution is pending, the Channel remains open until resolution completes. A late resolver failure also attempts to fail the cancelled promise and logs `IllegalStateException: complete already`.

Modification:

- Install the close-on-failure listener before address resolution starts so cancellation closes the registered Channel.
- Skip address resolution when cancellation wins the registration race.
- Ignore late resolver completion after the connect promise is done and use `tryFailure(...)` for cancellation races.
- Keep the resolver future active so shared in-flight resolutions are not cancelled.
- Add regression tests for cancellation during resolution with a real NIO Channel and before delayed registration completes.

Result:

Cancelling a Bootstrap connect closes its Channel while address resolution is pending, late resolver completion no longer tries to complete a cancelled promise, and delayed registration does not start unnecessary resolution.