### PR TITLE
Handle non-positive skip lengths in ByteBufInputStream

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufInputStream.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufInputStream.java
@@ -192,6 +192,9 @@ public class ByteBufInputStream extends InputStream implements DataInput {
 
     @Override
     public long skip(long n) throws IOException {
+        if (n <= 0) {
+            return 0;
+        }
         if (n > Integer.MAX_VALUE) {
             return skipBytes(Integer.MAX_VALUE);
         } else {
@@ -310,6 +313,9 @@ public class ByteBufInputStream extends InputStream implements DataInput {
 
     @Override
     public int skipBytes(int n) throws IOException {
+        if (n <= 0) {
+            return 0;
+        }
         int nBytes = Math.min(available(), n);
         buffer.skipBytes(nBytes);
         return nBytes;

--- a/buffer/src/test/java/io/netty/buffer/ByteBufStreamTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufStreamTest.java
@@ -189,6 +189,21 @@ public class ByteBufStreamTest {
     }
 
     @Test
+    public void testSkipNegativeLength() throws Exception {
+        ByteBuf buf = Unpooled.buffer();
+        buf.writeBytes(new byte[] { 1, 2, 3 });
+        ByteBufInputStream in = new ByteBufInputStream(buf);
+        try {
+            assertEquals(0, in.skip(-1));
+            assertEquals(0, in.skipBytes(-1));
+            assertEquals(0, buf.readerIndex());
+        } finally {
+            buf.release();
+            in.close();
+        }
+    }
+
+    @Test
     public void testReadLine() throws Exception {
         Charset utf8 = StandardCharsets.UTF_8;
         ByteBuf buf = Unpooled.buffer();


### PR DESCRIPTION
Motivation:

ByteBufInputStream currently delegates non-positive skip values to ByteBuf.skipBytes(). This means negative values result in an IllegalArgumentException.

While subclasses of InputStream may handle negative values differently, InputStream's default implementation returns 0 without skipping any bytes. Making ByteBufInputStream behave the same way provides more consistent
stream behavior.

Modification:

Return 0 immediately from ByteBufInputStream.skip(long) and skipBytes(int) when the requested length is non-positive.


Result:

ByteBufInputStream now handles non-positive skip lengths consistently with InputStream's default behavior.