### PR TITLE
Make the Linux codec-native-quic artifacts loadable on musl (Alpine)

### DIFF
--- a/.github/scripts/musl-verify/QuicMuslCheck.java
+++ b/.github/scripts/musl-verify/QuicMuslCheck.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
+import io.netty.channel.socket.nio.NioDatagramChannel;
+import io.netty.handler.codec.quic.InsecureQuicTokenHandler;
+import io.netty.handler.codec.quic.Quic;
+import io.netty.handler.codec.quic.QuicChannel;
+import io.netty.handler.codec.quic.QuicClientCodecBuilder;
+import io.netty.handler.codec.quic.QuicServerCodecBuilder;
+import io.netty.handler.codec.quic.QuicSslContext;
+import io.netty.handler.codec.quic.QuicSslContextBuilder;
+import io.netty.handler.codec.quic.QuicStreamChannel;
+import io.netty.handler.codec.quic.QuicStreamType;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty.util.CharsetUtil;
+
+import javax.net.ssl.KeyManagerFactory;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.security.KeyStore;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Checks that a Linux {@code libnetty_quiche*.so} built against glibc can be loaded, initialized
+ * and actually <em>used</em> by the libc of the machine running this class. Written for
+ * Alpine/musl, with a glibc run as the control.
+ *
+ * <p>The handshake level is the point of this class. musl does not fail a dlopen on a relocation
+ * it cannot resolve -- it defers it and aborts at the first call instead -- so "the library
+ * loaded" says very little about a library that carries a whole Rust standard library inside it.
+ * The undefined glibc-only symbols that motivated {@code musl_compat.c} (the LFS64 family,
+ * {@code __xstat64} and friends) sit in quiche's file and socket paths, which nothing before this
+ * level touches. A run that stops at {@code init} would have reported PASS for every artifact
+ * netty has ever released.
+ *
+ * <p>One level per JVM, chosen by the first argument, so a hard crash in an early level cannot
+ * hide a later one. The historical aarch64 failure in netty-tcnative was a SIGSEGV inside
+ * {@code JVM_LoadLibrary} rather than an exception, so the caller must also treat a JVM that dies
+ * without printing a RESULT line as a failure -- see verify.sh.
+ *
+ * <p>Client and server both run in this one JVM over the loopback interface: a QUIC handshake
+ * needs two peers, and putting them in two containers would test the container network rather
+ * than the library.
+ *
+ * <p>Deliberately kept to Java 8 syntax and to the netty artifacts themselves. The server
+ * certificate comes in as a PKCS#12 keystore built by keytool rather than from
+ * {@code SelfSignedCertificate}, which needs either a BouncyCastle jar or
+ * {@code --add-exports java.base/sun.security.x509} and would make the check fail for reasons
+ * that have nothing to do with musl.
+ */
+public final class QuicMuslCheck {
+
+    private static final String ALPN = "netty-musl-check";
+    private static final String PAYLOAD = "PING";
+    private static final long TIMEOUT_SECONDS = 30;
+
+    private static boolean failed;
+
+    public static void main(String[] args) {
+        if (args.length < 2) {
+            System.err.println("usage: QuicMuslCheck <load|init|handshake> <path-to-.so> [keystore.p12] [password]");
+            System.exit(2);
+        }
+        String level = args[0];
+        String soPath = args[1];
+
+        try {
+            // Every level needs the library loaded; the load itself is level "load".
+            load(soPath);
+            if (!"load".equals(level)) {
+                init();
+                if ("handshake".equals(level)) {
+                    if (args.length < 4) {
+                        throw new IllegalStateException("the handshake level needs a keystore and a password");
+                    }
+                    handshake(args[2], args[3]);
+                }
+            }
+        } catch (Throwable t) {
+            // A missing symbol surfaces here as the musl loader's own text, e.g.
+            // "Error relocating <lib>: __xstat64: symbol not found".
+            result(level, false, rootMessage(t));
+        }
+        System.exit(failed ? 1 : 0);
+    }
+
+    /**
+     * Loads the .so straight off disk, before netty gets a chance to unpack its own copy. This is
+     * the level that catches an unresolvable DT_NEEDED, which on musl is a hard dlopen failure
+     * rather than a deferred one.
+     *
+     * <p>Not a pure dlopen, and cannot be made into one: the library's {@code JNI_OnLoad} calls
+     * FindClass, so a successful dlopen continues straight into netty's own class and library
+     * loading. Reading a failure here therefore means looking at which file the message names --
+     * this one, or the temporary copy {@code NativeLibraryLoader} unpacks out of the jar.
+     */
+    private static void load(String soPath) {
+        File so = new File(soPath);
+        if (!so.isFile()) {
+            throw new IllegalStateException("not a file: " + soPath);
+        }
+        System.load(so.getAbsolutePath());
+        result("load", true, "System.load ok: " + so.getName());
+    }
+
+    private static void init() {
+        // Loads netty's own copy out of the jar and runs the static initializer, which calls into
+        // quiche for the version string.
+        Quic.ensureAvailability();
+        result("init", true, "Quic.isAvailable()=" + Quic.isAvailable());
+    }
+
+    private static void handshake(String keystorePath, String password) throws Exception {
+        EventLoopGroup group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        Channel serverChannel = null;
+        Channel clientChannel = null;
+        try {
+            InetAddress loopback = InetAddress.getLoopbackAddress();
+            serverChannel = new Bootstrap()
+                    .group(group)
+                    .channel(NioDatagramChannel.class)
+                    .handler(newServerCodec(keystorePath, password))
+                    .bind(new InetSocketAddress(loopback, 0)).sync().channel();
+            int port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
+            result("handshake", true, "server bound on " + loopback.getHostAddress() + ':' + port);
+
+            QuicSslContext clientSslContext = QuicSslContextBuilder.forClient()
+                    .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                    .applicationProtocols(ALPN)
+                    .build();
+            ChannelHandler clientCodec = new QuicClientCodecBuilder()
+                    .sslContext(clientSslContext)
+                    .maxIdleTimeout(5000, TimeUnit.MILLISECONDS)
+                    .initialMaxData(1000000)
+                    .initialMaxStreamDataBidirectionalLocal(100000)
+                    .build();
+            clientChannel = new Bootstrap()
+                    .group(group)
+                    .channel(NioDatagramChannel.class)
+                    .handler(clientCodec)
+                    .bind(new InetSocketAddress(loopback, 0)).sync().channel();
+
+            QuicChannel quicChannel = QuicChannel.newBootstrap(clientChannel)
+                    .streamHandler(new ChannelInboundHandlerAdapter())
+                    .remoteAddress(new InetSocketAddress(loopback, port))
+                    .connect()
+                    .get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            result("handshake", true, "connected, alpn=" + ALPN);
+
+            // A queue rather than a latch plus a field: it carries the echoed bytes and the
+            // "stream closed with nothing" case in one place, and poll() gives the timeout.
+            LinkedBlockingQueue<String> echoed = new LinkedBlockingQueue<String>();
+            QuicStreamChannel stream = quicChannel.createStream(
+                    QuicStreamType.BIDIRECTIONAL, new EchoCollector(echoed)).sync().getNow();
+            stream.writeAndFlush(Unpooled.copiedBuffer(PAYLOAD, CharsetUtil.US_ASCII))
+                    .addListener(QuicStreamChannel.SHUTDOWN_OUTPUT);
+
+            String received = echoed.poll(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            if (received == null) {
+                throw new IllegalStateException("no echo within " + TIMEOUT_SECONDS + "s");
+            }
+            if (!PAYLOAD.equals(received)) {
+                throw new IllegalStateException("echo mismatch: expected '" + PAYLOAD
+                        + "' but got '" + received + '\'');
+            }
+            result("handshake", true, "bidirectional stream echoed " + received.length() + " bytes");
+
+            quicChannel.close().sync();
+        } finally {
+            if (clientChannel != null) {
+                clientChannel.close().sync();
+            }
+            if (serverChannel != null) {
+                serverChannel.close().sync();
+            }
+            group.shutdownGracefully(0, 1, TimeUnit.SECONDS).sync();
+        }
+    }
+
+    private static ChannelHandler newServerCodec(String keystorePath, String password) throws Exception {
+        KeyStore keyStore = KeyStore.getInstance("PKCS12");
+        InputStream in = new FileInputStream(keystorePath);
+        try {
+            keyStore.load(in, password.toCharArray());
+        } finally {
+            in.close();
+        }
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        kmf.init(keyStore, password.toCharArray());
+
+        QuicSslContext sslContext = QuicSslContextBuilder.forServer(kmf, password)
+                .applicationProtocols(ALPN)
+                .build();
+        return new QuicServerCodecBuilder()
+                .sslContext(sslContext)
+                .maxIdleTimeout(5000, TimeUnit.MILLISECONDS)
+                .initialMaxData(1000000)
+                .initialMaxStreamDataBidirectionalLocal(100000)
+                .initialMaxStreamDataBidirectionalRemote(100000)
+                .initialMaxStreamsBidirectional(10)
+                .tokenHandler(InsecureQuicTokenHandler.INSTANCE)
+                .handler(new SharableNoopHandler())
+                .streamHandler(new ChannelInitializer<QuicStreamChannel>() {
+                    @Override
+                    protected void initChannel(QuicStreamChannel ch) {
+                        ch.pipeline().addLast(new ChannelInboundHandlerAdapter() {
+                            @Override
+                            public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                                // Echo straight back and send the FIN with it. The payload is a
+                                // handful of bytes, so it cannot arrive split.
+                                ctx.writeAndFlush(msg).addListener(QuicStreamChannel.SHUTDOWN_OUTPUT);
+                            }
+                        });
+                    }
+                })
+                .build();
+    }
+
+    /** Collects the echoed bytes and hands them over once the peer has sent its FIN. */
+    private static final class EchoCollector extends ChannelInboundHandlerAdapter {
+
+        private final LinkedBlockingQueue<String> out;
+        private final StringBuilder received = new StringBuilder();
+
+        EchoCollector(LinkedBlockingQueue<String> out) {
+            this.out = out;
+        }
+
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) {
+            ByteBuf buf = (ByteBuf) msg;
+            try {
+                received.append(buf.toString(CharsetUtil.US_ASCII));
+            } finally {
+                buf.release();
+            }
+        }
+
+        @Override
+        public void channelInactive(ChannelHandlerContext ctx) {
+            out.offer(received.toString());
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            out.offer("exception: " + cause);
+            ctx.close();
+        }
+    }
+
+    /** The server needs one connection-level handler instance across every connection. */
+    private static final class SharableNoopHandler extends ChannelInboundHandlerAdapter {
+        @Override
+        public boolean isSharable() {
+            return true;
+        }
+    }
+
+    private static void result(String level, boolean pass, String detail) {
+        if (!pass) {
+            failed = true;
+        }
+        System.out.println("RESULT\t" + level + '\t' + (pass ? "PASS" : "FAIL") + '\t' + detail);
+    }
+
+    /** Walks to the deepest cause and flattens it onto one line. */
+    private static String rootMessage(Throwable t) {
+        Throwable root = t;
+        while (root.getCause() != null && root.getCause() != root) {
+            root = root.getCause();
+        }
+        String msg = root.getMessage();
+        if (msg == null || msg.isEmpty()) {
+            msg = root.toString();
+        }
+        return root.getClass().getSimpleName() + ": " + msg.replace('\n', ' ').replace('\r', ' ');
+    }
+
+    private QuicMuslCheck() {
+    }
+}

