### PR TITLE
Channel: Add unit tests for AbstractChannel edge-case failures and buffer releases

### DIFF
--- a/transport/src/test/java/io/netty/channel/AbstractChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/AbstractChannelTest.java
@@ -19,7 +19,10 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.channels.ClosedChannelException;
+import java.nio.channels.NotYetConnectedException;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.util.NetUtil;
 import io.netty.util.internal.PlatformDependent;
 import org.junit.jupiter.api.Test;
@@ -29,6 +32,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
@@ -164,6 +168,131 @@ public class AbstractChannelTest {
             channel.close();
             loop.shutdownGracefully();
         }
+    }
+
+    @Test
+    public void ensureClosedChannelOnWriteReleaseMsg() throws Exception {
+        final IOException ioException = new IOException();
+        final Channel channel = new TestChannel() {
+            private boolean open = true;
+            private boolean active;
+
+            @Override
+            protected AbstractUnsafe newUnsafe() {
+                return new AbstractUnsafe() {
+                    @Override
+                    public void connect(SocketAddress remoteAddress, SocketAddress localAddress,
+                                        ChannelPromise promise) {
+                        active = true;
+                        promise.setSuccess();
+                    }
+                };
+            }
+
+            @Override
+            protected void doClose() {
+                active = false;
+                open = false;
+            }
+
+            @Override
+            protected void doWrite(ChannelOutboundBuffer in) throws Exception {
+                throw ioException;
+            }
+
+            @Override
+            public boolean isOpen() {
+                return open;
+            }
+
+            @Override
+            public boolean isActive() {
+                return active;
+            }
+        };
+        EventLoop loop = new DefaultEventLoop();
+        try {
+            registerChannel(loop, channel);
+            channel.connect(new InetSocketAddress(NetUtil.LOCALHOST, 8888)).sync();
+
+            assertSame(ioException, channel.writeAndFlush("").await().cause());
+            ByteBuf msg = Unpooled.wrappedBuffer(new byte[16]);
+            assertEquals(1, msg.refCnt());
+            ChannelPromise promise = channel.newPromise();
+            channel.unsafe().write(msg, promise);
+
+            assertTrue(promise.isDone());
+            assertInstanceOf(ClosedChannelException.class, promise.cause());
+            assertEquals(0, msg.refCnt());
+        } finally {
+            channel.close();
+            loop.shutdownGracefully();
+        }
+    }
+
+    @Test
+    public void flushOnUnconnectedOpenChannelFailsWithNotYetConnected() throws Exception {
+        EventLoop eventLoop = mock(EventLoop.class);
+        when(eventLoop.inEventLoop()).thenReturn(true);
+        TestChannel channel = new TestChannel() {
+            @Override
+            public boolean isOpen() {
+                //Open, but never connected
+                return true;
+            }
+
+            @Override
+            public boolean isActive() {
+                return false;
+            }
+        };
+
+        registerChannel(eventLoop, channel);
+        ByteBuf msg = Unpooled.wrappedBuffer(new byte[16]);
+        ChannelPromise promise = channel.newPromise();
+        channel.unsafe().write(msg, promise);
+
+        channel.unsafe().flush();
+        assertTrue(promise.isDone());
+        assertInstanceOf(NotYetConnectedException.class, promise.cause());
+        assertEquals(0, msg.refCnt());
+    }
+
+    @Test
+    public void flushOnUnconnectedClosedChannelFailsWithClosedChannel() throws Exception {
+        EventLoop eventLoop = mock(EventLoop.class);
+        when(eventLoop.inEventLoop()).thenReturn(true);
+        TestChannel channel = new TestChannel() {
+            private boolean open = true;
+
+            @Override
+            public boolean isOpen() {
+                return open;
+            }
+
+            @Override
+            public boolean isActive() {
+                return false;
+            }
+
+            @Override
+            public void doClose() {
+                this.open = false;
+            }
+        };
+
+        registerChannel(eventLoop, channel);
+        ByteBuf msg = Unpooled.wrappedBuffer(new byte[16]);
+        ChannelPromise promise = channel.newPromise();
+
+        channel.unsafe().write(msg, promise);
+
+        channel.unsafe().close(channel.unsafe().voidPromise());
+        channel.unsafe().flush();
+
+        assertTrue(promise.isDone());
+        assertInstanceOf(ClosedChannelException.class, promise.cause());
+        assertEquals(0, msg.refCnt());
     }
 
     private static void assertClosedChannelException(ChannelFuture future, IOException expected)

