### PR TITLE
Port to 5.0: io_uring: do not release write memory that the kernel still owns (#17238)

### DIFF
--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/AbstractIoUringChannel.java
@@ -26,6 +26,7 @@ import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.DefaultChannelId;
+import io.netty.channel.ChannelShutdownDirection;
 import io.netty.channel.ChannelShutdownType;
 import io.netty.channel.EventLoop;
 import io.netty.channel.IoEvent;
@@ -67,6 +68,9 @@ import static io.netty.util.internal.StringUtil.className;
 abstract class AbstractIoUringChannel extends AbstractChannel implements UnixChannel {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(AbstractIoUringChannel.class);
     final LinuxSocket socket;
+    // Owns every in-flight write operation this channel is tracking -- the pooled slot array, the overflow map,
+    // the foreign slot array, and the single stream slot. See WriteOperationTracker for the four namespaces.
+    final WriteOperationTracker writeTracker = new WriteOperationTracker();
     private final IoUringIoHandle ioHandle = new IoUringIoHandleImpl();
     protected volatile boolean active;
 
@@ -335,6 +339,25 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         }
     }
 
+    /**
+     * Retains every in-flight write's references before handing off to {@link #doShutdown0(ChannelShutdownType,
+     * Promise)}, so a write completion that races the shutdown still finds a live reference to release instead of
+     * one the outbound buffer already dropped. Only outbound shutdown needs this: an inbound shutdown never touches
+     * the outbound buffer, so there is no matching release for a retain done here.
+     */
+    @Override
+    protected final void doShutdown(ChannelShutdownType type, Promise<Void> promise) {
+        if (type.direction() == ChannelShutdownDirection.Outbound) {
+            writeTracker.retainAll();
+        }
+        doShutdown0(type, promise);
+    }
+
+    /**
+     * Performs the actual shutdown. Implemented by subclasses.
+     */
+    protected abstract void doShutdown0(ChannelShutdownType type, Promise<Void> promise);
+
     @Override
     protected final void doBeginRead() {
         if (inputClosedSeenErrorOnRead) {
@@ -406,17 +429,23 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         }
         Object msg = in.current();
 
+        int scheduled;
         if (msgCount > 1 && in.current() instanceof ByteBuf) {
-            numOutstandingWrites = (short) scheduleWriteMultiple(in);
+            scheduled = scheduleWriteMultiple(in);
         } else if (msg instanceof ByteBuf && ((ByteBuf) msg).nioBufferCount() > 1 ||
                     (msg instanceof ByteBufHolder && ((ByteBufHolder) msg).content().nioBufferCount() > 1)) {
             // We also need some special handling for CompositeByteBuf
-            numOutstandingWrites = (short) scheduleWriteMultiple(in);
+            scheduled = scheduleWriteMultiple(in);
         } else {
-            numOutstandingWrites = (short) scheduleWriteSingle(msg);
+            scheduled = scheduleWriteSingle(msg);
         }
-        // Ensure we never overflow
-        assert numOutstandingWrites > 0;
+        // A zero return means the write could not be scheduled: registration.submit(...) failed because the
+        // registration is no longer valid, a FileRegion's open() threw, or transferTo(...) produced no bytes or
+        // threw. numOutstandingWrites is a short, so guard the narrowing before it happens: a future
+        // scheduleWriteSingle/scheduleWriteMultiple override that batches more writes than a short can hold must
+        // not silently wrap around.
+        assert scheduled <= Short.MAX_VALUE;
+        numOutstandingWrites = (short) scheduled;
         return numOutstandingWrites;
     }
 
@@ -456,6 +485,15 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
         return (ioState & POLL_OUT_SCHEDULED) != 0;
     }
 
