### PR TITLE
Update to latest netty-tcnative release

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -73,7 +73,7 @@
 
   <properties>
     <!-- Keep in sync with ../pom.xml -->
-    <tcnative.version>2.0.81.Final</tcnative.version>
+    <tcnative.version>2.0.82.Final</tcnative.version>
   </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -598,7 +598,7 @@
       <id>boringssl-snapshot</id>
       <properties>
         <tcnative.artifactId>netty-tcnative-boringssl-static</tcnative.artifactId>
-        <tcnative.version>2.0.82.Final-SNAPSHOT</tcnative.version>
+        <tcnative.version>2.0.83.Final-SNAPSHOT</tcnative.version>
         <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
       </properties>
 
@@ -744,7 +744,7 @@
     <os.detection.classifierWithLikes>fedora,suse,arch</os.detection.classifierWithLikes>
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
     <!-- Keep in sync with bom/pom.xml -->
-    <tcnative.version>2.0.81.Final</tcnative.version>
+    <tcnative.version>2.0.82.Final</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <conscrypt.groupId>org.conscrypt</conscrypt.groupId>
     <conscrypt.artifactId>conscrypt-openjdk-uber</conscrypt.artifactId>


### PR DESCRIPTION
Motivation:

A new netty-tcnative release is out.

Modifications:

Update to 2.0.82.Final

Result:

Use latest release
