### PR TITLE
Update quiche to 0.29.2

### DIFF
--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -60,7 +60,7 @@
     <quicheHomeIncludeDir>${quicheHomeDir}/quiche/include</quicheHomeIncludeDir>
     <quicheRepository>https://github.com/cloudflare/quiche</quicheRepository>
     <quicheBranch>master</quicheBranch>
-    <quicheCommitSha>4f347477006bf7f928335d28f05056013f70b87e</quicheCommitSha>
+    <quicheCommitSha>839b23d0edcc98aa1cf90c2cf0797b8cc56d4f15</quicheCommitSha>
     <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
     <templateDir>${project.build.directory}/template</templateDir>
     <cargoTarget />

--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -60,7 +60,7 @@
     <quicheHomeIncludeDir>${quicheHomeDir}/quiche/include</quicheHomeIncludeDir>
     <quicheRepository>https://github.com/cloudflare/quiche</quicheRepository>
     <quicheBranch>master</quicheBranch>
-    <quicheCommitSha>839b23d0edcc98aa1cf90c2cf0797b8cc56d4f15</quicheCommitSha>
+    <quicheCommitSha>55886df3be579579207104c8e645825b6347a209</quicheCommitSha>
     <generatedSourcesDir>${project.build.directory}/generated-sources</generatedSourcesDir>
     <templateDir>${project.build.directory}/template</templateDir>
     <cargoTarget />

--- a/codec-native-quic/pom.xml
+++ b/codec-native-quic/pom.xml
@@ -49,9 +49,21 @@
     <boringsslHomeBuildDir>${boringsslHomeDir}/build</boringsslHomeBuildDir>
     <boringsslHomeIncludeDir>${boringsslHomeDir}/include</boringsslHomeIncludeDir>
     <boringsslRepository>https://boringssl.googlesource.com/boringssl</boringsslRepository>
-    <!-- Lets use what we use in netty-tcnative-boringssl-static -->
+    <!-- Lets use what we use in netty-tcnative-boringssl-static. Bumped forward from
+         0226f30467f540a3f62ef48d453f93927da199b6 (2025-09-07) to d03dbc3e5d7de44183ff17018af22323af650fbc
+         (2026-05-12): boring 5.x (see quicheBoringVersionReplacement below) unconditionally calls
+         SSL_get_signature_algorithm_used, which BoringSSL only added upstream on 2026-05-12. -->
     <boringsslBranch>main</boringsslBranch>
-    <boringsslCommitSha>0226f30467f540a3f62ef48d453f93927da199b6</boringsslCommitSha>
+    <boringsslCommitSha>d03dbc3e5d7de44183ff17018af22323af650fbc</boringsslCommitSha>
+    <!-- quiche's Cargo.toml pins "boring = { version = \"4.3\" }", but boring 4.x's Rust source
+         hard-codes references to a handful of BoringSSL symbols (e.g. the old SslCurve API, and
+         a cloudflare-only unconditional Raw Public Key patch) that don't exist in a recent/vanilla
+         BoringSSL checkout like the one we build above. boring 5.x removed the SslCurve API and
+         reworked RPK support to use upstream's own SSL_CREDENTIAL API (feature-gated), so it
+         builds cleanly against our BoringSSL revision. We patch quiche's requirement up to "5"
+         below rather than pin BoringSSL to boring-sys's old vendored (2023) revision. -->
+    <quicheBoringVersionReq>boring = { version = "4.3" }</quicheBoringVersionReq>
+    <quicheBoringVersionReplacement>boring = { version = "5" }</quicheBoringVersionReplacement>
 
     <quicheSourceDir>${project.build.directory}/quiche-source</quicheSourceDir>
     <quicheBuildDir>${quicheSourceDir}/target/release</quicheBuildDir>
@@ -858,6 +870,11 @@
                         </exec>
                       </else>
                     </if>
+
+                    <!-- See the comment next to quicheBoringVersionReq above: bump quiche's pinned
+                         "boring" dependency so it builds against our BoringSSL revision. -->
+                    <replace file="${quicheSourceDir}/Cargo.toml" token="${quicheBoringVersionReq}" value="${quicheBoringVersionReplacement}" summary="true" />
+
                     <echo message="Building Quiche" />
                     <if>
                       <equals arg1="${platform}" arg2="android" />
