### PR TITLE
Increase timeout in test to address flakyness

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
@@ -251,7 +251,7 @@ public class DataCompressionHttp2Test {
         testEncodingMessage(padding, text, compressionAlgorithm, new Callable<Void>() {
             @Override
             public Void call() throws Exception {
-                assertTrue(serverLatch.await(5, SECONDS));
+                assertTrue(serverLatch.await(10, SECONDS));
                 serverOut.flush();
                 Throwable cause = serverException.get();
                 if (cause == null) {


### PR DESCRIPTION
Motivation:

The DataCompressionHttpTest.encodingTooBigMessage(...) operates on a lot of data so we should use a higher timeout when waiting on the latch so we not fail due of slow execution time on the CI

Modifications:

Increase timeout to 10 seconds

Result:

Hopefully less flaky test
