### PR TITLE
Avoid double promise allocation in SslHandler.wrap() (#17382)

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -802,7 +802,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
             final int wrapDataSize = this.wrapDataSize;
             // Only continue to loop if the handler was not removed in the meantime.
             // See https://github.com/netty/netty/issues/5860
-            outer: while (!ctx.isRemoved()) {
+            outer: while (!ctx.isRemoved() && !pendingUnencryptedWrites.isEmpty()) {
                 Promise<Void> promise = ctx.newPromise();
                 ByteBuf buf = wrapDataSize > 0 ?
                         pendingUnencryptedWrites.remove(alloc, wrapDataSize, promise) :


### PR DESCRIPTION
Motivation:

Production allocation profiling identified `SslHandler.wrap()`'s
`ctx.newPromise()` as the source of ~79% of sampled
`DefaultChannelPromise` allocations. `wrap()` allocates the promise
before checking whether `pendingUnencryptedWrites` contains another
entry. After the last entry is consumed, the loop may iterate once more,
allocate a `ChannelPromise`, receive null from remove/removeFirst, and
immediately discard the promise.

<img width="1538" height="110" alt="image"
src="https://github.com/user-attachments/assets/e567e5f5-281e-4fcd-8c64-d5e5a320efcd"
/>

Flow:

```
iteration #1
  newPromise()        // useful
  removeFirst() -> buf
  encrypt buf
  queue now empty

iteration #2
  newPromise()        // wasted allocation
  removeFirst() -> null
  break
```

Modification:

Added a guard check `!pendingUnencryptedWrites.isEmpty()` to avoid
unnecessary loop iteration.

Result:

Less garbage in SslHandler for outgoing packets.

```
import io.netty.buffer.ByteBuf;
import org.openjdk.jmh.annotations.Benchmark;

public class SslHandlerWrapBenchmark extends AbstractSslHandlerThroughputBenchmark {

    @Benchmark
    public int wrapOneWrite() throws Exception {
        ByteBuf encrypted = doWrite(1);
        try {
            return encrypted.readableBytes();
        } finally {
            encrypted.release();
        }
    }
}
```

```
baseline: 1411.886 B/op
patched:  1336.061 B/op
delta:      75.825 B/op
```
