### PR TITLE
QPACK: Only call firstByteEquals(...) when we actually have readables bytes in decodeLiteralValue(...)

### DIFF
--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/QpackEncoderHandler.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/QpackEncoderHandler.java
@@ -227,13 +227,13 @@ final class QpackEncoderHandler extends ByteToMessageDecoder {
 
     @Nullable
     private CharSequence decodeLiteralValue(ByteBuf in) throws QpackException {
-        final boolean valueHuffEncoded = QpackUtil.firstByteEquals(in, (byte) 0b1000_0000);
+        int readerIndex = in.readerIndex();
         int valueLength = decodePrefixedIntegerAsInt(in, 7);
         if (valueLength < 0 || in.readableBytes() < valueLength) {
             // Not enough readable bytes
             return null;
         }
-
+        final boolean valueHuffEncoded = QpackUtil.byteEquals(in, readerIndex, (byte) 0b1000_0000);
         return decodeStringLiteral(in, valueHuffEncoded, valueLength);
     }
 

--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/QpackUtil.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/QpackUtil.java
@@ -116,7 +116,11 @@ final class QpackUtil {
     }
 
     static boolean firstByteEquals(ByteBuf in, byte mask) {
-        return (in.getByte(in.readerIndex()) & mask) == mask;
+        return byteEquals(in, in.readerIndex(), mask);
+    }
+
+    static boolean byteEquals(ByteBuf in, int offset, byte mask) {
+        return (in.getByte(offset) & mask) == mask;
     }
 
     /**


### PR DESCRIPTION
Motivation:

We should only call firstByteEquals(..) if we know that we have readable bytes in the ByteBuf. This was not the case here which was kind of harmless because we would just have discarded the "invalid" data later.
That said it is still not correct and so should be fixed

Modifications:

Move the firstByteEquals(...) call under the decodePrefixedIntegerAsInt(...) call as this ensures we have actually readables bytes

Result:

More correct code