--- a/.github/scripts/musl-verify/README.md
+++ b/.github/scripts/musl-verify/README.md
@@ -1,0 +1,73 @@
+# musl verification for netty-codec-native-quic
+
+The Linux native artifacts are built against glibc but are expected to load from the same jar on
+musl (Alpine). Nothing in the ordinary build notices when that stops being true: the build hosts
+are CentOS, the test hosts are Ubuntu, and musl does not fail a `dlopen` on a relocation it cannot
+resolve -- it defers it and aborts at the first call instead. So a broken artifact still loads.
+
+That is why `verify.sh` does not stop at loading. `codec-native-quic` links quiche statically, and
+quiche brings a Rust standard library that calls glibc-only entry points by name, so only a real
+QUIC handshake decides the outcome.
+
+## Running it
+
+```
+# build the jars (x86_64)
+docker compose -f docker/docker-compose.yaml -f docker/docker-compose.centos-7.111.yaml build
+docker compose -f docker/docker-compose.yaml -f docker/docker-compose.centos-7.111.yaml run build-native-quic
+
+# run them on bare Alpine
+docker run --rm \
+  -v "$PWD/.github/scripts/musl-verify:/verify:ro" \
+  -v "$HOME/.m2/repository/io/netty:/jars:ro" \
+  -e MUSL_VARIANT=bare -e MUSL_DROP_ELFTOOLS=1 \
+  eclipse-temurin:21-jdk-alpine \
+  sh -c 'apk add --no-cache --virtual .elftools binutils >/dev/null && sh /verify/verify.sh /jars'
+```
+
+`MUSL_DROP_ELFTOOLS=1` makes the script `apk del` binutils again before it executes anything.
+binutils depends on libgcc, so leaving it installed silently satisfies a `libgcc_s.so.1`
+`DT_NEEDED` and the bare run stops testing what it claims to.
+
+Swap the image for `eclipse-temurin:21-jdk-noble` as a glibc control: anything that fails on Alpine
+but also fails there is a broken harness, not a broken library.
+
+## What each check is for
+
+| check | catches |
+|---|---|
+| `ldd` | the musl loader's own verdict, with no JVM in the way |
+| `DT_NEEDED` | a name musl does not reserve and cannot find on disk, e.g. `ld-linux-x86-64.so.2` or `libgcc_s.so.1` |
+| undefined symbols | glibc-internal names musl never exported; reported, not fatal, because a deferred relocation nothing calls never aborts |
+| `load` | the `dlopen` itself, before netty unpacks its own copy |
+| `init` | `Quic.ensureAvailability()`, i.e. netty's loader and quiche's own startup |
+| `handshake` | a real client and server over loopback, exchanging a stream |
+
+A hard JVM crash prints no `RESULT` line, and the script turns that into a failure rather than
+letting a missing line read as success. That matters: the equivalent netty-tcnative bug killed the
+JVM with SIGSEGV inside `JVM_LoadLibrary` rather than raising `UnsatisfiedLinkError`.
+
+## Known failure signatures
+
+```
+Error loading shared library ld-linux-x86-64.so.2: No such file or directory
+```
+`ld-linux-...` does not begin with `lib`, so it is not one of the names musl satisfies internally
+and the loader goes to the filesystem. Fixed by the `patchelf --remove-needed` step in
+`codec-native-quic/pom.xml`.
+
+```
+Error loading shared library libgcc_s.so.1: No such file or directory
+```
+`gcc_s.` is not a musl-reserved stem either, so this resolves only on images that happen to ship
+Alpine's `libgcc` package. `eclipse-temurin:21-jdk-alpine` does; `amazoncorretto:21-alpine` does
+not. Fixed by linking the unwinder statically.
+
+```
+Error relocating ...: gnu_get_libc_version: symbol not found
+```
+A glibc-internal name musl does not export. Fixed by
+`codec-native-quic/src/main/c/musl_compat.c`.
+
+See https://github.com/netty/netty-tcnative/issues/907 for the original report against
+netty-tcnative and https://github.com/netty/netty-tcnative/pull/997 for the same treatment there.

