### PR TITLE
Update to latest netty-jni-util release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -853,7 +853,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-jni-util</artifactId>
-        <version>0.0.10.Final</version>
+        <version>0.0.11.Final</version>
         <classifier>sources</classifier>
         <optional>true</optional>
       </dependency>


### PR DESCRIPTION
Motivation:

We did cut a new netty-jni-util release, let's use it

Modifications:

Update to 0.0.11.Final

Result:

Use latest netty-jni-util release
