### PR TITLE
Protobuf: Update protobuf-javanano to non alpha release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -889,7 +889,7 @@
       <dependency>
         <groupId>com.google.protobuf.nano</groupId>
         <artifactId>protobuf-javanano</artifactId>
-        <version>3.0.0-alpha-7</version>
+        <version>3.1.0</version>
       </dependency>
 
       <!-- Our own Tomcat Native fork - completely optional for the native lib, used for accelerating SSL with OpenSSL. -->


### PR DESCRIPTION
Motivation:

We should better not depend on a alpha release and just use a final release

Modifications:

Update to final release

Result:

No more dependency on alpha release. Related to https://github.com/netty/netty/issues/17298
