### PR TITLE
Http2: Cleanup child channel method signatures

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
@@ -584,6 +584,14 @@ abstract class AbstractHttp2StreamChannel extends DefaultAttributeMap implements
         return parent().toString() + '/' + channelId.getSequenceId() + " (H2 - " + stream + ')';
     }
 
+    void fireChildExceptionCaught(Throwable cause) {
+        pipeline().fireExceptionCaught(cause);
+    }
+
+    void fireChildUserEventTriggered(Object evt) {
+        pipeline().fireUserEventTriggered(evt);
+    }
+
     /**
      * Receive a read message. This does not notify handlers unless a read is in progress on the
      * channel.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexHandler.java
@@ -180,7 +180,7 @@ public final class Http2MultiplexHandler extends Http2ChannelDuplexHandler {
             if (msg instanceof Http2ResetFrame || msg instanceof Http2PriorityFrame) {
                 // Reset and Priority frames needs to be propagated via user events as these are not flow-controlled and
                 // so must not be controlled by suppressing channel.read() on the child channel.
-                channel.pipeline().fireUserEventTriggered(msg);
+                channel.fireChildUserEventTriggered(msg);
 
                 // RST frames will also trigger closing of the streams which then will call
                 // AbstractHttp2StreamChannel.streamClosed()
@@ -287,7 +287,7 @@ public final class Http2MultiplexHandler extends Http2ChannelDuplexHandler {
             AbstractHttp2StreamChannel childChannel = (AbstractHttp2StreamChannel)
                     ((DefaultHttp2FrameStream) stream).attachment;
             try {
-                childChannel.pipeline().fireExceptionCaught(cause.getCause());
+                childChannel.fireChildExceptionCaught(cause.getCause());
             } finally {
                 // Close with the correct error that causes this stream exception.
                 // See https://github.com/netty/netty/issues/13235#issuecomment-1441994672
@@ -313,7 +313,7 @@ public final class Http2MultiplexHandler extends Http2ChannelDuplexHandler {
             public boolean visit(Http2FrameStream stream) {
                 AbstractHttp2StreamChannel childChannel = (AbstractHttp2StreamChannel)
                         ((DefaultHttp2FrameStream) stream).attachment;
-                childChannel.pipeline().fireExceptionCaught(cause);
+                childChannel.fireChildExceptionCaught(cause);
                 return true;
             }
         });
@@ -338,7 +338,7 @@ public final class Http2MultiplexHandler extends Http2ChannelDuplexHandler {
                     if (streamId > goAwayFrame.lastStreamId() && Http2CodecUtil.isStreamIdValid(streamId, server)) {
                         final AbstractHttp2StreamChannel childChannel = (AbstractHttp2StreamChannel)
                                 ((DefaultHttp2FrameStream) stream).attachment;
-                        childChannel.pipeline().fireUserEventTriggered(goAwayFrame.retainedDuplicate());
+                        childChannel.fireChildUserEventTriggered(goAwayFrame.retainedDuplicate());
                     }
                     return true;
                 }


### PR DESCRIPTION
Motivation:

When calling methods on the child channel we sometimes directly access its pipeline and sometimes not. Let's make it consistent and always use explicit methods. This makes the code also easier to reason about

Modifications:

- Add 2 more explicit methods to the abstract base class and use it

Result:

Cleanup
