### PR TITLE
Add missing EOF handling test for io_uring

### DIFF
--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketChannelEOFTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IoUringSocketChannelEOFTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.testsuite.transport.TestsuitePermutation;
+import io.netty.testsuite.transport.socket.SocketChannelEOFTest;
+
+import java.util.List;
+
+public class IoUringSocketChannelEOFTest extends SocketChannelEOFTest {
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
+        return IoUringSocketTestPermutation.INSTANCE.clientSocketWithFastOpen();
+    }
+}


### PR DESCRIPTION
Motivation:

6495f1124f91b401fd483b3371215abb170e8803 added EOF tests but did miss to also include a test for io_uring

Modifications:

Add test for io_uring

Result:

Better test-coverage