--- a/transport/src/test/java/io/netty/channel/AbstractChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/AbstractChannelTest.java
@@ -20,6 +20,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.NotYetConnectedException;
+import java.util.concurrent.TimeUnit;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -219,13 +220,16 @@ public class AbstractChannelTest {
             ByteBuf msg = Unpooled.wrappedBuffer(new byte[16]);
             assertEquals(1, msg.refCnt());
             ChannelPromise promise = channel.newPromise();
-            channel.unsafe().write(msg, promise);
+            loop.execute(() -> {
+                channel.unsafe().write(msg, promise);
+            });
 
+            assertTrue(promise.await(2, TimeUnit.SECONDS));
             assertTrue(promise.isDone());
             assertInstanceOf(ClosedChannelException.class, promise.cause());
             assertEquals(0, msg.refCnt());
         } finally {
-            channel.close();
+            channel.close().sync();
             loop.shutdownGracefully();
         }
     }
@@ -234,6 +238,13 @@ public class AbstractChannelTest {
     public void flushOnUnconnectedOpenChannelFailsWithNotYetConnected() throws Exception {
         EventLoop eventLoop = mock(EventLoop.class);
         when(eventLoop.inEventLoop()).thenReturn(true);
+        doAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocationOnMock) {
+                ((Runnable) invocationOnMock.getArgument(0)).run();
+                return null;
+            }
+        }).when(eventLoop).execute(any(Runnable.class));
         TestChannel channel = new TestChannel() {
             @Override
             public boolean isOpen() {
@@ -247,21 +258,37 @@ public class AbstractChannelTest {
             }
         };
 
-        registerChannel(eventLoop, channel);
-        ByteBuf msg = Unpooled.wrappedBuffer(new byte[16]);
-        ChannelPromise promise = channel.newPromise();
-        channel.unsafe().write(msg, promise);
+        try {
+            registerChannel(eventLoop, channel);
+            ByteBuf msg = Unpooled.wrappedBuffer(new byte[16]);
+            ChannelPromise promise = channel.newPromise();
 
-        channel.unsafe().flush();
-        assertTrue(promise.isDone());
-        assertInstanceOf(NotYetConnectedException.class, promise.cause());
-        assertEquals(0, msg.refCnt());
+            eventLoop.execute(new Runnable() {
+                @Override
+                public void run() {
+                    channel.unsafe().write(msg, promise);
+                    channel.unsafe().flush();
+                }
+            });
+            assertTrue(promise.isDone());
+            assertInstanceOf(NotYetConnectedException.class, promise.cause());
+            assertEquals(0, msg.refCnt());
+        } finally {
+            channel.close().sync();
+        }
     }
 
     @Test
     public void flushOnUnconnectedClosedChannelFailsWithClosedChannel() throws Exception {
         EventLoop eventLoop = mock(EventLoop.class);
         when(eventLoop.inEventLoop()).thenReturn(true);
+        doAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocationOnMock) {
+                ((Runnable) invocationOnMock.getArgument(0)).run();
+                return null;
+            }
+        }).when(eventLoop).execute(any(Runnable.class));
         TestChannel channel = new TestChannel() {
             private boolean open = true;
 
@@ -280,19 +307,23 @@ public class AbstractChannelTest {
                 this.open = false;
             }
         };
+        try {
+            registerChannel(eventLoop, channel);
+            ByteBuf msg = Unpooled.wrappedBuffer(new byte[16]);
+            ChannelPromise promise = channel.newPromise();
 
-        registerChannel(eventLoop, channel);
-        ByteBuf msg = Unpooled.wrappedBuffer(new byte[16]);
-        ChannelPromise promise = channel.newPromise();
+            eventLoop.execute(() -> {
+                channel.unsafe().write(msg, promise);
+                channel.unsafe().close(channel.unsafe().voidPromise());
+                channel.unsafe().flush();
+            });
 
-        channel.unsafe().write(msg, promise);
-
-        channel.unsafe().close(channel.unsafe().voidPromise());
-        channel.unsafe().flush();
-
-        assertTrue(promise.isDone());
-        assertInstanceOf(ClosedChannelException.class, promise.cause());
-        assertEquals(0, msg.refCnt());
+            assertTrue(promise.isDone());
+            assertInstanceOf(ClosedChannelException.class, promise.cause());
+            assertEquals(0, msg.refCnt());
+        } finally {
+            channel.close().sync();
+        }
     }
 
     private static void assertClosedChannelException(ChannelFuture future, IOException expected)


### PR DESCRIPTION
**Motivation:**
Core channel lifecycle paths in AbstractChannel (such as writing to a channel closed by an I/O error, flushing an unconnected open channel, and flushing a closed channel) lacked explicit unit test coverage for proper exception propagation and memory leak prevention.

**Modifications:**
Added unit tests to AbstractChannelTest covering:
- Writing to a channel closed via a write-error I/O exception to ensure proper ClosedChannelException propagation and buffer release.
- Flushing an unconnected but open channel to verify NotYetConnectedException handling and resource cleanup.
- Flushing an unconnected channel that subsequently closes to verify proper ClosedChannelException mapping and reference count management.

**Result:**
Improved test coverage and robustness for edge-case failure modes and resource-leak protections in AbstractChannel.