### PR TITLE
Fix JZlibDecoder truncating highly compressible streams

### DIFF
--- a/codec-compression/src/main/java/io/netty/handler/codec/compression/JZlibDecoder.java
+++ b/codec-compression/src/main/java/io/netty/handler/codec/compression/JZlibDecoder.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 public class JZlibDecoder extends ZlibDecoder {
 
+    private static final int MIN_OUTPUT_BUFFER_SIZE = 512;
     private final Inflater z = new Inflater();
     private byte[] dictionary;
     private static final int DEFAULT_MAX_FORWARD_BYTES = CompressionUtil.DEFAULT_MAX_FORWARD_BYTES;
@@ -167,7 +168,8 @@ public class JZlibDecoder extends ZlibDecoder {
 
             try {
                 loop: for (;;) {
-                    decompressed = prepareDecompressBuffer(ctx, decompressed, z.avail_in << 1);
+                    decompressed = prepareDecompressBuffer(
+                            ctx, decompressed, Math.max(z.avail_in << 1, MIN_OUTPUT_BUFFER_SIZE));
                     z.avail_out = decompressed.writableBytes();
                     z.next_out = decompressed.array();
                     z.next_out_index = decompressed.arrayOffset() + decompressed.writerIndex();

--- a/codec-compression/src/test/java/io/netty/handler/codec/compression/JZlibTest.java
+++ b/codec-compression/src/test/java/io/netty/handler/codec/compression/JZlibTest.java
@@ -15,6 +15,21 @@
  */
 package io.netty.handler.codec.compression;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
+import java.util.zip.Deflater;
+import java.util.zip.Inflater;
+import java.util.zip.InflaterInputStream;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
 public class JZlibTest extends ZlibTest {
 
     @Override
@@ -25,5 +40,62 @@ public class JZlibTest extends ZlibTest {
     @Override
     protected ZlibDecoder createDecoder(ZlibWrapper wrapper, int maxAllocation) {
         return new JZlibDecoder(wrapper, maxAllocation);
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "65537, 2147483647", "33333, 7" })
+    public void testHighlyCompressibleRawStreamIsFullyDecoded(int size, int chunkSize) throws Exception {
+        byte[] data = new byte[size];
+        Arrays.fill(data, (byte) 'a');
+        byte[] compressed = rawDeflate(data);
+
+        // Verify the fixture independently before using it to judge JZlibDecoder.
+        assertArrayEquals(data, jdkInflate(compressed));
+
+        EmbeddedChannel channel = new EmbeddedChannel(createDecoder(ZlibWrapper.NONE));
+        ByteArrayOutputStream decoded = new ByteArrayOutputStream();
+        try {
+            for (int offset = 0; offset < compressed.length; offset += chunkSize) {
+                int length = Math.min(chunkSize, compressed.length - offset);
+                channel.writeInbound(Unpooled.wrappedBuffer(compressed, offset, length).copy());
+            }
+            channel.finish();
+
+            ByteBuf message;
+            while ((message = channel.readInbound()) != null) {
+                message.readBytes(decoded, message.readableBytes());
+                message.release();
+            }
+            assertArrayEquals(data, decoded.toByteArray());
+        } finally {
+            decoded.close();
+            channel.close();
+        }
+    }
+
+    private static byte[] rawDeflate(byte[] data) {
+        Deflater deflater = new Deflater(Deflater.BEST_COMPRESSION, true);
+        deflater.setInput(data);
+        deflater.finish();
+        ByteArrayOutputStream compressed = new ByteArrayOutputStream();
+        byte[] buffer = new byte[8192];
+        while (!deflater.finished()) {
+            compressed.write(buffer, 0, deflater.deflate(buffer));
+        }
+        deflater.end();
+        return compressed.toByteArray();
+    }
+
+    private static byte[] jdkInflate(byte[] compressed) throws Exception {
+        ByteArrayOutputStream decoded = new ByteArrayOutputStream();
+        try (InflaterInputStream input = new InflaterInputStream(
+                new ByteArrayInputStream(compressed), new Inflater(true))) {
+            byte[] buffer = new byte[8192];
+            int length;
+            while ((length = input.read(buffer)) != -1) {
+                decoded.write(buffer, 0, length);
+            }
+        }
+        return decoded.toByteArray();
     }
 }


### PR DESCRIPTION
### Motivation

JZlibDecoder sizes each output buffer from the remaining compressed input. For highly compressible raw deflate streams, JZlib can consume the last input byte while decoded bytes remain buffered. The next zero-sized output buffer makes inflate return Z_BUF_ERROR, and the decoder silently emits a short body.

`JdkZlibDecoder`, in the same package, already floors that capacity at 512 bytes (#17364).

### Modification

Apply the same floor while draining JZlib. Add parameterized coverage for the downstream-forwarding and fragmented-input paths, with each compressed fixture cross-checked by the JDK inflater.

### Result

Raw streams of 65,537 bytes in one write and 33,333 bytes in 7-byte chunks are fully decoded. codec-compression passes 508 tests, and `verify` on JDK 11 is clean.
