### PR TITLE
Fix JdkZlibDecoder silently truncating highly compressible streams

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibDecoder.java
@@ -36,6 +36,14 @@ public class JdkZlibDecoder extends ZlibDecoder {
     private static final int FCOMMENT = 0x10;
     private static final int FRESERVED = 0xE0;
 
+    /**
+     * Smallest buffer we hand to {@link Inflater#inflate(byte[], int, int)}. The number of remaining input bytes is
+     * only a hint for how much output to expect: the inflater may still hold decoded data that did not fit into the
+     * previous output buffer, and by then it may have consumed all input bytes already
+     * ({@link Inflater#getRemaining()} == 0). Inflating into a zero-sized buffer can never make progress.
+     */
+    private static final int MIN_OUTPUT_BUFFER_SIZE = 512;
+
     private Inflater inflater;
     private final byte[] dictionary;
 
@@ -255,15 +263,21 @@ public class JdkZlibDecoder extends ZlibDecoder {
             }
         }
 
-        ByteBuf decompressed = prepareDecompressBuffer(ctx, null, inflater.getRemaining() << 1);
+        ByteBuf decompressed = prepareDecompressBuffer(ctx, null, preferredOutputBufferSize());
         try {
             boolean readFooter = false;
-            while (!inflater.needsInput()) {
+            // If this is true the last inflate(...) filled the output buffer completely, so the inflater may still
+            // hold decoded data even once all input bytes were consumed. needsInput() only tells us that the input
+            // was consumed, not that all output was produced, so on its own it would end the loop too early and
+            // the pending bytes would be dropped together with the input we skip below.
+            boolean pendingOutput = false;
+            while (pendingOutput || !inflater.needsInput()) {
                 byte[] outArray = decompressed.array();
                 int writerIndex = decompressed.writerIndex();
                 int outIndex = decompressed.arrayOffset() + writerIndex;
                 int writable = decompressed.writableBytes();
                 int outputLength = inflater.inflate(outArray, outIndex, writable);
+                pendingOutput = outputLength == writable;
                 if (outputLength > 0) {
                     decompressed.writerIndex(writerIndex + outputLength);
                     if (crc != null) {
@@ -293,7 +307,7 @@ public class JdkZlibDecoder extends ZlibDecoder {
                     }
                     break;
                 } else {
-                    decompressed = prepareDecompressBuffer(ctx, decompressed, inflater.getRemaining() << 1);
+                    decompressed = prepareDecompressBuffer(ctx, decompressed, preferredOutputBufferSize());
                 }
             }
 
@@ -315,6 +329,16 @@ public class JdkZlibDecoder extends ZlibDecoder {
                 }
             }
         }
+    }
+
+    /**
+     * The size we ask {@link #prepareDecompressBuffer(ChannelHandlerContext, ByteBuf, int)} for. Twice the remaining
+     * input is a good guess for how much output is still coming, but it must never be zero because
+     * {@link Inflater#inflate(byte[], int, int)} cannot write anything then. Any {@code maxAllocation} the user
+     * configured is still applied by {@code prepareDecompressBuffer(...)} and so keeps its meaning.
+     */
+    private int preferredOutputBufferSize() {
+        return Math.max(inflater.getRemaining() << 1, MIN_OUTPUT_BUFFER_SIZE);
     }
 
     private boolean handleGzipFooter(ByteBuf in) {

--- a/codec/src/test/java/io/netty/handler/codec/compression/JdkZlibTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/JdkZlibTest.java
@@ -26,13 +26,19 @@ import io.netty.util.internal.PlatformDependent;
 import org.apache.commons.compress.utils.IOUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Queue;
 import java.util.zip.Deflater;
+import java.util.zip.DeflaterOutputStream;
 import java.util.zip.GZIPOutputStream;
+import java.util.zip.Inflater;
+import java.util.zip.InflaterInputStream;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -194,6 +200,102 @@ public class JdkZlibTest extends ZlibTest {
             decoded.close();
         } finally {
             assertFalse(ch.finish());
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("highlyCompressibleStreams")
+    public void testHighlyCompressibleStreamIsFullyDecoded(ZlibWrapper wrapper, int size, int chunkSize)
+            throws Exception {
+        // Every output buffer is sized from the number of remaining input bytes. That is generous at
+        // ordinary compression ratios, but at a high ratio the inflater can pull the last input byte into
+        // its internal state while it still holds decoded data, and then the proposed size is zero and
+        // inflate(...) cannot make progress. The tail stayed inside the inflater and was dropped together
+        // with the input, without any exception, so a peer simply saw a short body.
+        assertFullyDecoded(wrapper, size, chunkSize);
+    }
+
+    private static Object[][] highlyCompressibleStreams() {
+        // The two payload shapes reach the two places a buffer is taken. 65537 bytes written in one go
+        // crosses the threshold at which the decoder forwards the buffer downstream and then allocates a
+        // fresh one; 33333 bytes arriving in 7-byte reads stays under that threshold but starts every
+        // decode(...) call with a fresh buffer. Only ZlibWrapper.NONE actually lost bytes before the fix,
+        // because the ZLIB and GZIP trailers keep bytes in the input buffer while output is still pending.
+        return new Object[][] {
+                { ZlibWrapper.NONE, 65537, Integer.MAX_VALUE },
+                { ZlibWrapper.NONE, 33333, 7 },
+                { ZlibWrapper.ZLIB, 65537, Integer.MAX_VALUE },
+                { ZlibWrapper.ZLIB, 33333, 7 },
+                { ZlibWrapper.GZIP, 65537, Integer.MAX_VALUE },
+                { ZlibWrapper.GZIP, 33333, 7 },
+        };
+    }
+
+    private void assertFullyDecoded(ZlibWrapper wrapper, int size, int chunkSize) throws Exception {
+        byte[] data = new byte[size];
+        Arrays.fill(data, (byte) 'a');
+        byte[] compressed = compress(wrapper, data);
+
+        // Cross-check the fixture with the JDK itself, so a failure below cannot be blamed on it.
+        assertArrayEquals(data, jdkInflate(wrapper, compressed));
+
+        EmbeddedChannel ch = new EmbeddedChannel(createDecoder(wrapper));
+        ByteArrayOutputStream decoded = new ByteArrayOutputStream();
+        try {
+            ByteBuf in = Unpooled.wrappedBuffer(compressed);
+            try {
+                while (in.isReadable()) {
+                    ch.writeInbound(in.readRetainedSlice(Math.min(chunkSize, in.readableBytes())));
+                }
+            } finally {
+                in.release();
+            }
+            ch.finish();
+
+            ByteBuf msg;
+            while ((msg = ch.readInbound()) != null) {
+                msg.readBytes(decoded, msg.readableBytes());
+                msg.release();
+            }
+            assertArrayEquals(data, decoded.toByteArray());
+        } finally {
+            decoded.close();
+            ch.close();
+        }
+    }
+
+    private static byte[] compress(ZlibWrapper wrapper, byte[] data) throws IOException {
+        if (wrapper == ZlibWrapper.GZIP) {
+            return gzip(data);
+        }
+        ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
+        DeflaterOutputStream deflaterOut = new DeflaterOutputStream(bytesOut,
+                new Deflater(Deflater.BEST_COMPRESSION, wrapper == ZlibWrapper.NONE));
+        deflaterOut.write(data);
+        deflaterOut.close();
+        return bytesOut.toByteArray();
+    }
+
+    private static byte[] jdkInflate(ZlibWrapper wrapper, byte[] compressed) throws IOException {
+        if (wrapper == ZlibWrapper.GZIP) {
+            return jdkGunzip(compressed);
+        }
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try {
+            InflaterInputStream in = new InflaterInputStream(new ByteArrayInputStream(compressed),
+                    new Inflater(wrapper == ZlibWrapper.NONE));
+            try {
+                byte[] buf = new byte[8192];
+                int n;
+                while ((n = in.read(buf)) != -1) {
+                    out.write(buf, 0, n);
+                }
+            } finally {
+                in.close();
+            }
+            return out.toByteArray();
+        } finally {
+            out.close();
         }
     }
 


### PR DESCRIPTION
Follow-up to #17191, as requested in that thread.

`JdkZlibDecoder` sizes each output buffer as `inflater.getRemaining() << 1`. Once the inflater holds decoded bytes but has consumed all input that is `0`, the loop exits on `needsInput()`, and `in.skipBytes(...)` drops the tail. Nothing is thrown, so a peer just sees a short body.

Fix: floor the proposed capacity at 512 bytes, and keep decoding while the last `inflate(...)` filled the buffer. `maxAllocation` is still applied by `prepareDecompressBuffer(...)`.

Added `JdkZlibTest#testHighlyCompressibleStreamIsFullyDecoded`; on unpatched 4.1 it fails with `expected: <65537> but was: <65536>`. A 1584-combination sweep: 87 losses before, 0 after, all `ZlibWrapper.NONE`. `./mvnw -pl codec test` on JDK 21: 704 tests, 0 failures; JDK 8 `verify -DskipTests=true` green.
