### PR TITLE
DatagramUnicastIpv6MappedTest should explicit bind to ipv4 address to make test less flaky

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastIPv6MappedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastIPv6MappedTest.java
@@ -20,15 +20,22 @@ import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.util.NetUtil;
 import io.netty.util.internal.PlatformDependent;
 
+import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.net.UnknownHostException;
 
 public class DatagramUnicastIPv6MappedTest extends DatagramUnicastIPv6Test {
 
     @Override
     protected SocketAddress newSocketAddress() {
-        return new InetSocketAddress(0);
+        // Explicit use IPv4 wildcard for bind while the channel is using SocketProtocolFamily.INET6.
+        try {
+            return new InetSocketAddress(InetAddress.getByAddress(new byte[] {0, 0 , 0, 0}), 0);
+        } catch (UnknownHostException e) {
+            throw new IllegalStateException(e);
+        }
     }
 
     @Override


### PR DESCRIPTION
Motivation:

How exactly an OS will behave when using a wildcard address when bind on an inet6 socket is somewhat not well defined so we should better explicit specify that we want to bind to an ipv4 wildcard address.

Modifications:

Explicit use ipv4 wildcard address

Result:

Less flaky test