@@ -866,7 +883,8 @@
                           <arg line="ndk ${cargoTarget} --platform ${androidNdkVersion} -- build -p quiche --features &quot;ffi qlog custom-client-dcid&quot; --release" />
                           <env key="CFLAGS" value="${extraCflags}" />
                           <env key="CXXFLAGS" value="${extraCxxflags}" />
-                          <env key="QUICHE_BSSL_PATH" value="${boringsslHomeDir}/" />
+                          <env key="BORING_BSSL_PATH" value="${boringsslHomeBuildDir}" />
+                          <env key="BORING_BSSL_INCLUDE_PATH" value="${boringsslHomeIncludeDir}" />
                         </exec>
                       </then>
                       <else>
@@ -879,7 +897,8 @@
                               <!-- See https://github.com/cloudflare/quiche/blob/0.7.0/src/build.rs#L73 -->
                               <env key="DEBUG" value="true" />
                               <env key="OPT_LEVEL" value="3" />
-                              <env key="QUICHE_BSSL_PATH" value="${boringsslHomeDir}/" />
+                              <env key="BORING_BSSL_PATH" value="${boringsslHomeBuildDir}" />
+                              <env key="BORING_BSSL_INCLUDE_PATH" value="${boringsslHomeIncludeDir}" />
                             </exec>
                           </then>
                           <elseif>
@@ -888,7 +907,8 @@
                               <exec executable="cargo" failonerror="true" dir="${quicheSourceDir}" resolveexecutable="true">
                                 <arg line="build -p quiche --features &quot;ffi qlog custom-client-dcid&quot; --release" />
                                 <arg value="${cargoTarget}" />
-                                <env key="QUICHE_BSSL_PATH" value="${boringsslHomeDir}/" />
+                                <env key="BORING_BSSL_PATH" value="${boringsslHomeBuildDir}" />
+                                <env key="BORING_BSSL_INCLUDE_PATH" value="${boringsslHomeIncludeDir}" />
                                 <!-- Lets enable frame-pointers so we can profile better -->
                                 <env key="RUSTFLAGS" value="-Cforce-frame-pointers=yes" />
                                 <env key="TARGET_CC" value="aarch64-none-linux-gnu-gcc" />
@@ -903,7 +923,8 @@
                                 <env key="CFLAGS" value="${extraCflags}" />
                                 <env key="CXXFLAGS" value="${extraCxxflags}" />
                                 <arg value="${cargoTarget}" />
-                                <env key="QUICHE_BSSL_PATH" value="${boringsslHomeDir}/" />
+                                <env key="BORING_BSSL_PATH" value="${boringsslHomeBuildDir}" />
+                                <env key="BORING_BSSL_INCLUDE_PATH" value="${boringsslHomeIncludeDir}" />
                                 <!-- Lets enable frame-pointers so we can profile better -->
                                 <env key="RUSTFLAGS" value="-Cforce-frame-pointers=yes" />
                                 <env key="MACOSX_DEPLOYMENT_TARGET" value="${macosxDeploymentTarget}" />
@@ -915,7 +936,8 @@
                               <arg line="build -p quiche --features &quot;ffi qlog custom-client-dcid&quot; --release" />
                               <env key="CFLAGS" value="${extraCflags}" />
                               <env key="CXXFLAGS" value="${extraCxxflags}" />
-                              <env key="QUICHE_BSSL_PATH" value="${boringsslHomeDir}/" />
+                              <env key="BORING_BSSL_PATH" value="${boringsslHomeBuildDir}" />
+                              <env key="BORING_BSSL_INCLUDE_PATH" value="${boringsslHomeIncludeDir}" />
                               <!-- Lets enable frame-pointers so we can profile better -->
                               <env key="RUSTFLAGS" value="-Cforce-frame-pointers=yes" />
                               <env key="MACOSX_DEPLOYMENT_TARGET" value="${macosxDeploymentTarget}" />

