### PR TITLE
Don't leak the delimiter CR into multipart data when a chunk boundary splits the preceding CRLF

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
@@ -1217,9 +1217,12 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
             }
             posDelimiter = HttpPostBodyUtil.findLastLineBreak(undecodedChunk, startReaderIndex + lastPosition);
             // No LineBreak, however CR can be at the end of the buffer, LF not yet there (issue #11668)
-            // Check if last CR (if any) shall not be in the content (definedLength vs actual length + buffer - 1)
+            // Check if last CR (if any) shall not be in the content (definedLength vs actual length + buffer - 1),
+            // while a data with unknown defined length shall always hold the last CR back since it may be
+            // the start of the CRLF preceding the delimiter
             if (posDelimiter < 0 &&
-                httpData.definedLength() == httpData.length() + readableBytes - 1 &&
+                (httpData.definedLength() == 0 ||
+                 httpData.definedLength() == httpData.length() + readableBytes - 1) &&
                 undecodedChunk.getByte(readableBytes + startReaderIndex - 1) == HttpConstants.CR) {
                 // Last CR shall precede a future LF
                 lastPosition = 0;

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostMultiPartRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostMultiPartRequestDecoderTest.java
@@ -96,6 +96,39 @@ public class HttpPostMultiPartRequestDecoderTest {
     }
 
     @Test
+    public void testSplitCrlfBeforeDelimiterMustNotLeakCrIntoData() throws Exception {
+        String boundary = "861fbeab-cd20-470c-9609-d40a0f704466";
+        String delimiter = "--" + boundary;
+        // The first chunk ends with the CR of the CRLF that precedes the next delimiter.
+        String firstChunk = delimiter + "\r\n" +
+                "Content-Disposition: form-data; name=\"foo\"\r\n\r\n" +
+                "bar\r";
+        String secondChunk = "\n" + delimiter + "\r\n" +
+                "Content-Disposition: form-data; name=\"file\"; filename=\"file.txt\"\r\n" +
+                "Content-Type: text/plain\r\n\r\n" +
+                "hello world\r";
+        String thirdChunk = "\n" + delimiter + "--\r\n";
+
+        HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/upload");
+        request.headers().set("content-type", "multipart/form-data; boundary=" + boundary);
+        request.headers().set("transfer-encoding", "chunked");
+        HttpPostMultipartRequestDecoder decoder =
+                new HttpPostMultipartRequestDecoder(new DefaultHttpDataFactory(false), request);
+        try {
+            decoder.offer(new DefaultHttpContent(Unpooled.copiedBuffer(firstChunk, CharsetUtil.UTF_8)));
+            decoder.offer(new DefaultHttpContent(Unpooled.copiedBuffer(secondChunk, CharsetUtil.UTF_8)));
+            decoder.offer(new DefaultLastHttpContent(Unpooled.copiedBuffer(thirdChunk, CharsetUtil.UTF_8)));
+
+            Attribute attribute = (Attribute) decoder.getBodyHttpData("foo");
+            assertEquals("bar", attribute.getValue());
+            FileUpload fileUpload = (FileUpload) decoder.getBodyHttpData("file");
+            assertEquals("hello world", fileUpload.getString(CharsetUtil.UTF_8));
+        } finally {
+            decoder.destroy();
+        }
+    }
+
+    @Test
     public void decodeMustCleanFilenameCharacters() {
         String content = "\n--861fbeab-cd20-470c-9609-d40a0f704466\r\n" +
                 "content-disposition: form-data; " +


### PR DESCRIPTION
### Motivation:

When a multipart part has no declared per-part Content-Length and an HTTP chunk ends exactly with the CR of the CRLF that precedes the next boundary delimiter, `HttpPostMultipartRequestDecoder` appends that CR to the attribute value or file upload content. The delimiter still matches on the next chunk, so decoding "succeeds" with silently corrupted data (`bar` becomes `bar\r`). The #11668 fix holds back a trailing CR only when `definedLength() == length() + readableBytes - 1`; parts without a declared length have `definedLength() == 0`, so it never applies to them.

### Modification:

Extend the trailing-CR hold-back in `loadDataMultipartOptimized()` to also apply when the `HttpData` has no defined length. The exact old condition is kept for known-length parts, whose declared-length content may legitimately end in CR bytes (covered by the existing `testNotBadReleaseBuffersDuringDecoding` tests).

### Result:

Chunk boundaries that split the CRLF preceding a multipart delimiter no longer corrupt decoded attribute values or file uploads. Verified with a new regression test (fails on `4.2`, passes with the fix) and a split-fuzz probe decoding the same bodies whole vs. split at every byte offset (previously 4 corruptions, now 0). `HttpPostMultiPartRequestDecoderTest` 17/17, `HttpPostRequestDecoderTest` 38/38, `HttpPostStandardRequestDecoderTest` 11/11.

Fixes #17383.