+    // Write completions may carry an id that fell back out of the short range, so they get the untruncated
+    // user_data. Connect completions always submit a short id, but connectComplete(...) takes a long to stay
+    // consistent with writeComplete(...), so it is also handed the untruncated value. The remaining completions
+    // (read, poll, cancel) only ever submit short ids, so narrowUserData(...) below asserts and narrows those.
+    private static short narrowUserData(long userData) {
+        assert userData == (short) userData : "user_data does not fit a short: " + userData;
+        return (short) userData;
+    }
+
     private final class IoUringIoHandleImpl implements IoUringIoHandle {
         private boolean closed;
 
@@ -465,13 +503,13 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
             byte op = event.opcode();
             int res = event.res();
             int flags = event.flags();
-            short data = (short) event.userData();
+            long userData = event.userData();
             switch (op) {
                 case Native.IORING_OP_RECV:
                 case Native.IORING_OP_ACCEPT:
                 case Native.IORING_OP_RECVMSG:
                 case Native.IORING_OP_READ:
-                    readComplete(op, res, flags, data);
+                    readComplete(op, res, flags, narrowUserData(userData));
                     break;
                 case Native.IORING_OP_WRITEV:
                 case Native.IORING_OP_SEND:
@@ -480,16 +518,16 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
                 case Native.IORING_OP_SPLICE:
                 case Native.IORING_OP_SEND_ZC:
                 case Native.IORING_OP_SENDMSG_ZC:
-                    writeComplete(op, res, flags, data);
+                    writeComplete(op, res, flags, userData);
                     break;
                 case Native.IORING_OP_POLL_ADD:
-                    pollAddComplete(res, flags, data);
+                    pollAddComplete(res, flags, narrowUserData(userData));
                     break;
                 case Native.IORING_OP_ASYNC_CANCEL:
-                    cancelComplete0(op, res, flags, data);
+                    cancelComplete0(op, res, flags, narrowUserData(userData));
                     break;
                 case Native.IORING_OP_CONNECT:
-                    connectComplete(op, res, flags, data);
+                    connectComplete(op, res, flags, userData);
 
                     // once the connect was completed we can also free some resources that are not needed anymore.
                     freeMsgHdrArray();
@@ -537,6 +575,9 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
     protected void unregistered() {
         freeMsgHdrArray();
         freeRemoteAddressMemory();
+        // No further completion arrives once a channel is deregistered, so references a shutdown retained on a
+        // slot via doShutdown(...) -> writeTracker.retainAll() would otherwise leak forever.
+        writeTracker.releaseAll();
     }
 
     @Override
@@ -547,13 +588,13 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
 
     /**
      * Schedule the write of multiple messages in the {@link ChannelOutboundBuffer} and returns the number of
-     * {@link #writeComplete(byte, int, int, short)} calls that are expected because of the scheduled write.
+     * {@link #writeComplete(byte, int, int, long)} calls that are expected because of the scheduled write.
      */
     protected abstract int scheduleWriteMultiple(ChannelOutboundBuffer in);
 
     /**
      * Schedule the write of a single message and returns the number of
-     * {@link #writeComplete(byte, int, int, short)} calls that are expected because of the scheduled write.
+     * {@link #writeComplete(byte, int, int, long)} calls that are expected because of the scheduled write.
      */
     protected abstract int scheduleWriteSingle(Object msg);
 
@@ -883,14 +924,20 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
      * @param flags the flags.
      * @param data  the data that was passed when submitting the op.
      */
-    private void writeComplete(byte op, int res, int flags, short data) {
+    private void writeComplete(byte op, int res, int flags, long data) {
+        writeTracker.complete(data, op, flags);
         if ((ioState & CONNECT_SCHEDULED) != 0) {
             // The writeComplete(...) callback was called because of a sendmsg(...) result that was used for
             // TCP_FASTOPEN_CONNECT.
             freeMsgHdrArray();
             if (res > 0) {
                 // Connect complete!
-                outboundBuffer().removeBytes(res);
+                // The completion may arrive after close() or shutdownOutput() already dropped the
+                // outbound buffer, in which case there is nothing left to remove.
+                ChannelOutboundBuffer channelOutboundBuffer = outboundBuffer();
+                if (channelOutboundBuffer != null) {
+                    channelOutboundBuffer.removeBytes(res);
+                }
 
                 // Explicit pass in 0 as this is returned by a connect(...) call when it was successful.
                 connectComplete(op, 0, flags, data);
@@ -943,7 +990,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
      * @param data          the data that was passed when submitting the op.
      * @param outstanding   the outstanding write completions.
      */
-    abstract boolean writeComplete0(byte op, int res, int flags, short data, int outstanding);
+    abstract boolean writeComplete0(byte op, int res, int flags, long data, int outstanding);
 
     /**
      * Called once a cancel was completed.
@@ -964,7 +1011,7 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
      * @param flags         the flags.
      * @param data          the data that was passed when submitting the op.
      */
-    void connectComplete(byte op, int res, int flags, short data) {
+    void connectComplete(byte op, int res, int flags, long data) {
         ioState &= ~CONNECT_SCHEDULED;
         assert connectPromise != null;
         freeRemoteAddressMemory();
@@ -1052,12 +1099,20 @@ abstract class AbstractIoUringChannel extends AbstractChannel implements UnixCha
 
                     int fd = fd().intValue();
                     IoRegistration registration = registration();
-                    IoUringIoOps ops = IoUringIoOps.newSendmsg(fd, (byte) 0, Native.MSG_FASTOPEN,
-                            hdr.address(), hdr.idx());
-                    connectId = registration.submit(ops);
-                    if (connectId == 0) {
-                        // Directly release the memory if submitting failed.
+                    short opsId = writeTracker.nextId();
+                    if (opsId == 0) {
                         freeMsgHdrArray();
+                        submitConnect(inetSocketAddress);
+                    } else {
+                        IoUringIoOps ops = IoUringIoOps.newSendmsg(fd, (byte) 0, Native.MSG_FASTOPEN,
+                                hdr.address(), opsId);
+                        writeTracker.record(opsId, ops.opcode(), initialData);
+                        connectId = registration.submit(ops);
+                        if (connectId == 0) {
+                            writeTracker.abandon(opsId, ops.opcode());
+                            // Directly release the memory if submitting failed.
+                            freeMsgHdrArray();
+                        }
                     }
                 } else {
                     submitConnect(inetSocketAddress);

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringDatagramChannel.java
@@ -131,7 +131,7 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
     }
 
     @Override
-    protected void doShutdown(ChannelShutdownType type, Promise<Void> promise) {
+    protected void doShutdown0(ChannelShutdownType type, Promise<Void> promise) {
         promise.setFailure(new UnsupportedOperationException());
     }
 
@@ -466,18 +466,26 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
     }
 
     @Override
-    boolean writeComplete0(byte op, int res, int flags, short data, int outstanding) {
-        ChannelOutboundBuffer outboundBuffer = outboundBuffer();
-
+    boolean writeComplete0(byte op, int res, int flags, long data, int outstanding) {
+        // data is the MsgHdrMemoryArray index that scheduleSendmsg(...) submitted, so it is always within
+        // [0, sendmsgHdrs.capacity()) (256) and never uses the overflow id range. Narrowing to int is safe.
+        assert data >= 0 && data < sendmsgHdrs.capacity();
+        int idx = (int) data;
         // Reset the id as this write was completed and so don't need to be cancelled later.
-        sendmsgHdrs.setId(data, MsgHdrMemoryArray.NO_ID);
-        sendmsgResArray[data] = res;
+        sendmsgHdrs.setId(idx, MsgHdrMemoryArray.NO_ID);
+        sendmsgResArray[idx] = res;
         // Store the result so we can handle it as soon as we have no outstanding writes anymore.
         if (outstanding == 0) {
             // All writes are done as part of a batch. Let's remove these from the ChannelOutboundBuffer
             boolean writtenSomething = false;
             int numWritten = sendmsgHdrs.length();
             sendmsgHdrs.clear();
+            ChannelOutboundBuffer outboundBuffer = outboundBuffer();
+            if (outboundBuffer == null) {
+                // The completion may arrive after close() or shutdownOutput() already dropped the
+                // outbound buffer.
+                return true;
+            }
             for (int i = 0; i < numWritten; i++) {
                 writtenSomething |= removeFromOutboundBuffer(
                         outboundBuffer, sendmsgResArray[i], "io_uring sendmsg");
@@ -505,7 +513,7 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
     }
 
     @Override
-    void connectComplete(byte op, int res, int flags, short data) {
+    void connectComplete(byte op, int res, int flags, long data) {
         if (res >= 0) {
             connected = true;
         }
@@ -543,10 +551,10 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
         }
 
         long bufferAddress = IoUring.memoryAddress(data) + data.readerIndex();
-        return scheduleSendmsg(remoteAddress, bufferAddress, data.readableBytes(), segmentSize, first);
+        return scheduleSendmsg(data, remoteAddress, bufferAddress, data.readableBytes(), segmentSize, first);
     }
 
-    private boolean scheduleSendmsg(InetSocketAddress remoteAddress, long bufferAddress,
+    private boolean scheduleSendmsg(ByteBuf data, InetSocketAddress remoteAddress, long bufferAddress,
                                     int bufferLength, int segmentSize, boolean first) {
         MsgHdrMemory hdr = sendmsgHdrs.nextHdr();
         if (hdr == null) {
@@ -560,10 +568,14 @@ public final class IoUringDatagramChannel extends AbstractIoUringChannel impleme
         int msgFlags = first ? 0 : Native.MSG_DONTWAIT;
         IoRegistration registration = registration();
         IoUringIoOps ops = IoUringIoOps.newSendmsg(fd, (byte) 0, msgFlags, hdr.address(), hdr.idx());
+        short opsId = hdr.idx();
+        // The id is the MsgHdrMemoryArray index, which that array allocates and recycles itself.
+        writeTracker.recordForeign(opsId, ops.opcode(), data);
         long id = registration.submit(ops);
         if (id == 0) {
             // Submission failed we don't used the MsgHdrMemory and so should give it back.
             sendmsgHdrs.restoreNextHdr(hdr);
+            writeTracker.abandon(opsId, ops.opcode());
             return false;
         }
         sendmsgHdrs.setId(hdr.idx(), id);

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoHandler.java
@@ -72,6 +72,7 @@ public final class IoUringIoHandler implements IoHandler {
     private final ByteBuffer timeoutMemory;
     private final long timeoutMemoryAddress;
     private final IovArray iovArray;
+    private final IovArrayReferenceCollector iovArrayReferenceCollector;
     private final MsgHdrMemoryArray msgHdrMemoryArray;
     private long eventfdReadSubmitted;
     private boolean eventFdClosing;
@@ -145,6 +146,7 @@ public final class IoUringIoHandler implements IoHandler {
         timeoutMemory = timeoutMemoryCleanable.buffer();
         timeoutMemoryAddress = Buffer.memoryAddress(timeoutMemory);
         iovArray = new IovArray(IoUring.NUM_ELEMENTS_IOVEC);
+        iovArrayReferenceCollector = new IovArrayReferenceCollector(iovArray);
         msgHdrMemoryArray = new MsgHdrMemoryArray((short) 1024);
     }
 
@@ -758,6 +760,14 @@ public final class IoUringIoHandler implements IoHandler {
         }
         assert iovArray.count() == 0;
         return iovArray;
+    }
+
+    /**
+     * Returns the {@link IovArrayReferenceCollector} paired with {@link #iovArray()}. A plain getter: callers are
+     * expected to have already called {@link #iovArray()} to make room, so this must not itself submit-and-clear.
+     */
+    IovArrayReferenceCollector iovArrayReferenceCollector() {
+        return iovArrayReferenceCollector;
     }
 
     MsgHdrMemoryArray msgHdrMemoryArray() {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoOps.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringIoOps.java
@@ -418,13 +418,13 @@ public final class IoUringIoOps implements IoOps {
 
     static IoUringIoOps newSendZc(
             int fd, long memoryAddress, int length,
-            int flags, short data, int zcFlags) {
+            int flags, long data, int zcFlags) {
         // See https://github.com/axboe/liburing/blob/liburing-2.8/src/include/liburing.h#L867
         return new IoUringIoOps(Native.IORING_OP_SEND_ZC, (byte) 0, (byte) zcFlags, fd,
                 0, memoryAddress, length, flags, data, (short) 0, (short) 0, 0, 0);
     }
 
-    static IoUringIoOps newSendmsgZc(int fd, byte flags, int msgFlags, long address, short data) {
+    static IoUringIoOps newSendmsgZc(int fd, byte flags, int msgFlags, long address, long data) {
         return new IoUringIoOps(Native.IORING_OP_SENDMSG_ZC, flags, (short) 0, fd, 0L, address, 1, msgFlags, data,
                 (short) 0, (short) 0, 0, 0);
     }

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringServerSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringServerSocketChannel.java
@@ -124,7 +124,7 @@ public final class IoUringServerSocketChannel extends AbstractIoUringChannel imp
     }
 
     @Override
-    protected void doShutdown(ChannelShutdownType type, Promise<Void> promise) {
+    protected void doShutdown0(ChannelShutdownType type, Promise<Void> promise) {
         promise.setFailure(new UnsupportedOperationException());
     }
 
@@ -166,7 +166,7 @@ public final class IoUringServerSocketChannel extends AbstractIoUringChannel imp
     }
 
     @Override
-    boolean writeComplete0(byte op, int res, int flags, short data, int outstanding) {
+    boolean writeComplete0(byte op, int res, int flags, long data, int outstanding) {
         throw new UnsupportedOperationException();
     }
 

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IoUringSocketChannel.java
@@ -33,6 +33,7 @@ import io.netty.channel.unix.DomainSocketReadMode;
 import io.netty.channel.unix.Errors;
 import io.netty.channel.unix.FileDescriptor;
 import io.netty.channel.unix.IovArray;
+import io.netty.util.ReferenceCounted;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
@@ -43,8 +44,6 @@ import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.NotYetConnectedException;
 import java.nio.channels.WritableByteChannel;
-import java.util.ArrayDeque;
-import java.util.Queue;
 
 import static io.netty.channel.unix.Errors.ioResult;
 
@@ -52,9 +51,6 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(IoUringSocketChannel.class);
     private final IoUringSocketChannelConfig config;
-
-    // Marker object that is used to mark a batch of buffers that were used with zero-copy write operations.
-    private static final Object ZC_BATCH_MARKER = new Object();
 
     /**
      * Maximum bytes per chunk when converting a generic {@link FileRegion} to a {@link ByteBuf}
@@ -81,11 +77,6 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
 
     // The configured buffer ring if any
     private IoUringBufferRing bufferRing;
-
-    /**
-     * Queue that holds buffers that we can't release yet as the kernel still holds a reference to these.
-     */
-    private Queue<Object> zcWriteQueue;
 
     public IoUringSocketChannel(EventLoop eventLoop) {
        this(eventLoop, null);
@@ -144,7 +135,7 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
     }
 
     @Override
-    protected void doShutdown(ChannelShutdownType type, Promise<Void> promise) {
+    protected void doShutdown0(ChannelShutdownType type, Promise<Void> promise) {
         if (type.data() != null) {
             promise.setFailure(new IllegalArgumentException("ChannelShutdownType with data is not supported: " + type));
             return;
@@ -198,39 +189,49 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
 
             IovArray iovArray = handler.iovArray();
             int offset = iovArray.count();
-            // Limit to the maximum number of fragments to ensure we don't get an error when we have too many
-            // buffers.
-            iovArray.maxCount(Native.MAX_SKB_FRAGS);
+            IovArrayReferenceCollector collector = handler.iovArrayReferenceCollector();
             try {
-                in.forEachFlushedMessage((ChannelOutboundBuffer.MessageProcessor) msg -> {
-                    if (msg instanceof ByteBuf) {
-                        ByteBuf buf = (ByteBuf) msg;
-                        int length = buf.readableBytes();
-                        if (config.shouldWriteZeroCopy(length)) {
-                            return iovArray.processMessage(msg);
+                // Limit to the maximum number of fragments to ensure we don't get an error when we have too many
+                // buffers.
+                iovArray.maxCount(Native.MAX_SKB_FRAGS);
+                try {
+                    in.forEachFlushedMessage((ChannelOutboundBuffer.MessageProcessor) msg -> {
+                        if (msg instanceof ByteBuf) {
+                            ByteBuf buf = (ByteBuf) msg;
+                            int length = buf.readableBytes();
+                            if (config.shouldWriteZeroCopy(length)) {
+                                return collector.processMessage(msg);
+                            }
                         }
-                    }
-                    return false;
-                });
-            } catch (Exception e) {
-                // This should never happen, anyway fallback to single write.
-                return scheduleWriteSingle(in.current());
-            }
-            long iovArrayAddress = iovArray.memoryAddress(offset);
-            int iovArrayLength = iovArray.count() - offset;
+                        return false;
+                    });
+                } catch (Exception e) {
+                    // This should never happen, anyway fallback to single write.
+                    return scheduleWriteSingle(in.current());
+                }
+                long iovArrayAddress = iovArray.memoryAddress(offset);
+                int iovArrayLength = iovArray.count() - offset;
 
-            MsgHdrMemoryArray msgHdrArray = handler.msgHdrMemoryArray();
-            MsgHdrMemory hdr = msgHdrArray.nextHdr();
-            assert hdr != null;
-            hdr.set(iovArrayAddress, iovArrayLength);
-            IoUringIoOps ops = IoUringIoOps.newSendmsgZc(fd().intValue(), (byte) 0, 0, hdr.address(), nextOpsId());
-            byte opCode = ops.opcode();
-            writeId = registration().submit(ops);
-            writeOpCode = opCode;
-            if (writeId == 0) {
-                return 0;
+                MsgHdrMemoryArray msgHdrArray = handler.msgHdrMemoryArray();
+                MsgHdrMemory hdr = msgHdrArray.nextHdr();
+                assert hdr != null;
+                hdr.set(iovArrayAddress, iovArrayLength);
+                long opsId = writeTracker.nextZeroCopyId();
+                IoUringIoOps ops = IoUringIoOps.newSendmsgZc(fd().intValue(), (byte) 0, 0, hdr.address(), opsId);
+                byte opCode = ops.opcode();
+                writeTracker.record(opsId, opCode, collector.referencesArray(), collector.referencesCount());
+                writeId = registration().submit(ops);
+                writeOpCode = opCode;
+                if (writeId == 0) {
+                    writeTracker.abandon(opsId, opCode);
+                    return 0;
+                }
+                return 1;
+            } finally {
+                // The slot copied the references it needs, and an exception must not leave the event loop's
+                // shared collector holding this write's buffers.
+                collector.reset();
             }
-            return 1;
         }
 
         int fd = fd().intValue();
@@ -238,25 +239,35 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
         IoUringIoHandler handler = registration.attachment();
         IovArray iovArray = handler.iovArray();
         int offset = iovArray.count();
+        IovArrayReferenceCollector collector = handler.iovArrayReferenceCollector();
 
         try {
-            in.forEachFlushedMessage(iovArray);
-        } catch (Exception e) {
-            // This should never happen, anyway fallback to single write.
-            return scheduleWriteSingle(in.current());
-        }
-        long iovArrayAddress = iovArray.memoryAddress(offset);
-        int iovArrayLength = iovArray.count() - offset;
-        // Should not use sendmsg_zc, just use normal writev.
-        IoUringIoOps ops = IoUringIoOps.newWritev(fd, (byte) 0, 0, iovArrayAddress, iovArrayLength, nextOpsId());
+            try {
+                in.forEachFlushedMessage(collector);
+            } catch (Exception e) {
+                // This should never happen, anyway fallback to single write.
+                return scheduleWriteSingle(in.current());
+            }
+            long iovArrayAddress = iovArray.memoryAddress(offset);
+            int iovArrayLength = iovArray.count() - offset;
+            // Should not use sendmsg_zc, just use normal writev.
+            IoUringIoOps ops = IoUringIoOps.newWritev(fd, (byte) 0, 0, iovArrayAddress, iovArrayLength, nextOpsId());
 
-        byte opCode = ops.opcode();
-        writeId = registration.submit(ops);
-        writeOpCode = opCode;
-        if (writeId == 0) {
-            return 0;
+            byte opCode = ops.opcode();
+            // record(...) copies the collector's references into the slot, so the collector stays reusable.
+            writeTracker.recordStream(opCode, collector.referencesArray(), collector.referencesCount());
+            writeId = registration.submit(ops);
+            writeOpCode = opCode;
+            if (writeId == 0) {
+                writeTracker.abandonStream();
+                return 0;
+            }
+            return 1;
+        } finally {
+            // The slot copied the references it needs, and an exception must not leave the event loop's
+            // shared collector holding this write's buffers.
+            collector.reset();
         }
-        return 1;
     }
 
     @Override
@@ -287,11 +298,14 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
             int length = buf.readableBytes();
             if (((IoUringSocketChannelConfig) config()).shouldWriteZeroCopy(length)) {
                 long address = IoUring.memoryAddress(buf) + buf.readerIndex();
-                IoUringIoOps ops = IoUringIoOps.newSendZc(fd().intValue(), address, length, 0, nextOpsId(), 0);
+                long opsId = writeTracker.nextZeroCopyId();
+                IoUringIoOps ops = IoUringIoOps.newSendZc(fd().intValue(), address, length, 0, opsId, 0);
                 byte opCode = ops.opcode();
+                writeTracker.record(opsId, opCode, buf);
                 writeId = registration().submit(ops);
                 writeOpCode = opCode;
                 if (writeId == 0) {
+                    writeTracker.abandon(opsId, opCode);
                     return 0;
                 }
                 return 1;
@@ -322,9 +336,15 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
             ops = IoUringIoOps.newSend(fd, (byte) 0, 0, address, length, opsid);
         }
         byte opCode = ops.opcode();
+        // A splice picks its own data to tell its two stages apart, so it never enters the channel-level
+        // slot array used for zero-copy writes. It still has to occupy this single slot though: the file and
+        // pipe descriptors it splices between have to outlive the SQE, and writeTracker.retainAll()
+        // only retains what was recorded here.
+        writeTracker.recordStream(opCode, (ReferenceCounted) msg);
         writeId = registration.submit(ops);
         writeOpCode = opCode;
         if (writeId == 0) {
+            writeTracker.abandonStream();
             return 0;
         }
         return 1;
@@ -375,13 +395,15 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
         int length = buf.readableBytes();
         IoUringIoOps ops = IoUringIoOps.newSend(fd, (byte) 0, 0, address, length, nextOpsId());
         byte opCode = ops.opcode();
+        writeTracker.recordStream(opCode, buf);
         writeId = registration.submit(ops);
         writeOpCode = opCode;
         if (writeId == 0) {
+            writeTracker.abandonStream();
             // Submission only fails when the registration is no longer valid (channel is
-            // being deregistered). unregistered() will release fileRegionChunkBuf and the
-            // outbound buffer will release the FileRegion, so nothing to clean up here --
-            // mirroring the plain ByteBuf path above.
+            // being deregistered). Ending the slot above is the only cleanup needed here:
+            // unregistered() will release fileRegionChunkBuf and the outbound buffer will
+            // release the FileRegion -- mirroring the plain ByteBuf path above.
             return 0;
         }
         return 1;
@@ -704,7 +726,7 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
     }
 
     @Override
-    boolean writeComplete0(byte op, int res, int flags, short data, int outstanding) {
+    boolean writeComplete0(byte op, int res, int flags, long data, int outstanding) {
         if ((flags & Native.IORING_CQE_F_NOTIF) == 0) {
             // We only want to reset these if IORING_CQE_F_NOTIF is not set.
             // If it's set we know this is only an extra notification for a write but we already handled
@@ -712,10 +734,17 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
             // See https://man7.org/linux/man-pages/man2/io_uring_enter.2.html section: IORING_OP_SEND_ZC
             writeId = 0;
             writeOpCode = 0;
+            // A completion that never went through the slot finds it inactive, which makes this a no-op.
+            writeTracker.completeStream(flags);
         }
         ChannelOutboundBuffer channelOutboundBuffer = outboundBuffer();
         if (op == Native.IORING_OP_SEND_ZC || op == Native.IORING_OP_SENDMSG_ZC) {
-            return handleWriteCompleteZeroCopy(op, channelOutboundBuffer, res, flags);
+            return handleWriteCompleteZeroCopy(op, channelOutboundBuffer, res, flags, data);
+        }
+        if (channelOutboundBuffer == null) {
+            // The completion may arrive after close() or shutdownOutput() already dropped the buffer.
+            releaseFileRegionChunkBuf();
+            return true;
         }
         if (op == Native.IORING_OP_SENDMSG) {
             if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
@@ -735,7 +764,8 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
         Object current = channelOutboundBuffer.current();
         if (current instanceof IoUringFileRegion) {
             IoUringFileRegion fileRegion = (IoUringFileRegion) current;
-            return handleWriteCompleteFileRegion(channelOutboundBuffer, fileRegion, res, data);
+            // A splice picks its own data to tell its two stages apart, so narrowing here can not drop bits.
+            return handleWriteCompleteFileRegion(channelOutboundBuffer, fileRegion, res, (short) data);
         }
 
         if (current instanceof FileRegion) {
@@ -818,124 +848,32 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
     }
 
     private boolean handleWriteCompleteZeroCopy(byte op, ChannelOutboundBuffer channelOutboundBuffer,
-                                                int res, int flags) {
-        if ((flags & Native.IORING_CQE_F_NOTIF) == 0) {
-            // We only want to reset these if IORING_CQE_F_NOTIF is not set.
-            // If it's set we know this is only an extra notification for a write but we already handled
-            // the write completions before.
-            // See https://man7.org/linux/man-pages/man2/io_uring_enter.2.html section: IORING_OP_SEND_ZC
-            writeId = 0;
-            writeOpCode = 0;
-
-            boolean more = (flags & Native.IORING_CQE_F_MORE) != 0;
-            if (more) {
-                // This is the result of send_sz or sendmsg_sc but there will also be another notification
-                // which will let us know that we can release the buffer(s). In this case let's retain the
-                // buffer(s) once and store it in an internal queue. Once we receive the notification we will
-                // call release() on the buffer(s) as it's not used by the kernel anymore.
-                if (zcWriteQueue == null) {
-                    zcWriteQueue = new ArrayDeque<>(8);
-                }
-            }
-            if (res >= 0) {
-                if (more) {
-
-                    // Loop through all the buffers that were part of the operation so we can add them to our
-                    // internal queue to release later.
-                    do {
-                        ByteBuf currentBuffer = (ByteBuf) channelOutboundBuffer.current();
-                        assert currentBuffer != null;
-                        zcWriteQueue.add(currentBuffer);
-                        currentBuffer.retain();
-                        int readable = currentBuffer.readableBytes();
-                        int skip = Math.min(readable, res);
-                        currentBuffer.skipBytes(skip);
-                        if (readable <= res) {
-                            boolean removed = channelOutboundBuffer.remove();
-                            assert removed;
-                        }
-                        res -= readable;
-                    } while (res > 0);
-                    // Add the marker so we know when we need to stop releasing
-                    zcWriteQueue.add(ZC_BATCH_MARKER);
-                } else {
-                    // We don't expect any extra notification, just directly let the buffer be released.
-                    channelOutboundBuffer.removeBytes(res);
-                }
-                return true;
-            } else {
-                if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
-                    if (more) {
-                        // The send was cancelled but we expect another notification. Just add the marker to the
-                        // queue so we don't get into trouble once the final notification for this operation is
-                        // received.
-                        zcWriteQueue.add(ZC_BATCH_MARKER);
-                    }
-                    return true;
-                }
-                try {
-                    String msg = op == Native.IORING_OP_SEND_ZC ? "io_uring sendzc" : "io_uring sendmsg_zc";
-                    int result = ioResult(msg, res);
-                    if (more) {
-                        try {
-                            // We expect another notification so we need to ensure we retain these buffers
-                            // so we can release these once we see IORING_CQE_F_NOTIF set.
-                            addFlushedToZcWriteQueue(channelOutboundBuffer);
-                        } catch (Exception e) {
-                            // should never happen but let's handle it anyway.
-                            handleWriteError(e);
-                        }
-                    }
-                    if (result == 0) {
-                        return false;
-                    }
-                } catch (Throwable cause) {
-                    if (more) {
-                        try {
-                            // We expect another notification as handleWriteError(...) will fail all flushed writes
-                            // and also release any buffers we need to ensure we retain these buffers
-                            // so we can release these once we see IORING_CQE_F_NOTIF set.
-                            addFlushedToZcWriteQueue(channelOutboundBuffer);
-                        } catch (Exception e) {
-                            // should never happen but let's handle it anyway.
-                            cause.addSuppressed(e);
-                        }
-                    }
-                    handleWriteError(cause);
-                }
-            }
-        } else {
-            if (zcWriteQueue != null) {
-                for (;;) {
-                    Object queued = zcWriteQueue.remove();
-                    assert queued != null;
-                    if (queued == ZC_BATCH_MARKER) {
-                        // Done releasing the buffers of the zero-copy batch.
-                        break;
-                    }
-                    // The buffer can now be released.
-                    ((ByteBuf) queued).release();
-                }
-            }
+                                                int res, int flags, long data) {
+        if ((flags & Native.IORING_CQE_F_NOTIF) != 0) {
+            return true;
         }
-        return true;
-    }
-
-    private void addFlushedToZcWriteQueue(ChannelOutboundBuffer channelOutboundBuffer) throws Exception {
-        // We expect another notification as handleWriteError(...) will fail all flushed writes
-        // and also release any buffers we need to ensure we retain these buffers
-        // so we can release these once we see IORING_CQE_F_NOTIF set.
+        if ((flags & Native.IORING_CQE_F_MORE) != 0) {
+            // Even errored requests may generate a notification, so the kernel still owns the memory
+            // until the follow-up IORING_CQE_F_NOTIF arrives. Retain before any release below.
+            // See https://man7.org/linux/man-pages/man2/io_uring_enter.2.html section: IORING_OP_SEND_ZC
+            writeTracker.retainReferences(data, op);
+        }
+        if (channelOutboundBuffer == null) {
+            return true;
+        }
+        if (res >= 0) {
+            channelOutboundBuffer.removeBytes(res);
+            return true;
+        }
+        if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
+            return true;
+        }
         try {
-            channelOutboundBuffer.forEachFlushedMessage(m -> {
-                if (!(m instanceof ByteBuf)) {
-                    return false;
-                }
-                zcWriteQueue.add(m);
-                ((ByteBuf) m).retain();
-                return true;
-            });
-        } finally {
-            zcWriteQueue.add(ZC_BATCH_MARKER);
+            String msg = op == Native.IORING_OP_SEND_ZC ? "io_uring sendzc" : "io_uring sendmsg_zc";
+            return ioResult(msg, res) != 0;
+        } catch (Throwable cause) {
+            handleWriteError(cause);
+            return true;
         }
     }
 
@@ -1010,6 +948,9 @@ public final class IoUringSocketChannel extends AbstractIoUringChannel implement
 
     @Override
     protected void unregistered() {
+        // super.unregistered() releases every in-flight write's references through writeTracker.releaseAll()
+        // before the chunk buffer is dropped below, so a reference a shutdown retained on that buffer is
+        // released first.
         super.unregistered();
         releaseFileRegionChunkBuf();
         if (readMsgHdrMemory != null) {

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IovArrayReferenceCollector.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/IovArrayReferenceCollector.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelOutboundBuffer;
+import io.netty.channel.unix.IovArray;
+import io.netty.util.ReferenceCounted;
+
+import java.util.Arrays;
+
+/**
+ * Fills the {@link IoUringIoHandler}'s {@link IovArray} from flushed outbound messages and records the
+ * {@link ByteBuf} behind each entry it added, so the caller can copy those references into a {@link WriteOperation}
+ * slot once the SQE is built.
+ *
+ * <p>One instance per {@link IoUringIoHandler}, matching the {@link IovArray} it wraps: the handler hands out the
+ * same {@link IovArray} instance to every channel it services, so a per-channel collector would be scoped smaller
+ * than the array it fills. This collector is only ever valid between a {@link #reset()} and the {@link WriteOperation}
+ * record call that copies its references out -- the caller then resets it from a {@code finally} that also covers
+ * the submit, so every exit from the write path, including the ones that throw, leaves it empty. Without that reset
+ * this instance, being permanently owned by the event loop rather than any one channel, would keep the previous
+ * write's buffers reachable for as long as this event loop went without servicing another write.
+ */
+final class IovArrayReferenceCollector implements ChannelOutboundBuffer.MessageProcessor {
+    private final IovArray iovArray;
+    private ReferenceCounted[] references = new ReferenceCounted[4];
+    private int count;
+
+    IovArrayReferenceCollector(IovArray iovArray) {
+        this.iovArray = iovArray;
+    }
+
+    /**
+     * Drops the previous references, keeping the array for reuse. Nulls out the dropped entries too: otherwise a
+     * smaller write reusing the collector after a larger one would leave stale {@code ByteBuf} references reachable
+     * through the backing array until the next reset, which risks promoting them into an old generation.
+     */
+    void reset() {
+        Arrays.fill(references, 0, count, null);
+        count = 0;
+    }
+
+    @Override
+    public boolean processMessage(Object msg) throws Exception {
+        int previousCount = iovArray.count();
+        boolean processed = iovArray.processMessage(msg);
+        recordIfAdded(msg, previousCount);
+        return processed;
+    }
+
+    /**
+     * Records the buffer behind {@code msg} once {@link IovArray} actually gained an entry for it. Split out of
+     * {@link #processMessage(Object)} so that method stays under HotSpot's default inline size threshold (35
+     * bytes), which it exceeded with the {@code if} check below inlined.
+     */
+    private void recordIfAdded(Object msg, int previousCount) {
+        // A 0-byte readable buffer makes IovArray.add(...) return true without adding an entry (see
+        // IovArray.add(ByteBuf, int, int)), so it never needs a slot here either -- comparing count before and
+        // after is what tells such a buffer apart from one that was actually added.
+        if (iovArray.count() != previousCount) {
+            add((ByteBuf) msg);
+        }
+    }
+
+    ReferenceCounted[] referencesArray() {
+        return references;
+    }
+
+    int referencesCount() {
+        return count;
+    }
+
+    private void add(ByteBuf buffer) {
+        if (count == references.length) {
+            grow();
+        }
+        references[count++] = buffer;
+    }
+
+    /**
+     * Doubles the backing array once it fills up. Split out of {@link #add(ByteBuf)} so that method stays under
+     * HotSpot's default inline size threshold (35 bytes); growing is genuinely the rare branch here, since
+     * {@link #reset()} clears the array in place for reuse instead of shrinking it back down.
+     */
+    private void grow() {
+        references = Arrays.copyOf(references, count << 1);
+    }
+}

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/WriteOperation.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/WriteOperation.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.ReferenceCounted;
+
+/**
+ * A slot tracking the references a submitted SQE handed to the kernel. Recording does not retain: the outbound buffer
+ * owns them until the write completes or {@link #retainReferences()} takes over. Slots are reused and the backing
+ * array is kept across reuses, so a slot allocates only on its first use and when a write hands it more references
+ * than any earlier use did. {@link #abandon()} is how a slot is ended outside of a completion CQE -- see its
+ * javadoc for the three situations that call it.
+ */
+final class WriteOperation {
+    private static final ReferenceCounted[] EMPTY_REFERENCES = new ReferenceCounted[0];
+
+    private byte opCode;
+    private ReferenceCounted[] references = EMPTY_REFERENCES;
+    private int count;
+    private boolean active;
+    private int retainedCount;
+
+    void record(byte opCode, ReferenceCounted reference) {
+        if (isActive()) {
+            throw new IllegalStateException("slot still owned by an operation that has not completed");
+        }
+        if (references.length < 1) {
+            references = new ReferenceCounted[1];
+        }
+        references[0] = reference;
+        count = 1;
+        this.opCode = opCode;
+        active = true;
+        retainedCount = 0;
+    }
+
+    /**
+     * Copies {@code references} so the caller may reuse the array: a zero-copy slot stays alive from its primary CQE
+     * until the follow-up {@code IORING_CQE_F_NOTIF}, during which a reused collector array would be overwritten.
+     */
+    void record(byte opCode, ReferenceCounted[] references, int count) {
+        if (isActive()) {
+            throw new IllegalStateException("slot still owned by an operation that has not completed");
+        }
+        if (this.references.length < count) {
+            this.references = new ReferenceCounted[count];
+        }
+        System.arraycopy(references, 0, this.references, 0, count);
+        this.count = count;
+        this.opCode = opCode;
+        active = true;
+        retainedCount = 0;
+    }
+
+    /**
+     * NOOP once every reference is retained or while the slot is inactive. {@code retainedCount} only advances
+     * past an index once its {@code retain()} call actually returns, so a {@code retain()} that throws partway
+     * leaves {@link #finish()} to release exactly the references that were retained, instead of over-releasing
+     * the ones that never were.
+     */
+    void retainReferences() {
+        if (!isActive() || retainedCount == count) {
+            return;
+        }
+        for (int i = retainedCount; i < count; i++) {
+            references[i].retain();
+            retainedCount = i + 1;
+        }
+    }
+
+    /**
+     * Whether this slot is occupied. A submitted SQE that ended up with zero references still occupies it.
+     */
+    boolean isActive() {
+        return active;
+    }
+
+    byte opCode() {
+        return opCode;
+    }
+
+    /**
+     * Releases the slot on the terminal CQE: a notification, or any completion without {@code IORING_CQE_F_MORE}.
+     */
+    void complete(int cqeFlags) {
+        if ((cqeFlags & Native.IORING_CQE_F_NOTIF) != 0 || (cqeFlags & Native.IORING_CQE_F_MORE) == 0) {
+            finish();
+        }
+    }
+
+    /**
+     * Ends this slot without it ever seeing a completion CQE. Called in three situations: (1) submission itself
+     * failed, so the kernel never saw the SQE and no CQE will ever arrive for it; (2) deregistration discards a
+     * slot whose completion this channel can no longer observe, and {@link #retainReferences()} never ran on it,
+     * making this call a plain discard; (3) deregistration discards a slot that {@link #retainReferences()} did
+     * retain before a shutdown, in which case this call is what actually releases those references.
+     */
+    void abandon() {
+        finish();
+    }
+
+    private void finish() {
+        if (!active) {
+            return;
+        }
+        active = false;
+        int releaseCount = retainedCount;
+        retainedCount = 0;
+        int finishedCount = count;
+        count = 0;
+        for (int i = 0; i < finishedCount; i++) {
+            if (i < releaseCount) {
+                // A completion, a failed submission and a deregistration all end up in this loop, so a reference
+                // that fails to release must not strand the ones after it or leave them reachable through the array.
+                ReferenceCountUtil.safeRelease(references[i]);
+            }
+            references[i] = null;
+        }
+    }
+}

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/WriteOperationTracker.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/WriteOperationTracker.java
@@ -1,0 +1,458 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.util.ReferenceCounted;
+import io.netty.util.collection.LongObjectHashMap;
+import io.netty.util.internal.MathUtil;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import java.util.Arrays;
+
+/**
+ * Owns every in-flight write operation a channel tracks, across the four namespaces a channel can have live at
+ * once: a pooled slot array (ids this class hands out itself), an overflow map (a long-id fallback once the
+ * pooled range is exhausted), a foreign slot array (ids an allocator this class does not own hands the caller,
+ * such as a {@link MsgHdrMemoryArray} index), and a single slot for the one non-zero-copy write a stream channel
+ * can have outstanding at a time. One instance per channel, created unconditionally in the channel constructor.
+ */
+final class WriteOperationTracker {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(WriteOperationTracker.class);
+
+    // Ids index the pooled array, so they run from 1 (0 is reserved for "no id") to Short.MAX_VALUE, the same
+    // bound scheduleWrite(...) already puts on the number of outstanding writes.
+    private static final int MAX_POOLED_ID = Short.MAX_VALUE;
+
+    // Ids issued by nextId()/nextZeroCopyId(). Dense, reused through freeIds, so allocating one never searches.
+    private WriteOperation[] pooled;
+    // Ids issued by an allocator this class does not own, such as the MsgHdrMemoryArray index the datagram
+    // sendmsg path submits directly. A separate array lets that namespace overlap the pooled one above.
+    private WriteOperation[] foreign;
+    private short[] freeIds;
+    private int freeIdCount;
+    private int issuedIds;
+
+    // Only ever holds values above MAX_POOLED_ID. Such a value does not survive a round-trip through short,
+    // so IoUringIoHandler.canUseFastPath(...) rejects it and the slow path preserves the full user_data. The
+    // counter only grows and never recycles, so a fallback id can never collide with a live one.
+    private long nextOverflowId = ((long) MAX_POOLED_ID) + 1;
+    // Never allocated before the short pool runs dry, so the common path never touches a map.
+    private LongObjectHashMap<WriteOperation> overflow;
+
+    // The one non-zero-copy write a stream channel can have in flight. Reused by direct field access -- no id,
+    // no array, no opcode match -- because WRITE_SCHEDULED caps a stream channel to one outstanding write.
+    // Exposed through recordStream/completeStream/abandonStream/isStreamActive below, and touched directly by
+    // retainAll()/releaseAll() the same way those touch the pooled/foreign/overflow namespaces; the field itself
+    // never leaves this class.
+    private final WriteOperation single = new WriteOperation();
+
+    /**
+     * Returns a write-operation id that no in-flight write owns, or {@code 0} when every id is held by a write
+     * that has not seen its terminal CQE yet. Released ids come back through a free list, so this does not
+     * search.
+     */
+    short nextId() {
+        if (freeIdCount > 0) {
+            return freeIds[--freeIdCount];
+        }
+        if (issuedIds == MAX_POOLED_ID) {
+            return 0;
+        }
+        return (short) ++issuedIds;
+    }
+
+    /**
+     * Returns a write-operation id for a zero-copy write, falling back to a long id outside the short range once
+     * every short id is held by an in-flight write, so the write still gets submitted instead of being deferred.
+     * Never returns 0.
+     */
+    long nextZeroCopyId() {
+        short id = nextId();
+        if (id != 0) {
+            return id;
+        }
+        return nextOverflowId++;
+    }
+
+    /**
+     * Registers a write whose id came from {@link #nextId()} or {@link #nextZeroCopyId()}. A pooled id goes back
+     * to the free list once the terminal CQE arrives; an overflow id is never reused, its map entry is simply
+     * dropped.
+     */
+    void record(long id, byte opCode, ReferenceCounted reference) {
+        if (id > MAX_POOLED_ID) {
+            recordOverflow(id, opCode, reference);
+            return;
+        }
+        short slot = (short) id;
+        WriteOperation[] grown = ensureCapacity(pooled, slot);
+        if (grown != pooled) {
+            pooled = grown;
+        }
+        slot(pooled, slot).record(opCode, reference);
+    }
+
+    // Split out of record(...) above so the overflow path -- taken only once every pooled id is in flight --
+    // does not add to the bytecode size of the hot method and keep it eligible for inlining.
+    private void recordOverflow(long id, byte opCode, ReferenceCounted reference) {
+        overflowSlot(id).record(opCode, reference);
+    }
+
+    /**
+     * Registers a write of multiple references whose id came from {@link #nextId()} or {@link #nextZeroCopyId()}.
+     * Copies {@code references}, so the caller may reuse the array.
+     */
+    void record(long id, byte opCode, ReferenceCounted[] references, int count) {
+        if (id > MAX_POOLED_ID) {
+            recordOverflow(id, opCode, references, count);
+            return;
+        }
+        short slot = (short) id;
+        WriteOperation[] grown = ensureCapacity(pooled, slot);
+        if (grown != pooled) {
+            pooled = grown;
+        }
+        slot(pooled, slot).record(opCode, references, count);
+    }
+
+    // Split out for the same reason as the single-reference overflow above: keep it out of the hot method.
+    private void recordOverflow(long id, byte opCode, ReferenceCounted[] references, int count) {
+        overflowSlot(id).record(opCode, references, count);
+    }
+
+    /**
+     * Registers a write whose id is owned by another allocator, such as the {@link MsgHdrMemoryArray} index used
+     * by the datagram sendmsg path. That id lives in its own slot array and never enters the free list.
+     */
+    void recordForeign(short id, byte opCode, ReferenceCounted reference) {
+        WriteOperation[] grown = ensureCapacity(foreign, id);
+        if (grown != foreign) {
+            foreign = grown;
+        }
+        slot(foreign, id).record(opCode, reference);
+    }
+
+    /**
+     * Ends the slot identified by {@code id}/{@code opCode} without it seeing a completion CQE: the submission
+     * itself failed, so the kernel never saw the SQE and no CQE will ever arrive for it. A pooled id goes back to
+     * the free list, an overflow entry is dropped. Deregistration ends its slots through {@link #releaseAll()}
+     * instead.
+     */
+    void abandon(long id, byte opCode) {
+        if (id > MAX_POOLED_ID) {
+            abandonOverflow(id, opCode);
+            return;
+        }
+        short slot = (short) id;
+        WriteOperation op = matching(pooled, slot, opCode);
+        if (op != null) {
+            op.abandon();
+            recycleId(slot);
+            return;
+        }
+        op = matching(foreign, slot, opCode);
+        if (op != null) {
+            op.abandon();
+        }
+    }
+
+    // Split out of abandon(...) above to keep the overflow path -- the rare case where every pooled id is
+    // in flight -- out of the hot method's bytecode.
+    private void abandonOverflow(long id, byte opCode) {
+        WriteOperation op = matchingOverflow(id, opCode);
+        if (op != null) {
+            op.abandon();
+            // Overflow ids are never recycled, so the entry has to go or the map grows without bound.
+            overflow.remove(id);
+        }
+    }
+
+    /**
+     * Applies a completion CQE to the slot identified by {@code id}/{@code opCode}. A terminated pooled slot's id
+     * is recycled back to the free list; a terminated overflow slot is removed from the map.
+     */
+    void complete(long id, byte opCode, int flags) {
+        if (id > MAX_POOLED_ID) {
+            completeOverflow(id, opCode, flags);
+            return;
+        }
+        short slot = (short) id;
+        WriteOperation op = matching(pooled, slot, opCode);
+        if (op != null) {
+            op.complete(flags);
+            if (!op.isActive()) {
+                recycleId(slot);
+            }
+            return;
+        }
+        op = matching(foreign, slot, opCode);
+        if (op != null) {
+            op.complete(flags);
+        }
+    }
+
+    // Split out of complete(...) above for the same reason as abandonOverflow(...): keep the rare overflow
+    // path out of the hot method's bytecode.
+    private void completeOverflow(long id, byte opCode, int flags) {
+        WriteOperation op = matchingOverflow(id, opCode);
+        if (op != null) {
+            op.complete(flags);
+            if (!op.isActive()) {
+                overflow.remove(id);
+            }
+        }
+    }
+
+    /**
+     * Retains the references held by the active slot identified by {@code id}/{@code opCode}, if any. Called from
+     * the zero-copy completion path, where {@code IORING_CQE_F_MORE} says the kernel still owns the memory until
+     * the follow-up {@code IORING_CQE_F_NOTIF}. The shutdown path uses {@link #retainAll()} instead.
+     */
+    void retainReferences(long id, byte opCode) {
+        if (id > MAX_POOLED_ID) {
+            retainOverflowReference(id, opCode);
+            return;
+        }
+        short slot = (short) id;
+        WriteOperation op = matching(pooled, slot, opCode);
+        if (op != null) {
+            op.retainReferences();
+            return;
+        }
+        op = matching(foreign, slot, opCode);
+        if (op != null) {
+            op.retainReferences();
+        }
+    }
+
+    // Split out of retainReferences(...) above for the same reason as abandonOverflow(...): keep the rare
+    // overflow path out of the hot method's bytecode. Named distinctly from retainOverflow() below, which
+    // retains every overflow slot instead of matching a single id/opCode pair.
+    private void retainOverflowReference(long id, byte opCode) {
+        WriteOperation op = matchingOverflow(id, opCode);
+        if (op != null) {
+            op.retainReferences();
+        }
+    }
+
+    /**
+     * The number of write operations parked in the overflow map. Test-only: no production caller, used to assert
+     * completions and abandons drop their entry.
+     */
+    int overflowCount() {
+        return overflow == null ? 0 : overflow.size();
+    }
+
+    /**
+     * Records a single reference on the non-zero-copy stream write slot. No id, no array, no opcode match.
+     */
+    void recordStream(byte opCode, ReferenceCounted reference) {
+        single.record(opCode, reference);
+    }
+
+    /**
+     * Records multiple references (e.g. writev) on the non-zero-copy stream write slot. Copies {@code references}.
+     */
+    void recordStream(byte opCode, ReferenceCounted[] references, int count) {
+        single.record(opCode, references, count);
+    }
+
+    /**
+     * Ends the stream slot without it ever seeing a completion CQE, for the same reason as
+     * {@link #abandon(long, byte)}: the submission itself failed. A no-op if the slot is inactive. There is no id,
+     * so there is no opcode match either -- the slot simply finishes. Deregistration ends this slot through
+     * {@link #releaseAll()} instead.
+     */
+    void abandonStream() {
+        if (single.isActive()) {
+            single.abandon();
+        }
+    }
+
+    /**
+     * Applies a completion CQE to the stream slot.
+     */
+    void completeStream(int flags) {
+        single.complete(flags);
+    }
+
+    /**
+     * Whether the stream slot is active. Test-only: no production caller, used to assert completions and abandons
+     * leave it inactive, same as {@link #overflowCount()}.
+     */
+    boolean isStreamActive() {
+        return single.isActive();
+    }
+
+    /**
+     * Retains every active slot's references across all four members (pooled, foreign, overflow, single) right
+     * before a shutdown, so a write completion that races the shutdown still finds a live reference to release
+     * instead of one the outbound buffer already dropped.
+     */
+    void retainAll() {
+        retainArray(pooled);
+        retainArray(foreign);
+        retainOverflow();
+        retainSingle();
+    }
+
+    /**
+     * Abandons every active slot across all four members and empties them, via {@link WriteOperation#abandon()}
+     * on each: a release for a slot {@link #retainAll()} retained, a plain discard for one it never reached.
+     * Named for the former, more consequential case -- the one this method exists to guard against -- rather
+     * than the latter, more common one. No further completion arrives once a channel is deregistered, so
+     * references a shutdown retained on a slot would otherwise leak forever.
+     */
+    void releaseAll() {
+        releaseArray(pooled);
+        releaseArray(foreign);
+        releaseOverflow();
+        if (single.isActive()) {
+            single.abandon();
+        }
+    }
+
+    private static WriteOperation[] ensureCapacity(WriteOperation[] operations, short id) {
+        if (operations == null) {
+            return new WriteOperation[Math.max(MathUtil.safeFindNextPositivePowerOfTwo(id + 1), 4)];
+        }
+        if (id >= operations.length) {
+            return Arrays.copyOf(operations, MathUtil.safeFindNextPositivePowerOfTwo(id + 1));
+        }
+        return operations;
+    }
+
+    private static WriteOperation slot(WriteOperation[] operations, short id) {
+        WriteOperation operation = operations[id];
+        if (operation == null) {
+            operation = new WriteOperation();
+            operations[id] = operation;
+        }
+        return operation;
+    }
+
+    private WriteOperation overflowSlot(long id) {
+        if (overflow == null) {
+            overflow = new LongObjectHashMap<WriteOperation>(2);
+        }
+        WriteOperation operation = overflow.get(id);
+        if (operation == null) {
+            operation = new WriteOperation();
+            overflow.put(id, operation);
+        }
+        return operation;
+    }
+
+    private WriteOperation matchingOverflow(long id, byte opCode) {
+        if (overflow == null) {
+            return null;
+        }
+        WriteOperation operation = overflow.get(id);
+        return operation != null && operation.isActive() && operation.opCode() == opCode ? operation : null;
+    }
+
+    private static WriteOperation matching(WriteOperation[] operations, short id, byte opCode) {
+        if (operations == null || id < 0 || id >= operations.length) {
+            return null;
+        }
+        WriteOperation operation = operations[id];
+        // Write user_data is not allocated from a single namespace. Every non-zero-copy stream write takes its id
+        // from AbstractIoUringChannel.nextOpsId(), and a splice picks a fixed id of its own to tell its two stages
+        // apart; both register in the single stream slot (see recordStream), not in this array, so their
+        // completions can land on a slot an unrelated zero-copy write occupies. Matching the opcode keeps such a
+        // completion from terminating what it finds.
+        return operation != null && operation.isActive() && operation.opCode() == opCode ? operation : null;
+    }
+
+    private void recycleId(short id) {
+        if (freeIds == null) {
+            freeIds = new short[8];
+        } else if (freeIdCount == freeIds.length) {
+            freeIds = Arrays.copyOf(freeIds, freeIdCount << 1);
+        }
+        freeIds[freeIdCount++] = id;
+    }
+
+    private static void retainArray(WriteOperation[] operations) {
+        if (operations == null) {
+            return;
+        }
+        for (WriteOperation operation : operations) {
+            if (operation == null) {
+                continue;
+            }
+            // One slot failing to retain must not stop the remaining slots from being retained.
+            try {
+                operation.retainReferences();
+            } catch (Throwable cause) {
+                logger.warn("Failed to retain in-flight write operation before shutdown", cause);
+            }
+        }
+    }
+
+    private void retainOverflow() {
+        if (overflow == null) {
+            return;
+        }
+        for (WriteOperation operation : overflow.values()) {
+            try {
+                operation.retainReferences();
+            } catch (Throwable cause) {
+                logger.warn("Failed to retain in-flight write operation before shutdown", cause);
+            }
+        }
+    }
+
+    // A failure here must not stop retainAll() from returning, the same guarantee retainArray(...) and
+    // retainOverflow() above give the array/map namespaces: doShutdown(...) still has to reach
+    // doShutdown0(...) -- the actual shutdown(2) -- even when this slot fails to retain.
+    private void retainSingle() {
+        try {
+            single.retainReferences();
+        } catch (Throwable cause) {
+            logger.warn("Failed to retain in-flight write operation before shutdown", cause);
+        }
+    }
+
+    private static void releaseArray(WriteOperation[] operations) {
+        if (operations == null) {
+            return;
+        }
+        for (int i = 0; i < operations.length; i++) {
+            WriteOperation operation = operations[i];
+            if (operation == null) {
+                continue;
+            }
+            if (operation.isActive()) {
+                operation.abandon();
+            }
+            operations[i] = null;
+        }
+    }
+
+    private void releaseOverflow() {
+        if (overflow == null) {
+            return;
+        }
+        for (WriteOperation operation : overflow.values()) {
+            if (operation.isActive()) {
+                operation.abandon();
+            }
+        }
+        overflow.clear();
+    }
+}

--- a/transport-classes-io_uring/src/test/java/io/netty/channel/uring/IoUringIoOpsTest.java
+++ b/transport-classes-io_uring/src/test/java/io/netty/channel/uring/IoUringIoOpsTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+// IoUringIoOps is compiled with release 9 (see the module's pom.xml), so it cannot be loaded on a Java 8
+// runtime; gate the whole class since every test here touches IoUringIoOps.
+@EnabledForJreRange(min = JRE.JAVA_9)
+class IoUringIoOpsTest {
+
+    private static final long OVERFLOW_DATA = 0x1_0000L + 5;
+    private static final long SHORT_RANGE_DATA = 100L;
+
+    @Test
+    void sendZcKeepsUserDataOutsideShortRange() {
+        IoUringIoOps ops = IoUringIoOps.newSendZc(1, 0xdeadbeefL, 128, 0, OVERFLOW_DATA, 0);
+
+        assertEquals(Native.IORING_OP_SEND_ZC, ops.opcode());
+        assertEquals(OVERFLOW_DATA, ops.userData());
+    }
+
+    @Test
+    void sendmsgZcKeepsUserDataOutsideShortRange() {
+        IoUringIoOps ops = IoUringIoOps.newSendmsgZc(1, (byte) 0, 0, 0xdeadbeefL, OVERFLOW_DATA);
+
+        assertEquals(Native.IORING_OP_SENDMSG_ZC, ops.opcode());
+        assertEquals(OVERFLOW_DATA, ops.userData());
+    }
+
+    @Test
+    void zeroCopyOpsKeepUserDataInsideShortRange() {
+        IoUringIoOps sendZc = IoUringIoOps.newSendZc(1, 0xdeadbeefL, 128, 0, SHORT_RANGE_DATA, 0);
+        assertEquals(SHORT_RANGE_DATA, sendZc.userData());
+
+        IoUringIoOps sendmsgZc = IoUringIoOps.newSendmsgZc(1, (byte) 0, 0, 0xdeadbeefL, SHORT_RANGE_DATA);
+        assertEquals(SHORT_RANGE_DATA, sendmsgZc.userData());
+    }
+}

--- a/transport-classes-io_uring/src/test/java/io/netty/channel/uring/WriteOperationTest.java
+++ b/transport-classes-io_uring/src/test/java/io/netty/channel/uring/WriteOperationTest.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.util.ReferenceCounted;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+// WriteOperation is compiled with release 9 (see the module's pom.xml), so it cannot be loaded on a Java 8
+// runtime; gate the whole class since every test here touches WriteOperation.
+@EnabledForJreRange(min = JRE.JAVA_9)
+class WriteOperationTest {
+
+    /**
+     * A reference that always fails to retain, so tests can force {@link WriteOperation#retainReferences()} to
+     * throw partway through its loop. {@link #release()} asserts it is never called, since a reference this class
+     * never actually retained must never be released either.
+     */
+    private static final class ThrowsOnRetain implements ReferenceCounted {
+        @Override
+        public int refCnt() {
+            return 1;
+        }
+
+        @Override
+        public ReferenceCounted retain() {
+            throw new RuntimeException("retain failed");
+        }
+
+        @Override
+        public ReferenceCounted retain(int increment) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ReferenceCounted touch() {
+            return this;
+        }
+
+        @Override
+        public ReferenceCounted touch(Object hint) {
+            return this;
+        }
+
+        @Override
+        public boolean release() {
+            throw new AssertionError("must not release a reference that was never retained");
+        }
+
+        @Override
+        public boolean release(int decrement) {
+            throw new AssertionError("must not release a reference that was never retained");
+        }
+    }
+
+    @Test
+    void recordDoesNotRetain() {
+        ByteBuf buffer = Unpooled.buffer();
+        WriteOperation operation = new WriteOperation();
+
+        operation.record(Native.IORING_OP_SEND, buffer);
+
+        assertEquals(Native.IORING_OP_SEND, operation.opCode());
+        assertEquals(1, buffer.refCnt());
+
+        operation.complete(0);
+        assertEquals(1, buffer.refCnt());
+        buffer.release();
+    }
+
+    @Test
+    void retainReferencesIsIdempotent() {
+        ByteBuf buffer = Unpooled.buffer();
+        WriteOperation operation = new WriteOperation();
+        operation.record(Native.IORING_OP_SEND, buffer);
+
+        operation.retainReferences();
+        assertEquals(2, buffer.refCnt());
+
+        operation.retainReferences();
+        assertEquals(2, buffer.refCnt());
+
+        operation.complete(0);
+        buffer.release();
+    }
+
+    @Test
+    void terminalCqeAfterShutdownRetainReleasesExactlyOnce() {
+        ByteBuf buffer = Unpooled.buffer();
+        WriteOperation operation = new WriteOperation();
+        operation.record(Native.IORING_OP_SEND, buffer);
+        operation.retainReferences();
+        assertEquals(2, buffer.refCnt());
+
+        operation.complete(0);
+        operation.complete(0);
+
+        assertFalse(operation.isActive());
+        assertEquals(1, buffer.refCnt());
+        buffer.release();
+    }
+
+    @Test
+    void terminalCqeWithoutShutdownRetainLeavesRefCntUnchanged() {
+        ByteBuf buffer = Unpooled.buffer();
+        WriteOperation operation = new WriteOperation();
+        operation.record(Native.IORING_OP_SEND, buffer);
+
+        operation.complete(0);
+        operation.complete(0);
+
+        assertFalse(operation.isActive());
+        assertEquals(1, buffer.refCnt());
+        buffer.release();
+    }
+
+    @Test
+    void zeroCopyMoreCompletionDefersReleaseUntilNotification() {
+        ByteBuf first = Unpooled.buffer();
+        ByteBuf second = Unpooled.buffer();
+        WriteOperation operation = new WriteOperation();
+        operation.record(Native.IORING_OP_SENDMSG_ZC, new ReferenceCounted[] {first, second}, 2);
+        operation.retainReferences();
+        assertEquals(2, first.refCnt());
+        assertEquals(2, second.refCnt());
+
+        operation.complete(Native.IORING_CQE_F_MORE);
+
+        assertTrue(operation.isActive());
+        assertEquals(2, first.refCnt());
+        assertEquals(2, second.refCnt());
+
+        operation.complete(Native.IORING_CQE_F_NOTIF);
+        operation.complete(Native.IORING_CQE_F_NOTIF);
+
+        assertFalse(operation.isActive());
+        assertEquals(1, first.refCnt());
+        assertEquals(1, second.refCnt());
+        first.release();
+        second.release();
+    }
+
+    @Test
+    void zeroCopyMoreCompletionWithoutRetainFinishesAtNotificationWithoutReleasing() {
+        ByteBuf first = Unpooled.buffer();
+        ByteBuf second = Unpooled.buffer();
+        WriteOperation operation = new WriteOperation();
+        operation.record(Native.IORING_OP_SENDMSG_ZC, new ReferenceCounted[] {first, second}, 2);
+
+        operation.complete(Native.IORING_CQE_F_MORE);
+
+        // Not retained, so the primary completion must leave refCnt alone and must not finish the operation.
+        assertTrue(operation.isActive());
+        assertEquals(1, first.refCnt());
+        assertEquals(1, second.refCnt());
+
+        operation.complete(Native.IORING_CQE_F_NOTIF);
+        operation.complete(Native.IORING_CQE_F_NOTIF);
+
+        assertFalse(operation.isActive());
+        assertEquals(1, first.refCnt());
+        assertEquals(1, second.refCnt());
+        first.release();
+        second.release();
+    }
+
+    @Test
+    void retainFailurePartwayReleasesOnlyWhatWasActuallyRetained() {
+        ByteBuf first = Unpooled.buffer();
+        ReferenceCounted second = new ThrowsOnRetain();
+        WriteOperation operation = new WriteOperation();
+        operation.record(Native.IORING_OP_WRITEV, new ReferenceCounted[] {first, second}, 2);
+
+        // references[1].retain() throws, after references[0].retain() already succeeded.
+        assertThrows(RuntimeException.class, operation::retainReferences);
+        assertEquals(2, first.refCnt());
+
+        // finish() must release only the one reference that was actually retained. Releasing "second" too --
+        // which never was retained -- would be an over-release; ThrowsOnRetain.release() asserts on that.
+        operation.complete(0);
+
+        assertFalse(operation.isActive());
+        assertEquals(1, first.refCnt());
+        first.release();
+    }
+
+    @Test
+    void abandonAfterShutdownRetainReleasesExactlyOnce() {
+        ByteBuf buffer = Unpooled.buffer();
+        WriteOperation operation = new WriteOperation();
+        operation.record(Native.IORING_OP_SEND, buffer);
+        operation.retainReferences();
+
+        // Deregistration discards a slot a shutdown had retained and no CQE ever arrives for it, so the abandon
+        // is the only release.
+        operation.abandon();
+        operation.abandon();
+
+        assertFalse(operation.isActive());
+        assertEquals(1, buffer.refCnt());
+        buffer.release();
+    }
+
+    @Test
+    void zeroReferenceRecordStillOccupiesTheSlot() {
+        WriteOperation operation = new WriteOperation();
+
+        operation.record(Native.IORING_OP_WRITEV, new ReferenceCounted[0], 0);
+
+        assertTrue(operation.isActive());
+
+        operation.complete(0);
+
+        assertFalse(operation.isActive());
+    }
+
+    @Test
+    void finishedOperationIsNoLongerActive() {
+        ByteBuf buffer = Unpooled.buffer();
+        WriteOperation operation = new WriteOperation();
+        operation.record(Native.IORING_OP_SEND, buffer);
+
+        assertTrue(operation.isActive());
+
+        operation.complete(0);
+
+        assertFalse(operation.isActive());
+        buffer.release();
+    }
+
+    @Test
+    void completeAndAbandonAfterFinishDoNotReleaseAgain() {
+        ByteBuf buffer = Unpooled.buffer();
+        WriteOperation operation = new WriteOperation();
+        operation.record(Native.IORING_OP_SEND, buffer);
+        operation.retainReferences();
+        assertEquals(2, buffer.refCnt());
+
+        operation.complete(0);
+        assertEquals(1, buffer.refCnt());
+
+        operation.complete(0);
+        operation.abandon();
+        operation.complete(Native.IORING_CQE_F_NOTIF);
+
+        assertFalse(operation.isActive());
+        assertEquals(1, buffer.refCnt());
+        buffer.release();
+    }
+
+    @Test
+    void arrayOverloadCopiesPassedInArraySoCallerCanReuseIt() {
+        ByteBuf first = Unpooled.buffer();
+        ByteBuf second = Unpooled.buffer();
+        ByteBuf replacement = Unpooled.buffer();
+        ReferenceCounted[] references = new ReferenceCounted[] {first, second};
+        WriteOperation operation = new WriteOperation();
+
+        operation.record(Native.IORING_OP_WRITEV, references, 2);
+
+        // Callers such as the per-event-loop IovArrayReferenceCollector reuse this array between writes.
+        references[0] = replacement;
+
+        operation.retainReferences();
+        assertEquals(2, first.refCnt());
+        assertEquals(1, replacement.refCnt());
+        assertEquals(2, second.refCnt());
+
+        operation.abandon();
+        assertEquals(1, first.refCnt());
+        assertEquals(1, second.refCnt());
+
+        first.release();
+        second.release();
+        replacement.release();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/AbstractWriteOperationTrackerTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/AbstractWriteOperationTrackerTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.channel.ChannelShutdownType;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.util.concurrent.Promise;
+import org.junit.jupiter.api.BeforeAll;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+// Shared by the tests that exercise WriteOperationTracker bookkeeping directly, both of which need a
+// registered channel's real event loop to run their assertions on.
+abstract class AbstractWriteOperationTrackerTest {
+
+    @BeforeAll
+    static void loadJNI() {
+        assumeTrue(IoUring.isAvailable());
+    }
+
+    interface BookkeepingTask {
+        void run(IoUringSocketChannel channel);
+    }
+
+    // The bookkeeping is event-loop state and the channel can only be closed once registered, so the task
+    // runs on a real event loop.
+    static void runOnEventLoop(final BookkeepingTask task) throws Exception {
+        MultiThreadIoEventLoopGroup group = new MultiThreadIoEventLoopGroup(1, IoUringIoHandler.newFactory());
+        final IoUringSocketChannel channel = new IoUringSocketChannel(group.next());
+        try {
+            channel.register().sync();
+            channel.executor().submit(new Runnable() {
+                @Override
+                public void run() {
+                    task.run(channel);
+                }
+            }).sync();
+        } finally {
+            channel.close().syncUninterruptibly();
+            group.shutdownGracefully().syncUninterruptibly();
+        }
+    }
+
+    // Calls doShutdown(...) directly instead of going through Channel.shutdown(...), which would bail out on
+    // isActive() before ever reaching it, since this channel is never connected. Going through doShutdown(...)
+    // directly is what this exercises: the retain has to happen before the shutdown(2) syscall runs, not after.
+    // The channel is not connected, so that syscall fails with ENOTCONN, which IoUringSocketChannel.doShutdown0(...)
+    // treats as an already-effectively-shutdown socket and completes the promise successfully instead of
+    // propagating the failure.
+    static void shutdownOutput(IoUringSocketChannel channel) {
+        Promise<Void> promise = channel.executor().newPromise();
+        channel.doShutdown(ChannelShutdownType.newOutbound(), promise);
+        assertTrue(promise.isSuccess(), "doShutdown should complete the promise successfully");
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDatagramWriteLifecycleTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringDatagramWriteLifecycleTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFactory;
+import io.netty.channel.ChannelInboundHandler;
+import io.netty.channel.EventLoop;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.socket.DatagramPacket;
+import io.netty.channel.socket.SocketProtocolFamily;
+import io.netty.util.NetUtil;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.netty.channel.uring.IoUringRefCntZeroAwaiter.awaitRefCntZero;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IoUringDatagramWriteLifecycleTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IoUring.isAvailable());
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    public void testCloseKeepsSendmsgDatagramAliveUntilTerminalCqe() throws Exception {
+        MultiThreadIoEventLoopGroup group = new MultiThreadIoEventLoopGroup(1, IoUringIoHandler.newFactory());
+        Channel channel = null;
+        try {
+            channel = new Bootstrap()
+                    .group(group)
+                    .channelFactory(new ChannelFactory<Channel>() {
+                        @Override
+                        public Channel newChannel(EventLoop eventLoop) {
+                            return new IoUringDatagramChannel(eventLoop, SocketProtocolFamily.INET);
+                        }
+                    })
+                    .handler(new ChannelInboundHandler() { })
+                    .bind(new InetSocketAddress(NetUtil.LOCALHOST4, 0)).sync().getNow();
+
+            AtomicReference<ByteBuf> bufferRef = new AtomicReference<>();
+            AtomicInteger refCntAfterClose = new AtomicInteger(-1);
+            CountDownLatch closeIssued = new CountDownLatch(1);
+            Channel finalChannel = channel;
+            finalChannel.executor().execute(new Runnable() {
+                @Override
+                public void run() {
+                    ByteBuf buffer = finalChannel.alloc().directBuffer(1024);
+                    buffer.writeZero(buffer.capacity());
+                    bufferRef.set(buffer);
+                    finalChannel.writeAndFlush(new DatagramPacket(buffer,
+                            new InetSocketAddress(NetUtil.LOCALHOST4, 9)));
+                    // CQEs can only be reaped once this task returns, so the sendmsg is still in flight here.
+                    finalChannel.close();
+                    refCntAfterClose.set(buffer.refCnt());
+                    closeIssued.countDown();
+                }
+            });
+
+            assertTrue(closeIssued.await(5, TimeUnit.SECONDS), "local close was not issued");
+            ByteBuf buffer = bufferRef.get();
+            assertNotNull(buffer, "datagram buffer was not allocated");
+            // WRITE_SCHEDULED is set, so close() parks in delayedClose instead of releasing the outbound
+            // buffer, keeping the flushed DatagramPacket alive on its own single reference until the CQE.
+            assertEquals(1, refCntAfterClose.get(), "close must keep sendmsg memory live before its terminal CQE");
+
+            assertTrue(channel.closeFuture().await(5, TimeUnit.SECONDS), "channel did not close in time");
+            assertTrue(awaitRefCntZero(channel, buffer, 5, TimeUnit.SECONDS),
+                    "sendmsg memory was not released by its terminal CQE");
+        } finally {
+            // Use a bounded await instead of syncUninterruptibly(): if the bug under test
+            // reproduces, close() never completes, and this finally block must not hang forever.
+            if (channel != null) {
+                channel.close().awaitUninterruptibly(5, TimeUnit.SECONDS);
+            }
+            group.shutdownGracefully(0, 2, TimeUnit.SECONDS).awaitUninterruptibly(5, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringRefCntZeroAwaiter.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringRefCntZeroAwaiter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.channel.Channel;
+import io.netty.util.ReferenceCounted;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+// Shared by the write-lifecycle tests, which all submit outbound memory that a terminal CQE releases
+// asynchronously and then need to wait for that release to confirm nothing leaked.
+final class IoUringRefCntZeroAwaiter {
+
+    private IoUringRefCntZeroAwaiter() {
+    }
+
+    static boolean awaitRefCntZero(Channel channel, ReferenceCounted referenceCounted, long timeout, TimeUnit unit)
+            throws InterruptedException {
+        CountDownLatch released = new CountDownLatch(1);
+        channel.executor().execute(new Runnable() {
+            @Override
+            public void run() {
+                if (referenceCounted.refCnt() == 0) {
+                    released.countDown();
+                } else {
+                    channel.executor().schedule(this, 10, TimeUnit.MILLISECONDS);
+                }
+            }
+        });
+        return released.await(timeout, unit);
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringShutdownOutputDuringInFlightSpliceTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringShutdownOutputDuringInFlightSpliceTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandler;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelShutdownType;
+import io.netty.channel.DefaultFileRegion;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.util.concurrent.Future;
+import io.netty.util.internal.PlatformDependent;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.RandomAccessFile;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.netty.channel.uring.IoUringRefCntZeroAwaiter.awaitRefCntZero;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * A splice picks up its file and pipe descriptors lazily, inside the kernel's async worker, so submitting the
+ * SQE does not itself pin them. If {@code shutdownOutput()} releases the {@link IoUringFileRegion} before the
+ * kernel has taken that reference, the fd it later dereferences may already be closed (and, on 7.x kernels,
+ * reused by an unrelated file), which is a use-after-free rather than a Netty-visible exception. This mirrors
+ * {@link IoUringShutdownOutputDuringInFlightWriteTest}, but for the splice write path.
+ */
+public class IoUringShutdownOutputDuringInFlightSpliceTest {
+
+    private static final byte[] PAYLOAD = "hello splice race".getBytes();
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IoUring.isAvailable());
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    public void testCloseCompletesAfterShutdownOutputDuringInFlightSplice() throws Exception {
+        assumeTrue(IoUring.isSpliceSupported());
+
+        MultiThreadIoEventLoopGroup serverGroup = new MultiThreadIoEventLoopGroup(1, IoUringIoHandler.newFactory());
+        MultiThreadIoEventLoopGroup clientGroup = new MultiThreadIoEventLoopGroup(1, IoUringIoHandler.newFactory());
+
+        Channel serverChannel = null;
+        Channel clientChannel = null;
+        File file = PlatformDependent.createTempFile("netty-iouring-splice-race-", ".tmp", null);
+        file.deleteOnExit();
+        AtomicReference<Future<Void>> writeFutureHolder = new AtomicReference<>();
+        AtomicReference<DefaultFileRegion> regionRef = new AtomicReference<>();
+        AtomicInteger refCntAfterShutdown = new AtomicInteger(-1);
+        AtomicReference<Boolean> openAfterShutdown = new AtomicReference<>();
+        CountDownLatch outputShutdown = new CountDownLatch(1);
+        try (FileOutputStream out = new FileOutputStream(file)) {
+            out.write(PAYLOAD);
+        }
+        try {
+            ServerBootstrap sb = new ServerBootstrap();
+            sb.group(serverGroup)
+                    .channel(IoUringServerSocketChannel.class)
+                    .childOption(ChannelOption.AUTO_READ, true)
+                    .childHandler(new ChannelInboundHandler() { });
+            serverChannel = sb.bind(0).sync().getNow();
+
+            Bootstrap cb = new Bootstrap();
+            cb.group(clientGroup)
+                    .channel(IoUringSocketChannel.class);
+            cb.handler(new ChannelInboundHandler() {
+                @Override
+                public void channelActive(ChannelHandlerContext ctx) throws Exception {
+                    DefaultFileRegion region = new DefaultFileRegion(
+                            new RandomAccessFile(file, "r").getChannel(), 0, PAYLOAD.length);
+                    regionRef.set(region);
+                    // Submit the SQE, then shut down output in the same event-loop task: submitAndRunNow() is a
+                    // NOOP for stream channels, so io_uring_enter(...) has not run yet and the SQE is still only
+                    // queued locally.
+                    writeFutureHolder.set(ctx.writeAndFlush(region));
+                    ctx.channel().shutdown(ChannelShutdownType.newOutbound());
+                    refCntAfterShutdown.set(region.refCnt());
+                    openAfterShutdown.set(region.isOpen());
+                    outputShutdown.countDown();
+                }
+            });
+            clientChannel = cb.connect(serverChannel.localAddress()).sync().getNow();
+
+            assertTrue(outputShutdown.await(5, TimeUnit.SECONDS), "shutdown() was not invoked");
+            DefaultFileRegion region = regionRef.get();
+            assertNotNull(region, "file region was never allocated");
+            // channel.shutdown(...) is the public path (AbstractChannel#shutdown): it only flips the
+            // outputShutdown flag and fires the shutdown event, it never touches the outbound buffer. Releasing
+            // (and closing) the outbound resource is the job of the private shutdownOutput(...), which only runs
+            // from the write-error path, not from here. So the region is still held by its original reference,
+            // and on top of that AbstractIoUringChannel#doShutdown retains it once more via
+            // writeTracker.retainAll() before this SQE's CQE lands, because the kernel still owns the submitted
+            // file and pipe descriptors until it posts the splice CQE. refCnt 2 here is that original reference
+            // plus the tracker's retain, not a release having failed to happen.
+            assertEquals(2, refCntAfterShutdown.get(), "shutdown() did not retain the in-flight splice's FileRegion");
+            assertTrue(openAfterShutdown.get(), "shutdown() closed an in-flight splice's file descriptor");
+
+            assertTrue(awaitRefCntZero(clientChannel, region, 5, TimeUnit.SECONDS),
+                    "file region was not released after its terminal completion");
+
+            assertTrue(clientChannel.close().await(5, TimeUnit.SECONDS),
+                    "channel did not close within the timeout after shutdown() raced an "
+                            + "in-flight splice");
+            assertFalse(clientChannel.isActive());
+            assertFalse(clientChannel.isOpen());
+
+            Future<Void> writeFuture = writeFutureHolder.get();
+            assertNotNull(writeFuture, "write was never submitted");
+            assertTrue(writeFuture.await(5, TimeUnit.SECONDS), "write future did not complete in time");
+            // In 4.2, shutdownOutput() was a single method that both flipped the outputShutdown flag and
+            // cleared the outbound buffer, so a pending write promise was failed right there with
+            // ChannelOutputShutdownException. In 5.0 that's split: the public shutdown(...) this test calls
+            // never touches the outbound buffer, and only the private shutdownOutput(...) -- reached from the
+            // write-error path, not from here -- clears the buffer and fails pending writes with
+            // ChannelOutputShutdownException. Here, by the time we check, the channel is already closed, so
+            // which of two racing paths failed the in-flight splice depends on timing: the kernel may have
+            // completed it against a socket that already had its output shut down (surfacing as a
+            // NativeIoException), or close() may have reaped it first (surfacing as a
+            // StacklessClosedChannelException). Either way is a legitimate failure; this test only asserts
+            // that the splice did not silently succeed or hang.
+            assertNotNull(writeFuture.cause(), "the in-flight splice should have failed");
+        } finally {
+            // Use a bounded await instead of syncUninterruptibly(): if the bug under test
+            // reproduces, close() never completes, and this finally block must not hang forever.
+            if (clientChannel != null) {
+                clientChannel.close().awaitUninterruptibly(5, TimeUnit.SECONDS);
+            }
+            if (serverChannel != null) {
+                serverChannel.close().awaitUninterruptibly(5, TimeUnit.SECONDS);
+            }
+            serverGroup.shutdownGracefully(0, 2, TimeUnit.SECONDS).awaitUninterruptibly(5, TimeUnit.SECONDS);
+            clientGroup.shutdownGracefully(0, 2, TimeUnit.SECONDS).awaitUninterruptibly(5, TimeUnit.SECONDS);
+            file.delete();
+        }
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringShutdownOutputDuringInFlightWriteTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringShutdownOutputDuringInFlightWriteTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandler;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelShutdownType;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.util.concurrent.Future;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.netty.channel.uring.IoUringRefCntZeroAwaiter.awaitRefCntZero;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * A write CQE (and, for zero-copy, its follow-up notification) that lands after the outbound buffer is gone
+ * must still be consumed, otherwise the channel's write-tracking state stays stuck and close() never completes.
+ */
+public class IoUringShutdownOutputDuringInFlightWriteTest {
+
+    private enum WriteMode {
+        PLAIN,
+        ZERO_COPY
+    }
+
+    // A payload this large, together with AUTO_READ=false on the peer, keeps the write from completing
+    // synchronously on submission, widening the window in which its CQE is still outstanding.
+    private static final int WRITE_SIZE = 1024 * 1024;
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IoUring.isAvailable());
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    public void testCloseCompletesAfterShutdownOutputDuringInFlightWrite() throws Exception {
+        runTest(WriteMode.PLAIN);
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    public void testCloseCompletesAfterShutdownOutputDuringInFlightZeroCopyWrite() throws Exception {
+        assumeTrue(IoUring.isSendZcSupported());
+        runTest(WriteMode.ZERO_COPY);
+    }
+
+    private static void runTest(WriteMode writeMode) throws Exception {
+        MultiThreadIoEventLoopGroup serverGroup = new MultiThreadIoEventLoopGroup(1, IoUringIoHandler.newFactory());
+        MultiThreadIoEventLoopGroup clientGroup = new MultiThreadIoEventLoopGroup(1, IoUringIoHandler.newFactory());
+
+        Channel serverChannel = null;
+        Channel clientChannel = null;
+        AtomicReference<Future<Void>> writeFutureHolder = new AtomicReference<>();
+        AtomicReference<ByteBuf> bufferRef = new AtomicReference<>();
+        AtomicInteger refCntAfterShutdown = new AtomicInteger(-1);
+        CountDownLatch outputShutdown = new CountDownLatch(1);
+        try {
+            ServerBootstrap sb = new ServerBootstrap();
+            sb.group(serverGroup)
+                    .channel(IoUringServerSocketChannel.class)
+                    .childOption(ChannelOption.AUTO_READ, false)
+                    .childHandler(new ChannelInboundHandler() { });
+            serverChannel = sb.bind(0).sync().getNow();
+
+            Bootstrap cb = new Bootstrap();
+            cb.group(clientGroup)
+                    .channel(IoUringSocketChannel.class);
+            if (writeMode == WriteMode.ZERO_COPY) {
+                cb.option(IoUringChannelOption.IO_URING_WRITE_ZERO_COPY_THRESHOLD, 1024);
+            }
+            cb.handler(new ChannelInboundHandler() {
+                @Override
+                public void channelActive(ChannelHandlerContext ctx) {
+                    ByteBuf buf = ctx.alloc().directBuffer(WRITE_SIZE);
+                    buf.writeZero(WRITE_SIZE);
+                    bufferRef.set(buf);
+                    // Submit the SQE, then shut down output in the same event-loop task:
+                    // no CQE for the write can have been processed by the loop yet.
+                    writeFutureHolder.set(ctx.writeAndFlush(buf));
+                    ctx.channel().shutdown(ChannelShutdownType.newOutbound());
+                    refCntAfterShutdown.set(buf.refCnt());
+                    outputShutdown.countDown();
+                }
+            });
+            clientChannel = cb.connect(serverChannel.localAddress()).sync().getNow();
+
+            assertTrue(outputShutdown.await(5, TimeUnit.SECONDS), "shutdown() was not invoked");
+            ByteBuf buffer = bufferRef.get();
+            assertNotNull(buffer, "write buffer was never allocated");
+            // channel.shutdown(...) is the public path (AbstractChannel#shutdown): it only flips the
+            // outputShutdown flag and fires the shutdown event, it never touches the outbound buffer. Releasing
+            // the outbound buffer is the job of the private shutdownOutput(...), which only runs from the
+            // write-error path, not from here. So the buffer is still held by its original reference, and on top
+            // of that AbstractIoUringChannel#doShutdown retains it once more via writeTracker.retainAll() before
+            // this SQE's CQE lands, because the kernel still owns the submitted buffer until it posts the write
+            // CQE (or the SEND_ZC notification). refCnt 2 here is that original reference plus the tracker's
+            // retain, not a release having failed to happen.
+            assertEquals(2, refCntAfterShutdown.get(), "shutdown() did not retain the in-flight write buffer");
+
+            assertTrue(awaitRefCntZero(clientChannel, buffer, 5, TimeUnit.SECONDS),
+                    "write buffer was not released after its terminal completion");
+
+            assertTrue(clientChannel.close().await(5, TimeUnit.SECONDS),
+                    "channel did not close within the timeout after shutdown() raced an "
+                            + "in-flight write");
+            assertFalse(clientChannel.isActive());
+            assertFalse(clientChannel.isOpen());
+
+            Future<Void> writeFuture = writeFutureHolder.get();
+            assertNotNull(writeFuture, "write was never submitted");
+            assertTrue(writeFuture.await(5, TimeUnit.SECONDS), "write future did not complete in time");
+            // In 4.2, shutdownOutput() was a single method that both flipped the outputShutdown flag and
+            // cleared the outbound buffer, so a pending write promise was failed right there with
+            // ChannelOutputShutdownException. In 5.0 that's split: the public shutdown(...) this test calls
+            // never touches the outbound buffer, and only the private shutdownOutput(...) -- reached from the
+            // write-error path, not from here -- clears the buffer and fails pending writes with
+            // ChannelOutputShutdownException. Here, by the time we check, the channel is already closed, so
+            // which of two racing paths failed the in-flight write depends on timing: the kernel may have
+            // completed it against a socket that already had its output shut down (surfacing as a
+            // NativeIoException), or close() may have reaped it first (surfacing as a
+            // StacklessClosedChannelException). Either way is a legitimate failure; this test only asserts
+            // that the write did not silently succeed or hang.
+            assertNotNull(writeFuture.cause(), "the in-flight write should have failed");
+        } finally {
+            // Use a bounded await instead of syncUninterruptibly(): if the bug under test
+            // reproduces, close() never completes, and this finally block must not hang forever.
+            if (clientChannel != null) {
+                clientChannel.close().awaitUninterruptibly(5, TimeUnit.SECONDS);
+            }
+            if (serverChannel != null) {
+                serverChannel.close().awaitUninterruptibly(5, TimeUnit.SECONDS);
+            }
+            serverGroup.shutdownGracefully(0, 2, TimeUnit.SECONDS).awaitUninterruptibly(5, TimeUnit.SECONDS);
+            clientGroup.shutdownGracefully(0, 2, TimeUnit.SECONDS).awaitUninterruptibly(5, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketSendSzSendmsgZcTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketSendSzSendmsgZcTest.java
@@ -24,6 +24,7 @@ import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.AbstractClientSocketTest;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
@@ -37,10 +38,18 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static io.netty.channel.uring.IoUringRefCntZeroAwaiter.awaitRefCntZero;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class IoUringSocketSendSzSendmsgZcTest extends AbstractClientSocketTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IoUring.isAvailable());
+    }
 
     @Override
     protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
@@ -180,13 +189,9 @@ public class IoUringSocketSendSzSendmsgZcTest extends AbstractClientSocketTest {
                     if (cause != null) {
                         fail(cause);
                     }
-                    // The buffer should still have a reference count of 1 as we did not receive the second notification
-                    // yet as the remote peer did not start reading and did not close the socket yet.
-                    if (multiple) {
-                        assertEquals(numBuffers, buffer.refCnt());
-                    } else {
-                        assertEquals(numBuffers, buffer.refCnt());
-                    }
+                    // This is the primary CQE with IORING_CQE_F_MORE. The zero-copy references must remain live
+                    // until the following IORING_CQE_F_NOTIF, because the peer has neither acknowledged nor closed.
+                    assertEquals(numBuffers, buffer.refCnt());
 
                     switch (remoteClose) {
                         case REMOTE:
@@ -213,9 +218,8 @@ public class IoUringSocketSendSzSendmsgZcTest extends AbstractClientSocketTest {
                     }
 
                     // Wait till the buffer was finally released, which should be done in a timely fashion.
-                    while (buffer.refCnt() != 0) {
-                        Thread.sleep(50);
-                    }
+                    assertTrue(awaitRefCntZero(channel, buffer, 5, TimeUnit.SECONDS),
+                            "zero-copy buffer was not released in time");
                 } finally {
                     // Close the channel now
                     channel.close().sync();

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IovArrayReferenceCollectorTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IovArrayReferenceCollectorTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.unix.IovArray;
+import io.netty.util.ReferenceCounted;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class IovArrayReferenceCollectorTest {
+
+    @BeforeAll
+    public static void loadJNI() {
+        assumeTrue(IoUring.isAvailable());
+    }
+
+    @Test
+    public void capturesOnlyBuffersAddedToIovArray() throws Exception {
+        IovArray iovArray = new IovArray(2);
+        ByteBuf first = Unpooled.directBuffer().writeZero(1);
+        ByteBuf second = Unpooled.directBuffer().writeZero(1);
+        ByteBuf third = Unpooled.directBuffer().writeZero(1);
+        try {
+            iovArray.maxCount(2);
+            IovArrayReferenceCollector collector = new IovArrayReferenceCollector(iovArray);
+            collector.reset();
+
+            assertTrue(collector.processMessage(first));
+            assertTrue(collector.processMessage(second));
+            assertFalse(collector.processMessage(third));
+
+            assertEquals(2, collector.referencesCount());
+            ReferenceCounted[] references = collector.referencesArray();
+            assertSame(first, references[0]);
+            assertSame(second, references[1]);
+        } finally {
+            first.release();
+            second.release();
+            third.release();
+            iovArray.release();
+        }
+    }
+
+    @Test
+    public void capturesPartiallyAddedCompositeBuffer() throws Exception {
+        IovArray iovArray = new IovArray(1);
+        CompositeByteBuf buffer = Unpooled.compositeBuffer(2);
+        buffer.addComponents(true, Unpooled.directBuffer().writeZero(1), Unpooled.directBuffer().writeZero(1));
+        try {
+            IovArrayReferenceCollector collector = new IovArrayReferenceCollector(iovArray);
+            collector.reset();
+
+            assertFalse(collector.processMessage(buffer));
+
+            assertEquals(1, collector.referencesCount());
+            assertSame(buffer, collector.referencesArray()[0]);
+        } finally {
+            buffer.release();
+            iovArray.release();
+        }
+    }
+
+    @Test
+    public void capturesFirstBufferWhenItExceedsMaxBytes() throws Exception {
+        IovArray iovArray = new IovArray(2);
+        ByteBuf first = Unpooled.directBuffer().writeZero(2);
+        ByteBuf second = Unpooled.directBuffer().writeZero(1);
+        try {
+            iovArray.maxBytes(1);
+            IovArrayReferenceCollector collector = new IovArrayReferenceCollector(iovArray);
+            collector.reset();
+
+            assertTrue(collector.processMessage(first));
+            assertFalse(collector.processMessage(second));
+
+            assertEquals(1, collector.referencesCount());
+            assertSame(first, collector.referencesArray()[0]);
+        } finally {
+            first.release();
+            second.release();
+            iovArray.release();
+        }
+    }
+
+    @Test
+    public void resetClearsEntriesLeftByALargerPreviousWrite() throws Exception {
+        IovArray iovArray = new IovArray(3);
+        ByteBuf first = Unpooled.directBuffer().writeZero(1);
+        ByteBuf second = Unpooled.directBuffer().writeZero(1);
+        ByteBuf third = Unpooled.directBuffer().writeZero(1);
+        ByteBuf fourth = Unpooled.directBuffer().writeZero(1);
+        try {
+            IovArrayReferenceCollector collector = new IovArrayReferenceCollector(iovArray);
+
+            // First write fills the collector up to a high water mark of 3 entries.
+            collector.reset();
+            assertTrue(collector.processMessage(first));
+            assertTrue(collector.processMessage(second));
+            assertTrue(collector.processMessage(third));
+            assertEquals(3, collector.referencesCount());
+
+            // A subsequent, smaller write must not leave the stale entries above its own count reachable:
+            // otherwise the backing array keeps those ByteBufs alive until the next reset.
+            iovArray.clear();
+            collector.reset();
+            assertTrue(collector.processMessage(fourth));
+            assertEquals(1, collector.referencesCount());
+
+            ReferenceCounted[] references = collector.referencesArray();
+            assertSame(fourth, references[0]);
+            assertNull(references[1]);
+            assertNull(references[2]);
+        } finally {
+            first.release();
+            second.release();
+            third.release();
+            fourth.release();
+            iovArray.release();
+        }
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/WriteOperationTrackerOverflowTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/WriteOperationTrackerOverflowTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class WriteOperationTrackerOverflowTest extends AbstractWriteOperationTrackerTest {
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    public void everyShortIdIsHandedOutOnceAndThenTheShortPoolReportsExhaustion() throws Exception {
+        runOnEventLoop(new BookkeepingTask() {
+            @Override
+            public void run(IoUringSocketChannel channel) {
+                // Ids are dense and start at 1, so the pool hands out exactly Short.MAX_VALUE of them.
+                for (int i = 1; i <= Short.MAX_VALUE; i++) {
+                    assertEquals((short) i, channel.writeTracker.nextId());
+                }
+                assertEquals(0, channel.writeTracker.nextId());
+            }
+        });
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    public void zeroCopyIdFallsBackOutsideTheShortRangeOnceEveryShortIdIsInFlight() throws Exception {
+        runOnEventLoop(new BookkeepingTask() {
+            @Override
+            public void run(IoUringSocketChannel channel) {
+                exhaustShortIds(channel);
+
+                // A value outside the short range is what makes IoUringIoHandler.canUseFastPath(...) fail, which
+                // is how the original user_data survives the round-trip through the slow path.
+                long overflowId = channel.writeTracker.nextZeroCopyId();
+                assertTrue(overflowId > Short.MAX_VALUE, "expected an overflow id, got " + overflowId);
+            }
+        });
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    public void overflowIdsAreMonotonicSoTheyCanNeverCollide() throws Exception {
+        runOnEventLoop(new BookkeepingTask() {
+            @Override
+            public void run(IoUringSocketChannel channel) {
+                exhaustShortIds(channel);
+
+                long first = channel.writeTracker.nextZeroCopyId();
+                long second = channel.writeTracker.nextZeroCopyId();
+                long third = channel.writeTracker.nextZeroCopyId();
+                assertTrue(first < second, first + " < " + second);
+                assertTrue(second < third, second + " < " + third);
+            }
+        });
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    public void recordingAnOverflowWriteDoesNotRetainAndItsTerminalCqeDropsTheEntry() throws Exception {
+        runOnEventLoop(new BookkeepingTask() {
+            @Override
+            public void run(IoUringSocketChannel channel) {
+                ByteBuf buffer = Unpooled.buffer(1).writeByte(1);
+                try {
+                    long overflowId = overflowId(channel);
+                    channel.writeTracker.record(overflowId, Native.IORING_OP_SEND_ZC, buffer);
+                    assertEquals(1, buffer.refCnt());
+
+                    channel.writeTracker.complete(overflowId, Native.IORING_OP_SEND_ZC, 0);
+                    assertEquals(1, buffer.refCnt());
+                    // Overflow ids are never recycled, so the map has to shrink back or it grows without bound.
+                    assertEquals(0, channel.writeTracker.overflowCount());
+                } finally {
+                    buffer.release();
+                }
+            }
+        });
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    public void shutdownRetainsAnOverflowWriteUntilItsCompletionReleasesItOnce() throws Exception {
+        runOnEventLoop(new BookkeepingTask() {
+            @Override
+            public void run(IoUringSocketChannel channel) {
+                ByteBuf buffer = Unpooled.buffer(1).writeByte(1);
+                try {
+                    long overflowId = overflowId(channel);
+                    channel.writeTracker.record(overflowId, Native.IORING_OP_SEND_ZC, buffer);
+
+                    shutdownOutput(channel);
+                    assertEquals(2, buffer.refCnt());
+
+                    channel.writeTracker.complete(overflowId, Native.IORING_OP_SEND_ZC,
+                            Native.IORING_CQE_F_NOTIF);
+                    assertEquals(1, buffer.refCnt());
+                    assertEquals(0, channel.writeTracker.overflowCount());
+                } finally {
+                    buffer.release();
+                }
+            }
+        });
+    }
+
+    @Test
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    public void deregistrationReleasesAnOverflowWriteThatWillNeverSeeItsCompletion() throws Exception {
+        runOnEventLoop(new BookkeepingTask() {
+            @Override
+            public void run(IoUringSocketChannel channel) {
+                ByteBuf buffer = Unpooled.buffer(1).writeByte(1);
+                try {
+                    long overflowId = overflowId(channel);
+                    channel.writeTracker.record(overflowId, Native.IORING_OP_SEND_ZC, buffer);
+
+                    shutdownOutput(channel);
+                    assertEquals(2, buffer.refCnt());
+
+                    channel.unregistered();
+                    assertEquals(1, buffer.refCnt());
+                    assertEquals(0, channel.writeTracker.overflowCount());
+                } finally {
+                    buffer.release();
+                }
+            }
+        });
+    }
+
+    private static void exhaustShortIds(IoUringSocketChannel channel) {
+        for (int i = 1; i <= Short.MAX_VALUE; i++) {
+            channel.writeTracker.nextId();
+        }
+    }
+
+    private static long overflowId(IoUringSocketChannel channel) {
+        exhaustShortIds(channel);
+        long id = channel.writeTracker.nextZeroCopyId();
+        assertTrue(id > Short.MAX_VALUE, "expected an overflow id, got " + id);
+        return id;
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/WriteOperationTrackerTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/WriteOperationTrackerTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class WriteOperationTrackerTest extends AbstractWriteOperationTrackerTest {
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    public void completionFromAForeignIdNamespaceDoesNotTerminateALiveOperation() throws Exception {
+        runOnEventLoop(new BookkeepingTask() {
+            @Override
+            public void run(IoUringSocketChannel channel) {
+                ByteBuf zeroCopyData = Unpooled.buffer(1).writeByte(1);
+                short id = channel.writeTracker.nextId();
+                try {
+                    channel.writeTracker.record(id, Native.IORING_OP_SEND_ZC, zeroCopyData);
+                    assertEquals(1, zeroCopyData.refCnt());
+
+                    // A splice picks its own data to tell its two stages apart and never allocates from
+                    // writeTracker.nextId(), so its completion can carry an id that a zero-copy send owns.
+                    channel.writeTracker.complete(id, Native.IORING_OP_SPLICE, 0);
+                    assertEquals(1, zeroCopyData.refCnt());
+                    channel.writeTracker.abandon(id, Native.IORING_OP_SPLICE);
+                    assertEquals(1, zeroCopyData.refCnt());
+
+                    // It was never retained (no shutdown raced it), so the terminal CQE leaves refCnt untouched.
+                    channel.writeTracker.complete(id, Native.IORING_OP_SEND_ZC, Native.IORING_CQE_F_NOTIF);
+                    assertEquals(1, zeroCopyData.refCnt());
+                    assertEquals(id, channel.writeTracker.nextId());
+                } finally {
+                    zeroCopyData.release();
+                }
+            }
+        });
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    public void terminalCompletionRecyclesTheWriteOperationId() throws Exception {
+        runOnEventLoop(new BookkeepingTask() {
+            @Override
+            public void run(IoUringSocketChannel channel) {
+                ByteBuf buffer = Unpooled.buffer(1).writeByte(1);
+                try {
+                    short id = channel.writeTracker.nextId();
+                    channel.writeTracker.record(id, Native.IORING_OP_SEND_ZC, buffer);
+                    channel.writeTracker.complete(id, Native.IORING_OP_SEND_ZC, Native.IORING_CQE_F_NOTIF);
+
+                    assertEquals(1, buffer.refCnt());
+                    assertEquals(id, channel.writeTracker.nextId());
+                } finally {
+                    buffer.release();
+                }
+            }
+        });
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    public void anIdOwnedByAnotherAllocatorNeverEntersTheFreeList() throws Exception {
+        runOnEventLoop(new BookkeepingTask() {
+            @Override
+            public void run(IoUringSocketChannel channel) {
+                ByteBuf buffer = Unpooled.buffer(1).writeByte(1);
+                try {
+                    // The datagram sendmsg path registers MsgHdrMemoryArray indices, which start at 0. Recycling
+                    // one would hand out 0, the value reserved for "no id".
+                    channel.writeTracker.recordForeign((short) 0, Native.IORING_OP_SENDMSG, buffer);
+                    channel.writeTracker.complete((short) 0, Native.IORING_OP_SENDMSG, 0);
+
+                    assertEquals(1, buffer.refCnt());
+                    assertNotEquals(0, channel.writeTracker.nextId());
+                } finally {
+                    buffer.release();
+                }
+            }
+        });
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    public void shutdownRetainsTheStreamWriteUntilItsCompletionReleasesItOnce() throws Exception {
+        runOnEventLoop(new BookkeepingTask() {
+            @Override
+            public void run(IoUringSocketChannel channel) {
+                ByteBuf buffer = Unpooled.buffer(1).writeByte(1);
+                try {
+                    channel.writeTracker.recordStream(Native.IORING_OP_SEND, buffer);
+                    assertEquals(1, buffer.refCnt());
+
+                    // doShutdown(...) reaches the single slot through this hook before it drops the
+                    // outbound buffer's own reference.
+                    channel.writeTracker.retainAll();
+                    assertEquals(2, buffer.refCnt());
+
+                    // Retaining twice must not stack references; a shutdown may race a zero-copy retain.
+                    channel.writeTracker.retainAll();
+                    assertEquals(2, buffer.refCnt());
+
+                    channel.writeTracker.completeStream(0);
+                    assertEquals(1, buffer.refCnt());
+                    assertFalse(channel.writeTracker.isStreamActive());
+
+                    // The slot is already inactive, so a second completion for it must not release again.
+                    channel.writeTracker.completeStream(0);
+                    assertEquals(1, buffer.refCnt());
+                } finally {
+                    buffer.release();
+                }
+            }
+        });
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    public void deregistrationReleasesAStreamWriteThatWillNeverSeeItsCompletion() throws Exception {
+        runOnEventLoop(new BookkeepingTask() {
+            @Override
+            public void run(IoUringSocketChannel channel) {
+                ByteBuf buffer = Unpooled.buffer(1).writeByte(1);
+                try {
+                    channel.writeTracker.recordStream(Native.IORING_OP_WRITEV, buffer);
+                    channel.writeTracker.retainAll();
+                    assertEquals(2, buffer.refCnt());
+
+                    channel.writeTracker.releaseAll();
+                    assertEquals(1, buffer.refCnt());
+                    assertFalse(channel.writeTracker.isStreamActive());
+                } finally {
+                    buffer.release();
+                }
+            }
+        });
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    public void shutdownRetainsAPooledWriteUntilItsCompletionReleasesItOnce() throws Exception {
+        runOnEventLoop(new BookkeepingTask() {
+            @Override
+            public void run(IoUringSocketChannel channel) {
+                ByteBuf buffer = Unpooled.buffer(1).writeByte(1);
+                try {
+                    short id = channel.writeTracker.nextId();
+                    channel.writeTracker.record(id, Native.IORING_OP_SEND_ZC, buffer);
+
+                    shutdownOutput(channel);
+                    assertEquals(2, buffer.refCnt());
+
+                    channel.writeTracker.complete(id, Native.IORING_OP_SEND_ZC, Native.IORING_CQE_F_NOTIF);
+                    assertEquals(1, buffer.refCnt());
+                    // Unlike an overflow id, a pooled id is recycled back to the free list once its slot
+                    // terminates.
+                    assertEquals(id, channel.writeTracker.nextId());
+                } finally {
+                    buffer.release();
+                }
+            }
+        });
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    public void deregistrationReleasesAPooledWriteThatWillNeverSeeItsCompletion() throws Exception {
+        runOnEventLoop(new BookkeepingTask() {
+            @Override
+            public void run(IoUringSocketChannel channel) {
+                ByteBuf buffer = Unpooled.buffer(1).writeByte(1);
+                try {
+                    short id = channel.writeTracker.nextId();
+                    channel.writeTracker.record(id, Native.IORING_OP_SEND_ZC, buffer);
+
+                    shutdownOutput(channel);
+                    assertEquals(2, buffer.refCnt());
+
+                    channel.unregistered();
+                    assertEquals(1, buffer.refCnt());
+                } finally {
+                    buffer.release();
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
Port of https://github.com/netty/netty/pull/17238 to 5.0.

Motivation:

Same defect as on 4.2. A write SQE is still in flight when the output shutdown drops the outbound buffer and releases the flushed messages, so the kernel keeps reading memory that already went back to the allocator, and for a pooled buffer possibly to someone else. #17238 has the full write-up.

Modification:

`WriteOperation`, `WriteOperationTracker` and `IovArrayReferenceCollector` come over as they were merged on 4.2, so they carry the review that landed there. The wiring is what differs, because this is not a cherry-pick: `AbstractIoUringStreamChannel`, `AbstractIoUringServerChannel` and `IoUringDomainSocketChannel` do not exist here, so the write paths they carried had to be laid out against `IoUringSocketChannel` instead.

Three things came out different from 4.2:

- 5.0 has no `doShutdownOutput()` hook, so `AbstractIoUringChannel` takes `doShutdown(ChannelShutdownType, Promise)` as final, retains on the outbound direction, and hands off to a new `doShutdown0(...)`. Going through the base keeps the retain ahead of the release for the datagram and server channels too, whose `doShutdown0(...)` fails immediately -- the core drops the outbound buffer from the listener either way.
- No separate domain-socket channel, so the null guard 4.2 added there is covered by the shared one already sitting ahead of that branch in `writeComplete0`.
- 5.0 splits shutdown into a public `shutdown(...)` that only flips the flag and a private `shutdownOutput(...)` that clears the buffer. The two ported tests call the public one, so they expect the tracker's reference to still be there, and they assert the in-flight write failed without pinning which exception failed it.

Completion dispatch had to widen as well: it reads the full long user_data instead of narrowing up front, since a zero-copy id can leave the short range once the pooled ids run out. Read, poll and cancel ids are always short, so they go through a `narrowUserData(...)` that asserts the value round-trips. `IoUringIoOps.newSendZc` and `newSendmsgZc` take a long to match.

`zcWriteQueue` and `ZC_BATCH_MARKER` are gone with the rest of the old zero-copy path, which also removes a deregistration that could strand whatever the queue was holding.

Result:

A write that is in flight when the output shuts down keeps its memory alive until the kernel is done with it. The references reach refCnt 0 on the terminal CQE, and `close()` completes instead of hanging.

io_uring tests pass on Linux, 21 of 21.