--- a/codec-native-quic/src/main/c/netty_quic_quiche.c
+++ b/codec-native-quic/src/main/c/netty_quic_quiche.c
@@ -707,11 +707,14 @@ static jlong netty_quiche_conn_new_scid(JNIEnv* env, jclass clazz, jlong conn, j
 static jbyteArray netty_quiche_conn_retired_scid_next(JNIEnv* env, jclass clazz, jlong conn) {
     const uint8_t *id = NULL;
     size_t len = 0;
+    jbyteArray array = NULL;
 
-    if (quiche_conn_retired_scid_next((quiche_conn *) conn, &id, &len)) {
-        return to_byte_array(env, id, len);
+    quiche_connection_id_iter* itr = quiche_conn_retired_scid_iter((quiche_conn *) conn);
+    if (quiche_connection_id_iter_next(itr, &id, &len)) {
+        array = to_byte_array(env, id, len);
     }
-    return NULL;
+    quiche_connection_id_iter_free(itr);
+    return array;
 }
 
 static jlong netty_quiche_conn_path_event_next(JNIEnv* env, jclass clazz, jlong conn) {

--- a/docker/Dockerfile.al2023
+++ b/docker/Dockerfile.al2023
@@ -13,6 +13,7 @@ RUN dnf install -yq \
  autoconf \
  automake \
  bzip2 \
+ clang \
  cmake \
  gcc \
  gcc-c++ \

--- a/docker/Dockerfile.centos7
+++ b/docker/Dockerfile.centos7
@@ -67,7 +67,7 @@ RUN wget -q https://go.dev/dl/go$GO_VERSION.linux-amd64.tar.gz && tar zxf go$GO_
 RUN curl -s https://cmake.org/files/v$CMAKE_VERSION_BASE/cmake-$CMAKE_VERSION-linux-x86_64.tar.gz --output cmake-$CMAKE_VERSION-linux-x86_64.tar.gz && tar zxf cmake-$CMAKE_VERSION-linux-x86_64.tar.gz && mv cmake-$CMAKE_VERSION-linux-x86_64 /opt/ && echo 'PATH=/opt/cmake-$CMAKE_VERSION-linux-x86_64/bin:$PATH' >> ~/.bashrc
 
 # Add pre-build clang so we can compile quiche.
-RUN curl -s https://github.com/netty/netty/releases/download/netty-clang-bin/centos-7-clang-18.1.8-bin.tar.xz --output centos-7-clang-18.1.8-bin.tar.xz && tar xf centos-7-clang-18.1.8-bin.tar.xz && mv clang-18.1.8 /opt/ && echo 'PATH=/opt/cclang-18.1.8/bin:$PATH' >> ~/.bashrc && echo 'LIBCLANG_PATH=/opt/clang-18.1.8/lib' >>  ~/.bashrc && echo 'BINDGEN_EXTRA_CLANG_ARGS="-I /opt/clang-18.1.8/lib/clang/18/include/"' >>  ~/.bashrc
+RUN wget -q https://github.com/netty/netty/releases/download/netty-clang-bin/centos-7-clang-18.1.8-bin.tar.xz && tar xf centos-7-clang-18.1.8-bin.tar.xz && mv clang-18.1.8 /opt/ && echo 'PATH=/opt/cclang-18.1.8/bin:$PATH' >> ~/.bashrc && echo 'LIBCLANG_PATH=/opt/clang-18.1.8/lib' >>  ~/.bashrc && echo 'BINDGEN_EXTRA_CLANG_ARGS="-I /opt/clang-18.1.8/lib/clang/18/include/"' >>  ~/.bashrc
  
 # Build OpenSSL 3.x from source using devtoolset-11
 RUN set -x && \

--- a/docker/Dockerfile.centos7
+++ b/docker/Dockerfile.centos7
@@ -66,6 +66,9 @@ RUN wget -q https://github.com/ninja-build/ninja/releases/download/v$NINJA_VERSI
 RUN wget -q https://go.dev/dl/go$GO_VERSION.linux-amd64.tar.gz && tar zxf go$GO_VERSION.linux-amd64.tar.gz && mv go /opt/ && echo 'PATH=/opt/go/bin:$PATH' >> ~/.bashrc && echo 'export GOROOT=/opt/go/' >> ~/.bashrc
 RUN curl -s https://cmake.org/files/v$CMAKE_VERSION_BASE/cmake-$CMAKE_VERSION-linux-x86_64.tar.gz --output cmake-$CMAKE_VERSION-linux-x86_64.tar.gz && tar zxf cmake-$CMAKE_VERSION-linux-x86_64.tar.gz && mv cmake-$CMAKE_VERSION-linux-x86_64 /opt/ && echo 'PATH=/opt/cmake-$CMAKE_VERSION-linux-x86_64/bin:$PATH' >> ~/.bashrc
 
+# Add pre-build clang so we can compile quiche.
+RUN curl -s https://github.com/netty/netty/releases/download/netty-clang-bin/centos-7-clang-18.1.8-bin.tar.xz --output centos-7-clang-18.1.8-bin.tar.xz && tar xf centos-7-clang-18.1.8-bin.tar.xz && mv clang-18.1.8 /opt/ && echo 'PATH=/opt/cclang-18.1.8/bin:$PATH' >> ~/.bashrc && echo 'LIBCLANG_PATH=/opt/clang-18.1.8/lib' >>  ~/.bashrc && echo 'BINDGEN_EXTRA_CLANG_ARGS="-I /opt/clang-18.1.8/lib/clang/18/include/"' >>  ~/.bashrc
+ 
 # Build OpenSSL 3.x from source using devtoolset-11
 RUN set -x && \
   source /opt/rh/devtoolset-11/enable && \

--- a/docker/Dockerfile.centos7
+++ b/docker/Dockerfile.centos7
@@ -67,8 +67,8 @@ RUN wget -q https://go.dev/dl/go$GO_VERSION.linux-amd64.tar.gz && tar zxf go$GO_
 RUN curl -s https://cmake.org/files/v$CMAKE_VERSION_BASE/cmake-$CMAKE_VERSION-linux-x86_64.tar.gz --output cmake-$CMAKE_VERSION-linux-x86_64.tar.gz && tar zxf cmake-$CMAKE_VERSION-linux-x86_64.tar.gz && mv cmake-$CMAKE_VERSION-linux-x86_64 /opt/ && echo 'PATH=/opt/cmake-$CMAKE_VERSION-linux-x86_64/bin:$PATH' >> ~/.bashrc
 
 # Add pre-build clang so we can compile quiche.
-RUN wget -q https://github.com/netty/netty/releases/download/netty-clang-bin/centos-7-clang-18.1.8-bin.tar.xz && tar xf centos-7-clang-18.1.8-bin.tar.xz && mv clang-18.1.8 /opt/ && echo 'PATH=/opt/cclang-18.1.8/bin:$PATH' >> ~/.bashrc && echo 'LIBCLANG_PATH=/opt/clang-18.1.8/lib' >>  ~/.bashrc && echo 'BINDGEN_EXTRA_CLANG_ARGS="-I /opt/clang-18.1.8/lib/clang/18/include/"' >>  ~/.bashrc
- 
+RUN wget -q https://github.com/netty/netty/releases/download/netty-clang-bin/centos-7-clang-18.1.8-bin.tar.xz && tar xf centos-7-clang-18.1.8-bin.tar.xz && mv clang-18.1.8 /opt/ && echo 'PATH=/opt/cclang-18.1.8/bin:$PATH' >> ~/.bashrc && echo 'export LIBCLANG_PATH=/opt/clang-18.1.8/lib' >>  ~/.bashrc && echo 'export BINDGEN_EXTRA_CLANG_ARGS="-I /opt/clang-18.1.8/lib/clang/18/include/"' >>  ~/.bashrc
+
 # Build OpenSSL 3.x from source using devtoolset-11
 RUN set -x && \
   source /opt/rh/devtoolset-11/enable && \

--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -25,6 +25,7 @@ RUN yum install -y \
  bzip2 \
  git \
  glibc-devel \
+ glibc-devel.i686 \
  golang \
  gnupg \
  libaio-devel \
@@ -52,7 +53,6 @@ WORKDIR $SOURCE_DIR
 RUN wget https://developer.arm.com/-/media/Files/downloads/gnu-a/$GCC_VERSION/binrel/gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu.tar.xz && \
   tar xf gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu.tar.xz && mv gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu /opt/
 ENV PATH="/opt/gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu/bin:${PATH}"
-
 
 # Install CMake
 RUN curl -s https://cmake.org/files/v$CMAKE_VERSION_BASE/cmake-$CMAKE_VERSION-linux-x86_64.tar.gz --output cmake-$CMAKE_VERSION-linux-x86_64.tar.gz && tar zxf cmake-$CMAKE_VERSION-linux-x86_64.tar.gz && mv cmake-$CMAKE_VERSION-linux-x86_64 /opt/ && echo 'PATH=/opt/cmake-$CMAKE_VERSION-linux-x86_64/bin:$PATH' >> ~/.bashrc

--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -25,7 +25,6 @@ RUN yum install -y \
  bzip2 \
  git \
  glibc-devel \
- glibc-devel.i686 \
  golang \
  gnupg \
  libaio-devel \
@@ -58,7 +57,7 @@ ENV PATH="/opt/gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu/bin:${PATH}"
 RUN curl -s https://cmake.org/files/v$CMAKE_VERSION_BASE/cmake-$CMAKE_VERSION-linux-x86_64.tar.gz --output cmake-$CMAKE_VERSION-linux-x86_64.tar.gz && tar zxf cmake-$CMAKE_VERSION-linux-x86_64.tar.gz && mv cmake-$CMAKE_VERSION-linux-x86_64 /opt/ && echo 'PATH=/opt/cmake-$CMAKE_VERSION-linux-x86_64/bin:$PATH' >> ~/.bashrc
 
 # Add pre-build clang so we can compile quiche.
-RUN wget -q https://github.com/netty/netty/releases/download/netty-clang-bin/centos-7-clang-18.1.8-bin.tar.xz && tar xf centos-7-clang-18.1.8-bin.tar.xz && mv clang-18.1.8 /opt/ && echo 'PATH=/opt/cclang-18.1.8/bin:$PATH' >> ~/.bashrc && echo 'export LIBCLANG_PATH=/opt/clang-18.1.8/lib' >>  ~/.bashrc && echo 'export BINDGEN_EXTRA_CLANG_ARGS="-I /opt/clang-18.1.8/lib/clang/18/include/"' >>  ~/.bashrc
+RUN wget -q https://github.com/netty/netty/releases/download/netty-clang-bin/centos-7-clang-18.1.8-bin.tar.xz && tar xf centos-7-clang-18.1.8-bin.tar.xz && mv clang-18.1.8 /opt/ && echo 'PATH=/opt/cclang-18.1.8/bin:$PATH' >> ~/.bashrc && echo 'export LIBCLANG_PATH=/opt/clang-18.1.8/lib' >>  ~/.bashrc && echo 'export BINDGEN_EXTRA_CLANG_ARGS="-I /opt/clang-18.1.8/lib/clang/18/include/ --sysroot=/opt/gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu/aarch64-none-linux-gnu/libc"' >>  ~/.bashrc
 
 # install rust and setup PATH and install correct toolchain
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y

--- a/docker/Dockerfile.cross_compile_aarch64
+++ b/docker/Dockerfile.cross_compile_aarch64
@@ -57,6 +57,9 @@ ENV PATH="/opt/gcc-arm-$GCC_VERSION-x86_64-aarch64-none-linux-gnu/bin:${PATH}"
 # Install CMake
 RUN curl -s https://cmake.org/files/v$CMAKE_VERSION_BASE/cmake-$CMAKE_VERSION-linux-x86_64.tar.gz --output cmake-$CMAKE_VERSION-linux-x86_64.tar.gz && tar zxf cmake-$CMAKE_VERSION-linux-x86_64.tar.gz && mv cmake-$CMAKE_VERSION-linux-x86_64 /opt/ && echo 'PATH=/opt/cmake-$CMAKE_VERSION-linux-x86_64/bin:$PATH' >> ~/.bashrc
 
+# Add pre-build clang so we can compile quiche.
+RUN wget -q https://github.com/netty/netty/releases/download/netty-clang-bin/centos-7-clang-18.1.8-bin.tar.xz && tar xf centos-7-clang-18.1.8-bin.tar.xz && mv clang-18.1.8 /opt/ && echo 'PATH=/opt/cclang-18.1.8/bin:$PATH' >> ~/.bashrc && echo 'export LIBCLANG_PATH=/opt/clang-18.1.8/lib' >>  ~/.bashrc && echo 'export BINDGEN_EXTRA_CLANG_ARGS="-I /opt/clang-18.1.8/lib/clang/18/include/"' >>  ~/.bashrc
+
 # install rust and setup PATH and install correct toolchain
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="$HOME/.cargo/bin:${PATH}"


### PR DESCRIPTION
Motivation:

Quiche 0.29.2 was released which fixes a possible crash due use-after-free.

Modifications:

- Update to 0.29.2
- Adjust API usage

Result:

No more possible crash