### PR TITLE
Release the in-flight field when a post decoder is destroyed

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
@@ -995,6 +995,20 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
                 httpData.release();
             }
         }
+        // A HttpData that is still being decoded was never added to bodyListHttpData, and a memory based
+        // one is not tracked by the factory either, so cleanFiles() above does not cover it.
+        if (currentFileUpload != null) {
+            if (currentFileUpload.refCnt() > 0) {
+                currentFileUpload.release();
+            }
+            currentFileUpload = null;
+        }
+        if (currentAttribute != null) {
+            if (currentAttribute.refCnt() > 0) {
+                currentAttribute.release();
+            }
+            currentAttribute = null;
+        }
 
         destroyed = true;
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
@@ -632,6 +632,14 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
                 httpData.release();
             }
         }
+        // An Attribute that is still being decoded was never added to bodyListHttpData, and a memory based
+        // one is not tracked by the factory either, so cleanFiles() above does not cover it.
+        if (currentAttribute != null) {
+            if (currentAttribute.refCnt() > 0) {
+                currentAttribute.release();
+            }
+            currentAttribute = null;
+        }
 
         destroyed = true;
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
@@ -1142,4 +1142,54 @@ public class HttpPostRequestDecoderTest {
         decoder.offer(new DefaultHttpContent(Unpooled.wrappedBuffer(bodyBytes)));
         decoder.destroy();
     }
+
+    @Test
+    public void testDestroyReleasesPartialAttributeStandardDecoder() {
+        HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
+        req.headers().add(HttpHeaderNames.CONTENT_TYPE, "application/x-www-form-urlencoded");
+
+        // memory only factory, so the attribute is not tracked by the factory either
+        HttpPostRequestDecoder decoder =
+                new HttpPostRequestDecoder(new DefaultHttpDataFactory(false), req);
+
+        // not a LastHttpContent, so the value of "field" is still being decoded
+        decoder.offer(new DefaultHttpContent(
+                Unpooled.copiedBuffer("field=partialvalue", CharsetUtil.UTF_8)));
+
+        InterfaceHttpData partial = decoder.currentPartialHttpData();
+        assertNotNull(partial);
+        assertEquals(1, partial.refCnt());
+
+        decoder.destroy();
+
+        assertEquals(0, partial.refCnt());
+    }
+
+    @Test
+    public void testDestroyReleasesPartialFileUploadMultipartDecoder() {
+        String boundary = "be38b42a9ad2713f";
+        HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
+        req.headers().add(HttpHeaderNames.CONTENT_TYPE, "multipart/form-data; boundary=" + boundary);
+
+        // memory only factory, so the file upload is not tracked by the factory either
+        HttpPostRequestDecoder decoder =
+                new HttpPostRequestDecoder(new DefaultHttpDataFactory(false), req);
+
+        String body = "--" + boundary + "\r\n" +
+                "Content-Disposition: form-data; name=\"file\"; filename=\"a.txt\"\r\n" +
+                "Content-Type: text/plain\r\n" +
+                "\r\n" +
+                "some partial content";
+
+        // not a LastHttpContent and the closing delimiter is missing, so the upload is still being decoded
+        decoder.offer(new DefaultHttpContent(Unpooled.copiedBuffer(body, CharsetUtil.UTF_8)));
+
+        InterfaceHttpData partial = decoder.currentPartialHttpData();
+        assertNotNull(partial);
+        assertEquals(1, partial.refCnt());
+
+        decoder.destroy();
+
+        assertEquals(0, partial.refCnt());
+    }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
@@ -1192,4 +1192,52 @@ public class HttpPostRequestDecoderTest {
 
         assertEquals(0, partial.refCnt());
     }
+
+    @Test
+    public void testDestroyReleasesPartialAttributeTrackedByFactory() {
+        HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
+        req.headers().add(HttpHeaderNames.CONTENT_TYPE, "application/x-www-form-urlencoded");
+
+        // the default factory checks the size, so it does track the attribute and cleanFiles()
+        // releases it before destroy() gets to it
+        HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(new DefaultHttpDataFactory(), req);
+
+        decoder.offer(new DefaultHttpContent(
+                Unpooled.copiedBuffer("field=partialvalue", CharsetUtil.UTF_8)));
+
+        InterfaceHttpData partial = decoder.currentPartialHttpData();
+        assertNotNull(partial);
+        assertEquals(1, partial.refCnt());
+
+        decoder.destroy();
+
+        assertEquals(0, partial.refCnt());
+    }
+
+    @Test
+    public void testDestroyReleasesPartialFileUploadTrackedByFactory() {
+        String boundary = "be38b42a9ad2713f";
+        HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
+        req.headers().add(HttpHeaderNames.CONTENT_TYPE, "multipart/form-data; boundary=" + boundary);
+
+        // the default factory checks the size, so it does track the upload and cleanFiles()
+        // releases it before destroy() gets to it
+        HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(new DefaultHttpDataFactory(), req);
+
+        String body = "--" + boundary + "\r\n" +
+                "Content-Disposition: form-data; name=\"file\"; filename=\"a.txt\"\r\n" +
+                "Content-Type: text/plain\r\n" +
+                "\r\n" +
+                "some partial content";
+
+        decoder.offer(new DefaultHttpContent(Unpooled.copiedBuffer(body, CharsetUtil.UTF_8)));
+
+        InterfaceHttpData partial = decoder.currentPartialHttpData();
+        assertNotNull(partial);
+        assertEquals(1, partial.refCnt());
+
+        decoder.destroy();
+
+        assertEquals(0, partial.refCnt());
+    }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
@@ -26,6 +26,7 @@ import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpConstants;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpMethod;
@@ -38,6 +39,7 @@ import org.junit.jupiter.api.function.Executable;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.Arrays;
 