--- a/.github/scripts/musl-verify/verify.sh
+++ b/.github/scripts/musl-verify/verify.sh
@@ -1,0 +1,224 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Copyright 2026 The Netty Project
+#
+# The Netty Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+# Verify a built netty-codec-native-quic Linux artifact under the libc of THIS container.
+#
+# Run it on Alpine to prove the glibc-built jar really works on musl, and on a glibc image as the
+# control -- anything that fails on Alpine but also fails here means the harness is broken, not the
+# library.
+#
+# The important part is that it does not stop at loading. musl defers a relocation it cannot
+# resolve rather than failing the dlopen, so a library with undefined glibc-only symbols loads
+# happily and dies at the first call. quiche carries a Rust standard library whose file and socket
+# paths reach exactly those symbols, so only a real handshake decides the outcome.
+#
+# usage: verify.sh <dir-containing-the-netty-jars>
+# env:   MUSL_VARIANT         label for the log, e.g. bare / gcompat / glibc-control
+#        MUSL_DROP_ELFTOOLS   1 to apk del the ELF tools before the runtime checks
+# exit:  0 all checks passed / 1 at least one failed / 2 usage or setup error
+set -u
+
+IN="${1:-}"
+if [ -z "$IN" ] || [ ! -d "$IN" ]; then
+  echo "usage: $0 <dir-containing-the-netty-jars>" >&2
+  exit 2
+fi
+VARIANT="${MUSL_VARIANT:-unknown}"
+HERE=$(dirname "$0")
+
+case "$(uname -m)" in
+  aarch64) CLS=linux-aarch_64 ;;
+  x86_64)  CLS=linux-x86_64 ;;
+  *) echo "$0: unsupported architecture $(uname -m)" >&2; exit 2 ;;
+esac
+
+# find returns paths relative to $IN, and both the unpack step and javac run from elsewhere.
+abspath() {
+  case "$1" in
+    /*) printf '%s\n' "$1" ;;
+    *)  printf '%s\n' "$PWD/${1#./}" ;;
+  esac
+}
+
+# Discover rather than hardcode a path: the directory layout inside a downloaded artifact or a
+# mounted ~/.m2 differs, and -sources/-javadoc/-tests jars are published alongside the real ones.
+NATIVE_JAR=$(find "$IN" -name "netty-codec-native-quic-*-$CLS.jar" \
+                        ! -name '*-sources.jar' ! -name '*-javadoc.jar' ! -name '*-tests.jar' | head -1)
+if [ -z "$NATIVE_JAR" ]; then
+  echo "$0: no netty-codec-native-quic $CLS jar under $IN" >&2
+  exit 2
+fi
+NATIVE_JAR=$(abspath "$NATIVE_JAR")
+HERE=$(abspath "$HERE")
+
+# Everything else the check needs -- common, buffer, transport, resolver, handler, codec-base,
+# codec-classes-quic -- comes from the same tree. Taking the whole set rather than naming each one
+# keeps this working when netty's module split changes again.
+CLASSPATH=$(find "$IN" -name 'netty-*.jar' \
+                       ! -name '*-sources.jar' ! -name '*-javadoc.jar' ! -name '*-tests.jar' \
+            | while read -r j; do abspath "$j"; done | tr '\n' ':')
+# A trailing colon is an empty classpath entry, which java reads as the current directory. That is
+# enough for netty's NativeLibraryLoader to find a second copy of the .so -- this script unpacks one
+# -- and refuse to load either.
+CLASSPATH=${CLASSPATH%:}
+if [ -z "$CLASSPATH" ]; then
+  echo "$0: no netty jars under $IN" >&2
+  exit 2
+fi
+
+echo "=================================================================="
+echo " arch     : $(uname -m)  ($CLS)"
+echo " variant  : $VARIANT"
+echo " libc     : $(apk info -v musl 2>/dev/null | head -1 || ldd --version 2>&1 | head -1)"
+echo " compat   : $(apk info 2>/dev/null | grep -Ex 'gcompat|libc6-compat|libgcc|libstdc\+\+' | sort | tr '\n' ' ')"
+echo " java     : $(java -version 2>&1 | head -1)"
+echo " jar      : $(basename "$NATIVE_JAR")"
+echo "=================================================================="
+
+FAILURES=0
+fail() { FAILURES=$((FAILURES + 1)); echo "   FAIL: $1"; }
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+(cd "$WORK" && jar xf "$NATIVE_JAR" META-INF/native) || { echo "$0: cannot unpack $NATIVE_JAR" >&2; exit 2; }
+SO=$(find "$WORK/META-INF/native" -name '*.so' | head -1)
+[ -n "$SO" ] || { echo "$0: no .so inside $NATIVE_JAR" >&2; exit 2; }
+
+# ---------------------------------------------------------------- ldd: the loader's own verdict
+# On Alpine `ldd` IS the musl loader, so this reports the real relocation errors with no JVM in the
+# way. Authoritative for dynamic linking, and worth printing even when it succeeds.
+echo "-- ldd"
+LDD_OUT=$(ldd "$SO" 2>&1)
+echo "$LDD_OUT" | sed 's/^/   /' | head -30
+if echo "$LDD_OUT" | grep -qE 'Error loading shared library|Error relocating|not found'; then
+  fail "ldd reports unresolved libraries or relocations"
+fi
+
+# ---------------------------------------------------------------- DT_NEEDED, resolved for real
+# On the build host this could only be judged against a hardcoded allowlist. Here the loader is
+# present, so ask it: resolution is read back out of the ldd output above rather than guessing at
+# library paths, which differ between musl (/lib) and glibc multiarch (/lib/<triplet>).
+echo "-- DT_NEEDED"
+MUSL_LDSO="/lib/ld-musl-$(uname -m).so.1"
+for lib in $(readelf -d "$SO" 2>/dev/null | sed -n 's/.*(NEEDED).*\[\(.*\)\]/\1/p'); do
+  case "$lib" in
+    # ldso/dynlink.c: static const char reserved[] = "c.pthread.rt.m.dl.util.xnet.";
+    # musl satisfies these from itself and never looks at the filesystem, which is also why
+    # installing gcompat does not help: it ships /lib/libc.so.6 -> libgcompat.so.0, but libc.so.6
+    # is reserved, so that symlink is never read.
+    libc.so*|libpthread.so*|librt.so*|libm.so*|libdl.so*|libutil.so*|libxnet.so*)
+      echo "   ok        $lib (musl-reserved)" ;;
+    *)
+      resolved=$(echo "$LDD_OUT" | awk -v l="$lib" '$1 == l && $2 == "=>" { print $3; exit }')
+      if [ -n "$resolved" ] && [ "$resolved" != "not" ]; then
+        echo "   ok        $lib -> $resolved"
+      else
+        fail "$lib in DT_NEEDED is neither musl-reserved nor resolvable on this system"
+      fi ;;
+  esac
+done
+
+# ---------------------------------------------------------------- undefined vs really exported
+# Reported, not fatal: a deferred relocation that nothing ever calls never aborts.
+# netty-transport-native-epoll ships __xpg_strerror_r this way and runs fine on bare Alpine. The
+# execution checks below are what actually decide the outcome -- but for this artifact the list is
+# the first place to look when the handshake dies, because that is where musl_compat.c's coverage
+# shows up or fails to.
+echo "-- undefined GLOBAL symbols not exported by anything installed"
+UND=$(mktemp); AVAIL=$(mktemp)
+nm -D --undefined-only "$SO" 2>/dev/null | awk '$1 == "U" { print $2 }' | sed 's/@.*//' | sort -u > "$UND"
+# The glibc control leg keeps its libraries under a multiarch triplet, so both spellings are
+# listed; a path that does not exist is simply skipped.
+for provider in "$MUSL_LDSO" /usr/lib/libgcc_s.so.1 /usr/lib/libstdc++.so.6 /lib/libgcompat.so.0 \
+                /usr/lib/libc.so.6 "/lib/$(uname -m)-linux-gnu/libc.so.6" \
+                "/lib/$(uname -m)-linux-gnu/libgcc_s.so.1" "/usr/lib/$(uname -m)-linux-gnu/libstdc++.so.6"; do
+  [ -e "$provider" ] && nm -D --defined-only "$provider" 2>/dev/null | awk '{ print $NF }' | sed 's/@.*//'
+done | sort -u > "$AVAIL"
+MISSING=$(comm -23 "$UND" "$AVAIL")
+if [ -z "$MISSING" ]; then
+  echo "   none"
+else
+  echo "$MISSING" | sed 's/^/   WARN /'
+fi
+rm -f "$UND" "$AVAIL"
+
+# ------------------------------------------------------- drop the ELF tools (and libgcc with them)
+# Everything above needs binutils; nothing below does. binutils depends on libgcc, so on an image
+# whose JDK does not itself require libgcc, installing it silently satisfies a libgcc_s.so.1
+# DT_NEEDED and the bare leg stops testing what it claims to. Removing it here means the execution
+# checks run against the package set a stock Alpine JDK image really has. Guarded on apk so a
+# glibc-control image skips this untouched.
+if [ "${MUSL_DROP_ELFTOOLS:-0}" = "1" ] && command -v apk >/dev/null 2>&1; then
+  echo "-- dropping ELF tools so the runtime checks see no libgcc"
+  apk del .elftools >/dev/null 2>&1 || echo "   WARN: could not remove the .elftools virtual package"
+  echo "   compat now: $(apk info 2>/dev/null | grep -Ex 'gcompat|libc6-compat|libgcc|libstdc\+\+' | sort | tr '\n' ' ')"
+  for lib in /usr/lib/libgcc_s.so.1 /usr/lib/libstdc++.so.6; do
+    if [ -e "$lib" ]; then
+      echo "   note: $lib is still present (the JDK itself depends on it)"
+    else
+      echo "   ok: $lib is absent"
+    fi
+  done
+fi
+
+# ---------------------------------------------------------------- execute
+echo "-- load, initialize and handshake"
+CLASSES="$WORK/classes"
+mkdir -p "$CLASSES"
+javac -nowarn -d "$CLASSES" -cp "$CLASSPATH" "$HERE/QuicMuslCheck.java" \
+  || { echo "$0: cannot compile QuicMuslCheck" >&2; exit 2; }
+
+# keytool rather than SelfSignedCertificate: that class needs either BouncyCastle on the classpath
+# or --add-exports java.base/sun.security.x509, and a failure there would look like a musl failure.
+KEYSTORE="$WORK/quic.p12"
+KEYSTORE_PASSWORD=password
+keytool -genkeypair -alias quic -keyalg RSA -keysize 2048 -validity 1 \
+  -dname CN=localhost -storetype PKCS12 -keystore "$KEYSTORE" \
+  -storepass "$KEYSTORE_PASSWORD" -keypass "$KEYSTORE_PASSWORD" -ext SAN=IP:127.0.0.1 >/dev/null 2>&1 \
+  || { echo "$0: keytool could not create the server keystore" >&2; exit 2; }
+
+# Keep core dumps and hs_err files out of the mounted work tree: a SIGSEGV here writes hundreds of
+# megabytes, and in netty-tcnative that was the normal outcome on aarch64 before the fix.
+ulimit -c 0 2>/dev/null || true
+JVM_OPTS="-ea -Xcheck:jni -XX:-CreateCoredumpOnCrash -XX:ErrorFile=$WORK/hs_err_%p.log"
+
+# A hard JVM crash prints no RESULT line. Synthesise a failure for it rather than letting a missing
+# line read as success -- this is the single most important behaviour in this script.
+run_level() {
+    level="$1"
+    out=$(java $JVM_OPTS -cp "$CLASSES:$CLASSPATH" QuicMuslCheck "$level" "$SO" "$KEYSTORE" "$KEYSTORE_PASSWORD" 2>&1)
+    rc=$?
+    if echo "$out" | grep -q '^RESULT'; then
+        echo "$out" | grep '^RESULT' | sed 's/^/   /'
+    else
+        printf '   RESULT\t%s\tFAIL\tJVM died without a result line (exit=%s)\n' "$level" "$rc"
+        echo "$out" | grep -E '^#  (SIGSEGV|SIGBUS|SIGILL)|^# C  \[' | sed 's/^/     crash| /'
+    fi
+    if [ "$rc" -ne 0 ]; then
+        fail "level '$level' exited $rc"
+    fi
+}
+
+run_level load
+run_level init
+run_level handshake
+
+echo "------------------------------------------------------------------"
+if [ "$FAILURES" -ne 0 ]; then
+  echo "musl-verify: FAIL ($FAILURES check(s)) on $(uname -m)/$VARIANT"
+  exit 1
+fi
+echo "musl-verify: PASS on $(uname -m)/$VARIANT"

--- a/.github/workflows/ci-verify-musl.yml
+++ b/.github/workflows/ci-verify-musl.yml
@@ -1,0 +1,159 @@
+# ----------------------------------------------------------------------------
+# Copyright 2026 The Netty Project
+#
+# The Netty Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+# The Linux native artifacts are glibc-built but are expected to load from the same jar on musl.
+# Nothing in the normal build notices when that stops being true: the build hosts are CentOS, the
+# test hosts are Ubuntu, and musl does not fail a dlopen on a relocation it cannot resolve, so a
+# broken artifact still loads and only dies later. These legs run the real thing on real Alpine.
+name: Verify native library loading on musl
+
+on:
+  push:
+    branches: [ "4.1", "4.2", "5.0" ]
+
+  pull_request:
+    branches: [ "4.1", "4.2", "5.0" ]
+
+  workflow_dispatch:
+
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryhandler.count=5 -Dmaven.wagon.httpconnectionManager.ttlSeconds=240
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-jars:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            docker-compose-build: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-7.111.yaml build"
+            docker-compose-run: "-f docker/docker-compose.yaml -f docker/docker-compose.centos-7.111.yaml run build-native-quic"
+          - arch: aarch64
+            docker-compose-build: "-f docker/docker-compose.centos-7.cross.yaml build"
+            docker-compose-run: "-f docker/docker-compose.centos-7.cross.yaml run cross-compile-aarch64-build-native-quic"
+
+    name: build-jars-${{ matrix.arch }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        continue-on-error: true
+        with:
+          path: ~/.m2/repository
+          key: cache-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            cache-maven-${{ hashFiles('**/pom.xml') }}
+            cache-maven-
+
+      - name: Build docker image
+        run: docker compose ${{ matrix.docker-compose-build }}
+
+      - name: Build the native quic jars
+        run: docker compose ${{ matrix.docker-compose-run }}
+
+      - name: Upload the netty jars
+        uses: actions/upload-artifact@v4
+        with:
+          name: netty-jars-${{ matrix.arch }}
+          path: ~/.m2/repository/io/netty/
+          if-no-files-found: error
+
+  musl-verify:
+    runs-on: ubuntu-latest
+    needs: build-jars
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # bare is the case that matters: a stock Alpine JDK image, nothing added.
+          - leg: alpine-x86_64
+            arch: x86_64
+            platform: linux/amd64
+            image: eclipse-temurin:21-jdk-alpine
+            packages: ""
+            variant: bare
+          - leg: alpine-aarch64
+            arch: aarch64
+            platform: linux/arm64
+            image: eclipse-temurin:21-jdk-alpine
+            packages: ""
+            variant: bare
+          # gcompat is not expected to change the answer. It exists so that a bare failure is
+          # diagnostic: if bare fails and gcompat passes, the artifact has re-acquired a dependency
+          # on the shim, which is how netty-tcnative 2.0.65 appeared to work on Alpine.
+          - leg: alpine-x86_64-gcompat
+            arch: x86_64
+            platform: linux/amd64
+            image: eclipse-temurin:21-jdk-alpine
+            packages: "gcompat"
+            variant: gcompat
+          - leg: alpine-aarch64-gcompat
+            arch: aarch64
+            platform: linux/arm64
+            image: eclipse-temurin:21-jdk-alpine
+            packages: "gcompat"
+            variant: gcompat
+          # The control. Anything that fails on Alpine but also fails here is a broken harness, not
+          # a broken library.
+          - leg: glibc-control-x86_64
+            arch: x86_64
+            platform: linux/amd64
+            image: eclipse-temurin:21-jdk-noble
+            packages: ""
+            variant: glibc-control
+
+    name: musl-verify-${{ matrix.leg }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download the netty jars
+        uses: actions/download-artifact@v4
+        with:
+          name: netty-jars-${{ matrix.arch }}
+          path: /home/runner/jars
+
+      # The runners are x86_64, so the aarch64 legs need binfmt.
+      - name: Set up QEMU
+        if: ${{ matrix.arch == 'aarch64' }}
+        uses: docker/setup-qemu-action@v3
+
+      - name: Verify
+        run: |
+          docker run --rm --platform ${{ matrix.platform }} \
+            -v "$PWD/.github/scripts/musl-verify:/verify:ro" \
+            -v /home/runner/jars:/jars:ro \
+            -e MUSL_VARIANT='${{ matrix.variant }}' \
+            -e MUSL_DROP_ELFTOOLS=1 \
+            ${{ matrix.image }} \
+            sh -c '
+              set -e
+              if command -v apk >/dev/null 2>&1; then
+                # Virtual package so verify.sh can drop the ELF tools again before it executes
+                # anything: binutils depends on libgcc, and leaving it installed would silently
+                # satisfy a libgcc_s.so.1 DT_NEEDED that the bare leg exists to catch.
+                apk add --no-cache --virtual .elftools binutils >/dev/null
+                if [ -n "${{ matrix.packages }}" ]; then
+                  apk add --no-cache ${{ matrix.packages }} >/dev/null
+                fi
+              else
+                apt-get update -qq && apt-get install -qq -y binutils >/dev/null
+              fi
+              sh /verify/verify.sh /jars
+            '

--- a/codec-native-quic/README.md
+++ b/codec-native-quic/README.md
@@ -1,0 +1,77 @@
+# netty-codec-native-quic
+
+Native QUIC support, built on [quiche](https://github.com/cloudflare/quiche) and BoringSSL. The
+artifact bundles both, compiled from pinned commits, so no system QUIC or TLS library is required at
+runtime.
+
+## Running on Alpine or another musl distribution
+
+**Use jemalloc.** On musl, install it and preload it:
+
+```dockerfile
+RUN apk add --no-cache jemalloc
+ENV LD_PRELOAD=/usr/lib/libjemalloc.so.2
+```
+
+This is not a nicety. Without it, QUIC throughput on musl is measurably below the same workload on
+glibc, and with it the difference disappears.
+
+### Why
+
+QUIC allocates heavily. In a steady echo workload this module issued roughly **16 to 21 `malloc`
+calls per request**, about 870k/s on a four-core host, with allocations and frees balanced: the
+working set is stable and essentially all of it is transient churn. Ninety percent of those calls
+come from the native QUIC library rather than from the JVM.
+
+musl's default allocator, `mallocng`, serialises every allocation on a **single process-wide
+exclusive lock** (`__malloc_lock` in `src/malloc/mallocng/glue.h`, with `RDLOCK_IS_EXCLUSIVE`). It
+spins ten times and then parks on a futex. At this allocation rate that produces an order of
+magnitude more context switches and a double-digit throughput loss. glibc is unaffected because it
+uses per-thread caches and multiple arenas, so most allocations never touch a shared lock.
+
+Measured on one host, five interleaved rounds, 500 QUIC connections, 1 KB payload, pinned CPU clock
+with no thermal throttling, median requests/s with the range across rounds:
+
+| configuration | median req/s | range | vs glibc default |
+|---|---|---|---|
+| musl, default `mallocng` | 54,208 | 46,613 - 54,324 | **-14.8%** |
+| musl + jemalloc | 63,358 | 61,157 - 63,726 | -0.4%, indistinguishable |
+| musl + mimalloc | 58,282 | 55,442 - 59,997 | -8.4% |
+| glibc, default malloc | 63,631 | 62,265 - 63,978 | baseline |
+
+With jemalloc the musl range overlaps the glibc range, so the remaining difference is not
+distinguishable from noise. **Prefer jemalloc over mimalloc**: mimalloc recovers only part of the
+gap on musl, though it performs fine on glibc. That asymmetry is unexplained.
+
+### Scope of the measurement
+
+One machine, one workload, one payload size. The mechanism generalises (any heavy native allocator
+on musl meets the same lock), but the exact percentages should not be quoted as universal. Re-measure
+for your own workload if the number matters to you.
+
+### Why netty does not simply bundle an allocator
+
+Two reasons, both deliberate.
+
+Replacing `malloc` is a **process-wide** decision. Exporting a bundled allocator from a JNI library
+would capture allocation for the entire JVM, including the heap, the JIT and every other native
+library in the process. That is the application's choice to make, not a networking codec's.
+
+And keeping it internal instead creates a cross-allocator hazard: memory allocated by one allocator
+and released by another is heap corruption. This module is careful to release every native object
+through the API that allocated it, but a bundled allocator would make that a permanent constraint
+on every future call site.
+
+`LD_PRELOAD` puts the decision where it belongs, at deployment, and applies it consistently to the
+whole process.
+
+## Other Alpine notes
+
+The Linux artifacts are built so that they load under musl, which requires more than compiling
+against it: the interpreter entry is removed from `DT_NEEDED` after linking, and glibc-only symbols
+have weak fallbacks. `.github/workflows/ci-verify-musl.yml` loads the built artifacts inside
+`eclipse-temurin:21-jdk-alpine` and `amazoncorretto:21-alpine` on x86_64 and aarch64 to keep that
+working.
+
+If the native library fails to load on Alpine with a message about `ld-linux-x86-64.so.2`, the
+artifact predates that work; upgrade rather than trying to install a loader.

--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -211,7 +211,21 @@
         <libssl>libssl.a</libssl>
         <libcrypto>libcrypto.a</libcrypto>
         <libquiche>libquiche.a</libquiche>
-        <extraLdflags>-static-libstdc++ -l:libstdc++.a -Wl,--strip-debug -Wl,--exclude-libs,ALL -Wl,-lrt</extraLdflags>
+        <!-- The libgcc archives must come *after* libstdc++.a and libquiche.a: those are what pull
+             in the _Unwind_* symbols, and libgcc_eh.a is what defines them. Linking them
+             statically is what keeps libgcc_s.so.1 out of DT_NEEDED - `gcc_s.` is not one of the
+             names musl reserves, so on Alpine that entry is a real file lookup, and it fails on
+             any image without the `libgcc` package. Alpine JDK images disagree about shipping it:
+             eclipse-temurin does, amazoncorretto and a good number of vendor images do not, so the
+             dependency is not safe, merely invisible on some bases.
+
+             NOTE: spell this as `-l:` and never `-static-libgcc`. GNU libtool links the shared
+             library via archive_cmds, which expands only $libobjs $deplibs $compiler_flags; `-l*`
+             is parsed into deplibs, but `-static-lib*` falls into func_mode_link's catch-all
+             `-* | +*)` branch and reaches only the *program* link path, so gcc never sees it. That
+             is also why the -static-libstdc++ that used to sit here was doing nothing.
+             `grep dependency_libs target/native-build/lib${jniLibName}.la` shows what survived. -->
+        <extraLdflags>-l:libstdc++.a -l:libgcc.a -l:libgcc_eh.a -Wl,--strip-debug -Wl,--exclude-libs,ALL -Wl,-lrt</extraLdflags>
         <bundleNativeCode>META-INF/native/lib${jniLibName}.so;osname=linux;processor=${os.detected.arch}</bundleNativeCode>
       </properties>
       <dependencies>
@@ -499,7 +513,8 @@
         <libssl>libssl.a</libssl>
         <libcrypto>libcrypto.a</libcrypto>
         <libquiche>libquiche.a</libquiche>
-        <extraLdflags>-static-libstdc++ -l:libstdc++.a -Wl,--strip-debug -Wl,--exclude-libs,ALL</extraLdflags>
+        <!-- Same static unwinder as the `linux` profile above; see the note there. -->
+        <extraLdflags>-l:libstdc++.a -l:libgcc.a -l:libgcc_eh.a -Wl,--strip-debug -Wl,--exclude-libs,ALL</extraLdflags>
         <bundleNativeCode>META-INF/native/lib${jniLibName}.so;osname=linux;processor=aarch64</bundleNativeCode>
         <jniLibName>${jniLibPrefix}_linux_aarch_64</jniLibName>
         <jni.classifier>linux-aarch_64</jni.classifier>
@@ -1002,6 +1017,88 @@
                     <filter token="EXTRA_CFLAGS" value="${extraCflags}" />
                     <copy file="src/main/native-package/m4/custom.m4.template" tofile="${templateDir}/m4/custom.m4" filtering="true" overwrite="true" verbose="true" />
                   </else>
+                </if>
+              </target>
+            </configuration>
+          </execution>
+
+          <!-- Drop the DT_NEEDED on ld-linux-<arch>.so from the freshly linked library, before
+               anything copies it anywhere.
+
+               PHASE: process-test-resources, and declared immediately before
+               copy-native-lib-and-license rather than anywhere earlier. hawtjni 1.18 binds its
+               `generate` goal to process-classes but its `build` goal to generate-test-resources,
+               so the library does not exist until then; at process-classes there would be nothing
+               to patch. Executions of the same plugin in the same phase run in the order they are
+               declared here, which is what puts this ahead of the copy.
+
+               The entry gets recorded because __tls_get_addr lives in
+               glibc's loader, but musl defines that symbol itself, so only the *filename* lookup
+               fails: `ld-linux-...` does not start with `lib`, so it is not one of the names musl
+               satisfies internally, and the library is unloadable on Alpine purely because of it.
+               Removing it is a no-op on glibc, where the loader is already mapped.
+
+               Applied unconditionally on Linux rather than per architecture, because whether the
+               entry appears at all depends on the toolchain and link path: it is present in the
+               released x86_64 artifact and absent from the aarch64 cross build. patchelf exits 0
+               when the name is not there, so naming both is safe from either host.
+
+               Same approach as async-profiler:
+               https://github.com/async-profiler/async-profiler/blob/bb8f0476a1804ac77b48b84a3905fb26e9ca7428/Makefile#L156
+               and as netty-tcnative, see https://github.com/netty/netty-tcnative/issues/907 -->
+          <execution>
+            <id>remove-ld-linux-dt-needed</id>
+            <phase>process-test-resources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
+                <if>
+                  <and>
+                    <equals arg1="${os.detected.name}" arg2="linux" />
+                    <!-- The Android libraries are loaded by bionic, not by musl or glibc, and the
+                         android profile drives its own copy of this build. -->
+                    <not>
+                      <equals arg1="${platform}" arg2="android" />
+                    </not>
+                  </and>
+                  <then>
+                    <property environment="env" />
+                    <if>
+                      <not>
+                        <available file="patchelf" filepath="${env.PATH}" />
+                      </not>
+                      <then>
+                        <!-- Say so plainly rather than letting ant report an IOException from
+                             Execute. objcopy is not an alternative: it cannot remove a DT_NEEDED. -->
+                        <fail message="patchelf is required to build the Linux native library and was not found on PATH. It is installed in docker/Dockerfile.centos7 and docker/Dockerfile.cross_compile_aarch64; on a workstation install the distribution package or the upstream release from https://github.com/NixOS/patchelf/releases" />
+                      </then>
+                    </if>
+                    <!-- Located rather than spelled out: hawtjni nests its output under a
+                         platform directory, META-INF/native/linux64/lib<name>.so, which is why
+                         copy-native-lib-and-license below needs a regexpmapper to flatten it.
+                         The resourcecount check keeps a future layout change from turning this
+                         into a silent no-op, which is the one failure mode that would ship a
+                         broken artifact rather than break the build. -->
+                    <fileset id="nativeLibToPatch" dir="${nativeLibOnlyDir}/META-INF/native"
+                             includes="**/lib${jniLibName}.so" />
+                    <fail message="expected exactly one lib${jniLibName}.so under ${nativeLibOnlyDir}/META-INF/native to patch">
+                      <condition>
+                        <not>
+                          <resourcecount refid="nativeLibToPatch" count="1" />
+                        </not>
+                      </condition>
+                    </fail>
+                    <apply executable="patchelf" failonerror="true" resolveexecutable="true">
+                      <arg value="--remove-needed" />
+                      <arg value="ld-linux-x86-64.so.2" />
+                      <arg value="--remove-needed" />
+                      <arg value="ld-linux-aarch64.so.1" />
+                      <fileset refid="nativeLibToPatch" />
+                    </apply>
+                  </then>
                 </if>
               </target>
             </configuration>

--- a/codec-native-quic/src/main/c/musl_compat.c
+++ b/codec-native-quic/src/main/c/musl_compat.c
@@ -1,0 +1,336 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Fallbacks for glibc-internal symbols that musl (Alpine Linux) does not export, so that the
+ * single glibc-built shared library also loads and runs under musl.
+ *
+ * netty-codec-native-quic links quiche statically, and quiche brings the Rust standard library
+ * with it. Rust's std on *-unknown-linux-gnu calls the LFS64 entry points by name (open64,
+ * mmap64, readdir64, ...) and, on the older glibc of the release images, reaches stat through
+ * the __xstat64 family. musl 1.2.4 removed the LFS64 aliases altogether and never had the
+ * __?xstat64 family, so those references have nothing to bind to there. BoringSSL contributes
+ * fopen64 on top; that one is shared with netty-tcnative and with the ohttp-hpke artifact.
+ *
+ * Verified against the musl 1.2.5 export set shipped by Alpine 3.22 on both x86_64 and
+ * aarch64: every name defined below is absent from it, and every function it forwards to is
+ * present.
+ *
+ * Undefined symbols are not by themselves fatal on musl -- its loader defers a relocation it
+ * cannot resolve instead of failing the dlopen, so the library still loads and aborts at the
+ * first call. That is why this file matters even though the DT_NEEDED fixes alone make the
+ * library loadable: without it, loading succeeds and the first QUIC handshake dies.
+ *
+ * These are deliberately compiled in on a GLIBC host -- the release images are CentOS 7 -- and
+ * the guard below is `#ifdef __GLIBC__` for that reason. Inverting it would compile the
+ * definitions out of exactly the artifacts that need them. `weak` is what keeps them from
+ * colliding with glibc's own definitions at link time. At runtime on glibc these are never
+ * reached: a JNI library is dlopened into a local scope, so the global scope -- which already
+ * holds libc.so.6 -- is searched first and glibc's own definitions win. On musl the global scope
+ * has no such symbol and the definition below is used.
+ *
+ * `visibility("default")` is required because the build passes -fvisibility=hidden
+ * (src/main/native-package/m4/custom.m4.template). Hidden would still satisfy the references
+ * from libquiche.a at static link time, but it would also pin them to these forwarders on
+ * glibc rather than letting the real libc entry points interpose.
+ *
+ * See https://github.com/netty/netty-tcnative/pull/997 for the same treatment in tcnative, and
+ * https://github.com/netty/netty-tcnative/issues/907 for the original report.
+ */
+
+#ifdef __linux__
+
+/*
+ * MUST come before any include. With _FILE_OFFSET_BITS=64 glibc's headers __REDIRECT open to
+ * open64, stat to stat64 and so on -- inside this file that would turn every forwarder below
+ * into infinite recursion. The quic build does not currently set it (see custom.m4.template),
+ * so this is a guard against a future -D on the command line rather than a fix for today.
+ */
+#undef _FILE_OFFSET_BITS
+#undef __USE_FILE_OFFSET64
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+/* Declares the *64 entry points and struct stat64 on glibc. Not defined by the build. */
+#ifndef _LARGEFILE64_SOURCE
+#define _LARGEFILE64_SOURCE
+#endif
+
+/* Defines __GLIBC__ when there is one, via <features.h>. Must precede the test below. */
+#include <stdlib.h>
+
+/*
+ * Compile the fallbacks in only where they are both needed and expressible: a glibc build.
+ *
+ * Note the direction. Guarding them OUT on glibc (`#ifndef __GLIBC__`) would be the bug -- the
+ * release images are glibc, so that would remove the definitions from exactly the artifacts that
+ * need them. Guarding them IN on glibc is the opposite, and is required, because the types these
+ * shims are declared with -- off64_t, struct stat64, struct dirent64 -- do not exist on musl.
+ * Without this a musl-native build of the module fails to compile, and it would not want the
+ * shims anyway: a musl-linked artifact has no glibc symbols to stand in for.
+ */
+#ifdef __GLIBC__
+
+#include <dirent.h>
+#include <fcntl.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <sys/mman.h>
+#include <sys/sendfile.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+/*
+ * <sys/auxv.h> and getauxval() only exist from glibc 2.16. Probing keeps this file compilable
+ * on a glibc-2.12 host (the netty 4.1 x86_64 release image is CentOS 6), where including it is
+ * a fatal error.
+ */
+#if defined(__has_include)
+#  if __has_include(<sys/auxv.h>)
+#    define NETTY_HAVE_SYS_AUXV 1
+#  endif
+#endif
+#ifdef NETTY_HAVE_SYS_AUXV
+#  include <sys/auxv.h>
+#endif
+
+#define NETTY_MUSL_COMPAT __attribute__((weak, visibility("default")))
+
+/*
+ * Some glibc versions define these internal names as function-like MACROS rather than only
+ * declaring them, in which case a definition here expands into the macro body and fails to
+ * compile. Undefine them first; on the glibc versions that only declare them this is invisible,
+ * so it must not be removed just because the toolchain at hand is happy without it.
+ */
+#undef __getauxval
+#undef fopen64
+#undef open64
+#undef openat64
+#undef mmap64
+#undef lseek64
+#undef pread64
+#undef pwrite64
+#undef sendfile64
+#undef ftruncate64
+#undef readdir64
+#undef stat64
+#undef fstat64
+#undef lstat64
+#undef fstatat64
+#undef __xstat64
+#undef __fxstat64
+#undef __lxstat64
+#undef __fxstatat64
+
+/* ------------------------------------------------------------------ LFS64 aliases
+ *
+ * musl 1.2.4 (Alpine 3.19+) removed these. off_t is unconditionally 64-bit there and on every
+ * 64-bit glibc target, so forwarding to the unsuffixed entry point is exact, not a narrowing.
+ */
+
+NETTY_MUSL_COMPAT FILE* fopen64(const char* path, const char* mode) {
+    return fopen(path, mode);
+}
+
+/* glibc's __OPEN_NEEDS_MODE: the mode argument is only present for O_CREAT and O_TMPFILE. */
+static int netty_open_needs_mode(int flags) {
+#ifdef O_TMPFILE
+    return (flags & O_CREAT) != 0 || (flags & O_TMPFILE) == O_TMPFILE;
+#else
+    return (flags & O_CREAT) != 0;
+#endif
+}
+
+NETTY_MUSL_COMPAT int open64(const char* path, int flags, ...) {
+    mode_t mode = 0;
+    if (netty_open_needs_mode(flags)) {
+        va_list ap;
+        va_start(ap, flags);
+        mode = va_arg(ap, mode_t);
+        va_end(ap);
+    }
+    return open(path, flags, mode);
+}
+
+NETTY_MUSL_COMPAT int openat64(int dirfd, const char* path, int flags, ...) {
+    mode_t mode = 0;
+    if (netty_open_needs_mode(flags)) {
+        va_list ap;
+        va_start(ap, flags);
+        mode = va_arg(ap, mode_t);
+        va_end(ap);
+    }
+    return openat(dirfd, path, flags, mode);
+}
+
+NETTY_MUSL_COMPAT void* mmap64(void* addr, size_t length, int prot, int flags, int fd, off64_t offset) {
+    return mmap(addr, length, prot, flags, fd, (off_t) offset);
+}
+
+NETTY_MUSL_COMPAT off64_t lseek64(int fd, off64_t offset, int whence) {
+    return (off64_t) lseek(fd, (off_t) offset, whence);
+}
+
+NETTY_MUSL_COMPAT ssize_t pread64(int fd, void* buf, size_t count, off64_t offset) {
+    return pread(fd, buf, count, (off_t) offset);
+}
+
+NETTY_MUSL_COMPAT ssize_t pwrite64(int fd, const void* buf, size_t count, off64_t offset) {
+    return pwrite(fd, buf, count, (off_t) offset);
+}
+
+NETTY_MUSL_COMPAT ssize_t sendfile64(int out_fd, int in_fd, off64_t* offset, size_t count) {
+    /* off_t and off64_t are the same 64-bit type here, so the in/out parameter can be aliased. */
+    return sendfile(out_fd, in_fd, (off_t*) offset, count);
+}
+
+NETTY_MUSL_COMPAT int ftruncate64(int fd, off64_t length) {
+    return ftruncate(fd, (off_t) length);
+}
+
+/*
+ * struct dirent64 and musl's struct dirent have the same layout on every 64-bit target: both
+ * mirror the kernel's linux_dirent64 (ino, off, reclen, type, name[256]).
+ */
+NETTY_MUSL_COMPAT struct dirent64* readdir64(DIR* dirp) {
+    return (struct dirent64*) readdir(dirp);
+}
+
+/* ------------------------------------------------------------------ stat, both spellings
+ *
+ * Two families, because which one a build emits depends on the glibc it was compiled against:
+ * before 2.33 stat() is not an exported function at all but a libc_nonshared.a stub that calls
+ * __xstat(_STAT_VER, ...), from 2.33 it is a normal symbol. The released x86_64 artifact
+ * carries the __?xstat64 family and the aarch64 one carries the plain *64 names, so one file
+ * has to cover both.
+ *
+ * These go straight to the kernel rather than forwarding to stat()/fstatat() like every other
+ * shim here does, and that is not a stylistic choice. Compiled on glibc 2.17 -- the CentOS 7
+ * release image -- a call to stat() links that nonshared stub into this very library, and the
+ * stub calls __xstat, which musl does not export either. The forwarding version would therefore
+ * resolve one dead symbol into another and abort in exactly the case it exists to fix.
+ *
+ * The buffer needs no conversion: what these syscalls fill is the kernel's struct stat, which
+ * is what glibc calls struct stat64 and what musl calls struct stat. All three are the same
+ * layout on x86_64 and aarch64. The `ver` argument of the __?xstat64 family selects that same
+ * struct (_STAT_VER) and is therefore ignored.
+ *
+ * SYS_newfstatat and SYS_fstat are the two that exist on both architectures: x86_64 also has
+ * SYS_stat and SYS_lstat, aarch64 has neither and expects AT_FDCWD through newfstatat.
+ */
+
+static int netty_fstatat64(int dirfd, const char* path, struct stat64* buf, int flags) {
+    return (int) syscall(SYS_newfstatat, dirfd, path, buf, flags);
+}
+
+NETTY_MUSL_COMPAT int stat64(const char* path, struct stat64* buf) {
+    return netty_fstatat64(AT_FDCWD, path, buf, 0);
+}
+
+NETTY_MUSL_COMPAT int fstat64(int fd, struct stat64* buf) {
+    return (int) syscall(SYS_fstat, fd, buf);
+}
+
+NETTY_MUSL_COMPAT int lstat64(const char* path, struct stat64* buf) {
+    return netty_fstatat64(AT_FDCWD, path, buf, AT_SYMLINK_NOFOLLOW);
+}
+
+NETTY_MUSL_COMPAT int fstatat64(int dirfd, const char* path, struct stat64* buf, int flags) {
+    return netty_fstatat64(dirfd, path, buf, flags);
+}
+
+NETTY_MUSL_COMPAT int __xstat64(int ver, const char* path, struct stat64* buf) {
+    (void) ver;
+    return netty_fstatat64(AT_FDCWD, path, buf, 0);
+}
+
+NETTY_MUSL_COMPAT int __fxstat64(int ver, int fd, struct stat64* buf) {
+    (void) ver;
+    return (int) syscall(SYS_fstat, fd, buf);
+}
+
+NETTY_MUSL_COMPAT int __lxstat64(int ver, const char* path, struct stat64* buf) {
+    (void) ver;
+    return netty_fstatat64(AT_FDCWD, path, buf, AT_SYMLINK_NOFOLLOW);
+}
+
+NETTY_MUSL_COMPAT int __fxstatat64(int ver, int dirfd, const char* path, struct stat64* buf, int flags) {
+    (void) ver;
+    return netty_fstatat64(dirfd, path, buf, flags);
+}
+
+/* ------------------------------------------------------------------ the rest */
+
+/*
+ * glibc exports getauxval and the __-prefixed alias; musl exports only getauxval. This one is
+ * load-fatal rather than latent on aarch64: linking libgcc statically (see the linux profiles
+ * in pom.xml) brings in init_have_lse_atomics, an .init_array constructor that calls
+ * __getauxval during dlopen, so an unresolved reference kills the JVM with SIGSEGV inside
+ * JVM_LoadLibrary instead of raising UnsatisfiedLinkError. It must not be dropped later on the
+ * grounds that no netty code calls it.
+ */
+NETTY_MUSL_COMPAT unsigned long __getauxval(unsigned long type) {
+#ifdef NETTY_HAVE_SYS_AUXV
+    return getauxval(type);
+#else
+    unsigned long entry[2];
+    unsigned long value = 0;
+    int fd = open("/proc/self/auxv", O_RDONLY);
+    if (fd < 0) {
+        return 0;
+    }
+    while (read(fd, entry, sizeof(entry)) == (ssize_t) sizeof(entry)) {
+        if (entry[0] == type) {
+            value = entry[1];
+            break;
+        }
+        if (entry[0] == 0) { /* AT_NULL terminates the vector */
+            break;
+        }
+    }
+    close(fd);
+    return value;
+#endif
+}
+
+/*
+ * Rust's standard library calls gnu_get_libc_version() to decide between a modern code path and
+ * a workaround for an old glibc. There is no glibc here, so report a version new enough that
+ * every such workaround is skipped -- the workarounds are the dangerous answer, because they
+ * reach for further glibc internals (__pthread_get_minstack for the pre-2.27 stack-size
+ * handling, for one) that musl does not have either.
+ */
+NETTY_MUSL_COMPAT const char* gnu_get_libc_version(void) {
+    return "2.38";
+}
+
+/*
+ * musl's own res_init() is a stub that returns 0, so returning 0 here is exactly what a musl
+ * build of the same caller would do. Forwarding to res_init() instead would be worse than
+ * useless: glibc's <resolv.h> macro-defines res_init to __res_init, and on glibc 2.17 the
+ * un-prefixed symbol lives in libresolv.so.2, so the forward would either recurse or add a
+ * DT_NEEDED on libresolv -- another name musl does not reserve.
+ */
+NETTY_MUSL_COMPAT int __res_init(void) {
+    return 0;
+}
+
+#endif /* __GLIBC__ */
+
+#endif /* __linux__ */

--- a/docker/Dockerfile.centos7
+++ b/docker/Dockerfile.centos7
@@ -5,6 +5,11 @@ ARG openssl_sha256=b1bfedcd5b289ff22aee87c9d600f515767ebf45f77168cb6d64f231f518a
 ENV OPENSSL_VERSION $openssl_version
 ENV OPENSSL_SHA256 $openssl_sha256
 
+ARG patchelf_version=0.18.0
+ARG patchelf_sha256=ce84f2447fb7a8679e58bc54a20dc2b01b37b5802e12c57eece772a6f14bf3f0
+ENV PATCHELF_VERSION $patchelf_version
+ENV PATCHELF_SHA256 $patchelf_sha256
+
 ENV SOURCE_DIR=/root/source
 ENV LIBS_DIR=/root/libs
 ENV CMAKE_VERSION_BASE=3.26
@@ -52,6 +57,16 @@ RUN sed -i -e 's/^mirrorlist/#mirrorlist/g' -e 's/^#baseurl=http:\/\/mirror.cent
 
 RUN yum -y install devtoolset-11-gcc devtoolset-11-gcc-c++
 RUN echo 'source /opt/rh/devtoolset-11/enable' >> ~/.bashrc
+
+# patchelf drops the DT_NEEDED on ld-linux-<arch>.so from the linked native libraries, which is
+# what makes them loadable under musl; see codec-native-quic/pom.xml. The upstream release is a
+# fully static binary with no DT_NEEDED of its own, so it runs on this ancient base as-is - and
+# EPEL 7, the obvious alternative, is archived.
+RUN wget -q https://github.com/NixOS/patchelf/releases/download/$PATCHELF_VERSION/patchelf-$PATCHELF_VERSION-x86_64.tar.gz && \
+  echo "$PATCHELF_SHA256  patchelf-$PATCHELF_VERSION-x86_64.tar.gz" | sha256sum -c - && \
+  tar zxf patchelf-$PATCHELF_VERSION-x86_64.tar.gz -C /usr/local ./bin/patchelf && \
+  rm patchelf-$PATCHELF_VERSION-x86_64.tar.gz && \
+  patchelf --version
 
 RUN wget -q https://github.com/ninja-build/ninja/releases/download/v$NINJA_VERSION/ninja-linux.zip && unzip ninja-linux.zip && mkdir -p /opt/ninja-$NINJA_VERSION/bin && mv ninja /opt/ninja-$NINJA_VERSION/bin && echo 'PATH=/opt/ninja-$NINJA_VERSION/bin:$PATH' >> ~/.bashrc
 RUN wget -q https://go.dev/dl/go$GO_VERSION.linux-amd64.tar.gz && tar zxf go$GO_VERSION.linux-amd64.tar.gz && mv go /opt/ && echo 'PATH=/opt/go/bin:$PATH' >> ~/.bashrc && echo 'export GOROOT=/opt/go/' >> ~/.bashrc

--- a/docker/Dockerfile.centos7
+++ b/docker/Dockerfile.centos7
@@ -5,11 +5,6 @@ ARG openssl_sha256=b1bfedcd5b289ff22aee87c9d600f515767ebf45f77168cb6d64f231f518a
 ENV OPENSSL_VERSION $openssl_version
 ENV OPENSSL_SHA256 $openssl_sha256
 
-ARG patchelf_version=0.18.0
-ARG patchelf_sha256=ce84f2447fb7a8679e58bc54a20dc2b01b37b5802e12c57eece772a6f14bf3f0
-ENV PATCHELF_VERSION $patchelf_version
-ENV PATCHELF_SHA256 $patchelf_sha256
-
 ENV SOURCE_DIR=/root/source
 ENV LIBS_DIR=/root/libs
 ENV CMAKE_VERSION_BASE=3.26
@@ -59,13 +54,12 @@ RUN yum -y install devtoolset-11-gcc devtoolset-11-gcc-c++
 RUN echo 'source /opt/rh/devtoolset-11/enable' >> ~/.bashrc
 
 # patchelf drops the DT_NEEDED on ld-linux-<arch>.so from the linked native libraries, which is
-# what makes them loadable under musl; see codec-native-quic/pom.xml. The upstream release is a
-# fully static binary with no DT_NEEDED of its own, so it runs on this ancient base as-is - and
-# EPEL 7, the obvious alternative, is archived.
-RUN wget -q https://github.com/NixOS/patchelf/releases/download/$PATCHELF_VERSION/patchelf-$PATCHELF_VERSION-x86_64.tar.gz && \
-  echo "$PATCHELF_SHA256  patchelf-$PATCHELF_VERSION-x86_64.tar.gz" | sha256sum -c - && \
-  tar zxf patchelf-$PATCHELF_VERSION-x86_64.tar.gz -C /usr/local ./bin/patchelf && \
-  rm patchelf-$PATCHELF_VERSION-x86_64.tar.gz && \
+# what makes them loadable under musl; see codec-native-quic/pom.xml. EPEL is enabled here rather
+# than next to the dependency list above so that it cannot change what those packages resolve to.
+# The version call is not decoration: it fails the image build if EPEL ever stops resolving,
+# instead of leaving that to be discovered halfway through a maven run.
+RUN yum -y install epel-release && \
+  yum -y install patchelf && \
   patchelf --version
 
 RUN wget -q https://github.com/ninja-build/ninja/releases/download/v$NINJA_VERSION/ninja-linux.zip && unzip ninja-linux.zip && mkdir -p /opt/ninja-$NINJA_VERSION/bin && mv ninja /opt/ninja-$NINJA_VERSION/bin && echo 'PATH=/opt/ninja-$NINJA_VERSION/bin:$PATH' >> ~/.bashrc

--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -1,5 +1,10 @@
 FROM --platform=linux/amd64 centos:7.9.2009
 
+ARG patchelf_version=0.18.0
+ARG patchelf_sha256=ce84f2447fb7a8679e58bc54a20dc2b01b37b5802e12c57eece772a6f14bf3f0
+ENV PATCHELF_VERSION $patchelf_version
+ENV PATCHELF_SHA256 $patchelf_sha256
+
 ARG gcc_version=10.3-2021.07
 ENV GCC_VERSION=$gcc_version
 ENV SOURCE_DIR=/root/source
@@ -37,6 +42,16 @@ RUN yum install -y \
  unzip \
  wget \
  zip
+
+# patchelf drops the DT_NEEDED on ld-linux-<arch>.so from the linked native libraries, which is
+# what makes them loadable under musl; see codec-native-quic/pom.xml. The upstream release is a
+# fully static binary with no DT_NEEDED of its own, so it runs on this ancient base as-is - and
+# EPEL 7, the obvious alternative, is archived.
+RUN wget -q https://github.com/NixOS/patchelf/releases/download/$PATCHELF_VERSION/patchelf-$PATCHELF_VERSION-x86_64.tar.gz && \
+  echo "$PATCHELF_SHA256  patchelf-$PATCHELF_VERSION-x86_64.tar.gz" | sha256sum -c - && \
+  tar zxf patchelf-$PATCHELF_VERSION-x86_64.tar.gz -C /usr/local ./bin/patchelf && \
+  rm patchelf-$PATCHELF_VERSION-x86_64.tar.gz && \
+  patchelf --version
 
 # Install Java
 RUN yum install -y java-11-openjdk-devel

--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -1,10 +1,5 @@
 FROM --platform=linux/amd64 centos:7.9.2009
 
-ARG patchelf_version=0.18.0
-ARG patchelf_sha256=ce84f2447fb7a8679e58bc54a20dc2b01b37b5802e12c57eece772a6f14bf3f0
-ENV PATCHELF_VERSION $patchelf_version
-ENV PATCHELF_SHA256 $patchelf_sha256
-
 ARG gcc_version=10.3-2021.07
 ENV GCC_VERSION=$gcc_version
 ENV SOURCE_DIR=/root/source
@@ -20,7 +15,9 @@ RUN sed -i -e 's/^mirrorlist/#mirrorlist/g' -e 's/^#baseurl=http:\/\/mirror.cent
 
 RUN yum -y install epel-release
 
-# Install requirements
+# Install requirements. patchelf is what drops the DT_NEEDED on ld-linux-<arch>.so from the
+# linked native libraries, which is what makes them loadable under musl; see
+# codec-native-quic/pom.xml.
 RUN yum install -y \
  apr-devel \
  autoconf \
@@ -37,21 +34,12 @@ RUN yum install -y \
  ninja-build \
  make \
  openssl-devel \
+ patchelf \
  perl \
  tar \
  unzip \
  wget \
  zip
-
-# patchelf drops the DT_NEEDED on ld-linux-<arch>.so from the linked native libraries, which is
-# what makes them loadable under musl; see codec-native-quic/pom.xml. The upstream release is a
-# fully static binary with no DT_NEEDED of its own, so it runs on this ancient base as-is - and
-# EPEL 7, the obvious alternative, is archived.
-RUN wget -q https://github.com/NixOS/patchelf/releases/download/$PATCHELF_VERSION/patchelf-$PATCHELF_VERSION-x86_64.tar.gz && \
-  echo "$PATCHELF_SHA256  patchelf-$PATCHELF_VERSION-x86_64.tar.gz" | sha256sum -c - && \
-  tar zxf patchelf-$PATCHELF_VERSION-x86_64.tar.gz -C /usr/local ./bin/patchelf && \
-  rm patchelf-$PATCHELF_VERSION-x86_64.tar.gz && \
-  patchelf --version
 
 # Install Java
 RUN yum install -y java-11-openjdk-devel

--- a/docker/docker-compose.centos-7.111.yaml
+++ b/docker/docker-compose.centos-7.111.yaml
@@ -11,6 +11,9 @@ services:
   build:
     image: netty:centos-7-1.11
 
+  build-native-quic:
+    image: netty:centos-7-1.11
+
   build-leak:
     image: netty:centos-7-1.11
 

--- a/docker/docker-compose.centos-7.cross.yaml
+++ b/docker/docker-compose.centos-7.cross.yaml
@@ -26,6 +26,11 @@ services:
       - ..:/code
     working_dir: /code
 
+  # See build-native-quic in docker-compose.yaml.
+  cross-compile-aarch64-build-native-quic:
+    <<: *cross-compile-aarch64-common
+    command: /bin/bash -cl "./mvnw -B -ntp -Plinux-aarch64 -pl codec-native-quic -am clean install -DskipTests=true -Drevapi.skip=true -Dcheckstyle.skip=true -Dforbiddenapis.skip=true"
+
   cross-compile-aarch64-deploy:
     <<: *cross-compile-aarch64-common
     command: /bin/bash -cl "./mvnw -B -ntp -Plinux-aarch64 -pl transport-native-unix-common,transport-native-epoll,transport-native-io_uring,codec-native-quic -am clean deploy -DskipTests=true -Drevapi.skip=true -Dcheckstyle.skip=true -Dforbiddenapis.skip=true"

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -37,6 +37,13 @@ services:
       ../mvnw -B -ntp integration-test failsafe:verify -Dtcnative.classifier=linux-x86_64-fedora -Drevapi.skip=true -Dcheckstyle.skip=true -Dforbiddenapis.skip=true
     "'
 
+  # Build just what netty-codec-native-quic needs, and install it so the musl verification legs
+  # can pick the jars out of ~/.m2. `build` above runs the whole reactor plus its tests, which is
+  # far more than a load check needs.
+  build-native-quic:
+    <<: *common
+    command: /bin/bash -cl "./mvnw -B -ntp -pl codec-native-quic -am clean install -DskipTests=true -Drevapi.skip=true -Dcheckstyle.skip=true -Dforbiddenapis.skip=true"
+
   deploy:
     <<: *common
     command: /bin/bash -cl "./mvnw -B -ntp clean deploy -DskipTests=true -Drevapi.skip=true -Dcheckstyle.skip=true -Dforbiddenapis.skip=true"


### PR DESCRIPTION
Motivation:

The published Linux `netty-codec-native-quic` artifacts cannot be loaded on musl-based
distributions such as Alpine. On x86_64 the library lists `ld-linux-x86-64.so.2` in `DT_NEEDED`;
musl never resolves that name, so the library fails to load and the application sees an
`UnsatisfiedLinkError`:

```
java.lang.UnsatisfiedLinkError: /tmp/libnetty_quiche42_linux_x86_64...so:
  Error loading shared library ld-linux-x86-64.so.2: No such file or directory
  (needed by /tmp/libnetty_quiche42_linux_x86_64...so)
```

On aarch64 the failure is worse and is **not** catchable. The library loads, and then libgcc's
outline-atomics probe `init_have_lse_atomics` calls `__getauxval` from an `.init_array` constructor
during `dlopen`. musl does not export `__getauxval`. musl normally defers unresolvable relocations
rather than failing the `dlopen`, but a constructor running during `dlopen` cannot defer, so this is
a SIGSEGV inside `JVM_LoadLibrary` that an application cannot recover from.

Testing one architecture and generalising therefore gets the severity wrong: x86_64 degrades to a
catchable error, aarch64 takes the JVM down.

This is the same class of problem, and the same remedy, as netty-tcnative #997 ("Make the Linux
artifacts loadable on musl (Alpine) again"), which fixed it for tcnative. `codec-native-quic` was
not covered by that change.

Modifications:

* Add `codec-native-quic/src/main/c/musl_compat.c`, providing weak fallbacks for the glibc-only
  symbols the build pulls in. The stat family is implemented over raw syscalls (`SYS_newfstatat`)
  because glibc 2.17's `libc_nonshared.a` stubs call `__xstat`, which musl does not have. The whole
  file is guarded `#ifdef __linux__` then `#ifdef __GLIBC__`, so it compiles away to nothing when the
  toolchain is musl.
* Link `libstdc++`, `libgcc` and `libgcc_eh` statically, and run `patchelf --remove-needed` on the
  produced `.so` to drop the interpreter entry that musl cannot resolve. The antrun execution is
  bound to `process-test-resources`: hawtjni 1.18 binds its `build` goal to `generate-test-resources`,
  so an earlier phase runs before the `.so` exists and silently patches nothing. It uses a fileset
  with a `resourcecount count="1"` guard rather than a hardcoded path, because hawtjni nests the
  artifact under `META-INF/native/linux64/`.
* Install `patchelf` in `docker/Dockerfile.centos7` and `docker/Dockerfile.cross_compile_aarch64`,
  and add the corresponding compose services, so the existing CI images can build and verify this.
* Add `.github/workflows/ci-verify-musl.yml` and `.github/scripts/musl-verify/`, which build the
  native artifacts and then load them inside `eclipse-temurin:21-jdk-alpine` and
  `amazoncorretto:21-alpine` on both architectures. `QuicMuslCheck.java` runs a QUIC client and
  server in one JVM at three levels, `load` / `init` / `handshake`, so a regression is caught as a
  failing check rather than by a user.
* Add `codec-native-quic/README.md`. The module had no README while `codec-http3`, `microbench` and
  `docker` do, and making the artifact loadable on musl raises a second question that a user hits
  immediately afterwards. See the Result section.

Result:

The Linux `codec-native-quic` artifacts load and run on musl.

Verified on Alpine with the artifact resolved from a Maven repository rather than a local build, so
this reflects what a consumer would get:

```
$ readelf -d libnetty_quiche42_linux_x86_64.so | grep NEEDED
  before:  librt.so.1  libgcc_s.so.1  libc.so.6  ld-linux-x86-64.so.2
  after:   librt.so.1  libc.so.6
```

Both remaining entries are in musl's reserved set (`ldso/dynlink.c`, `reserved[] =
"c.pthread.rt.m.dl.util.xnet."`), which musl satisfies internally without a file lookup.

**Once it loads, musl needs jemalloc, and the new README says so.**

QUIC on musl runs measurably slower than on glibc with the default allocator, and the cause is not
in netty. QUIC allocates about 16 to 21 times per request (roughly 870k `malloc`/s on a four-core
host, 90% of them from the native QUIC library), while musl's `mallocng` serialises every allocation
on a single process-wide exclusive lock. That produces an order of magnitude more context switches
and a double-digit throughput loss. glibc is unaffected because it uses per-thread caches and
multiple arenas.

Five interleaved rounds, order alternating between rounds and the host cooled between them, 500 QUIC
connections, 1 KB payload, pinned CPU clock with zero thermal throttle events in every cell:

| configuration | median req/s | range | vs glibc default |
|---|---|---|---|
| musl, default `mallocng` | 54,208 | 46,613 - 54,324 | **-14.8%** |
| musl + jemalloc | 63,358 | 61,157 - 63,726 | -0.4% |
| musl + mimalloc | 58,282 | 55,442 - 59,997 | -8.4% |
| glibc, default malloc | 63,631 | 62,265 - 63,978 | baseline |

With jemalloc the musl range **overlaps** the glibc range, so the remaining difference is not
distinguishable from noise: `LD_PRELOAD=/usr/lib/libjemalloc.so.2` closes the gap entirely. Note
that jemalloc and mimalloc are not interchangeable here; mimalloc recovers only part of it on musl
while performing fine on glibc, which is unexplained.

The README also records why this is a deployment setting rather than something the artifact should
bundle: replacing `malloc` is a process-wide decision that would capture the JVM heap, the JIT and
every other native library, and keeping a bundled allocator internal instead would make
allocate-here-free-there a permanent constraint on every future call site.

Scope, stated plainly: the throughput figures are one host, one workload, one payload size. The
mechanism generalises, the exact percentages should not be quoted as universal. Only x86_64 was
load-tested; the aarch64 fix is covered by the CI check added here rather than by a throughput run,
which is worth weighing given aarch64 is the uncatchable failure.
