### PR TITLE
HttpUtil.getCharset() must accept whitespace before the next Content-Type parameter

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
@@ -451,6 +451,9 @@ public final class HttpUtil {
         if (contentTypeValue != null) {
             CharSequence charsetRaw = getCharsetAsSequence(contentTypeValue);
             if (charsetRaw != null) {
+                // Remove the optional whitespace (OWS) that RFC 9110 allows before the semicolon
+                // starting the next parameter, see https://www.rfc-editor.org/rfc/rfc9110#section-5.6.6
+                charsetRaw = AsciiString.trim(charsetRaw);
                 if (charsetRaw.length() > 2) { // at least contains 2 quotes(")
                     if (charsetRaw.charAt(0) == '"' && charsetRaw.charAt(charsetRaw.length() - 1) == '"') {
                         charsetRaw = charsetRaw.subSequence(1, charsetRaw.length() - 1);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
@@ -451,9 +451,18 @@ public final class HttpUtil {
         if (contentTypeValue != null) {
             CharSequence charsetRaw = getCharsetAsSequence(contentTypeValue);
             if (charsetRaw != null) {
-                // Remove the optional whitespace (OWS) that RFC 9110 allows before the semicolon
-                // starting the next parameter, see https://www.rfc-editor.org/rfc/rfc9110#section-5.6.6
-                charsetRaw = AsciiString.trim(charsetRaw);
+                // Remove only the trailing optional whitespace (OWS) that RFC 9110 allows before
+                // the semicolon starting the next parameter, see
+                // https://www.rfc-editor.org/rfc/rfc9110#section-5.6.6
+                // Leading whitespace after '=' is not grammar-legal and is deliberately kept, so
+                // such values keep failing the charset lookup below.
+                int end = charsetRaw.length();
+                while (end > 0 && isOws(charsetRaw.charAt(end - 1))) {
+                    end--;
+                }
+                if (end < charsetRaw.length()) {
+                    charsetRaw = charsetRaw.subSequence(0, end);
+                }
                 if (charsetRaw.length() > 2) { // at least contains 2 quotes(")
                     if (charsetRaw.charAt(0) == '"' && charsetRaw.charAt(charsetRaw.length() - 1) == '"') {
                         charsetRaw = charsetRaw.subSequence(1, charsetRaw.length() - 1);
@@ -467,6 +476,14 @@ public final class HttpUtil {
             }
         }
         return defaultCharset;
+    }
+
+    /**
+     * Whether the given character is optional whitespace (OWS) as defined by
+     * <a href="https://www.rfc-editor.org/rfc/rfc9110#section-5.6.3">RFC 9110 section 5.6.3</a>.
+     */
+    private static boolean isOws(char c) {
+        return c == ' ' || c == '\t';
     }
 
     /**

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpUtilTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpUtilTest.java
@@ -161,6 +161,18 @@ public class HttpUtilTest {
     }
 
     @Test
+    public void testGetCharsetWithWhitespaceBeforeNextParameter() {
+        // RFC 9110 5.6.6: parameters = *( OWS ";" OWS [ parameter ] ), so optional
+        // whitespace is allowed before the semicolon starting the next parameter
+        testGetCharsetUtf8("text/html; charset=utf-8 ; action=\"foo\"");
+    }
+
+    @Test
+    public void testGetCharsetQuotedWithWhitespaceBeforeNextParameter() {
+        testGetCharsetUtf8("text/html; charset=\"utf-8\" ; action=\"foo\"");
+    }
+
+    @Test
     public void testGetCharsetNoLeadingQuotes() {
         testGetCharsetInvalidQuotes("text/html;charset=utf-8\"");
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpUtilTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpUtilTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -170,6 +171,26 @@ public class HttpUtilTest {
     @Test
     public void testGetCharsetQuotedWithWhitespaceBeforeNextParameter() {
         testGetCharsetUtf8("text/html; charset=\"utf-8\" ; action=\"foo\"");
+    }
+
+    @Test
+    public void testGetCharsetWithWhitespaceBeforeNextParameterNonStringCharSequence() {
+        // must behave identically for a general CharSequence implementation
+        CharSequence contentType = CharBuffer.wrap("text/html; charset=utf-8 ; action=\"foo\"");
+        assertEquals(CharsetUtil.UTF_8, HttpUtil.getCharset(contentType, CharsetUtil.ISO_8859_1));
+
+        CharSequence emptyCharset = CharBuffer.wrap("text/html; charset= ; action=\"foo\"");
+        assertEquals(CharsetUtil.ISO_8859_1, HttpUtil.getCharset(emptyCharset, CharsetUtil.ISO_8859_1));
+    }
+
+    @Test
+    public void testGetCharsetWithLeadingWhitespaceIsNotAccepted() {
+        // Only trailing OWS is grammar-legal per RFC 9110 5.6.6; whitespace after '='
+        // is not, so such values keep falling back to the default charset.
+        assertEquals(CharsetUtil.ISO_8859_1,
+                HttpUtil.getCharset("text/html; charset= utf-8 ; action=\"foo\"", CharsetUtil.ISO_8859_1));
+        assertEquals(CharsetUtil.ISO_8859_1,
+                HttpUtil.getCharset("text/html; charset= ; action=\"foo\"", CharsetUtil.ISO_8859_1));
     }
 
     @Test


### PR DESCRIPTION
### Motivation:

RFC 9110 section 5.6.6 defines media type parameters as `*( OWS ";" OWS [ parameter ] )`, so optional whitespace is allowed before the semicolon that starts the next parameter. For a header like `text/html; charset=utf-8 ; action="foo"`, `HttpUtil.getCharset()` extracted `utf-8 ` (with the trailing space), failed to resolve the charset, and silently fell back to the default charset — decoding the body with the wrong charset. The quoted form `charset="utf-8" ; ...` was broken the same way because the trailing space defeats the quote-stripping.

### Modification:

Trim the extracted charset sequence in `HttpUtil.getCharset()` before stripping quotes and resolving the `Charset`. The raw-sequence API `getCharsetAsSequence` is deliberately left unchanged (its tests pin the raw behavior).

### Result:

Content-Type headers with optional whitespace before the next parameter now resolve to the correct charset instead of the default. Two regression tests added (fail on `4.2`, pass with the fix); `HttpUtilTest` passes 150/150.

Fixes #17384.