@@ -1231,6 +1233,45 @@ public class HttpPostRequestDecoderTest {
                 "some partial content";
 
         decoder.offer(new DefaultHttpContent(Unpooled.copiedBuffer(body, CharsetUtil.UTF_8)));
+
+        InterfaceHttpData partial = decoder.currentPartialHttpData();
+        assertNotNull(partial);
+        assertEquals(1, partial.refCnt());
+
+        decoder.destroy();
+
+        assertEquals(0, partial.refCnt());
+    }
+
+    /**
+     * A factory shaped like the ones frameworks actually install: memory only, so nothing is tracked,
+     * with only the upload creation overridden. vert.x's NettyFileUploadDataFactory is this exact shape.
+     */
+    private static final class MemoryOnlyOverridingFactory extends DefaultHttpDataFactory {
+        MemoryOnlyOverridingFactory() {
+            super(false);
+        }
+
+        @Override
+        public FileUpload createFileUpload(HttpRequest request, String name, String filename,
+                                           String contentType, String contentTransferEncoding,
+                                           Charset charset, long size) {
+            return super.createFileUpload(request, name, filename, contentType,
+                    contentTransferEncoding, charset, size);
+        }
+    }
+
+    @Test
+    public void testDestroyReleasesPartialAttributeAfterMaxBufferedBytes() {
+        HttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
+        req.headers().add(HttpHeaderNames.CONTENT_TYPE, "application/x-www-form-urlencoded");
+
+        // the buffered bytes limit trips while "field" is still being decoded, which is the case a
+        // framework reaches when it catches the decoder exception and calls destroy() in response
+        HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(
+                new MemoryOnlyOverridingFactory(), req, HttpConstants.DEFAULT_CHARSET, -1, 6);
+
+        decoder.offer(new DefaultHttpContent(Unpooled.copiedBuffer("field=partialvalue", CharsetUtil.UTF_8)));
 
         InterfaceHttpData partial = decoder.currentPartialHttpData();
         assertNotNull(partial);


### PR DESCRIPTION
### Motivation

`destroy()` on both post decoders releases everything in `bodyListHttpData` and asks the
factory to clean up , but the field that is **still being decoded** is in neither .

`setFinalBuffer()` only calls `addHttpData()` once a field terminates , so a partial one never
reaches `bodyListHttpData` . and `DefaultHttpDataFactory.createAttribute` only puts it in
`getList(request)` on the `useDisk` and `checkSize` branches . the memory fallthrough returns a
bare `MemoryAttribute` that nothing tracks .

so on the ordinary path where a client goes away in the middle of a form post and the server
calls `decoder.destroy()` , the in flight `Attribute` or `FileUpload` leaks , along with the
retained slice of the inbound buffer it holds . netty's own leak detector fires on it .

this only bites when the factory hands back untracked memory data , which is
`new DefaultHttpDataFactory(false)` , the documented *always in Memory* mode , or a custom
factory . the default constructor , `MINSIZE` and `useDisk=true` all already reach refCnt 0 ,
i checked all three .

#11188 added that `bodyListHttpData` release loop saying `destroy()` should clean up memory
based data too , it just did not cover the item still in progress .

### Modification

release `currentAttribute` , and `currentFileUpload` in the multipart decoder , at the end of
`destroy()` . the `refCnt() > 0` guard matches the loop just above it , so a disk or mixed item
that `cleanFiles()` already freed is not released twice .

i did not go the other way and make the factory track memory data . that was tried in #10432
and closed as a breaking change , and #11109 was closed with *MemoryAttribute is not concerned
by this method* . nothing here touches the factory .

### Result

no leak from a decoder destroyed mid field .

two tests added . both fail without the change with `expected: <0> but was: <1>` , and the leak
detector raises `Possible memory leak detected` on top , so they are not passing off their own
assertions .

`codec-http` is 8985 tests , 0 failures . checkstyle and forbiddenapis are clean on the module .

the same `destroy()` is on 4.1 , so this probably wants `needs-cherry-pick-4.1` .
