### PR TITLE
QUIC: Ensure writable events reflect stream capacity

### DIFF
--- a/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicStreamChannel.java
+++ b/codec-classes-quic/src/main/java/io/netty/handler/codec/quic/QuicheQuicStreamChannel.java
@@ -710,7 +710,7 @@ final class QuicheQuicStreamChannel extends DefaultAttributeMap implements QuicS
                     }
                 }
                 if (written) {
-                    updateWritabilityIfNeeded(true);
+                    updateWritabilityIfNeeded(capacity > 0);
                 }
                 return written;
             } finally {

--- a/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicWritableTest.java
+++ b/codec-native-quic/src/test/java/io/netty/handler/codec/quic/QuicWritableTest.java
@@ -16,7 +16,6 @@
 package io.netty.handler.codec.quic;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -198,16 +197,17 @@ public class QuicWritableTest extends AbstractQuicTest {
                                 assertEquals(before, newBefore + size);
                                 before = newBefore;
                             }
-                            ctx.writeAndFlush(Unpooled.EMPTY_BUFFER).addListener(new PromiseNotifier<>(writePromise));
+                            ctx.write(ctx.alloc().buffer(firstWriteNumBytes).writeZero(firstWriteNumBytes))
+                                    .addListener(new PromiseNotifier<>(writePromise));
+                            ctx.writeAndFlush(ctx.alloc().buffer(maxData).writeZero(maxData));
                         }
                     }
 
                     @Override
                     public void channelWritabilityChanged(ChannelHandlerContext ctx) {
                         if (ctx.channel().isWritable()) {
-                            if (ctx.channel().bytesBeforeUnwritable() > 0) {
-                                writableAgainLatch.countDown();
-                            }
+                            assertTrue(ctx.channel().bytesBeforeUnwritable() > 0);
+                            writableAgainLatch.countDown();
                         }
                     }
 


### PR DESCRIPTION
Motivation:

Draining queued QUIC stream writes could fire `channelWritabilityChanged` with `isWritable() == true` after the drain had consumed all remaining stream capacity. Handlers that resumed producing data synchronously from this callback therefore observed a transient writable state and immediately became unwritable again.

Modification:

Derive the writability update in `writeQueued()` from the stream capacity refreshed by the completed writes instead of unconditionally marking the stream writable.

Extend `QuicWritableTest` to queue two real buffers after exhausting stream capacity. This reproduces the partial-drain case and verifies that every writable callback observes positive remaining capacity.

Result:

QUIC stream writability callbacks now expose the stable post-drain capacity state, so synchronous backpressure consumers no longer resume during a zero-capacity transition.

Testing:

- `QuicWritableTest`: 6 tests passed across both SSL executor variants
- Focused regression repeated successfully
- `codec-classes-quic` compilation and checkstyle passed
- `codec-native-quic` test compilation and checkstyle passed

Resolves #17429