### PR TITLE
Fix quiche flow-control double-counting

### DIFF
--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -850,14 +850,25 @@
                           <arg value="${quicheRepository}" />
                           <arg value="${quicheSourceDir}" />
                         </exec>
-
-                        <!-- Use the known SHA of the commit -->
-                        <exec executable="git" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
-                          <arg value="checkout" />
-                          <arg value="${quicheCommitSha}" />
-                        </exec>
                       </else>
                     </if>
+
+                    <!-- Use the known SHA of the commit and apply the fix for
+                         https://github.com/cloudflare/quiche/pull/2697. -->
+                    <exec executable="git" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
+                      <arg value="checkout" />
+                      <arg value="--force" />
+                      <arg value="${quicheCommitSha}" />
+                    </exec>
+                    <exec executable="git" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
+                      <arg value="apply" />
+                      <arg value="--check" />
+                      <arg value="${project.basedir}/src/main/patches/quiche-flow-control.patch" />
+                    </exec>
+                    <exec executable="git" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
+                      <arg value="apply" />
+                      <arg value="${project.basedir}/src/main/patches/quiche-flow-control.patch" />
+                    </exec>
                     <echo message="Building Quiche" />
                     <if>
                       <equals arg1="${platform}" arg2="android" />

--- a/codec-native-quic/src/main/patches/quiche-flow-control.patch
+++ b/codec-native-quic/src/main/patches/quiche-flow-control.patch
@@ -1,0 +1,62 @@
+diff --git a/quiche/src/lib.rs b/quiche/src/lib.rs
+index a93bfb5b..d9f8b9b6 100644
+--- a/quiche/src/lib.rs
++++ b/quiche/src/lib.rs
+@@ -4229,6 +4229,7 @@ impl<F: BufFactory> Connection<F> {
+         let mut in_flight = false;
+         let mut is_pmtud_probe = false;
+         let mut has_data = false;
++        let mut stream_data_skipped = false;
+ 
+         // Whether or not we should explicitly elicit an ACK via PING frame if we
+         // implicitly elicit one otherwise.
+@@ -4911,6 +4912,23 @@ impl<F: BufFactory> Connection<F> {
+                 let (len, fin) =
+                     stream.send.emit(&mut stream_payload.as_mut()[..max_len])?;
+ 
++                // Skip zero-length non-fin frames. Such frames carry no data,
++                // but their offset advances the peer's largest received
++                // offset and must be accounted for by the receiver.
++                if len == 0 && !fin {
++                    stream_data_skipped = true;
++
++                    let priority_key = Arc::clone(&stream.priority_key);
++                    if !stream.is_flushable() {
++                        self.streams.remove_flushable(&priority_key);
++                    } else if stream.incremental {
++                        self.streams.remove_flushable(&priority_key);
++                        self.streams.insert_flushable(&priority_key);
++                    }
++
++                    break;
++                }
++
+                 // Encode the frame's header.
+                 //
+                 // Due to how `OctetsMut::split_at()` works, `stream_hdr` starts
+@@ -4991,6 +5009,7 @@ impl<F: BufFactory> Connection<F> {
+         }
+ 
+         if !has_data &&
++            !stream_data_skipped &&
+             !dgram_emitted &&
+             cwnd_available > frame::MAX_STREAM_OVERHEAD
+         {
+diff --git a/quiche/src/stream/recv_buf.rs b/quiche/src/stream/recv_buf.rs
+index bc69dde6..fe12424a 100644
+--- a/quiche/src/stream/recv_buf.rs
++++ b/quiche/src/stream/recv_buf.rs
+@@ -123,8 +123,12 @@ impl RecvBuf {
+             self.fin_off = Some(buf.max_off());
+         }
+ 
+-        // No need to store empty buffer that doesn't carry the fin flag.
++        // No need to store empty buffer that doesn't carry the fin flag, but
++        // its offset still advances the largest received offset. The caller
++        // charges connection-level flow control from that offset, so the
++        // high-water mark must advance in lockstep.
+         if !buf.fin() && buf.is_empty() {
++            self.len = cmp::max(self.len, buf.max_off());
+             return Ok(());
+         }
+ 

--- a/handler/src/test/java/io/netty/handler/stream/ChunkedWriteHandlerSslMemoryTest.java
+++ b/handler/src/test/java/io/netty/handler/stream/ChunkedWriteHandlerSslMemoryTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.stream;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.channel.WriteBufferWaterMark;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.HttpResponseEncoder;
+import io.netty.handler.ssl.SslHandler;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ChunkedWriteHandlerSslMemoryTest {
+
+    @Test
+    public void testUnflushedSslWritesDoNotAffectChannelWritability() throws Exception {
+        PooledByteBufAllocator allocator = new PooledByteBufAllocator(true);
+        SSLEngine engine = SSLContext.getDefault().createSSLEngine();
+        engine.setUseClientMode(true);
+
+        // startTls avoids handshake output changing the channel's writability before the test writes application data.
+        EmbeddedChannel channel = new EmbeddedChannel(false, false,
+                new SslHandler(engine, true), new HttpResponseEncoder(), new ChunkedWriteHandler());
+        channel.config().setAllocator(allocator);
+        channel.config().setWriteBufferWaterMark(new WriteBufferWaterMark(32 * 1024, 64 * 1024));
+        channel.register();
+
+        long directMemoryBeforeWrites = allocator.metric().usedDirectMemory();
+        int bytesWritten = 0;
+        try {
+            for (int i = 0; i < 128; ++i) {
+                ByteBuf content = allocator.directBuffer(16 * 1024).writeZero(16 * 1024);
+                bytesWritten += content.readableBytes();
+                channel.write(new DefaultHttpContent(content));
+            }
+
+            long directMemoryAfterWrites = allocator.metric().usedDirectMemory();
+            assertTrue(directMemoryAfterWrites > directMemoryBeforeWrites,
+                    "unflushed writes should be retained as pooled direct buffers");
+            assertTrue(bytesWritten > channel.config().getWriteBufferHighWaterMark());
+            assertTrue(channel.isWritable(),
+                    "bytes queued before SslHandler.flush() are not reflected in channel writability");
+        } finally {
+            channel.finishAndReleaseAll();
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

The quiche revision used by `codec-native-quic` can incorrectly count connection-level flow-control credit twice when receiving a zero-length non-FIN STREAM frame at a forward offset. During sustained transfers, the inflated accounting can cause a valid STREAM frame to be rejected with `FLOW_CONTROL_ERROR` and close the entire QUIC connection.

Modification:

- Backport the corresponding quiche receiver and sender fixes to the currently pinned revision.
- Advance the receive stream’s high-water mark when processing an empty non-FIN STREAM frame.
- Prevent the sender from emitting zero-length non-FIN STREAM frames.
- Preserve the correct application-limited state when stream data cannot fit in the current packet.
- Apply and validate the patch as part of the native quiche build.

Result:

Prevents connection-level flow-control double-counting and the resulting spurious `FLOW_CONTROL_ERROR`.

Fixes #17377.