### PR TITLE
Fix typos in comments/javadoc

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/FastThreadLocalThread.java
+++ b/common/src/main/java/io/netty/util/concurrent/FastThreadLocalThread.java
@@ -189,7 +189,7 @@ public class FastThreadLocalThread extends Thread {
      * Subclasses of {@link FastThreadLocalThread} can override this method if they are not meant to be used for
      * running event-loops.
      *
-     * @return {@code false}, unless overriden by a subclass.
+     * @return {@code false}, unless overridden by a subclass.
      */
     public boolean permitBlockingCalls() {
         return false;

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1175,7 +1175,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         StacklessClosedChannelException exception = StacklessClosedChannelException.newInstance(
                 SslHandler.class, "channelInactive(ChannelHandlerContext)");
 
-        // Add a supressed exception if the handshake was not completed yet.
+        // Add a suppressed exception if the handshake was not completed yet.
         if (isStateSet(STATE_HANDSHAKE_STARTED) && !handshakePromise.isDone()) {
             ThrowableUtil.addSuppressed(exception, StacklessSSLHandshakeException.newInstance(
                     "Connection closed while SSL/TLS handshake was in progress",

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -772,7 +772,7 @@ public class DnsNameResolver extends InetNameResolver {
      * system property.
      *
      * @param hostname the hostname that's being looked up
-     * @return true if the hostname should point to the loopback adress. False otherwise.
+     * @return true if the hostname should point to the loopback address. False otherwise.
      * @see <a href="https://github.com/netty/netty/issues/5386">Issue 5386</a>
      * @see <a href="https://github.com/netty/netty/issues/11142">Issue 11142</a>
      * @see <a href="https://github.com/netty/netty/issues/16744">Issue 16744</a>

--- a/transport-classes-epoll/src/main/java/io/netty/channel/epoll/Native.java
+++ b/transport-classes-epoll/src/main/java/io/netty/channel/epoll/Native.java
@@ -75,7 +75,7 @@ public final class Native {
             throw new ExceptionInInitializerError(e);
         }
 
-        // Preload all classes that will be used in the OnLoad(...) function of JNI to eliminate the possiblity of a
+        // Preload all classes that will be used in the OnLoad(...) function of JNI to eliminate the possibility of a
         // class-loader deadlock. This is a workaround for https://github.com/netty/netty/issues/11209.
 
         // This needs to match all the classes that are loaded via NETTY_JNI_UTIL_LOAD_CLASS or looked up via

--- a/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-classes-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -51,7 +51,7 @@ final class Native {
             // Just ignore
         }
 
-        // Preload all classes that will be used in the OnLoad(...) function of JNI to eliminate the possiblity of a
+        // Preload all classes that will be used in the OnLoad(...) function of JNI to eliminate the possibility of a
         // class-loader deadlock. This is a workaround for https://github.com/netty/netty/issues/11209.
 
         // This needs to match all the classes that are loaded via NETTY_JNI_UTIL_LOAD_CLASS or looked up via

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/BsdSocket.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/BsdSocket.java
@@ -236,7 +236,7 @@ final class BsdSocket extends Socket {
                                         long offset, long length) throws IOException;
 
     /**
-     * @return If successful, zero or positive number of bytes transfered, otherwise negative errno.
+     * @return If successful, zero or positive number of bytes transferred, otherwise negative errno.
      */
     private static native int connectx(
             int socketFd,

--- a/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/Native.java
+++ b/transport-classes-kqueue/src/main/java/io/netty/channel/kqueue/Native.java
@@ -57,7 +57,7 @@ final class Native {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(Native.class);
 
     static {
-        // Preload all classes that will be used in the OnLoad(...) function of JNI to eliminate the possiblity of a
+        // Preload all classes that will be used in the OnLoad(...) function of JNI to eliminate the possibility of a
         // class-loader deadlock. This is a workaround for https://github.com/netty/netty/issues/11209.
 
         // This needs to match all the classes that are loaded via NETTY_JNI_UTIL_LOAD_CLASS or looked up via

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/Unix.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/Unix.java
@@ -32,7 +32,7 @@ public final class Unix {
     private static final AtomicBoolean registered = new AtomicBoolean();
 
     static {
-        // Preload all classes that will be used in the OnLoad(...) function of JNI to eliminate the possiblity of a
+        // Preload all classes that will be used in the OnLoad(...) function of JNI to eliminate the possibility of a
         // class-loader deadlock. This is a workaround for https://github.com/netty/netty/issues/11209.
 
         // This needs to match all the classes that are loaded via NETTY_JNI_UTIL_LOAD_CLASS or looked up via


### PR DESCRIPTION
Fix minor typos in comments/javadoc/log messages. No functional change.